### PR TITLE
Handle leading whitespace on code blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ _coverage/
 
 # For local experiments.
 scratch/
+
+# opam v2
+_opam/

--- a/odoc.opam
+++ b/odoc.opam
@@ -16,6 +16,7 @@ dev-repo: "http://github.com/ocaml-doc/odoc.git"
 
 available: [ocaml-version >= "4.03.0"]
 depends: [
+  "astring" {build}
   "bos" {build}
   "cmdliner" {build}
   "cppo" {build}

--- a/src/parser/jbuild
+++ b/src/parser/jbuild
@@ -5,4 +5,4 @@
 (library
  ((name parser_)
   (preprocess (pps (bisect_ppx)))
-  (libraries (model))))
+  (libraries (model str))))

--- a/src/parser/jbuild
+++ b/src/parser/jbuild
@@ -5,4 +5,4 @@
 (library
  ((name parser_)
   (preprocess (pps (bisect_ppx)))
-  (libraries (model str))))
+  (libraries (model astring))))

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -70,6 +70,32 @@ let trim_trailing_blank_lines : string -> string = fun s ->
     in
     String.sub s 0 trim_from
 
+let trim_leading_whitespace : string -> string = fun s ->
+  let count_leading_whitespace : string -> int = fun line ->
+    let rec count_leading_whitespace' : int -> int = fun index ->
+      if index >= String.length line then
+        index
+      else
+        match line.[index] with
+        | ' ' | '\t' -> count_leading_whitespace' (index + 1)
+        | _ -> index
+    in
+    count_leading_whitespace' 0
+  in
+  let lines = Str.(split (regexp "\n") s) in
+  let least_amount_of_whitespace =
+    lines
+    |> List.map count_leading_whitespace
+    |> List.fold_left min max_int
+  in
+  let remove_whitespace : string -> string = fun line ->
+    String.sub line least_amount_of_whitespace (String.length line - least_amount_of_whitespace)
+  in
+  lines
+  |> List.map remove_whitespace
+  |> String.concat "\n"
+
+
 
 
 module Location = Model.Location_
@@ -256,6 +282,7 @@ rule token input = parse
   | "{[" (code_block_text as c) "]}"
     { let c = trim_leading_blank_lines c in
       let c = trim_trailing_blank_lines c in
+      let c = trim_leading_whitespace c in
       emit input (`Code_block c) }
 
   | "{v" (verbatim_text as t) "v}"

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -92,7 +92,10 @@ let trim_leading_whitespace : string -> string = fun s ->
     |> List.fold_left min max_int
   in
   let remove_whitespace : string -> string = fun line ->
-    String.sub line least_amount_of_whitespace (String.length line - least_amount_of_whitespace)
+    String.sub
+      line
+      least_amount_of_whitespace
+      (String.length line - least_amount_of_whitespace)
   in
   lines
   |> List.map remove_whitespace

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -86,6 +86,9 @@ let trim_leading_whitespace : string -> string = fun s ->
   let least_amount_of_whitespace =
     lines
     |> List.map count_leading_whitespace
+    (* Note that if [lines] is empty, [least_amount_of_whitespace] will be
+       [max_int]. But this is okay since if it's indeed empty, the value
+       will not be used when trying to remove whitespace below. *)
     |> List.fold_left min max_int
   in
   let remove_whitespace : string -> string = fun line ->

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -82,7 +82,7 @@ let trim_leading_whitespace : string -> string = fun s ->
     in
     count_leading_whitespace' 0
   in
-  let lines = Str.(split (regexp "\n") s) in
+  let lines = Astring.String.cuts ~sep:"\n" s in
   let least_amount_of_whitespace =
     lines
     |> List.map count_leading_whitespace

--- a/test/parser/expect/code-block/leading-newline-with-space.txt
+++ b/test/parser/expect/code-block/leading-newline-with-space.txt
@@ -1,1 +1,1 @@
-((output (ok (((f.ml (1 0) (2 6)) (code_block " foo"))))) (warnings ()))
+((output (ok (((f.ml (1 0) (2 6)) (code_block foo))))) (warnings ()))

--- a/test/parser/expect/code-block/leading-tab-two-different-indent.txt
+++ b/test/parser/expect/code-block/leading-tab-two-different-indent.txt
@@ -1,0 +1,3 @@
+((output (ok (((f.ml (1 0) (2 7)) (code_block  "foo\
+                                              \n\tbar")))))
+ (warnings ()))

--- a/test/parser/expect/code-block/leading-tab-two.txt
+++ b/test/parser/expect/code-block/leading-tab-two.txt
@@ -1,0 +1,3 @@
+((output (ok (((f.ml (1 0) (2 6)) (code_block  "foo\
+                                              \nbar")))))
+ (warnings ()))

--- a/test/parser/expect/code-block/leading-tab.txt
+++ b/test/parser/expect/code-block/leading-tab.txt
@@ -1,1 +1,1 @@
-((output (ok (((f.ml (1 0) (1 8)) (code_block "\tfoo"))))) (warnings ()))
+((output (ok (((f.ml (1 0) (1 8)) (code_block foo))))) (warnings ()))

--- a/test/parser/expect/code-block/leading-whitespace-two-cr-lf.txt
+++ b/test/parser/expect/code-block/leading-whitespace-two-cr-lf.txt
@@ -1,0 +1,3 @@
+((output (ok (((f.ml (1 0) (2 6)) (code_block  "foo\r\
+                                              \nbar")))))
+ (warnings ()))

--- a/test/parser/expect/code-block/leading-whitespace-two-different-indent-rev.txt
+++ b/test/parser/expect/code-block/leading-whitespace-two-different-indent-rev.txt
@@ -1,0 +1,3 @@
+((output (ok (((f.ml (1 0) (2 6)) (code_block  "  foo\
+                                              \nbar")))))
+ (warnings ()))

--- a/test/parser/expect/code-block/leading-whitespace-two-different-indent.txt
+++ b/test/parser/expect/code-block/leading-whitespace-two-different-indent.txt
@@ -1,0 +1,3 @@
+((output (ok (((f.ml (1 0) (2 8)) (code_block  "foo\
+                                              \n  bar")))))
+ (warnings ()))

--- a/test/parser/expect/code-block/leading-whitespace-two.txt
+++ b/test/parser/expect/code-block/leading-whitespace-two.txt
@@ -1,0 +1,3 @@
+((output (ok (((f.ml (1 0) (2 6)) (code_block  "foo\
+                                              \nbar")))))
+ (warnings ()))

--- a/test/parser/expect/code-block/leading-whitespace.txt
+++ b/test/parser/expect/code-block/leading-whitespace.txt
@@ -1,1 +1,1 @@
-((output (ok (((f.ml (1 0) (1 8)) (code_block " foo"))))) (warnings ()))
+((output (ok (((f.ml (1 0) (1 8)) (code_block foo))))) (warnings ()))

--- a/test/parser/test.ml
+++ b/test/parser/test.ml
@@ -271,7 +271,13 @@ let tests : test_suite list = [
     t "cr-lf" "{[foo\r\nbar]}";
     t "blank-line" "{[foo\n\nbar]}";
     t "leading-whitespace" "{[ foo]}";
+    t "leading-whitespace-two" "{[ foo\n bar]}";
+    t "leading-whitespace-two-cr-lf" "{[ foo\r\n bar]}";
+    t "leading-whitespace-two-different-indent" "{[ foo\n   bar]}";
+    t "leading-whitespace-two-different-indent-rev" "{[   foo\n bar]}";
     t "leading-tab" "{[\tfoo]}";
+    t "leading-tab-two" "{[\tfoo\n\tbar]}";
+    t "leading-tab-two-different-indent" "{[\tfoo\n\t\tbar]}";
     t "leading-newline" "{[\nfoo]}";
     t "leading-cr-lf" "{[\r\nfoo]}";
     t "leading-newlines" "{[\n\nfoo]}";


### PR DESCRIPTION
Tries to address #133.

The implementation brings in `Str` module to split strings (since `split_on_chars` is available only since 4.04.0). Let me know if you have concerns.

I also wondered whether we need to specially handle weird spaces and tabs combo, but decided not to since I don't think there's a use case for that.