### PR TITLE
Create links in module title

### DIFF
--- a/src/html/to_html_tree.ml
+++ b/src/html/to_html_tree.ml
@@ -22,6 +22,8 @@ module Comment = Model.Comment
 module Lang = Model.Lang
 module Html = Tyxml.Html
 
+open Utils
+
 
 
 type rendered_item = (Html_types.div_content Html.elt) list
@@ -34,16 +36,6 @@ type ('inner, 'outer) text =
   [> `PCDATA | `Span | `A of ([> `PCDATA ] as 'inner) ] as 'outer
 
 let a_href = Html_tree.Relative_link.to_sub_element
-
-let rec list_concat_map ?sep ~f = function
-  | [] -> []
-  | [x] -> f x
-  | x :: xs ->
-    let hd = f x in
-    let tl = list_concat_map ?sep ~f xs in
-    match sep with
-    | None -> hd @ tl
-    | Some sep -> hd @ sep :: tl
 
 let functor_arg_pos { Model.Lang.FunctorArgument.id ; _ } =
   match id with

--- a/src/html/utils.ml
+++ b/src/html/utils.ml
@@ -1,0 +1,12 @@
+
+(* Shared utility functions *)
+
+let rec list_concat_map ?sep ~f = function
+  | [] -> []
+  | [x] -> f x
+  | x :: xs ->
+    let hd = f x in
+    let tl = list_concat_map ?sep ~f xs in
+    match sep with
+    | None -> hd @ tl
+    | Some sep -> hd @ sep :: tl


### PR DESCRIPTION
For deep modules, it's really nice to be able to skip up the hierarchy to a specific location. This PR turns the relevant parts of the module title into links up the hierarchy. A simple example is pictured:

![image](https://user-images.githubusercontent.com/87875/40757525-f15e9246-6456-11e8-9d61-1ea7c1d4dee4.png)
