### PR TITLE
Relax heading restriction

### DIFF
--- a/test/parser/expect/section-contexts/two-titles-permissive.txt
+++ b/test/parser/expect/section-contexts/two-titles-permissive.txt
@@ -1,5 +1,13 @@
 ((output
-  (error
+  (ok
+   (((f.ml (1 0) (1 7))
+     (1 (label ((root (f.ml (page f.ml) "") f.ml) (label foo)))
+      (((f.ml (1 3) (1 6)) (word Foo)))))
+    ((f.ml (2 0) (2 7))
+     (2 (label ((root (f.ml (page f.ml) "") f.ml) (label bar)))
+      (((f.ml (2 3) (2 6)) (word Bar))))))))
+ (warnings
+  ( "File \"f.ml\", line 2, characters 0-7:\
+   \nonly one title-level heading is allowed"
     "File \"f.ml\", line 2, characters 0-7:\
-   \nonly one title-level heading is allowed"))
- (warnings ()))
+   \n'1': bad section level (2-4 allowed)")))

--- a/test/parser/expect/warnings/multiple-with-bad-section.txt
+++ b/test/parser/expect/warnings/multiple-with-bad-section.txt
@@ -1,0 +1,18 @@
+((output
+  (ok
+   (((f.ml (1 0) (1 7))
+     (2 (label ((root (f.ml (page f.ml) "") f.ml) (label foo)))
+      (((f.ml (1 3) (1 6)) (word Foo)))))
+    ((f.ml (2 0) (2 7))
+     (1 (label ((root (f.ml (page f.ml) "") f.ml) (label foo)))
+      (((f.ml (2 3) (2 6)) (word Foo)))))
+    ((f.ml (3 0) (3 7))
+     (2 (label ((root (f.ml (page f.ml) "") f.ml) (label foo)))
+      (((f.ml (3 3) (3 6)) (word Foo))))))))
+ (warnings
+  ( "File \"f.ml\", line 1, characters 0-7:\
+   \n'0': bad section level (2-4 allowed)"
+    "File \"f.ml\", line 3, characters 0-7:\
+   \nonly one title-level heading is allowed"
+    "File \"f.ml\", line 3, characters 0-7:\
+   \n'1': bad section level (2-4 allowed)")))

--- a/test/parser/expect/warnings/with-error.txt
+++ b/test/parser/expect/warnings/with-error.txt
@@ -1,7 +1,0 @@
-((output
-  (error
-    "File \"f.ml\", line 3, characters 0-7:\
-   \nonly one title-level heading is allowed"))
- (warnings
-  ( "File \"f.ml\", line 1, characters 0-7:\
-   \n'0': bad section level (2-4 allowed)")))

--- a/test/parser/test.ml
+++ b/test/parser/test.ml
@@ -503,7 +503,7 @@ let tests : test_suite list = [
   "warnings", [
     t "multiple" "{1 Foo}\n{1 Foo}"
       ~permissive:true;
-    t "with-error" "{0 Foo}\n{1 Foo}\n{1 Foo}"
+    t "multiple-with-bad-section" "{0 Foo}\n{1 Foo}\n{1 Foo}"
       ~permissive:true ~sections_allowed:`All;
   ];
 


### PR DESCRIPTION
This PR relaxes the heading level restriction reported in #141 which affects many existing packages. It does not change the current behaviour in which (a) the heading levels in docstrings are clamped to the interval [2-4] and (b) only one level-1 heading is allowed in manual pages.

The current implementation had a bug which resulted in the produced HTML page being cut off after parsing the first level-1 heading.

Based on my research I concluded that the bug was caused by the fact that the HTML generation code assumed that there was only one `` `Title `` heading. Specifically the [To_html_tree.Top_level_markup.section_comment](https://github.com/rizo/odoc/blob/fd68d5b7a479cce21cf2353304178c9162c152a6/src/html/to_html_tree.ml#L842) function checks for section nesting by comparing levels. In the case of duplicate `` `Title `` levels the function will terminate leaving unprocessed comment items.

This PR fixes that by mapping repeated `Title` levels to `Section` levels, thus avoiding the described issue. A warning is produced when this happens (previously it resulted in an error).


#### Note on Design

The sole intent of this PR is to fix the issue in the existing design in order to allow testing of packages with odoc. It was [suggested](https://github.com/ocaml/odoc/issues/141)  that the current design is not ideal and might be changed in the future; these concerns are out of scope of this PR.