### PR TITLE
Add jbuilder subst command when pinning

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -34,5 +34,6 @@ depends: [
 ]
 
 build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]


### PR DESCRIPTION
This is useful to display the correct version with $ odoc --version

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>