### PR TITLE
Add documentation stanza to generate mlds

### DIFF
--- a/src/odoc/jbuild
+++ b/src/odoc/jbuild
@@ -5,6 +5,8 @@
   (libraries
    (bos compiler-libs.common html fpath loader tyxml unix xref))))
 
+(documentation ())
+
 (rule
  ((targets (css_file.ml))
   (deps (etc/odoc.css))


### PR DESCRIPTION
See [this comment](https://github.com/ocaml/dune/issues/856#issuecomment-394868711).

This will generate `index.mld` and `manual_usage.mld` into `index.html` and `manual_usage.html` when generating docs via dune (`jbuilder build @doc` or `dune build @doc`).

Note that on the generated pages, there are some broken references, particularly from `index` to `manual_usage`, which is confusing. I'll take a look at it, but I think this PR should be mergeable on its own.