### PR TITLE
Add html --fragment option and Odoc.Html_fragment module.

### DIFF
--- a/src/html/html.ml
+++ b/src/html/html.ml
@@ -1,4 +1,5 @@
 module Html_tree = Html_tree
+module Documentation = Documentation
 module To_html_tree = struct
   module ML = To_html_tree
   module RE = To_re_html_tree

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -177,13 +177,19 @@ module Html : sig
 end = struct
 
   let html semantic_uris closed_details _hidden directories output_dir index_for
-        syntax theme_uri input_file =
+        syntax fragment theme_uri input_file =
     Html.Html_tree.Relative_link.semantic_uris := semantic_uris;
     Html.Html_tree.open_details := not closed_details;
     let env = Env.create ~important_digests:false ~directories in
     let file = Fs.File.of_string input_file in
     match index_for with
+    | None when fragment ->
+      Html_fragment.from_odoc ~env ~output:output_dir file
     | None -> Html_page.from_odoc ~env ~syntax ~theme_uri ~output:output_dir file
+    | Some _ when fragment ->
+      Printf.eprintf "ERROR: The --index-for option cannot be used with --fragment. \
+                      Please compile the mld file first.\n";
+      exit 1
     | Some pkg_name ->
       Html_page.from_mld ~env ~syntax ~output:output_dir ~package:pkg_name file
 
@@ -201,6 +207,12 @@ end = struct
                  be closed by default."
       in
       Arg.(value & flag (info ~doc ["closed-details"]))
+    in
+    let fragment =
+      let doc = "Produce an HTML fragment instead of a full document. \
+                 Currently only works with documentation pages."
+      in
+      Arg.(value & flag (info ~doc ["fragment"]))
     in
     let index_for =
       let doc = "DEPRECATED: you should use 'odoc compile' to process .mld \
@@ -224,7 +236,7 @@ end = struct
       Arg.(value & opt (pconv convert_syntax) (Html.Html_tree.OCaml) @@ info ~docv:"SYNTAX" ~doc ["syntax"])
     in
     Term.(const html $ semantic_uris $ closed_details $ hidden $
-      odoc_file_directories $ dst $ index_for $ syntax $ theme_uri $ input)
+          odoc_file_directories $ dst $ index_for $ syntax $ fragment $ theme_uri $ input)
 
   let info =
     Term.info ~doc:"Generates an html file from an odoc one" "html"

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -1,0 +1,26 @@
+
+let from_odoc ~env ~output:root_dir input =
+  let root = Root.read input in
+  match root.file with
+  | Page page_name ->
+    let page = Page.load input in
+    let odoctree =
+      let resolve_env = Env.build env (`Page page) in
+      Xref.resolve_page (Env.resolver resolve_env) page
+    in
+    let pkg_name = root.package in
+    let pkg_dir = Fs.Directory.reach_from ~dir:root_dir pkg_name in
+    Fs.Directory.mkdir_p pkg_dir;
+    let content = Html.Documentation.to_html odoctree.content in
+    let oc =
+      let f = Fs.File.create ~directory:pkg_dir ~name:(page_name ^ ".html") in
+      open_out (Fs.File.to_string f)
+    in
+    let fmt = Format.formatter_of_out_channel oc in
+    List.iter (Format.fprintf fmt "%a" (Tyxml.Html.pp_elt ())) content;
+    close_out oc
+  | Compilation_unit _ ->
+    Printf.eprintf "ERROR: HTML fragments for compilation units are not \
+                    currently supported.\n%!";
+    exit 1
+

--- a/src/odoc/html_fragment.mli
+++ b/src/odoc/html_fragment.mli
@@ -1,0 +1,29 @@
+(*
+ * Copyright (c) 2014 Leo White <leo@lpw25.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Produces .html fragment files from a .odoc file. *)
+
+val from_odoc : env:Env.builder -> output:Fs.Directory.t -> Fs.File.t -> unit
+(** [from_odoc ~env ~output input] parses the content of the odoc input file
+    containing a documentation page, generates the equivalent HTML
+    representation and writes the result as a file into the output directory.
+
+    The produced file is an HTML fragment that can be embedded into other
+    documents.
+
+    The program terminates with an error if the input odoc file does not
+    contain a page documentation. *)
+


### PR DESCRIPTION
A very straightforward solution for https://github.com/ocaml/odoc/issues/89.

This adds an option to generate HTML fragments for documentation pages contained in odoc files. Compilation units are not currently supported as they're both less important and harder to implement.

The full command sequence to convert an `mld` file into an HTML fragment file is:

```
$ odoc compile --package=PKG -o page-PAGE.odoc PAGE.mld
$ odoc html --fragment -o PATH page-PAGE.odoc
```

This will generate a file located at `./PKG/PAGE.html` containing only the HTML markup without the document wrapper.

Note that the `--package` option is required to resolve cross-references.