### PR TITLE
fix dune's build after a change to `dune subst` to use the `dune-proj…

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 1.0)
+(name odoc)

--- a/odoc.opam
+++ b/odoc.opam
@@ -35,6 +35,6 @@ depends: [
 ]
 
 build: [
-  ["dune" "subst" "-n" name] {pinned}
+  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]


### PR DESCRIPTION
Currently any `opam install odoc` command using dune results in the following error
```
[ERROR] The compilation of odoc failed at
        "/Users/sharno/.opam/opam-init/hooks/sandbox.sh build dune subst -p
        odoc".

#=== ERROR while compiling odoc.dev ===========================================#
# context     2.0.0 | macos/x86_64 | ocaml-base-compiler.4.06.1 | pinned(git+file:///Users/sharno/projects/odoc#master#7fe7bd7d)
# path        ~/projects/odoc/_opam/.opam-switch/build/odoc.dev
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune subst -p odoc
# exit-code   1
# env-file    ~/.opam/log/odoc-33873-a71bb4.env
# output-file ~/.opam/log/odoc-33873-a71bb4.out
### output ###
# dune: unknown option `-p'.
# Usage: dune subst [OPTION]...
# Try `dune subst --help' or `dune --help' for more information.

<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
┌─ The following actions failed
│ λ build odoc dev
pick 6688394 fix opam
└─
╶─ No changes have been performed
```

I found this: https://github.com/ocaml/dune/pull/960
And changed the `dune subst` usage accordingly