### PR TITLE
Use regular dash in arrows to support ligatures

### DIFF
--- a/src/html/markup.ml
+++ b/src/html/markup.ml
@@ -30,7 +30,7 @@ module ML = struct
   end
 
   let arrow =
-    Html.span [ Html.entity "#8209"; Html.entity "gt" ]
+    Html.span [ Html.entity "#45"; Html.entity "gt" ]
 
   let label = function
     | Model.Lang.TypeExpr.Label s -> [ Html.pcdata s ]


### PR DESCRIPTION
As shown in #179, this replaces the dash as shown in the right side of the pictures, for a regular dash (`-`) on the left side that can be leveraged by fonts with ligatures.

![screen shot 2018-09-10 at 14 55 46](https://user-images.githubusercontent.com/854222/45321430-a1663100-b545-11e8-9408-6961fadc7b48.png)

A full example:

![screen shot 2018-09-10 at 22 04 53](https://user-images.githubusercontent.com/854222/45321480-c22e8680-b545-11e8-86cf-49bca2c5b480.png)

I'll continue experimenting to see what other symbols don't work well with ligatures but this is a start! 🙌 
