### PR TITLE
Print preamble for nested items

### DIFF
--- a/src/html/html_generator.mli
+++ b/src/html/html_generator.mli
@@ -140,7 +140,7 @@ module type Html_generator = sig
          item_to_id:('item -> string option)
       -> item_to_spec:('item -> string option)
       -> render_leaf_item:('item -> rendered_item * Comment.docs)
-      -> render_nested_article:('item -> rendered_item * Html_tree.t list)
+      -> render_nested_article:('item -> rendered_item * Comment.docs * Html_tree.t list)
       -> (_, 'item) tagged_item list
       -> rendered_item * toc * Html_tree.t list
 
@@ -200,12 +200,12 @@ module type Html_generator = sig
     val class_ :
          ?theme_uri:Html_tree.uri
       -> Lang.Class.t
-      -> Html_types.article_content Html.elt list * Html_tree.t list
+      -> rendered_item * Comment.docs * Html_tree.t list
 
     val class_type :
          ?theme_uri:Html_tree.uri
       -> Lang.ClassType.t
-      -> Html_types.article_content Html.elt list * Html_tree.t list
+      -> rendered_item * Comment.docs * Html_tree.t list
   end
 
   module Module : sig

--- a/test/html/cases/nested.mli
+++ b/test/html/cases/nested.mli
@@ -1,0 +1,35 @@
+
+(** This is module X.
+
+    Some additional comments. *)
+module X : sig
+  type t
+  (** Some type. *)
+
+  val x : t
+  (** The value of x. *)
+end
+
+
+
+(** This is module type Y.
+
+    Some additional comments. *)
+module type Y = sig
+  type t
+  (** Some type. *)
+
+  val y : t
+  (** The value of y. *)
+end
+
+
+(** This is class z.
+
+    Some additional comments. *)
+class z : object
+
+  method z : int
+  (** Some method. *)
+end
+

--- a/test/html/expect/test_package+custom_theme,ml/Include/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Include/index.html
@@ -21,10 +21,10 @@
      Module <code>Include</code>
     </h1>
    </header>
-   <article class="spec module-type" id="module-type-Not_inlined">
+   <div class="spec module-type" id="module-type-Not_inlined">
     <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
@@ -39,11 +39,11 @@
       </details>
      </div>
     </div>
-   </article>
-   <article class="spec module-type" id="module-type-Inlined">
+   </div>
+   <div class="spec module-type" id="module-type-Inlined">
     <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <dl>
@@ -53,11 +53,11 @@
       </dl>
      </div>
     </div>
-   </article>
-   <article class="spec module-type" id="module-type-Not_inlined_and_closed">
+   </div>
+   <div class="spec module-type" id="module-type-Not_inlined_and_closed">
     <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <details>
@@ -72,11 +72,11 @@
       </details>
      </div>
     </div>
-   </article>
-   <article class="spec module-type" id="module-type-Not_inlined_and_opened">
+   </div>
+   <div class="spec module-type" id="module-type-Not_inlined_and_opened">
     <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
@@ -91,7 +91,7 @@
       </details>
      </div>
     </div>
-   </article>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -34,44 +34,44 @@
      </p>
     </dd>
    </dl>
-   <article class="spec module-type" id="module-type-S">
+   <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S1">
+   </div>
+   <div class="spec module-type" id="module-type-S1">
     <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a></code>
-   </article>
-   <article class="spec module-type" id="module-type-S2">
+   </div>
+   <div class="spec module-type" id="module-type-S2">
     <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code>
-   </article>
-   <article class="spec module-type" id="module-type-S3">
+   </div>
+   <div class="spec module-type" id="module-type-S3">
     <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string</code>
-   </article>
-   <article class="spec module-type" id="module-type-S4">
+   </div>
+   <div class="spec module-type" id="module-type-S4">
     <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int</code>
-   </article>
-   <article class="spec module-type" id="module-type-S5">
+   </div>
+   <div class="spec module-type" id="module-type-S5">
     <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
-   </article>
+   </div>
    <dl>
     <dt class="spec type" id="type-result">
      <a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) result</code>
     </dt>
    </dl>
-   <article class="spec module-type" id="module-type-S6">
+   <div class="spec module-type" id="module-type-S6">
     <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
-   </article>
-   <article class="spec module" id="module-M'">
+   </div>
+   <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S7">
+   </div>
+   <div class="spec module-type" id="module-type-S7">
     <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
-   </article>
-   <article class="spec module-type" id="module-type-S8">
+   </div>
+   <div class="spec module-type" id="module-type-S8">
     <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
-   </article>
-   <article class="spec module-type" id="module-type-S9">
+   </div>
+   <div class="spec module-type" id="module-type-S9">
     <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a></code>
-   </article>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -21,9 +21,9 @@
      Module <code>Class</code>
     </h1>
    </header>
-   <article class="spec class-type" id="class-type-empty">
+   <div class="spec class-type" id="class-type-empty">
     <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class type </span><a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
-   </article>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Functor/index.html
+++ b/test/html/expect/test_package+ml/Functor/index.html
@@ -21,24 +21,24 @@
      Module <code>Functor</code>
     </h1>
    </header>
-   <article class="spec module-type" id="module-type-S">
+   <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S1">
+   </div>
+   <div class="spec module-type" id="module-type-S1">
     <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a> : <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
-   </article>
-   <article class="spec module" id="module-F1">
+   </div>
+   <div class="spec module" id="module-F1">
     <a href="#module-F1" class="anchor"></a><code><span class="keyword">module </span><a href="F1/index.html">F1</a> : <span class="keyword">functor</span> (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
-   </article>
-   <article class="spec module" id="module-F2">
+   </div>
+   <div class="spec module" id="module-F2">
     <a href="#module-F2" class="anchor"></a><code><span class="keyword">module </span><a href="F2/index.html">F2</a> : <span class="keyword">functor</span> (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="F2/index.html#type-t">t</a><span class="keyword"> = </span><a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></code>
-   </article>
-   <article class="spec module" id="module-F3">
+   </div>
+   <div class="spec module" id="module-F3">
     <a href="#module-F3" class="anchor"></a><code><span class="keyword">module </span><a href="F3/index.html">F3</a> : <span class="keyword">functor</span> (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article class="spec module" id="module-F4">
+   </div>
+   <div class="spec module" id="module-F4">
     <a href="#module-F4" class="anchor"></a><code><span class="keyword">module </span><a href="F4/index.html">F4</a> : <span class="keyword">functor</span> (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
-   </article>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Include/index.html
+++ b/test/html/expect/test_package+ml/Include/index.html
@@ -21,10 +21,10 @@
      Module <code>Include</code>
     </h1>
    </header>
-   <article class="spec module-type" id="module-type-Not_inlined">
+   <div class="spec module-type" id="module-type-Not_inlined">
     <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
@@ -39,11 +39,11 @@
       </details>
      </div>
     </div>
-   </article>
-   <article class="spec module-type" id="module-type-Inlined">
+   </div>
+   <div class="spec module-type" id="module-type-Inlined">
     <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <dl>
@@ -53,11 +53,11 @@
       </dl>
      </div>
     </div>
-   </article>
-   <article class="spec module-type" id="module-type-Not_inlined_and_closed">
+   </div>
+   <div class="spec module-type" id="module-type-Not_inlined_and_closed">
     <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <details>
@@ -72,11 +72,11 @@
       </details>
      </div>
     </div>
-   </article>
-   <article class="spec module-type" id="module-type-Not_inlined_and_opened">
+   </div>
+   <div class="spec module-type" id="module-type-Not_inlined_and_opened">
     <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
@@ -91,7 +91,7 @@
       </details>
      </div>
     </div>
-   </article>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -34,44 +34,44 @@
      </p>
     </dd>
    </dl>
-   <article class="spec module-type" id="module-type-S">
+   <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S1">
+   </div>
+   <div class="spec module-type" id="module-type-S1">
     <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a></code>
-   </article>
-   <article class="spec module-type" id="module-type-S2">
+   </div>
+   <div class="spec module-type" id="module-type-S2">
     <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code>
-   </article>
-   <article class="spec module-type" id="module-type-S3">
+   </div>
+   <div class="spec module-type" id="module-type-S3">
     <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string</code>
-   </article>
-   <article class="spec module-type" id="module-type-S4">
+   </div>
+   <div class="spec module-type" id="module-type-S4">
     <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int</code>
-   </article>
-   <article class="spec module-type" id="module-type-S5">
+   </div>
+   <div class="spec module-type" id="module-type-S5">
     <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
-   </article>
+   </div>
    <dl>
     <dt class="spec type" id="type-result">
      <a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) result</code>
     </dt>
    </dl>
-   <article class="spec module-type" id="module-type-S6">
+   <div class="spec module-type" id="module-type-S6">
     <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
-   </article>
-   <article class="spec module" id="module-M'">
+   </div>
+   <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S7">
+   </div>
+   <div class="spec module-type" id="module-type-S7">
     <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
-   </article>
-   <article class="spec module-type" id="module-type-S8">
+   </div>
+   <div class="spec module-type" id="module-type-S8">
     <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
-   </article>
-   <article class="spec module-type" id="module-type-S9">
+   </div>
+   <div class="spec module-type" id="module-type-S9">
     <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a></code>
-   </article>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Nested (test_package+ml.Nested)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Nested
+    </nav>
+    <h1>
+     Module <code>Nested</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec module" id="module-X">
+     <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is module X.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec module-type" id="module-type-Y">
+     <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Y/index.html">Y</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is module type Y.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec class" id="class-z">
+     <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is class z.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Stop/index.html
+++ b/test/html/expect/test_package+ml/Stop/index.html
@@ -47,9 +47,9 @@
      Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
     </p>
    </aside>
-   <article class="spec module" id="module-N">
+   <div class="spec module" id="module-N">
     <a href="#module-N" class="anchor"></a><code><span class="keyword">module </span><a href="N/index.html">N</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
+   </div>
    <dl>
     <dt class="spec value" id="val-lol">
      <a href="#val-lol" class="anchor"></a><code><span class="keyword">val </span>lol : int</code>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -291,9 +291,9 @@
      <a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>&lt; a : int; b : int; c : int; &gt;</code>
     </dt>
    </dl>
-   <article class="spec module-type" id="module-type-X">
+   <div class="spec module-type" id="module-type-X">
     <a href="#module-type-X" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-X/index.html">X</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-   </article>
+   </div>
    <dl>
     <dt class="spec type" id="type-module_">
      <a href="#type-module_" class="anchor"></a><code><span class="keyword">type </span>module_</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a>)</code>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -21,9 +21,9 @@
      Module <code>Class</code>
     </h1>
    </header>
-   <article class="spec class-type" id="class-type-empty">
+   <div class="spec class-type" id="class-type-empty">
     <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class type </span><a href="class-type-empty/index.html">empty</a> = <span class="keyword">{</span> ... <span class="keyword">}</span></code>
-   </article>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Functor/index.html
+++ b/test/html/expect/test_package+re/Functor/index.html
@@ -21,24 +21,24 @@
      Module <code>Functor</code>
     </h1>
    </header>
-   <article class="spec module-type" id="module-type-S">
+   <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S1">
+   </div>
+   <div class="spec module-type" id="module-type-S1">
     <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a>:  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module" id="module-F1">
+   </div>
+   <div class="spec module" id="module-F1">
     <a href="#module-F1" class="anchor"></a><code><span class="keyword">module </span><a href="F1/index.html">F1</a>:  (<a href="F1/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module" id="module-F2">
+   </div>
+   <div class="spec module" id="module-F2">
     <a href="#module-F2" class="anchor"></a><code><span class="keyword">module </span><a href="F2/index.html">F2</a>:  (<a href="F2/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="F2/index.html#type-t">t</a><span class="keyword"> = </span><a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module" id="module-F3">
+   </div>
+   <div class="spec module" id="module-F3">
     <a href="#module-F3" class="anchor"></a><code><span class="keyword">module </span><a href="F3/index.html">F3</a>:  (<a href="F3/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module" id="module-F4">
+   </div>
+   <div class="spec module" id="module-F4">
     <a href="#module-F4" class="anchor"></a><code><span class="keyword">module </span><a href="F4/index.html">F4</a>:  (<a href="F4/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
-   </article>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Include/index.html
+++ b/test/html/expect/test_package+re/Include/index.html
@@ -21,10 +21,10 @@
      Module <code>Include</code>
     </h1>
    </header>
-   <article class="spec module-type" id="module-type-Not_inlined">
+   <div class="spec module-type" id="module-type-Not_inlined">
     <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
@@ -39,11 +39,11 @@
       </details>
      </div>
     </div>
-   </article>
-   <article class="spec module-type" id="module-type-Inlined">
+   </div>
+   <div class="spec module-type" id="module-type-Inlined">
     <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <dl>
@@ -53,11 +53,11 @@
       </dl>
      </div>
     </div>
-   </article>
-   <article class="spec module-type" id="module-type-Not_inlined_and_closed">
+   </div>
+   <div class="spec module-type" id="module-type-Not_inlined_and_closed">
     <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <details>
@@ -72,11 +72,11 @@
       </details>
      </div>
     </div>
-   </article>
-   <article class="spec module-type" id="module-type-Not_inlined_and_opened">
+   </div>
+   <div class="spec module-type" id="module-type-Not_inlined_and_opened">
     <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-   </article>
-   <article>
+   </div>
+   <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
@@ -91,7 +91,7 @@
       </details>
      </div>
     </div>
-   </article>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -34,44 +34,44 @@
      </p>
     </dd>
    </dl>
-   <article class="spec module-type" id="module-type-S">
+   <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S1">
+   </div>
+   <div class="spec module-type" id="module-type-S1">
     <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S2">
+   </div>
+   <div class="spec module-type" id="module-type-S2">
     <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S3">
+   </div>
+   <div class="spec module-type" id="module-type-S3">
     <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string<span class="keyword">;</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S4">
+   </div>
+   <div class="spec module-type" id="module-type-S4">
     <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int<span class="keyword">;</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S5">
+   </div>
+   <div class="spec module-type" id="module-type-S5">
     <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S5/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>)<span class="keyword">;</span></code>
-   </article>
+   </div>
    <dl>
     <dt class="spec type" id="type-result">
      <a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>result('a, 'b)</code><span class="keyword">;</span>
     </dt>
    </dl>
-   <article class="spec module-type" id="module-type-S6">
+   <div class="spec module-type" id="module-type-S6">
     <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)<span class="keyword">;</span></code>
-   </article>
-   <article class="spec module" id="module-M'">
+   </div>
+   <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S7">
+   </div>
+   <div class="spec module-type" id="module-type-S7">
     <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S8">
+   </div>
+   <div class="spec module-type" id="module-type-S8">
     <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
-   </article>
-   <article class="spec module-type" id="module-type-S9">
+   </div>
+   <div class="spec module-type" id="module-type-S9">
     <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a>: <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
-   </article>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Nested (test_package+re.Nested)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Nested
+    </nav>
+    <h1>
+     Module <code>Nested</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec module" id="module-X">
+     <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is module X.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec module-type" id="module-type-Y">
+     <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Y/index.html">Y</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is module type Y.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec class" id="class-z">
+     <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><a href="class-z/index.html">z</a>: <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is class z.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Stop/index.html
+++ b/test/html/expect/test_package+re/Stop/index.html
@@ -47,9 +47,9 @@
      Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
     </p>
    </aside>
-   <article class="spec module" id="module-N">
+   <div class="spec module" id="module-N">
     <a href="#module-N" class="anchor"></a><code><span class="keyword">module </span><a href="N/index.html">N</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-   </article>
+   </div>
    <dl>
     <dt class="spec value" id="val-lol">
      <a href="#val-lol" class="anchor"></a><code><span class="keyword">let </span>lol: int<span class="keyword">;</span></code>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -295,9 +295,9 @@
      <a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>{. a: int, b: int, c: int, }</code><span class="keyword">;</span>
     </dt>
    </dl>
-   <article class="spec module-type" id="module-type-X">
+   <div class="spec module-type" id="module-type-X">
     <a href="#module-type-X" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-X/index.html">X</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-   </article>
+   </div>
    <dl>
     <dt class="spec type" id="type-module_">
      <a href="#type-module_" class="anchor"></a><code><span class="keyword">type </span>module_</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a>)</code><span class="keyword">;</span>

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -239,6 +239,7 @@ let source_files = [
   "interlude.mli";
   "include.mli";
   "mld.mld";
+  "nested.mli";
   "type.mli";
   "external.mli";
   "functor.mli";


### PR DESCRIPTION
This PR reimplements https://github.com/ocaml/odoc/pull/175 in a similar way.

The main difference is in the generated markup, where `dl` tags are used for the nested item and its preamble documentation. Regular `div` tags are used for nested items without documentation.

Thanks to @trefis for the original effort!