### PR TITLE
Automatically support ligature fonts if installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - OCAML=4.07.0
 
 before_script:
-  - sudo add-apt-repository -y ppa:robert7/nixnote21
+  - sudo add-apt-repository -y ppa:robert7/tidy-html5
   - sudo add-apt-repository -y ppa:avsm/ocaml42+opam12
   - sudo apt-get update
   - sudo apt-get install opam tidy


### PR DESCRIPTION
This would let docs fallback to ligature fonts if the user already has them, but not force them upon users who don't have them installed.

I put the 4 most common I've seen people use but more can be added (or some removed).

@rizo let me know if there's any important ligature fonts missing here!

And I can't remember @aantron's stance on this 🙈 