### PR TITLE
Testing: commit pretty-printed HTML output for nicer git diffs

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -29,7 +29,7 @@ depends: [
   # opam repo.
   "alcotest" {>= "0.8.3"}
   "bisect_ppx"  {>= "1.3.0"}
-  "markup" {>= "0.7.6"}
+  "markup" {>= "0.8.0"}
   "lambdasoup"
   "ocamlfind"
   "sexplib"

--- a/test/html/expect/test_package+custom_theme,ml/Include/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Include/index.html
@@ -1,2 +1,97 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Include (test_package+custom_theme,ml.Include)</title><link rel="stylesheet" href="../../../b/c/odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> &#x00BB; Include</nav><h1>Module <code>Include</code></h1></header><article class="spec module-type" id="module-type-Not_inlined"><a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article><div class="spec include"><div class="doc"><details open="open"><summary><span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined">Not_inlined</a></code></span></summary><dl><dt class="spec type" id="type-t"><a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code></dt></dl></details></div></div></article><article class="spec module-type" id="module-type-Inlined"><a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article><div class="spec include"><div class="doc"><dl><dt class="spec type" id="type-u"><a href="#type-u" class="anchor"></a><code><span class="keyword">type </span>u</code></dt></dl></div></div></article><article class="spec module-type" id="module-type-Not_inlined_and_closed"><a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article><div class="spec include"><div class="doc"><details><summary><span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a></code></span></summary><dl><dt class="spec type" id="type-v"><a href="#type-v" class="anchor"></a><code><span class="keyword">type </span>v</code></dt></dl></details></div></div></article><article class="spec module-type" id="module-type-Not_inlined_and_opened"><a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article><div class="spec include"><div class="doc"><details open="open"><summary><span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a></code></span></summary><dl><dt class="spec type" id="type-w"><a href="#type-w" class="anchor"></a><code><span class="keyword">type </span>w</code></dt></dl></details></div></div></article></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include (test_package+custom_theme,ml.Include)
+  </title>
+  <link rel="stylesheet" href="../../../b/c/odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Include
+    </nav>
+    <h1>
+     Module <code>Include</code>
+    </h1>
+   </header>
+   <article class="spec module-type" id="module-type-Not_inlined">
+    <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <details open="open">
+       <summary>
+        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined">Not_inlined</a></code></span>
+       </summary>
+       <dl>
+        <dt class="spec type" id="type-t">
+         <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+        </dt>
+       </dl>
+      </details>
+     </div>
+    </div>
+   </article>
+   <article class="spec module-type" id="module-type-Inlined">
+    <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <dl>
+       <dt class="spec type" id="type-u">
+        <a href="#type-u" class="anchor"></a><code><span class="keyword">type </span>u</code>
+       </dt>
+      </dl>
+     </div>
+    </div>
+   </article>
+   <article class="spec module-type" id="module-type-Not_inlined_and_closed">
+    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <details>
+       <summary>
+        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a></code></span>
+       </summary>
+       <dl>
+        <dt class="spec type" id="type-v">
+         <a href="#type-v" class="anchor"></a><code><span class="keyword">type </span>v</code>
+        </dt>
+       </dl>
+      </details>
+     </div>
+    </div>
+   </article>
+   <article class="spec module-type" id="module-type-Not_inlined_and_opened">
+    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <details open="open">
+       <summary>
+        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a></code></span>
+       </summary>
+       <dl>
+        <dt class="spec type" id="type-w">
+         <a href="#type-w" class="anchor"></a><code><span class="keyword">type </span>w</code>
+        </dt>
+       </dl>
+      </details>
+     </div>
+    </div>
+   </article>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -1,2 +1,77 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Module (test_package+custom_theme,ml.Module)</title><link rel="stylesheet" href="/a/b/c/odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> &#x00BB; Module</nav><h1>Module <code>Module</code></h1><p>Foo.</p></header><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code></dt><dd><p>The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.</p></dd></dl><article class="spec module-type" id="module-type-S"><a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article class="spec module-type" id="module-type-S1"><a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a></code></article><article class="spec module-type" id="module-type-S2"><a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code></article><article class="spec module-type" id="module-type-S3"><a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string</code></article><article class="spec module-type" id="module-type-S4"><a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int</code></article><article class="spec module-type" id="module-type-S5"><a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code></article><dl><dt class="spec type" id="type-result"><a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) result</code></dt></dl><article class="spec module-type" id="module-type-S6"><a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>, <span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code></article><article class="spec module" id="module-M'"><a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article class="spec module-type" id="module-type-S7"><a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code></article><article class="spec module-type" id="module-type-S8"><a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code></article><article class="spec module-type" id="module-type-S9"><a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a></code></article></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Module (test_package+custom_theme,ml.Module)
+  </title>
+  <link rel="stylesheet" href="/a/b/c/odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Module
+    </nav>
+    <h1>
+     Module <code>Module</code>
+    </h1>
+    <p>
+     Foo.
+    </p>
+   </header>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+    </dt>
+    <dd>
+     <p>
+      The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.
+     </p>
+    </dd>
+   </dl>
+   <article class="spec module-type" id="module-type-S">
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S1">
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a></code>
+   </article>
+   <article class="spec module-type" id="module-type-S2">
+    <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code>
+   </article>
+   <article class="spec module-type" id="module-type-S3">
+    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string</code>
+   </article>
+   <article class="spec module-type" id="module-type-S4">
+    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int</code>
+   </article>
+   <article class="spec module-type" id="module-type-S5">
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
+   </article>
+   <dl>
+    <dt class="spec type" id="type-result">
+     <a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) result</code>
+    </dt>
+   </dl>
+   <article class="spec module-type" id="module-type-S6">
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
+   </article>
+   <article class="spec module" id="module-M'">
+    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S7">
+    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
+   </article>
+   <article class="spec module-type" id="module-type-S8">
+    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
+   </article>
+   <article class="spec module-type" id="module-type-S9">
+    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a></code>
+   </article>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+custom_theme,ml/Section/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Section/index.html
@@ -1,2 +1,131 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Section (test_package+custom_theme,ml.Section)</title><link rel="stylesheet" href="../../b/c/odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> &#x00BB; Section</nav><h1>Module <code>Section</code></h1><p>This is the module comment. Eventually, sections won't be allowed in it.</p><nav class="toc"><ul><li><a href="#empty-section">Empty section</a></li><li><a href="#text-only">Text only</a></li><li><a href="#aside-only">Aside only</a></li><li><a href="#value-only">Value only</a></li><li><a href="#empty-section">Empty section</a></li><li><a href="#within-a-comment">within a comment</a><ul><li><a href="#and-one-with-a-nested-section">and one with a nested section</a></li></ul></li><li><a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a></li></ul></nav></header><section><header><h2 id="empty-section"><a href="#empty-section" class="anchor"></a>Empty section</h2></header></section><section><header><h2 id="text-only"><a href="#text-only" class="anchor"></a>Text only</h2><p>Foo bar.</p></header></section><section><header><h2 id="aside-only"><a href="#aside-only" class="anchor"></a>Aside only</h2></header><aside><p>Foo bar.</p></aside></section><section><header><h2 id="value-only"><a href="#value-only" class="anchor"></a>Value only</h2></header><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code></dt></dl></section><section><header><h2 id="empty-section"><a href="#empty-section" class="anchor"></a>Empty section</h2></header></section><section><header><h2 id="within-a-comment"><a href="#within-a-comment" class="anchor"></a>within a comment</h2></header><section><header><h3 id="and-one-with-a-nested-section"><a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section</h3></header></section></section><section><header><h2 id="this-section-title-has-markup"><a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></h2><p>But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.</p></header></section></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Section (test_package+custom_theme,ml.Section)
+  </title>
+  <link rel="stylesheet" href="../../b/c/odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Section
+    </nav>
+    <h1>
+     Module <code>Section</code>
+    </h1>
+    <p>
+     This is the module comment. Eventually, sections won't be allowed in it.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#empty-section">Empty section</a>
+      </li>
+      <li>
+       <a href="#text-only">Text only</a>
+      </li>
+      <li>
+       <a href="#aside-only">Aside only</a>
+      </li>
+      <li>
+       <a href="#value-only">Value only</a>
+      </li>
+      <li>
+       <a href="#empty-section">Empty section</a>
+      </li>
+      <li>
+       <a href="#within-a-comment">within a comment</a>
+       <ul>
+        <li>
+         <a href="#and-one-with-a-nested-section">and one with a nested section</a>
+        </li>
+       </ul>
+      </li>
+      <li>
+       <a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="empty-section">
+      <a href="#empty-section" class="anchor"></a>Empty section
+     </h2>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="text-only">
+      <a href="#text-only" class="anchor"></a>Text only
+     </h2>
+     <p>
+      Foo bar.
+     </p>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="aside-only">
+      <a href="#aside-only" class="anchor"></a>Aside only
+     </h2>
+    </header>
+    <aside>
+     <p>
+      Foo bar.
+     </p>
+    </aside>
+   </section>
+   <section>
+    <header>
+     <h2 id="value-only">
+      <a href="#value-only" class="anchor"></a>Value only
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+     </dt>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="empty-section">
+      <a href="#empty-section" class="anchor"></a>Empty section
+     </h2>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="within-a-comment">
+      <a href="#within-a-comment" class="anchor"></a>within a comment
+     </h2>
+    </header>
+    <section>
+     <header>
+      <h3 id="and-one-with-a-nested-section">
+       <a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section
+      </h3>
+     </header>
+    </section>
+   </section>
+   <section>
+    <header>
+     <h2 id="this-section-title-has-markup">
+      <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
+     </h2>
+     <p>
+      But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+     </p>
+    </header>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+custom_theme,ml/Val/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Val/index.html
@@ -1,2 +1,49 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Val (test_package+custom_theme,ml.Val)</title><link rel="stylesheet" href="https://foo.com/a/b/c/odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> &#x00BB; Val</nav><h1>Module <code>Val</code></h1></header><dl><dt class="spec value" id="val-documented"><a href="#val-documented" class="anchor"></a><code><span class="keyword">val </span>documented : unit</code></dt><dd><p>Foo.</p></dd></dl><dl><dt class="spec value" id="val-undocumented"><a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val </span>undocumented : unit</code></dt><dt class="spec value" id="val-documented_above"><a href="#val-documented_above" class="anchor"></a><code><span class="keyword">val </span>documented_above : unit</code></dt><dd><p>Bar.</p></dd></dl></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Val (test_package+custom_theme,ml.Val)
+  </title>
+  <link rel="stylesheet" href="https://foo.com/a/b/c/odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Val
+    </nav>
+    <h1>
+     Module <code>Val</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec value" id="val-documented">
+     <a href="#val-documented" class="anchor"></a><code><span class="keyword">val </span>documented : unit</code>
+    </dt>
+    <dd>
+     <p>
+      Foo.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-undocumented">
+     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val </span>undocumented : unit</code>
+    </dt>
+    <dt class="spec value" id="val-documented_above">
+     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">val </span>documented_above : unit</code>
+    </dt>
+    <dd>
+     <p>
+      Bar.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -1,2 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Class (test_package+ml.Class)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; Class</nav><h1>Module <code>Class</code></h1></header><article class="spec class-type" id="class-type-empty"><a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class type </span><a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code></article></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Class (test_package+ml.Class)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Class
+    </nav>
+    <h1>
+     Module <code>Class</code>
+    </h1>
+   </header>
+   <article class="spec class-type" id="class-type-empty">
+    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class type </span><a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+   </article>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/External/index.html
+++ b/test/html/expect/test_package+ml/External/index.html
@@ -1,2 +1,36 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>External (test_package+ml.External)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; External</nav><h1>Module <code>External</code></h1></header><dl><dt class="spec external" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">external </span>foo : unit <span>&#45;&gt;</span> unit = &quot;bar&quot; </code></dt><dd><p>Foo <em>bar</em>.</p></dd></dl></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   External (test_package+ml.External)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » External
+    </nav>
+    <h1>
+     Module <code>External</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec external" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">external </span>foo : unit <span>-&gt;</span> unit = "bar" </code>
+    </dt>
+    <dd>
+     <p>
+      Foo <em>bar</em>.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Functor/index.html
+++ b/test/html/expect/test_package+ml/Functor/index.html
@@ -1,2 +1,44 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Functor (test_package+ml.Functor)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; Functor</nav><h1>Module <code>Functor</code></h1></header><article class="spec module-type" id="module-type-S"><a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article class="spec module-type" id="module-type-S1"><a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a> : <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>&#45;&gt;</span> <a href="index.html#module-type-S">S</a></code></article><article class="spec module" id="module-F1"><a href="#module-F1" class="anchor"></a><code><span class="keyword">module </span><a href="F1/index.html">F1</a> : <span class="keyword">functor</span> (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>&#45;&gt;</span> <a href="index.html#module-type-S">S</a></code></article><article class="spec module" id="module-F2"><a href="#module-F2" class="anchor"></a><code><span class="keyword">module </span><a href="F2/index.html">F2</a> : <span class="keyword">functor</span> (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>&#45;&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="F2/index.html#type-t">t</a><span class="keyword"> = </span><a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></code></article><article class="spec module" id="module-F3"><a href="#module-F3" class="anchor"></a><code><span class="keyword">module </span><a href="F3/index.html">F3</a> : <span class="keyword">functor</span> (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>&#45;&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article class="spec module" id="module-F4"><a href="#module-F4" class="anchor"></a><code><span class="keyword">module </span><a href="F4/index.html">F4</a> : <span class="keyword">functor</span> (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>&#45;&gt;</span> <a href="index.html#module-type-S">S</a></code></article></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Functor (test_package+ml.Functor)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Functor
+    </nav>
+    <h1>
+     Module <code>Functor</code>
+    </h1>
+   </header>
+   <article class="spec module-type" id="module-type-S">
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S1">
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a> : <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
+   </article>
+   <article class="spec module" id="module-F1">
+    <a href="#module-F1" class="anchor"></a><code><span class="keyword">module </span><a href="F1/index.html">F1</a> : <span class="keyword">functor</span> (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
+   </article>
+   <article class="spec module" id="module-F2">
+    <a href="#module-F2" class="anchor"></a><code><span class="keyword">module </span><a href="F2/index.html">F2</a> : <span class="keyword">functor</span> (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="F2/index.html#type-t">t</a><span class="keyword"> = </span><a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></code>
+   </article>
+   <article class="spec module" id="module-F3">
+    <a href="#module-F3" class="anchor"></a><code><span class="keyword">module </span><a href="F3/index.html">F3</a> : <span class="keyword">functor</span> (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article class="spec module" id="module-F4">
+    <a href="#module-F4" class="anchor"></a><code><span class="keyword">module </span><a href="F4/index.html">F4</a> : <span class="keyword">functor</span> (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
+   </article>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Include/index.html
+++ b/test/html/expect/test_package+ml/Include/index.html
@@ -1,2 +1,97 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Include (test_package+ml.Include)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; Include</nav><h1>Module <code>Include</code></h1></header><article class="spec module-type" id="module-type-Not_inlined"><a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article><div class="spec include"><div class="doc"><details open="open"><summary><span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined">Not_inlined</a></code></span></summary><dl><dt class="spec type" id="type-t"><a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code></dt></dl></details></div></div></article><article class="spec module-type" id="module-type-Inlined"><a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article><div class="spec include"><div class="doc"><dl><dt class="spec type" id="type-u"><a href="#type-u" class="anchor"></a><code><span class="keyword">type </span>u</code></dt></dl></div></div></article><article class="spec module-type" id="module-type-Not_inlined_and_closed"><a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article><div class="spec include"><div class="doc"><details><summary><span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a></code></span></summary><dl><dt class="spec type" id="type-v"><a href="#type-v" class="anchor"></a><code><span class="keyword">type </span>v</code></dt></dl></details></div></div></article><article class="spec module-type" id="module-type-Not_inlined_and_opened"><a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article><div class="spec include"><div class="doc"><details open="open"><summary><span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a></code></span></summary><dl><dt class="spec type" id="type-w"><a href="#type-w" class="anchor"></a><code><span class="keyword">type </span>w</code></dt></dl></details></div></div></article></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include (test_package+ml.Include)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Include
+    </nav>
+    <h1>
+     Module <code>Include</code>
+    </h1>
+   </header>
+   <article class="spec module-type" id="module-type-Not_inlined">
+    <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <details open="open">
+       <summary>
+        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined">Not_inlined</a></code></span>
+       </summary>
+       <dl>
+        <dt class="spec type" id="type-t">
+         <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+        </dt>
+       </dl>
+      </details>
+     </div>
+    </div>
+   </article>
+   <article class="spec module-type" id="module-type-Inlined">
+    <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <dl>
+       <dt class="spec type" id="type-u">
+        <a href="#type-u" class="anchor"></a><code><span class="keyword">type </span>u</code>
+       </dt>
+      </dl>
+     </div>
+    </div>
+   </article>
+   <article class="spec module-type" id="module-type-Not_inlined_and_closed">
+    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <details>
+       <summary>
+        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a></code></span>
+       </summary>
+       <dl>
+        <dt class="spec type" id="type-v">
+         <a href="#type-v" class="anchor"></a><code><span class="keyword">type </span>v</code>
+        </dt>
+       </dl>
+      </details>
+     </div>
+    </div>
+   </article>
+   <article class="spec module-type" id="module-type-Not_inlined_and_opened">
+    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <details open="open">
+       <summary>
+        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a></code></span>
+       </summary>
+       <dl>
+        <dt class="spec type" id="type-w">
+         <a href="#type-w" class="anchor"></a><code><span class="keyword">type </span>w</code>
+        </dt>
+       </dl>
+      </details>
+     </div>
+    </div>
+   </article>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Interlude/index.html
+++ b/test/html/expect/test_package+ml/Interlude/index.html
@@ -1,2 +1,83 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Interlude (test_package+ml.Interlude)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; Interlude</nav><h1>Module <code>Interlude</code></h1><p>This is the comment associated to the module.</p></header><aside><p>Some separate stray text at the top of the module.</p></aside><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code></dt><dd><p>Foo.</p></dd></dl><aside><p>Some stray text that is not associated with any signature item.</p><p>It has multiple paragraphs.</p></aside><aside><p>A separate block of stray text, adjacent to the preceding one.</p></aside><dl><dt class="spec value" id="val-bar"><a href="#val-bar" class="anchor"></a><code><span class="keyword">val </span>bar : unit</code></dt><dd><p>Bar.</p></dd></dl><dl><dt class="spec value" id="val-multiple"><a href="#val-multiple" class="anchor"></a><code><span class="keyword">val </span>multiple : unit</code></dt><dt class="spec value" id="val-signature"><a href="#val-signature" class="anchor"></a><code><span class="keyword">val </span>signature : unit</code></dt><dt class="spec value" id="val-items"><a href="#val-items" class="anchor"></a><code><span class="keyword">val </span>items : unit</code></dt></dl><aside><p>Stray text at the bottom of the module.</p></aside></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Interlude (test_package+ml.Interlude)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Interlude
+    </nav>
+    <h1>
+     Module <code>Interlude</code>
+    </h1>
+    <p>
+     This is the comment associated to the module.
+    </p>
+   </header>
+   <aside>
+    <p>
+     Some separate stray text at the top of the module.
+    </p>
+   </aside>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+    </dt>
+    <dd>
+     <p>
+      Foo.
+     </p>
+    </dd>
+   </dl>
+   <aside>
+    <p>
+     Some stray text that is not associated with any signature item.
+    </p>
+    <p>
+     It has multiple paragraphs.
+    </p>
+   </aside>
+   <aside>
+    <p>
+     A separate block of stray text, adjacent to the preceding one.
+    </p>
+   </aside>
+   <dl>
+    <dt class="spec value" id="val-bar">
+     <a href="#val-bar" class="anchor"></a><code><span class="keyword">val </span>bar : unit</code>
+    </dt>
+    <dd>
+     <p>
+      Bar.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-multiple">
+     <a href="#val-multiple" class="anchor"></a><code><span class="keyword">val </span>multiple : unit</code>
+    </dt>
+    <dt class="spec value" id="val-signature">
+     <a href="#val-signature" class="anchor"></a><code><span class="keyword">val </span>signature : unit</code>
+    </dt>
+    <dt class="spec value" id="val-items">
+     <a href="#val-items" class="anchor"></a><code><span class="keyword">val </span>items : unit</code>
+    </dt>
+   </dl>
+   <aside>
+    <p>
+     Stray text at the bottom of the module.
+    </p>
+   </aside>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -1,13 +1,388 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Markup (test_package+ml.Markup)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; Markup</nav><h1>Module <code>Markup</code></h1><p>Here, we test the rendering of comment markup.</p><nav class="toc"><ul><li><a href="#sections">Sections</a><ul><li><a href="#subsection-headings">Subsection headings</a><ul><li><a href="#sub-subsection-headings">Sub-subsection headings</a></li><li><a href="#anchors">Anchors</a></li></ul></li></ul></li><li><a href="#styling">Styling</a></li><li><a href="#links-and-references">Links and references</a></li><li><a href="#preformatted-text">Preformatted text</a></li><li><a href="#lists">Lists</a></li><li><a href="#unicode">Unicode</a></li><li><a href="#raw-html">Raw HTML</a></li><li><a href="#tags">Tags</a></li></ul></nav></header><section><header><h2 id="sections"><a href="#sections" class="anchor"></a>Sections</h2><p>Let's get these done first, because sections will be used to break up the rest of this test.</p><p>Besides the section heading above, there are also</p></header><section><header><h3 id="subsection-headings"><a href="#subsection-headings" class="anchor"></a>Subsection headings</h3><p>and</p></header><section><header><h4 id="sub-subsection-headings"><a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings</h4><p>but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.</p></header></section><section><header><h4 id="anchors"><a href="#anchors" class="anchor"></a>Anchors</h4><p>Sections can have attached <a href="index.html#anchors"><span>Anchors</span></a>, and it is possible to <a href="index.html#anchors"><span>link</span></a> to them. Links to section headers should not be set in source code style.</p></header></section></section></section><section><header><h2 id="styling"><a href="#styling" class="anchor"></a>Styling</h2><p>This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em>emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.</p><p><code>code</code> is a different kind of markup that doesn't allow nested markup.</p><p>It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.</p><p>Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.</p></header></section><section><header><h2 id="links-and-references"><a href="#links-and-references" class="anchor"></a>Links and references</h2><p>This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.</p><p>This is a reference to <a href="index.html#val-foo"><code>foo</code></a>. References can have replacement text: <a href="index.html#val-foo"><span>the value foo</span></a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="index.html#val-foo"><span><b>bold</b></span></a>, <a href="index.html#val-foo"><span><i>italic</i></span></a>, <a href="index.html#val-foo"><span><em>emphasis</em></span></a>, <a href="index.html#val-foo"><span>super<sup>script</sup></span></a>, <a href="index.html#val-foo"><span>sub<sub>script</sub></span></a>, and <a href="index.html#val-foo"><span><code>code</code></span></a>. It's also possible to surround a reference in a style: <b><a href="index.html#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.</p></header></section><section><header><h2 id="preformatted-text"><a href="#preformatted-text" class="anchor"></a>Preformatted text</h2><p>This is a code block:</p><pre><code class="ml">let foo = ()
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Markup (test_package+ml.Markup)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Markup
+    </nav>
+    <h1>
+     Module <code>Markup</code>
+    </h1>
+    <p>
+     Here, we test the rendering of comment markup.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#sections">Sections</a>
+       <ul>
+        <li>
+         <a href="#subsection-headings">Subsection headings</a>
+         <ul>
+          <li>
+           <a href="#sub-subsection-headings">Sub-subsection headings</a>
+          </li>
+          <li>
+           <a href="#anchors">Anchors</a>
+          </li>
+         </ul>
+        </li>
+       </ul>
+      </li>
+      <li>
+       <a href="#styling">Styling</a>
+      </li>
+      <li>
+       <a href="#links-and-references">Links and references</a>
+      </li>
+      <li>
+       <a href="#preformatted-text">Preformatted text</a>
+      </li>
+      <li>
+       <a href="#lists">Lists</a>
+      </li>
+      <li>
+       <a href="#unicode">Unicode</a>
+      </li>
+      <li>
+       <a href="#raw-html">Raw HTML</a>
+      </li>
+      <li>
+       <a href="#tags">Tags</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="sections">
+      <a href="#sections" class="anchor"></a>Sections
+     </h2>
+     <p>
+      Let's get these done first, because sections will be used to break up the rest of this test.
+     </p>
+     <p>
+      Besides the section heading above, there are also
+     </p>
+    </header>
+    <section>
+     <header>
+      <h3 id="subsection-headings">
+       <a href="#subsection-headings" class="anchor"></a>Subsection headings
+      </h3>
+      <p>
+       and
+      </p>
+     </header>
+     <section>
+      <header>
+       <h4 id="sub-subsection-headings">
+        <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings
+       </h4>
+       <p>
+        but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
+       </p>
+      </header>
+     </section>
+     <section>
+      <header>
+       <h4 id="anchors">
+        <a href="#anchors" class="anchor"></a>Anchors
+       </h4>
+       <p>
+        Sections can have attached <a href="index.html#anchors"><span>Anchors</span></a>, and it is possible to <a href="index.html#anchors"><span>link</span></a> to them. Links to section headers should not be set in source code style.
+       </p>
+      </header>
+     </section>
+    </section>
+   </section>
+   <section>
+    <header>
+     <h2 id="styling">
+      <a href="#styling" class="anchor"></a>Styling
+     </h2>
+     <p>
+      This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em>emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
+     </p>
+     <p>
+      <code>code</code> is a different kind of markup that doesn't allow nested markup.
+     </p>
+     <p>
+      It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.
+     </p>
+     <p>
+      Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.
+     </p>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="links-and-references">
+      <a href="#links-and-references" class="anchor"></a>Links and references
+     </h2>
+     <p>
+      This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
+     </p>
+     <p>
+      This is a reference to <a href="index.html#val-foo"><code>foo</code></a>. References can have replacement text: <a href="index.html#val-foo"><span>the value foo</span></a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="index.html#val-foo"><span><b>bold</b></span></a>, <a href="index.html#val-foo"><span><i>italic</i></span></a>, <a href="index.html#val-foo"><span><em>emphasis</em></span></a>, <a href="index.html#val-foo"><span>super<sup>script</sup></span></a>, <a href="index.html#val-foo"><span>sub<sub>script</sub></span></a>, and <a href="index.html#val-foo"><span><code>code</code></span></a>. It's also possible to surround a reference in a style: <b><a href="index.html#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.
+     </p>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="preformatted-text">
+      <a href="#preformatted-text" class="anchor"></a>Preformatted text
+     </h2>
+     <p>
+      This is a code block:
+     </p>
+     <pre><code class="ml">let foo = ()
 (** There are some nested comments in here, but an unpaired comment
     terminator would terminate the whole doc surrounding comment. It's
     best to keep code blocks no wider than 72 characters. *)
 
 let bar =
-  ignore foo</code></pre><p>There are also verbatim blocks:</p><pre>The main difference is these don't get syntax highlighting.</pre></header></section><section><header><h2 id="lists"><a href="#lists" class="anchor"></a>Lists</h2><ul><li>This is a</li><li>shorthand bulleted list,</li><li>and the paragraphs in each list item support <em>styling</em>.</li></ul><ol><li>This is a</li><li>shorthand numbered list.</li></ol><ul><li>Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break</li></ul><p>just creates a paragraph outside the list.</p><ul><li>Similarly, inserting a blank line between two list items</li></ul><ul><li>creates two separate lists.</li></ul><ul><li><p>To get around this limitation, one</p><p>can use explicitly-delimited lists.</p></li><li>This one is bulleted,</li></ul><ol><li>but there is also the numbered variant.</li></ol><ul><li><ul><li>lists</li><li>can be nested.</li></ul></li></ul></header></section><section><header><h2 id="unicode"><a href="#unicode" class="anchor"></a>Unicode</h2><p>The parser supports any ASCII-compatible encoding, in particuλar UTF-8.</p></header></section><section><header><h2 id="raw-html"><a href="#raw-html" class="anchor"></a>Raw HTML</h2><p>Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.</p>
-    <blockquote>
+  ignore foo</code></pre>
+     <p>
+      There are also verbatim blocks:
+     </p>
+     <pre>The main difference is these don't get syntax highlighting.</pre>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="lists">
+      <a href="#lists" class="anchor"></a>Lists
+     </h2>
+     <ul>
+      <li>
+       This is a
+      </li>
+      <li>
+       shorthand bulleted list,
+      </li>
+      <li>
+       and the paragraphs in each list item support <em>styling</em>.
+      </li>
+     </ul>
+     <ol>
+      <li>
+       This is a
+      </li>
+      <li>
+       shorthand numbered list.
+      </li>
+     </ol>
+     <ul>
+      <li>
+       Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
+      </li>
+     </ul>
+     <p>
+      just creates a paragraph outside the list.
+     </p>
+     <ul>
+      <li>
+       Similarly, inserting a blank line between two list items
+      </li>
+     </ul>
+     <ul>
+      <li>
+       creates two separate lists.
+      </li>
+     </ul>
+     <ul>
+      <li>
+       <p>
+        To get around this limitation, one
+       </p>
+       <p>
+        can use explicitly-delimited lists.
+       </p>
+      </li>
+      <li>
+       This one is bulleted,
+      </li>
+     </ul>
+     <ol>
+      <li>
+       but there is also the numbered variant.
+      </li>
+     </ol>
+     <ul>
+      <li>
+       <ul>
+        <li>
+         lists
+        </li>
+        <li>
+         can be nested.
+        </li>
+       </ul>
+      </li>
+     </ul>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="unicode">
+      <a href="#unicode" class="anchor"></a>Unicode
+     </h2>
+     <p>
+      The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
+     </p>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="raw-html">
+      <a href="#raw-html" class="anchor"></a>Raw HTML
+     </h2>
+     <p>
+      Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
+     </p>
+     <blockquote>
       If the raw HTML is the only thing in a paragraph, it is treated as a block
       element, and won't be wrapped in paragraph tags by the HTML generator.
-    </blockquote>
-    </header></section><section><header><h2 id="tags"><a href="#tags" class="anchor"></a>Tags</h2><p>Each comment can end with zero or more tags. Here are some examples:</p><dl><dt>author</dt><dd>antron</dd></dl><dl><dt>deprecated</dt><dd><p>a <em>long</em> time ago</p></dd></dl><dl><dt>parameter foo</dt><dd><p>unused</p></dd></dl><dl><dt>raises Failure</dt><dd><p>always</p></dd></dl><dl><dt>returns</dt><dd><p>never</p></dd></dl><dl><dt>see <a href="#">#</a></dt><dd><p>this url</p></dd></dl><dl><dt>see <code>foo.ml</code></dt><dd><p>this file</p></dd></dl><dl><dt>see Foo</dt><dd><p>this document</p></dd></dl><dl><dt>since</dt><dd>0</dd></dl><dl><dt>before 1.0</dt><dd><p>it was in b<sup>e</sup>t<sub>a</sub></p></dd></dl><dl><dt>version</dt><dd>-1</dd></dl></header><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code></dt><dd><p>Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.</p></dd></dl></section></div></body></html>
+     </blockquote>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="tags">
+      <a href="#tags" class="anchor"></a>Tags
+     </h2>
+     <p>
+      Each comment can end with zero or more tags. Here are some examples:
+     </p>
+     <dl>
+      <dt>
+       author
+      </dt>
+      <dd>
+       antron
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       deprecated
+      </dt>
+      <dd>
+       <p>
+        a <em>long</em> time ago
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       parameter foo
+      </dt>
+      <dd>
+       <p>
+        unused
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       raises Failure
+      </dt>
+      <dd>
+       <p>
+        always
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       returns
+      </dt>
+      <dd>
+       <p>
+        never
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       see <a href="#">#</a>
+      </dt>
+      <dd>
+       <p>
+        this url
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       see <code>foo.ml</code>
+      </dt>
+      <dd>
+       <p>
+        this file
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       see Foo
+      </dt>
+      <dd>
+       <p>
+        this document
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       since
+      </dt>
+      <dd>
+       0
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       before 1.0
+      </dt>
+      <dd>
+       <p>
+        it was in b<sup>e</sup>t<sub>a</sub>
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       version
+      </dt>
+      <dd>
+       -1
+      </dd>
+     </dl>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+     </dt>
+     <dd>
+      <p>
+       Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -1,2 +1,77 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Module (test_package+ml.Module)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; Module</nav><h1>Module <code>Module</code></h1><p>Foo.</p></header><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code></dt><dd><p>The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.</p></dd></dl><article class="spec module-type" id="module-type-S"><a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article class="spec module-type" id="module-type-S1"><a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a></code></article><article class="spec module-type" id="module-type-S2"><a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code></article><article class="spec module-type" id="module-type-S3"><a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string</code></article><article class="spec module-type" id="module-type-S4"><a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int</code></article><article class="spec module-type" id="module-type-S5"><a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code></article><dl><dt class="spec type" id="type-result"><a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) result</code></dt></dl><article class="spec module-type" id="module-type-S6"><a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>, <span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code></article><article class="spec module" id="module-M'"><a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><article class="spec module-type" id="module-type-S7"><a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code></article><article class="spec module-type" id="module-type-S8"><a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code></article><article class="spec module-type" id="module-type-S9"><a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a></code></article></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Module (test_package+ml.Module)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Module
+    </nav>
+    <h1>
+     Module <code>Module</code>
+    </h1>
+    <p>
+     Foo.
+    </p>
+   </header>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+    </dt>
+    <dd>
+     <p>
+      The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.
+     </p>
+    </dd>
+   </dl>
+   <article class="spec module-type" id="module-type-S">
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S1">
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a></code>
+   </article>
+   <article class="spec module-type" id="module-type-S2">
+    <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code>
+   </article>
+   <article class="spec module-type" id="module-type-S3">
+    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string</code>
+   </article>
+   <article class="spec module-type" id="module-type-S4">
+    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int</code>
+   </article>
+   <article class="spec module-type" id="module-type-S5">
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
+   </article>
+   <dl>
+    <dt class="spec type" id="type-result">
+     <a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) result</code>
+    </dt>
+   </dl>
+   <article class="spec module-type" id="module-type-S6">
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
+   </article>
+   <article class="spec module" id="module-M'">
+    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S7">
+    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
+   </article>
+   <article class="spec module-type" id="module-type-S8">
+    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
+   </article>
+   <article class="spec module-type" id="module-type-S9">
+    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a></code>
+   </article>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Section/index.html
+++ b/test/html/expect/test_package+ml/Section/index.html
@@ -1,2 +1,131 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Section (test_package+ml.Section)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; Section</nav><h1>Module <code>Section</code></h1><p>This is the module comment. Eventually, sections won't be allowed in it.</p><nav class="toc"><ul><li><a href="#empty-section">Empty section</a></li><li><a href="#text-only">Text only</a></li><li><a href="#aside-only">Aside only</a></li><li><a href="#value-only">Value only</a></li><li><a href="#empty-section">Empty section</a></li><li><a href="#within-a-comment">within a comment</a><ul><li><a href="#and-one-with-a-nested-section">and one with a nested section</a></li></ul></li><li><a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a></li></ul></nav></header><section><header><h2 id="empty-section"><a href="#empty-section" class="anchor"></a>Empty section</h2></header></section><section><header><h2 id="text-only"><a href="#text-only" class="anchor"></a>Text only</h2><p>Foo bar.</p></header></section><section><header><h2 id="aside-only"><a href="#aside-only" class="anchor"></a>Aside only</h2></header><aside><p>Foo bar.</p></aside></section><section><header><h2 id="value-only"><a href="#value-only" class="anchor"></a>Value only</h2></header><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code></dt></dl></section><section><header><h2 id="empty-section"><a href="#empty-section" class="anchor"></a>Empty section</h2></header></section><section><header><h2 id="within-a-comment"><a href="#within-a-comment" class="anchor"></a>within a comment</h2></header><section><header><h3 id="and-one-with-a-nested-section"><a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section</h3></header></section></section><section><header><h2 id="this-section-title-has-markup"><a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></h2><p>But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.</p></header></section></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Section (test_package+ml.Section)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Section
+    </nav>
+    <h1>
+     Module <code>Section</code>
+    </h1>
+    <p>
+     This is the module comment. Eventually, sections won't be allowed in it.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#empty-section">Empty section</a>
+      </li>
+      <li>
+       <a href="#text-only">Text only</a>
+      </li>
+      <li>
+       <a href="#aside-only">Aside only</a>
+      </li>
+      <li>
+       <a href="#value-only">Value only</a>
+      </li>
+      <li>
+       <a href="#empty-section">Empty section</a>
+      </li>
+      <li>
+       <a href="#within-a-comment">within a comment</a>
+       <ul>
+        <li>
+         <a href="#and-one-with-a-nested-section">and one with a nested section</a>
+        </li>
+       </ul>
+      </li>
+      <li>
+       <a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="empty-section">
+      <a href="#empty-section" class="anchor"></a>Empty section
+     </h2>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="text-only">
+      <a href="#text-only" class="anchor"></a>Text only
+     </h2>
+     <p>
+      Foo bar.
+     </p>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="aside-only">
+      <a href="#aside-only" class="anchor"></a>Aside only
+     </h2>
+    </header>
+    <aside>
+     <p>
+      Foo bar.
+     </p>
+    </aside>
+   </section>
+   <section>
+    <header>
+     <h2 id="value-only">
+      <a href="#value-only" class="anchor"></a>Value only
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+     </dt>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="empty-section">
+      <a href="#empty-section" class="anchor"></a>Empty section
+     </h2>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="within-a-comment">
+      <a href="#within-a-comment" class="anchor"></a>within a comment
+     </h2>
+    </header>
+    <section>
+     <header>
+      <h3 id="and-one-with-a-nested-section">
+       <a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section
+      </h3>
+     </header>
+    </section>
+   </section>
+   <section>
+    <header>
+     <h2 id="this-section-title-has-markup">
+      <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
+     </h2>
+     <p>
+      But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+     </p>
+    </header>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Stop/index.html
+++ b/test/html/expect/test_package+ml/Stop/index.html
@@ -1,2 +1,60 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Stop (test_package+ml.Stop)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; Stop</nav><h1>Module <code>Stop</code></h1><p>This test cases exercises stop comments.</p></header><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : int</code></dt><dd><p>This is normal commented text.</p></dd></dl><aside><p>The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.</p></aside><aside><p>Documentation is on again.</p><p>Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.</p></aside><article class="spec module" id="module-N"><a href="#module-N" class="anchor"></a><code><span class="keyword">module </span><a href="N/index.html">N</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><dl><dt class="spec value" id="val-lol"><a href="#val-lol" class="anchor"></a><code><span class="keyword">val </span>lol : int</code></dt></dl></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Stop (test_package+ml.Stop)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Stop
+    </nav>
+    <h1>
+     Module <code>Stop</code>
+    </h1>
+    <p>
+     This test cases exercises stop comments.
+    </p>
+   </header>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : int</code>
+    </dt>
+    <dd>
+     <p>
+      This is normal commented text.
+     </p>
+    </dd>
+   </dl>
+   <aside>
+    <p>
+     The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
+    </p>
+   </aside>
+   <aside>
+    <p>
+     Documentation is on again.
+    </p>
+    <p>
+     Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
+    </p>
+   </aside>
+   <article class="spec module" id="module-N">
+    <a href="#module-N" class="anchor"></a><code><span class="keyword">module </span><a href="N/index.html">N</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <dl>
+    <dt class="spec value" id="val-lol">
+     <a href="#val-lol" class="anchor"></a><code><span class="keyword">val </span>lol : int</code>
+    </dt>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -1,2 +1,368 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Type (test_package+ml.Type)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; Type</nav><h1>Module <code>Type</code></h1></header><dl><dt class="spec type" id="type-abstract"><a href="#type-abstract" class="anchor"></a><code><span class="keyword">type </span>abstract</code></dt><dd><p>Some <em>documentation</em>.</p></dd></dl><dl><dt class="spec type" id="type-alias"><a href="#type-alias" class="anchor"></a><code><span class="keyword">type </span>alias</code><code><span class="keyword"> = </span>int</code></dt><dt class="spec type" id="type-private_"><a href="#type-private_" class="anchor"></a><code><span class="keyword">type </span>private_</code><code><span class="keyword"> = </span><span class="keyword">private </span>int</code></dt><dt class="spec type" id="type-constructor"><a href="#type-constructor" class="anchor"></a><code><span class="keyword">type </span>'a constructor</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code></dt><dt class="spec type" id="type-arrow"><a href="#type-arrow" class="anchor"></a><code><span class="keyword">type </span>arrow</code><code><span class="keyword"> = </span>int <span>&#45;&gt;</span> int</code></dt><dt class="spec type" id="type-higher_order"><a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type </span>higher_order</code><code><span class="keyword"> = </span>(int <span>&#45;&gt;</span> int) <span>&#45;&gt;</span> int</code></dt><dt class="spec type" id="type-labeled"><a href="#type-labeled" class="anchor"></a><code><span class="keyword">type </span>labeled</code><code><span class="keyword"> = </span>l:int <span>&#45;&gt;</span> int</code></dt><dt class="spec type" id="type-optional"><a href="#type-optional" class="anchor"></a><code><span class="keyword">type </span>optional</code><code><span class="keyword"> = </span>?&#8288;l:int <span>&#45;&gt;</span> int</code></dt><dt class="spec type" id="type-labeled_higher_order"><a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type </span>labeled_higher_order</code><code><span class="keyword"> = </span>(l:int <span>&#45;&gt;</span> int) <span>&#45;&gt;</span> (?&#8288;l:int <span>&#45;&gt;</span> int) <span>&#45;&gt;</span> int</code></dt><dt class="spec type" id="type-pair"><a href="#type-pair" class="anchor"></a><code><span class="keyword">type </span>pair</code><code><span class="keyword"> = </span>int<span class="keyword"> * </span>int</code></dt><dt class="spec type" id="type-parens_dropped"><a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type </span>parens_dropped</code><code><span class="keyword"> = </span>int<span class="keyword"> * </span>int</code></dt><dt class="spec type" id="type-triple"><a href="#type-triple" class="anchor"></a><code><span class="keyword">type </span>triple</code><code><span class="keyword"> = </span>int<span class="keyword"> * </span>int<span class="keyword"> * </span>int</code></dt><dt class="spec type" id="type-nested_pair"><a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type </span>nested_pair</code><code><span class="keyword"> = </span>(int<span class="keyword"> * </span>int)<span class="keyword"> * </span>int</code></dt><dt class="spec type" id="type-instance"><a href="#type-instance" class="anchor"></a><code><span class="keyword">type </span>instance</code><code><span class="keyword"> = </span>int <a href="index.html#type-constructor">constructor</a></code></dt><dt class="spec type" id="type-variant_e"><a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type </span>variant_e</code><code><span class="keyword"> = </span></code><code>{</code><table class="record"><tr id="type-variant_e.a" class="anchored"><td class="def field"><a href="#type-variant_e.a" class="anchor"></a><code>a : int;</code></td></tr></table><code>}</code></dt><dt class="spec type" id="type-variant"><a href="#type-variant" class="anchor"></a><code><span class="keyword">type </span>variant</code><code><span class="keyword"> = </span></code><table class="variant"><tr id="type-variant.A" class="anchored"><td class="def constructor"><a href="#type-variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code></td></tr><tr id="type-variant.B" class="anchored"><td class="def constructor"><a href="#type-variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span><span class="keyword"> of </span>int</code></td></tr><tr id="type-variant.C" class="anchored"><td class="def constructor"><a href="#type-variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span></code></td><td class="doc"><p>foo</p></td></tr><tr id="type-variant.D" class="anchored"><td class="def constructor"><a href="#type-variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">D</span></code></td><td class="doc"><p><em>bar</em></p></td></tr><tr id="type-variant.E" class="anchored"><td class="def constructor"><a href="#type-variant.E" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">E</span><span class="keyword"> of </span><a href="index.html#type-variant_e">variant_e</a></code></td></tr></table></dt><dt class="spec type" id="type-variant_c"><a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type </span>variant_c</code><code><span class="keyword"> = </span></code><code>{</code><table class="record"><tr id="type-variant_c.a" class="anchored"><td class="def field"><a href="#type-variant_c.a" class="anchor"></a><code>a : int;</code></td></tr></table><code>}</code></dt><dt class="spec type" id="type-gadt"><a href="#type-gadt" class="anchor"></a><code><span class="keyword">type </span>_ gadt</code><code><span class="keyword"> = </span></code><table class="variant"><tr id="type-gadt.A" class="anchored"><td class="def constructor"><a href="#type-gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> int <a href="index.html#type-gadt">gadt</a></code></td></tr><tr id="type-gadt.B" class="anchored"><td class="def constructor"><a href="#type-gadt.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span><span class="keyword"> : </span>int <span>&#45;&gt;</span> string <a href="index.html#type-gadt">gadt</a></code></td></tr><tr id="type-gadt.C" class="anchored"><td class="def constructor"><a href="#type-gadt.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span><span class="keyword"> : </span><a href="index.html#type-variant_c">variant_c</a> <span>&#45;&gt;</span> unit <a href="index.html#type-gadt">gadt</a></code></td></tr></table></dt><dt class="spec type" id="type-degenerate_gadt"><a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type </span>degenerate_gadt</code><code><span class="keyword"> = </span></code><table class="variant"><tr id="type-degenerate_gadt.A" class="anchored"><td class="def constructor"><a href="#type-degenerate_gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code></td></tr></table></dt><dt class="spec type" id="type-private_variant"><a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type </span>private_variant</code><code><span class="keyword"> = </span><span class="keyword">private </span></code><table class="variant"><tr id="type-private_variant.A" class="anchored"><td class="def constructor"><a href="#type-private_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code></td></tr></table></dt><dt class="spec type" id="type-record"><a href="#type-record" class="anchor"></a><code><span class="keyword">type </span>record</code><code><span class="keyword"> = </span></code><code>{</code><table class="record"><tr id="type-record.a" class="anchored"><td class="def field"><a href="#type-record.a" class="anchor"></a><code>a : int;</code></td></tr><tr id="type-record.b" class="anchored"><td class="def field"><a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable </span>b : int;</code></td></tr><tr id="type-record.c" class="anchored"><td class="def field"><a href="#type-record.c" class="anchor"></a><code>c : int;</code></td><td class="doc"><p>foo</p></td></tr><tr id="type-record.d" class="anchored"><td class="def field"><a href="#type-record.d" class="anchor"></a><code>d : int;</code></td><td class="doc"><p><em>bar</em></p></td></tr><tr id="type-record.e" class="anchored"><td class="def field"><a href="#type-record.e" class="anchor"></a><code>e : a. <span class="type-var">'a</span>;</code></td></tr></table><code>}</code></dt><dt class="spec type" id="type-polymorphic_variant"><a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant</code><span class="keyword"> = </span><code>[ </code><table class="variant"><tr id="type-polymorphic_variant.A" class="anchored"><td class="def constructor"><a href="#type-polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A</code></td></tr><tr id="type-polymorphic_variant.B" class="anchored"><td class="def constructor"><a href="#type-polymorphic_variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code>`B<span class="keyword"> of </span>int</code></td></tr><tr id="type-polymorphic_variant.C" class="anchored"><td class="def constructor"><a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C</code></td></tr><tr id="type-polymorphic_variant.D" class="anchored"><td class="def constructor"><a href="#type-polymorphic_variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code>`D</code></td></tr></table><code> ]</code></dt><dt class="spec type" id="type-polymorphic_variant_extension"><a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant_extension</code><span class="keyword"> = </span><code>[ </code><table class="variant"><tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored"><td class="def type"><a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span class="keyword">| </span></code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code></td></tr><tr id="type-polymorphic_variant_extension.E" class="anchored"><td class="def constructor"><a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span class="keyword">| </span></code><code>`E</code></td></tr></table><code> ]</code></dt><dt class="spec type" id="type-nested_polymorphic_variant"><a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>nested_polymorphic_variant</code><span class="keyword"> = </span><code>[ </code><table class="variant"><tr id="type-nested_polymorphic_variant.A" class="anchored"><td class="def constructor"><a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A<span class="keyword"> of </span>[ `B<span class="keyword"> | </span>`C ]</code></td></tr></table><code> ]</code></dt><dt class="spec type" id="type-object_"><a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>&lt; a : int; b : int; c : int; &gt;</code></dt></dl><article class="spec module-type" id="module-type-X"><a href="#module-type-X" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-X/index.html">X</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code></article><dl><dt class="spec type" id="type-module_"><a href="#type-module_" class="anchor"></a><code><span class="keyword">type </span>module_</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a>)</code></dt><dt class="spec type" id="type-module_substitution"><a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type </span>module_substitution</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type </span><a href="module-type-X/index.html#type-t">t</a> <span class="keyword">=</span> int)</code></dt><dt class="spec type" id="type-covariant"><a href="#type-covariant" class="anchor"></a><code><span class="keyword">type </span>+'a covariant</code></dt><dt class="spec type" id="type-contravariant"><a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type </span>-'a contravariant</code></dt><dt class="spec type" id="type-bivariant"><a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type </span>_ bivariant</code><code><span class="keyword"> = </span>int</code></dt><dt class="spec type" id="type-binary"><a href="#type-binary" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) binary</code></dt><dt class="spec type" id="type-using_binary"><a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type </span>using_binary</code><code><span class="keyword"> = </span>(int, int) <a href="index.html#type-binary">binary</a></code></dt><dt class="spec type" id="type-name"><a href="#type-name" class="anchor"></a><code><span class="keyword">type </span>'custom name</code></dt><dt class="spec type" id="type-constrained"><a href="#type-constrained" class="anchor"></a><code><span class="keyword">type </span>'a constrained</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = int</code></dt><dt class="spec type" id="type-exact_variant"><a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type </span>'a exact_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [ `A<span class="keyword"> | </span>`B of int ]</code></dt><dt class="spec type" id="type-lower_variant"><a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type </span>'a lower_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt; `A<span class="keyword"> | </span>`B of int ]</code></dt><dt class="spec type" id="type-any_variant"><a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type </span>'a any_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt;  ]</code></dt><dt class="spec type" id="type-upper_variant"><a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type </span>'a upper_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; `A<span class="keyword"> | </span>`B of int ]</code></dt><dt class="spec type" id="type-named_variant"><a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type </span>'a named_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code></dt><dt class="spec type" id="type-exact_object"><a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type </span>'a exact_object</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = &lt; a : int; b : int; &gt;</code></dt><dt class="spec type" id="type-lower_object"><a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type </span>'a lower_object</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = &lt; a : int; b : int; .. &gt;</code></dt><dt class="spec type" id="type-poly_object"><a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type </span>'a poly_object</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = &lt; a : a. <span class="type-var">'a</span>; &gt;</code></dt><dt class="spec type" id="type-as_"><a href="#type-as_" class="anchor"></a><code><span class="keyword">type </span>as_</code><code><span class="keyword"> = </span>int<span class="keyword"> as </span>a<span class="keyword"> * </span><span class="type-var">'a</span></code></dt><dt class="spec type" id="type-extensible"><a href="#type-extensible" class="anchor"></a><code><span class="keyword">type </span>extensible</code><code><span class="keyword"> = </span></code><code><span class="keyword">..</span></code></dt></dl><dl><dt><code><span class="keyword">type </span><a href="index.html#type-extensible">extensible</a><span class="keyword"> += </span></code><code><span class="extension">Extension</span></code></dt></dl><dl><dt class="spec exception" id="exception-Foo"><a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception </span></code><code><span class="exception">Foo</span><span class="keyword"> of </span>int<span class="keyword"> * </span>int</code></dt></dl></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Type (test_package+ml.Type)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Type
+    </nav>
+    <h1>
+     Module <code>Type</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec type" id="type-abstract">
+     <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type </span>abstract</code>
+    </dt>
+    <dd>
+     <p>
+      Some <em>documentation</em>.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec type" id="type-alias">
+     <a href="#type-alias" class="anchor"></a><code><span class="keyword">type </span>alias</code><code><span class="keyword"> = </span>int</code>
+    </dt>
+    <dt class="spec type" id="type-private_">
+     <a href="#type-private_" class="anchor"></a><code><span class="keyword">type </span>private_</code><code><span class="keyword"> = </span><span class="keyword">private </span>int</code>
+    </dt>
+    <dt class="spec type" id="type-constructor">
+     <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type </span>'a constructor</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code>
+    </dt>
+    <dt class="spec type" id="type-arrow">
+     <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type </span>arrow</code><code><span class="keyword"> = </span>int <span>-&gt;</span> int</code>
+    </dt>
+    <dt class="spec type" id="type-higher_order">
+     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type </span>higher_order</code><code><span class="keyword"> = </span>(int <span>-&gt;</span> int) <span>-&gt;</span> int</code>
+    </dt>
+    <dt class="spec type" id="type-labeled">
+     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type </span>labeled</code><code><span class="keyword"> = </span>l:int <span>-&gt;</span> int</code>
+    </dt>
+    <dt class="spec type" id="type-optional">
+     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type </span>optional</code><code><span class="keyword"> = </span>?⁠l:int <span>-&gt;</span> int</code>
+    </dt>
+    <dt class="spec type" id="type-labeled_higher_order">
+     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type </span>labeled_higher_order</code><code><span class="keyword"> = </span>(l:int <span>-&gt;</span> int) <span>-&gt;</span> (?⁠l:int <span>-&gt;</span> int) <span>-&gt;</span> int</code>
+    </dt>
+    <dt class="spec type" id="type-pair">
+     <a href="#type-pair" class="anchor"></a><code><span class="keyword">type </span>pair</code><code><span class="keyword"> = </span>int<span class="keyword"> * </span>int</code>
+    </dt>
+    <dt class="spec type" id="type-parens_dropped">
+     <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type </span>parens_dropped</code><code><span class="keyword"> = </span>int<span class="keyword"> * </span>int</code>
+    </dt>
+    <dt class="spec type" id="type-triple">
+     <a href="#type-triple" class="anchor"></a><code><span class="keyword">type </span>triple</code><code><span class="keyword"> = </span>int<span class="keyword"> * </span>int<span class="keyword"> * </span>int</code>
+    </dt>
+    <dt class="spec type" id="type-nested_pair">
+     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type </span>nested_pair</code><code><span class="keyword"> = </span>(int<span class="keyword"> * </span>int)<span class="keyword"> * </span>int</code>
+    </dt>
+    <dt class="spec type" id="type-instance">
+     <a href="#type-instance" class="anchor"></a><code><span class="keyword">type </span>instance</code><code><span class="keyword"> = </span>int <a href="index.html#type-constructor">constructor</a></code>
+    </dt>
+    <dt class="spec type" id="type-variant_e">
+     <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type </span>variant_e</code><code><span class="keyword"> = </span></code><code>{</code>
+     <table class="record">
+      <tbody>
+       <tr id="type-variant_e.a" class="anchored">
+        <td class="def field">
+         <a href="#type-variant_e.a" class="anchor"></a><code>a : int;</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code>}</code>
+    </dt>
+    <dt class="spec type" id="type-variant">
+     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type </span>variant</code><code><span class="keyword"> = </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code>
+        </td>
+       </tr>
+       <tr id="type-variant.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span><span class="keyword"> of </span>int</code>
+        </td>
+       </tr>
+       <tr id="type-variant.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.D" class="anchored">
+        <td class="def constructor">
+         <a href="#type-variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">D</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <em>bar</em>
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.E" class="anchored">
+        <td class="def constructor">
+         <a href="#type-variant.E" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">E</span><span class="keyword"> of </span><a href="index.html#type-variant_e">variant_e</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </dt>
+    <dt class="spec type" id="type-variant_c">
+     <a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type </span>variant_c</code><code><span class="keyword"> = </span></code><code>{</code>
+     <table class="record">
+      <tbody>
+       <tr id="type-variant_c.a" class="anchored">
+        <td class="def field">
+         <a href="#type-variant_c.a" class="anchor"></a><code>a : int;</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code>}</code>
+    </dt>
+    <dt class="spec type" id="type-gadt">
+     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type </span>_ gadt</code><code><span class="keyword"> = </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-gadt.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> int <a href="index.html#type-gadt">gadt</a></code>
+        </td>
+       </tr>
+       <tr id="type-gadt.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-gadt.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span><span class="keyword"> : </span>int <span>-&gt;</span> string <a href="index.html#type-gadt">gadt</a></code>
+        </td>
+       </tr>
+       <tr id="type-gadt.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-gadt.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span><span class="keyword"> : </span><a href="index.html#type-variant_c">variant_c</a> <span>-&gt;</span> unit <a href="index.html#type-gadt">gadt</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </dt>
+    <dt class="spec type" id="type-degenerate_gadt">
+     <a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type </span>degenerate_gadt</code><code><span class="keyword"> = </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-degenerate_gadt.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </dt>
+    <dt class="spec type" id="type-private_variant">
+     <a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type </span>private_variant</code><code><span class="keyword"> = </span><span class="keyword">private </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-private_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-private_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </dt>
+    <dt class="spec type" id="type-record">
+     <a href="#type-record" class="anchor"></a><code><span class="keyword">type </span>record</code><code><span class="keyword"> = </span></code><code>{</code>
+     <table class="record">
+      <tbody>
+       <tr id="type-record.a" class="anchored">
+        <td class="def field">
+         <a href="#type-record.a" class="anchor"></a><code>a : int;</code>
+        </td>
+       </tr>
+       <tr id="type-record.b" class="anchored">
+        <td class="def field">
+         <a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable </span>b : int;</code>
+        </td>
+       </tr>
+       <tr id="type-record.c" class="anchored">
+        <td class="def field">
+         <a href="#type-record.c" class="anchor"></a><code>c : int;</code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-record.d" class="anchored">
+        <td class="def field">
+         <a href="#type-record.d" class="anchor"></a><code>d : int;</code>
+        </td>
+        <td class="doc">
+         <p>
+          <em>bar</em>
+         </p>
+        </td>
+       </tr>
+       <tr id="type-record.e" class="anchored">
+        <td class="def field">
+         <a href="#type-record.e" class="anchor"></a><code>e : a. <span class="type-var">'a</span>;</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code>}</code>
+    </dt>
+    <dt class="spec type" id="type-polymorphic_variant">
+     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant</code><span class="keyword"> = </span><code>[ </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-polymorphic_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A</code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code>`B<span class="keyword"> of </span>int</code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C</code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.D" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code>`D</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code> ]</code>
+    </dt>
+    <dt class="spec type" id="type-polymorphic_variant_extension">
+     <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant_extension</code><span class="keyword"> = </span><code>[ </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
+        <td class="def type">
+         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span class="keyword">| </span></code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant_extension.E" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span class="keyword">| </span></code><code>`E</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code> ]</code>
+    </dt>
+    <dt class="spec type" id="type-nested_polymorphic_variant">
+     <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>nested_polymorphic_variant</code><span class="keyword"> = </span><code>[ </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-nested_polymorphic_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A<span class="keyword"> of </span>[ `B<span class="keyword"> | </span>`C ]</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code> ]</code>
+    </dt>
+    <dt class="spec type" id="type-object_">
+     <a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>&lt; a : int; b : int; c : int; &gt;</code>
+    </dt>
+   </dl>
+   <article class="spec module-type" id="module-type-X">
+    <a href="#module-type-X" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-X/index.html">X</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </article>
+   <dl>
+    <dt class="spec type" id="type-module_">
+     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type </span>module_</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a>)</code>
+    </dt>
+    <dt class="spec type" id="type-module_substitution">
+     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type </span>module_substitution</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type </span><a href="module-type-X/index.html#type-t">t</a> <span class="keyword">=</span> int)</code>
+    </dt>
+    <dt class="spec type" id="type-covariant">
+     <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type </span>+'a covariant</code>
+    </dt>
+    <dt class="spec type" id="type-contravariant">
+     <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type </span>-'a contravariant</code>
+    </dt>
+    <dt class="spec type" id="type-bivariant">
+     <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type </span>_ bivariant</code><code><span class="keyword"> = </span>int</code>
+    </dt>
+    <dt class="spec type" id="type-binary">
+     <a href="#type-binary" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) binary</code>
+    </dt>
+    <dt class="spec type" id="type-using_binary">
+     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type </span>using_binary</code><code><span class="keyword"> = </span>(int,&nbsp;int) <a href="index.html#type-binary">binary</a></code>
+    </dt>
+    <dt class="spec type" id="type-name">
+     <a href="#type-name" class="anchor"></a><code><span class="keyword">type </span>'custom name</code>
+    </dt>
+    <dt class="spec type" id="type-constrained">
+     <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type </span>'a constrained</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = int</code>
+    </dt>
+    <dt class="spec type" id="type-exact_variant">
+     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type </span>'a exact_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [ `A<span class="keyword"> | </span>`B of int ]</code>
+    </dt>
+    <dt class="spec type" id="type-lower_variant">
+     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type </span>'a lower_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt; `A<span class="keyword"> | </span>`B of int ]</code>
+    </dt>
+    <dt class="spec type" id="type-any_variant">
+     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type </span>'a any_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt;  ]</code>
+    </dt>
+    <dt class="spec type" id="type-upper_variant">
+     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type </span>'a upper_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; `A<span class="keyword"> | </span>`B of int ]</code>
+    </dt>
+    <dt class="spec type" id="type-named_variant">
+     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type </span>'a named_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code>
+    </dt>
+    <dt class="spec type" id="type-exact_object">
+     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type </span>'a exact_object</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = &lt; a : int; b : int; &gt;</code>
+    </dt>
+    <dt class="spec type" id="type-lower_object">
+     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type </span>'a lower_object</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = &lt; a : int; b : int; .. &gt;</code>
+    </dt>
+    <dt class="spec type" id="type-poly_object">
+     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type </span>'a poly_object</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = &lt; a : a. <span class="type-var">'a</span>; &gt;</code>
+    </dt>
+    <dt class="spec type" id="type-as_">
+     <a href="#type-as_" class="anchor"></a><code><span class="keyword">type </span>as_</code><code><span class="keyword"> = </span>int<span class="keyword"> as </span>a<span class="keyword"> * </span><span class="type-var">'a</span></code>
+    </dt>
+    <dt class="spec type" id="type-extensible">
+     <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type </span>extensible</code><code><span class="keyword"> = </span></code><code><span class="keyword">..</span></code>
+    </dt>
+   </dl>
+   <dl>
+    <dt>
+     <code><span class="keyword">type </span><a href="index.html#type-extensible">extensible</a><span class="keyword"> += </span></code><code><span class="extension">Extension</span></code>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec exception" id="exception-Foo">
+     <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception </span></code><code><span class="exception">Foo</span><span class="keyword"> of </span>int<span class="keyword"> * </span>int</code>
+    </dt>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Val/index.html
+++ b/test/html/expect/test_package+ml/Val/index.html
@@ -1,2 +1,49 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Val (test_package+ml.Val)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; Val</nav><h1>Module <code>Val</code></h1></header><dl><dt class="spec value" id="val-documented"><a href="#val-documented" class="anchor"></a><code><span class="keyword">val </span>documented : unit</code></dt><dd><p>Foo.</p></dd></dl><dl><dt class="spec value" id="val-undocumented"><a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val </span>undocumented : unit</code></dt><dt class="spec value" id="val-documented_above"><a href="#val-documented_above" class="anchor"></a><code><span class="keyword">val </span>documented_above : unit</code></dt><dd><p>Bar.</p></dd></dl></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Val (test_package+ml.Val)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Val
+    </nav>
+    <h1>
+     Module <code>Val</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec value" id="val-documented">
+     <a href="#val-documented" class="anchor"></a><code><span class="keyword">val </span>documented : unit</code>
+    </dt>
+    <dd>
+     <p>
+      Foo.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-undocumented">
+     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val </span>undocumented : unit</code>
+    </dt>
+    <dt class="spec value" id="val-documented_above">
+     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">val </span>documented_above : unit</code>
+    </dt>
+    <dd>
+     <p>
+      Bar.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/mld.html
+++ b/test/html/expect/test_package+ml/mld.html
@@ -1,2 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>mld (test_package+ml.mld)</title><link rel="stylesheet" href="../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> &#x00BB; mld</nav></header><p>This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.</p><p>The whole thing is <b>written</b> <i>in</i><sup>ocamldoc</sup><sub>syntax</sub>.</p></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   mld (test_package+ml.mld)
+  </title>
+  <link rel="stylesheet" href="../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » mld
+    </nav>
+   </header>
+   <p>
+    This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
+   </p>
+   <p>
+    The whole thing is <b>written</b> <i>in</i><sup>ocamldoc</sup><sub>syntax</sub>.
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -1,2 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Class (test_package+re.Class)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; Class</nav><h1>Module <code>Class</code></h1></header><article class="spec class-type" id="class-type-empty"><a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class type </span><a href="class-type-empty/index.html">empty</a> = <span class="keyword">{</span> ... <span class="keyword">}</span></code></article></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Class (test_package+re.Class)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Class
+    </nav>
+    <h1>
+     Module <code>Class</code>
+    </h1>
+   </header>
+   <article class="spec class-type" id="class-type-empty">
+    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class type </span><a href="class-type-empty/index.html">empty</a> = <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+   </article>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/External/index.html
+++ b/test/html/expect/test_package+re/External/index.html
@@ -1,2 +1,36 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>External (test_package+re.External)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; External</nav><h1>Module <code>External</code></h1></header><dl><dt class="spec external" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">external </span>foo : unit <span>=&gt;</span> unit = &quot;bar&quot;<span class="keyword">;</span></code></dt><dd><p>Foo <em>bar</em>.</p></dd></dl></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   External (test_package+re.External)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » External
+    </nav>
+    <h1>
+     Module <code>External</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec external" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">external </span>foo : unit <span>=&gt;</span> unit = "bar"<span class="keyword">;</span></code>
+    </dt>
+    <dd>
+     <p>
+      Foo <em>bar</em>.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Functor/index.html
+++ b/test/html/expect/test_package+re/Functor/index.html
@@ -1,2 +1,44 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Functor (test_package+re.Functor)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; Functor</nav><h1>Module <code>Functor</code></h1></header><article class="spec module-type" id="module-type-S"><a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code></article><article class="spec module-type" id="module-type-S1"><a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a> :  (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code></article><article class="spec module" id="module-F1"><a href="#module-F1" class="anchor"></a><code><span class="keyword">module </span><a href="F1/index.html">F1</a> :  (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code></article><article class="spec module" id="module-F2"><a href="#module-F2" class="anchor"></a><code><span class="keyword">module </span><a href="F2/index.html">F2</a> :  (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="F2/index.html#type-t">t</a><span class="keyword"> = </span><a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a><span class="keyword">;</span></code></article><article class="spec module" id="module-F3"><a href="#module-F3" class="anchor"></a><code><span class="keyword">module </span><a href="F3/index.html">F3</a> :  (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code></article><article class="spec module" id="module-F4"><a href="#module-F4" class="anchor"></a><code><span class="keyword">module </span><a href="F4/index.html">F4</a> :  (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code></article></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Functor (test_package+re.Functor)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Functor
+    </nav>
+    <h1>
+     Module <code>Functor</code>
+    </h1>
+   </header>
+   <article class="spec module-type" id="module-type-S">
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S1">
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a> :  (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module" id="module-F1">
+    <a href="#module-F1" class="anchor"></a><code><span class="keyword">module </span><a href="F1/index.html">F1</a> :  (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module" id="module-F2">
+    <a href="#module-F2" class="anchor"></a><code><span class="keyword">module </span><a href="F2/index.html">F2</a> :  (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="F2/index.html#type-t">t</a><span class="keyword"> = </span><a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module" id="module-F3">
+    <a href="#module-F3" class="anchor"></a><code><span class="keyword">module </span><a href="F3/index.html">F3</a> :  (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module" id="module-F4">
+    <a href="#module-F4" class="anchor"></a><code><span class="keyword">module </span><a href="F4/index.html">F4</a> :  (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+   </article>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Include/index.html
+++ b/test/html/expect/test_package+re/Include/index.html
@@ -1,2 +1,97 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Include (test_package+re.Include)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; Include</nav><h1>Module <code>Include</code></h1></header><article class="spec module-type" id="module-type-Not_inlined"><a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code></article><article><div class="spec include"><div class="doc"><details open="open"><summary><span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined">Not_inlined</a><span class="keyword">;</span></code></span></summary><dl><dt class="spec type" id="type-t"><a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span></dt></dl></details></div></div></article><article class="spec module-type" id="module-type-Inlined"><a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code></article><article><div class="spec include"><div class="doc"><dl><dt class="spec type" id="type-u"><a href="#type-u" class="anchor"></a><code><span class="keyword">type </span>u</code><span class="keyword">;</span></dt></dl></div></div></article><article class="spec module-type" id="module-type-Not_inlined_and_closed"><a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code></article><article><div class="spec include"><div class="doc"><details><summary><span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a><span class="keyword">;</span></code></span></summary><dl><dt class="spec type" id="type-v"><a href="#type-v" class="anchor"></a><code><span class="keyword">type </span>v</code><span class="keyword">;</span></dt></dl></details></div></div></article><article class="spec module-type" id="module-type-Not_inlined_and_opened"><a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code></article><article><div class="spec include"><div class="doc"><details open="open"><summary><span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a><span class="keyword">;</span></code></span></summary><dl><dt class="spec type" id="type-w"><a href="#type-w" class="anchor"></a><code><span class="keyword">type </span>w</code><span class="keyword">;</span></dt></dl></details></div></div></article></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include (test_package+re.Include)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Include
+    </nav>
+    <h1>
+     Module <code>Include</code>
+    </h1>
+   </header>
+   <article class="spec module-type" id="module-type-Not_inlined">
+    <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <details open="open">
+       <summary>
+        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined">Not_inlined</a><span class="keyword">;</span></code></span>
+       </summary>
+       <dl>
+        <dt class="spec type" id="type-t">
+         <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span>
+        </dt>
+       </dl>
+      </details>
+     </div>
+    </div>
+   </article>
+   <article class="spec module-type" id="module-type-Inlined">
+    <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <dl>
+       <dt class="spec type" id="type-u">
+        <a href="#type-u" class="anchor"></a><code><span class="keyword">type </span>u</code><span class="keyword">;</span>
+       </dt>
+      </dl>
+     </div>
+    </div>
+   </article>
+   <article class="spec module-type" id="module-type-Not_inlined_and_closed">
+    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <details>
+       <summary>
+        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a><span class="keyword">;</span></code></span>
+       </summary>
+       <dl>
+        <dt class="spec type" id="type-v">
+         <a href="#type-v" class="anchor"></a><code><span class="keyword">type </span>v</code><span class="keyword">;</span>
+        </dt>
+       </dl>
+      </details>
+     </div>
+    </div>
+   </article>
+   <article class="spec module-type" id="module-type-Not_inlined_and_opened">
+    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+   </article>
+   <article>
+    <div class="spec include">
+     <div class="doc">
+      <details open="open">
+       <summary>
+        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a><span class="keyword">;</span></code></span>
+       </summary>
+       <dl>
+        <dt class="spec type" id="type-w">
+         <a href="#type-w" class="anchor"></a><code><span class="keyword">type </span>w</code><span class="keyword">;</span>
+        </dt>
+       </dl>
+      </details>
+     </div>
+    </div>
+   </article>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Interlude/index.html
+++ b/test/html/expect/test_package+re/Interlude/index.html
@@ -1,2 +1,83 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Interlude (test_package+re.Interlude)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; Interlude</nav><h1>Module <code>Interlude</code></h1><p>This is the comment associated to the module.</p></header><aside><p>Some separate stray text at the top of the module.</p></aside><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code></dt><dd><p>Foo.</p></dd></dl><aside><p>Some stray text that is not associated with any signature item.</p><p>It has multiple paragraphs.</p></aside><aside><p>A separate block of stray text, adjacent to the preceding one.</p></aside><dl><dt class="spec value" id="val-bar"><a href="#val-bar" class="anchor"></a><code><span class="keyword">let </span>bar : unit<span class="keyword">;</span></code></dt><dd><p>Bar.</p></dd></dl><dl><dt class="spec value" id="val-multiple"><a href="#val-multiple" class="anchor"></a><code><span class="keyword">let </span>multiple : unit<span class="keyword">;</span></code></dt><dt class="spec value" id="val-signature"><a href="#val-signature" class="anchor"></a><code><span class="keyword">let </span>signature : unit<span class="keyword">;</span></code></dt><dt class="spec value" id="val-items"><a href="#val-items" class="anchor"></a><code><span class="keyword">let </span>items : unit<span class="keyword">;</span></code></dt></dl><aside><p>Stray text at the bottom of the module.</p></aside></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Interlude (test_package+re.Interlude)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Interlude
+    </nav>
+    <h1>
+     Module <code>Interlude</code>
+    </h1>
+    <p>
+     This is the comment associated to the module.
+    </p>
+   </header>
+   <aside>
+    <p>
+     Some separate stray text at the top of the module.
+    </p>
+   </aside>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code>
+    </dt>
+    <dd>
+     <p>
+      Foo.
+     </p>
+    </dd>
+   </dl>
+   <aside>
+    <p>
+     Some stray text that is not associated with any signature item.
+    </p>
+    <p>
+     It has multiple paragraphs.
+    </p>
+   </aside>
+   <aside>
+    <p>
+     A separate block of stray text, adjacent to the preceding one.
+    </p>
+   </aside>
+   <dl>
+    <dt class="spec value" id="val-bar">
+     <a href="#val-bar" class="anchor"></a><code><span class="keyword">let </span>bar : unit<span class="keyword">;</span></code>
+    </dt>
+    <dd>
+     <p>
+      Bar.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-multiple">
+     <a href="#val-multiple" class="anchor"></a><code><span class="keyword">let </span>multiple : unit<span class="keyword">;</span></code>
+    </dt>
+    <dt class="spec value" id="val-signature">
+     <a href="#val-signature" class="anchor"></a><code><span class="keyword">let </span>signature : unit<span class="keyword">;</span></code>
+    </dt>
+    <dt class="spec value" id="val-items">
+     <a href="#val-items" class="anchor"></a><code><span class="keyword">let </span>items : unit<span class="keyword">;</span></code>
+    </dt>
+   </dl>
+   <aside>
+    <p>
+     Stray text at the bottom of the module.
+    </p>
+   </aside>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -1,13 +1,388 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Markup (test_package+re.Markup)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; Markup</nav><h1>Module <code>Markup</code></h1><p>Here, we test the rendering of comment markup.</p><nav class="toc"><ul><li><a href="#sections">Sections</a><ul><li><a href="#subsection-headings">Subsection headings</a><ul><li><a href="#sub-subsection-headings">Sub-subsection headings</a></li><li><a href="#anchors">Anchors</a></li></ul></li></ul></li><li><a href="#styling">Styling</a></li><li><a href="#links-and-references">Links and references</a></li><li><a href="#preformatted-text">Preformatted text</a></li><li><a href="#lists">Lists</a></li><li><a href="#unicode">Unicode</a></li><li><a href="#raw-html">Raw HTML</a></li><li><a href="#tags">Tags</a></li></ul></nav></header><section><header><h2 id="sections"><a href="#sections" class="anchor"></a>Sections</h2><p>Let's get these done first, because sections will be used to break up the rest of this test.</p><p>Besides the section heading above, there are also</p></header><section><header><h3 id="subsection-headings"><a href="#subsection-headings" class="anchor"></a>Subsection headings</h3><p>and</p></header><section><header><h4 id="sub-subsection-headings"><a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings</h4><p>but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.</p></header></section><section><header><h4 id="anchors"><a href="#anchors" class="anchor"></a>Anchors</h4><p>Sections can have attached <a href="index.html#anchors"><span>Anchors</span></a>, and it is possible to <a href="index.html#anchors"><span>link</span></a> to them. Links to section headers should not be set in source code style.</p></header></section></section></section><section><header><h2 id="styling"><a href="#styling" class="anchor"></a>Styling</h2><p>This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em>emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.</p><p><code>code</code> is a different kind of markup that doesn't allow nested markup.</p><p>It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.</p><p>Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.</p></header></section><section><header><h2 id="links-and-references"><a href="#links-and-references" class="anchor"></a>Links and references</h2><p>This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.</p><p>This is a reference to <a href="index.html#val-foo"><code>foo</code></a>. References can have replacement text: <a href="index.html#val-foo"><span>the value foo</span></a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="index.html#val-foo"><span><b>bold</b></span></a>, <a href="index.html#val-foo"><span><i>italic</i></span></a>, <a href="index.html#val-foo"><span><em>emphasis</em></span></a>, <a href="index.html#val-foo"><span>super<sup>script</sup></span></a>, <a href="index.html#val-foo"><span>sub<sub>script</sub></span></a>, and <a href="index.html#val-foo"><span><code>code</code></span></a>. It's also possible to surround a reference in a style: <b><a href="index.html#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.</p></header></section><section><header><h2 id="preformatted-text"><a href="#preformatted-text" class="anchor"></a>Preformatted text</h2><p>This is a code block:</p><pre><code class="ml">let foo = ()
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Markup (test_package+re.Markup)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Markup
+    </nav>
+    <h1>
+     Module <code>Markup</code>
+    </h1>
+    <p>
+     Here, we test the rendering of comment markup.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#sections">Sections</a>
+       <ul>
+        <li>
+         <a href="#subsection-headings">Subsection headings</a>
+         <ul>
+          <li>
+           <a href="#sub-subsection-headings">Sub-subsection headings</a>
+          </li>
+          <li>
+           <a href="#anchors">Anchors</a>
+          </li>
+         </ul>
+        </li>
+       </ul>
+      </li>
+      <li>
+       <a href="#styling">Styling</a>
+      </li>
+      <li>
+       <a href="#links-and-references">Links and references</a>
+      </li>
+      <li>
+       <a href="#preformatted-text">Preformatted text</a>
+      </li>
+      <li>
+       <a href="#lists">Lists</a>
+      </li>
+      <li>
+       <a href="#unicode">Unicode</a>
+      </li>
+      <li>
+       <a href="#raw-html">Raw HTML</a>
+      </li>
+      <li>
+       <a href="#tags">Tags</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="sections">
+      <a href="#sections" class="anchor"></a>Sections
+     </h2>
+     <p>
+      Let's get these done first, because sections will be used to break up the rest of this test.
+     </p>
+     <p>
+      Besides the section heading above, there are also
+     </p>
+    </header>
+    <section>
+     <header>
+      <h3 id="subsection-headings">
+       <a href="#subsection-headings" class="anchor"></a>Subsection headings
+      </h3>
+      <p>
+       and
+      </p>
+     </header>
+     <section>
+      <header>
+       <h4 id="sub-subsection-headings">
+        <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings
+       </h4>
+       <p>
+        but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
+       </p>
+      </header>
+     </section>
+     <section>
+      <header>
+       <h4 id="anchors">
+        <a href="#anchors" class="anchor"></a>Anchors
+       </h4>
+       <p>
+        Sections can have attached <a href="index.html#anchors"><span>Anchors</span></a>, and it is possible to <a href="index.html#anchors"><span>link</span></a> to them. Links to section headers should not be set in source code style.
+       </p>
+      </header>
+     </section>
+    </section>
+   </section>
+   <section>
+    <header>
+     <h2 id="styling">
+      <a href="#styling" class="anchor"></a>Styling
+     </h2>
+     <p>
+      This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em>emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
+     </p>
+     <p>
+      <code>code</code> is a different kind of markup that doesn't allow nested markup.
+     </p>
+     <p>
+      It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.
+     </p>
+     <p>
+      Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.
+     </p>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="links-and-references">
+      <a href="#links-and-references" class="anchor"></a>Links and references
+     </h2>
+     <p>
+      This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
+     </p>
+     <p>
+      This is a reference to <a href="index.html#val-foo"><code>foo</code></a>. References can have replacement text: <a href="index.html#val-foo"><span>the value foo</span></a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="index.html#val-foo"><span><b>bold</b></span></a>, <a href="index.html#val-foo"><span><i>italic</i></span></a>, <a href="index.html#val-foo"><span><em>emphasis</em></span></a>, <a href="index.html#val-foo"><span>super<sup>script</sup></span></a>, <a href="index.html#val-foo"><span>sub<sub>script</sub></span></a>, and <a href="index.html#val-foo"><span><code>code</code></span></a>. It's also possible to surround a reference in a style: <b><a href="index.html#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.
+     </p>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="preformatted-text">
+      <a href="#preformatted-text" class="anchor"></a>Preformatted text
+     </h2>
+     <p>
+      This is a code block:
+     </p>
+     <pre><code class="ml">let foo = ()
 (** There are some nested comments in here, but an unpaired comment
     terminator would terminate the whole doc surrounding comment. It's
     best to keep code blocks no wider than 72 characters. *)
 
 let bar =
-  ignore foo</code></pre><p>There are also verbatim blocks:</p><pre>The main difference is these don't get syntax highlighting.</pre></header></section><section><header><h2 id="lists"><a href="#lists" class="anchor"></a>Lists</h2><ul><li>This is a</li><li>shorthand bulleted list,</li><li>and the paragraphs in each list item support <em>styling</em>.</li></ul><ol><li>This is a</li><li>shorthand numbered list.</li></ol><ul><li>Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break</li></ul><p>just creates a paragraph outside the list.</p><ul><li>Similarly, inserting a blank line between two list items</li></ul><ul><li>creates two separate lists.</li></ul><ul><li><p>To get around this limitation, one</p><p>can use explicitly-delimited lists.</p></li><li>This one is bulleted,</li></ul><ol><li>but there is also the numbered variant.</li></ol><ul><li><ul><li>lists</li><li>can be nested.</li></ul></li></ul></header></section><section><header><h2 id="unicode"><a href="#unicode" class="anchor"></a>Unicode</h2><p>The parser supports any ASCII-compatible encoding, in particuλar UTF-8.</p></header></section><section><header><h2 id="raw-html"><a href="#raw-html" class="anchor"></a>Raw HTML</h2><p>Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.</p>
-    <blockquote>
+  ignore foo</code></pre>
+     <p>
+      There are also verbatim blocks:
+     </p>
+     <pre>The main difference is these don't get syntax highlighting.</pre>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="lists">
+      <a href="#lists" class="anchor"></a>Lists
+     </h2>
+     <ul>
+      <li>
+       This is a
+      </li>
+      <li>
+       shorthand bulleted list,
+      </li>
+      <li>
+       and the paragraphs in each list item support <em>styling</em>.
+      </li>
+     </ul>
+     <ol>
+      <li>
+       This is a
+      </li>
+      <li>
+       shorthand numbered list.
+      </li>
+     </ol>
+     <ul>
+      <li>
+       Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
+      </li>
+     </ul>
+     <p>
+      just creates a paragraph outside the list.
+     </p>
+     <ul>
+      <li>
+       Similarly, inserting a blank line between two list items
+      </li>
+     </ul>
+     <ul>
+      <li>
+       creates two separate lists.
+      </li>
+     </ul>
+     <ul>
+      <li>
+       <p>
+        To get around this limitation, one
+       </p>
+       <p>
+        can use explicitly-delimited lists.
+       </p>
+      </li>
+      <li>
+       This one is bulleted,
+      </li>
+     </ul>
+     <ol>
+      <li>
+       but there is also the numbered variant.
+      </li>
+     </ol>
+     <ul>
+      <li>
+       <ul>
+        <li>
+         lists
+        </li>
+        <li>
+         can be nested.
+        </li>
+       </ul>
+      </li>
+     </ul>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="unicode">
+      <a href="#unicode" class="anchor"></a>Unicode
+     </h2>
+     <p>
+      The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
+     </p>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="raw-html">
+      <a href="#raw-html" class="anchor"></a>Raw HTML
+     </h2>
+     <p>
+      Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
+     </p>
+     <blockquote>
       If the raw HTML is the only thing in a paragraph, it is treated as a block
       element, and won't be wrapped in paragraph tags by the HTML generator.
-    </blockquote>
-    </header></section><section><header><h2 id="tags"><a href="#tags" class="anchor"></a>Tags</h2><p>Each comment can end with zero or more tags. Here are some examples:</p><dl><dt>author</dt><dd>antron</dd></dl><dl><dt>deprecated</dt><dd><p>a <em>long</em> time ago</p></dd></dl><dl><dt>parameter foo</dt><dd><p>unused</p></dd></dl><dl><dt>raises Failure</dt><dd><p>always</p></dd></dl><dl><dt>returns</dt><dd><p>never</p></dd></dl><dl><dt>see <a href="#">#</a></dt><dd><p>this url</p></dd></dl><dl><dt>see <code>foo.ml</code></dt><dd><p>this file</p></dd></dl><dl><dt>see Foo</dt><dd><p>this document</p></dd></dl><dl><dt>since</dt><dd>0</dd></dl><dl><dt>before 1.0</dt><dd><p>it was in b<sup>e</sup>t<sub>a</sub></p></dd></dl><dl><dt>version</dt><dd>-1</dd></dl></header><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code></dt><dd><p>Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.</p></dd></dl></section></div></body></html>
+     </blockquote>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="tags">
+      <a href="#tags" class="anchor"></a>Tags
+     </h2>
+     <p>
+      Each comment can end with zero or more tags. Here are some examples:
+     </p>
+     <dl>
+      <dt>
+       author
+      </dt>
+      <dd>
+       antron
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       deprecated
+      </dt>
+      <dd>
+       <p>
+        a <em>long</em> time ago
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       parameter foo
+      </dt>
+      <dd>
+       <p>
+        unused
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       raises Failure
+      </dt>
+      <dd>
+       <p>
+        always
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       returns
+      </dt>
+      <dd>
+       <p>
+        never
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       see <a href="#">#</a>
+      </dt>
+      <dd>
+       <p>
+        this url
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       see <code>foo.ml</code>
+      </dt>
+      <dd>
+       <p>
+        this file
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       see Foo
+      </dt>
+      <dd>
+       <p>
+        this document
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       since
+      </dt>
+      <dd>
+       0
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       before 1.0
+      </dt>
+      <dd>
+       <p>
+        it was in b<sup>e</sup>t<sub>a</sub>
+       </p>
+      </dd>
+     </dl>
+     <dl>
+      <dt>
+       version
+      </dt>
+      <dd>
+       -1
+      </dd>
+     </dl>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code>
+     </dt>
+     <dd>
+      <p>
+       Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -1,2 +1,77 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Module (test_package+re.Module)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; Module</nav><h1>Module <code>Module</code></h1><p>Foo.</p></header><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code></dt><dd><p>The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.</p></dd></dl><article class="spec module-type" id="module-type-S"><a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code></article><article class="spec module-type" id="module-type-S1"><a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a><span class="keyword">;</span></code></article><article class="spec module-type" id="module-type-S2"><a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code></article><article class="spec module-type" id="module-type-S3"><a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string<span class="keyword">;</span></code></article><article class="spec module-type" id="module-type-S4"><a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int<span class="keyword">;</span></code></article><article class="spec module-type" id="module-type-S5"><a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S5/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>)<span class="keyword">;</span></code></article><dl><dt class="spec type" id="type-result"><a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>result('a, 'b)</code><span class="keyword">;</span></dt></dl><article class="spec module-type" id="module-type-S6"><a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a>(<span class="type-var">'a</span>, <span class="type-var">'b</span>)<span class="keyword">;</span></code></article><article class="spec module" id="module-M'"><a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code></article><article class="spec module-type" id="module-type-S7"><a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code></article><article class="spec module-type" id="module-type-S8"><a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code></article><article class="spec module-type" id="module-type-S9"><a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a><span class="keyword">;</span></code></article></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Module (test_package+re.Module)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Module
+    </nav>
+    <h1>
+     Module <code>Module</code>
+    </h1>
+    <p>
+     Foo.
+    </p>
+   </header>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code>
+    </dt>
+    <dd>
+     <p>
+      The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.
+     </p>
+    </dd>
+   </dl>
+   <article class="spec module-type" id="module-type-S">
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S1">
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S2">
+    <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S3">
+    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string<span class="keyword">;</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S4">
+    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int<span class="keyword">;</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S5">
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S5/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>)<span class="keyword">;</span></code>
+   </article>
+   <dl>
+    <dt class="spec type" id="type-result">
+     <a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>result('a, 'b)</code><span class="keyword">;</span>
+    </dt>
+   </dl>
+   <article class="spec module-type" id="module-type-S6">
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)<span class="keyword">;</span></code>
+   </article>
+   <article class="spec module" id="module-M'">
+    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S7">
+    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S8">
+    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
+   </article>
+   <article class="spec module-type" id="module-type-S9">
+    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
+   </article>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Section/index.html
+++ b/test/html/expect/test_package+re/Section/index.html
@@ -1,2 +1,131 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Section (test_package+re.Section)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; Section</nav><h1>Module <code>Section</code></h1><p>This is the module comment. Eventually, sections won't be allowed in it.</p><nav class="toc"><ul><li><a href="#empty-section">Empty section</a></li><li><a href="#text-only">Text only</a></li><li><a href="#aside-only">Aside only</a></li><li><a href="#value-only">Value only</a></li><li><a href="#empty-section">Empty section</a></li><li><a href="#within-a-comment">within a comment</a><ul><li><a href="#and-one-with-a-nested-section">and one with a nested section</a></li></ul></li><li><a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a></li></ul></nav></header><section><header><h2 id="empty-section"><a href="#empty-section" class="anchor"></a>Empty section</h2></header></section><section><header><h2 id="text-only"><a href="#text-only" class="anchor"></a>Text only</h2><p>Foo bar.</p></header></section><section><header><h2 id="aside-only"><a href="#aside-only" class="anchor"></a>Aside only</h2></header><aside><p>Foo bar.</p></aside></section><section><header><h2 id="value-only"><a href="#value-only" class="anchor"></a>Value only</h2></header><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code></dt></dl></section><section><header><h2 id="empty-section"><a href="#empty-section" class="anchor"></a>Empty section</h2></header></section><section><header><h2 id="within-a-comment"><a href="#within-a-comment" class="anchor"></a>within a comment</h2></header><section><header><h3 id="and-one-with-a-nested-section"><a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section</h3></header></section></section><section><header><h2 id="this-section-title-has-markup"><a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></h2><p>But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.</p></header></section></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Section (test_package+re.Section)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Section
+    </nav>
+    <h1>
+     Module <code>Section</code>
+    </h1>
+    <p>
+     This is the module comment. Eventually, sections won't be allowed in it.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#empty-section">Empty section</a>
+      </li>
+      <li>
+       <a href="#text-only">Text only</a>
+      </li>
+      <li>
+       <a href="#aside-only">Aside only</a>
+      </li>
+      <li>
+       <a href="#value-only">Value only</a>
+      </li>
+      <li>
+       <a href="#empty-section">Empty section</a>
+      </li>
+      <li>
+       <a href="#within-a-comment">within a comment</a>
+       <ul>
+        <li>
+         <a href="#and-one-with-a-nested-section">and one with a nested section</a>
+        </li>
+       </ul>
+      </li>
+      <li>
+       <a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="empty-section">
+      <a href="#empty-section" class="anchor"></a>Empty section
+     </h2>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="text-only">
+      <a href="#text-only" class="anchor"></a>Text only
+     </h2>
+     <p>
+      Foo bar.
+     </p>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="aside-only">
+      <a href="#aside-only" class="anchor"></a>Aside only
+     </h2>
+    </header>
+    <aside>
+     <p>
+      Foo bar.
+     </p>
+    </aside>
+   </section>
+   <section>
+    <header>
+     <h2 id="value-only">
+      <a href="#value-only" class="anchor"></a>Value only
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code>
+     </dt>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="empty-section">
+      <a href="#empty-section" class="anchor"></a>Empty section
+     </h2>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="within-a-comment">
+      <a href="#within-a-comment" class="anchor"></a>within a comment
+     </h2>
+    </header>
+    <section>
+     <header>
+      <h3 id="and-one-with-a-nested-section">
+       <a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section
+      </h3>
+     </header>
+    </section>
+   </section>
+   <section>
+    <header>
+     <h2 id="this-section-title-has-markup">
+      <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
+     </h2>
+     <p>
+      But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+     </p>
+    </header>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Stop/index.html
+++ b/test/html/expect/test_package+re/Stop/index.html
@@ -1,2 +1,60 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Stop (test_package+re.Stop)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; Stop</nav><h1>Module <code>Stop</code></h1><p>This test cases exercises stop comments.</p></header><dl><dt class="spec value" id="val-foo"><a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : int<span class="keyword">;</span></code></dt><dd><p>This is normal commented text.</p></dd></dl><aside><p>The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.</p></aside><aside><p>Documentation is on again.</p><p>Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.</p></aside><article class="spec module" id="module-N"><a href="#module-N" class="anchor"></a><code><span class="keyword">module </span><a href="N/index.html">N</a> : <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code></article><dl><dt class="spec value" id="val-lol"><a href="#val-lol" class="anchor"></a><code><span class="keyword">let </span>lol : int<span class="keyword">;</span></code></dt></dl></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Stop (test_package+re.Stop)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Stop
+    </nav>
+    <h1>
+     Module <code>Stop</code>
+    </h1>
+    <p>
+     This test cases exercises stop comments.
+    </p>
+   </header>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : int<span class="keyword">;</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is normal commented text.
+     </p>
+    </dd>
+   </dl>
+   <aside>
+    <p>
+     The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
+    </p>
+   </aside>
+   <aside>
+    <p>
+     Documentation is on again.
+    </p>
+    <p>
+     Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
+    </p>
+   </aside>
+   <article class="spec module" id="module-N">
+    <a href="#module-N" class="anchor"></a><code><span class="keyword">module </span><a href="N/index.html">N</a> : <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+   </article>
+   <dl>
+    <dt class="spec value" id="val-lol">
+     <a href="#val-lol" class="anchor"></a><code><span class="keyword">let </span>lol : int<span class="keyword">;</span></code>
+    </dt>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -1,2 +1,372 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Type (test_package+re.Type)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; Type</nav><h1>Module <code>Type</code></h1></header><dl><dt class="spec type" id="type-abstract"><a href="#type-abstract" class="anchor"></a><code><span class="keyword">type </span>abstract</code><span class="keyword">;</span></dt><dd><p>Some <em>documentation</em>.</p></dd></dl><dl><dt class="spec type" id="type-alias"><a href="#type-alias" class="anchor"></a><code><span class="keyword">type </span>alias</code><code><span class="keyword"> = </span>int</code><span class="keyword">;</span></dt><dt class="spec type" id="type-private_"><a href="#type-private_" class="anchor"></a><code><span class="keyword">type </span>private_</code><code><span class="keyword"> = </span><span class="keyword">pri </span>int</code><span class="keyword">;</span></dt><dt class="spec type" id="type-constructor"><a href="#type-constructor" class="anchor"></a><code><span class="keyword">type </span>constructor('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><span class="keyword">;</span></dt><dt class="spec type" id="type-arrow"><a href="#type-arrow" class="anchor"></a><code><span class="keyword">type </span>arrow</code><code><span class="keyword"> = </span>int <span>=&gt;</span> int</code><span class="keyword">;</span></dt><dt class="spec type" id="type-higher_order"><a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type </span>higher_order</code><code><span class="keyword"> = </span>(int <span>=&gt;</span> int) <span>=&gt;</span> int</code><span class="keyword">;</span></dt><dt class="spec type" id="type-labeled"><a href="#type-labeled" class="anchor"></a><code><span class="keyword">type </span>labeled</code><code><span class="keyword"> = </span>l:int <span>=&gt;</span> int</code><span class="keyword">;</span></dt><dt class="spec type" id="type-optional"><a href="#type-optional" class="anchor"></a><code><span class="keyword">type </span>optional</code><code><span class="keyword"> = </span>?&#8288;l:int <span>=&gt;</span> int</code><span class="keyword">;</span></dt><dt class="spec type" id="type-labeled_higher_order"><a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type </span>labeled_higher_order</code><code><span class="keyword"> = </span>(l:int <span>=&gt;</span> int) <span>=&gt;</span> (?&#8288;l:int <span>=&gt;</span> int) <span>=&gt;</span> int</code><span class="keyword">;</span></dt><dt class="spec type" id="type-pair"><a href="#type-pair" class="anchor"></a><code><span class="keyword">type </span>pair</code><code><span class="keyword"> = </span>(int<span class="keyword">, </span>int)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-parens_dropped"><a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type </span>parens_dropped</code><code><span class="keyword"> = </span>(int<span class="keyword">, </span>int)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-triple"><a href="#type-triple" class="anchor"></a><code><span class="keyword">type </span>triple</code><code><span class="keyword"> = </span>(int<span class="keyword">, </span>int<span class="keyword">, </span>int)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-nested_pair"><a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type </span>nested_pair</code><code><span class="keyword"> = </span>((int<span class="keyword">, </span>int)<span class="keyword">, </span>int)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-instance"><a href="#type-instance" class="anchor"></a><code><span class="keyword">type </span>instance</code><code><span class="keyword"> = </span><a href="index.html#type-constructor">constructor</a>(int)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-variant_e"><a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type </span>variant_e</code><code><span class="keyword"> = </span></code><code>{</code><table class="record"><tr id="type-variant_e.a" class="anchored"><td class="def field"><a href="#type-variant_e.a" class="anchor"></a><code>a : int,</code></td></tr></table><code>}</code><span class="keyword">;</span></dt><dt class="spec type" id="type-variant"><a href="#type-variant" class="anchor"></a><code><span class="keyword">type </span>variant</code><code><span class="keyword"> = </span></code><table class="variant"><tr id="type-variant.A" class="anchored"><td class="def constructor"><a href="#type-variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code></td></tr><tr id="type-variant.B" class="anchored"><td class="def constructor"><a href="#type-variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span>(int)</code></td></tr><tr id="type-variant.C" class="anchored"><td class="def constructor"><a href="#type-variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span></code></td><td class="doc"><p>foo</p></td></tr><tr id="type-variant.D" class="anchored"><td class="def constructor"><a href="#type-variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">D</span></code></td><td class="doc"><p><em>bar</em></p></td></tr><tr id="type-variant.E" class="anchored"><td class="def constructor"><a href="#type-variant.E" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">E</span>(<a href="index.html#type-variant_e">variant_e</a>)</code></td></tr></table><span class="keyword">;</span></dt><dt class="spec type" id="type-variant_c"><a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type </span>variant_c</code><code><span class="keyword"> = </span></code><code>{</code><table class="record"><tr id="type-variant_c.a" class="anchored"><td class="def field"><a href="#type-variant_c.a" class="anchor"></a><code>a : int,</code></td></tr></table><code>}</code><span class="keyword">;</span></dt><dt class="spec type" id="type-gadt"><a href="#type-gadt" class="anchor"></a><code><span class="keyword">type </span>gadt(_)</code><code><span class="keyword"> = </span></code><table class="variant"><tr id="type-gadt.A" class="anchored"><td class="def constructor"><a href="#type-gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> <a href="index.html#type-gadt">gadt</a>(int)</code></td></tr><tr id="type-gadt.B" class="anchored"><td class="def constructor"><a href="#type-gadt.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span>(int) : <a href="index.html#type-gadt">gadt</a>(string)</code></td></tr><tr id="type-gadt.C" class="anchored"><td class="def constructor"><a href="#type-gadt.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span>(<a href="index.html#type-variant_c">variant_c</a>) : <a href="index.html#type-gadt">gadt</a>(unit)</code></td></tr></table><span class="keyword">;</span></dt><dt class="spec type" id="type-degenerate_gadt"><a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type </span>degenerate_gadt</code><code><span class="keyword"> = </span></code><table class="variant"><tr id="type-degenerate_gadt.A" class="anchored"><td class="def constructor"><a href="#type-degenerate_gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code></td></tr></table><span class="keyword">;</span></dt><dt class="spec type" id="type-private_variant"><a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type </span>private_variant</code><code><span class="keyword"> = </span><span class="keyword">pri </span></code><table class="variant"><tr id="type-private_variant.A" class="anchored"><td class="def constructor"><a href="#type-private_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code></td></tr></table><span class="keyword">;</span></dt><dt class="spec type" id="type-record"><a href="#type-record" class="anchor"></a><code><span class="keyword">type </span>record</code><code><span class="keyword"> = </span></code><code>{</code><table class="record"><tr id="type-record.a" class="anchored"><td class="def field"><a href="#type-record.a" class="anchor"></a><code>a : int,</code></td></tr><tr id="type-record.b" class="anchored"><td class="def field"><a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable </span>b : int,</code></td></tr><tr id="type-record.c" class="anchored"><td class="def field"><a href="#type-record.c" class="anchor"></a><code>c : int,</code></td><td class="doc"><p>foo</p></td></tr><tr id="type-record.d" class="anchored"><td class="def field"><a href="#type-record.d" class="anchor"></a><code>d : int,</code></td><td class="doc"><p><em>bar</em></p></td></tr><tr id="type-record.e" class="anchored"><td class="def field"><a href="#type-record.e" class="anchor"></a><code>e : a. <span class="type-var">'a</span>,</code></td></tr></table><code>}</code><span class="keyword">;</span></dt><dt class="spec type" id="type-polymorphic_variant"><a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant</code><span class="keyword"> = </span><code>[ </code><table class="variant"><tr id="type-polymorphic_variant.A" class="anchored"><td class="def constructor"><a href="#type-polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A</code></td></tr><tr id="type-polymorphic_variant.B" class="anchored"><td class="def constructor"><a href="#type-polymorphic_variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code>`B(int)</code></td></tr><tr id="type-polymorphic_variant.C" class="anchored"><td class="def constructor"><a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C</code></td></tr><tr id="type-polymorphic_variant.D" class="anchored"><td class="def constructor"><a href="#type-polymorphic_variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code>`D</code></td></tr></table><code> ]</code><span class="keyword">;</span></dt><dt class="spec type" id="type-polymorphic_variant_extension"><a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant_extension</code><span class="keyword"> = </span><code>[ </code><table class="variant"><tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored"><td class="def type"><a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span class="keyword">| </span></code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code></td></tr><tr id="type-polymorphic_variant_extension.E" class="anchored"><td class="def constructor"><a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span class="keyword">| </span></code><code>`E</code></td></tr></table><code> ]</code><span class="keyword">;</span></dt><dt class="spec type" id="type-nested_polymorphic_variant"><a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>nested_polymorphic_variant</code><span class="keyword"> = </span><code>[ </code><table class="variant"><tr id="type-nested_polymorphic_variant.A" class="anchored"><td class="def constructor"><a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A([ `B<span class="keyword"> | </span>`C ])</code></td></tr></table><code> ]</code><span class="keyword">;</span></dt><dt class="spec type" id="type-object_"><a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>{. a : int, b : int, c : int, }</code><span class="keyword">;</span></dt></dl><article class="spec module-type" id="module-type-X"><a href="#module-type-X" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-X/index.html">X</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code></article><dl><dt class="spec type" id="type-module_"><a href="#type-module_" class="anchor"></a><code><span class="keyword">type </span>module_</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a>)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-module_substitution"><a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type </span>module_substitution</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type </span><a href="module-type-X/index.html#type-t">t</a> <span class="keyword">=</span> int)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-covariant"><a href="#type-covariant" class="anchor"></a><code><span class="keyword">type </span>covariant(+'a)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-contravariant"><a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type </span>contravariant(-'a)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-bivariant"><a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type </span>bivariant(_)</code><code><span class="keyword"> = </span>int</code><span class="keyword">;</span></dt><dt class="spec type" id="type-binary"><a href="#type-binary" class="anchor"></a><code><span class="keyword">type </span>binary('a, 'b)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-using_binary"><a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type </span>using_binary</code><code><span class="keyword"> = </span><a href="index.html#type-binary">binary</a>(int, int)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-name"><a href="#type-name" class="anchor"></a><code><span class="keyword">type </span>name('custom)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-constrained"><a href="#type-constrained" class="anchor"></a><code><span class="keyword">type </span>constrained('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = int</code><span class="keyword">;</span></dt><dt class="spec type" id="type-exact_variant"><a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type </span>exact_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [ `A<span class="keyword"> | </span>`B(int) ]</code><span class="keyword">;</span></dt><dt class="spec type" id="type-lower_variant"><a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type </span>lower_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt; `A<span class="keyword"> | </span>`B(int) ]</code><span class="keyword">;</span></dt><dt class="spec type" id="type-any_variant"><a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type </span>any_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt;  ]</code><span class="keyword">;</span></dt><dt class="spec type" id="type-upper_variant"><a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type </span>upper_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; `A<span class="keyword"> | </span>`B(int) ]</code><span class="keyword">;</span></dt><dt class="spec type" id="type-named_variant"><a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type </span>named_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code><span class="keyword">;</span></dt><dt class="spec type" id="type-exact_object"><a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type </span>exact_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a : int, b : int, }</code><span class="keyword">;</span></dt><dt class="spec type" id="type-lower_object"><a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type </span>lower_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {.. a : int, b : int, }</code><span class="keyword">;</span></dt><dt class="spec type" id="type-poly_object"><a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type </span>poly_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a : a. <span class="type-var">'a</span>, }</code><span class="keyword">;</span></dt><dt class="spec type" id="type-as_"><a href="#type-as_" class="anchor"></a><code><span class="keyword">type </span>as_</code><code><span class="keyword"> = </span>(int<span class="keyword"> as </span>a<span class="keyword">, </span><span class="type-var">'a</span>)</code><span class="keyword">;</span></dt><dt class="spec type" id="type-extensible"><a href="#type-extensible" class="anchor"></a><code><span class="keyword">type </span>extensible</code><code><span class="keyword"> = </span></code><code><span class="keyword">..</span></code><span class="keyword">;</span></dt></dl><dl><dt><code><span class="keyword">type </span><a href="index.html#type-extensible">extensible</a><span class="keyword"> += </span></code><code><span class="extension">Extension</span></code><span class="keyword">;</span></dt></dl><dl><dt class="spec exception" id="exception-Foo"><a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception </span></code><code><span class="exception">Foo</span>(int<span class="keyword">, </span>int)</code><span class="keyword">;</span></dt></dl></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Type (test_package+re.Type)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Type
+    </nav>
+    <h1>
+     Module <code>Type</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec type" id="type-abstract">
+     <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type </span>abstract</code><span class="keyword">;</span>
+    </dt>
+    <dd>
+     <p>
+      Some <em>documentation</em>.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec type" id="type-alias">
+     <a href="#type-alias" class="anchor"></a><code><span class="keyword">type </span>alias</code><code><span class="keyword"> = </span>int</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-private_">
+     <a href="#type-private_" class="anchor"></a><code><span class="keyword">type </span>private_</code><code><span class="keyword"> = </span><span class="keyword">pri </span>int</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-constructor">
+     <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type </span>constructor('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-arrow">
+     <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type </span>arrow</code><code><span class="keyword"> = </span>int <span>=&gt;</span> int</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-higher_order">
+     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type </span>higher_order</code><code><span class="keyword"> = </span>(int <span>=&gt;</span> int) <span>=&gt;</span> int</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-labeled">
+     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type </span>labeled</code><code><span class="keyword"> = </span>l:int <span>=&gt;</span> int</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-optional">
+     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type </span>optional</code><code><span class="keyword"> = </span>?⁠l:int <span>=&gt;</span> int</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-labeled_higher_order">
+     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type </span>labeled_higher_order</code><code><span class="keyword"> = </span>(l:int <span>=&gt;</span> int) <span>=&gt;</span> (?⁠l:int <span>=&gt;</span> int) <span>=&gt;</span> int</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-pair">
+     <a href="#type-pair" class="anchor"></a><code><span class="keyword">type </span>pair</code><code><span class="keyword"> = </span>(int<span class="keyword">, </span>int)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-parens_dropped">
+     <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type </span>parens_dropped</code><code><span class="keyword"> = </span>(int<span class="keyword">, </span>int)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-triple">
+     <a href="#type-triple" class="anchor"></a><code><span class="keyword">type </span>triple</code><code><span class="keyword"> = </span>(int<span class="keyword">, </span>int<span class="keyword">, </span>int)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-nested_pair">
+     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type </span>nested_pair</code><code><span class="keyword"> = </span>((int<span class="keyword">, </span>int)<span class="keyword">, </span>int)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-instance">
+     <a href="#type-instance" class="anchor"></a><code><span class="keyword">type </span>instance</code><code><span class="keyword"> = </span><a href="index.html#type-constructor">constructor</a>(int)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-variant_e">
+     <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type </span>variant_e</code><code><span class="keyword"> = </span></code><code>{</code>
+     <table class="record">
+      <tbody>
+       <tr id="type-variant_e.a" class="anchored">
+        <td class="def field">
+         <a href="#type-variant_e.a" class="anchor"></a><code>a : int,</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code>}</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-variant">
+     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type </span>variant</code><code><span class="keyword"> = </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code>
+        </td>
+       </tr>
+       <tr id="type-variant.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span>(int)</code>
+        </td>
+       </tr>
+       <tr id="type-variant.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.D" class="anchored">
+        <td class="def constructor">
+         <a href="#type-variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">D</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <em>bar</em>
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.E" class="anchored">
+        <td class="def constructor">
+         <a href="#type-variant.E" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">E</span>(<a href="index.html#type-variant_e">variant_e</a>)</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-variant_c">
+     <a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type </span>variant_c</code><code><span class="keyword"> = </span></code><code>{</code>
+     <table class="record">
+      <tbody>
+       <tr id="type-variant_c.a" class="anchored">
+        <td class="def field">
+         <a href="#type-variant_c.a" class="anchor"></a><code>a : int,</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code>}</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-gadt">
+     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type </span>gadt(_)</code><code><span class="keyword"> = </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-gadt.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> <a href="index.html#type-gadt">gadt</a>(int)</code>
+        </td>
+       </tr>
+       <tr id="type-gadt.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-gadt.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span>(int) : <a href="index.html#type-gadt">gadt</a>(string)</code>
+        </td>
+       </tr>
+       <tr id="type-gadt.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-gadt.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span>(<a href="index.html#type-variant_c">variant_c</a>) : <a href="index.html#type-gadt">gadt</a>(unit)</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-degenerate_gadt">
+     <a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type </span>degenerate_gadt</code><code><span class="keyword"> = </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-degenerate_gadt.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-private_variant">
+     <a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type </span>private_variant</code><code><span class="keyword"> = </span><span class="keyword">pri </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-private_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-private_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-record">
+     <a href="#type-record" class="anchor"></a><code><span class="keyword">type </span>record</code><code><span class="keyword"> = </span></code><code>{</code>
+     <table class="record">
+      <tbody>
+       <tr id="type-record.a" class="anchored">
+        <td class="def field">
+         <a href="#type-record.a" class="anchor"></a><code>a : int,</code>
+        </td>
+       </tr>
+       <tr id="type-record.b" class="anchored">
+        <td class="def field">
+         <a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable </span>b : int,</code>
+        </td>
+       </tr>
+       <tr id="type-record.c" class="anchored">
+        <td class="def field">
+         <a href="#type-record.c" class="anchor"></a><code>c : int,</code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-record.d" class="anchored">
+        <td class="def field">
+         <a href="#type-record.d" class="anchor"></a><code>d : int,</code>
+        </td>
+        <td class="doc">
+         <p>
+          <em>bar</em>
+         </p>
+        </td>
+       </tr>
+       <tr id="type-record.e" class="anchored">
+        <td class="def field">
+         <a href="#type-record.e" class="anchor"></a><code>e : a. <span class="type-var">'a</span>,</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code>}</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-polymorphic_variant">
+     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant</code><span class="keyword"> = </span><code>[ </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-polymorphic_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A</code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code>`B(int)</code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C</code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.D" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code>`D</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code> ]</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-polymorphic_variant_extension">
+     <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant_extension</code><span class="keyword"> = </span><code>[ </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
+        <td class="def type">
+         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span class="keyword">| </span></code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant_extension.E" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span class="keyword">| </span></code><code>`E</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code> ]</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-nested_polymorphic_variant">
+     <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>nested_polymorphic_variant</code><span class="keyword"> = </span><code>[ </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-nested_polymorphic_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A([ `B<span class="keyword"> | </span>`C ])</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code> ]</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-object_">
+     <a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>{. a : int, b : int, c : int, }</code><span class="keyword">;</span>
+    </dt>
+   </dl>
+   <article class="spec module-type" id="module-type-X">
+    <a href="#module-type-X" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-X/index.html">X</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+   </article>
+   <dl>
+    <dt class="spec type" id="type-module_">
+     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type </span>module_</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a>)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-module_substitution">
+     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type </span>module_substitution</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type </span><a href="module-type-X/index.html#type-t">t</a> <span class="keyword">=</span> int)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-covariant">
+     <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type </span>covariant(+'a)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-contravariant">
+     <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type </span>contravariant(-'a)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-bivariant">
+     <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type </span>bivariant(_)</code><code><span class="keyword"> = </span>int</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-binary">
+     <a href="#type-binary" class="anchor"></a><code><span class="keyword">type </span>binary('a, 'b)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-using_binary">
+     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type </span>using_binary</code><code><span class="keyword"> = </span><a href="index.html#type-binary">binary</a>(int,&nbsp;int)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-name">
+     <a href="#type-name" class="anchor"></a><code><span class="keyword">type </span>name('custom)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-constrained">
+     <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type </span>constrained('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = int</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-exact_variant">
+     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type </span>exact_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [ `A<span class="keyword"> | </span>`B(int) ]</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-lower_variant">
+     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type </span>lower_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt; `A<span class="keyword"> | </span>`B(int) ]</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-any_variant">
+     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type </span>any_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt;  ]</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-upper_variant">
+     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type </span>upper_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; `A<span class="keyword"> | </span>`B(int) ]</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-named_variant">
+     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type </span>named_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-exact_object">
+     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type </span>exact_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a : int, b : int, }</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-lower_object">
+     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type </span>lower_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {.. a : int, b : int, }</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-poly_object">
+     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type </span>poly_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a : a. <span class="type-var">'a</span>, }</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-as_">
+     <a href="#type-as_" class="anchor"></a><code><span class="keyword">type </span>as_</code><code><span class="keyword"> = </span>(int<span class="keyword"> as </span>a<span class="keyword">, </span><span class="type-var">'a</span>)</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-extensible">
+     <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type </span>extensible</code><code><span class="keyword"> = </span></code><code><span class="keyword">..</span></code><span class="keyword">;</span>
+    </dt>
+   </dl>
+   <dl>
+    <dt>
+     <code><span class="keyword">type </span><a href="index.html#type-extensible">extensible</a><span class="keyword"> += </span></code><code><span class="extension">Extension</span></code><span class="keyword">;</span>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec exception" id="exception-Foo">
+     <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception </span></code><code><span class="exception">Foo</span>(int<span class="keyword">, </span>int)</code><span class="keyword">;</span>
+    </dt>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Val/index.html
+++ b/test/html/expect/test_package+re/Val/index.html
@@ -1,2 +1,49 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Val (test_package+re.Val)</title><link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; Val</nav><h1>Module <code>Val</code></h1></header><dl><dt class="spec value" id="val-documented"><a href="#val-documented" class="anchor"></a><code><span class="keyword">let </span>documented : unit<span class="keyword">;</span></code></dt><dd><p>Foo.</p></dd></dl><dl><dt class="spec value" id="val-undocumented"><a href="#val-undocumented" class="anchor"></a><code><span class="keyword">let </span>undocumented : unit<span class="keyword">;</span></code></dt><dt class="spec value" id="val-documented_above"><a href="#val-documented_above" class="anchor"></a><code><span class="keyword">let </span>documented_above : unit<span class="keyword">;</span></code></dt><dd><p>Bar.</p></dd></dl></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Val (test_package+re.Val)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Val
+    </nav>
+    <h1>
+     Module <code>Val</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec value" id="val-documented">
+     <a href="#val-documented" class="anchor"></a><code><span class="keyword">let </span>documented : unit<span class="keyword">;</span></code>
+    </dt>
+    <dd>
+     <p>
+      Foo.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-undocumented">
+     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">let </span>undocumented : unit<span class="keyword">;</span></code>
+    </dt>
+    <dt class="spec value" id="val-documented_above">
+     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">let </span>documented_above : unit<span class="keyword">;</span></code>
+    </dt>
+    <dd>
+     <p>
+      Bar.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/mld.html
+++ b/test/html/expect/test_package+re/mld.html
@@ -1,2 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><head><title>mld (test_package+re.mld)</title><link rel="stylesheet" href="../odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><script src="../highlight.pack.js"></script><script>hljs.initHighlightingOnLoad();</script></head><body><div class="content"><header><nav><a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> &#x00BB; mld</nav></header><p>This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.</p><p>The whole thing is <b>written</b> <i>in</i><sup>ocamldoc</sup><sub>syntax</sub>.</p></div></body></html>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   mld (test_package+re.mld)
+  </title>
+  <link rel="stylesheet" href="../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » mld
+    </nav>
+   </header>
+   <p>
+    This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
+   </p>
+   <p>
+    The whole thing is <b>written</b> <i>in</i><sup>ocamldoc</sup><sub>syntax</sub>.
+   </p>
+  </div>
+ </body>
+</html>


### PR DESCRIPTION
This requires pinning `markup` and `tyxml` for now:

```
opam pin add --dev-repo markup
opam pin add --dev-repo tyxml
```

The TyXML pin is needed because of a depopt from released of TyXML on Markup.ml. There is a breaking change in Markup.ml (I added the `` `Raw`` signal), but only the TyXML PPX depends on Markup.ml, and we don't use the PPX. cc @Drup.

cc @ostera, @rizo

Resolves #187.
