### PR TITLE
Support references in Lists

### DIFF
--- a/src/model/maps.ml
+++ b/src/model/maps.ml
@@ -892,6 +892,12 @@ class virtual documentation = object (self)
         (list_map (Location_.map self#documentation_inline_element) elements)
     | `Modules modules ->
       `Modules (List.map self#documentation_special_modules modules)
+    | `List (tag, elements) ->
+        `List (tag,
+          (List.map
+            (List.map
+              (Location_.map self#documentation_nestable_block_element))
+            elements))
     | element ->
       element
 

--- a/test/html/cases/markup.mli
+++ b/test/html/cases/markup.mli
@@ -114,7 +114,9 @@ v}
       {li
         {ul
           {li lists}
-          {li can be nested.}}}}
+          {li can be nested}
+          {li and can include references}
+          {li {!foo}}}}}
 
 
     {2 Unicode}

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -228,7 +228,13 @@ let bar =
          lists
         </li>
         <li>
-         can be nested.
+         can be nested
+        </li>
+        <li>
+         and can include references
+        </li>
+        <li>
+         <a href="index.html#val-foo"><code>foo</code></a>
         </li>
        </ul>
       </li>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -228,7 +228,13 @@ let bar =
          lists
         </li>
         <li>
-         can be nested.
+         can be nested
+        </li>
+        <li>
+         and can include references
+        </li>
+        <li>
+         <a href="index.html#val-foo"><code>foo</code></a>
         </li>
        </ul>
       </li>


### PR DESCRIPTION
This will recurse into List tags, but will only allow for reference links on:

-> Paragraphs
-> Modules
-> Lists

Code blocks and Verbatim tags will not be recursed since they only contain a `string`.

Should close #202.