### PR TITLE
Fix all label separators in Reason syntax

### DIFF
--- a/src/html/html_generator.ml
+++ b/src/html/html_generator.ml
@@ -109,8 +109,6 @@ module type Syntax = sig
 
     module Record : sig
       val field_separator : string
-
-      val label_value_separator : string
     end
 
     val var_prefix : string
@@ -461,7 +459,7 @@ struct
             ; Html.code (
                 (if mutable_ then Markup.keyword "mutable " else Html.pcdata "")
                 :: (Html.pcdata name)
-                :: (Html.pcdata Syn.Type.Record.label_value_separator)
+                :: (Html.pcdata Syn.label_separator)
                 :: (type_expr typ)
                 @  [Html.pcdata Syn.Type.Record.field_separator]
               )

--- a/src/html/html_generator.ml
+++ b/src/html/html_generator.ml
@@ -64,7 +64,7 @@ type toc = section list
 
 module type Syntax = sig
 
-  val label_separator : string
+  val separator : string
 
   module Obj : sig
     val close_tag_closed : string
@@ -298,7 +298,7 @@ struct
     let fields =
       list_concat_map t.fields ~f:(function
         | Model.Lang.TypeExpr.Object.Method {name; type_} ->
-            (Html.pcdata (name ^ Syn.label_separator) :: type_expr type_)
+            (Html.pcdata (name ^ Syn.separator) :: type_expr type_)
             @ [Html.pcdata Syn.Obj.field_separator]
         | Inherit type_ ->
             type_expr type_ @ [Html.pcdata Syn.Obj.field_separator] )
@@ -459,7 +459,7 @@ struct
             ; Html.code (
                 (if mutable_ then Markup.keyword "mutable " else Html.pcdata "")
                 :: (Html.pcdata name)
-                :: (Html.pcdata Syn.label_separator)
+                :: (Html.pcdata Syn.separator)
                 :: (type_expr typ)
                 @  [Html.pcdata Syn.Type.Record.field_separator]
               )
@@ -527,13 +527,13 @@ struct
               if Syn.Type.Variant.parenthesize_params
               then Html.pcdata "(" :: params @ [ Html.pcdata ")" ]
               else
-                Markup.keyword (if is_gadt then Syn.label_separator else " of ") :: params
+                Markup.keyword (if is_gadt then Syn.separator else " of ") :: params
             )
             @ ret_type
           )
         ]
       | Record fields ->
-        Html.code [ cstr; Markup.keyword (if is_gadt then Syn.label_separator else " of ") ]
+        Html.code [ cstr; Markup.keyword (if is_gadt then Syn.separator else " of ") ]
         :: record fields
         @ [ Html.code ret_type ]
 
@@ -781,7 +781,7 @@ struct
     let value =
       Markup.keyword (Syn.Value.variable_keyword ^ " ") ::
       Html.pcdata name ::
-      Html.pcdata Syn.label_separator ::
+      Html.pcdata Syn.separator ::
       type_expr t.type_
       @ ( if Syn.Value.semicolon then [ Markup.keyword ";" ] else [] )
     in
@@ -792,7 +792,7 @@ struct
     let external_ =
       Markup.keyword "external " ::
       Html.pcdata name ::
-      Html.pcdata Syn.label_separator ::
+      Html.pcdata Syn.separator ::
       type_expr t.type_ @
       Html.pcdata " = " ::
       Syn.Type.External.handle_primitives t.primitives
@@ -1250,7 +1250,7 @@ struct
       private_ ::
       virtual_ ::
       Html.pcdata name ::
-      Html.pcdata Syn.label_separator ::
+      Html.pcdata Syn.separator ::
       type_expr t.type_
     in
     [Html.code method_], t.doc
@@ -1266,7 +1266,7 @@ struct
       mutable_ ::
       virtual_ ::
       Html.pcdata name ::
-      Html.pcdata Syn.label_separator ::
+      Html.pcdata Syn.separator ::
       type_expr t.type_
     in
     [Html.code val_], t.doc
@@ -1325,7 +1325,7 @@ struct
       virtual_ ::
       params ::
       cname ::
-      Html.pcdata Syn.label_separator ::
+      Html.pcdata Syn.separator ::
       cd
     in
     let region =
@@ -1464,7 +1464,7 @@ struct
       | None ->
         (
           Html.pcdata (Paths.Identifier.name arg.id) ::
-          Html.pcdata Syn.label_separator ::
+          Html.pcdata Syn.separator ::
           mty (Paths.Identifier.signature_of_module arg.id) arg.expr
         ), []
       | Some expansion ->
@@ -1483,7 +1483,7 @@ struct
         Html_tree.leave ();
         (
           Html.a ~a:[ a_href ~kind:`Arg link_name ] [Html.pcdata name] ::
-          Html.pcdata Syn.label_separator ::
+          Html.pcdata Syn.separator ::
           mty (Paths.Identifier.signature_of_module arg.id) arg.expr
         ), [subtree]
     in
@@ -1567,7 +1567,7 @@ struct
   and module_decl (base : Paths.Identifier.signature) md =
     begin match md with
     | Alias _ -> Html.pcdata " = "
-    | ModuleType _ -> Html.pcdata Syn.label_separator
+    | ModuleType _ -> Html.pcdata Syn.separator
     end ::
     module_decl' base md
 
@@ -1602,7 +1602,7 @@ struct
         begin match expr with
         | Signature _
         | Path _ -> Html.pcdata " = "
-        | _ -> Html.pcdata Syn.label_separator
+        | _ -> Html.pcdata Syn.separator
         end ::
         mty (Paths.Identifier.signature_of_module_type t.id) expr
     in
@@ -1670,7 +1670,7 @@ struct
         | href -> Html.a ~a:[ Html.a_href href ] [ to_print ]
       in
       ( if Syn.Mod.functor_keyword then [ Markup.keyword "functor" ] else [] ) @
-      Html.pcdata " (" :: name :: Html.pcdata Syn.label_separator ::
+      Html.pcdata " (" :: name :: Html.pcdata Syn.separator ::
       mty base arg.expr @
       [Html.pcdata ")"; Html.pcdata " "] @ Syn.Type.arrow :: Html.pcdata " " ::
       mty base expr

--- a/src/html/html_generator.ml
+++ b/src/html/html_generator.ml
@@ -63,6 +63,9 @@ type toc = section list
 
 
 module type Syntax = sig
+
+  val label_separator : string
+
   module Obj : sig
     val close_tag_closed : string
 
@@ -297,7 +300,7 @@ struct
     let fields =
       list_concat_map t.fields ~f:(function
         | Model.Lang.TypeExpr.Object.Method {name; type_} ->
-            (Html.pcdata (name ^ " : ") :: type_expr type_)
+            (Html.pcdata (name ^ Syn.label_separator) :: type_expr type_)
             @ [Html.pcdata Syn.Obj.field_separator]
         | Inherit type_ ->
             type_expr type_ @ [Html.pcdata Syn.Obj.field_separator] )
@@ -526,13 +529,13 @@ struct
               if Syn.Type.Variant.parenthesize_params
               then Html.pcdata "(" :: params @ [ Html.pcdata ")" ]
               else
-                Markup.keyword (if is_gadt then " : " else " of ") :: params
+                Markup.keyword (if is_gadt then Syn.label_separator else " of ") :: params
             )
             @ ret_type
           )
         ]
       | Record fields ->
-        Html.code [ cstr; Markup.keyword (if is_gadt then " : " else " of ") ]
+        Html.code [ cstr; Markup.keyword (if is_gadt then Syn.label_separator else " of ") ]
         :: record fields
         @ [ Html.code ret_type ]
 
@@ -780,7 +783,7 @@ struct
     let value =
       Markup.keyword (Syn.Value.variable_keyword ^ " ") ::
       Html.pcdata name ::
-      Html.pcdata " : " ::
+      Html.pcdata Syn.label_separator ::
       type_expr t.type_
       @ ( if Syn.Value.semicolon then [ Markup.keyword ";" ] else [] )
     in
@@ -791,7 +794,7 @@ struct
     let external_ =
       Markup.keyword "external " ::
       Html.pcdata name ::
-      Html.pcdata " : " ::
+      Html.pcdata Syn.label_separator ::
       type_expr t.type_ @
       Html.pcdata " = " ::
       Syn.Type.External.handle_primitives t.primitives
@@ -1249,7 +1252,7 @@ struct
       private_ ::
       virtual_ ::
       Html.pcdata name ::
-      Html.pcdata " : " ::
+      Html.pcdata Syn.label_separator ::
       type_expr t.type_
     in
     [Html.code method_], t.doc
@@ -1265,7 +1268,7 @@ struct
       mutable_ ::
       virtual_ ::
       Html.pcdata name ::
-      Html.pcdata " : " ::
+      Html.pcdata Syn.label_separator ::
       type_expr t.type_
     in
     [Html.code val_], t.doc
@@ -1324,7 +1327,7 @@ struct
       virtual_ ::
       params ::
       cname ::
-      Html.pcdata " : " ::
+      Html.pcdata Syn.label_separator ::
       cd
     in
     let region =
@@ -1463,7 +1466,7 @@ struct
       | None ->
         (
           Html.pcdata (Paths.Identifier.name arg.id) ::
-          Html.pcdata " : " ::
+          Html.pcdata Syn.label_separator ::
           mty (Paths.Identifier.signature_of_module arg.id) arg.expr
         ), []
       | Some expansion ->
@@ -1482,7 +1485,7 @@ struct
         Html_tree.leave ();
         (
           Html.a ~a:[ a_href ~kind:`Arg link_name ] [Html.pcdata name] ::
-          Html.pcdata " : " ::
+          Html.pcdata Syn.label_separator ::
           mty (Paths.Identifier.signature_of_module arg.id) arg.expr
         ), [subtree]
     in
@@ -1566,7 +1569,7 @@ struct
   and module_decl (base : Paths.Identifier.signature) md =
     begin match md with
     | Alias _ -> Html.pcdata " = "
-    | ModuleType _ -> Html.pcdata " : "
+    | ModuleType _ -> Html.pcdata Syn.label_separator
     end ::
     module_decl' base md
 
@@ -1601,7 +1604,7 @@ struct
         begin match expr with
         | Signature _
         | Path _ -> Html.pcdata " = "
-        | _ -> Html.pcdata " : "
+        | _ -> Html.pcdata Syn.label_separator
         end ::
         mty (Paths.Identifier.signature_of_module_type t.id) expr
     in
@@ -1669,7 +1672,7 @@ struct
         | href -> Html.a ~a:[ Html.a_href href ] [ to_print ]
       in
       ( if Syn.Mod.functor_keyword then [ Markup.keyword "functor" ] else [] ) @
-      Html.pcdata " (" :: name :: Html.pcdata " : " ::
+      Html.pcdata " (" :: name :: Html.pcdata Syn.label_separator ::
       mty base arg.expr @
       [Html.pcdata ")"; Html.pcdata " "] @ Syn.Type.arrow :: Html.pcdata " " ::
       mty base expr

--- a/src/html/html_generator.ml
+++ b/src/html/html_generator.ml
@@ -63,9 +63,6 @@ type toc = section list
 
 
 module type Syntax = sig
-
-  val label_separator : string
-
   module Obj : sig
     val close_tag_closed : string
 
@@ -79,6 +76,8 @@ module type Syntax = sig
   end
 
   module Type : sig
+    val annotation_separator : string
+
     val handle_constructor_params :
          ('inner, 'outer) text Html.elt list
       -> ('inner, 'outer) text Html.elt list
@@ -298,7 +297,7 @@ struct
     let fields =
       list_concat_map t.fields ~f:(function
         | Model.Lang.TypeExpr.Object.Method {name; type_} ->
-            (Html.pcdata (name ^ Syn.label_separator) :: type_expr type_)
+            (Html.pcdata (name ^ Syn.Type.annotation_separator) :: type_expr type_)
             @ [Html.pcdata Syn.Obj.field_separator]
         | Inherit type_ ->
             type_expr type_ @ [Html.pcdata Syn.Obj.field_separator] )
@@ -459,7 +458,7 @@ struct
             ; Html.code (
                 (if mutable_ then Markup.keyword "mutable " else Html.pcdata "")
                 :: (Html.pcdata name)
-                :: (Html.pcdata Syn.label_separator)
+                :: (Html.pcdata Syn.Type.annotation_separator)
                 :: (type_expr typ)
                 @  [Html.pcdata Syn.Type.Record.field_separator]
               )
@@ -527,13 +526,13 @@ struct
               if Syn.Type.Variant.parenthesize_params
               then Html.pcdata "(" :: params @ [ Html.pcdata ")" ]
               else
-                Markup.keyword (if is_gadt then Syn.label_separator else " of ") :: params
+                Markup.keyword (if is_gadt then Syn.Type.annotation_separator else " of ") :: params
             )
             @ ret_type
           )
         ]
       | Record fields ->
-        Html.code [ cstr; Markup.keyword (if is_gadt then Syn.label_separator else " of ") ]
+        Html.code [ cstr; Markup.keyword (if is_gadt then Syn.Type.annotation_separator else " of ") ]
         :: record fields
         @ [ Html.code ret_type ]
 
@@ -781,7 +780,7 @@ struct
     let value =
       Markup.keyword (Syn.Value.variable_keyword ^ " ") ::
       Html.pcdata name ::
-      Html.pcdata Syn.label_separator ::
+      Html.pcdata Syn.Type.annotation_separator ::
       type_expr t.type_
       @ ( if Syn.Value.semicolon then [ Markup.keyword ";" ] else [] )
     in
@@ -792,7 +791,7 @@ struct
     let external_ =
       Markup.keyword "external " ::
       Html.pcdata name ::
-      Html.pcdata Syn.label_separator ::
+      Html.pcdata Syn.Type.annotation_separator ::
       type_expr t.type_ @
       Html.pcdata " = " ::
       Syn.Type.External.handle_primitives t.primitives
@@ -1250,7 +1249,7 @@ struct
       private_ ::
       virtual_ ::
       Html.pcdata name ::
-      Html.pcdata Syn.label_separator ::
+      Html.pcdata Syn.Type.annotation_separator ::
       type_expr t.type_
     in
     [Html.code method_], t.doc
@@ -1266,7 +1265,7 @@ struct
       mutable_ ::
       virtual_ ::
       Html.pcdata name ::
-      Html.pcdata Syn.label_separator ::
+      Html.pcdata Syn.Type.annotation_separator ::
       type_expr t.type_
     in
     [Html.code val_], t.doc
@@ -1325,7 +1324,7 @@ struct
       virtual_ ::
       params ::
       cname ::
-      Html.pcdata Syn.label_separator ::
+      Html.pcdata Syn.Type.annotation_separator ::
       cd
     in
     let region =
@@ -1464,7 +1463,7 @@ struct
       | None ->
         (
           Html.pcdata (Paths.Identifier.name arg.id) ::
-          Html.pcdata Syn.label_separator ::
+          Html.pcdata Syn.Type.annotation_separator ::
           mty (Paths.Identifier.signature_of_module arg.id) arg.expr
         ), []
       | Some expansion ->
@@ -1483,7 +1482,7 @@ struct
         Html_tree.leave ();
         (
           Html.a ~a:[ a_href ~kind:`Arg link_name ] [Html.pcdata name] ::
-          Html.pcdata Syn.label_separator ::
+          Html.pcdata Syn.Type.annotation_separator ::
           mty (Paths.Identifier.signature_of_module arg.id) arg.expr
         ), [subtree]
     in
@@ -1567,7 +1566,7 @@ struct
   and module_decl (base : Paths.Identifier.signature) md =
     begin match md with
     | Alias _ -> Html.pcdata " = "
-    | ModuleType _ -> Html.pcdata Syn.label_separator
+    | ModuleType _ -> Html.pcdata Syn.Type.annotation_separator
     end ::
     module_decl' base md
 
@@ -1602,7 +1601,7 @@ struct
         begin match expr with
         | Signature _
         | Path _ -> Html.pcdata " = "
-        | _ -> Html.pcdata Syn.label_separator
+        | _ -> Html.pcdata Syn.Type.annotation_separator
         end ::
         mty (Paths.Identifier.signature_of_module_type t.id) expr
     in
@@ -1670,7 +1669,7 @@ struct
         | href -> Html.a ~a:[ Html.a_href href ] [ to_print ]
       in
       ( if Syn.Mod.functor_keyword then [ Markup.keyword "functor" ] else [] ) @
-      Html.pcdata " (" :: name :: Html.pcdata Syn.label_separator ::
+      Html.pcdata " (" :: name :: Html.pcdata Syn.Type.annotation_separator ::
       mty base arg.expr @
       [Html.pcdata ")"; Html.pcdata " "] @ Syn.Type.arrow :: Html.pcdata " " ::
       mty base expr

--- a/src/html/html_generator.ml
+++ b/src/html/html_generator.ml
@@ -64,7 +64,7 @@ type toc = section list
 
 module type Syntax = sig
 
-  val separator : string
+  val label_separator : string
 
   module Obj : sig
     val close_tag_closed : string
@@ -298,7 +298,7 @@ struct
     let fields =
       list_concat_map t.fields ~f:(function
         | Model.Lang.TypeExpr.Object.Method {name; type_} ->
-            (Html.pcdata (name ^ Syn.separator) :: type_expr type_)
+            (Html.pcdata (name ^ Syn.label_separator) :: type_expr type_)
             @ [Html.pcdata Syn.Obj.field_separator]
         | Inherit type_ ->
             type_expr type_ @ [Html.pcdata Syn.Obj.field_separator] )
@@ -459,7 +459,7 @@ struct
             ; Html.code (
                 (if mutable_ then Markup.keyword "mutable " else Html.pcdata "")
                 :: (Html.pcdata name)
-                :: (Html.pcdata Syn.separator)
+                :: (Html.pcdata Syn.label_separator)
                 :: (type_expr typ)
                 @  [Html.pcdata Syn.Type.Record.field_separator]
               )
@@ -527,13 +527,13 @@ struct
               if Syn.Type.Variant.parenthesize_params
               then Html.pcdata "(" :: params @ [ Html.pcdata ")" ]
               else
-                Markup.keyword (if is_gadt then Syn.separator else " of ") :: params
+                Markup.keyword (if is_gadt then Syn.label_separator else " of ") :: params
             )
             @ ret_type
           )
         ]
       | Record fields ->
-        Html.code [ cstr; Markup.keyword (if is_gadt then Syn.separator else " of ") ]
+        Html.code [ cstr; Markup.keyword (if is_gadt then Syn.label_separator else " of ") ]
         :: record fields
         @ [ Html.code ret_type ]
 
@@ -781,7 +781,7 @@ struct
     let value =
       Markup.keyword (Syn.Value.variable_keyword ^ " ") ::
       Html.pcdata name ::
-      Html.pcdata Syn.separator ::
+      Html.pcdata Syn.label_separator ::
       type_expr t.type_
       @ ( if Syn.Value.semicolon then [ Markup.keyword ";" ] else [] )
     in
@@ -792,7 +792,7 @@ struct
     let external_ =
       Markup.keyword "external " ::
       Html.pcdata name ::
-      Html.pcdata Syn.separator ::
+      Html.pcdata Syn.label_separator ::
       type_expr t.type_ @
       Html.pcdata " = " ::
       Syn.Type.External.handle_primitives t.primitives
@@ -1250,7 +1250,7 @@ struct
       private_ ::
       virtual_ ::
       Html.pcdata name ::
-      Html.pcdata Syn.separator ::
+      Html.pcdata Syn.label_separator ::
       type_expr t.type_
     in
     [Html.code method_], t.doc
@@ -1266,7 +1266,7 @@ struct
       mutable_ ::
       virtual_ ::
       Html.pcdata name ::
-      Html.pcdata Syn.separator ::
+      Html.pcdata Syn.label_separator ::
       type_expr t.type_
     in
     [Html.code val_], t.doc
@@ -1325,7 +1325,7 @@ struct
       virtual_ ::
       params ::
       cname ::
-      Html.pcdata Syn.separator ::
+      Html.pcdata Syn.label_separator ::
       cd
     in
     let region =
@@ -1464,7 +1464,7 @@ struct
       | None ->
         (
           Html.pcdata (Paths.Identifier.name arg.id) ::
-          Html.pcdata Syn.separator ::
+          Html.pcdata Syn.label_separator ::
           mty (Paths.Identifier.signature_of_module arg.id) arg.expr
         ), []
       | Some expansion ->
@@ -1483,7 +1483,7 @@ struct
         Html_tree.leave ();
         (
           Html.a ~a:[ a_href ~kind:`Arg link_name ] [Html.pcdata name] ::
-          Html.pcdata Syn.separator ::
+          Html.pcdata Syn.label_separator ::
           mty (Paths.Identifier.signature_of_module arg.id) arg.expr
         ), [subtree]
     in
@@ -1567,7 +1567,7 @@ struct
   and module_decl (base : Paths.Identifier.signature) md =
     begin match md with
     | Alias _ -> Html.pcdata " = "
-    | ModuleType _ -> Html.pcdata Syn.separator
+    | ModuleType _ -> Html.pcdata Syn.label_separator
     end ::
     module_decl' base md
 
@@ -1602,7 +1602,7 @@ struct
         begin match expr with
         | Signature _
         | Path _ -> Html.pcdata " = "
-        | _ -> Html.pcdata Syn.separator
+        | _ -> Html.pcdata Syn.label_separator
         end ::
         mty (Paths.Identifier.signature_of_module_type t.id) expr
     in
@@ -1670,7 +1670,7 @@ struct
         | href -> Html.a ~a:[ Html.a_href href ] [ to_print ]
       in
       ( if Syn.Mod.functor_keyword then [ Markup.keyword "functor" ] else [] ) @
-      Html.pcdata " (" :: name :: Html.pcdata Syn.separator ::
+      Html.pcdata " (" :: name :: Html.pcdata Syn.label_separator ::
       mty base arg.expr @
       [Html.pcdata ")"; Html.pcdata " "] @ Syn.Type.arrow :: Html.pcdata " " ::
       mty base expr

--- a/src/html/html_generator.mli
+++ b/src/html/html_generator.mli
@@ -35,9 +35,6 @@ type toc = section list
   @see {!To_re_html_tree} and {!To_ml_html_tree}
   *)
 module type Syntax = sig
-
-  val label_separator : string
-
   module Obj : sig
     val close_tag_closed : string
 
@@ -51,6 +48,8 @@ module type Syntax = sig
   end
 
   module Type : sig
+    val annotation_separator : string
+
     val handle_constructor_params :
          ('inner, 'outer) text Html.elt list
       -> ('inner, 'outer) text Html.elt list

--- a/src/html/html_generator.mli
+++ b/src/html/html_generator.mli
@@ -81,8 +81,6 @@ module type Syntax = sig
 
     module Record : sig
       val field_separator : string
-
-      val label_value_separator : string
     end
 
     val var_prefix : string

--- a/src/html/html_generator.mli
+++ b/src/html/html_generator.mli
@@ -35,6 +35,9 @@ type toc = section list
   @see {!To_re_html_tree} and {!To_ml_html_tree}
   *)
 module type Syntax = sig
+
+  val label_separator : string
+
   module Obj : sig
     val close_tag_closed : string
 

--- a/src/html/html_generator.mli
+++ b/src/html/html_generator.mli
@@ -36,7 +36,7 @@ type toc = section list
   *)
 module type Syntax = sig
 
-  val label_separator : string
+  val separator : string
 
   module Obj : sig
     val close_tag_closed : string

--- a/src/html/html_generator.mli
+++ b/src/html/html_generator.mli
@@ -36,7 +36,7 @@ type toc = section list
   *)
 module type Syntax = sig
 
-  val separator : string
+  val label_separator : string
 
   module Obj : sig
     val close_tag_closed : string

--- a/src/html/to_ml_html_tree.ml
+++ b/src/html/to_ml_html_tree.ml
@@ -2,6 +2,8 @@ module Html = Tyxml.Html
 open Utils
 
 module ML = Html_generator.Make (struct
+  let label_separator = " : "
+
   module Obj = struct
     let close_tag_closed = ">"
 

--- a/src/html/to_ml_html_tree.ml
+++ b/src/html/to_ml_html_tree.ml
@@ -45,8 +45,6 @@ module ML = Html_generator.Make (struct
 
     module Record = struct
       let field_separator = ";"
-
-      let label_value_separator = " : "
     end
 
     let var_prefix = "'"

--- a/src/html/to_ml_html_tree.ml
+++ b/src/html/to_ml_html_tree.ml
@@ -2,7 +2,7 @@ module Html = Tyxml.Html
 open Utils
 
 module ML = Html_generator.Make (struct
-  let label_separator = " : "
+  let separator = " : "
 
   module Obj = struct
     let close_tag_closed = ">"

--- a/src/html/to_ml_html_tree.ml
+++ b/src/html/to_ml_html_tree.ml
@@ -2,7 +2,7 @@ module Html = Tyxml.Html
 open Utils
 
 module ML = Html_generator.Make (struct
-  let separator = " : "
+  let label_separator = " : "
 
   module Obj = struct
     let close_tag_closed = ">"

--- a/src/html/to_ml_html_tree.ml
+++ b/src/html/to_ml_html_tree.ml
@@ -2,8 +2,6 @@ module Html = Tyxml.Html
 open Utils
 
 module ML = Html_generator.Make (struct
-  let label_separator = " : "
-
   module Obj = struct
     let close_tag_closed = ">"
 
@@ -17,6 +15,8 @@ module ML = Html_generator.Make (struct
   end
 
   module Type = struct
+    let annotation_separator = " : "
+
     let handle_params name args =
       if args <> [ Html.pcdata "" ]
       then args @ [ Html.pcdata " " ] @ name

--- a/src/html/to_re_html_tree.ml
+++ b/src/html/to_re_html_tree.ml
@@ -2,7 +2,7 @@ module Html = Tyxml.Html
 open Utils
 
 module RE = Html_generator.Make (struct
-  let label_separator = ": "
+  let separator = ": "
 
   module Obj = struct
     let close_tag_closed = "}"

--- a/src/html/to_re_html_tree.ml
+++ b/src/html/to_re_html_tree.ml
@@ -2,7 +2,7 @@ module Html = Tyxml.Html
 open Utils
 
 module RE = Html_generator.Make (struct
-  let separator = ": "
+  let label_separator = ": "
 
   module Obj = struct
     let close_tag_closed = "}"

--- a/src/html/to_re_html_tree.ml
+++ b/src/html/to_re_html_tree.ml
@@ -2,8 +2,6 @@ module Html = Tyxml.Html
 open Utils
 
 module RE = Html_generator.Make (struct
-  let label_separator = ": "
-
   module Obj = struct
     let close_tag_closed = "}"
 
@@ -17,6 +15,8 @@ module RE = Html_generator.Make (struct
   end
 
   module Type = struct
+    let annotation_separator = ": "
+
     let handle_constructor_params name args = name @ args
 
     let handle_substitution_params name args = name @ args

--- a/src/html/to_re_html_tree.ml
+++ b/src/html/to_re_html_tree.ml
@@ -41,8 +41,6 @@ module RE = Html_generator.Make (struct
 
     module Record = struct
       let field_separator = ","
-
-      let label_value_separator = ": "
     end
 
     let var_prefix = "'"

--- a/src/html/to_re_html_tree.ml
+++ b/src/html/to_re_html_tree.ml
@@ -2,6 +2,8 @@ module Html = Tyxml.Html
 open Utils
 
 module RE = Html_generator.Make (struct
+  let label_separator = ": "
+
   module Obj = struct
     let close_tag_closed = "}"
 

--- a/test/html/expect/test_package+re/External/index.html
+++ b/test/html/expect/test_package+re/External/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec external" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">external </span>foo : unit <span>=&gt;</span> unit = "bar"<span class="keyword">;</span></code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">external </span>foo: unit <span>=&gt;</span> unit = "bar"<span class="keyword">;</span></code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+re/Functor/index.html
+++ b/test/html/expect/test_package+re/Functor/index.html
@@ -25,19 +25,19 @@
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
    </article>
    <article class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a> :  (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a>:  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
    </article>
    <article class="spec module" id="module-F1">
-    <a href="#module-F1" class="anchor"></a><code><span class="keyword">module </span><a href="F1/index.html">F1</a> :  (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+    <a href="#module-F1" class="anchor"></a><code><span class="keyword">module </span><a href="F1/index.html">F1</a>:  (<a href="F1/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
    </article>
    <article class="spec module" id="module-F2">
-    <a href="#module-F2" class="anchor"></a><code><span class="keyword">module </span><a href="F2/index.html">F2</a> :  (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="F2/index.html#type-t">t</a><span class="keyword"> = </span><a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a><span class="keyword">;</span></code>
+    <a href="#module-F2" class="anchor"></a><code><span class="keyword">module </span><a href="F2/index.html">F2</a>:  (<a href="F2/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="F2/index.html#type-t">t</a><span class="keyword"> = </span><a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a><span class="keyword">;</span></code>
    </article>
    <article class="spec module" id="module-F3">
-    <a href="#module-F3" class="anchor"></a><code><span class="keyword">module </span><a href="F3/index.html">F3</a> :  (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-F3" class="anchor"></a><code><span class="keyword">module </span><a href="F3/index.html">F3</a>:  (<a href="F3/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
    </article>
    <article class="spec module" id="module-F4">
-    <a href="#module-F4" class="anchor"></a><code><span class="keyword">module </span><a href="F4/index.html">F4</a> :  (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+    <a href="#module-F4" class="anchor"></a><code><span class="keyword">module </span><a href="F4/index.html">F4</a>:  (<a href="F4/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
    </article>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Interlude/index.html
+++ b/test/html/expect/test_package+re/Interlude/index.html
@@ -31,7 +31,7 @@
    </aside>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: unit<span class="keyword">;</span></code>
     </dt>
     <dd>
      <p>
@@ -54,7 +54,7 @@
    </aside>
    <dl>
     <dt class="spec value" id="val-bar">
-     <a href="#val-bar" class="anchor"></a><code><span class="keyword">let </span>bar : unit<span class="keyword">;</span></code>
+     <a href="#val-bar" class="anchor"></a><code><span class="keyword">let </span>bar: unit<span class="keyword">;</span></code>
     </dt>
     <dd>
      <p>
@@ -64,13 +64,13 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-multiple">
-     <a href="#val-multiple" class="anchor"></a><code><span class="keyword">let </span>multiple : unit<span class="keyword">;</span></code>
+     <a href="#val-multiple" class="anchor"></a><code><span class="keyword">let </span>multiple: unit<span class="keyword">;</span></code>
     </dt>
     <dt class="spec value" id="val-signature">
-     <a href="#val-signature" class="anchor"></a><code><span class="keyword">let </span>signature : unit<span class="keyword">;</span></code>
+     <a href="#val-signature" class="anchor"></a><code><span class="keyword">let </span>signature: unit<span class="keyword">;</span></code>
     </dt>
     <dt class="spec value" id="val-items">
-     <a href="#val-items" class="anchor"></a><code><span class="keyword">let </span>items : unit<span class="keyword">;</span></code>
+     <a href="#val-items" class="anchor"></a><code><span class="keyword">let </span>items: unit<span class="keyword">;</span></code>
     </dt>
    </dl>
    <aside>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -380,7 +380,7 @@ let bar =
     </header>
     <dl>
      <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code>
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: unit<span class="keyword">;</span></code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -26,7 +26,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: unit<span class="keyword">;</span></code>
     </dt>
     <dd>
      <p>
@@ -44,13 +44,13 @@
     <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
    </article>
    <article class="spec module-type" id="module-type-S3">
-    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string<span class="keyword">;</span></code>
+    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string<span class="keyword">;</span></code>
    </article>
    <article class="spec module-type" id="module-type-S4">
-    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int<span class="keyword">;</span></code>
+    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int<span class="keyword">;</span></code>
    </article>
    <article class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S5/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>)<span class="keyword">;</span></code>
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S5/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>)<span class="keyword">;</span></code>
    </article>
    <dl>
     <dt class="spec type" id="type-result">
@@ -58,19 +58,19 @@
     </dt>
    </dl>
    <article class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)<span class="keyword">;</span></code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)<span class="keyword">;</span></code>
    </article>
    <article class="spec module" id="module-M'">
-    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
    </article>
    <article class="spec module-type" id="module-type-S7">
-    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
+    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
    </article>
    <article class="spec module-type" id="module-type-S8">
-    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
+    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
    </article>
    <article class="spec module-type" id="module-type-S9">
-    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
+    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a>: <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
    </article>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Section/index.html
+++ b/test/html/expect/test_package+re/Section/index.html
@@ -91,7 +91,7 @@
     </header>
     <dl>
      <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : unit<span class="keyword">;</span></code>
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: unit<span class="keyword">;</span></code>
      </dt>
     </dl>
    </section>

--- a/test/html/expect/test_package+re/Stop/index.html
+++ b/test/html/expect/test_package+re/Stop/index.html
@@ -26,7 +26,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo : int<span class="keyword">;</span></code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: int<span class="keyword">;</span></code>
     </dt>
     <dd>
      <p>
@@ -48,11 +48,11 @@
     </p>
    </aside>
    <article class="spec module" id="module-N">
-    <a href="#module-N" class="anchor"></a><code><span class="keyword">module </span><a href="N/index.html">N</a> : <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-N" class="anchor"></a><code><span class="keyword">module </span><a href="N/index.html">N</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
    </article>
    <dl>
     <dt class="spec value" id="val-lol">
-     <a href="#val-lol" class="anchor"></a><code><span class="keyword">let </span>lol : int<span class="keyword">;</span></code>
+     <a href="#val-lol" class="anchor"></a><code><span class="keyword">let </span>lol: int<span class="keyword">;</span></code>
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -292,7 +292,7 @@
      <code> ]</code><span class="keyword">;</span>
     </dt>
     <dt class="spec type" id="type-object_">
-     <a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>{. a : int, b : int, c : int, }</code><span class="keyword">;</span>
+     <a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>{. a: int, b: int, c: int, }</code><span class="keyword">;</span>
     </dt>
    </dl>
    <article class="spec module-type" id="module-type-X">
@@ -342,13 +342,13 @@
      <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type </span>named_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code><span class="keyword">;</span>
     </dt>
     <dt class="spec type" id="type-exact_object">
-     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type </span>exact_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a : int, b : int, }</code><span class="keyword">;</span>
+     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type </span>exact_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a: int, b: int, }</code><span class="keyword">;</span>
     </dt>
     <dt class="spec type" id="type-lower_object">
-     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type </span>lower_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {.. a : int, b : int, }</code><span class="keyword">;</span>
+     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type </span>lower_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {.. a: int, b: int, }</code><span class="keyword">;</span>
     </dt>
     <dt class="spec type" id="type-poly_object">
-     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type </span>poly_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a : a. <span class="type-var">'a</span>, }</code><span class="keyword">;</span>
+     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type </span>poly_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a: a. <span class="type-var">'a</span>, }</code><span class="keyword">;</span>
     </dt>
     <dt class="spec type" id="type-as_">
      <a href="#type-as_" class="anchor"></a><code><span class="keyword">type </span>as_</code><code><span class="keyword"> = </span>(int<span class="keyword"> as </span>a<span class="keyword">, </span><span class="type-var">'a</span>)</code><span class="keyword">;</span>

--- a/test/html/expect/test_package+re/Val/index.html
+++ b/test/html/expect/test_package+re/Val/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-documented">
-     <a href="#val-documented" class="anchor"></a><code><span class="keyword">let </span>documented : unit<span class="keyword">;</span></code>
+     <a href="#val-documented" class="anchor"></a><code><span class="keyword">let </span>documented: unit<span class="keyword">;</span></code>
     </dt>
     <dd>
      <p>
@@ -33,10 +33,10 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-undocumented">
-     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">let </span>undocumented : unit<span class="keyword">;</span></code>
+     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">let </span>undocumented: unit<span class="keyword">;</span></code>
     </dt>
     <dt class="spec value" id="val-documented_above">
-     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">let </span>documented_above : unit<span class="keyword">;</span></code>
+     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">let </span>documented_above: unit<span class="keyword">;</span></code>
     </dt>
     <dd>
      <p>


### PR DESCRIPTION
As it turns out, label separators seem to be pretty uniform within each
syntax, so I figured I'd pull that out of the `Syntax.Type` submodule
and solve it once for all of them.

Can be specialized if need be, but solves the issue for now.

Work on #199

cc @ryyppy @aantron 