### PR TITLE
Add custom remote fonts. Small visual adjustments.

### DIFF
--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -296,7 +296,7 @@ pre code {
 
 /* Indent the second line in multiline spec definitions. */
 .spec:not(.type) > code {
-  display: inline-block;
+  display: block;
   padding-left: 4ex;
   text-indent: -4ex;
 }

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -310,7 +310,7 @@ dd> :first-child {
   margin-top: 0;
 }
 
-dl, article, .doc, aside {
+dl, article, div.spec, .doc, aside {
   margin-bottom: 25px;
 }
 

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -4,7 +4,6 @@
    %%NAME%% %%VERSION%% */
 
 /* Fonts */
-@import url('https://fonts.googleapis.com/css?family=Inconsolata:400,700');
 @import url('https://fonts.googleapis.com/css?family=Fira+Mono:400,500');
 @import url('https://fonts.googleapis.com/css?family=Noticia+Text:400,400i,700');
 @import url('https://fonts.googleapis.com/css?family=Fira+Sans:400,400i,500,500i,600,600i,700,700i');

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -3,6 +3,13 @@
    Distributed under the ISC license, see terms at the end of the file.
    %%NAME%% %%VERSION%% */
 
+/* Fonts */
+@import url('https://fonts.googleapis.com/css?family=Inconsolata:400,700');
+@import url('https://fonts.googleapis.com/css?family=Fira+Mono:400,500');
+@import url('https://fonts.googleapis.com/css?family=Noticia+Text:400,400i,700');
+@import url('https://fonts.googleapis.com/css?family=Fira+Sans:400,400i,500,500i,600,600i,700,700i');
+
+
 /* Reset a few things. */
 
 html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {
@@ -27,10 +34,13 @@ table {
   box-sizing: border-box;
 }
 
+html {
+  font-size: 14px;
+}
+
 body {
-  font-family: Helvetica, "DejaVu Sans", Arial, sans-serif;
+  font-family: "Fira Sans", Helvetica, Arial, sans-serif;
   font-weight: 300;
-  font-size: 1em;
   line-height: 1.5;
   text-align: left;
   color: #333;
@@ -39,7 +49,7 @@ body {
 
 .content {
   max-width: 80ex;
-  margin-left: calc(10% + 19ex);
+  margin-left: calc(10vw + 20ex);
   margin-right: 4ex;
   margin-top: 20px;
   margin-bottom: 50px;
@@ -49,10 +59,14 @@ body {
   margin-bottom: 30px;
 }
 
+.content p, .content ul {
+  font-family: "Noticia Text", Georgia, serif;
+}
+
 /* Basic markup elements */
 
 b, strong {
-  font-weight: 400;
+  font-weight: 500;
 }
 
 i, em {
@@ -77,7 +91,7 @@ p {
   margin-bottom: 0.5em;
 }
 pre {
-  margin: 1.5em 0;
+  margin: 1.0em 0;
 }
 
 ul, ol {
@@ -167,33 +181,34 @@ a.anchor {
 }
 
 .xref-unresolved {
-  box-shadow: 0 1px 0 0 red
+  color: #2C5CBD;
+}
+.xref-unresolved:hover {
+  box-shadow: 0 1px 0 0 #CC6666;
 }
 
 /* Section and document divisions.
    Until at least 4.03 many of the modules of the stdlib start at .h7,
    we restart the sequence there like h2  */
 
-section > header {
-  margin-bottom: 30px;
-}
-
 h1, h2, h3, h4, h5, h6, .h7, .h8, .h9, .h10 {
-  font-weight: 600;
+  font-weight: 400;
   margin: 1em 0 0.5em;
   line-height: 1.2;
   overflow-wrap: break-word;
 }
 
 h1 {
+  font-weight: 500;
   font-size: 2.441em;
   margin-top: 1.214em;
 }
 
 h2 {
+  font-weight: 500;
   font-size: 1.953em;
   box-shadow: 0 1px 0 0 #ddd;
-  padding-bottom: 0.1em;
+  padding-bottom: 0.2em;
 }
 
 h3 {
@@ -231,9 +246,8 @@ h4 code, h4 tt {
 /* Preformatted and code */
 
 tt, code, pre {
-  font-family: Menlo, "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
-  font-weight: normal;
-  font-size: 0.95em
+  font-family: "Fira Code", "Fira Mono", courier;
+  font-weight: 400;
 }
 
 pre {
@@ -256,24 +270,24 @@ p a > code {
 /* Code blocks (e.g. Examples) */
 
 pre code {
-  font-size: 0.90rem;
+  font-size: 0.893rem;
 }
 
 /* Code lexemes */
 
 .keyword {
-  font-weight: 500;
+  font-weight: 700;
 }
 
 /* Module member specification */
 
 .spec:not(.include), .spec.include details summary {
-  font-size: 0.95em;
+  font-size: 1rem;
   background-color: #f6f8fa;
   border-radius: 3px;
   border-left: 4px solid #5c9cf5;
   border-right: 5px solid transparent;
-  padding: 0.5em;
+  padding: 0.35em 0.5em;
 }
 
 .spec.include details summary:hover {
@@ -288,7 +302,7 @@ pre code {
 }
 
 dl > dd {
-  padding: 0.75em;
+  padding: 0.5em;
   padding-bottom: 0;
 }
 
@@ -297,7 +311,15 @@ dd> :first-child {
 }
 
 dl, article, .doc, aside {
+  margin-bottom: 25px;
+}
+
+section {
   margin-bottom: 30px;
+}
+
+section > header {
+  margin-bottom: 25px;
 }
 
 dl:last-child, aside:last-child, article:last-child {
@@ -332,9 +354,9 @@ div.doc>*:first-child {
 }
 
 /* The elements other than heading should be wrapped in <aside> elements. */
-heading, body>p, body>ul, body>ol, h3, h4, body>pre {
-  margin-bottom: 16px;
-}
+/* heading, body>p, body>ul, body>ol, h3, h4, body>pre { */
+/*   margin-bottom: 30px; */
+/* } */
 
 /* Collapsible inlined include and module */
 
@@ -561,9 +583,9 @@ h1+.modules, h1+.sel {
   display: block;
   content: "Topics";
   text-transform: uppercase;
-  font-size: 0.95em;
+  font-size: 1em;
   margin: 1.414em 0 0.5em;
-  font-weight: 600;
+  font-weight: 500;
   color: #777;
   line-height: 1.2;
 }
@@ -584,9 +606,12 @@ h1+.modules, h1+.sel {
 }
 
 .toc ul li a {
+  font-family: "Fira Sans", sans-serif;
   font-size: 0.95em;
   color: #333;
   font-weight: 400;
+  line-height: 1.6em;
+  display: block;
 }
 
 .toc ul li a:hover {
@@ -597,24 +622,28 @@ h1+.modules, h1+.sel {
 /* First level titles */
 
 .toc>ul>li>a {
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .toc li ul {
-  margin-top: 3px;
-  margin-left: 0;
+  margin: 0px;
 }
 
-.toc > ul {
+.toc ul {
   list-style-type: none;
 }
 
 .toc ul li {
   margin: 0;
 }
+.toc>ul>li {
+  margin-bottom: 0.3em;
+}
 
 .toc ul li li {
-  margin-left: 20px;
+  border-left: 1px solid #ccc;
+  margin-left: 5px;
+  padding-left: 12px;
 }
 
 /* Mobile adjustements. */
@@ -622,7 +651,7 @@ h1+.modules, h1+.sel {
 @media only screen and (max-width: 95ex) {
   .content {
     margin: auto;
-    padding: 2.5em;
+    padding: 2.0em;
   }
   .toc {
     position: static;
@@ -630,7 +659,7 @@ h1+.modules, h1+.sel {
     min-width: unset;
     max-width: unset;
     border: none;
-    padding: 0.2em 0.5em;
+    padding: 0.2em 1em;
     border-radius: 5px;
   }
 }
@@ -650,7 +679,7 @@ h1+.modules, h1+.sel {
 /* Syntax highlighting (based on github-gist) */
 
 .keyword {
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .hljs {

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -254,6 +254,7 @@ pre {
   padding: 0.1em;
   border: 1px solid #eee;
   border-radius: 5px;
+  overflow-x: auto;
 }
 
 p code {


### PR DESCRIPTION
This makes small adjustments to the CSS based on the feedback I received for the current theme. 

Custom fonts are included here as an experiment, we'll include them as static files when https://github.com/ocaml/odoc/issues/155 is resolved.

Here're some examples of packages with this change: [order](
http://odis.io/odoc-demo/order/Order/index.html), [lwt](
http://odis.io/odoc-demo/lwt/Lwt/index.html), [fmt](
http://odis.io/odoc-demo/fmt/Fmt/index.html), [cmdliner](
http://odis.io/odoc-demo/cmdliner/Cmdliner/index.html) and [base](
http://odis.io/odoc-demo/base/Base/index.html).

CC @aantron @ostera @ryyppy 