### PR TITLE
Add info do Readme about pid odoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ This means we follow the same installation than above, but using the
 ```sh
 λ opam switch 4.02.3+buckle-master
 λ eval `opam config env`
-λ opam install odoc
+λ opam pin add odoc.dev git+https://github.com/ocaml/odoc
 λ odoc --version
 1.2.0
 ```
 
-> if you have problem with installing odoc by `opam install odoc` the try to use `opam pin add odoc.dev git+https://github.com/ocaml/odoc`
+> BuckleScript support currently requires the latest development version of odoc.
 
 Now with that working, we can point `odoc` to the path where BuckleScript saves
 the compiled code that we can use to generate our documentation. This path is

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The generated docs can then be found locally at
 
 ## Using `odoc` with BuckleScript/Reason
 
+> BuckleScript support currently requires the latest development version of odoc.
+
 While the BuckleScript/Reason toolchain relies on `npm`, `odoc` at the moment
 needs to be used from a working OCaml toolchain.
 
@@ -63,8 +65,6 @@ This means we follow the same installation than above, but using the
 λ opam pin add odoc.dev git+https://github.com/ocaml/odoc
 
 ```
-
-> BuckleScript support currently requires the latest development version of odoc.
 
 Now with that working, we can point `odoc` to the path where BuckleScript saves
 the compiled code that we can use to generate our documentation. This path is

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # odoc
 
-**odoc** is a documentation generator for OCaml. It reads *doc comments*,
+**odoc** is a documentation generator for OCaml. It reads _doc comments_,
 delimited with `(** ... *)`, and outputs HTML. See example output at
 [docs.mirage.io][mirage-docs].
 
@@ -64,6 +64,8 @@ This means we follow the same installation than above, but using the
 λ odoc --version
 1.2.0
 ```
+
+> if you have problem with installing odoc by `opam install odoc` the try to use `opam pin add odoc.dev git+https://github.com/ocaml/odoc`
 
 Now with that working, we can point `odoc` to the path where BuckleScript saves
 the compiled code that we can use to generate our documentation. This path is

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # odoc
 
-**odoc** is a documentation generator for OCaml. It reads _doc comments_,
+**odoc** is a documentation generator for OCaml. It reads *doc comments* ,
 delimited with `(** ... *)`, and outputs HTML. See example output at
 [docs.mirage.io][mirage-docs].
 
@@ -61,8 +61,7 @@ This means we follow the same installation than above, but using the
 λ opam switch 4.02.3+buckle-master
 λ eval `opam config env`
 λ opam pin add odoc.dev git+https://github.com/ocaml/odoc
-λ odoc --version
-1.2.0
+
 ```
 
 > BuckleScript support currently requires the latest development version of odoc.


### PR DESCRIPTION
Added information about how to pin the `odoc` in ReasonML projects. I placed information below installation step because I don't want to change the maim installation section.

#195 