### PR TITLE
Rename root-uri to xref-base-uri and fix empty string bug.

### DIFF
--- a/src/html/documentation.ml
+++ b/src/html/documentation.ml
@@ -80,12 +80,12 @@ module Reference = struct
   let rec to_html
       : type a.
         ?text:(non_link_phrasing Html.elt) ->
-        ?root_uri:string ->
+        ?xref_base_uri:string ->
         stop_before:bool ->
         a Reference.t ->
           phrasing Html.elt =
 
-    fun ?text ?root_uri ~stop_before ref ->
+    fun ?text ?xref_base_uri ~stop_before ref ->
       let span' (txt : phrasing Html.elt list) : phrasing Html.elt =
         Html.span txt ~a:[ Html.a_class ["xref-unresolved"]
                   ; Html.a_title (Printf.sprintf "unresolved reference to %S"
@@ -100,33 +100,33 @@ module Reference = struct
         | Some s -> (span' [(s :> phrasing Html.elt)] :> phrasing Html.elt)
         end
       | Dot (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Module (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | ModuleType (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Type (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Constructor (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Field (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Extension (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Exception (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Value (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Class (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | ClassType (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Method (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | InstanceVariable (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Label (parent, s) ->
-        unresolved_parts_to_html ?root_uri ?text span' parent s
+        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
       | Resolved r ->
         (* IDENTIFIER MUST BE RENAMED TO DEFINITION. *)
         let id = Reference.Resolved.identifier r in
@@ -135,7 +135,7 @@ module Reference = struct
           | None -> Html.code [Html.pcdata (render_resolved r)]
           | Some s -> s
         in
-        begin match Id.href ?root_uri ~stop_before id with
+        begin match Id.href ?xref_base_uri ~stop_before id with
         | exception Id.Not_linkable -> (txt :> phrasing Html.elt)
         | exception exn ->
           (* FIXME: better error message *)
@@ -148,18 +148,18 @@ module Reference = struct
   and unresolved_parts_to_html
       : type a.
         ?text:(non_link_phrasing Html.elt) ->
-        ?root_uri:string ->
+        ?xref_base_uri:string ->
         ((phrasing Html.elt list) -> (phrasing Html.elt)) ->
         a Reference.t ->
         string ->
           (phrasing Html.elt) =
-    fun ?text ?root_uri span' parent s ->
+    fun ?text ?xref_base_uri span' parent s ->
       match text with
       | Some s -> (span' [(s :> phrasing Html.elt)] :> phrasing Html.elt)
       | None ->
         let tail = [ Html.pcdata ("." ^ s) ] in
         span' (
-          match to_html ?root_uri ~stop_before:true parent with
+          match to_html ?xref_base_uri ~stop_before:true parent with
           | content -> content::tail
         )
 end
@@ -210,12 +210,12 @@ let link_content_to_html =
 
 
 
-let rec inline_element ?root_uri : Comment.inline_element -> (phrasing Html.elt) option =
+let rec inline_element ?xref_base_uri : Comment.inline_element -> (phrasing Html.elt) option =
   function
   | #Comment.leaf_inline_element as e ->
     (leaf_inline_element e :> (phrasing Html.elt) option)
   | `Styled (style, content) ->
-    Some ((style_to_combinator style) (inline_element_list ?root_uri content))
+    Some ((style_to_combinator style) (inline_element_list ?xref_base_uri content))
   | `Reference (path, content) ->
     (* TODO Rework that ugly function. *)
     (* TODO References should be set in code style, if they are to code
@@ -225,7 +225,7 @@ let rec inline_element ?root_uri : Comment.inline_element -> (phrasing Html.elt)
       | [] -> None
       | _ -> Some (Html.span (non_link_inline_element_list content))
     in
-    Some (Reference.to_html ?text:content ?root_uri ~stop_before:false path)
+    Some (Reference.to_html ?text:content ?xref_base_uri ~stop_before:false path)
   | `Link (target, content) ->
     let content =
       match content with
@@ -234,9 +234,9 @@ let rec inline_element ?root_uri : Comment.inline_element -> (phrasing Html.elt)
     in
     Some (Html.a ~a:[Html.a_href target] content)
 
-and inline_element_list ?root_uri elements =
+and inline_element_list ?xref_base_uri elements =
   List.fold_left (fun html_elements ast_element ->
-    match inline_element ?root_uri ast_element.Model.Location_.value with
+    match inline_element ?xref_base_uri ast_element.Model.Location_.value with
     | None -> html_elements
     | Some e -> e::html_elements)
     [] elements
@@ -245,12 +245,12 @@ and inline_element_list ?root_uri elements =
 
 
 let rec nestable_block_element
-    : 'a. ?root_uri:string ->
+    : 'a. ?xref_base_uri:string ->
     to_syntax:Html_tree.syntax -> from_syntax:Html_tree.syntax ->
     Comment.nestable_block_element -> ([> flow ] as 'a) Html.elt =
-  fun ?root_uri ~to_syntax ~from_syntax -> function
+  fun ?xref_base_uri ~to_syntax ~from_syntax -> function
   | `Paragraph [{value = `Raw_markup (`Html, s); _}] -> Html.Unsafe.data s
-  | `Paragraph content -> Html.p (inline_element_list ?root_uri content)
+  | `Paragraph content -> Html.p (inline_element_list ?xref_base_uri content)
   | `Code_block s ->
     let open Html_tree in
     (*
@@ -277,7 +277,7 @@ let rec nestable_block_element
     Html.pre [Html.code ~a:[Html.a_class [classname]] [Html.pcdata code]]
   | `Verbatim s -> Html.pre [Html.pcdata s]
   | `Modules ms ->
-    let items = List.map (Reference.to_html ?root_uri ~stop_before:false) ms in
+    let items = List.map (Reference.to_html ?xref_base_uri ~stop_before:false) ms in
     let items = (items :> (Html_types.li_content Html.elt) list) in
     let items = List.map (fun e -> Html.li [e]) items in
     Html.ul items
@@ -286,9 +286,9 @@ let rec nestable_block_element
       items
       |> List.map begin function
         | [{Model.Location_.value = `Paragraph content; _}] ->
-          (inline_element_list ?root_uri content :> (Html_types.li_content Html.elt) list)
+          (inline_element_list ?xref_base_uri content :> (Html_types.li_content Html.elt) list)
         | item ->
-          nested_block_element_list ?root_uri ~to_syntax ~from_syntax item
+          nested_block_element_list ?xref_base_uri ~to_syntax ~from_syntax item
         end
     in
     let items = List.map Html.li items in
@@ -297,20 +297,20 @@ let rec nestable_block_element
     | `Unordered -> Html.ul items
     | `Ordered -> Html.ol items
 
-and nestable_block_element_list ?root_uri ~to_syntax ~from_syntax elements =
+and nestable_block_element_list ?xref_base_uri ~to_syntax ~from_syntax elements =
   elements
   |> List.map Model.Location_.value
-  |> List.map (nestable_block_element ?root_uri ~to_syntax ~from_syntax)
+  |> List.map (nestable_block_element ?xref_base_uri ~to_syntax ~from_syntax)
 
-and nested_block_element_list ?root_uri ~to_syntax ~from_syntax elements =
-  (nestable_block_element_list ?root_uri ~to_syntax ~from_syntax elements :> (Html_types.flow5 Html.elt) list)
+and nested_block_element_list ?xref_base_uri ~to_syntax ~from_syntax elements =
+  (nestable_block_element_list ?xref_base_uri ~to_syntax ~from_syntax elements :> (Html_types.flow5 Html.elt) list)
 
 
 
-let tag : ?root_uri:string ->
+let tag : ?xref_base_uri:string ->
   to_syntax:Html_tree.syntax -> from_syntax:Html_tree.syntax ->
   Comment.tag -> ([> flow ] Html.elt) option =
-  fun ?root_uri ~to_syntax ~from_syntax t ->
+  fun ?xref_base_uri ~to_syntax ~from_syntax t ->
     match t with
   | `Author s ->
     Some (Html.(dl [
@@ -319,19 +319,19 @@ let tag : ?root_uri:string ->
   | `Deprecated content ->
     Some (Html.(dl [
       dt [pcdata "deprecated"];
-      dd (nested_block_element_list ?root_uri ~to_syntax ~from_syntax content)]))
+      dd (nested_block_element_list ?xref_base_uri ~to_syntax ~from_syntax content)]))
   | `Param (name, content) ->
     Some (Html.(dl [
       dt [pcdata "parameter "; pcdata name];
-      dd (nested_block_element_list ?root_uri ~to_syntax ~from_syntax content)]))
+      dd (nested_block_element_list ?xref_base_uri ~to_syntax ~from_syntax content)]))
   | `Raise (name, content) ->
     Some (Html.(dl [
       dt [pcdata "raises "; pcdata name];
-      dd (nested_block_element_list ?root_uri ~to_syntax ~from_syntax content)]))
+      dd (nested_block_element_list ?xref_base_uri ~to_syntax ~from_syntax content)]))
   | `Return content ->
     Some (Html.(dl [
       dt [pcdata "returns"];
-      dd (nested_block_element_list ?root_uri ~to_syntax ~from_syntax content)]))
+      dd (nested_block_element_list ?xref_base_uri ~to_syntax ~from_syntax content)]))
   | `See (kind, target, content) ->
     let target =
       match kind with
@@ -341,7 +341,7 @@ let tag : ?root_uri:string ->
     in
     Some (Html.(dl [
       dt [pcdata "see "; target];
-      dd (nested_block_element_list ?root_uri ~to_syntax ~from_syntax content)]))
+      dd (nested_block_element_list ?xref_base_uri ~to_syntax ~from_syntax content)]))
   | `Since s ->
     Some (Html.(dl [
       dt [pcdata "since"];
@@ -349,7 +349,7 @@ let tag : ?root_uri:string ->
   | `Before (version, content) ->
     Some (Html.(dl [
       dt [pcdata "before "; pcdata version];
-      dd (nested_block_element_list ?root_uri ~to_syntax ~from_syntax content)]))
+      dd (nested_block_element_list ?xref_base_uri ~to_syntax ~from_syntax content)]))
   | `Version s ->
     Some (Html.(dl [
       dt [pcdata "version"];
@@ -360,11 +360,11 @@ let tag : ?root_uri:string ->
 
 
 let block_element
-  : 'a. ?root_uri:string -> to_syntax:Html_tree.syntax -> from_syntax:Html_tree.syntax ->
+  : 'a. ?xref_base_uri:string -> to_syntax:Html_tree.syntax -> from_syntax:Html_tree.syntax ->
   Comment.block_element -> (([> flow ] as 'a) Html.elt) option =
-  fun ?root_uri ~to_syntax ~from_syntax -> function
+  fun ?xref_base_uri ~to_syntax ~from_syntax -> function
   | #Comment.nestable_block_element as e ->
-    Some (nestable_block_element ?root_uri ~to_syntax ~from_syntax e)
+    Some (nestable_block_element ?xref_base_uri ~to_syntax ~from_syntax e)
 
   | `Heading (level, label, content) ->
     (* TODO Simplify the id/label formatting. *)
@@ -393,11 +393,11 @@ let block_element
     Some element
 
   | `Tag t ->
-    tag ?root_uri ~to_syntax ~from_syntax t
+    tag ?xref_base_uri ~to_syntax ~from_syntax t
 
-let block_element_list ?root_uri ~to_syntax elements =
+let block_element_list ?xref_base_uri ~to_syntax elements =
   List.fold_left (fun html_elements (from_syntax, block) ->
-    match block_element ?root_uri  ~to_syntax ~from_syntax block with
+    match block_element ?xref_base_uri  ~to_syntax ~from_syntax block with
     | Some e -> e::html_elements
     | None -> html_elements)
     [] elements
@@ -405,16 +405,16 @@ let block_element_list ?root_uri ~to_syntax elements =
 
 
 
-let first_to_html ?root_uri ?syntax:(to_syntax=Html_tree.OCaml) = function
+let first_to_html ?xref_base_uri ?syntax:(to_syntax=Html_tree.OCaml) = function
   | {Model.Location_.value = `Paragraph _ as first_paragraph; location} ::_ ->
-    begin match block_element ?root_uri ~to_syntax ~from_syntax:(location_to_syntax location) first_paragraph with
+    begin match block_element ?xref_base_uri ~to_syntax ~from_syntax:(location_to_syntax location) first_paragraph with
     | Some element -> [element]
     | None -> []
     end
   | _ -> []
 
-let to_html ?root_uri ?syntax:(to_syntax=Html_tree.OCaml) docs =
-  block_element_list ?root_uri ~to_syntax
+let to_html ?xref_base_uri ?syntax:(to_syntax=Html_tree.OCaml) docs =
+  block_element_list ?xref_base_uri ~to_syntax
     (List.map (fun el -> Model.Location_.((location el |> location_to_syntax, value el))) docs)
 
 let has_doc docs =

--- a/src/html/documentation.mli
+++ b/src/html/documentation.mli
@@ -1,13 +1,13 @@
 module Html = Tyxml.Html
 
 val to_html :
-  ?root_uri:string ->
+  ?xref_base_uri:string ->
   ?syntax:Html_tree.syntax ->
   Model.Comment.docs ->
     ([> Html_types.flow5_without_header_footer ] Html.elt) list
 
 val first_to_html :
-  ?root_uri:string ->
+  ?xref_base_uri:string ->
   ?syntax:Html_tree.syntax ->
   Model.Comment.docs ->
     ([> Html_types.flow5_without_header_footer ] Html.elt) list

--- a/src/html/html_tree.ml
+++ b/src/html/html_tree.ml
@@ -66,7 +66,7 @@ module Relative_link = struct
     exception Not_linkable
     exception Can't_stop_before
 
-    val href : ?root_uri:string -> stop_before:bool -> _ Identifier.t -> string
+    val href : ?xref_base_uri:string -> stop_before:bool -> _ Identifier.t -> string
   end = struct
     exception Not_linkable
 
@@ -78,10 +78,10 @@ module Relative_link = struct
 
     exception Can't_stop_before
 
-    let href ?root_uri ~stop_before id =
-      match root_uri, Url.from_identifier ~stop_before id with
-      (* If root_uri is defined, do not perform relative URI resolution. *)
-      | Some root_uri, Ok { Url. page; anchor; kind } ->
+    let href ?xref_base_uri ~stop_before id =
+      match xref_base_uri, Url.from_identifier ~stop_before id with
+      (* If xref_base_uri is defined, do not perform relative URI resolution. *)
+      | Some xref_base_uri, Ok { Url. page; anchor; kind } ->
         let absolute_target =
           List.rev (
             if !semantic_uris || kind = "page" then
@@ -90,7 +90,7 @@ module Relative_link = struct
               "index.html" :: page
           )
         in
-        let page = root_uri ^ String.concat "/" absolute_target in
+        let page = xref_base_uri ^ String.concat "/" absolute_target in
         begin match anchor with
         | "" -> page
         | anchor -> page ^ "#" ^ anchor

--- a/src/html/html_tree.mli
+++ b/src/html/html_tree.mli
@@ -72,7 +72,7 @@ module Relative_link : sig
   module Id : sig
     exception Not_linkable
 
-    val href : ?root_uri:string -> stop_before:bool -> _ Paths.Identifier.t -> string
+    val href : ?xref_base_uri:string -> stop_before:bool -> _ Paths.Identifier.t -> string
   end
 
   val of_path : stop_before:bool -> _ Paths.Path.t

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -251,15 +251,17 @@ module Html_fragment : sig
   val info: Term.info
 end = struct
 
-  let html_fragment directories root_uri output_file input_file =
+  let html_fragment directories xref_base_uri output_file input_file =
     let env = Env.create ~important_digests:false ~directories in
     let input_file = Fs.File.of_string input_file in
     let output_file = Fs.File.of_string output_file in
-    let root_uri =
-      let last_char = String.get root_uri (String.length root_uri - 1) in
-      if last_char <> '/' then root_uri ^ "/" else root_uri
+    let xref_base_uri =
+      if xref_base_uri = "" then xref_base_uri
+      else
+        let last_char = String.get xref_base_uri (String.length xref_base_uri - 1) in
+        if last_char <> '/' then xref_base_uri ^ "/" else xref_base_uri
     in
-    Html_fragment.from_mld ~env ~root_uri ~output:output_file input_file
+    Html_fragment.from_mld ~env ~xref_base_uri ~output:output_file input_file
 
   let cmd =
     let output =
@@ -271,13 +273,13 @@ end = struct
       let doc = "Input documentation page file" in
       Arg.(required & pos 0 (some file) None & info ~doc ~docv:"file.mld" [])
     in
-    let root_uri =
-      let doc = "Root URI used to resolve cross-references. Set this to the \
+    let xref_base_uri =
+      let doc = "Base URI used to resolve cross-references. Set this to the \
                  root of the global docset during local development. By default \
                  `.' is used." in
-      Arg.(value & opt string "" & info ~docv:"URI" ~doc ["root-uri"])
+      Arg.(value & opt string "" & info ~docv:"URI" ~doc ["xref-base-uri"])
     in
-    Term.(const html_fragment $ odoc_file_directories $ root_uri $ output $ input)
+    Term.(const html_fragment $ odoc_file_directories $ xref_base_uri $ output $ input)
 
   let info =
     Term.info ~doc:"Generates an html fragment file from an mld one" "html-fragment"

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -1,5 +1,5 @@
 
-let from_mld ~root_uri ~env ~output input =
+let from_mld ~xref_base_uri ~env ~output input =
   (* Internal names, they don't have effect on the output. *)
   let page_name = "__fragment_page__" in
   let package = "__fragment_package__" in
@@ -37,7 +37,7 @@ let from_mld ~root_uri ~env ~output input =
     let env = Env.build env (`Page page) in
     let resolved = Xref.resolve_page (Env.resolver env) page in
 
-    let content = Html.Documentation.to_html ~root_uri resolved.content in
+    let content = Html.Documentation.to_html ~xref_base_uri resolved.content in
     let oc = open_out (Fs.File.to_string output) in
     let fmt = Format.formatter_of_out_channel oc in
     Format.fprintf fmt "%a@." (Format.pp_print_list (Tyxml.Html.pp_elt ())) content;

--- a/src/odoc/html_fragment.mli
+++ b/src/odoc/html_fragment.mli
@@ -16,12 +16,12 @@
 
 (** Produces html fragment files from a mld file. *)
 
-val from_mld : root_uri:string -> env:Env.builder -> output:Fs.File.t -> Fs.File.t -> unit
-(** [from_mld ~root_uri ~env ~output input] parses the content of the [input]
+val from_mld : xref_base_uri:string -> env:Env.builder -> output:Fs.File.t -> Fs.File.t -> unit
+(** [from_mld ~xref_base_uri ~env ~output input] parses the content of the [input]
     file as a documentation page ({e i.e.} the ocamldoc syntax), generates the
     equivalent HTML representation and writes the result into the [output]
     file. The produced file is an HTML fragment that can be embedded into other
     documents.
 
-    Cross-reference resolution uses the provided [root_uri] to locate docset
+    Cross-reference resolution uses the provided [xref_base_uri] to locate docset
     packages. *)


### PR DESCRIPTION
This renames `root-uri` to `xref-base-uri` as suggested by https://github.com/ocaml/odoc/issues/27#issuecomment-427862082. And more importantly fixes a bug where the default value for this option resulted in out of bounds access.

@aantron this is a breaking change on the command-line interface level but I don't think anyone is using this in 1.3 yet.

CC @dbuenzli 