### PR TITLE
Add odoc lint command for mli and mld validation

### DIFF
--- a/src/compat/compat.ml
+++ b/src/compat/compat.ml
@@ -29,3 +29,17 @@ struct
 #endif
 
 end
+
+module Filename = struct
+  include Filename
+
+#if OCAML_MAJOR = 4 && OCAML_MINOR < 04
+  let extension filename =
+    let dot_index = String.rindex filename '.' in
+    String.sub filename dot_index (String.length filename - dot_index)
+
+  let remove_extension filename =
+    let dot_index = String.index filename '.' in
+    String.sub filename 0 dot_index
+#endif
+end

--- a/src/loader/attrs.ml
+++ b/src/loader/attrs.ml
@@ -41,7 +41,7 @@ let load_payload : Parsetree.payload -> (string * Location.t) option = function
   | _ ->
     None
 
-let read_attributes parent _id attrs =
+let read_attributes parent attrs =
   let ocaml_deprecated = ref None in
   let rec loop first nb_deprecated acc
       : _ -> (Model.Comment.docs, Model.Error.t) result =

--- a/src/loader/attrs.mli
+++ b/src/loader/attrs.mli
@@ -24,7 +24,6 @@ val empty : Model.Comment.docs
 
 val read_attributes :
   Paths.Identifier.label_parent ->
-  'kind Paths.Identifier.t ->
   Parsetree.attributes ->
     Model.Comment.docs
 

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -512,7 +512,7 @@ let read_value_description env parent id vd =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id vd.val_attributes in
+  let doc = read_attributes container vd.val_attributes in
     mark_value_description vd;
     let type_ = read_type_expr env vd.val_type in
     match vd.val_kind with
@@ -534,8 +534,7 @@ let read_label_declaration env parent ld =
   let name = parenthesise (Ident.name ld.ld_id) in
   let id = Identifier.Field(parent, name) in
   let doc =
-    read_attributes (Identifier.label_parent_of_parent parent) id
-      ld.ld_attributes
+    read_attributes (Identifier.label_parent_of_parent parent) ld.ld_attributes
   in
   let mutable_ = (ld.ld_mutable = Mutable) in
   let type_ = read_type_expr env ld.ld_type in
@@ -562,7 +561,7 @@ let read_constructor_declaration env parent cd =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_datatype parent)
   in
-  let doc = read_attributes container id cd.cd_attributes in
+  let doc = read_attributes container cd.cd_attributes in
   let args =
     read_constructor_declaration_arguments env
       (Identifier.parent_of_datatype parent) cd.cd_args
@@ -623,7 +622,7 @@ let read_type_declaration env parent id decl =
   let container = Identifier.label_parent_of_parent
                     (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id decl.type_attributes in
+  let doc = read_attributes container decl.type_attributes in
   let params = mark_type_declaration decl in
   let manifest = opt_map (read_type_expr env) decl.type_manifest in
   let constraints = read_type_constraints env params in
@@ -654,7 +653,7 @@ let read_extension_constructor env parent id ext =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id ext.ext_attributes in
+  let doc = read_attributes container ext.ext_attributes in
   let args =
     read_constructor_declaration_arguments env
       (Identifier.parent_of_signature parent) ext.ext_args
@@ -689,7 +688,7 @@ let read_exception env parent id ext =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id ext.ext_attributes in
+  let doc = read_attributes container ext.ext_attributes in
     mark_exception ext;
     let args =
       read_constructor_declaration_arguments env
@@ -792,7 +791,7 @@ let read_class_type_declaration env parent id cltd =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id cltd.clty_attributes in
+  let doc = read_attributes container cltd.clty_attributes in
     mark_class_type_declaration cltd;
     let params =
       List.map2
@@ -830,7 +829,7 @@ let read_class_declaration env parent id cld =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id cld.cty_attributes in
+  let doc = read_attributes container cld.cty_attributes in
     mark_class_declaration cld;
     let params =
       List.map2
@@ -875,7 +874,7 @@ and read_module_type_declaration env parent id mtd =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id mtd.mtd_attributes in
+  let doc = read_attributes container mtd.mtd_attributes in
   let expr = opt_map (read_module_type env id 1) mtd.mtd_type in
   let expansion =
     match expr with
@@ -891,7 +890,7 @@ and read_module_declaration env parent ident md =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id md.md_attributes in
+  let doc = read_attributes container md.md_attributes in
   let canonical =
     let doc = List.map Model.Location_.value doc in
     match List.find (function `Tag (`Canonical _) -> true | _ -> false) doc with

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -83,7 +83,7 @@ let read_value_binding env parent vb =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container parent vb.vb_attributes in
+  let doc = read_attributes container vb.vb_attributes in
     read_pattern env parent doc vb.vb_pat
 
 let read_value_bindings env parent vbs =
@@ -108,7 +108,7 @@ let read_type_extension env parent tyext =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container parent tyext.tyext_attributes in
+  let doc = read_attributes container tyext.tyext_attributes in
   let type_params =
     List.map (fun (ctyp, _) -> ctyp.ctyp_type) tyext.tyext_params
   in
@@ -138,7 +138,7 @@ let rec read_class_type_field env parent ctf =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_class_signature parent)
   in
-  let doc = read_attributes container parent ctf.ctf_attributes in
+  let doc = read_attributes container ctf.ctf_attributes in
   match ctf.ctf_desc with
   | Tctf_val(name, mutable_, virtual_, typ) ->
       let open InstanceVariable in
@@ -218,7 +218,7 @@ let rec read_class_field env parent cf =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_class_signature parent)
   in
-  let doc = read_attributes container parent (cf.cf_attributes) in
+  let doc = read_attributes container (cf.cf_attributes) in
   match cf.cf_desc with
   | Tcf_val({txt = name; _}, mutable_, _, kind, _) ->
       let open InstanceVariable in
@@ -319,7 +319,7 @@ let read_class_declaration env parent cld =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id cld.ci_attributes in
+  let doc = read_attributes container cld.ci_attributes in
     Cmi.mark_class_declaration cld.ci_decl;
     let virtual_ = (cld.ci_virt = Virtual) in
     let clparams =
@@ -394,7 +394,7 @@ and read_module_binding env parent mb =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id mb.mb_attributes in
+  let doc = read_attributes container mb.mb_attributes in
   let canonical =
     let doc = List.map Model.Location_.value doc in
     match List.find (function `Tag (`Canonical _) -> true | _ -> false) doc with
@@ -491,7 +491,7 @@ and read_include env parent incl =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container parent incl.incl_attributes in
+  let doc = read_attributes container incl.incl_attributes in
   let decl =
     let open Module in
     match unwrap_module_expr_desc incl.incl_mod.mod_desc with

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -141,7 +141,7 @@ let read_value_description env parent vd =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id vd.val_attributes in
+  let doc = read_attributes container vd.val_attributes in
   let type_ = read_core_type env vd.val_desc in
   match vd.val_prim with
   | [] -> Value {Value.id; doc; type_}
@@ -168,7 +168,7 @@ let read_label_declaration env parent ld =
   let name = parenthesise (Ident.name ld.ld_id) in
   let id = Identifier.Field(parent, name) in
   let doc =
-    read_attributes (Identifier.label_parent_of_parent parent) id ld.ld_attributes
+    read_attributes (Identifier.label_parent_of_parent parent) ld.ld_attributes
   in
   let mutable_ = (ld.ld_mutable = Mutable) in
   let type_ = read_core_type env ld.ld_type in
@@ -191,7 +191,7 @@ let read_constructor_declaration env parent cd =
   let name = parenthesise (Ident.name cd.cd_id) in
   let id = Identifier.Constructor(parent, name) in
   let container = Identifier.parent_of_datatype parent in
-  let doc = read_attributes (Identifier.label_parent_of_parent container) id cd.cd_attributes in
+  let doc = read_attributes (Identifier.label_parent_of_parent container) cd.cd_attributes in
   let args = read_constructor_declaration_arguments env container cd.cd_args in
   let res = opt_map (read_core_type env) cd.cd_res in
     {id; doc; args; res}
@@ -229,7 +229,7 @@ let read_type_declaration env parent decl =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id decl.typ_attributes in
+  let doc = read_attributes container decl.typ_attributes in
   let equation = read_type_equation env decl in
   let representation = read_type_kind env id decl.typ_kind in
     {id; doc; equation; representation}
@@ -255,7 +255,7 @@ let read_extension_constructor env parent ext =
   let name = parenthesise (Ident.name ext.ext_id) in
   let id = Identifier.Extension(parent, name) in
   let container = Identifier.parent_of_signature parent in
-  let doc = read_attributes (Identifier.label_parent_of_parent container) id ext.ext_attributes in
+  let doc = read_attributes (Identifier.label_parent_of_parent container) ext.ext_attributes in
   match ext.ext_kind with
   | Text_rebind _ -> assert false
   | Text_decl(args, res) ->
@@ -269,7 +269,7 @@ let read_type_extension env parent tyext =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container parent tyext.tyext_attributes in
+  let doc = read_attributes container tyext.tyext_attributes in
   let type_params = List.map read_type_parameter tyext.tyext_params in
   let private_ = (tyext.tyext_private = Private) in
   let constructors =
@@ -282,7 +282,7 @@ let read_exception env parent ext =
   let name = parenthesise (Ident.name ext.ext_id) in
   let id = Identifier.Exception(parent, name) in
   let container = Identifier.parent_of_signature parent in
-  let doc = read_attributes (Identifier.label_parent_of_parent container) id ext.ext_attributes in
+  let doc = read_attributes (Identifier.label_parent_of_parent container) ext.ext_attributes in
   match ext.ext_kind with
   | Text_rebind _ -> assert false
   | Text_decl(args, res) ->
@@ -296,7 +296,7 @@ let rec read_class_type_field env parent ctf =
     Identifier.label_parent_of_parent
       (Identifier.parent_of_class_signature parent)
   in
-  let doc = read_attributes container parent ctf.ctf_attributes in
+  let doc = read_attributes container ctf.ctf_attributes in
   match ctf.ctf_desc with
   | Tctf_val(name, mutable_, virtual_, typ) ->
       let open InstanceVariable in
@@ -361,7 +361,7 @@ let read_class_type_declaration env parent cltd =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id cltd.ci_attributes in
+  let doc = read_attributes container cltd.ci_attributes in
   let virtual_ = (cltd.ci_virt = Virtual) in
   let params = List.map read_type_parameter cltd.ci_params in
   let expr = read_class_signature env id cltd.ci_expr in
@@ -404,7 +404,7 @@ let read_class_description env parent cld =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id cld.ci_attributes in
+  let doc = read_attributes container cld.ci_attributes in
   let virtual_ = (cld.ci_virt = Virtual) in
   let params = List.map read_type_parameter cld.ci_params in
   let type_ = read_class_type env id cld.ci_expr in
@@ -494,7 +494,7 @@ and read_module_type_declaration env parent mtd =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id mtd.mtd_attributes in
+  let doc = read_attributes container mtd.mtd_attributes in
   let expr = opt_map (read_module_type env id 1) mtd.mtd_type in
   let expansion =
     match expr with
@@ -510,7 +510,7 @@ and read_module_declaration env parent md =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container id md.md_attributes in
+  let doc = read_attributes container md.md_attributes in
   let canonical =
     let doc = List.map Model.Location_.value doc in
     match List.find (function `Tag (`Canonical _) -> true | _ -> false) doc with
@@ -596,7 +596,7 @@ and read_include env parent incl =
   let container =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
-  let doc = read_attributes container parent incl.incl_attributes in
+  let doc = read_attributes container incl.incl_attributes in
   let expr = read_module_type env parent 1 incl.incl_mod in
   let decl = Module.ModuleType expr in
   let content = Cmi.read_signature env parent incl.incl_type in

--- a/src/loader/loader.ml
+++ b/src/loader/loader.ml
@@ -3,6 +3,7 @@ open Result
 
 module Error = Model.Error
 
+module Attrs = Attrs
 
 
 let read_string parent_definition location text =

--- a/src/loader/loader.mli
+++ b/src/loader/loader.mli
@@ -1,5 +1,7 @@
 open Result
 
+module Attrs = Attrs
+
 val read_string :
   Model.Paths.Identifier.label_parent ->
   Location.t ->

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -377,6 +377,33 @@ module Targets = struct
   end
 end
 
+
+module Lint : sig
+  val cmd : unit Term.t
+  val info: Term.info
+end = struct
+  let main input_file =
+    let input_file = Fs.File.of_string input_file in
+    if Fs.File.has_ext "mli" input_file then
+      Lint.mli input_file
+    else
+    if Fs.File.has_ext "mld" input_file then
+      Lint.mld input_file
+    else begin
+      Printf.eprintf "Unknown extension, expected one of: mli or mld.\n%!";
+      exit 2
+    end
+  let cmd =
+    let input =
+      let doc = "Input mld or mli file" in
+      Arg.(required & pos 0 (some file) None & info ~doc ~docv:"FILE" [])
+    in
+    Term.(const main $ input)
+  let info =
+    Term.info ~doc:"Validate odoc comment syntax in mli and mld files" "lint"
+end
+
+
 let () =
   let subcommands =
     [ Compile.(cmd, info)
@@ -388,6 +415,7 @@ let () =
     ; Depends.Html.(cmd, info)
     ; Targets.Compile.(cmd, info)
     ; Targets.Html.(cmd, info)
+    ; Lint.(cmd, info)
     ]
   in
   let default =

--- a/src/odoc/lint.ml
+++ b/src/odoc/lint.ml
@@ -1,0 +1,54 @@
+open Compat
+
+let mli file =
+  let filename = Fs.File.to_string file in
+  let items =
+    let ic = open_in filename in
+    let lexbuf = Lexing.from_channel ic in
+    Location.init lexbuf filename;
+    try Parse.interface lexbuf with
+    | Syntaxerr.Error e ->
+      Format.printf "%a" Syntaxerr.report_error e;
+      exit 1
+  in
+  let parent =
+    let name = Filename.remove_extension filename in
+    let file = Model.Root.Odoc_file.create_unit name ~force_hidden:false in
+    let root = {Model.Root.package = ""; file; digest = Digest.file filename} in
+    Model.Paths.Identifier.Root (root, name)
+  in
+  let mapper = {
+    Ast_mapper.default_mapper with
+    attribute = fun _self attr ->
+      ignore (Loader.Attrs.read_comment parent attr);
+      ignore (Loader.Attrs.read_attributes parent [attr]);
+      attr
+  } in
+  ignore (mapper.signature mapper items)
+
+
+let mld file =
+  let filename = Fs.File.to_string file in
+  let parent =
+    let name = Filename.remove_extension filename in
+    let file = Model.Root.Odoc_file.create_unit name ~force_hidden:false in
+    let root = {Model.Root.package = ""; file; digest = Digest.file filename} in
+    Model.Paths.Identifier.Root (root, name)
+  in
+  let location =
+    let pos =
+      Lexing.{
+        pos_fname = filename;
+        pos_lnum = 0;
+        pos_cnum = 0;
+        pos_bol = 0
+      }
+    in
+    Location.{ loc_start = pos; loc_end = pos; loc_ghost = true }
+  in
+  match Fs.File.read file with
+  | Ok content ->
+    ignore (Loader.Attrs.read_string parent location content)
+  | Error (`Msg err) ->
+    prerr_endline err;
+    exit 1

--- a/src/odoc/lint.mli
+++ b/src/odoc/lint.mli
@@ -1,0 +1,4 @@
+
+val mli : Fs.File.t -> unit
+
+val mld : Fs.File.t -> unit

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -11,16 +11,6 @@ let command label =
     if exit_code <> 0 then
       Alcotest.failf "'%s' exited with %i" label exit_code)
 
-(* Filename.extension is only available on 4.04. *)
-module Filename = struct
-  include Filename
-
-  let extension filename =
-    let dot_index = String.rindex filename '.' in
-    String.sub filename dot_index (String.length filename - dot_index)
-end
-
-
 (* Testing environment *)
 
 module Env = struct

--- a/test/parser/lint/cases/ast.mli
+++ b/test/parser/lint/cases/ast.mli
@@ -1,0 +1,79 @@
+
+(** @TxtAttribute *)
+
+val v1 : int
+(** @ValueDeclaration *)
+
+(** @ValueDeclaration *)
+val v2 : int
+(** @ValueDeclaration *)
+
+type t1 = int
+(** @TypeDeclaration *)
+
+(** @TypeDeclaration *)
+type t2 = A (** @ConstructorDeclaration *)
+        | B (** @ConstructorDeclaration *)
+
+type t3 = [
+| `A (** @Tag *)
+| `B (** @Tag *)
+]
+
+(** @TypeDeclaration *)
+type t3 = {
+  a : int; (** @LabelDeclaration *)
+  b : bool; (** @LabelDeclaration *)
+}
+
+type te = ..
+(** @TypeDeclaration *)
+
+(** @TypeExtension *)
+type te += A (** @Extension *)
+         | B (** @Extension *)
+
+(** @ModuleTypeDeclaration *)
+module type Mt = sig
+  (** @TxtAttribute *)
+
+  type t = int
+  (** @TypeDeclaration *)
+end
+
+(** @ModuleDeclaration *)
+module M : sig
+  (** @TxtAttribute *)
+
+  (** @ModuleDeclaration *)
+  module N : sig
+    (** @TxtAttribute *)
+
+    type t = int
+    (** @TypeDeclaration *)
+  end
+end
+
+exception Kaboom
+(** @Exception *)
+
+(**/**)
+(** @Hidden *)
+(**/**)
+
+(** @Functor *)
+module F : functor (M : Map.OrderedType) -> Map.S
+
+(** @IncludeDescription *)
+include sig
+  (** @TxtAttribute *)
+
+  type t = int
+  (** @TypeDeclaration *)
+end
+
+(** @Class *)
+class empty_class : object
+  method go : unit
+  (** @Method *)
+end

--- a/test/parser/lint/cases/parser_errors.mli
+++ b/test/parser/lint/cases/parser_errors.mli
@@ -1,0 +1,51 @@
+
+(** {x This is bad markup} *)
+val x : int
+
+(** {9 Bad hading level} *)
+val x : int
+
+(* {4 Heading} this should be on it's own line *)
+val x : int
+
+(** {ul {limust be followed by whitespace}} *)
+val x : int
+
+(** {limust in a ul} *)
+val x : int
+
+(** {vmust be followed by whitespace v} *)
+val x : int
+
+(** {v must be preceded by whitespacev} *)
+val x : int
+
+(** @ stray *)
+val x : int
+
+(** Expect something on the same line: *)
+val x : int
+
+(** @before *)
+val x : int
+
+(** @param *)
+val x : int
+
+(** @raise *)
+val x : int
+
+(** @see *)
+val x : int
+
+(** @UnknownTag *)
+val x : int
+
+(** } unpaired *)
+val x : int
+
+(** ] unpaired *)
+val x : int
+
+(** {%invalid: raw markup target %} *)
+val x : int

--- a/test/parser/lint/dune
+++ b/test/parser/lint/dune
@@ -1,0 +1,19 @@
+
+(rule
+	(deps (:input cases/ast.mli))
+  (targets ast.output)
+  (action (with-stderr-to ast.output
+		        (run %{workspace_root}/src/odoc/bin/main.exe lint %{input}))))
+(alias
+  (name runtest)
+  (action (diff expect/ast.expected ast.output)))
+
+
+(rule
+	(deps (:input cases/parser_errors.mli))
+  (targets parser_errors.output)
+  (action (with-stderr-to parser_errors.output
+		        (run %{workspace_root}/src/odoc/bin/main.exe lint %{input}))))
+(alias
+  (name runtest)
+  (action (diff expect/parser_errors.expected parser_errors.output)))

--- a/test/parser/lint/expect/ast.expected
+++ b/test/parser/lint/expect/ast.expected
@@ -1,0 +1,66 @@
+File "cases/ast.mli", line 2, characters 1-14:
+unknown tag '@TxtAttribute'
+File "cases/ast.mli", line 5, characters 1-18:
+unknown tag '@ValueDeclaration'
+File "cases/ast.mli", line 7, characters 1-18:
+unknown tag '@ValueDeclaration'
+File "cases/ast.mli", line 9, characters 1-18:
+unknown tag '@ValueDeclaration'
+File "cases/ast.mli", line 12, characters 1-17:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 15, characters 13-36:
+unknown tag '@ConstructorDeclaration'
+File "cases/ast.mli", line 16, characters 13-36:
+unknown tag '@ConstructorDeclaration'
+File "cases/ast.mli", line 14, characters 1-17:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 19, characters 6-10:
+unknown tag '@Tag'
+File "cases/ast.mli", line 20, characters 6-10:
+unknown tag '@Tag'
+File "cases/ast.mli", line 25, characters 12-29:
+unknown tag '@LabelDeclaration'
+File "cases/ast.mli", line 26, characters 13-30:
+unknown tag '@LabelDeclaration'
+File "cases/ast.mli", line 23, characters 1-17:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 30, characters 1-17:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 33, characters 14-24:
+unknown tag '@Extension'
+File "cases/ast.mli", line 34, characters 14-24:
+unknown tag '@Extension'
+File "cases/ast.mli", line 32, characters 1-15:
+unknown tag '@TypeExtension'
+File "cases/ast.mli", line 38, characters 3-16:
+unknown tag '@TxtAttribute'
+File "cases/ast.mli", line 41, characters 3-19:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 36, characters 1-23:
+unknown tag '@ModuleTypeDeclaration'
+File "cases/ast.mli", line 46, characters 3-16:
+unknown tag '@TxtAttribute'
+File "cases/ast.mli", line 50, characters 5-18:
+unknown tag '@TxtAttribute'
+File "cases/ast.mli", line 53, characters 5-21:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 48, characters 3-21:
+unknown tag '@ModuleDeclaration'
+File "cases/ast.mli", line 44, characters 1-19:
+unknown tag '@ModuleDeclaration'
+File "cases/ast.mli", line 58, characters 1-11:
+unknown tag '@Exception'
+File "cases/ast.mli", line 61, characters 1-8:
+unknown tag '@Hidden'
+File "cases/ast.mli", line 64, characters 1-9:
+unknown tag '@Functor'
+File "cases/ast.mli", line 69, characters 3-16:
+unknown tag '@TxtAttribute'
+File "cases/ast.mli", line 72, characters 3-19:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 67, characters 1-20:
+unknown tag '@IncludeDescription'
+File "cases/ast.mli", line 78, characters 3-10:
+unknown tag '@Method'
+File "cases/ast.mli", line 75, characters 1-7:
+unknown tag '@Class'

--- a/test/parser/lint/expect/parser_errors.expected
+++ b/test/parser/lint/expect/parser_errors.expected
@@ -1,0 +1,31 @@
+File "cases/parser_errors.mli", line 2, characters 1-3:
+'{x': bad markup
+File "cases/parser_errors.mli", line 5, characters 1-21:
+'9': bad heading level (0-5 allowed)
+File "cases/parser_errors.mli", line 11, characters 5-8:
+'{li ...}' must be followed by space, a tab, or a new line
+File "cases/parser_errors.mli", line 14, characters 1-4:
+'{li ...}' (list item) is not allowed in top-level text
+Suggestion: move '{li ...}' into '{ul ...}' (bulleted list), or use '-' (bulleted list item)
+File "cases/parser_errors.mli", line 17, characters 1-3:
+'{v' must be followed by whitespace
+File "cases/parser_errors.mli", line 20, characters 34-36:
+'v}' must be preceded by whitespace
+File "cases/parser_errors.mli", line 23, characters 1-2:
+stray '@'
+File "cases/parser_errors.mli", line 29, characters 1-8:
+'@before' expects version number on the same line
+File "cases/parser_errors.mli", line 32, characters 1-7:
+'@param' expects parameter name on the same line
+File "cases/parser_errors.mli", line 35, characters 1-7:
+'@raise' expects exception constructor on the same line
+File "cases/parser_errors.mli", line 38, characters 1-5:
+'@see' must be followed by <url>, 'file', or "document title"
+File "cases/parser_errors.mli", line 41, characters 1-12:
+unknown tag '@UnknownTag'
+File "cases/parser_errors.mli", line 44, characters 1-2:
+unpaired '}' (end of markup)
+File "cases/parser_errors.mli", line 47, characters 1-2:
+unpaired ']' (end of code)
+File "cases/parser_errors.mli", line 50, characters 1-32:
+'{%invalid:': bad raw markup target


### PR DESCRIPTION
From https://github.com/ocaml/odoc/pull/217#issuecomment-430969591 by @avsm: 
> (...) is it feasible to have a odoc-lint binary that that runs over an ml/mli source file and displays any parsing inconsistencies?

This PR implements an `odoc lint` command that does exactly that. It parser `mli` and `mld` files and uses an AST mapper to go through all `[@@ocaml.doc ...]`/`[@@ocaml.text ...]` attributes running odoc's parser on them and producing errors (see the test expect files in this PR for examples).

I got excited about this and started implementing a ppx (https://github.com/ocaml/odoc/issues/147) to validate docstings and report errors with merlin. Unfortunately I was surprised to discover that merlin doesn't convert docstrings into documentation attributes (see https://github.com/ocaml/merlin/issues/876). After that is fixed implementing the ppx should be simple.

#### Changes
- Implement the `odoc lint FILE.{ml,mld}` command.
- Remove an unused `id` argument from `Loader.Attrs.read_attributes`.
- Expose `Attrs` module in `Loader` interface.
- Add `Compat.Filename.remove_extension`.
- Add tests for the new lint command.

#### Notes

- The current parser does not recover from errors. This means that for a documentation attributes or `mld` files that have multiple errors only the first one will be reported (related to https://github.com/ocaml/odoc/issues/108).
- Some old versions of the compiler don't seem to produce the `[@@ocaml.doc]` attribute on
  polymorphic variants (the CI should report all the culprits). I don't have a workaround for this.
- The column number reported in errors seems to be slightly shifted (I'll investigate this soon).
  - _Update_: seems like it is already present in `master`. The location of the attributes is off by -3, I assume it's because it's not counting `(**`.
- Support for more file formats (like `ml`) should be easy to implement and can be done separately.
- The current implementation could be improved but would require significant changes to the error/warning management in the whole project. @aantron has already plans for that AFAIK.
- I think the command could be extended to check for unresolved cross-references in the future.

Thoughts and suggestions are welcome!