### PR TITLE
Fix #101, assertion failure on some optional arguments in structure items

### DIFF
--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -368,7 +368,7 @@ let rec read_type_expr env typ =
           let arg =
             if Btype.is_optional lbl then
               match (Btype.repr arg).desc with
-              | Tconstr(_path, [arg], _) -> read_type_expr env arg
+              | Tconstr(_option, [arg], _) -> read_type_expr env arg
               | _ -> assert false
             else read_type_expr env arg
           in

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -368,9 +368,7 @@ let rec read_type_expr env typ =
           let arg =
             if Btype.is_optional lbl then
               match (Btype.repr arg).desc with
-              | Tconstr(path, [arg], _)
-                  when OCamlPath.same path Predef.path_option ->
-                    read_type_expr env arg
+              | Tconstr(_path, [arg], _) -> read_type_expr env arg
               | _ -> assert false
             else read_type_expr env arg
           in

--- a/test/html/cases/bugs.ml
+++ b/test/html/cases/bugs.ml
@@ -1,0 +1,4 @@
+type 'a opt = 'a option
+let foo (type a) ?(bar : a opt) () = ()
+(** Triggers an assertion failure when
+    {:https://github.com/ocaml/odoc/issues/101} is not fixed. *)

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Bugs (test_package+ml.Bugs)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Bugs
+    </nav>
+    <h1>
+     Module <code>Bugs</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec type" id="type-opt">
+     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type </span>'a opt</code><code><span class="keyword"> = </span><span class="type-var">'a</span> option</code>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : ?⁠bar:<span class="type-var">'a</span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
+    </dt>
+    <dd>
+     <p>
+      Triggers an assertion failure when <a href="https://github.com/ocaml/odoc/issues/101">https://github.com/ocaml/odoc/issues/101</a> is not fixed.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Bugs/index.html
+++ b/test/html/expect/test_package+re/Bugs/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Bugs (test_package+re.Bugs)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Bugs
+    </nav>
+    <h1>
+     Module <code>Bugs</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec type" id="type-opt">
+     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type </span>opt('a)</code><code><span class="keyword"> = </span>option(<span class="type-var">'a</span>)</code><span class="keyword">;</span>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: ?⁠bar:<span class="type-var">'a</span> <span>=&gt;</span> unit <span>=&gt;</span> unit<span class="keyword">;</span></code>
+    </dt>
+    <dd>
+     <p>
+      Triggers an assertion failure when <a href="https://github.com/ocaml/odoc/issues/101">https://github.com/ocaml/odoc/issues/101</a> is not fixed.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -61,7 +61,7 @@ end
 module Case = struct
   type t = {
     name: string;
-    kind: [ `mld | `mli ];
+    kind: [ `mli | `mld | `ml ];
     theme_uri: string option;
     syntax: [ `ml | `re ];
   }
@@ -72,7 +72,9 @@ module Case = struct
       match Filename.extension basename with
       | ".mli" -> `mli
       | ".mld" -> `mld
-      | _ -> invalid_arg (sprintf "Expected mli or mld files, got %s" basename)
+      | ".ml" -> `ml
+      | _ ->
+        invalid_arg (sprintf "Expected mli, mld, or ml files, got %s" basename)
     in
     { name; kind; theme_uri; syntax }
 
@@ -96,22 +98,25 @@ module Case = struct
 
   let cmi_file case  = Env.path `scratch // (case.name ^ ".cmi")
   let cmti_file case = Env.path `scratch // (case.name ^ ".cmti")
+  let cmo_file case = Env.path `scratch // (case.name ^ ".cmo")
+  let cmt_file case = Env.path `scratch // (case.name ^ ".cmt")
 
   let odoc_file case =
     match case.kind with
-    | `mli -> Env.path `scratch // (case.name ^ ".odoc")
+    | `mli | `ml -> Env.path `scratch // (case.name ^ ".odoc")
     | `mld -> Env.path `scratch // ("page-" ^ case.name ^ ".odoc")
 
   let source_file case =
     match case.kind with
     | `mli -> Env.path `cases // case.name ^ ".mli"
     | `mld -> Env.path `cases // case.name ^ ".mld"
+    | `ml -> Env.path `cases // case.name ^ ".ml"
 
   (* Produces an HTML file path for a given case, starting with [dir]. *)
   let html_file dir case =
     let module_name = String.capitalize_ascii case.name in
     match case.kind with
-    | `mli -> dir // package case // module_name // "index.html"
+    | `mli | `ml -> dir // package case // module_name // "index.html"
     | `mld -> dir // package case // case.name ^ ".html"
 
   let actual_html_file   ?from_root = html_file (Env.path ?from_root `scratch)
@@ -155,10 +160,22 @@ let generate_html case =
 
   | `mld ->
     command "odoc compile" "%s compile --package=%s -o %s %s"
-      Env.odoc (Case.package case) (Case.odoc_file case) (Case.source_file case);
+      Env.odoc
+      (Case.package case) (Case.odoc_file case) (Case.source_file case);
 
     command "odoc html" "%s html %s --output-dir=%s %s"
       Env.odoc theme_uri_option (Env.path `scratch) (Case.odoc_file case)
+
+  | `ml ->
+    command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
+      (Case.cmo_file case) (Case.source_file case);
+
+    command "odoc compile" "%s compile --package=%s %s"
+      Env.odoc (Case.package case) (Case.cmt_file case);
+
+    command "odoc html" "%s html %s --syntax=%s --output-dir=%s %s"
+      Env.odoc theme_uri_option (Case.string_of_syntax case.syntax)
+      (Env.path `scratch) (Case.odoc_file case)
 
 let diff =
   (* Alcotest will run all tests. We need to know when something fails for the
@@ -245,6 +262,7 @@ let source_files = [
   "functor.mli";
   "class.mli";
   "stop.mli";
+  "bugs.ml";
 ]
 
 


### PR DESCRIPTION
@lpw25, It looks like we can fix the assertion failure by simply not checking which constructor we have, since:

- We don't print it. Whatever the constructor is in `?(foo : bar some_option)` in the `.cmt` file, we print `?foo:bar` in the output, since we are using the `val` syntax of signatures, rather than the `let` syntax of structures.
- I think we can rely on the compiler to have unified the constructor with `option`.

The commit includes a test which reproduces the failure, if the fix is left out. The output looks right to me, as `let foo (type a) ?(bar : a opt) () = ()` should indeed generate `val foo : ?bar:'a -> unit -> unit`.

Fixes #101.