### PR TITLE
Port new error message tests from #226 to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ serve :
 .PHONY : test
 test : build
 	dune build @test/parser/runtest --no-buffer -j 1
+	dune build @test/compile/runtest --no-buffer -j 1
 	dune build @test/html/runtest --no-buffer -j 1
 
 ODOC_RELATIVE_PATH := ../../_build/install/default/bin/

--- a/test/compile/cases/ast.mli
+++ b/test/compile/cases/ast.mli
@@ -1,0 +1,78 @@
+(** @TxtAttribute *)
+
+val v1 : int
+(** @ValueDeclaration *)
+
+(** @ValueDeclaration *)
+val v2 : int
+(** @ValueDeclaration *)
+
+type t1 = int
+(** @TypeDeclaration *)
+
+(** @TypeDeclaration *)
+type t2 = A (** @ConstructorDeclaration *)
+        | B (** @ConstructorDeclaration *)
+
+type t3 = [
+| `A (** @Tag *)
+| `B (** @Tag *)
+]
+
+(** @TypeDeclaration *)
+type t4 = {
+  a : int; (** @LabelDeclaration *)
+  b : bool; (** @LabelDeclaration *)
+}
+
+type te = ..
+(** @TypeDeclaration *)
+
+(** @TypeExtension *)
+type te += A (** @Extension *)
+         | B (** @Extension *)
+
+(** @ModuleTypeDeclaration *)
+module type Mt = sig
+  (** @TxtAttribute *)
+
+  type t = int
+  (** @TypeDeclaration *)
+end
+
+(** @ModuleDeclaration *)
+module M : sig
+  (** @TxtAttribute *)
+
+  (** @ModuleDeclaration *)
+  module N : sig
+    (** @TxtAttribute *)
+
+    type t = int
+    (** @TypeDeclaration *)
+  end
+end
+
+exception Kaboom
+(** @Exception *)
+
+(**/**)
+(** @Hidden *)
+(**/**)
+
+(** @Functor *)
+module F : functor (M : Map.OrderedType) -> Map.S
+
+(** @IncludeDescription *)
+include sig
+  (** @TxtAttribute *)
+
+  type t = int
+  (** @TypeDeclaration *)
+end
+
+(** @Class *)
+class empty_class : object
+  method go : unit
+  (** @Method *)
+end

--- a/test/compile/cases/parser_errors.mli
+++ b/test/compile/cases/parser_errors.mli
@@ -1,0 +1,50 @@
+(** {x This is bad markup} *)
+val x : int
+
+(** {9 Bad hading level} *)
+val x : int
+
+(* {4 Heading} this should be on it's own line *)
+val x : int
+
+(** {ul {limust be followed by whitespace}} *)
+val x : int
+
+(** {limust in a ul} *)
+val x : int
+
+(** {vmust be followed by whitespace v} *)
+val x : int
+
+(** {v must be preceded by whitespacev} *)
+val x : int
+
+(** @ stray *)
+val x : int
+
+(** Expect something on the same line: *)
+val x : int
+
+(** @before *)
+val x : int
+
+(** @param *)
+val x : int
+
+(** @raise *)
+val x : int
+
+(** @see *)
+val x : int
+
+(** @UnknownTag *)
+val x : int
+
+(** } unpaired *)
+val x : int
+
+(** ] unpaired *)
+val x : int
+
+(** {%invalid: raw markup target %} *)
+val x : int

--- a/test/compile/dune
+++ b/test/compile/dune
@@ -1,0 +1,28 @@
+(rule
+ (deps cases/ast.mli)
+ (targets ast.output)
+ (action
+  (progn
+   (run %{ocamlc} -bin-annot -o ast.cmi -c cases/ast.mli)
+   (with-stderr-to ast.output
+	  (run
+     %{workspace_root}/src/odoc/bin/main.exe compile --package foo ast.cmti)))))
+
+(alias
+ (name runtest)
+ (action (diff expect/ast.txt ast.output)))
+
+(rule
+ (deps cases/parser_errors.mli)
+ (targets parser_errors.output)
+ (action
+  (progn
+   (run %{ocamlc} -bin-annot -o parser_errors.cmi -c cases/parser_errors.mli)
+   (with-stderr-to parser_errors.output
+	  (run
+      %{workspace_root}/src/odoc/bin/main.exe compile
+       --package foo parser_errors.cmti)))))
+
+(alias
+ (name runtest)
+ (action (diff expect/parser_errors.txt parser_errors.output)))

--- a/test/compile/expect/ast.txt
+++ b/test/compile/expect/ast.txt
@@ -1,0 +1,64 @@
+File "cases/ast.mli", line 1, characters 1-14:
+unknown tag '@TxtAttribute'
+File "cases/ast.mli", line 4, characters 1-18:
+unknown tag '@ValueDeclaration'
+File "cases/ast.mli", line 6, characters 1-18:
+unknown tag '@ValueDeclaration'
+File "cases/ast.mli", line 8, characters 1-18:
+unknown tag '@ValueDeclaration'
+File "cases/ast.mli", line 11, characters 1-17:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 13, characters 1-17:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 14, characters 13-36:
+unknown tag '@ConstructorDeclaration'
+File "cases/ast.mli", line 15, characters 13-36:
+unknown tag '@ConstructorDeclaration'
+File "cases/ast.mli", line 22, characters 1-17:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 24, characters 12-29:
+unknown tag '@LabelDeclaration'
+File "cases/ast.mli", line 25, characters 13-30:
+unknown tag '@LabelDeclaration'
+File "cases/ast.mli", line 29, characters 1-17:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 31, characters 1-15:
+unknown tag '@TypeExtension'
+File "cases/ast.mli", line 32, characters 14-24:
+unknown tag '@Extension'
+File "cases/ast.mli", line 33, characters 14-24:
+unknown tag '@Extension'
+File "cases/ast.mli", line 35, characters 1-23:
+unknown tag '@ModuleTypeDeclaration'
+File "cases/ast.mli", line 37, characters 3-16:
+unknown tag '@TxtAttribute'
+File "cases/ast.mli", line 40, characters 3-19:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 43, characters 1-19:
+unknown tag '@ModuleDeclaration'
+File "cases/ast.mli", line 45, characters 3-16:
+unknown tag '@TxtAttribute'
+File "cases/ast.mli", line 47, characters 3-21:
+unknown tag '@ModuleDeclaration'
+File "cases/ast.mli", line 49, characters 5-18:
+unknown tag '@TxtAttribute'
+File "cases/ast.mli", line 52, characters 5-21:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 57, characters 1-11:
+unknown tag '@Exception'
+File "cases/ast.mli", line 60, characters 1-8:
+unknown tag '@Hidden'
+File "cases/ast.mli", line 63, characters 1-9:
+unknown tag '@Functor'
+File "cases/ast.mli", line 66, characters 1-20:
+unknown tag '@IncludeDescription'
+File "cases/ast.mli", line 68, characters 3-16:
+unknown tag '@TxtAttribute'
+File "cases/ast.mli", line 71, characters 3-19:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 71, characters 3-19:
+unknown tag '@TypeDeclaration'
+File "cases/ast.mli", line 74, characters 1-7:
+unknown tag '@Class'
+File "cases/ast.mli", line 77, characters 3-10:
+unknown tag '@Method'

--- a/test/compile/expect/parser_errors.txt
+++ b/test/compile/expect/parser_errors.txt
@@ -1,0 +1,31 @@
+File "cases/parser_errors.mli", line 1, characters 1-3:
+'{x': bad markup
+File "cases/parser_errors.mli", line 4, characters 1-21:
+'9': bad heading level (0-5 allowed)
+File "cases/parser_errors.mli", line 10, characters 5-8:
+'{li ...}' must be followed by space, a tab, or a new line
+File "cases/parser_errors.mli", line 13, characters 1-4:
+'{li ...}' (list item) is not allowed in top-level text
+Suggestion: move '{li ...}' into '{ul ...}' (bulleted list), or use '-' (bulleted list item)
+File "cases/parser_errors.mli", line 16, characters 1-3:
+'{v' must be followed by whitespace
+File "cases/parser_errors.mli", line 19, characters 34-36:
+'v}' must be preceded by whitespace
+File "cases/parser_errors.mli", line 22, characters 1-2:
+stray '@'
+File "cases/parser_errors.mli", line 28, characters 1-8:
+'@before' expects version number on the same line
+File "cases/parser_errors.mli", line 31, characters 1-7:
+'@param' expects parameter name on the same line
+File "cases/parser_errors.mli", line 34, characters 1-7:
+'@raise' expects exception constructor on the same line
+File "cases/parser_errors.mli", line 37, characters 1-5:
+'@see' must be followed by <url>, 'file', or "document title"
+File "cases/parser_errors.mli", line 40, characters 1-12:
+unknown tag '@UnknownTag'
+File "cases/parser_errors.mli", line 43, characters 1-2:
+unpaired '}' (end of markup)
+File "cases/parser_errors.mli", line 46, characters 1-2:
+unpaired ']' (end of code)
+File "cases/parser_errors.mli", line 49, characters 1-32:
+'{%invalid:': bad raw markup target


### PR DESCRIPTION
@rizo This PR is the test cases for the `odoc lint` command you proposed, ported to work with `odoc compile` instead (https://github.com/ocaml/odoc/pull/226#issuecomment-432717405). I set you as the author, because you wrote these tests. I want to commit them now, so I can make use of them in work I want to do next.

These tests will probably need some quality-of-life improvements for developers, but I'll make them as I go, as needed by (at least) me.
