### PR TITLE
Add odoc support-files-targets

### DIFF
--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -157,7 +157,7 @@ end = struct
       ~doc:"Compile a cmti, cmt, cmi or mld file to an odoc file."
 end
 
-module Support_files = struct
+module Support_files_command = struct
   let support_files without_theme output_dir =
     Support_files.write ~without_theme output_dir
 
@@ -177,7 +177,7 @@ module Support_files = struct
 end
 
 module Css = struct
-  let cmd = Support_files.cmd
+  let cmd = Support_files_command.cmd
 
   let info =
     let doc =
@@ -375,6 +375,19 @@ module Targets = struct
     let info =
       Term.info "html-targets" ~doc:"TODO: Fill in."
   end
+
+  module Support_files =
+  struct
+    let list_targets () =
+      List.iter Support_files.filenames ~f:print_endline
+
+    let cmd =
+      Term.(const list_targets $ const ())
+
+    let info =
+      Term.info "support-files-targets"
+        ~doc:"Lists the names of the files that 'odoc support-files' outputs."
+  end
 end
 
 let () =
@@ -384,12 +397,13 @@ let () =
     [ Compile.(cmd, info)
     ; Html.(cmd, info)
     ; Html_fragment.(cmd, info)
-    ; Support_files.(cmd, info)
+    ; Support_files_command.(cmd, info)
     ; Css.(cmd, info)
     ; Depends.Compile.(cmd, info)
     ; Depends.Html.(cmd, info)
     ; Targets.Compile.(cmd, info)
     ; Targets.Html.(cmd, info)
+    ; Targets.Support_files.(cmd, info)
     ]
   in
   let default =

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -161,11 +161,11 @@ module Support_files_command = struct
   let support_files without_theme output_dir =
     Support_files.write ~without_theme output_dir
 
+  let without_theme =
+    let doc = "Don't copy the default theme to output directory." in
+    Arg.(value & flag & info ~doc ["without-theme"])
+
   let cmd =
-    let without_theme =
-      let doc = "Don't copy the default theme to output directory." in
-      Arg.(value & flag & info ~doc ["without-theme"])
-    in
     Term.(const support_files $ without_theme $ dst)
 
   let info =
@@ -378,11 +378,11 @@ module Targets = struct
 
   module Support_files =
   struct
-    let list_targets () =
-      List.iter Support_files.filenames ~f:print_endline
+    let list_targets without_theme output_directory =
+      Support_files.print_filenames ~without_theme output_directory
 
     let cmd =
-      Term.(const list_targets $ const ())
+      Term.(const list_targets $ Support_files_command.without_theme $ dst)
 
     let info =
       Term.info "support-files-targets"

--- a/src/odoc/support_files.ml
+++ b/src/odoc/support_files.ml
@@ -1,21 +1,23 @@
-let odoc_css = "odoc.css"
-let highlight_js = "highlight.pack.js"
-
-let write ?(without_theme = false) output_dir =
+let iter_files f ?(without_theme = false) output_directory =
   let file name content =
-    let channel =
-      Fs.File.create ~directory:output_dir ~name
+    let name =
+      Fs.File.create ~directory:output_directory ~name
       |> Fs.File.to_string
-      |> Pervasives.open_out
     in
-    Pervasives.output_string channel content;
-    Pervasives.close_out channel
+    f name content
   in
 
   if not without_theme then begin
-    file odoc_css Css_file.content
+    file "odoc.css" Css_file.content
   end;
-  file highlight_js Highlight_js.content
+  file "highlight.pack.js" Highlight_js.content
 
-let filenames =
-  [odoc_css; highlight_js]
+let write =
+  iter_files begin fun name content ->
+    let channel = Pervasives.open_out name in
+    Pervasives.output_string channel content;
+    Pervasives.close_out channel
+  end
+
+let print_filenames =
+  iter_files (fun name _content -> print_endline name)

--- a/src/odoc/support_files.ml
+++ b/src/odoc/support_files.ml
@@ -1,3 +1,6 @@
+let odoc_css = "odoc.css"
+let highlight_js = "highlight.pack.js"
+
 let write ?(without_theme = false) output_dir =
   let file name content =
     let channel =
@@ -10,6 +13,9 @@ let write ?(without_theme = false) output_dir =
   in
 
   if not without_theme then begin
-    file "odoc.css" Css_file.content
+    file odoc_css Css_file.content
   end;
-  file "highlight.pack.js" Highlight_js.content
+  file highlight_js Highlight_js.content
+
+let filenames =
+  [odoc_css; highlight_js]

--- a/src/odoc/support_files.mli
+++ b/src/odoc/support_files.mli
@@ -5,3 +5,7 @@ val write : ?without_theme: bool -> Fs.Directory.t -> unit
 (** [write ?without_theme output_dir] copies the support files to the
     [output_dir]. If [without_theme] is [true] the theme will {e not} be
     copied, the default value is [false]. *)
+
+val filenames : string list
+(** The list of the names of the files that calling [Support_files.write] would
+    output. *)

--- a/src/odoc/support_files.mli
+++ b/src/odoc/support_files.mli
@@ -1,11 +1,11 @@
 (** Copies odoc's support files (default theme and JS files) to a specified
     location. *)
 
-val write : ?without_theme: bool -> Fs.Directory.t -> unit
+val write : ?without_theme:bool -> Fs.Directory.t -> unit
 (** [write ?without_theme output_dir] copies the support files to the
     [output_dir]. If [without_theme] is [true] the theme will {e not} be
     copied, the default value is [false]. *)
 
-val filenames : string list
-(** The list of the names of the files that calling [Support_files.write] would
-    output. *)
+val print_filenames : ?without_theme:bool -> Fs.Directory.t -> unit
+(** Prints, to STDOUT, the names of the files that calling [Support_files.write]
+    would output, one filename per line. *)


### PR DESCRIPTION
With this PR:

```
$ odoc support-files-targets
odoc.css
highlight.pack.js
```

~~The command has no options~~.

I assume this output is suitable for consumption. cc @dbuenzli, @rgrinberg (though I will/can make a PR to Dune to use this).

Resolves #174.

See also https://github.com/ocaml/odoc/issues/153#issuecomment-434551361.