### PR TITLE
Fix exception spacing

### DIFF
--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -300,17 +300,6 @@ dl, div.spec, .doc, aside {
   margin-bottom: 20px;
 }
 
-/* Indent the second line in multiline spec definitions. */
-.spec:not(.type) > code {
-  display: block;
-  padding-left: 4ex;
-  text-indent: -4ex;
-}
-
-.spec.exception > code {
-  display: inline-block;
-}
-
 dl > dd {
   padding: 0.5em;
 }

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -279,7 +279,7 @@ pre code {
 /* Code lexemes */
 
 .keyword {
-  font-weight: 700;
+  font-weight: 500;
 }
 
 /* Module member specification */
@@ -679,10 +679,6 @@ h1+.modules, h1+.sel {
 }
 
 /* Syntax highlighting (based on github-gist) */
-
-.keyword {
-  font-weight: 500;
-}
 
 .hljs {
   display: block;


### PR DESCRIPTION
Fixes #245 on Chrome (https://github.com/ocaml/odoc/issues/245#issuecomment-438677135). Not sure if that's the same problem that @jorisgio originally reported on Firefox, as well. @jorisgio, could you pin this branch, `fix-exception-spacing`, and try it?

@rizo, I removed the CSS for indenting lines in declarations:

```diff
-/* Indent the second line in multiline spec definitions. */
-.spec:not(.type) > code {
-  display: block;
-  padding-left: 4ex;
-  text-indent: -4ex;
-}
-
-.spec.exception > code {
-  display: inline-block;
-}
```

They were causing the issue in Chrome.

We have to indent by laying out the specifications correctly during HTML generation. Doing it with CSS gives undesirable results. For example, sometimes I saw line breaks in the middle of `->`, making the declaration difficult to read, and suppressing the ligature.