### PR TITLE
Print mutually-recursive types with "and"

### DIFF
--- a/src/html/html_generator.mli
+++ b/src/html/html_generator.mli
@@ -149,7 +149,8 @@ module type Html_generator = sig
   end
 
   module Type_declaration : sig
-    val type_decl : Lang.TypeDecl.t -> rendered_item * Comment.docs
+    val type_decl :
+      Lang.Signature.recursive * Lang.TypeDecl.t -> rendered_item * Comment.docs
 
     val extension : Lang.Extension.t -> rendered_item * Comment.docs
 

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -918,6 +918,12 @@ and read_module_declaration env parent ident md =
   in
     {id; doc; type_; expansion; canonical; hidden; display_type = None}
 
+and read_rec_status rec_status =
+  let open Signature in
+  match rec_status with
+  | Trec_next -> And
+  | _ -> Ordinary
+
 and read_signature env parent items =
   let env = Env.add_signature_type_items parent items env in
   let rec loop acc items =
@@ -928,9 +934,9 @@ and read_signature env parent items =
           loop (vd :: acc) rest
     | Sig_type(id, _, _) :: rest when Btype.is_row_name (Ident.name id) ->
         loop acc rest
-    | Sig_type(id, decl, _) :: rest ->
+    | Sig_type(id, decl, rec_status)::rest ->
         let decl = read_type_declaration env parent id decl in
-          loop (Type decl :: acc) rest
+      loop (Type (read_rec_status rec_status, decl)::acc) rest
     | Sig_typext (id, ext, Text_first) :: rest ->
         let rec inner_loop inner_acc = function
           | Sig_typext(id, ext, Text_next) :: rest ->

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -239,14 +239,15 @@ let read_type_declarations env parent decls =
     Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
   in
   let items =
+    let open Signature in
     List.fold_left
-      (fun acc decl ->
-         let open Signature in
+      (fun (acc, recursive) decl ->
          let comments = read_comments container decl.typ_attributes in
          let comments = List.map (fun com -> Comment com) comments in
          let decl = read_type_declaration env parent decl in
-           (Type decl) :: (List.rev_append comments acc))
-      [] decls
+         ((Type (recursive, decl)) :: (List.rev_append comments acc), And))
+      ([], Ordinary) decls
+    |> fst
   in
     List.rev items
 

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -85,10 +85,14 @@ end = ModuleType
 
 and Signature : sig
 
+  type recursive =
+    | Ordinary
+    | And
+
   type item =
     | Module of Module.t
     | ModuleType of ModuleType.t
-    | Type of TypeDecl.t
+    | Type of recursive * TypeDecl.t
     | TypExt of Extension.t
     | Exception of Exception.t
     | Value of Value.t

--- a/src/model/maps.ml
+++ b/src/model/maps.ml
@@ -1202,9 +1202,9 @@ class virtual signature = object (self)
           let ve' = self#external_ ve in
             if ve != ve' then External ve'
             else item
-      | Type decl ->
+      | Type (recursive, decl) ->
           let decl' = self#type_decl decl in
-            if decl != decl' then Type decl'
+            if decl != decl' then Type (recursive, decl')
             else item
       | TypExt ext ->
           let ext' = self#extension ext in

--- a/src/xref/component_table.ml
+++ b/src/xref/component_table.ml
@@ -480,7 +480,7 @@ and signature_items local =
         let sg = signature_items local rest in
         let sg = add_documentation mty.doc sg in
           add_module_type name expr sg
-    | Type decl :: rest ->
+    | Type (_, decl) :: rest ->
         let open TypeDecl in
         let sg = signature_items local rest in
         let sg = add_documentation decl.doc sg in

--- a/src/xref/expand.ml
+++ b/src/xref/expand.ml
@@ -82,9 +82,9 @@ let map_type name ex f =
       | [] ->
         List.rev acc
         (* raise Not_found *)
-      | Type decl :: rest when Identifier.name decl.id = name ->
+      | Type (recursive, decl) :: rest when Identifier.name decl.id = name ->
         let decl' = f decl in
-        List.rev_append acc ((Type decl') :: rest)
+        List.rev_append acc ((Type (recursive, decl')) :: rest)
       | item :: rest -> loop name rest f (item :: acc)
   in
     match ex with

--- a/src/xref/name_env.ml
+++ b/src/xref/name_env.ml
@@ -409,7 +409,7 @@ and add_signature_item item env =
   match item with
   | Module md -> add_module md env
   | ModuleType mtyp -> add_module_type mtyp env
-  | Type decl -> add_type_decl decl env
+  | Type (_, decl) -> add_type_decl decl env
   | TypExt tyext -> add_extension tyext env
   | Exception exn -> add_exception exn env
   | Value vl -> add_value vl env

--- a/test/html/cases/type.mli
+++ b/test/html/cases/type.mli
@@ -121,5 +121,8 @@ type extensible = ..
 
 type extensible += Extension
 
+type mutually = A of recursive
+and recursive = B of mutually
+
 (* Not a type, but analogous to extensions. *)
 exception Foo of int * int

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -372,7 +372,7 @@
      </table>
     </dt>
     <dt class="spec type" id="type-recursive">
-     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">type </span>recursive</code><code><span class="keyword"> = </span></code>
+     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">and </span>recursive</code><code><span class="keyword"> = </span></code>
      <table class="variant">
       <tbody>
        <tr id="type-recursive.B" class="anchored">

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -359,6 +359,32 @@
     </dt>
    </dl>
    <dl>
+    <dt class="spec type" id="type-mutually">
+     <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type </span>mutually</code><code><span class="keyword"> = </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-mutually.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-mutually.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span><span class="keyword"> of </span><a href="index.html#type-recursive">recursive</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </dt>
+    <dt class="spec type" id="type-recursive">
+     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">type </span>recursive</code><code><span class="keyword"> = </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-recursive.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-recursive.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span><span class="keyword"> of </span><a href="index.html#type-mutually">mutually</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </dt>
+   </dl>
+   <dl>
     <dt class="spec exception" id="exception-Foo">
      <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception </span></code><code><span class="exception">Foo</span><span class="keyword"> of </span>int<span class="keyword"> * </span>int</code>
     </dt>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -363,6 +363,34 @@
     </dt>
    </dl>
    <dl>
+    <dt class="spec type" id="type-mutually">
+     <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type </span>mutually</code><code><span class="keyword"> = </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-mutually.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-mutually.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span>(<a href="index.html#type-recursive">recursive</a>)</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-recursive">
+     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">type </span>recursive</code><code><span class="keyword"> = </span></code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-recursive.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-recursive.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span>(<a href="index.html#type-mutually">mutually</a>)</code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <span class="keyword">;</span>
+    </dt>
+   </dl>
+   <dl>
     <dt class="spec exception" id="exception-Foo">
      <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception </span></code><code><span class="exception">Foo</span>(int<span class="keyword">, </span>int)</code><span class="keyword">;</span>
     </dt>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -377,7 +377,7 @@
      <span class="keyword">;</span>
     </dt>
     <dt class="spec type" id="type-recursive">
-     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">type </span>recursive</code><code><span class="keyword"> = </span></code>
+     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">and </span>recursive</code><code><span class="keyword"> = </span></code>
      <table class="variant">
       <tbody>
        <tr id="type-recursive.B" class="anchored">


### PR DESCRIPTION
Fixes #105.

Typedtree represents mutually-recursive type declarations as lists of type declarations (of length two or more), but odoc breaks these up into individual declarations.

In this PR, I decided to associate a flag with each type declaration, which indicates whether it was first in its list when loaded. This is a similar representation to the compiler's `types.mli`. It might not be optimal for some future purposes, however, so we may need to refactor it later.

Right now, the flag is passed straight through odoc, and controls only what keyword is used to render the type declaration.

I plan to use this for `nonrec` as well (#249), but I suspect the cross-referencer will need some changes to work with `nonrec` fully. The cross-referencer currently manages to resolve mutually-recursive type declarations, which makes me think that it will wrongly resolve non-recursive types that mention their own name to themselves.

It looks like modules, classes, and class types will need this kind of change as well.

This PR is FYI.