### PR TITLE
Render TOC in nested pages

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -1355,13 +1355,14 @@ struct
           | None -> acc
           | Some arg ->
             let arg, arg_subpages = functor_argument ?theme_uri arg in
-            (args @ arg, subpages @ arg_subpages)
+            let arg = Html.li arg in
+            (args @ [arg], subpages @ arg_subpages)
         )
         ([], []) args
       in
       let html =
         Html.h3 ~a:[ Html.a_class ["heading"] ] [ Html.txt "Parameters" ] ::
-        Html.dl (List.map Html.Unsafe.coerce_elt params) ::
+        Html.ul (List.map Html.Unsafe.coerce_elt params) ::
         Html.h3 ~a:[ Html.a_class ["heading"] ] [ Html.txt "Signature" ] ::
         sig_html
       in

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -1163,14 +1163,8 @@ struct
       | Some csig ->
         Tree.enter ~kind:(`Class) name;
         let doc = Comment.to_html t.doc in
-        let doc = (doc :> (Html_types.div_content Html.elt) list) in
         let expansion, _, _ = class_signature csig in
-        let expansion =
-          match doc with
-          | [] -> expansion
-          | _ -> Html.div ~a:[ Html.a_class ["doc"] ] doc :: expansion
-        in
-        let subtree = Tree.make ?theme_uri expansion [] in
+        let subtree = Tree.make ~header_docs:doc ?theme_uri expansion [] in
         Tree.leave ();
         Html.a ~a:[ a_href ~kind:`Class name ] [Html.txt name], [subtree]
     in
@@ -1204,14 +1198,8 @@ struct
       | Some csig ->
         Tree.enter ~kind:(`Cty) name;
         let doc = Comment.to_html t.doc in
-        let doc = (doc :> (Html_types.div_content Html.elt) list) in
         let expansion, _, _ = class_signature csig in
-        let expansion =
-          match doc with
-          | [] -> expansion
-          | _ -> Html.div ~a:[ Html.a_class ["doc"] ] doc :: expansion
-        in
-        let subtree = Tree.make ?theme_uri expansion [] in
+        let subtree = Tree.make ~header_docs:doc ?theme_uri expansion [] in
         Tree.leave ();
         Html.a ~a:[ a_href ~kind:`Cty name ] [Html.txt name], [subtree]
     in

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -1367,7 +1367,7 @@ struct
           | None -> acc
           | Some arg ->
             let arg, arg_subpages = functor_argument ?theme_uri arg in
-            (arg @ args, arg_subpages @ subpages)
+            (args @ arg, subpages @ arg_subpages)
         )
         ([], []) args
       in

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -1163,8 +1163,13 @@ struct
       | Some csig ->
         Tree.enter ~kind:(`Class) name;
         let doc = Comment.to_html t.doc in
-        let expansion, _, _ = class_signature csig in
-        let subtree = Tree.make ~header_docs:doc ?theme_uri expansion [] in
+        let expansion, toc, _ = class_signature csig in
+        let header_docs =
+          match toc with
+          | [] -> doc
+          | _ -> doc @ (Top_level_markup.render_toc toc)
+        in
+        let subtree = Tree.make ~header_docs ?theme_uri expansion [] in
         Tree.leave ();
         Html.a ~a:[ a_href ~kind:`Class name ] [Html.txt name], [subtree]
     in
@@ -1326,8 +1331,9 @@ struct
           | e -> e
         in
         Tree.enter ~kind:(`Arg) link_name;
-        let (docs, subpages) = module_expansion expansion in
-        let subtree = Tree.make ?theme_uri docs subpages in
+        let (doc, toc, subpages) = module_expansion expansion in
+        let header_docs = Top_level_markup.render_toc toc in
+        let subtree = Tree.make ~header_docs ?theme_uri doc subpages in
         Tree.leave ();
         (
           Html.a ~a:[ a_href ~kind:`Arg link_name ] [Html.txt name] ::
@@ -1340,15 +1346,15 @@ struct
 
   and module_expansion
     : ?theme_uri:Tree.uri -> Model.Lang.Module.expansion
-    -> Html_types.div_content_fun Html.elt list * Tree.t list
+    -> Html_types.div_content_fun Html.elt list * toc * Tree.t list
   = fun ?theme_uri t ->
     match t with
     | AlreadyASig -> assert false
     | Signature sg ->
-      let expansion, _, subpages = signature sg in
-      expansion, subpages
+      let expansion, toc, subpages = signature sg in
+      expansion, toc, subpages
     | Functor (args, sg) ->
-      let sig_html, _, subpages = signature sg in
+      let sig_html, toc, subpages = signature sg in
       let params, params_subpages =
         List.fold_left (fun (args, subpages as acc) arg ->
           match arg with
@@ -1366,7 +1372,7 @@ struct
         Html.h3 ~a:[ Html.a_class ["heading"] ] [ Html.txt "Signature" ] ::
         sig_html
       in
-      html, params_subpages @ subpages
+      html, toc, params_subpages @ subpages
 
   and module_
       : ?theme_uri:Tree.uri -> Model.Lang.Signature.recursive ->
@@ -1396,8 +1402,13 @@ struct
         in
         Tree.enter ~kind:(`Mod) modname;
         let doc = Comment.to_html t.doc in
-        let expansion, subpages = module_expansion ?theme_uri expansion in
-        let subtree = Tree.make ~header_docs:doc ?theme_uri expansion subpages in
+        let expansion, toc, subpages = module_expansion ?theme_uri expansion in
+        let header_docs =
+          match toc with
+          | [] -> doc
+          | _ -> doc @ (Top_level_markup.render_toc toc)
+        in
+        let subtree = Tree.make ~header_docs ?theme_uri expansion subpages in
         Tree.leave ();
         Html.a ~a:[ a_href ~kind:`Mod modname ] [Html.txt modname], [subtree]
     in
@@ -1471,14 +1482,13 @@ struct
         in
         Tree.enter ~kind:(`Mty) modname;
         let doc = Comment.to_html t.doc in
-        let doc = (doc :> (Html_types.div_content Html.elt) list) in
-        let expansion, subpages = module_expansion expansion in
-        let expansion =
-          match doc with
-          | [] -> expansion
-          | _ -> Html.div ~a:[ Html.a_class ["doc"] ] doc :: expansion
+        let expansion, toc, subpages = module_expansion expansion in
+        let header_docs =
+          match toc with
+          | [] -> doc
+          | _ -> doc @ (Top_level_markup.render_toc toc)
         in
-        let subtree = Tree.make ?theme_uri expansion subpages in
+        let subtree = Tree.make ~header_docs ?theme_uri expansion subpages in
         Tree.leave ();
         Html.a ~a:[ a_href ~kind:`Mty modname ] [Html.txt modname], [subtree]
     in

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -441,7 +441,7 @@ span.at-tag {
 
 .heading {
   margin-top: 10px;
-  border-top: solid;
+  border-bottom: solid;
   border-width: 1px;
   border-color: #DDD;
   text-align: right;

--- a/test/html/cases/nested.mli
+++ b/test/html/cases/nested.mli
@@ -1,33 +1,71 @@
 
+(** This comment needs to be here before #235 is fixed. *)
+
+(** {1 Module} *)
+
 (** This is module X.
 
     Some additional comments. *)
 module X : sig
+
+  (** {1 Type} *)
+
   type t
   (** Some type. *)
+
+  (** {1 Values} *)
 
   val x : t
   (** The value of x. *)
 end
 
 
+(** {1 Module type} *)
 
 (** This is module type Y.
 
     Some additional comments. *)
 module type Y = sig
+
+  (** {1 Type} *)
+
   type t
   (** Some type. *)
+
+  (** {1 Values} *)
 
   val y : t
   (** The value of y. *)
 end
 
 
+(** {1 Functor} *)
+
+(** This is a functor F.
+
+    Some additional comments. *)
+module F
+    (Arg1 : Y) (Arg2 : sig
+    (** {1 Type} *)
+
+    type t
+    (** Some type. *)
+  end) : sig
+  (** {1 Type} *)
+
+  type t = Arg1.t * Arg2.t
+  (** Some type. *)
+end
+
+
+(** {1 Class} *)
+
 (** This is class z.
 
     Some additional comments. *)
 class z : object
+
+  (** {1 Methods} *)
 
   method z : int
   (** Some method. *)

--- a/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   1-Arg1 (test_package+ml.Nested.F.1-Arg1)
+  </title>
+  <link rel="stylesheet" href="../../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+ml</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 1-Arg1
+    </nav>
+    <h1>
+     Parameter <code>F.1-Arg1</code>
+    </h1>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#type">Type</a>
+      </li>
+      <li>
+       <a href="#values">Values</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="type">
+      <a href="#type" class="anchor"></a>Type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+     </dt>
+     <dd>
+      <p>
+       Some type.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="values">
+      <a href="#values" class="anchor"></a>Values
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-y">
+      <a href="#val-y" class="anchor"></a><code><span class="keyword">val </span>y : <a href="index.html#type-t">t</a></code>
+     </dt>
+     <dd>
+      <p>
+       The value of y.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   2-Arg2 (test_package+ml.Nested.F.2-Arg2)
+  </title>
+  <link rel="stylesheet" href="../../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+ml</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 2-Arg2
+    </nav>
+    <h1>
+     Parameter <code>F.2-Arg2</code>
+    </h1>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#type">Type</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="type">
+      <a href="#type" class="anchor"></a>Type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+     </dt>
+     <dd>
+      <p>
+       Some type.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   F (test_package+ml.Nested.F)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » F
+    </nav>
+    <h1>
+     Module <code>Nested.F</code>
+    </h1>
+    <p>
+     This is a functor F.
+    </p>
+    <p>
+     Some additional comments.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#type">Type</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <h3 class="heading">
+    Parameters
+   </h3>
+   <ul>
+    <li>
+     <code><a href="argument-1-Arg1/index.html">Arg1</a> : <a href="../index.html#module-type-Y">Y</a></code>
+    </li>
+    <li>
+     <code><a href="argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    </li>
+   </ul>
+   <h3 class="heading">
+    Signature
+   </h3>
+   <section>
+    <header>
+     <h2 id="type">
+      <a href="#type" class="anchor"></a>Type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><code><span class="keyword"> = </span><a href="argument-1-Arg1/index.html#type-t">Arg1.t</a><span class="keyword"> * </span><a href="argument-2-Arg2/index.html#type-t">Arg2.t</a></code>
+     </dt>
+     <dd>
+      <p>
+       Some type.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   X (test_package+ml.Nested.X)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » X
+    </nav>
+    <h1>
+     Module <code>Nested.X</code>
+    </h1>
+    <p>
+     This is module X.
+    </p>
+    <p>
+     Some additional comments.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#type">Type</a>
+      </li>
+      <li>
+       <a href="#values">Values</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="type">
+      <a href="#type" class="anchor"></a>Type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+     </dt>
+     <dd>
+      <p>
+       Some type.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="values">
+      <a href="#values" class="anchor"></a>Values
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-x">
+      <a href="#val-x" class="anchor"></a><code><span class="keyword">val </span>x : <a href="index.html#type-t">t</a></code>
+     </dt>
+     <dd>
+      <p>
+       The value of x.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Nested/class-z/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-z/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   z (test_package+ml.Nested.z)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » z
+    </nav>
+    <h1>
+     Class <code>Nested.z</code>
+    </h1>
+    <p>
+     This is class z.
+    </p>
+    <p>
+     Some additional comments.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#methods">Methods</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="methods">
+      <a href="#methods" class="anchor"></a>Methods
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec method" id="method-z">
+      <a href="#method-z" class="anchor"></a><code><span class="keyword">method </span>z : int</code>
+     </dt>
+     <dd>
+      <p>
+       Some method.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -20,37 +20,94 @@
     <h1>
      Module <code>Nested</code>
     </h1>
+    <p>
+     This comment needs to be here before #235 is fixed.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#module">Module</a>
+      </li>
+      <li>
+       <a href="#module-type">Module type</a>
+      </li>
+      <li>
+       <a href="#functor">Functor</a>
+      </li>
+      <li>
+       <a href="#class">Class</a>
+      </li>
+     </ul>
+    </nav>
    </header>
-   <dl>
-    <dt class="spec module" id="module-X">
-     <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
-     <p>
-      This is module X.
-     </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-Y">
-     <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Y/index.html">Y</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
-     <p>
-      This is module type Y.
-     </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec class" id="class-z">
-     <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
-     <p>
-      This is class z.
-     </p>
-    </dd>
-   </dl>
+   <section>
+    <header>
+     <h2 id="module">
+      <a href="#module" class="anchor"></a>Module
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec module" id="module-X">
+      <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+     </dt>
+     <dd>
+      <p>
+       This is module X.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="module-type">
+      <a href="#module-type" class="anchor"></a>Module type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec module-type" id="module-type-Y">
+      <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Y/index.html">Y</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+     </dt>
+     <dd>
+      <p>
+       This is module type Y.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="functor">
+      <a href="#functor" class="anchor"></a>Functor
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec module" id="module-F">
+      <a href="#module-F" class="anchor"></a><code><span class="keyword">module </span><a href="F/index.html">F</a> : <span class="keyword">functor</span> (<a href="F/argument-1-Arg1/index.html">Arg1</a> : <a href="index.html#module-type-Y">Y</a>) <span>-&gt;</span> <span class="keyword">functor</span> (<a href="F/argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+     </dt>
+     <dd>
+      <p>
+       This is a functor F.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="class">
+      <a href="#class" class="anchor"></a>Class
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec class" id="class-z">
+      <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+     </dt>
+     <dd>
+      <p>
+       This is class z.
+      </p>
+     </dd>
+    </dl>
+   </section>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Y (test_package+ml.Nested.Y)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » Y
+    </nav>
+    <h1>
+     Module type <code>Nested.Y</code>
+    </h1>
+    <p>
+     This is module type Y.
+    </p>
+    <p>
+     Some additional comments.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#type">Type</a>
+      </li>
+      <li>
+       <a href="#values">Values</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="type">
+      <a href="#type" class="anchor"></a>Type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+     </dt>
+     <dd>
+      <p>
+       Some type.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="values">
+      <a href="#values" class="anchor"></a>Values
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-y">
+      <a href="#val-y" class="anchor"></a><code><span class="keyword">val </span>y : <a href="index.html#type-t">t</a></code>
+     </dt>
+     <dd>
+      <p>
+       The value of y.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   1-Arg1 (test_package+re.Nested.F.1-Arg1)
+  </title>
+  <link rel="stylesheet" href="../../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+re</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 1-Arg1
+    </nav>
+    <h1>
+     Parameter <code>F.1-Arg1</code>
+    </h1>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#type">Type</a>
+      </li>
+      <li>
+       <a href="#values">Values</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="type">
+      <a href="#type" class="anchor"></a>Type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span>
+     </dt>
+     <dd>
+      <p>
+       Some type.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="values">
+      <a href="#values" class="anchor"></a>Values
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-y">
+      <a href="#val-y" class="anchor"></a><code><span class="keyword">let </span>y: <a href="index.html#type-t">t</a><span class="keyword">;</span></code>
+     </dt>
+     <dd>
+      <p>
+       The value of y.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   2-Arg2 (test_package+re.Nested.F.2-Arg2)
+  </title>
+  <link rel="stylesheet" href="../../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+re</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 2-Arg2
+    </nav>
+    <h1>
+     Parameter <code>F.2-Arg2</code>
+    </h1>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#type">Type</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="type">
+      <a href="#type" class="anchor"></a>Type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span>
+     </dt>
+     <dd>
+      <p>
+       Some type.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   F (test_package+re.Nested.F)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » F
+    </nav>
+    <h1>
+     Module <code>Nested.F</code>
+    </h1>
+    <p>
+     This is a functor F.
+    </p>
+    <p>
+     Some additional comments.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#type">Type</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <h3 class="heading">
+    Parameters
+   </h3>
+   <ul>
+    <li>
+     <code><a href="argument-1-Arg1/index.html">Arg1</a>: <a href="../index.html#module-type-Y">Y</a></code>
+    </li>
+    <li>
+     <code><a href="argument-2-Arg2/index.html">Arg2</a>: <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+    </li>
+   </ul>
+   <h3 class="heading">
+    Signature
+   </h3>
+   <section>
+    <header>
+     <h2 id="type">
+      <a href="#type" class="anchor"></a>Type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><code><span class="keyword"> = </span>(<a href="argument-1-Arg1/index.html#type-t">Arg1.t</a><span class="keyword">, </span><a href="argument-2-Arg2/index.html#type-t">Arg2.t</a>)</code><span class="keyword">;</span>
+     </dt>
+     <dd>
+      <p>
+       Some type.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   X (test_package+re.Nested.X)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » X
+    </nav>
+    <h1>
+     Module <code>Nested.X</code>
+    </h1>
+    <p>
+     This is module X.
+    </p>
+    <p>
+     Some additional comments.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#type">Type</a>
+      </li>
+      <li>
+       <a href="#values">Values</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="type">
+      <a href="#type" class="anchor"></a>Type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span>
+     </dt>
+     <dd>
+      <p>
+       Some type.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="values">
+      <a href="#values" class="anchor"></a>Values
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-x">
+      <a href="#val-x" class="anchor"></a><code><span class="keyword">let </span>x: <a href="index.html#type-t">t</a><span class="keyword">;</span></code>
+     </dt>
+     <dd>
+      <p>
+       The value of x.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Nested/class-z/index.html
+++ b/test/html/expect/test_package+re/Nested/class-z/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   z (test_package+re.Nested.z)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » z
+    </nav>
+    <h1>
+     Class <code>Nested.z</code>
+    </h1>
+    <p>
+     This is class z.
+    </p>
+    <p>
+     Some additional comments.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#methods">Methods</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="methods">
+      <a href="#methods" class="anchor"></a>Methods
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec method" id="method-z">
+      <a href="#method-z" class="anchor"></a><code><span class="keyword">method </span>z: int</code>
+     </dt>
+     <dd>
+      <p>
+       Some method.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -20,37 +20,94 @@
     <h1>
      Module <code>Nested</code>
     </h1>
+    <p>
+     This comment needs to be here before #235 is fixed.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#module">Module</a>
+      </li>
+      <li>
+       <a href="#module-type">Module type</a>
+      </li>
+      <li>
+       <a href="#functor">Functor</a>
+      </li>
+      <li>
+       <a href="#class">Class</a>
+      </li>
+     </ul>
+    </nav>
    </header>
-   <dl>
-    <dt class="spec module" id="module-X">
-     <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-    </dt>
-    <dd>
-     <p>
-      This is module X.
-     </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-Y">
-     <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Y/index.html">Y</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
-    </dt>
-    <dd>
-     <p>
-      This is module type Y.
-     </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec class" id="class-z">
-     <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><a href="class-z/index.html">z</a>: <span class="keyword">{</span> ... <span class="keyword">}</span></code>
-    </dt>
-    <dd>
-     <p>
-      This is class z.
-     </p>
-    </dd>
-   </dl>
+   <section>
+    <header>
+     <h2 id="module">
+      <a href="#module" class="anchor"></a>Module
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec module" id="module-X">
+      <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+     </dt>
+     <dd>
+      <p>
+       This is module X.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="module-type">
+      <a href="#module-type" class="anchor"></a>Module type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec module-type" id="module-type-Y">
+      <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Y/index.html">Y</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+     </dt>
+     <dd>
+      <p>
+       This is module type Y.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="functor">
+      <a href="#functor" class="anchor"></a>Functor
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec module" id="module-F">
+      <a href="#module-F" class="anchor"></a><code><span class="keyword">module </span><a href="F/index.html">F</a>:  (<a href="F/argument-1-Arg1/index.html">Arg1</a>: <a href="index.html#module-type-Y">Y</a>) <span>=&gt;</span>  (<a href="F/argument-2-Arg2/index.html">Arg2</a>: <span class="keyword">{</span> ... <span class="keyword">}</span>) <span>=&gt;</span> <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+     </dt>
+     <dd>
+      <p>
+       This is a functor F.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="class">
+      <a href="#class" class="anchor"></a>Class
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec class" id="class-z">
+      <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><a href="class-z/index.html">z</a>: <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+     </dt>
+     <dd>
+      <p>
+       This is class z.
+      </p>
+     </dd>
+    </dl>
+   </section>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Y (test_package+re.Nested.Y)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » Y
+    </nav>
+    <h1>
+     Module type <code>Nested.Y</code>
+    </h1>
+    <p>
+     This is module type Y.
+    </p>
+    <p>
+     Some additional comments.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#type">Type</a>
+      </li>
+      <li>
+       <a href="#values">Values</a>
+      </li>
+     </ul>
+    </nav>
+   </header>
+   <section>
+    <header>
+     <h2 id="type">
+      <a href="#type" class="anchor"></a>Type
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span>
+     </dt>
+     <dd>
+      <p>
+       Some type.
+      </p>
+     </dd>
+    </dl>
+   </section>
+   <section>
+    <header>
+     <h2 id="values">
+      <a href="#values" class="anchor"></a>Values
+     </h2>
+    </header>
+    <dl>
+     <dt class="spec value" id="val-y">
+      <a href="#val-y" class="anchor"></a><code><span class="keyword">let </span>y: <a href="index.html#type-t">t</a><span class="keyword">;</span></code>
+     </dt>
+     <dd>
+      <p>
+       The value of y.
+      </p>
+     </dd>
+    </dl>
+   </section>
+  </div>
+ </body>
+</html>

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -259,7 +259,15 @@ let source_files = [
   ("interlude.mli", ["Interlude/index.html"]);
   ("include.mli", ["Include/index.html"]);
   ("mld.mld", ["mld.html"]);
-  ("nested.mli", ["Nested/index.html"]);
+  ("nested.mli", [
+      "Nested/index.html";
+      "Nested/F/index.html";
+      "Nested/F/argument-1-Arg1/index.html";
+      "Nested/F/argument-2-Arg2/index.html";
+      "Nested/X/index.html";
+      "Nested/class-z/index.html";
+      "Nested/module-type-Y/index.html";
+    ]);
   ("type.mli", ["Type/index.html"]);
   ("external.mli", ["External/index.html"]);
   ("functor.mli", ["Functor/index.html"]);


### PR DESCRIPTION
Currently the table of contents is only rendered for top-level modules. This PR implements the rendering for all nested items (modules, module types, classes, functors and functor parameters) and makes some other minor adjustments.

### Full list of changes

* Render TOC (if not empty) inside header in all nested pages.
* Fix a bug where functor arguments were listed in reverse order ([diff](https://github.com/ocaml/odoc/compare/master...rizo:render-nested-toc?expand=1#diff-46e526e8d708dd25c7f790e20662ad2eR1371)).
* Remove the `doc` CSS class from class items, to be consistent with other nested items ([diff](https://github.com/ocaml/odoc/compare/master...rizo:render-nested-toc?expand=1#diff-46e526e8d708dd25c7f790e20662ad2eL1171)).
* Render functor parameters as `ul` (and not as a `dl`).
* Extend the "nested" HTML test to cover the proposed changes.
  * The TOC rendering for nested pages is not currently tested because of https://github.com/ocaml/odoc/issues/213.