### PR TITLE
Prepend output path when generating HTML targets.

### DIFF
--- a/src/odoc/fs.ml
+++ b/src/odoc/fs.ml
@@ -54,6 +54,8 @@ module Directory = struct
   let dirname = Fpath.parent
   let basename = Fpath.base
 
+  let append = Fpath.append
+
   let make_path p name =
     match Fpath.of_string name with
     | Error _ as e -> e

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -29,6 +29,8 @@ module Directory : sig
   val dirname : t -> t
   val basename : t -> t
 
+  val append : t -> t -> t
+
   val reach_from : dir:t -> string -> t
   (** @raises [Invalid_arg _] if [parent/name] exists but is not a directory. *)
 

--- a/src/odoc/targets.ml
+++ b/src/odoc/targets.ml
@@ -25,7 +25,7 @@ let for_compile_step ~output input =
   in
   [Fs.File.create ~directory:output ~name]
 
-let unit ~env ~output:_root_dir input =
+let unit ~env ~output:root_dir input =
   let unit = Compilation_unit.load input in
   let env = Env.build env (`Unit unit) in
   let odoctree = Xref.resolve (Env.resolver env) unit in
@@ -36,7 +36,7 @@ let unit ~env ~output:_root_dir input =
   (* CR-someday trefis: have [List_targets] return a tree instead of
      postprocessing. *)
   List.map targets ~f:(fun path ->
-    let directory = Fs.Directory.of_string path in
+    let directory = Fs.Directory.(append root_dir (of_string path)) in
     Fs.File.create ~directory ~name:"index.html"
   )
 


### PR DESCRIPTION
Fixes https://github.com/ocaml/odoc/issues/173.