### PR TITLE
Fix styling of records to match variants

### DIFF
--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -327,6 +327,13 @@ section+section, section > header + dl {
   margin: 0;
   font-style: italic;
 }
+.spec.type .record {
+  margin-left: 2ch;
+}
+.spec.type .record p {
+  margin: 0;
+  font-style: italic;
+}
 
 div.def {
   margin-top: 0;


### PR DESCRIPTION
This adds styling to the records that matches that introduced in
c/s c3a8f709acaee7a19ca928b277bdcf072ba3579f

Fixes #260.

Signed-off-by: Jon Ludlam <jon@recoil.org>