### PR TITLE
Scan include directories for odoc files eagerly

### DIFF
--- a/src/odoc/env.ml
+++ b/src/odoc/env.ml
@@ -61,11 +61,10 @@ module Accessible_paths = struct
             | Compilation_unit { name; _ } -> name
           in
           if Hashtbl.mem t.file_map filename then begin
-            let other = Hashtbl.find t.file_map filename in
-            let other_path = Model.Root.Hash_table.find t.root_map other in
-            Printf.eprintf
-              "Error: Duplicate root name found in include path: %s (also at %s)"
-              (Fs.File.to_string path) (Fs.File.to_string other_path);
+            let err = Model.Error.filename_only
+              "Duplicate root name found in include path"
+              (Fs.File.to_string path) in
+            Model.Error.raise_exception err
           end;
           Hashtbl.add t.file_map filename root;
           Model.Root.Hash_table.add t.root_map root path)

--- a/src/odoc/env.ml
+++ b/src/odoc/env.ml
@@ -52,11 +52,16 @@ module Accessible_paths = struct
         Fs.Directory.ls d
         |> List.filter (Fs.File.has_ext ".odoc")
       in
+      let valid_odocs =
+        List.fold_left (fun acc path ->
+          try (path, Root.read path)::acc
+          with End_of_file -> acc) 
+          [] odoc_files
+      in
       List.iter
-        (fun path ->
-          let root = Root.read path in
+        (fun (path,root) ->
           let filename =
-            match root.file with
+            match root.Model.Root.file with
             | Page page_name -> "page-" ^ page_name
             | Compilation_unit { name; _ } -> name
           in
@@ -68,7 +73,7 @@ module Accessible_paths = struct
           end;
           Hashtbl.add t.file_map filename root;
           Model.Root.Hash_table.add t.root_map root path)
-        odoc_files
+        valid_odocs
     in
     List.iter scan_directory t.directories
 end

--- a/src/odoc/env.ml
+++ b/src/odoc/env.ml
@@ -66,8 +66,10 @@ module Accessible_paths = struct
             | Compilation_unit { name; _ } -> name
           in
           if Hashtbl.mem t.file_map filename then begin
+            let other = Hashtbl.find t.file_map filename in
+            let other_path = Model.Root.Hash_table.find t.root_map other |> Fs.File.to_string in
             let err = Model.Error.filename_only
-              "Duplicate root name found in include path"
+              (Printf.sprintf "Duplicate root name found in include path (%s)" other_path)
               (Fs.File.to_string path) in
             Model.Error.raise_exception err
           end;

--- a/src/odoc/fs.ml
+++ b/src/odoc/fs.ml
@@ -27,6 +27,7 @@ module File = struct
 
   let set_ext e p = Fpath.set_ext e p
   let has_ext e p = Fpath.has_ext e p
+  let rem_ext p = Fpath.rem_ext p
 
   let create ~directory ~name =
     match Fpath.of_string name with

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -55,6 +55,7 @@ module File : sig
 
   val set_ext : string -> t -> t
   val has_ext : string -> t -> bool
+  val rem_ext : t -> t
 
   val of_string : string -> t
   val to_string : t -> string


### PR DESCRIPTION
Goes some way to addressing #148.

This is an RFC, particularly the error handling. As is, this still results in a nasty backtrace spewed to the terminal so I don't think it should be merged yet. Before I just wrapped the invocations of Env.create in an exception handler I thought I'd better ask whether there was a better plan in mind for this sort of non-recoverable one?