### PR TITLE
Cli: be more lenient with directory existence.

### DIFF
--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -19,7 +19,7 @@ let convert_syntax : Html.Tree.syntax Arg.converter =
   (syntax_parser, syntax_printer)
 
 let convert_directory ?(create=false) () : Fs.Directory.t Arg.converter =
-  let (dir_parser, dir_printer) = Arg.dir in
+  let (dir_parser, dir_printer) = Arg.string in
   let odoc_dir_parser str =
     let () = if create then Fs.Directory.(mkdir_p (of_string str)) in
     match dir_parser str with


### PR DESCRIPTION
Do not require -I directories to exist in `compile` command
(closes #35). Do not require the -o directory to exist in
`*-targets` commands (closes #170).

I have checked the transitive usage of `convert_directory` via `dst` a few lines below and I believe this to be correct.