### PR TITLE
Fix compile-targets.

### DIFF
--- a/src/odoc/targets.ml
+++ b/src/odoc/targets.ml
@@ -16,15 +16,6 @@
 
 open StdLabels
 
-let for_compile_step ~output input =
-  let name =
-    Fs.File.to_string input
-    |> Filename.basename
-    |> Filename.chop_extension
-    |> fun s -> s ^ ".odoc"
-  in
-  [Fs.File.create ~directory:output ~name]
-
 let unit ~env ~output:root_dir input =
   let unit = Compilation_unit.load input in
   let env = Env.build env (`Unit unit) in

--- a/src/odoc/targets.mli
+++ b/src/odoc/targets.mli
@@ -14,9 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val for_compile_step :
-  output:Fs.Directory.t -> Fs.File.t -> Fs.File.t list
-
 val unit :
   env:Env.builder -> output:Fs.Directory.t ->
   Fs.File.t -> Fs.File.t list


### PR DESCRIPTION
Rather than duplicate output logic in the Target module, we
delete it and expose both cli arguments and logic from the compile
command for usage by the compile-targets command. This decreases
the probability of those getting out of sync. Closes #172.