### PR TITLE
render externals as function signature

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -631,12 +631,10 @@ struct
   let external_ (t : Model.Lang.External.t) =
     let name = Paths.Identifier.name t.id in
     let external_ =
-      keyword "external " ::
+      keyword (Syntax.Value.variable_keyword ^ " ") ::
       Html.txt name ::
       Html.txt Syntax.Type.annotation_separator ::
-      type_expr t.type_ @
-      Html.txt " = " ::
-      Syntax.Type.External.handle_primitives t.primitives
+      type_expr t.type_
       @ (if Syntax.Type.External.semicolon then [ keyword ";" ] else [])
     in
     [Html.code external_], t.doc

--- a/test/html/expect/test_package+ml/External/index.html
+++ b/test/html/expect/test_package+ml/External/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec external" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">external </span>foo : unit <span>-&gt;</span> unit = "bar" </code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit <span>-&gt;</span> unit</code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+re/External/index.html
+++ b/test/html/expect/test_package+re/External/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec external" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">external </span>foo: unit <span>=&gt;</span> unit = "bar"<span class="keyword">;</span></code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: unit <span>=&gt;</span> unit<span class="keyword">;</span></code>
     </dt>
     <dd>
      <p>


### PR DESCRIPTION
Closes #275 

This is how the ReasonReact docs would look like after this change:

![screenshot 2019-01-15 at 10 15 59](https://user-images.githubusercontent.com/223045/51170388-a39f1a00-18ae-11e9-8952-a2aa31675fb2.png)
