### PR TITLE
ignore node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ _esy
 
 # Generated docs
 docs/
+
+# Node Modules
+node_modules/


### PR DESCRIPTION
When following the CONTRIBUTION.md guide during the install process a `node_modules` directory is created. I believe it should be ignored for git