### PR TITLE
Use binary mode where needed

### DIFF
--- a/src/odoc/compilation_unit.ml
+++ b/src/odoc/compilation_unit.ml
@@ -25,7 +25,7 @@ let root (t : Model.Lang.Compilation_unit.t) =
 
 let save file t =
   Fs.Directory.mkdir_p (Fs.File.dirname file);
-  let oc = open_out (Fs.File.to_string file) in
+  let oc = open_out_bin (Fs.File.to_string file) in
   Root.save oc (root t);
   Marshal.to_channel oc t [];
   close_out oc
@@ -38,7 +38,7 @@ let load =
     | unit -> unit
     | exception Not_found ->
       try
-        let ic = open_in file in
+        let ic = open_in_bin file in
         let _root = Root.load file ic in
         let res = Marshal.from_channel ic in
         close_in ic;

--- a/src/odoc/page.ml
+++ b/src/odoc/page.ml
@@ -32,7 +32,7 @@ let save file t =
       Fs.File.create ~directory:dir ~name:("page-" ^ base)
   in
   Fs.Directory.mkdir_p dir;
-  let oc = open_out (Fs.File.to_string file) in
+  let oc = open_out_bin (Fs.File.to_string file) in
   Root.save oc (root t);
   Marshal.to_channel oc t [];
   close_out oc
@@ -45,7 +45,7 @@ let load =
     | page -> page
     | exception Not_found ->
       try
-        let ic = open_in file in
+        let ic = open_in_bin file in
         let _root = Root.load file ic in
         let res = Marshal.from_channel ic in
         close_in ic;

--- a/src/odoc/root.ml
+++ b/src/odoc/root.ml
@@ -34,7 +34,7 @@ let save oc t =
 
 let read file =
   let file = Fs.File.to_string file in
-  let ic = open_in file in
+  let ic = open_in_bin file in
   let root = load file ic in
   close_in ic;
   root


### PR DESCRIPTION
This hopes to solve #281.

After these changes I hit the following:
```
PS C:\LocalDevelopment\revery> esy doc
    ocamlopt .ppx/95c43a5e8eeb6d851e1995d1bca87765/ppx.exe (exit 2)
(cd C:/LocalDevelopment/revery/_esy/default/store/b/revery-37b15f89\default && C:/LocalDevelopment/.esy/3_/i/ocaml-4.7.1003-d6263879/bin\ocamlopt.opt.exe -o .ppx/95c43a5e8eeb6d851e1995d1bca87765/ppx.exe -I C:/LocalDevelopment/.esy/3_/i/ocaml-4.7.1003-d6263879/lib/ocaml\compiler-libs -I C:/LocalDevelopment/.esy/3_/i/opam__s__lwt__ppx-opam__c__1.2.1-8fb7029d/lib\lwt_ppx -I C:/LocalDevelopment/.esy/3_/i/opam__s__ocaml_migrate_parsetree-opam__c__1.2.0-a491cf88/lib\ocaml-migrate-parsetree -I C:/LocalDevelopment/.esy/3_/i/opam__s__ppx__derivers-opam__c__1.0-de0fe9e4/lib\ppx_derivers -I C:/LocalDevelopment/.esy/3_/i/opam__s__ppx__tools__versioned-opam__c__5.2.1-f6b2c1dd/lib\ppx_tools_versioned -I C:/LocalDevelopment/.esy/3_/i/opam__s__result-opam__c__1.3-30781bb9/lib\result C:/LocalDevelopment/.esy/3_/i/ocaml-4.7.1003-d6263879/lib/ocaml\compiler-libs\ocamlcommon.cmxa C:/LocalDevelopment/.esy/3_/i/opam__s__ppx__derivers-opam__c__1.0-de0fe9e4/lib\ppx_derivers\ppx_derivers.cmxa C:/LocalDevelopment/.esy/3_/i/opam__s__result-opam__c__1.3-30781bb9/lib\result\result.cmxa C:/LocalDevelopment/.esy/3_/i/opam__s__ocaml_migrate_parsetree-opam__c__1.2.0-a491cf88/lib\ocaml-migrate-parsetree\migrate_parsetree.cmxa C:/LocalDevelopment/.esy/3_/i/opam__s__ppx__tools__versioned-opam__c__5.2.1-f6b2c1dd/lib\ppx_tools_versioned\ppx_tools_versioned.cmxa C:/LocalDevelopment/.esy/3_/i/opam__s__lwt__ppx-opam__c__1.2.1-8fb7029d/lib\lwt_ppx\ppx_lwt.cmxa
.ppx/95c43a5e8eeb6d851e1995d1bca87765/ppx.ml)
'x86_64-w64-mingw32-as' is not recognized as an internal or external command,
operable program or batch file.
File ".ppx/95c43a5e8eeb6d851e1995d1bca87765/ppx.ml", line 1:
Error: Assembler error, input left in file C:\Users\ULRIK~1.STR\AppData\Local\Temp\camlasm4106c8.s
```