### PR TITLE
Partially fix html cmds

### DIFF
--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -357,7 +357,7 @@ module Targets = struct
       let env = Env.create ~important_digests:false ~directories in
       let odoc_file = Fs.File.of_string odoc_file in
       let targets =
-        Targets.unit ~env ~output:output_dir odoc_file
+        Targets.of_odoc_file ~env ~output:output_dir odoc_file
         |> List.map ~f:Fs.File.to_string
       in
       Printf.printf "%s\n%!" (String.concat ~sep:"\n" targets)

--- a/src/odoc/targets.mli
+++ b/src/odoc/targets.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val unit :
+val of_odoc_file :
   env:Env.builder -> output:Fs.Directory.t ->
   Fs.File.t -> Fs.File.t list
 


### PR DESCRIPTION
A few commits for `html-{targets,deps}`. 

1. Do not generate targets for modules that are between stop comments (#276). The sub-sub module problem mentioned in the issue remains though.
2. `html-{deps,targets}` do not segfault in presence of `odoc` pages. 

For now `html-deps` will simply output nothing which is certainly wrong. Didn't figure out what needs to be done yet, I'll open a new issue to track it once this is in.