### PR TITLE
Update CONTRIBUTING file with tidy installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ To make edits to the HTML generation, run the following commands:
     opam install --deps-only odoc
     ```
 
-    Also make sure to install a recent version of `tidy-html5` (required for
-    pretty-printing html):
+    Also make sure to install a recent version of
+    [tidy](http://www.html-tidy.org/) (used for HTML validity testing):
 
     ```
     # On MacOS (should be version 5.6.0 by the date of this writing)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,17 @@ To make edits to the HTML generation, run the following commands:
     opam install --deps-only odoc
     ```
 
+    Also make sure to install a recent version of `tidy-html5` (required for
+    pretty-printing html):
+
+    ```
+    # On MacOS (should be version 5.6.0 by the date of this writing)
+    brew install tidy-html5
+
+    # Debian / Ubuntu
+    sudo apt-get install tidy
+    ```
+
 2. Make changes to the code. To compile it,
 
     ```


### PR DESCRIPTION
This fixes an issue I had when I ran `make test` with my stock `tidy` binary shipped with MacOS.
Installing `tidy-html5` via `brew` made the tests green :-)