### PR TITLE
No more GADTs

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,7 @@
+; Note: We disable warning 18 here to support compiler versions < 4.03
+; See https://caml.inria.fr/mantis/view.php?id=7135 for details
+(env
+ (dev
+  (flags (:standard -w -18)))
+ (release
+  (flags (:standard -w -18))))

--- a/src/html/comment.ml
+++ b/src/html/comment.ml
@@ -19,6 +19,8 @@
 module Comment = Model.Comment
 module Html = Tyxml.Html
 
+open Model.Names
+
 type flow = Html_types.flow5_without_header_footer
 type phrasing = Html_types.phrasing
 type non_link_phrasing = Html_types.phrasing_without_interactive
@@ -30,60 +32,61 @@ module Reference = struct
 
   open Model.Paths
 
-  let rec render_resolved : type a. a Reference.Resolved.t -> string =
+  let rec render_resolved : Reference.Resolved.t -> string =
     fun r ->
       let open Reference.Resolved in
       match r with
-      | Identifier id -> Identifier.name id
-      | SubstAlias(_, r) -> render_resolved r
-      | Module (r, s) -> render_resolved r ^ "." ^ s
-      | Canonical (_, Reference.Resolved r) -> render_resolved r
-      | Canonical (p, _) -> render_resolved p
-      | ModuleType (r, s) -> render_resolved r ^ "." ^ s
-      | Type (r, s) -> render_resolved r ^ "." ^ s
-      | Constructor (r, s) -> render_resolved r ^ "." ^ s
-      | Field (r, s) -> render_resolved r ^ "." ^ s
-      | Extension (r, s) -> render_resolved r ^ "." ^ s
-      | Exception (r, s) -> render_resolved r ^ "." ^ s
-      | Value (r, s) -> render_resolved r ^ "." ^ s
-      | Class (r, s) -> render_resolved r ^ "." ^ s
-      | ClassType (r, s) -> render_resolved r ^ "." ^ s
-      | Method (r, s) ->
+      | `Identifier id -> Identifier.name id
+      | `SubstAlias(_, r) -> render_resolved (r :> t)
+      | `Module (r, s) -> render_resolved (r :> t) ^ "." ^ (ModuleName.to_string s)
+      | `Canonical (_, `Resolved r) -> render_resolved (r :> t)
+      | `Canonical (p, _) -> render_resolved (p :> t)
+      | `ModuleType (r, s) -> render_resolved (r :> t) ^ "." ^ (ModuleTypeName.to_string s)
+      | `Type (r, s) -> render_resolved (r :> t) ^ "." ^ (TypeName.to_string s)
+      | `Constructor (r, s) -> render_resolved (r :> t) ^ "." ^ (ConstructorName.to_string s)
+      | `Field (r, s) -> render_resolved (r :> t) ^ "." ^ (FieldName.to_string s)
+      | `Extension (r, s) -> render_resolved (r :> t) ^ "." ^ (ExtensionName.to_string s)
+      | `Exception (r, s) -> render_resolved (r :> t) ^ "." ^ (ExceptionName.to_string s)
+      | `Value (r, s) -> render_resolved (r :> t) ^ "." ^ (ValueName.to_string s)
+      | `Class (r, s) -> render_resolved (r :> t) ^ "." ^ (ClassName.to_string s)
+      | `ClassType (r, s) -> render_resolved (r :> t) ^ "." ^ (ClassTypeName.to_string s)
+      | `Method (r, s) ->
         (* CR trefis: do we really want to print anything more than [s] here?  *)
-        render_resolved r ^ "." ^ s
-      | InstanceVariable (r, s) ->
+        render_resolved (r :> t) ^ "." ^ (MethodName.to_string s)
+      | `InstanceVariable (r, s) ->
         (* CR trefis: the following makes no sense to me... *)
-        render_resolved r ^ "." ^ s
-      | Label (r, s) -> render_resolved r ^ ":" ^ s
+        render_resolved (r :> t) ^ "." ^ (InstanceVariableName.to_string s)
+      | `Label (r, s) -> render_resolved (r :> t) ^ ":" ^ (LabelName.to_string s)
 
-  let rec ref_to_string : type a. a Reference.t -> string = function
-    | Reference.Root (s, _) -> s
-    | Reference.Dot (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Module (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.ModuleType (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Type (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Constructor (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Field (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Extension (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Exception (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Value (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Class (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.ClassType (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Method (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.InstanceVariable (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Label (parent, s) -> ref_to_string parent ^ "." ^ s
-    | Reference.Resolved r -> render_resolved r
+  let rec ref_to_string : Reference.t -> string =
+    let open Reference in
+    function
+    | `Root (s, _) -> UnitName.to_string s
+    | `Dot (parent, s) -> ref_to_string (parent :> t) ^ "." ^ s
+    | `Module (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ModuleName.to_string s)
+    | `ModuleType (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ModuleTypeName.to_string s)
+    | `Type (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (TypeName.to_string s)
+    | `Constructor (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ConstructorName.to_string s)
+    | `Field (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (FieldName.to_string s)
+    | `Extension (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ExtensionName.to_string s)
+    | `Exception (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ExceptionName.to_string s)
+    | `Value (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ValueName.to_string s)
+    | `Class (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ClassName.to_string s)
+    | `ClassType (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ClassTypeName.to_string s)
+    | `Method (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (MethodName.to_string s)
+    | `InstanceVariable (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (InstanceVariableName.to_string s)
+    | `Label (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (LabelName.to_string s)
+    | `Resolved r -> render_resolved r
 
 
   (* This is the entry point. stop_before is false on entry, true on recursive
      call. *)
   let rec to_html
-      : type a.
-        ?text:(non_link_phrasing Html.elt) ->
+      : ?text:(non_link_phrasing Html.elt) ->
         ?xref_base_uri:string ->
         stop_before:bool ->
-        a Reference.t ->
-          phrasing Html.elt =
+        Reference.t ->
+        phrasing Html.elt =
 
     fun ?text ?xref_base_uri ~stop_before ref ->
       let span' (txt : phrasing Html.elt list) : phrasing Html.elt =
@@ -94,40 +97,40 @@ module Reference = struct
       in
       let open Reference in
       match ref with
-      | Root (s, _) ->
+      | `Root (s, _) ->
         begin match text with
-        | None -> Html.code [Html.txt s]
+        | None -> Html.code [Html.txt (Model.Names.UnitName.to_string s)]
         | Some s -> (span' [(s :> phrasing Html.elt)] :> phrasing Html.elt)
         end
-      | Dot (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Module (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | ModuleType (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Type (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Constructor (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Field (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Extension (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Exception (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Value (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Class (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | ClassType (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Method (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | InstanceVariable (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Label (parent, s) ->
-        unresolved_parts_to_html ?xref_base_uri ?text span' parent s
-      | Resolved r ->
+      | `Dot (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) s
+      | `Module (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (ModuleName.to_string s)
+      | `ModuleType (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (ModuleTypeName.to_string s)
+      | `Type (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (TypeName.to_string s)
+      | `Constructor (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (ConstructorName.to_string s)
+      | `Field (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (FieldName.to_string s)
+      | `Extension (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (ExtensionName.to_string s)
+      | `Exception (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (ExceptionName.to_string s)
+      | `Value (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (ValueName.to_string s)
+      | `Class (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (ClassName.to_string s)
+      | `ClassType (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (ClassTypeName.to_string s)
+      | `Method (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (MethodName.to_string s)
+      | `InstanceVariable (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (InstanceVariableName.to_string s)
+      | `Label (parent, s) ->
+        unresolved_parts_to_html ?xref_base_uri ?text span' (parent :> t) (LabelName.to_string s)
+      | `Resolved r ->
         (* IDENTIFIER MUST BE RENAMED TO DEFINITION. *)
         let id = Reference.Resolved.identifier r in
         let txt : non_link_phrasing Html.elt =
@@ -146,11 +149,10 @@ module Reference = struct
         end
 
   and unresolved_parts_to_html
-      : type a.
-        ?text:(non_link_phrasing Html.elt) ->
+      : ?text:(non_link_phrasing Html.elt) ->
         ?xref_base_uri:string ->
         ((phrasing Html.elt list) -> (phrasing Html.elt)) ->
-        a Reference.t ->
+        Reference.t ->
         string ->
           (phrasing Html.elt) =
     fun ?text ?xref_base_uri span' parent s ->
@@ -277,7 +279,7 @@ let rec nestable_block_element
     Html.pre [Html.code ~a:[Html.a_class [classname]] [Html.txt code]]
   | `Verbatim s -> Html.pre [Html.txt s]
   | `Modules ms ->
-    let items = List.map (Reference.to_html ?xref_base_uri ~stop_before:false) ms in
+    let items = List.map (Reference.to_html ?xref_base_uri ~stop_before:false) (ms :> Model.Paths.Reference.t list)  in
     let items = (items :> (Html_types.li_content Html.elt) list) in
     let items = List.map (fun e -> Html.li [e]) items in
     Html.ul items
@@ -369,17 +371,17 @@ let block_element
   | `Heading (level, label, content) ->
     (* TODO Simplify the id/label formatting. *)
     let attributes =
-      let Model.Paths.Identifier.Label (_, label) = label in
-      [Html.a_id label]
+      let `Label (_, label) = label in
+      [Html.a_id (Model.Names.LabelName.to_string label)]
     in
     let a = attributes in
 
     let content =
       (non_link_inline_element_list content :> (phrasing Html.elt) list) in
     let content =
-      let Model.Paths.Identifier.Label (_, label) = label in
+      let `Label (_, label) = label in
       let anchor =
-        Html.a ~a:[Html.a_href ("#" ^ label); Html.a_class ["anchor"]] [] in
+        Html.a ~a:[Html.a_href ("#" ^ (Model.Names.LabelName.to_string label)); Html.a_class ["anchor"]] [] in
       anchor::content
     in
 

--- a/src/html/targets.ml
+++ b/src/html/targets.ml
@@ -19,7 +19,7 @@ open Model.Paths
 
 let functor_arg_pos { Model.Lang.FunctorArgument.id ; _ } =
   match id with
-  | Identifier.Argument (_, nb, _) -> nb
+  | `Argument (_, nb, _) -> nb
   | _ ->
     failwith "TODO"
     (* let id = string_of_sexp @@ Identifier.sexp_of_t id in

--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -19,6 +19,8 @@
 module Html = Tyxml.Html
 module Paths = Model.Paths
 
+open Model.Names
+
 type syntax = OCaml | Reason
 
 type kind = [ `Arg | `Mod | `Mty | `Class | `Cty | `Page ]
@@ -66,7 +68,7 @@ module Relative_link = struct
     exception Not_linkable
     exception Can't_stop_before
 
-    val href : ?xref_base_uri:string -> stop_before:bool -> _ Identifier.t -> string
+    val href : ?xref_base_uri:string -> stop_before:bool -> Identifier.t -> string
   end = struct
     exception Not_linkable
 
@@ -138,20 +140,19 @@ module Relative_link = struct
   end
 
   module Of_path = struct
-    let rec to_html : type a. stop_before:bool -> a Path.t -> _ =
+    let rec to_html : stop_before:bool -> Path.t -> _ =
       fun ~stop_before path ->
-        let open Path in
         match path with
-        | Root root -> [ Html.txt root ]
-        | Forward root -> [ Html.txt root ] (* FIXME *)
-        | Dot (prefix, suffix) ->
-          let link = to_html ~stop_before:true prefix in
+        | `Root root -> [ Html.txt root ]
+        | `Forward root -> [ Html.txt root ] (* FIXME *)
+        | `Dot (prefix, suffix) ->
+          let link = to_html ~stop_before:true (prefix :> Path.t) in
           link @ [ Html.txt ("." ^ suffix) ]
-        | Apply (p1, p2) ->
-          let link1 = to_html ~stop_before p1 in
-          let link2 = to_html ~stop_before p2 in
+        | `Apply (p1, p2) ->
+          let link1 = to_html ~stop_before (p1 :> Path.t) in
+          let link2 = to_html ~stop_before (p2 :> Path.t) in
           link1 @ Html.txt "(":: link2 @ [ Html.txt ")" ]
-        | Resolved rp ->
+        | `Resolved rp ->
           let id = Path.Resolved.identifier rp in
           let txt = Url.render_path path in
           begin match Id.href ~stop_before id with
@@ -169,32 +170,31 @@ module Relative_link = struct
       | "" -> suffix
       | _  -> prefix ^ "." ^ suffix
 
-    let rec render_raw : type a. (a, _) Fragment.raw -> string =
+    let rec render_raw : Fragment.t -> string =
       fun fragment ->
-        let open Fragment in
         match fragment with
-        | Resolved rr -> render_resolved rr
-        | Dot (prefix, suffix) -> dot (render_raw prefix) suffix
+        | `Resolved rr -> render_resolved rr
+        | `Dot (prefix, suffix) -> dot (render_raw (prefix :> Fragment.t)) suffix
 
-    and render_resolved : type a. (a, _) Fragment.Resolved.raw -> string =
+    and render_resolved : Fragment.Resolved.t -> string =
+      let open Fragment.Resolved in
       fun fragment ->
-        let open Fragment.Resolved in
         match fragment with
-        | Root -> ""
-        | Subst (_, rr) -> render_resolved (any_sort rr)
-        | SubstAlias (_, rr) -> render_resolved (any_sort rr)
-        | Module (rr, s) -> dot (render_resolved rr) s
-        | Type (rr, s) -> dot (render_resolved rr) s
-        | Class (rr, s) -> dot (render_resolved rr) s
-        | ClassType (rr, s) -> dot (render_resolved rr) s
+        | `Root -> ""
+        | `Subst (_, rr) -> render_resolved (rr :> t)
+        | `SubstAlias (_, rr) -> render_resolved (rr :> t)
+        | `Module (rr, s) -> dot (render_resolved (rr :> t)) (ModuleName.to_string s)
+        | `Type (rr, s) -> dot (render_resolved (rr :> t)) (TypeName.to_string s)
+        | `Class (rr, s) -> dot (render_resolved ( rr :> t)) (ClassName.to_string s)
+        | `ClassType (rr, s) -> dot (render_resolved (rr :> t)) (ClassTypeName.to_string s)
 
-    let rec to_html : type a. stop_before:bool ->
-      Identifier.signature -> (a, _) Fragment.raw -> _ =
+    let rec to_html : stop_before:bool ->
+      Identifier.Signature.t -> Fragment.t -> _ =
       fun ~stop_before id fragment ->
         let open Fragment in
         match fragment with
-        | Resolved Resolved.Root ->
-          begin match Id.href ~stop_before:true id with
+        | `Resolved `Root ->
+          begin match Id.href ~stop_before:true (id :> Identifier.t) with
           | href ->
             [Html.a ~a:[Html.a_href href] [Html.txt (Identifier.name id)]]
           | exception Id.Not_linkable -> [ Html.txt (Identifier.name id) ]
@@ -202,8 +202,8 @@ module Relative_link = struct
             Printf.eprintf "[FRAG] Id.href failed: %S\n%!" (Printexc.to_string exn);
             [ Html.txt (Identifier.name id) ]
           end
-        | Resolved rr ->
-          let id = Resolved.identifier id (Obj.magic rr : a Resolved.t) in
+        | `Resolved rr ->
+          let id = Resolved.identifier id (rr :> Resolved.t) in
           let txt = render_resolved rr in
           begin match Id.href ~stop_before id with
           | href ->
@@ -213,8 +213,8 @@ module Relative_link = struct
             Printf.eprintf "[FRAG] Id.href failed: %S\n%!" (Printexc.to_string exn);
             [ Html.txt txt ]
           end
-        | Dot (prefix, suffix) ->
-          let link = to_html ~stop_before:true id prefix in
+        | `Dot (prefix, suffix) ->
+          let link = to_html ~stop_before:true id (prefix :> Fragment.t) in
           link @ [ Html.txt ("." ^ suffix) ]
   end
 

--- a/src/html/tree.mli
+++ b/src/html/tree.mli
@@ -72,20 +72,20 @@ module Relative_link : sig
   module Id : sig
     exception Not_linkable
 
-    val href : ?xref_base_uri:string -> stop_before:bool -> _ Paths.Identifier.t -> string
+    val href : ?xref_base_uri:string -> stop_before:bool -> Paths.Identifier.t -> string
   end
 
-  val of_path : stop_before:bool -> _ Paths.Path.t
+  val of_path : stop_before:bool -> Paths.Path.t
     -> [> `A of [> `PCDATA ] | `PCDATA ] Html.elt list
 
-  val of_fragment : base:Paths.Identifier.signature
-    -> (_, Paths.Fragment.sort) Paths.Fragment.raw
+  val of_fragment : base:Paths.Identifier.Signature.t
+    -> Paths.Fragment.t
     -> [> `A of [> `PCDATA ] | `PCDATA ] Html.elt list
 
   val to_sub_element : kind:kind -> string -> [> `Href ] Html.attrib
 end
 
-val render_fragment : (_, Paths.Fragment.sort) Paths.Fragment.raw -> string
+val render_fragment : Paths.Fragment.t -> string
 
 (* TODO: move to a centralized [State] module or something. Along with
    Relative_link.semantic_uris. *)

--- a/src/html/url.mli
+++ b/src/html/url.mli
@@ -30,18 +30,18 @@ end
 
 val from_identifier
   : stop_before:bool
-  -> _ Identifier.t
+  -> Identifier.t
   -> (t, Error.t) result
 
 val anchor_of_id_exn
-  : _ Identifier.t
+  : Identifier.t
   -> string
 
 val kind_of_id_exn
-  : _ Identifier.t
+  : Identifier.t
   -> string
 
-val render_path : _ Path.t -> string
+val render_path : Path.t -> string
 
 module Anchor : sig
   type t = {
@@ -51,12 +51,12 @@ module Anchor : sig
 
   module Polymorphic_variant_decl : sig
     val from_element
-      : type_ident:_ Identifier.t
+      : type_ident:Identifier.t
       -> Model.Lang.TypeExpr.Polymorphic_variant.element
       -> t
   end
 
   module Module_listing : sig
-    val from_reference : Reference.module_ -> t
+    val from_reference : Reference.t -> t
   end
 end

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -510,10 +510,8 @@ and read_object env fi nm =
 let read_value_description env parent id vd =
   let open Signature in
   let name = parenthesise (Ident.name id) in
-  let id = Identifier.Value(parent, name) in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let id = `Value(parent, Model.Names.ValueName.of_string name) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container vd.val_attributes in
     mark_value_description vd;
     let type_ = read_type_expr env vd.val_type in
@@ -534,10 +532,10 @@ let read_value_description env parent id vd =
 let read_label_declaration env parent ld =
   let open TypeDecl.Field in
   let name = parenthesise (Ident.name ld.ld_id) in
-  let id = Identifier.Field(parent, name) in
+  let id = `Field(parent, Model.Names.FieldName.of_string name) in
   let doc =
     Doc_attr.attached
-      (Identifier.label_parent_of_parent parent) ld.ld_attributes
+      (parent :> Identifier.LabelParent.t) ld.ld_attributes
   in
   let mutable_ = (ld.ld_mutable = Mutable) in
   let type_ = read_type_expr env ld.ld_type in
@@ -560,14 +558,12 @@ let read_constructor_declaration_arguments env parent arg =
 let read_constructor_declaration env parent cd =
   let open TypeDecl.Constructor in
   let name = parenthesise (Ident.name cd.cd_id) in
-  let id = Identifier.Constructor(parent, name) in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_datatype parent)
-  in
+  let id = `Constructor(parent, Model.Names.ConstructorName.of_string name) in
+  let container = (parent : Identifier.DataType.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container cd.cd_attributes in
   let args =
     read_constructor_declaration_arguments env
-      (Identifier.parent_of_datatype parent) cd.cd_args
+      (parent :> Identifier.Parent.t) cd.cd_args
   in
   let res = opt_map (read_type_expr env) cd.cd_res in
     {id; doc; args; res}
@@ -583,7 +579,7 @@ let read_type_kind env parent =
     | Type_record(lbls, _) ->
         let lbls =
           List.map
-            (read_label_declaration env (Identifier.parent_of_datatype parent))
+            (read_label_declaration env (parent :> Identifier.Parent.t))
             lbls
         in
           Some (Record lbls)
@@ -621,10 +617,8 @@ let read_type_constraints env params =
 let read_type_declaration env parent id decl =
   let open TypeDecl in
   let name = parenthesise (Ident.name id) in
-  let id = Identifier.Type(parent, name) in
-  let container = Identifier.label_parent_of_parent
-                    (Identifier.parent_of_signature parent)
-  in
+  let id = `Type(parent, Model.Names.TypeName.of_string name) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container decl.type_attributes in
   let params = mark_type_declaration decl in
   let manifest = opt_map (read_type_expr env) decl.type_manifest in
@@ -652,14 +646,12 @@ let read_type_declaration env parent id decl =
 let read_extension_constructor env parent id ext =
   let open Extension.Constructor in
   let name = parenthesise (Ident.name id) in
-  let id = Identifier.Extension(parent, name) in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let id = `Extension(parent, Model.Names.ExtensionName.of_string name) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container ext.ext_attributes in
   let args =
     read_constructor_declaration_arguments env
-      (Identifier.parent_of_signature parent) ext.ext_args
+      (parent : Identifier.Signature.t :> Identifier.Parent.t) ext.ext_args
   in
   let res = opt_map (read_type_expr env) ext.ext_ret_type in
     {id; doc; args; res}
@@ -687,15 +679,13 @@ let read_type_extension env parent id ext rest =
 let read_exception env parent id ext =
   let open Exception in
   let name = parenthesise (Ident.name id) in
-  let id = Identifier.Exception(parent, name) in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let id = `Exception(parent, Model.Names.ExceptionName.of_string name) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container ext.ext_attributes in
     mark_exception ext;
     let args =
       read_constructor_declaration_arguments env
-        (Identifier.parent_of_signature parent) ext.ext_args
+        (parent : Identifier.Signature.t :> Identifier.Parent.t) ext.ext_args
     in
     let res = opt_map (read_type_expr env) ext.ext_ret_type in
       {id; doc; args; res}
@@ -703,7 +693,7 @@ let read_exception env parent id ext =
 let read_method env parent concrete (name, kind, typ) =
   let open Method in
   let name = parenthesise name in
-  let id = Identifier.Method(parent, name) in
+  let id = `Method(parent, Model.Names.MethodName.of_string name) in
   let doc = Doc_attr.empty in
   let private_ = (Btype.field_kind_repr kind) <> Fpresent in
   let virtual_ = not (Concr.mem name concrete) in
@@ -713,7 +703,7 @@ let read_method env parent concrete (name, kind, typ) =
 let read_instance_variable env parent (name, mutable_, virtual_, typ) =
   let open InstanceVariable in
   let name = parenthesise name in
-  let id = Identifier.InstanceVariable(parent, name) in
+  let id = `InstanceVariable(parent, Model.Names.InstanceVariableName.of_string name) in
   let doc = Doc_attr.empty in
   let mutable_ = (mutable_ = Mutable) in
   let virtual_ = (virtual_ = Virtual) in
@@ -790,10 +780,8 @@ let rec read_virtual = function
 let read_class_type_declaration env parent id cltd =
   let open ClassType in
   let name = parenthesise (Ident.name id) in
-  let id = Identifier.ClassType(parent, name) in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let id = `ClassType(parent, Model.Names.ClassTypeName.of_string name) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container cltd.clty_attributes in
     mark_class_type_declaration cltd;
     let params =
@@ -828,10 +816,8 @@ let rec read_class_type env parent params =
 let read_class_declaration env parent id cld =
   let open Class in
   let name = parenthesise (Ident.name id) in
-  let id = Identifier.Class(parent, name) in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let id = `Class(parent, Model.Names.ClassName.of_string name) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container cld.cty_attributes in
     mark_class_declaration cld;
     let params =
@@ -856,7 +842,7 @@ let rec read_module_type env parent pos mty =
           | None -> None
           | Some arg ->
               let name = parenthesise (Ident.name id) in
-              let id = Identifier.Argument(parent, pos, name) in
+              let id = `Argument(parent, pos, Model.Names.ArgumentName.of_string name) in
               let arg = read_module_type env id 1 arg in
               let expansion =
                 match arg with
@@ -873,10 +859,8 @@ let rec read_module_type env parent pos mty =
 and read_module_type_declaration env parent id mtd =
   let open ModuleType in
   let name = parenthesise (Ident.name id) in
-  let id = Identifier.ModuleType(parent, name) in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let id = `ModuleType(parent, Model.Names.ModuleTypeName.of_string name) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container mtd.mtd_attributes in
   let expr = opt_map (read_module_type env id 1) mtd.mtd_type in
   let expansion =
@@ -889,10 +873,8 @@ and read_module_type_declaration env parent id mtd =
 and read_module_declaration env parent ident md =
   let open Module in
   let name = parenthesise (Ident.name ident) in
-  let id = Identifier.Module(parent, name) in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let id = `Module(parent, Model.Names.ModuleName.of_string name) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container md.md_attributes in
   let canonical =
     let doc = List.map Model.Location_.value doc in
@@ -986,7 +968,7 @@ and read_signature env parent items =
     loop [] items
 
 let read_interface root name intf =
-  let id = Identifier.Root(root, name) in
+  let id = `Root(root, Model.Names.UnitName.of_string name) in
   let doc = Doc_attr.empty in
   let items = read_signature Env.empty id intf in
     (id, doc, items)

--- a/src/loader/cmi.mli
+++ b/src/loader/cmi.mli
@@ -22,7 +22,7 @@ module Ident_env = Model.Ident_env
 
 
 val read_interface: Model.Root.t -> string -> Types.signature ->
-  Paths.Identifier.module_ *
+  Paths.Identifier.Module.t *
   Model.Comment.docs *
   Model.Lang.Signature.t
 
@@ -53,28 +53,28 @@ val read_type_constraints : Ident_env.t -> Types.type_expr list ->
                              * Model.Lang.TypeExpr.t) list
 
 val read_class_signature : Ident_env.t ->
-                           Paths.Identifier.class_signature ->
+                           Paths.Identifier.ClassSignature.t ->
                            Types.type_expr list -> Types.class_type ->
                            Model.Lang.ClassType.expr
 
 val read_class_type : Ident_env.t ->
-                      Paths.Identifier.class_signature ->
+                      Paths.Identifier.ClassSignature.t ->
                       Types.type_expr list -> Types.class_type ->
                       Model.Lang.Class.decl
 
 val read_module_type : Ident_env.t ->
-                       Paths.Identifier.signature -> int ->
+                       Paths.Identifier.Signature.t -> int ->
                        Types.module_type -> Model.Lang.ModuleType.expr
 
 val read_signature : Ident_env.t ->
-                     Paths.Identifier.signature ->
+                     Paths.Identifier.Signature.t ->
                      Types.signature -> Model.Lang.Signature.t
 
 val read_extension_constructor : Ident_env.t ->
-                       Paths.Identifier.signature ->
+                       Paths.Identifier.Signature.t ->
                        Ident.t -> Types.extension_constructor ->
                        Model.Lang.Extension.Constructor.t
 
 val read_exception : Ident_env.t ->
-  Paths.Identifier.signature -> Ident.t ->
+  Paths.Identifier.Signature.t -> Ident.t ->
   Types.extension_constructor -> Model.Lang.Exception.t

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -41,20 +41,21 @@ let read_core_type env ctyp =
   Cmi.read_type_expr env ctyp.ctyp_type
 
 let rec read_pattern env parent doc pat =
+  let open Model.Names in
   let open Signature in
     match pat.pat_desc with
     | Tpat_any -> []
     | Tpat_var(id, _) ->
         let open Value in
         let name = parenthesise (Ident.name id) in
-        let id = Identifier.Value(parent, name) in
+        let id = `Value(parent, ValueName.of_string name) in
           Cmi.mark_type_expr pat.pat_type;
           let type_ = Cmi.read_type_expr env pat.pat_type in
             [Value {id; doc; type_}]
     | Tpat_alias(pat, id, _) ->
         let open Value in
         let name = parenthesise (Ident.name id) in
-        let id = Identifier.Value(parent, name) in
+        let id = `Value(parent, ValueName.of_string name) in
           Cmi.mark_type_expr pat.pat_type;
           let type_ = Cmi.read_type_expr env pat.pat_type in
             Value {id; doc; type_} :: read_pattern env parent doc pat
@@ -79,16 +80,12 @@ let rec read_pattern env parent doc pat =
         read_pattern env parent doc pat
 
 let read_value_binding env parent vb =
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container vb.vb_attributes in
     read_pattern env parent doc vb.vb_pat
 
 let read_value_bindings env parent vbs =
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let items =
     List.fold_left
       (fun acc vb ->
@@ -105,9 +102,7 @@ let read_value_bindings env parent vbs =
 let read_type_extension env parent tyext =
   let open Extension in
   let type_path = Env.Path.read_type env tyext.tyext_path in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container tyext.tyext_attributes in
   let type_params =
     List.map (fun (ctyp, _) -> ctyp.ctyp_type) tyext.tyext_params
@@ -135,15 +130,15 @@ let read_type_extension env parent tyext =
 
 let rec read_class_type_field env parent ctf =
   let open ClassSignature in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_class_signature parent)
-  in
+  let open Model.Names in
+
+  let container = (parent : Identifier.ClassSignature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container ctf.ctf_attributes in
   match ctf.ctf_desc with
   | Tctf_val(name, mutable_, virtual_, typ) ->
       let open InstanceVariable in
       let name = parenthesise name in
-      let id = Identifier.InstanceVariable(parent, name) in
+      let id = `InstanceVariable(parent, InstanceVariableName.of_string name) in
       let mutable_ = (mutable_ = Mutable) in
       let virtual_ = (virtual_ = Virtual) in
       let type_ = read_core_type env typ in
@@ -151,7 +146,7 @@ let rec read_class_type_field env parent ctf =
   | Tctf_method(name, private_, virtual_, typ) ->
       let open Method in
       let name = parenthesise name in
-      let id = Identifier.Method(parent, name) in
+      let id = `Method(parent, MethodName.of_string name) in
       let private_ = (private_ = Private) in
       let virtual_ = (virtual_ = Virtual) in
       let type_ = read_core_type env typ in
@@ -215,15 +210,14 @@ let rec read_class_type env parent params cty =
 
 let rec read_class_field env parent cf =
   let open ClassSignature in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_class_signature parent)
-  in
+  let open Model.Names in
+  let container = (parent : Identifier.ClassSignature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container (cf.cf_attributes) in
   match cf.cf_desc with
   | Tcf_val({txt = name; _}, mutable_, _, kind, _) ->
       let open InstanceVariable in
       let name = parenthesise name in
-      let id = Identifier.InstanceVariable(parent, name) in
+      let id = `InstanceVariable(parent, InstanceVariableName.of_string name) in
       let mutable_ = (mutable_ = Mutable) in
       let virtual_, type_ =
         match kind with
@@ -236,7 +230,7 @@ let rec read_class_field env parent cf =
   | Tcf_method({txt = name; _}, private_, kind) ->
       let open Method in
       let name = parenthesise name in
-      let id = Identifier.Method(parent, name) in
+      let id = `Method(parent, MethodName.of_string name) in
       let private_ = (private_ = Private) in
       let virtual_, type_ =
         match kind with
@@ -314,11 +308,10 @@ let rec read_class_expr env parent params cl =
 
 let read_class_declaration env parent cld =
   let open Class in
+  let open Model.Names in
   let name = parenthesise (Ident.name cld.ci_id_class) in
-  let id = Identifier.Class(parent, name) in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let id = `Class(parent, ClassName.of_string name) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container cld.ci_attributes in
     Cmi.mark_class_declaration cld.ci_decl;
     let virtual_ = (cld.ci_virt = Virtual) in
@@ -334,9 +327,7 @@ let read_class_declaration env parent cld =
       { id; doc; virtual_; params; type_; expansion = None }
 
 let read_class_declarations env parent clds =
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-  in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let open Signature in
   List.fold_left begin fun (acc, recursive) cld ->
     let comments = Doc_attr.standalone_multiple container cld.ci_attributes in
@@ -349,6 +340,7 @@ let read_class_declarations env parent clds =
 
 let rec read_module_expr env parent label_parent pos mexpr =
   let open ModuleType in
+  let open Model.Names in
     match mexpr.mod_desc with
     | Tmod_ident _ ->
         Cmi.read_module_type env parent pos mexpr.mod_type
@@ -359,7 +351,7 @@ let rec read_module_expr env parent label_parent pos mexpr =
           | None -> None
           | Some arg ->
               let name = parenthesise (Ident.name id) in
-              let id = Identifier.Argument(parent, pos, name) in
+              let id = `Argument(parent, pos, ArgumentName.of_string name) in
           let arg = Cmti.read_module_type env id label_parent 1 arg in
               let expansion =
                 match arg with
@@ -387,10 +379,10 @@ and unwrap_module_expr_desc = function
 
 and read_module_binding env parent mb =
   let open Module in
+  let open Model.Names in
   let name = parenthesise (Ident.name mb.mb_id) in
-  let id = Identifier.Module(parent, name) in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent) in
+  let id = `Module(parent, ModuleName.of_string name) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container mb.mb_attributes in
   let canonical =
     let doc = List.map Model.Location_.value doc in
@@ -417,8 +409,7 @@ and read_module_binding env parent mb =
     {id; doc; type_; expansion; canonical; hidden; display_type = None}
 
 and read_module_bindings env parent mbs =
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t)
   in
   let open Signature in
   List.fold_left
@@ -481,17 +472,14 @@ and read_structure_item env parent item =
         let cltyps = List.map (fun (_, _, clty) -> clty) cltyps in
           Cmti.read_class_type_declarations env parent cltyps
     | Tstr_attribute attr ->
-      let container =
-        Identifier.label_parent_of_parent (Identifier.parent_of_signature parent)
-      in
+      let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
           match Doc_attr.standalone container attr with
           | None -> []
           | Some doc -> [Comment doc]
 
 and read_include env parent incl =
   let open Include in
-  let container =
-    Identifier.label_parent_of_parent (Identifier.parent_of_signature parent) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container incl.incl_attributes in
   let decl =
     let open Module in
@@ -514,7 +502,7 @@ and read_structure env parent str =
     List.rev items
 
 let read_implementation root name impl =
-  let id = Identifier.Root(root, name) in
+  let id = `Root(root, Model.Names.UnitName.of_string name) in
   let items = read_structure Env.empty id impl in
   let doc, items =
     let open Signature in

--- a/src/loader/cmt.mli
+++ b/src/loader/cmt.mli
@@ -15,6 +15,6 @@
  *)
 
 val read_implementation: Model.Root.t -> string -> Typedtree.structure ->
-  Model.Paths.Identifier.module_ *
+  Model.Paths.Identifier.Module.t *
   Model.Comment.docs *
   Model.Lang.Signature.t

--- a/src/loader/cmti.mli
+++ b/src/loader/cmti.mli
@@ -22,33 +22,33 @@ module Ident_env = Model.Ident_env
 
 
 val read_interface: Model.Root.t -> string -> Typedtree.signature ->
-  Paths.Identifier.module_ *
+  Paths.Identifier.Module.t *
   Model.Comment.docs *
   Model.Lang.Signature.t
 
 val read_module_type :
   Ident_env.t ->
-  Paths.Identifier.signature ->
-  Paths.Identifier.label_parent ->
+  Paths.Identifier.Signature.t ->
+  Paths.Identifier.LabelParent.t ->
   int ->
   Typedtree.module_type ->
     Model.Lang.ModuleType.expr
 
 val read_value_description : Ident_env.t ->
-  Paths.Identifier.signature ->
+  Paths.Identifier.Signature.t ->
   Typedtree.value_description -> Model.Lang.Signature.item
 
 val read_type_declarations : Ident_env.t ->
-  Paths.Identifier.signature ->
+  Paths.Identifier.Signature.t ->
   Model.Lang.Signature.recursive ->
   Typedtree.type_declaration list ->
   Model.Lang.Signature.item list
 
 val read_module_type_declaration : Ident_env.t ->
-  Paths.Identifier.signature ->
+  Paths.Identifier.Signature.t ->
   Typedtree.module_type_declaration -> Model.Lang.ModuleType.t
 
 val read_class_type_declarations : Ident_env.t ->
-  Paths.Identifier.signature ->
+  Paths.Identifier.Signature.t ->
   Typedtree.class_type Typedtree.class_infos list ->
   Model.Lang.Signature.item list

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -23,12 +23,12 @@ module Paths = Model.Paths
 val empty : Model.Comment.docs
 
 val attached :
-  Paths.Identifier.label_parent ->
+  Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
     Model.Comment.docs
 
 val page :
-  Paths.Identifier.label_parent ->
+  Paths.Identifier.LabelParent.t ->
   Location.t ->
   string ->
     Model.Comment.docs_or_stop
@@ -40,11 +40,11 @@ val page :
     the ocamldoc syntax. *)
 
 val standalone :
-  Paths.Identifier.label_parent ->
+  Paths.Identifier.LabelParent.t ->
   Parsetree.attribute ->
     Model.Comment.docs_or_stop option
 
 val standalone_multiple :
-  Paths.Identifier.label_parent ->
+  Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
     Model.Comment.docs_or_stop list

--- a/src/loader/odoc__loader.ml
+++ b/src/loader/odoc__loader.ml
@@ -93,7 +93,7 @@ let read_cmt ~make_root ~filename =
       in
       let hidden = Model.Root.contains_double_underscore name in
       let root = make_root ~module_name:name ~digest in
-      let id = Model.Paths.Identifier.Root(root, name) in
+      let id = `Root(root, Model.Names.UnitName.of_string name) in
       let items =
         List.map (fun file ->
           let pref = Misc.chop_extensions file in
@@ -103,8 +103,8 @@ let read_cmt ~make_root ~filename =
       let items = List.sort String.compare items in
       let items =
         List.map (fun name ->
-          let id = Model.Paths.Identifier.Module(id, name) in
-          let path = Model.Paths.Path.Root name in
+          let id = `Module(id, Model.Names.ModuleName.of_string name) in
+          let path = `Root name in
           {Model.Lang.Compilation_unit.Packed.id; path})
           items
       in

--- a/src/loader/odoc__loader.mli
+++ b/src/loader/odoc__loader.mli
@@ -1,7 +1,7 @@
 open Result
 
 val read_string :
-  Model.Paths.Identifier.label_parent ->
+  Model.Paths.Identifier.LabelParent.t ->
   Location.t ->
   string ->
     (Model.Comment.docs_or_stop, Model.Error.t) result

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -38,7 +38,7 @@ type link_content = (non_link_inline_element with_location) list
 type inline_element = [
   | leaf_inline_element
   | `Styled of style * (inline_element with_location) list
-  | `Reference of Reference.any * link_content
+  | `Reference of Reference.t * link_content
   | `Link of string * link_content
 ]
 
@@ -46,7 +46,7 @@ type nestable_block_element = [
   | `Paragraph of (inline_element with_location) list
   | `Code_block of string
   | `Verbatim of string
-  | `Modules of Reference.module_ list
+  | `Modules of Reference.Module.t list
   | `List of
     [ `Unordered | `Ordered ] *
     ((nestable_block_element with_location) list) list
@@ -65,7 +65,7 @@ type tag = [
   | `Since of string
   | `Before of string * (nestable_block_element with_location) list
   | `Version of string
-  | `Canonical of Path.module_ * Reference.module_
+  | `Canonical of Path.Module.t * Reference.Module.t
   | `Inline
   | `Open
   | `Closed
@@ -82,7 +82,7 @@ type heading_level = [
 
 type block_element = [
   | nestable_block_element
-  | `Heading of heading_level * Identifier.label * link_content
+  | `Heading of heading_level * Identifier.Label.t * link_content
   | `Tag of tag
 ]
 

--- a/src/model/ident_env.mli
+++ b/src/model/ident_env.mli
@@ -14,47 +14,45 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Paths.Identifier
-
 type t
 
 val empty : t
 
-val add_module : signature -> Ident.t -> t -> t
+val add_module : Paths.Identifier.Signature.t -> Ident.t -> t -> t
 
-val add_argument : signature -> int -> Ident.t -> t -> t
+val add_argument : Paths.Identifier.Signature.t -> int -> Ident.t -> t -> t
 
-val add_module_type : signature -> Ident.t -> t -> t
+val add_module_type : Paths.Identifier.Signature.t -> Ident.t -> t -> t
 
-val add_type : signature -> Ident.t -> t -> t
+val add_type : Paths.Identifier.Signature.t -> Ident.t -> t -> t
 
-val add_class : signature -> Ident.t -> Ident.t -> Ident.t -> Ident.t -> t -> t
+val add_class : Paths.Identifier.Signature.t -> Ident.t -> Ident.t -> Ident.t -> Ident.t -> t -> t
 
-val add_class_type : signature -> Ident.t -> Ident.t -> Ident.t -> t -> t
+val add_class_type : Paths.Identifier.Signature.t -> Ident.t -> Ident.t -> Ident.t -> t -> t
 
-val add_signature_type_items : signature -> Types.signature -> t -> t
+val add_signature_type_items : Paths.Identifier.Signature.t -> Types.signature -> t -> t
 
-val add_signature_tree_items : signature -> Typedtree.signature -> t -> t
+val add_signature_tree_items : Paths.Identifier.Signature.t -> Typedtree.signature -> t -> t
 
-val add_structure_tree_items : signature -> Typedtree.structure -> t -> t
+val add_structure_tree_items : Paths.Identifier.Signature.t -> Typedtree.structure -> t -> t
 
 module Path : sig
 
-  val read_module : t -> Path.t -> Paths.Path.module_
+  val read_module : t -> Path.t -> Paths.Path.Module.t
 
-  val read_module_type : t -> Path.t -> Paths.Path.module_type
+  val read_module_type : t -> Path.t -> Paths.Path.ModuleType.t
 
-  val read_type : t -> Path.t -> Paths.Path.type_
+  val read_type : t -> Path.t -> Paths.Path.Type.t
 
-  val read_class_type : t -> Path.t -> Paths.Path.class_type
+  val read_class_type : t -> Path.t -> Paths.Path.ClassType.t
 
 end
 
 
 module Fragment : sig
 
-  val read_module : Longident.t -> Paths.Fragment.module_
+  val read_module : Longident.t -> Paths.Fragment.Module.t
 
-  val read_type : Longident.t -> Paths.Fragment.type_
+  val read_type : Longident.t -> Paths.Fragment.Type.t
 
 end

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -26,14 +26,14 @@ module rec Module : sig
     | Functor of FunctorArgument.t option list * Signature.t
 
   type decl =
-    | Alias of Path.module_
+    | Alias of Path.Module.t
     | ModuleType of ModuleType.expr
 
   type t =
-    { id: Identifier.module_;
+    { id: Identifier.Module.t;
       doc: Comment.docs;
       type_: decl;
-      canonical : (Path.module_ * Reference.module_) option;
+      canonical : (Path.Module.t * Reference.Module.t) option;
       hidden : bool;
       display_type : decl option;
       expansion: expansion option;
@@ -49,7 +49,7 @@ end = Module
 
 and FunctorArgument : sig
   type t = {
-    id : Identifier.module_;
+    id : Identifier.Module.t;
     expr : ModuleType.expr;
     expansion: Module.expansion option;
   }
@@ -60,20 +60,20 @@ end = FunctorArgument
 and ModuleType : sig
 
   type substitution =
-    | ModuleEq of Fragment.module_ * Module.Equation.t
-    | TypeEq of Fragment.type_ * TypeDecl.Equation.t
-    | ModuleSubst of Fragment.module_ * Path.module_
-    | TypeSubst of Fragment.type_ * TypeDecl.Equation.t
+    | ModuleEq of Fragment.Module.t * Module.Equation.t
+    | TypeEq of Fragment.Type.t * TypeDecl.Equation.t
+    | ModuleSubst of Fragment.Module.t * Path.Module.t
+    | TypeSubst of Fragment.Type.t * TypeDecl.Equation.t
 
   type expr =
-    | Path of Path.module_type
+    | Path of Path.ModuleType.t
     | Signature of Signature.t
     | Functor of FunctorArgument.t option * expr
     | With of expr * substitution list
     | TypeOf of Module.decl
 
   type t =
-    { id: Identifier.module_type;
+    { id: Identifier.ModuleType.t;
       doc: Comment.docs;
       expr: expr option;
       expansion: Module.expansion option;
@@ -117,7 +117,7 @@ and Include : sig
   }
 
   type t =
-    { parent: Identifier.signature;
+    { parent: Identifier.Signature.t;
       doc: Comment.docs;
       decl: Module.decl;
       expansion: expansion; }
@@ -131,7 +131,7 @@ and TypeDecl : sig
   module Field : sig
 
     type t =
-      { id: Identifier.field;
+      { id: Identifier.Field.t;
         doc: Comment.docs;
         mutable_ : bool;
         type_: TypeExpr.t; }
@@ -144,7 +144,7 @@ and TypeDecl : sig
       | Record of Field.t list
 
     type t =
-      { id: Identifier.constructor;
+      { id: Identifier.Constructor.t;
         doc: Comment.docs;
         args: argument;
         res: TypeExpr.t option; }
@@ -182,7 +182,7 @@ and TypeDecl : sig
   end
 
   type t =
-    { id: Identifier.type_;
+    { id: Identifier.Type.t;
       doc: Comment.docs;
       equation: Equation.t;
       representation: Representation.t option; }
@@ -196,7 +196,7 @@ and Extension : sig
   module Constructor : sig
 
     type t =
-      { id: Identifier.extension;
+      { id: Identifier.Extension.t;
         doc: Comment.docs;
         args: TypeDecl.Constructor.argument;
         res: TypeExpr.t option; }
@@ -204,7 +204,7 @@ and Extension : sig
   end
 
   type t =
-    { type_path: Path.type_;
+    { type_path: Path.Type.t;
       doc: Comment.docs;
       type_params: TypeDecl.param list;
       private_: bool;
@@ -216,7 +216,7 @@ end = Extension
 and Exception : sig
 
   type t =
-    { id: Identifier.exception_;
+    { id: Identifier.Exception.t;
       doc: Comment.docs;
       args: TypeDecl.Constructor.argument;
       res: TypeExpr.t option; }
@@ -229,7 +229,7 @@ end = Exception
 and Value : sig
 
   type t =
-    { id: Identifier.value;
+    { id: Identifier.Value.t;
       doc: Comment.docs;
       type_: TypeExpr.t; }
 
@@ -240,7 +240,7 @@ end = Value
 and External : sig
 
   type t =
-    { id: Identifier.value;
+    { id: Identifier.Value.t;
       doc: Comment.docs;
       type_: TypeExpr.t;
       primitives: string list; }
@@ -256,7 +256,7 @@ and Class : sig
     | Arrow of TypeExpr.label option * TypeExpr.t * decl
 
   type t =
-    { id: Identifier.class_;
+    { id: Identifier.Class.t;
       doc: Comment.docs;
       virtual_: bool;
       params: TypeDecl.param list;
@@ -270,11 +270,11 @@ end = Class
 and ClassType : sig
 
   type expr =
-    | Constr of Path.class_type * TypeExpr.t list
+    | Constr of Path.ClassType.t * TypeExpr.t list
     | Signature of ClassSignature.t
 
   type t =
-    { id: Identifier.class_type;
+    { id: Identifier.ClassType.t;
       doc: Comment.docs;
       virtual_: bool;
       params: TypeDecl.param list;
@@ -305,7 +305,7 @@ end = ClassSignature
 and Method : sig
 
   type t =
-    { id: Identifier.method_;
+    { id: Identifier.Method.t;
       doc: Comment.docs;
       private_: bool;
       virtual_: bool;
@@ -318,7 +318,7 @@ end = Method
 and InstanceVariable : sig
 
   type t =
-    { id: Identifier.instance_variable;
+    { id: Identifier.InstanceVariable.t;
       doc: Comment.docs;
       mutable_: bool;
       virtual_: bool;
@@ -375,10 +375,10 @@ and TypeExpr : sig
 
   module Package : sig
 
-    type substitution = Fragment.type_ * TypeExpr.t
+    type substitution = Fragment.Type.t * TypeExpr.t
 
     type t =
-      { path: Path.module_type;
+      { path: Path.ModuleType.t;
         substitutions: substitution list; }
 
   end
@@ -393,10 +393,10 @@ and TypeExpr : sig
     | Alias of t * string
     | Arrow of label option * t * t
     | Tuple of t list
-    | Constr of Path.type_ * t list
+    | Constr of Path.Type.t * t list
     | Polymorphic_variant of TypeExpr.Polymorphic_variant.t
     | Object of TypeExpr.Object.t
-    | Class of Path.class_type * t list
+    | Class of Path.ClassType.t * t list
     | Poly of string list * t
     | Package of TypeExpr.Package.t
 
@@ -426,8 +426,8 @@ module rec Compilation_unit : sig
   module Packed : sig
 
     type item =
-      { id: Identifier.module_;
-        path: Path.module_; }
+      { id: Identifier.Module.t;
+        path: Path.Module.t; }
 
     type t = item list
 
@@ -438,7 +438,7 @@ module rec Compilation_unit : sig
     | Pack of Packed.t
 
   type t =
-    { id: Identifier.module_;
+    { id: Identifier.Module.t;
       doc: Comment.docs;
       digest: Digest.t;
       imports: Import.t list;
@@ -452,7 +452,7 @@ end = Compilation_unit
 
 module rec Page : sig
   type t =
-    { name: Identifier.page;
+    { name: Identifier.Page.t;
       content: Comment.docs;
       digest: Digest.t; }
 end = Page

--- a/src/model/maps.ml
+++ b/src/model/maps.ml
@@ -28,9 +28,6 @@ let pair_map f g p =
     if a != a' || b != b' then (a', b')
     else p
 
-(* It would be much nicer not to have to have these functions *)
-
-
 
 class virtual identifier = object (self)
 

--- a/src/model/maps.ml
+++ b/src/model/maps.ml
@@ -28,133 +28,129 @@ let pair_map f g p =
     if a != a' || b != b' then (a', b')
     else p
 
+(* It would be much nicer not to have to have these functions *)
+
+
+
 class virtual identifier = object (self)
 
   method virtual root : Root.t -> Root.t
 
-  method identifier : type k . k Identifier.t -> k Identifier.t =
+  method identifier : Identifier.t -> Identifier.t =
     fun id ->
-      let open Identifier in
         match id with
-        | Root(root, name) ->
+        | `Root(root, name) ->
             let root' = self#root root in
             let name' = self#identifier_root_name name in
-              if root != root' || name != name' then Root(root', name')
+              if root != root' || name != name' then `Root(root', name')
               else id
-        | Page(root, name) ->
+        | `Page(root, name) ->
             let root' = self#root root in
             let name' = self#identifier_page_name name in
-              if root != root' || name != name' then Page(root', name')
+              if root != root' || name != name' then `Page(root', name')
               else id
-        | Module(parent, name) ->
+        | `Module(parent, name) ->
             let parent' = self#identifier_signature parent in
             let name' = self#identifier_module_name name in
               if parent != parent' || name != name' then
-                Module(parent', name')
+                `Module(parent', name')
               else id
-        | Argument(parent, pos, name) ->
+        | `Argument(parent, pos, name) ->
             let parent' = self#identifier_signature parent in
             let pos' = self#identifier_argument_position pos in
             let name' = self#identifier_argument_name name in
               if parent != parent' || pos != pos' || name != name' then
-                Argument(parent', pos', name')
+                `Argument(parent', pos', name')
               else id
-        | ModuleType(parent, name) ->
+        | `ModuleType(parent, name) ->
             let parent' = self#identifier_signature parent in
             let name' = self#identifier_module_type_name name in
               if parent != parent' || name != name' then
-                ModuleType(parent', name')
+                `ModuleType(parent', name')
               else id
-        | Type(parent, name) ->
+        | `Type(parent, name) ->
             let parent' = self#identifier_signature parent in
             let name' = self#identifier_type_name name in
               if parent != parent' || name != name' then
-                Type(parent', name')
+                `Type(parent', name')
               else id
-        | CoreType name ->
+        | `CoreType name ->
             let name' = self#identifier_core_type_name name in
-              if name != name' then CoreType name'
+              if name != name' then `CoreType name'
               else id
-        | Constructor(parent, name) ->
-            let parent' = self#identifier parent in
+        | `Constructor(parent, name) ->
+            let parent' = self#identifier_type parent in
             let name' = self#identifier_constructor_name name in
               if parent != parent' || name != name' then
-                Constructor(parent', name')
+                `Constructor(parent', name')
               else id
-        | Field(parent, name) ->
-            let parent' = self#identifier parent in
+        | `Field(parent, name) ->
+            let parent' = self#identifier_parent parent in
             let name' = self#identifier_field_name name in
               if parent != parent' || name != name' then
-                Field(parent', name')
+                `Field(parent', name')
               else id
-        | Extension(parent, name) ->
+        | `Extension(parent, name) ->
             let parent' = self#identifier_signature parent in
             let name' = self#identifier_extension_name name in
               if parent != parent' || name != name' then
-                Extension(parent', name')
+                `Extension(parent', name')
               else id
-        | Exception(parent, name) ->
+        | `Exception(parent, name) ->
             let parent' = self#identifier_signature parent in
             let name' = self#identifier_exception_name name in
               if parent != parent' || name != name' then
-                Exception(parent', name')
+                `Exception(parent', name')
               else id
-        | CoreException name ->
+        | `CoreException name ->
             let name' = self#identifier_core_exception_name name in
-              if name != name' then CoreException name'
+              if name != name' then `CoreException name'
               else id
-        | Value(parent, name) ->
+        | `Value(parent, name) ->
             let parent' = self#identifier_signature parent in
             let name' = self#identifier_value_name name in
               if parent != parent' || name != name' then
-                Value(parent', name')
+                `Value(parent', name')
               else id
-        | Class(parent, name) ->
+        | `Class(parent, name) ->
             let parent' = self#identifier_signature parent in
             let name' = self#identifier_class_name name in
               if parent != parent' || name != name' then
-                Class(parent', name')
+                `Class(parent', name')
               else id
-        | ClassType(parent, name) ->
+        | `ClassType(parent, name) ->
             let parent' = self#identifier_signature parent in
             let name' = self#identifier_class_type_name name in
               if parent != parent' || name != name' then
-                ClassType(parent', name')
+                `ClassType(parent', name')
               else id
-        | Method(parent, name) ->
+        | `Method(parent, name) ->
             let parent' = self#identifier_class_signature parent in
             let name' = self#identifier_method_name name in
               if parent != parent' || name != name' then
-                Method(parent', name')
+                `Method(parent', name')
               else id
-        | InstanceVariable(parent, name) ->
+        | `InstanceVariable(parent, name) ->
             let parent' = self#identifier_class_signature parent in
             let name' = self#identifier_instance_variable_name name in
               if parent != parent' || name != name' then
-                InstanceVariable(parent', name')
+                `InstanceVariable(parent', name')
               else id
-        | Label(parent, name) ->
+        | `Label(parent, name) ->
             let parent' =
               match parent with
-              | (Root _ | Module _ | Argument _ | ModuleType _) as parent ->
-                label_parent_of_parent
-                  (parent_of_signature
-                     (self#identifier_signature parent))
-              | (Class _ | ClassType _) as parent ->
-                label_parent_of_parent
-                  (parent_of_class_signature
-                     (self#identifier_class_signature parent))
-              | Type _ | CoreType _ as parent ->
-                label_parent_of_parent
-                  (parent_of_datatype
-                    (self#identifier_datatype parent))
-              | Page _ as parent ->
-                label_parent_of_page
-                  (self#identifier_page parent)
+              | (`Root _ | `Module _ | `Argument _ | `ModuleType _) as parent ->
+                  (self#identifier_signature parent :> Identifier.LabelParent.t)
+              | (`Class _ | `ClassType _) as parent ->
+                  (self#identifier_class_signature parent :> Identifier.LabelParent.t)
+              | (`Type _ | `CoreType _) as parent ->
+                  (self#identifier_datatype parent :> Identifier.LabelParent.t)
+              | `Page _ as parent ->
+                  (self#identifier_page parent :> Identifier.LabelParent.t)
             in
             let name' = self#identifier_label_name name in
               if parent != parent' || name != name' then
-                Label(parent', name')
+                `Label(parent', name')
               else id
 
   method identifier_root_name name = name
@@ -195,122 +191,142 @@ class virtual identifier = object (self)
 
   method identifier_label_name name = name
 
-  method identifier_page (id : Identifier.page) =
-    self#identifier id
+  method identifier_parent : Identifier.Parent.t -> Identifier.Parent.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.parent_of_t
 
-  method identifier_signature (id : Identifier.signature) =
-    self#identifier id
+  method identifier_page : Identifier.Page.t -> Identifier.Page.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.page_of_t
 
-  method identifier_class_signature (id : Identifier.class_signature) =
-    self#identifier id
+  method identifier_signature : Identifier.Signature.t -> Identifier.Signature.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.signature_of_t
 
-  method identifier_datatype (id : Identifier.datatype) =
-    self#identifier id
-
-  method identifier_module (id : Identifier.module_) =
-    self#identifier id
-
-  method identifier_module_type (id : Identifier.module_type) =
-    self#identifier id
-
-  method identifier_type (id : Identifier.type_) =
-    self#identifier id
-
-  method identifier_constructor (id : Identifier.constructor) =
-    self#identifier id
-
-  method identifier_field (id : Identifier.field) =
-    self#identifier id
-
-  method identifier_extension (id : Identifier.extension) =
-    self#identifier id
-
-  method identifier_exception (id : Identifier.exception_) =
-    self#identifier id
-
-  method identifier_value (id : Identifier.value) =
-    self#identifier id
-
-  method identifier_class (id : Identifier.class_) =
-    self#identifier id
-
-  method identifier_class_type (id : Identifier.class_type) =
-    self#identifier id
-
-  method identifier_method (id : Identifier.method_) =
-    self#identifier id
-
-  method identifier_instance_variable (id : Identifier.instance_variable) =
-    self#identifier id
-
-  method identifier_label (id : Identifier.label) =
-    self#identifier id
-
+  method identifier_class_signature : Identifier.ClassSignature.t -> Identifier.ClassSignature.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.class_signature_of_t
+    
+  method identifier_datatype : Identifier.DataType.t -> Identifier.DataType.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.datatype_of_t
+  
+  method identifier_module : Identifier.Module.t -> Identifier.Module.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.module_of_t
+    
+  method identifier_module_type : Identifier.ModuleType.t -> Identifier.ModuleType.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.module_type_of_t
+    
+  method identifier_type : Identifier.Type.t -> Identifier.Type.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.type_of_t
+    
+  method identifier_constructor : Identifier.Constructor.t -> Identifier.Constructor.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.constructor_of_t
+    
+  method identifier_field : Identifier.Field.t -> Identifier.Field.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.field_of_t
+    
+  method identifier_extension : Identifier.Extension.t -> Identifier.Extension.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.extension_of_t
+    
+  method identifier_exception : Identifier.Exception.t -> Identifier.Exception.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.exception_of_t
+    
+  method identifier_value : Identifier.Value.t -> Identifier.Value.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.value_of_t
+    
+  method identifier_class : Identifier.Class.t -> Identifier.Class.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.class_of_t
+    
+  method identifier_class_type : Identifier.ClassType.t -> Identifier.ClassType.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.class_type_of_t
+    
+  method identifier_method : Identifier.Method.t -> Identifier.Method.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.method_of_t
+    
+  method identifier_instance_variable : Identifier.InstanceVariable.t -> Identifier.InstanceVariable.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.instance_variable_of_t
+  
+  method identifier_label : Identifier.Label.t -> Identifier.Label.t = fun id ->
+    self#identifier (id :> Identifier.t) |>
+    Identifier.label_of_t
+    
 end
 
 class virtual path = object (self)
 
-  method virtual identifier : 'k . 'k Identifier.t -> 'k Identifier.t
+  method virtual identifier : Identifier.t -> Identifier.t
 
-  method path_resolved : type k. k Path.Resolved.t -> k Path.Resolved.t =
+  method path_resolved : Path.Resolved.t -> Path.Resolved.t =
     fun p ->
-      let open Path.Resolved in
         match p with
-        | Identifier id ->
+        | `Identifier id ->
             let id' = self#identifier id in
-              if id != id' then Identifier id'
+              if id != id' then `Identifier id'
               else p
-        | Subst(sub, orig) ->
-            let sub' = self#path_resolved sub in
-            let orig' = self#path_resolved orig in
-              if sub != sub' || orig != orig' then Subst(sub', orig')
+        | `Subst(sub, orig) ->
+            let sub' = self#path_resolved_module_type sub in
+            let orig' = self#path_resolved_module orig in
+              if sub != sub' || orig != orig' then `Subst(sub', orig')
               else p
-        | SubstAlias(sub, orig) ->
-            let sub' = self#path_resolved sub in
-            let orig' = self#path_resolved orig in
-              if sub != sub' || orig != orig' then SubstAlias(sub', orig')
+        | `SubstAlias(sub, orig) ->
+            let sub' = self#path_resolved_module sub in
+            let orig' = self#path_resolved_module orig in
+              if sub != sub' || orig != orig' then `SubstAlias(sub', orig')
               else p
-        | Hidden hp ->
-            let hp' = self#path_resolved hp in
-              if hp != hp' then Hidden hp'
+        | `Hidden hp ->
+            let hp' = self#path_resolved_module hp in
+              if hp != hp' then `Hidden hp'
               else p
-        | Module(parent, name) ->
-            let parent' = self#path_resolved parent in
+        | `Module(parent, name) ->
+            let parent' = self#path_resolved_module parent in
             let name' = self#path_resolved_module_name name in
               if parent != parent' || name != name' then
-                Module(parent', name')
+                `Module(parent', name')
               else p
-        | Canonical(orig, cano) ->
-            let orig' = self#path_resolved orig in
-            let cano' = self#path cano in
-              if orig != orig' || cano != cano' then Canonical(orig', cano')
+        | `Canonical(orig, cano) ->
+            let orig' = self#path_resolved_module orig in
+            let cano' = self#path_module cano in
+              if orig != orig' || cano != cano' then `Canonical(orig', cano')
               else p
-        | Apply(fn, arg) ->
-            let fn' = self#path_resolved fn in
-            let arg' = self#path arg in
-              if fn != fn' || arg != arg' then Apply(fn', arg')
+        | `Apply(fn, arg) ->
+            let fn' = self#path_resolved_module fn in
+            let arg' = self#path_module arg in
+              if fn != fn' || arg != arg' then `Apply(fn', arg')
               else p
-        | ModuleType(parent, name) ->
-            let parent' = self#path_resolved parent in
+        | `ModuleType(parent, name) ->
+            let parent' = self#path_resolved_module parent in
             let name' = self#path_resolved_module_type_name name in
               if parent != parent' || name != name' then
-                ModuleType(parent', name')
+                `ModuleType(parent', name')
               else p
-        | Type(parent, name) ->
-            let parent' = self#path_resolved parent in
+        | `Type(parent, name) ->
+            let parent' = self#path_resolved_module parent in
             let name' = self#path_resolved_type_name name in
-              if parent != parent' || name != name' then Type(parent', name')
+              if parent != parent' || name != name' then `Type(parent', name')
               else p
-        | Class(parent, name) ->
-            let parent' = self#path_resolved parent in
+        | `Class(parent, name) ->
+            let parent' = self#path_resolved_module parent in
             let name' = self#path_resolved_class_name name in
-              if parent != parent' || name != name' then Class(parent', name')
+              if parent != parent' || name != name' then `Class(parent', name')
               else p
-        | ClassType(parent, name) ->
-            let parent' = self#path_resolved parent in
+        | `ClassType(parent, name) ->
+            let parent' = self#path_resolved_module parent in
             let name' = self#path_resolved_class_type_name name in
               if parent != parent' || name != name' then
-                ClassType(parent', name')
+                `ClassType(parent', name')
               else p
 
   method path_resolved_module_name name = name
@@ -323,104 +339,113 @@ class virtual path = object (self)
 
   method path_resolved_class_type_name name = name
 
-  method path_resolved_module (p : Path.Resolved.module_) =
-    self#path_resolved p
+  method path_resolved_module : Path.Resolved.Module.t -> Path.Resolved.Module.t = fun p ->
+    self#path_resolved (p :> Path.Resolved.t) |>
+    Path.Resolved.module_of_t
 
-  method path_resolved_module_type (p : Path.Resolved.module_type) =
-    self#path_resolved p
+  method path_resolved_module_type : Path.Resolved.ModuleType.t -> Path.Resolved.ModuleType.t = fun p ->
+    self#path_resolved (p :> Path.Resolved.t) |>
+    Path.Resolved.module_type_of_t
 
-  method path_resolved_type (p : Path.Resolved.type_) =
-    self#path_resolved p
+  method path_resolved_type : Path.Resolved.Type.t -> Path.Resolved.Type.t = fun p ->
+    self#path_resolved (p :> Path.Resolved.t) |>
+    Path.Resolved.type_of_t
 
-  method path_resolved_class_type (p : Path.Resolved.class_type) =
-    self#path_resolved p
+  method path_resolved_class_type : Path.Resolved.ClassType.t -> Path.Resolved.ClassType.t = fun p ->
+    self#path_resolved (p :> Path.Resolved.t) |>
+    Path.Resolved.class_type_of_t
 
-  method path : type k . k Path.t -> k Path.t =
+  method path : Path.t -> Path.t =
     fun p ->
-      let open Path in
         match p with
-        | Resolved res ->
+        | `Resolved res ->
             let res' = self#path_resolved res in
-              if res != res' then Resolved res'
+              if res != res' then `Resolved res'
               else p
-        | Root name ->
+        | `Root name ->
             let name' = self#path_root_name name in
-              if name != name' then Root name'
+              if name != name' then `Root name'
               else p
-        | Forward name ->
+        | `Forward name ->
             let name' = self#path_root_name name in
-              if name != name' then Forward name'
+              if name != name' then `Forward name'
               else p
-        | Dot(parent, name) ->
-            let parent' = self#path parent in
+        | `Dot(parent, name) ->
+            let parent' = self#path_module parent in
             let name' = self#path_dot_name name in
-              if parent != parent' || name != name' then Dot(parent', name')
+              if parent != parent' || name != name' then `Dot(parent', name')
               else p
-        | Apply(fn, arg) ->
-            let fn' = self#path fn in
-            let arg' = self#path arg in
-              if fn != fn' || arg != arg' then Apply(fn', arg')
+        | `Apply(fn, arg) ->
+            let fn' = self#path_module fn in
+            let arg' = self#path_module arg in
+              if fn != fn' || arg != arg' then `Apply(fn', arg')
               else p
 
   method path_root_name name = name
 
   method path_dot_name name = name
 
-  method path_module (p : Path.module_) =
-    self#path p
+  method path_module : Path.Module.t -> Path.Module.t = fun p ->
+    self#path (p :> Path.t) |> 
+    Path.module_of_t
 
-  method path_module_type (p : Path.module_type) =
-    self#path p
+  method path_module_type : Path.ModuleType.t -> Path.ModuleType.t = fun p ->
+    self#path (p :> Path.t) |>
+    Path.module_type_of_t
 
-  method path_type (p : Path.type_) =
-    self#path p
+  method path_type : Path.Type.t -> Path.Type.t = fun p ->
+    self#path (p :> Path.t) |>
+    Path.type_of_t
 
-  method path_class_type (p : Path.class_type) =
-    self#path p
+  method path_class_type : Path.ClassType.t -> Path.ClassType.t = fun p ->
+    self#path (p :> Path.t) |>
+    Path.class_type_of_t
 
 end
 
 class virtual fragment = object (self)
 
-  method virtual path_resolved : 'k. 'k Path.Resolved.t ->
-                                   'k Path.Resolved.t
+  method virtual path_resolved : Path.Resolved.t ->
+                                   Path.Resolved.t
 
-  method fragment_resolved : type k s. (k, s) Fragment.Resolved.raw ->
-                                         (k, s) Fragment.Resolved.raw =
+  method virtual path_resolved_module : Path.Resolved.Module.t -> Path.Resolved.Module.t
+
+  method virtual path_resolved_module_type : Path.Resolved.ModuleType.t -> Path.Resolved.ModuleType.t
+
+  method fragment_resolved : Fragment.Resolved.t -> Fragment.Resolved.t =
     fun p ->
-      let open Fragment.Resolved in
         match p with
-        | Root -> p
-        | Subst(sub, orig) ->
-            let sub' = self#path_resolved sub in
-            let orig' = self#fragment_resolved orig in
-              if sub != sub' || orig != orig' then Subst(sub', orig')
+        | `Root -> p
+        | `Subst(sub, orig) ->
+            let sub' = self#path_resolved_module_type sub in
+            let orig' = self#fragment_resolved_module orig in
+              if sub != sub' || orig != orig' then `Subst(sub', orig')
               else p
-        | SubstAlias(sub, orig) ->
-            let sub' = self#path_resolved sub in
-            let orig' = self#fragment_resolved orig in
-              if sub != sub' || orig != orig' then SubstAlias(sub', orig')
+        | `SubstAlias(sub, orig) ->
+            let sub' = self#path_resolved_module sub in
+            let orig' = self#fragment_resolved_module orig in
+              if sub != sub' || orig != orig' then `SubstAlias(sub', orig')
               else p
-        | Module(parent, name) ->
-            let parent' = self#fragment_resolved parent in
+        | `Module(parent, name) ->
+            let parent' = self#fragment_resolved_signature parent in
             let name' = self#fragment_resolved_module_name name in
-              if parent != parent' || name != name' then Module(parent', name')
+              if parent != parent' || name != name' then `Module(parent', name')
               else p
-        | Type(parent, name) ->
-            let parent' = self#fragment_resolved parent in
+        | `Type(parent, name) ->
+            let parent' = self#fragment_resolved_signature parent in
             let name' = self#fragment_resolved_type_name name in
-              if parent != parent' || name != name' then Type(parent', name')
+              if parent != parent' || name != name' then `Type(parent', name')
               else p
-        | Class(parent, name) ->
-            let parent' = self#fragment_resolved parent in
+        | `Class(parent, name) ->
+            let parent' = self#fragment_resolved_signature parent in
             let name' = self#fragment_resolved_class_name name in
-              if parent != parent' || name != name' then Class(parent', name')
+              if parent != parent' || name != name' then `Class(parent', name')
               else p
-        | ClassType(parent, name) ->
-            let parent' = self#fragment_resolved parent in
+        | `ClassType(parent, name) ->
+            let parent' = self#fragment_resolved_signature parent in
             let name' = self#fragment_resolved_class_type_name name in
               if parent != parent' || name != name' then
-                ClassType(parent', name')
+                `ClassType(parent', name')
               else p
 
   method fragment_resolved_module_name name = name
@@ -431,140 +456,151 @@ class virtual fragment = object (self)
 
   method fragment_resolved_class_type_name name = name
 
-  method fragment_resolved_module (p : Fragment.Resolved.module_) =
-    self#fragment_resolved p
+  method fragment_resolved_signature : Fragment.Resolved.Signature.t -> Fragment.Resolved.Signature.t = fun p ->
+    self#fragment_resolved (p :> Fragment.Resolved.t) |>
+    Fragment.Resolved.signature_of_t
+     
+  method fragment_resolved_module : Fragment.Resolved.Module.t -> Fragment.Resolved.Module.t = fun p ->
+    self#fragment_resolved (p :> Fragment.Resolved.t) |>
+    Fragment.Resolved.module_of_t
 
-  method fragment_resolved_type (p : Fragment.Resolved.type_) =
-    self#fragment_resolved p
+  method fragment_resolved_type : Fragment.Resolved.Type.t -> Fragment.Resolved.Type.t = fun p ->
+    self#fragment_resolved (p :> Fragment.Resolved.t) |>
+    Fragment.Resolved.type_of_t
 
-  method fragment : type k s. (k, s) Fragment.raw -> (k, s) Fragment.raw =
+  method fragment : Fragment.t -> Fragment.t =
     fun p ->
-      let open Fragment in
         match p with
-        | Resolved res ->
+        | `Resolved res ->
             let res' = self#fragment_resolved res in
-              if res != res' then Resolved res'
+              if res != res' then `Resolved res'
               else p
-        | Dot(parent, name) ->
-            let parent' = self#fragment parent in
+        | `Dot(parent, name) ->
+            let parent' = self#fragment_signature parent in
             let name' = self#fragment_name name in
-              if parent != parent' || name != name' then Dot(parent', name')
+              if parent != parent' || name != name' then `Dot(parent', name')
               else p
 
   method fragment_name name = name
 
-  method fragment_module (p : Fragment.module_) =
-    self#fragment p
+  method fragment_signature : Fragment.Signature.t -> Fragment.Signature.t = fun p ->
+    self#fragment (p :> Fragment.t) |>
+    Fragment.signature_of_t
 
-  method fragment_type (p : Fragment.type_) =
-    self#fragment p
+  method fragment_module : Fragment.Module.t -> Fragment.Module.t = fun p ->
+    self#fragment (p :> Fragment.t) |>
+    Fragment.module_of_t
+
+  method fragment_type : Fragment.Type.t -> Fragment.Type.t = fun p ->
+    self#fragment (p :> Fragment.t) |>
+    Fragment.type_of_t
 
 end
 
 class virtual reference = object (self)
 
-  method virtual identifier : 'k . 'k Identifier.t -> 'k Identifier.t
+  method virtual identifier : Identifier.t -> Identifier.t
 
-  method virtual path_resolved : 'k. 'k Path.Resolved.t -> 'k Path.Resolved.t
+  method virtual path_resolved : Path.Resolved.t -> Path.Resolved.t
 
-  method reference_resolved : type k. k Reference.Resolved.t ->
-                                        k Reference.Resolved.t =
+  method virtual path_resolved_module : Path.Resolved.Module.t -> Path.Resolved.Module.t
+
+  method reference_resolved : Reference.Resolved.t -> Reference.Resolved.t =
     fun r ->
-      let open Reference.Resolved in
         match r with
-        | Identifier id ->
+        | `Identifier id ->
             let id' = self#identifier id in
-              if id != id' then Identifier id'
+              if id != id' then `Identifier id'
               else r
-        | SubstAlias(sub, orig) ->
-            let sub' = self#path_resolved sub in
-            let orig' = self#reference_resolved orig in
+        | `SubstAlias(sub, orig) ->
+            let sub' = self#path_resolved_module sub in
+            let orig' = self#reference_resolved_module orig in
               if sub != sub' || orig != orig' then
-                SubstAlias(sub', orig')
+                `SubstAlias(sub', orig')
               else r
-        | Module(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `Module(parent, name) ->
+            let parent' = self#reference_resolved_signature parent in
             let name' = self#reference_resolved_module_name name in
               if parent != parent' || name != name' then
-                Module(parent', name')
+                `Module(parent', name')
               else r
-        | Canonical(orig, cano) ->
-            let orig' = self#reference_resolved orig in
-            let cano' = self#reference cano in
+        | `Canonical(orig, cano) ->
+            let orig' = self#reference_resolved_module orig in
+            let cano' = self#reference_module cano in
               if orig != orig' || cano != cano' then
-                Canonical(orig', cano')
+                `Canonical(orig', cano')
               else r
-        | ModuleType(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `ModuleType(parent, name) ->
+            let parent' = self#reference_resolved_signature parent in
             let name' = self#reference_resolved_module_type_name name in
               if parent != parent' || name != name' then
-                ModuleType(parent', name')
+                `ModuleType(parent', name')
               else r
-        | Type(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `Type(parent, name) ->
+            let parent' = self#reference_resolved_signature parent in
             let name' = self#reference_resolved_type_name name in
               if parent != parent' || name != name' then
-                Type(parent', name')
+                `Type(parent', name')
               else r
-        | Constructor(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `Constructor(parent, name) ->
+            let parent' = self#reference_resolved_datatype parent in
             let name' = self#reference_resolved_constructor_name name in
               if parent != parent' || name != name' then
-                Constructor(parent', name')
+                `Constructor(parent', name')
               else r
-        | Field(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `Field(parent, name) ->
+            let parent' = self#reference_resolved_parent parent in
             let name' = self#reference_resolved_field_name name in
               if parent != parent' || name != name' then
-                Field(parent', name')
+                `Field(parent', name')
               else r
-        | Extension(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `Extension(parent, name) ->
+            let parent' = self#reference_resolved_signature parent in
             let name' = self#reference_resolved_extension_name name in
               if parent != parent' || name != name' then
-                Extension(parent', name')
+                `Extension(parent', name')
               else r
-        | Exception(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `Exception(parent, name) ->
+            let parent' = self#reference_resolved_signature parent in
             let name' = self#reference_resolved_exception_name name in
               if parent != parent' || name != name' then
-                Exception(parent', name')
+                `Exception(parent', name')
               else r
-        | Value(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `Value(parent, name) ->
+            let parent' = self#reference_resolved_signature parent in
             let name' = self#reference_resolved_value_name name in
               if parent != parent' || name != name' then
-                Value(parent', name')
+                `Value(parent', name')
               else r
-        | Class(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `Class(parent, name) ->
+            let parent' = self#reference_resolved_signature parent in
             let name' = self#reference_resolved_class_name name in
               if parent != parent' || name != name' then
-                Class(parent', name')
+                `Class(parent', name')
               else r
-        | ClassType(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `ClassType(parent, name) ->
+            let parent' = self#reference_resolved_signature parent in
             let name' = self#reference_resolved_class_type_name name in
               if parent != parent' || name != name' then
-                ClassType(parent', name')
+                `ClassType(parent', name')
               else r
-        | Method(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `Method(parent, name) ->
+            let parent' = self#reference_resolved_class_signature parent in
             let name' = self#reference_resolved_method_name name in
               if parent != parent' || name != name' then
-                Method(parent', name')
+                `Method(parent', name')
               else r
-        | InstanceVariable(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `InstanceVariable(parent, name) ->
+            let parent' = self#reference_resolved_class_signature parent in
             let name' = self#reference_resolved_instance_variable_name name in
               if parent != parent' || name != name' then
-                InstanceVariable(parent', name')
+                `InstanceVariable(parent', name')
               else r
-        | Label(parent, name) ->
-            let parent' = self#reference_resolved parent in
+        | `Label(parent, name) ->
+            let parent' = self#reference_resolved_label_parent parent in
             let name' = self#reference_resolved_label_name name in
               if parent != parent' || name != name' then
-                Label(parent', name')
+                `Label(parent', name')
               else r
 
   method reference_resolved_module_name name = name
@@ -593,131 +629,160 @@ class virtual reference = object (self)
 
   method reference_resolved_label_name name = name
 
-  method reference_resolved_module (r : Reference.Resolved.module_) =
-    self#reference_resolved r
+  method reference_resolved_signature : Reference.Resolved.Signature.t -> Reference.Resolved.Signature.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.signature_of_t
+
+  method reference_resolved_class_signature : Reference.Resolved.ClassSignature.t -> Reference.Resolved.ClassSignature.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.class_signature_of_t
+
+  method reference_resolved_module : Reference.Resolved.Module.t -> Reference.Resolved.Module.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.module_of_t
+
+  method reference_resolved_parent : Reference.Resolved.Parent.t -> Reference.Resolved.Parent.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.parent_of_t
+
+  method reference_resolved_label_parent : Reference.Resolved.LabelParent.t -> Reference.Resolved.LabelParent.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.label_parent_of_t
 
   method reference_resolved_module_type
-           (r : Reference.Resolved.module_type) =
-    self#reference_resolved r
+           : Reference.Resolved.ModuleType.t -> Reference.Resolved.ModuleType.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.module_type_of_t
 
-  method reference_resolved_type (r : Reference.Resolved.type_) =
-    self#reference_resolved r
+  method reference_resolved_type : Reference.Resolved.Type.t -> Reference.Resolved.Type.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.type_of_t
 
-  method reference_resolved_constructor (r : Reference.Resolved.constructor) =
-    self#reference_resolved r
+  method reference_resolved_datatype : Reference.Resolved.DataType.t -> Reference.Resolved.DataType.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.datatype_of_t
 
-  method reference_resolved_field (r : Reference.Resolved.field) =
-    self#reference_resolved r
+  method reference_resolved_constructor : Reference.Resolved.Constructor.t -> Reference.Resolved.Constructor.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.constructor_of_t
 
-  method reference_resolved_extension (r : Reference.Resolved.extension) =
-    self#reference_resolved r
+  method reference_resolved_field : Reference.Resolved.Field.t -> Reference.Resolved.Field.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.field_of_t
 
-  method reference_resolved_exception (r : Reference.Resolved.exception_) =
-    self#reference_resolved r
+  method reference_resolved_extension : Reference.Resolved.Extension.t -> Reference.Resolved.Extension.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.extension_of_t
 
-  method reference_resolved_value (r : Reference.Resolved.value) =
-    self#reference_resolved r
+  method reference_resolved_exception : Reference.Resolved.Exception.t -> Reference.Resolved.Exception.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.exception_of_t
 
-  method reference_resolved_class (r : Reference.Resolved.class_) =
-    self#reference_resolved r
+  method reference_resolved_value : Reference.Resolved.Value.t -> Reference.Resolved.Value.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.value_of_t
 
-  method reference_resolved_class_type (r : Reference.Resolved.class_type) =
-    self#reference_resolved r
+  method reference_resolved_class : Reference.Resolved.Class.t -> Reference.Resolved.Class.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.class_of_t
 
-  method reference_resolved_method (r : Reference.Resolved.method_) =
-    self#reference_resolved r
+  method reference_resolved_class_type : Reference.Resolved.ClassType.t -> Reference.Resolved.ClassType.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.class_type_of_t
+
+  method reference_resolved_method : Reference.Resolved.Method.t -> Reference.Resolved.Method.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.method_of_t
 
   method reference_resolved_instance_variable
-           (r : Reference.Resolved.instance_variable) =
-    self#reference_resolved r
+           : Reference.Resolved.InstanceVariable.t -> Reference.Resolved.InstanceVariable.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.instance_variable_of_t
 
-  method reference_resolved_label (r : Reference.Resolved.label) =
-    self#reference_resolved r
+  method reference_resolved_label : Reference.Resolved.Label.t -> Reference.Resolved.Label.t = fun r ->
+    self#reference_resolved (r :> Reference.Resolved.t) |>
+    Reference.Resolved.label_of_t
 
-  method reference_resolved_any (r : Reference.Resolved.any) =
-    self#reference_resolved r
-
-  method reference : type k . k Reference.t -> k Reference.t =
+  method reference_any : Reference.t -> Reference.t =
     fun r ->
-      let open Reference in
         match r with
-        | Resolved res ->
-            let res' = self#reference_resolved res in
-              if res != res' then Resolved res'
+        | `Resolved res ->
+            let res' = self#reference_resolved (res :> Reference.Resolved.t) in
+              if res != res' then `Resolved res'
               else r
-        | Root (name, kind) ->
+        | `Root (name, kind) ->
             let name' = self#reference_root_name name in
-              if name != name' then Root (name', kind)
+              if name != name' then `Root (name', kind)
               else r
-        | Dot(parent, name) ->
-            let parent' = self#reference parent in
+        | `Dot(parent, name) ->
+            let parent' = self#reference_label_parent parent in
             let name' = self#reference_dot_name name in
-              if parent != parent' || name != name' then Dot(parent', name')
+              if parent != parent' || name != name' then `Dot(parent', name')
               else r
-        | Module(parent, name) ->
-            let parent' = self#reference parent in
+        | `Module(parent, name) ->
+            let parent' = self#reference_signature parent in
             let name' = self#reference_module_name name in
-              if parent != parent' || name != name' then Module(parent', name')
+              if parent != parent' || name != name' then `Module(parent', name')
               else r
-        | ModuleType(parent, name) ->
-            let parent' = self#reference parent in
+        | `ModuleType(parent, name) ->
+            let parent' = self#reference_signature parent in
             let name' = self#reference_module_type_name name in
-              if parent != parent' || name != name' then ModuleType(parent', name')
+              if parent != parent' || name != name' then `ModuleType(parent', name')
               else r
-        | Type(parent, name) ->
-            let parent' = self#reference parent in
+        | `Type(parent, name) ->
+            let parent' = self#reference_signature parent in
             let name' = self#reference_type_name name in
-              if parent != parent' || name != name' then Type(parent', name')
+              if parent != parent' || name != name' then `Type(parent', name')
               else r
-        | Constructor(parent, name) ->
-            let parent' = self#reference parent in
+        | `Constructor(parent, name) ->
+            let parent' = self#reference_datatype parent in
             let name' = self#reference_constructor_name name in
-              if parent != parent' || name != name' then Constructor(parent', name')
+              if parent != parent' || name != name' then `Constructor(parent', name')
               else r
-        | Extension(parent, name) ->
-            let parent' = self#reference parent in
+        | `Extension(parent, name) ->
+            let parent' = self#reference_signature parent in
             let name' = self#reference_extension_name name in
-              if parent != parent' || name != name' then Extension(parent', name')
+              if parent != parent' || name != name' then `Extension(parent', name')
               else r
-        | Exception(parent, name) ->
-            let parent' = self#reference parent in
+        | `Exception(parent, name) ->
+            let parent' = self#reference_signature parent in
             let name' = self#reference_exception_name name in
-              if parent != parent' || name != name' then Exception(parent', name')
+              if parent != parent' || name != name' then `Exception(parent', name')
               else r
-        | Field(parent, name) ->
-            let parent' = self#reference parent in
+        | `Field(parent, name) ->
+            let parent' = self#reference_parent parent in
             let name' = self#reference_field_name name in
-              if parent != parent' || name != name' then Field(parent', name')
+              if parent != parent' || name != name' then `Field(parent', name')
               else r
-        | Value(parent, name) ->
-            let parent' = self#reference parent in
+        | `Value(parent, name) ->
+            let parent' = self#reference_signature parent in
             let name' = self#reference_value_name name in
-              if parent != parent' || name != name' then Value(parent', name')
+              if parent != parent' || name != name' then `Value(parent', name')
               else r
-        | Class(parent, name) ->
-            let parent' = self#reference parent in
+        | `Class(parent, name) ->
+            let parent' = self#reference_signature parent in
             let name' = self#reference_class_name name in
-              if parent != parent' || name != name' then Class(parent', name')
+              if parent != parent' || name != name' then `Class(parent', name')
               else r
-        | ClassType(parent, name) ->
-            let parent' = self#reference parent in
+        | `ClassType(parent, name) ->
+            let parent' = self#reference_signature parent in
             let name' = self#reference_class_type_name name in
-              if parent != parent' || name != name' then ClassType(parent', name')
+              if parent != parent' || name != name' then `ClassType(parent', name')
               else r
-        | Method(parent, name) ->
-            let parent' = self#reference parent in
+        | `Method(parent, name) ->
+            let parent' = self#reference_class_signature parent in
             let name' = self#reference_method_name name in
-              if parent != parent' || name != name' then Method(parent', name')
+              if parent != parent' || name != name' then `Method(parent', name')
               else r
-        | InstanceVariable(parent, name) ->
-            let parent' = self#reference parent in
+        | `InstanceVariable(parent, name) ->
+            let parent' = self#reference_class_signature parent in
             let name' = self#reference_instance_variable_name name in
-              if parent != parent' || name != name' then InstanceVariable(parent', name')
+              if parent != parent' || name != name' then `InstanceVariable(parent', name')
               else r
-        | Label(parent, name) ->
-            let parent' = self#reference parent in
+        | `Label(parent, name) ->
+            let parent' = self#reference_label_parent parent in
             let name' = self#reference_label_name name in
-              if parent != parent' || name != name' then Label(parent', name')
+              if parent != parent' || name != name' then `Label(parent', name')
               else r
 
   method reference_root_name name = name
@@ -750,47 +815,77 @@ class virtual reference = object (self)
 
   method reference_label_name name = name
 
-  method reference_module (r : Reference.module_) =
-    self#reference r
+  method reference_signature : Reference.Signature.t -> Reference.Signature.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.signature_of_t
 
-  method reference_module_type (r : Reference.module_type) =
-    self#reference r
+  method reference_class_signature : Reference.ClassSignature.t -> Reference.ClassSignature.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.class_signature_of_t
 
-  method reference_type (r : Reference.type_) =
-    self#reference r
+  method reference_label_parent : Reference.LabelParent.t -> Reference.LabelParent.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.label_parent_of_t
 
-  method reference_constructor (r : Reference.constructor) =
-    self#reference r
+  method reference_parent : Reference.Parent.t -> Reference.Parent.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.parent_of_t
 
-  method reference_field (r : Reference.field) =
-    self#reference r
+  method reference_datatype : Reference.DataType.t -> Reference.DataType.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.datatype_of_t
 
-  method reference_extension (r : Reference.extension) =
-    self#reference r
+  method reference_module : Reference.Module.t -> Reference.Module.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.module_of_t
 
-  method reference_exception (r : Reference.exception_) =
-    self#reference r
+  method reference_module_type : Reference.ModuleType.t -> Reference.ModuleType.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.module_type_of_t
 
-  method reference_value (r : Reference.value) =
-    self#reference r
+  method reference_type : Reference.Type.t -> Reference.Type.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.type_of_t
 
-  method reference_class (r : Reference.class_) =
-    self#reference r
+  method reference_constructor : Reference.Constructor.t -> Reference.Constructor.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.constructor_of_t
 
-  method reference_class_type (r : Reference.class_type) =
-    self#reference r
+  method reference_field : Reference.Field.t -> Reference.Field.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.field_of_t
 
-  method reference_method (r : Reference.method_) =
-    self#reference r
+  method reference_extension : Reference.Extension.t -> Reference.Extension.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.extension_of_t
 
-  method reference_instance_variable (r : Reference.instance_variable) =
-    self#reference r
+  method reference_exception : Reference.Exception.t -> Reference.Exception.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.exception_of_t
 
-  method reference_label (r : Reference.label) =
-    self#reference r
+  method reference_value : Reference.Value.t -> Reference.Value.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.value_of_t
 
-  method reference_any (r : Reference.any) =
-    self#reference r
+  method reference_class : Reference.Class.t -> Reference.Class.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.class_of_t
+
+  method reference_class_type : Reference.ClassType.t -> Reference.ClassType.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.class_type_of_t
+
+  method reference_method : Reference.Method.t -> Reference.Method.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.method_of_t
+
+  method reference_instance_variable : Reference.InstanceVariable.t -> Reference.InstanceVariable.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.instance_variable_of_t
+
+  method reference_label : Reference.Label.t -> Reference.Label.t = fun r ->
+    self#reference_any (r :> Reference.t) |>
+    Reference.label_of_t
 
 end
 
@@ -804,55 +899,55 @@ end
 class virtual documentation = object (self)
 
   method virtual identifier_label :
-    Identifier.label -> Identifier.label
+    Identifier.Label.t -> Identifier.Label.t
 
   method virtual identifier :
-    'k. 'k Identifier.t -> 'k Identifier.t
+    Identifier.t -> Identifier.t
 
   method virtual path_module :
-    Path.module_ -> Path.module_
+    Path.Module.t -> Path.Module.t
 
   method virtual reference_module :
-    Reference.module_ -> Reference.module_
+    Reference.Module.t -> Reference.Module.t
 
   method virtual reference_module_type :
-    Reference.module_type -> Reference.module_type
+    Reference.ModuleType.t -> Reference.ModuleType.t
 
   method virtual reference_type :
-    Reference.type_ -> Reference.type_
+    Reference.Type.t -> Reference.Type.t
 
   method virtual reference_constructor :
-    Reference.constructor -> Reference.constructor
+    Reference.Constructor.t -> Reference.Constructor.t
 
   method virtual reference_field :
-    Reference.field -> Reference.field
+    Reference.Field.t -> Reference.Field.t
 
   method virtual reference_extension :
-    Reference.extension -> Reference.extension
+    Reference.Extension.t -> Reference.Extension.t
 
   method virtual reference_exception :
-    Reference.exception_ -> Reference.exception_
+    Reference.Exception.t -> Reference.Exception.t
 
   method virtual reference_value :
-    Reference.value -> Reference.value
+    Reference.Value.t -> Reference.Value.t
 
   method virtual reference_class :
-    Reference.class_ -> Reference.class_
+    Reference.Class.t -> Reference.Class.t
 
   method virtual reference_class_type :
-    Reference.class_type -> Reference.class_type
+    Reference.ClassType.t -> Reference.ClassType.t
 
   method virtual reference_method :
-    Reference.method_ -> Reference.method_
+    Reference.Method.t -> Reference.Method.t
 
   method virtual reference_instance_variable :
-    Reference.instance_variable -> Reference.instance_variable
+    Reference.InstanceVariable.t -> Reference.InstanceVariable.t
 
   method virtual reference_label :
-    Reference.label -> Reference.label
+    Reference.Label.t -> Reference.Label.t
 
   method virtual reference_any :
-    Reference.any -> Reference.any
+    Reference.t -> Reference.t
 
   method documentation_reference ((path, content) as r) =
     let path' = self#reference_any path in
@@ -966,13 +1061,13 @@ end
 class virtual module_ = object (self)
 
   method virtual identifier_module :
-    Identifier.module_ -> Identifier.module_
+    Identifier.Module.t -> Identifier.Module.t
 
   method virtual path_module :
-    Path.module_ -> Path.module_
+    Path.Module.t -> Path.Module.t
 
   method virtual reference_module :
-    Reference.module_ -> Reference.module_
+    Reference.Module.t -> Reference.Module.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1041,25 +1136,25 @@ end
 class virtual module_type = object (self)
 
   method virtual identifier_module :
-    Identifier.module_ -> Identifier.module_
+    Identifier.Module.t -> Identifier.Module.t
 
   method virtual identifier_module_type :
-    Identifier.module_type -> Identifier.module_type
+    Identifier.ModuleType.t -> Identifier.ModuleType.t
 
   method virtual path_module :
-    Path.module_ -> Path.module_
+    Path.Module.t -> Path.Module.t
 
   method virtual path_module_type :
-    Path.module_type -> Path.module_type
+    Path.ModuleType.t -> Path.ModuleType.t
 
   method virtual path_type :
-    Path.type_ -> Path.type_
+    Path.Type.t -> Path.Type.t
 
   method virtual fragment_module :
-    Fragment.module_ -> Fragment.module_
+    Fragment.Module.t -> Fragment.Module.t
 
   method virtual fragment_type :
-    Fragment.type_ -> Fragment.type_
+    Fragment.Type.t -> Fragment.Type.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1250,7 +1345,7 @@ class virtual include_ = object (self)
     Module.decl -> Module.decl
 
   method virtual identifier_signature :
-    Identifier.signature -> Identifier.signature
+    Identifier.Signature.t -> Identifier.Signature.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1285,13 +1380,13 @@ end
 class virtual type_decl = object (self)
 
   method virtual identifier_type :
-    Identifier.type_ -> Identifier.type_
+    Identifier.Type.t -> Identifier.Type.t
 
   method virtual identifier_constructor :
-    Identifier.constructor -> Identifier.constructor
+    Identifier.Constructor.t -> Identifier.Constructor.t
 
   method virtual identifier_field :
-    Identifier.field -> Identifier.field
+    Identifier.Field.t -> Identifier.Field.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1414,10 +1509,10 @@ end
 class virtual extension = object (self)
 
   method virtual identifier_extension :
-    Identifier.extension -> Identifier.extension
+    Identifier.Extension.t -> Identifier.Extension.t
 
   method virtual path_type :
-    Path.type_ -> Path.type_
+    Path.Type.t -> Path.Type.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1465,7 +1560,7 @@ end
 class virtual exception_ = object (self)
 
   method virtual identifier_exception :
-    Identifier.exception_ -> Identifier.exception_
+    Identifier.Exception.t -> Identifier.Exception.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1492,7 +1587,7 @@ end
 class virtual value = object (self)
 
   method virtual identifier_value :
-    Identifier.value -> Identifier.value
+    Identifier.Value.t -> Identifier.Value.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1515,7 +1610,7 @@ end
 class virtual external_ = object (self)
 
   method virtual identifier_value :
-    Identifier.value -> Identifier.value
+    Identifier.Value.t -> Identifier.Value.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1543,7 +1638,7 @@ end
 class virtual class_ = object (self)
 
   method virtual identifier_class :
-    Identifier.class_ -> Identifier.class_
+    Identifier.Class.t -> Identifier.Class.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1601,10 +1696,10 @@ end
 class virtual class_type = object (self)
 
   method virtual identifier_class_type :
-    Identifier.class_type -> Identifier.class_type
+    Identifier.ClassType.t -> Identifier.ClassType.t
 
   method virtual path_class_type :
-    Path.class_type -> Path.class_type
+    Path.ClassType.t -> Path.ClassType.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1707,7 +1802,7 @@ end
 class virtual method_ = object (self)
 
   method virtual identifier_method :
-    Identifier.method_ -> Identifier.method_
+    Identifier.Method.t -> Identifier.Method.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1739,7 +1834,7 @@ end
 class virtual instance_variable = object (self)
 
   method virtual identifier_instance_variable :
-    Identifier.instance_variable -> Identifier.instance_variable
+    Identifier.InstanceVariable.t -> Identifier.InstanceVariable.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1771,16 +1866,16 @@ end
 class virtual type_expr = object (self)
 
   method virtual path_module_type :
-    Path.module_type -> Path.module_type
+    Path.ModuleType.t -> Path.ModuleType.t
 
   method virtual path_type :
-    Path.type_ -> Path.type_
+    Path.Type.t -> Path.Type.t
 
   method virtual path_class_type :
-    Path.class_type -> Path.class_type
+    Path.ClassType.t -> Path.ClassType.t
 
   method virtual fragment_type :
-    Fragment.type_ -> Fragment.type_
+    Fragment.Type.t -> Fragment.Type.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -1947,10 +2042,10 @@ class virtual unit = object (self)
   method virtual root : Root.t -> Root.t
 
   method virtual identifier_module :
-    Identifier.module_ -> Identifier.module_
+    Identifier.Module.t -> Identifier.Module.t
 
   method virtual path_module :
-    Path.module_ -> Path.module_
+    Path.Module.t -> Path.Module.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs
@@ -2051,7 +2146,7 @@ end
 class virtual page = object (self)
 
   method virtual identifier_page :
-    Identifier.page -> Identifier.page
+    Identifier.Page.t -> Identifier.Page.t
 
   method virtual documentation :
     Comment.docs -> Comment.docs

--- a/src/model/maps.mli
+++ b/src/model/maps.mli
@@ -16,6 +16,7 @@
 
 open Paths
 open Lang
+open Names
 
 val option_map : ('a -> 'a) -> 'a option -> 'a option
 
@@ -27,297 +28,323 @@ class virtual identifier : object
 
   method virtual root : Root.t -> Root.t
 
-  method identifier : 'k. 'k Identifier.t -> 'k Identifier.t
+  method identifier : Identifier.t -> Identifier.t
 
-  method identifier_root_name : string -> string
+  method identifier_root_name : UnitName.t -> UnitName.t
 
-  method identifier_page_name : string -> string
+  method identifier_page_name : PageName.t -> PageName.t
 
-  method identifier_module_name : string -> string
+  method identifier_module_name : ModuleName.t -> ModuleName.t
 
   method identifier_argument_position : int -> int
 
-  method identifier_argument_name : string -> string
+  method identifier_argument_name : ArgumentName.t -> ArgumentName.t
 
-  method identifier_module_type_name : string -> string
+  method identifier_module_type_name : ModuleTypeName.t -> ModuleTypeName.t
 
-  method identifier_type_name : string -> string
+  method identifier_type_name : TypeName.t -> TypeName.t
 
-  method identifier_core_type_name : string -> string
+  method identifier_core_type_name : TypeName.t -> TypeName.t
 
-  method identifier_constructor_name : string -> string
+  method identifier_constructor_name : ConstructorName.t -> ConstructorName.t
 
-  method identifier_field_name : string -> string
+  method identifier_field_name : FieldName.t -> FieldName.t
 
-  method identifier_extension_name : string -> string
+  method identifier_extension_name : ExtensionName.t -> ExtensionName.t
 
-  method identifier_exception_name : string -> string
+  method identifier_exception_name : ExceptionName.t -> ExceptionName.t
 
-  method identifier_core_exception_name : string -> string
+  method identifier_core_exception_name : ExceptionName.t -> ExceptionName.t
 
-  method identifier_value_name : string -> string
+  method identifier_value_name : ValueName.t -> ValueName.t
 
-  method identifier_class_name : string -> string
+  method identifier_class_name : ClassName.t -> ClassName.t
 
-  method identifier_class_type_name : string -> string
+  method identifier_class_type_name : ClassTypeName.t -> ClassTypeName.t
 
-  method identifier_method_name : string -> string
+  method identifier_method_name : MethodName.t -> MethodName.t
 
-  method identifier_instance_variable_name : string -> string
+  method identifier_instance_variable_name : InstanceVariableName.t -> InstanceVariableName.t
 
-  method identifier_label_name : string -> string
+  method identifier_label_name : LabelName.t -> LabelName.t
 
-  method identifier_page : Identifier.page -> Identifier.page
+  method identifier_page : Identifier.Page.t -> Identifier.Page.t
 
-  method identifier_signature : Identifier.signature -> Identifier.signature
+  method identifier_signature : Identifier.Signature.t -> Identifier.Signature.t
 
-  method identifier_class_signature : Identifier.class_signature ->
-    Identifier.class_signature
+  method identifier_class_signature : Identifier.ClassSignature.t ->
+    Identifier.ClassSignature.t
 
-  method identifier_datatype : Identifier.datatype -> Identifier.datatype
+  method identifier_datatype : Identifier.DataType.t -> Identifier.DataType.t
 
-  method identifier_module : Identifier.module_ -> Identifier.module_
+  method identifier_module : Identifier.Module.t -> Identifier.Module.t
 
-  method identifier_module_type : Identifier.module_type ->
-    Identifier.module_type
+  method identifier_module_type : Identifier.ModuleType.t ->
+    Identifier.ModuleType.t
 
-  method identifier_type : Identifier.type_ -> Identifier.type_
+  method identifier_type : Identifier.Type.t -> Identifier.Type.t
 
-  method identifier_constructor : Identifier.constructor ->
-    Identifier.constructor
+  method identifier_constructor : Identifier.Constructor.t ->
+    Identifier.Constructor.t
 
-  method identifier_field : Identifier.field -> Identifier.field
+  method identifier_parent : Identifier.Parent.t -> Identifier.Parent.t
 
-  method identifier_extension : Identifier.extension -> Identifier.extension
+  method identifier_field : Identifier.Field.t -> Identifier.Field.t
 
-  method identifier_exception : Identifier.exception_ -> Identifier.exception_
+  method identifier_extension : Identifier.Extension.t -> Identifier.Extension.t
 
-  method identifier_value : Identifier.value -> Identifier.value
+  method identifier_exception : Identifier.Exception.t -> Identifier.Exception.t
 
-  method identifier_class : Identifier.class_ -> Identifier.class_
+  method identifier_value : Identifier.Value.t -> Identifier.Value.t
 
-  method identifier_class_type : Identifier.class_type -> Identifier.class_type
+  method identifier_class : Identifier.Class.t -> Identifier.Class.t
 
-  method identifier_method : Identifier.method_ -> Identifier.method_
+  method identifier_class_type : Identifier.ClassType.t -> Identifier.ClassType.t
 
-  method identifier_instance_variable : Identifier.instance_variable ->
-    Identifier.instance_variable
+  method identifier_method : Identifier.Method.t -> Identifier.Method.t
 
-  method identifier_label : Identifier.label -> Identifier.label
+  method identifier_instance_variable : Identifier.InstanceVariable.t ->
+    Identifier.InstanceVariable.t
+
+  method identifier_label : Identifier.Label.t -> Identifier.Label.t
 
 end
 
 class virtual path : object
 
-  method virtual identifier : 'k. 'k Identifier.t -> 'k Identifier.t
+  method virtual identifier : Identifier.t -> Identifier.t
 
-  method path_resolved : 'k. 'k Path.Resolved.t -> 'k Path.Resolved.t
+  method path_resolved : Path.Resolved.t -> Path.Resolved.t
 
-  method path_resolved_module_name : string -> string
+  method path_resolved_module_name : ModuleName.t -> ModuleName.t
 
-  method path_resolved_module_type_name : string -> string
+  method path_resolved_module_type_name : ModuleTypeName.t -> ModuleTypeName.t
 
-  method path_resolved_type_name : string -> string
+  method path_resolved_type_name : TypeName.t -> TypeName.t
 
-  method path_resolved_class_name : string -> string
+  method path_resolved_class_name : ClassName.t -> ClassName.t
 
-  method path_resolved_class_type_name : string -> string
+  method path_resolved_class_type_name : ClassTypeName.t -> ClassTypeName.t
 
-  method path_resolved_module : Path.Resolved.module_ -> Path.Resolved.module_
+  method path_resolved_module : Path.Resolved.Module.t -> Path.Resolved.Module.t
 
-  method path_resolved_module_type : Path.Resolved.module_type ->
-    Path.Resolved.module_type
+  method path_resolved_module_type : Path.Resolved.ModuleType.t ->
+    Path.Resolved.ModuleType.t
 
-  method path_resolved_type : Path.Resolved.type_ -> Path.Resolved.type_
+  method path_resolved_type : Path.Resolved.Type.t -> Path.Resolved.Type.t
 
-  method path_resolved_class_type : Path.Resolved.class_type ->
-    Path.Resolved.class_type
+  method path_resolved_class_type : Path.Resolved.ClassType.t ->
+    Path.Resolved.ClassType.t
 
-  method path : 'k . 'k Path.t -> 'k Path.t
+  method path : Path.t -> Path.t
 
   method path_root_name : string -> string
 
   method path_dot_name : string -> string
 
-  method path_module : Path.module_ -> Path.module_
+  method path_module : Path.Module.t -> Path.Module.t
 
-  method path_module_type : Path.module_type -> Path.module_type
+  method path_module_type : Path.ModuleType.t -> Path.ModuleType.t
 
-  method path_type : Path.type_ -> Path.type_
+  method path_type : Path.Type.t -> Path.Type.t
 
-  method path_class_type : Path.class_type -> Path.class_type
+  method path_class_type : Path.ClassType.t -> Path.ClassType.t
 
 end
 
 class virtual fragment : object
 
-  method virtual path_resolved : 'k. 'k Path.Resolved.t -> 'k Path.Resolved.t
+  method virtual path_resolved : Path.Resolved.t -> Path.Resolved.t
 
-  method fragment_resolved : 'k 's. ('k, 's) Fragment.Resolved.raw ->
-    ('k, 's) Fragment.Resolved.raw
+  method virtual path_resolved_module : Path.Resolved.Module.t -> Path.Resolved.Module.t
 
-  method fragment_resolved_module_name : string -> string
+  method virtual path_resolved_module_type : Path.Resolved.ModuleType.t -> Path.Resolved.ModuleType.t
 
-  method fragment_resolved_type_name : string -> string
+  method fragment_resolved : Fragment.Resolved.t ->
+    Fragment.Resolved.t
 
-  method fragment_resolved_class_name : string -> string
+  method fragment_resolved_signature : Fragment.Resolved.Signature.t -> Fragment.Resolved.Signature.t 
 
-  method fragment_resolved_class_type_name : string -> string
+  method fragment_resolved_module_name : ModuleName.t -> ModuleName.t
 
-  method fragment_resolved_module : Fragment.Resolved.module_ ->
-    Fragment.Resolved.module_
+  method fragment_resolved_type_name : TypeName.t -> TypeName.t
 
-  method fragment_resolved_type : Fragment.Resolved.type_ ->
-    Fragment.Resolved.type_
+  method fragment_resolved_class_name : ClassName.t -> ClassName.t
 
-  method fragment : 'k 's. ('k, 's) Fragment.raw -> ('k, 's) Fragment.raw
+  method fragment_resolved_class_type_name : ClassTypeName.t -> ClassTypeName.t
+
+  method fragment_resolved_module : Fragment.Resolved.Module.t ->
+    Fragment.Resolved.Module.t
+
+  method fragment_resolved_type : Fragment.Resolved.Type.t ->
+    Fragment.Resolved.Type.t
+
+  method fragment : Fragment.t -> Fragment.t
 
   method fragment_name : string -> string
 
-  method fragment_module : Fragment.module_ -> Fragment.module_
+  method fragment_module : Fragment.Module.t -> Fragment.Module.t
 
-  method fragment_type : Fragment.type_ -> Fragment.type_
+  method fragment_type : Fragment.Type.t -> Fragment.Type.t
 
+  method fragment_signature : Fragment.Signature.t -> Fragment.Signature.t
 end
 
 class virtual reference : object
 
-  method virtual identifier : 'k. 'k Identifier.t -> 'k Identifier.t
+  method virtual identifier : Identifier.t -> Identifier.t
 
-  method virtual path_resolved : 'k. 'k Path.Resolved.t -> 'k Path.Resolved.t
+  method virtual path_resolved : Path.Resolved.t -> Path.Resolved.t
 
-  method reference_resolved : 'k. 'k Reference.Resolved.t ->
-    'k Reference.Resolved.t
+  method virtual path_resolved_module : Path.Resolved.Module.t -> Path.Resolved.Module.t
 
-  method reference_resolved_module_name : string -> string
+  method reference_resolved : Reference.Resolved.t ->
+    Reference.Resolved.t
 
-  method reference_resolved_module_type_name : string -> string
+  method reference_resolved_module_name : ModuleName.t -> ModuleName.t
 
-  method reference_resolved_type_name : string -> string
+  method reference_resolved_module_type_name : ModuleTypeName.t -> ModuleTypeName.t
 
-  method reference_resolved_class_name : string -> string
+  method reference_resolved_type_name : TypeName.t -> TypeName.t
 
-  method reference_resolved_class_type_name : string -> string
+  method reference_resolved_class_name : ClassName.t -> ClassName.t
 
-  method reference_resolved_constructor_name : string -> string
+  method reference_resolved_class_type_name : ClassTypeName.t -> ClassTypeName.t
 
-  method reference_resolved_extension_name : string -> string
+  method reference_resolved_constructor_name : ConstructorName.t -> ConstructorName.t
 
-  method reference_resolved_exception_name : string -> string
+  method reference_resolved_extension_name : ExtensionName.t -> ExtensionName.t
 
-  method reference_resolved_field_name : string -> string
+  method reference_resolved_exception_name : ExceptionName.t -> ExceptionName.t
 
-  method reference_resolved_value_name : string -> string
+  method reference_resolved_field_name : FieldName.t -> FieldName.t
 
-  method reference_resolved_method_name : string -> string
+  method reference_resolved_value_name : ValueName.t -> ValueName.t
 
-  method reference_resolved_instance_variable_name : string -> string
+  method reference_resolved_method_name : MethodName.t -> MethodName.t
 
-  method reference_resolved_label_name : string -> string
+  method reference_resolved_instance_variable_name : InstanceVariableName.t -> InstanceVariableName.t
 
-  method reference_resolved_module : Reference.Resolved.module_ ->
-    Reference.Resolved.module_
+  method reference_resolved_label_name : LabelName.t -> LabelName.t
 
-  method reference_resolved_module_type : Reference.Resolved.module_type ->
-    Reference.Resolved.module_type
+  method reference_resolved_signature : Reference.Resolved.Signature.t -> Reference.Resolved.Signature.t
 
-  method reference_resolved_type : Reference.Resolved.type_ ->
-    Reference.Resolved.type_
+  method reference_resolved_class_signature : Reference.Resolved.ClassSignature.t -> Reference.Resolved.ClassSignature.t
 
-  method reference_resolved_constructor : Reference.Resolved.constructor ->
-    Reference.Resolved.constructor
+  method reference_resolved_parent : Reference.Resolved.Parent.t -> Reference.Resolved.Parent.t
 
-  method reference_resolved_field : Reference.Resolved.field ->
-    Reference.Resolved.field
+  method reference_resolved_label_parent : Reference.Resolved.LabelParent.t -> Reference.Resolved.LabelParent.t
 
-  method reference_resolved_extension : Reference.Resolved.extension ->
-    Reference.Resolved.extension
+  method reference_resolved_module : Reference.Resolved.Module.t ->
+    Reference.Resolved.Module.t
 
-  method reference_resolved_exception : Reference.Resolved.exception_ ->
-    Reference.Resolved.exception_
+  method reference_resolved_datatype : Reference.Resolved.DataType.t -> Reference.Resolved.DataType.t
 
-  method reference_resolved_value : Reference.Resolved.value ->
-    Reference.Resolved.value
+  method reference_resolved_module_type : Reference.Resolved.ModuleType.t ->
+    Reference.Resolved.ModuleType.t
 
-  method reference_resolved_class : Reference.Resolved.class_ ->
-    Reference.Resolved.class_
+  method reference_resolved_type : Reference.Resolved.Type.t ->
+    Reference.Resolved.Type.t
 
-  method reference_resolved_class_type : Reference.Resolved.class_type ->
-    Reference.Resolved.class_type
+  method reference_resolved_constructor : Reference.Resolved.Constructor.t ->
+    Reference.Resolved.Constructor.t
 
-  method reference_resolved_method : Reference.Resolved.method_ ->
-    Reference.Resolved.method_
+  method reference_resolved_field : Reference.Resolved.Field.t ->
+    Reference.Resolved.Field.t
+
+  method reference_resolved_extension : Reference.Resolved.Extension.t ->
+    Reference.Resolved.Extension.t
+
+  method reference_resolved_exception : Reference.Resolved.Exception.t ->
+    Reference.Resolved.Exception.t
+
+  method reference_resolved_value : Reference.Resolved.Value.t ->
+    Reference.Resolved.Value.t
+
+  method reference_resolved_class : Reference.Resolved.Class.t ->
+    Reference.Resolved.Class.t
+
+  method reference_resolved_class_type : Reference.Resolved.ClassType.t ->
+    Reference.Resolved.ClassType.t
+
+  method reference_resolved_method : Reference.Resolved.Method.t ->
+    Reference.Resolved.Method.t
 
   method reference_resolved_instance_variable :
-    Reference.Resolved.instance_variable ->
-    Reference.Resolved.instance_variable
+    Reference.Resolved.InstanceVariable.t ->
+    Reference.Resolved.InstanceVariable.t
 
-  method reference_resolved_label : Reference.Resolved.label ->
-    Reference.Resolved.label
+  method reference_resolved_label : Reference.Resolved.Label.t ->
+    Reference.Resolved.Label.t
 
-  method reference_resolved_any : Reference.Resolved.any ->
-    Reference.Resolved.any
-
-  method reference : 'k. 'k Reference.t -> 'k Reference.t
-
-  method reference_root_name : string -> string
+  method reference_root_name : UnitName.t -> UnitName.t
 
   method reference_dot_name : string -> string
 
-  method reference_module_name : string -> string
+  method reference_module_name : ModuleName.t -> ModuleName.t
 
-  method reference_module_type_name : string -> string
+  method reference_module_type_name : ModuleTypeName.t -> ModuleTypeName.t
 
-  method reference_type_name : string -> string
+  method reference_type_name : TypeName.t -> TypeName.t
 
-  method reference_constructor_name : string -> string
+  method reference_constructor_name : ConstructorName.t -> ConstructorName.t
 
-  method reference_field_name : string -> string
+  method reference_field_name : FieldName.t -> FieldName.t
 
-  method reference_extension_name : string -> string
+  method reference_extension_name : ExtensionName.t -> ExtensionName.t
 
-  method reference_exception_name : string -> string
+  method reference_exception_name : ExceptionName.t -> ExceptionName.t
 
-  method reference_value_name : string -> string
+  method reference_value_name : ValueName.t -> ValueName.t
 
-  method reference_class_name : string -> string
+  method reference_class_name : ClassName.t -> ClassName.t
 
-  method reference_class_type_name : string -> string
+  method reference_class_type_name : ClassTypeName.t -> ClassTypeName.t
 
-  method reference_method_name : string -> string
+  method reference_method_name : MethodName.t -> MethodName.t
 
-  method reference_instance_variable_name : string -> string
+  method reference_instance_variable_name : InstanceVariableName.t -> InstanceVariableName.t
 
-  method reference_label_name : string -> string
+  method reference_label_name : LabelName.t -> LabelName.t
 
-  method reference_module : Reference.module_ -> Reference.module_
+  method reference_signature : Reference.Signature.t -> Reference.Signature.t 
 
-  method reference_module_type : Reference.module_type -> Reference.module_type
+  method reference_label_parent : Reference.LabelParent.t -> Reference.LabelParent.t 
 
-  method reference_type : Reference.type_ -> Reference.type_
+  method reference_parent : Reference.Parent.t -> Reference.Parent.t
 
-  method reference_constructor : Reference.constructor -> Reference.constructor
+  method reference_module : Reference.Module.t -> Reference.Module.t
 
-  method reference_field : Reference.field -> Reference.field
+  method reference_datatype : Reference.DataType.t -> Reference.DataType.t
 
-  method reference_extension : Reference.extension -> Reference.extension
+  method reference_module_type : Reference.ModuleType.t -> Reference.ModuleType.t
 
-  method reference_exception : Reference.exception_ -> Reference.exception_
+  method reference_type : Reference.Type.t -> Reference.Type.t
 
-  method reference_value : Reference.value -> Reference.value
+  method reference_constructor : Reference.Constructor.t -> Reference.Constructor.t
 
-  method reference_class : Reference.class_ -> Reference.class_
+  method reference_field : Reference.Field.t -> Reference.Field.t
 
-  method reference_class_type : Reference.class_type -> Reference.class_type
+  method reference_extension : Reference.Extension.t -> Reference.Extension.t
 
-  method reference_method : Reference.method_ -> Reference.method_
+  method reference_exception : Reference.Exception.t -> Reference.Exception.t
 
-  method reference_instance_variable : Reference.instance_variable ->
-    Reference.instance_variable
+  method reference_value : Reference.Value.t -> Reference.Value.t
 
-  method reference_label : Reference.label -> Reference.label
+  method reference_class : Reference.Class.t -> Reference.Class.t
 
-  method reference_any : Reference.any -> Reference.any
+  method reference_class_type : Reference.ClassType.t -> Reference.ClassType.t
+
+  method reference_class_signature : Reference.ClassSignature.t -> Reference.ClassSignature.t 
+
+  method reference_method : Reference.Method.t -> Reference.Method.t
+
+  method reference_instance_variable : Reference.InstanceVariable.t ->
+    Reference.InstanceVariable.t
+
+  method reference_label : Reference.Label.t -> Reference.Label.t
+
+  method reference_any : Reference.t -> Reference.t
 
 end
 
@@ -330,49 +357,49 @@ end
 
 class virtual documentation : object
 
-  method virtual identifier_label : Identifier.label -> Identifier.label
+  method virtual identifier_label : Identifier.Label.t -> Identifier.Label.t
 
-  method virtual identifier : 'k. 'k Identifier.t -> 'k Identifier.t
+  method virtual identifier : Identifier.t -> Identifier.t
 
-  method virtual path_module : Path.module_ -> Path.module_
+  method virtual path_module : Path.Module.t -> Path.Module.t
 
-  method virtual reference_module : Reference.module_ -> Reference.module_
+  method virtual reference_module : Reference.Module.t -> Reference.Module.t
 
-  method virtual reference_module_type : Reference.module_type ->
-    Reference.module_type
+  method virtual reference_module_type : Reference.ModuleType.t ->
+    Reference.ModuleType.t
 
-  method virtual reference_type : Reference.type_ -> Reference.type_
+  method virtual reference_type : Reference.Type.t -> Reference.Type.t
 
-  method virtual reference_constructor : Reference.constructor ->
-    Reference.constructor
+  method virtual reference_constructor : Reference.Constructor.t ->
+    Reference.Constructor.t
 
-  method virtual reference_field : Reference.field -> Reference.field
+  method virtual reference_field : Reference.Field.t -> Reference.Field.t
 
-  method virtual reference_extension : Reference.extension ->
-    Reference.extension
+  method virtual reference_extension : Reference.Extension.t ->
+    Reference.Extension.t
 
-  method virtual reference_exception : Reference.exception_ ->
-    Reference.exception_
+  method virtual reference_exception : Reference.Exception.t ->
+    Reference.Exception.t
 
-  method virtual reference_value : Reference.value -> Reference.value
+  method virtual reference_value : Reference.Value.t -> Reference.Value.t
 
-  method virtual reference_class : Reference.class_ -> Reference.class_
+  method virtual reference_class : Reference.Class.t -> Reference.Class.t
 
-  method virtual reference_class_type : Reference.class_type ->
-    Reference.class_type
+  method virtual reference_class_type : Reference.ClassType.t ->
+    Reference.ClassType.t
 
-  method virtual reference_method : Reference.method_ -> Reference.method_
+  method virtual reference_method : Reference.Method.t -> Reference.Method.t
 
-  method virtual reference_instance_variable : Reference.instance_variable ->
-    Reference.instance_variable
+  method virtual reference_instance_variable : Reference.InstanceVariable.t ->
+    Reference.InstanceVariable.t
 
-  method virtual reference_label : Reference.label -> Reference.label
+  method virtual reference_label : Reference.Label.t -> Reference.Label.t
 
-  method virtual reference_any : Reference.any -> Reference.any
+  method virtual reference_any : Reference.t -> Reference.t
 
   method documentation_reference :
-    Paths.Reference.any * Comment.link_content ->
-      Paths.Reference.any * Comment.link_content
+    Paths.Reference.t * Comment.link_content ->
+      Paths.Reference.t * Comment.link_content
 
   method documentation : Comment.docs -> Comment.docs
 
@@ -382,11 +409,11 @@ end
 
 class virtual module_ : object
 
-  method virtual identifier_module : Identifier.module_ -> Identifier.module_
+  method virtual identifier_module : Identifier.Module.t -> Identifier.Module.t
 
-  method virtual path_module : Path.module_ -> Path.module_
+  method virtual path_module : Path.Module.t -> Path.Module.t
 
-  method virtual reference_module : Reference.module_ -> Reference.module_
+  method virtual reference_module : Reference.Module.t -> Reference.Module.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -410,20 +437,20 @@ end
 
 class virtual module_type : object
 
-  method virtual identifier_module : Identifier.module_ -> Identifier.module_
+  method virtual identifier_module : Identifier.Module.t -> Identifier.Module.t
 
-  method virtual identifier_module_type : Identifier.module_type ->
-    Identifier.module_type
+  method virtual identifier_module_type : Identifier.ModuleType.t ->
+    Identifier.ModuleType.t
 
-  method virtual path_module : Path.module_ -> Path.module_
+  method virtual path_module : Path.Module.t -> Path.Module.t
 
-  method virtual path_module_type : Path.module_type -> Path.module_type
+  method virtual path_module_type : Path.ModuleType.t -> Path.ModuleType.t
 
-  method virtual path_type : Path.type_ -> Path.type_
+  method virtual path_type : Path.Type.t -> Path.Type.t
 
-  method virtual fragment_module : Fragment.module_ -> Fragment.module_
+  method virtual fragment_module : Fragment.Module.t -> Fragment.Module.t
 
-  method virtual fragment_type : Fragment.type_ -> Fragment.type_
+  method virtual fragment_type : Fragment.Type.t -> Fragment.Type.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -486,8 +513,8 @@ class virtual include_ : object
 
   method virtual module_decl : Module.decl -> Module.decl
 
-  method virtual identifier_signature : Identifier.signature ->
-                                        Identifier.signature
+  method virtual identifier_signature : Identifier.Signature.t ->
+                                        Identifier.Signature.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -503,12 +530,12 @@ end
 
 class virtual type_decl : object
 
-  method virtual identifier_type : Identifier.type_ -> Identifier.type_
+  method virtual identifier_type : Identifier.Type.t -> Identifier.Type.t
 
-  method virtual identifier_constructor : Identifier.constructor ->
-    Identifier.constructor
+  method virtual identifier_constructor : Identifier.Constructor.t ->
+    Identifier.Constructor.t
 
-  method virtual identifier_field : Identifier.field -> Identifier.field
+  method virtual identifier_field : Identifier.Field.t -> Identifier.Field.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -548,10 +575,10 @@ end
 
 class virtual extension : object
 
-  method virtual identifier_extension : Identifier.extension ->
-    Identifier.extension
+  method virtual identifier_extension : Identifier.Extension.t ->
+    Identifier.Extension.t
 
-  method virtual path_type : Path.type_ -> Path.type_
+  method virtual path_type : Path.Type.t -> Path.Type.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -573,8 +600,8 @@ end
 
 class virtual exception_ : object
 
-  method virtual identifier_exception : Identifier.exception_ ->
-    Identifier.exception_
+  method virtual identifier_exception : Identifier.Exception.t ->
+    Identifier.Exception.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -589,7 +616,7 @@ end
 
 class virtual value : object
 
-  method virtual identifier_value : Identifier.value -> Identifier.value
+  method virtual identifier_value : Identifier.Value.t -> Identifier.Value.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -600,7 +627,7 @@ end
 
 class virtual external_ : object
 
-  method virtual identifier_value : Identifier.value -> Identifier.value
+  method virtual identifier_value : Identifier.Value.t -> Identifier.Value.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -614,7 +641,7 @@ end
 
 class virtual class_ : object
 
-  method virtual identifier_class : Identifier.class_ -> Identifier.class_
+  method virtual identifier_class : Identifier.Class.t -> Identifier.Class.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -638,10 +665,10 @@ end
 
 class virtual class_type : object
 
-  method virtual identifier_class_type : Identifier.class_type ->
-    Identifier.class_type
+  method virtual identifier_class_type : Identifier.ClassType.t ->
+    Identifier.ClassType.t
 
-  method virtual path_class_type : Path.class_type -> Path.class_type
+  method virtual path_class_type : Path.ClassType.t -> Path.ClassType.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -682,8 +709,8 @@ end
 
 class virtual method_ : object
 
-  method virtual identifier_method : Identifier.method_ ->
-    Identifier.method_
+  method virtual identifier_method : Identifier.Method.t ->
+    Identifier.Method.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -700,7 +727,7 @@ end
 class virtual instance_variable : object
 
   method virtual identifier_instance_variable :
-    Identifier.instance_variable -> Identifier.instance_variable
+    Identifier.InstanceVariable.t -> Identifier.InstanceVariable.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -716,13 +743,13 @@ end
 
 class virtual type_expr : object
 
-  method virtual path_module_type : Path.module_type -> Path.module_type
+  method virtual path_module_type : Path.ModuleType.t -> Path.ModuleType.t
 
-  method virtual path_type : Path.type_ -> Path.type_
+  method virtual path_type : Path.Type.t -> Path.Type.t
 
-  method virtual path_class_type : Path.class_type -> Path.class_type
+  method virtual path_class_type : Path.ClassType.t -> Path.ClassType.t
 
-  method virtual fragment_type : Fragment.type_ -> Fragment.type_
+  method virtual fragment_type : Fragment.Type.t -> Fragment.Type.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -770,11 +797,11 @@ class virtual unit : object
 
   method virtual root : Root.t -> Root.t
 
-  method virtual identifier_module : Identifier.module_ ->
-    Identifier.module_
+  method virtual identifier_module : Identifier.Module.t ->
+    Identifier.Module.t
 
   method virtual path_module :
-    Path.module_ -> Path.module_
+    Path.Module.t -> Path.Module.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 
@@ -817,7 +844,7 @@ end
 
 class virtual page : object
 
-  method virtual identifier_page : Identifier.page -> Identifier.page
+  method virtual identifier_page : Identifier.Page.t -> Identifier.Page.t
 
   method virtual documentation : Comment.docs -> Comment.docs
 

--- a/src/model/names.ml
+++ b/src/model/names.ml
@@ -1,0 +1,70 @@
+module type Name = sig
+
+    type t
+
+    val to_string : t -> string
+
+    val of_string : string -> t
+
+    val of_ident : Ident.t -> t
+
+    val equal : t -> t -> bool
+
+    val is_hidden : t -> bool
+
+end
+
+module Name : Name = struct
+
+    type t = string
+
+    let to_string s = s
+
+    let of_string s = s
+    
+    let of_ident id = of_string (Ident.name id)
+
+    let equal = String.equal
+
+    let is_hidden s =
+        let len = String.length s in
+        let rec aux i =
+            if i > len - 2 then false else
+            if Char.equal s.[i] '_' && Char.equal s.[i + 1] '_' then true
+            else aux (i + 1)
+        in aux 0
+end
+
+module ModuleName = Name
+
+module ArgumentName = Name
+
+module ModuleTypeName = Name
+
+module TypeName = Name
+
+module ConstructorName = Name
+
+module FieldName = Name
+
+module ExtensionName = Name
+
+module ExceptionName = Name
+
+module ValueName = Name
+
+module ClassName = Name
+
+module ClassTypeName = Name
+
+module MethodName = Name
+
+module InstanceVariableName = Name
+
+module UnitName = Name
+
+module LabelName = Name
+
+module PageName = Name
+
+

--- a/src/model/names.ml
+++ b/src/model/names.ml
@@ -24,13 +24,13 @@ module Name : Name = struct
     
     let of_ident id = of_string (Ident.name id)
 
-    let equal = String.equal
+    let equal (x : t) (y : t) = x = y
 
     let is_hidden s =
         let len = String.length s in
         let rec aux i =
             if i > len - 2 then false else
-            if Char.equal s.[i] '_' && Char.equal s.[i + 1] '_' then true
+            if s.[i] = '_' && s.[i + 1] = '_' then true
             else aux (i + 1)
         in aux 0
 end

--- a/src/model/names.mli
+++ b/src/model/names.mli
@@ -1,0 +1,46 @@
+module type Name = sig
+
+    type t
+
+    val to_string : t -> string
+
+    val of_string : string -> t
+
+    val of_ident : Ident.t -> t
+
+    val equal : t -> t -> bool
+
+    val is_hidden : t -> bool
+end
+
+module ModuleName : Name
+
+module ArgumentName : Name
+
+module ModuleTypeName : Name
+
+module TypeName : Name
+
+module ConstructorName : Name
+
+module FieldName : Name
+
+module ExtensionName : Name
+
+module ExceptionName : Name
+
+module ValueName : Name
+
+module ClassName : Name
+
+module ClassTypeName : Name
+
+module MethodName : Name
+
+module InstanceVariableName : Name
+
+module UnitName : Name
+
+module LabelName : Name
+
+module PageName : Name

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -14,16 +14,14 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Kind = Paths_types.Kind
-
-open Kind
+open Names
 
 module Reversed = struct
   type elt =
-    | Root of string
-    | Module of string
-    | ModuleType of string
-    | Argument of int * string
+    | Root of UnitName.t
+    | Module of ModuleName.t
+    | ModuleType of ModuleTypeName.t
+    | Argument of int * ArgumentName.t
 
   type t = elt list
 
@@ -36,635 +34,1051 @@ end
 
 module Identifier = struct
 
-  include Paths_types.Identifier
+  type t = Paths_types.Identifier.any
 
-  let signature_of_module : module_ -> _ = function
-    | Root _ | Module _ | Argument _ as x -> x
+  let name : [< t] -> string = function
+    | `Root(_, name) -> UnitName.to_string name
+    | `Page(_, name) -> PageName.to_string name
+    | `Module(_, name) -> ModuleName.to_string name
+    | `Argument(_, _, name) -> ArgumentName.to_string name
+    | `ModuleType(_, name) -> ModuleTypeName.to_string name
+    | `Type(_, name) -> TypeName.to_string name
+    | `CoreType name -> TypeName.to_string name
+    | `Constructor(_, name) -> ConstructorName.to_string name
+    | `Field(_, name) -> FieldName.to_string name
+    | `Extension(_, name) -> ExtensionName.to_string name
+    | `Exception(_, name) -> ExceptionName.to_string name
+    | `CoreException name -> ExceptionName.to_string name
+    | `Value(_, name) -> ValueName.to_string name
+    | `Class(_, name) -> ClassName.to_string name
+    | `ClassType(_, name) -> ClassTypeName.to_string name
+    | `Method(_, name) -> MethodName.to_string name
+    | `InstanceVariable(_, name) -> InstanceVariableName.to_string name
+    | `Label(_, name) -> LabelName.to_string name
 
-  let signature_of_module_type : module_type -> _  = function
-    | ModuleType _ as x -> x
+  let rec equal : t -> t -> bool =
+    let open Paths_types.Identifier in
+    fun p1 p2 ->
+      match p1, p2 with
+      | `Root (r1, n1), `Root (r2, n2) ->
+        UnitName.equal n1 n2 && Root.equal r1 r2
+      | `Module (s1,n1), `Module (s2,n2) ->
+        ModuleName.equal n1 n2 && equal (s1 : signature :> any) (s2 : signature :> any) 
+      | `Argument (s1,i1,n1), `Argument (s2,i2,n2) ->
+        i1=i2 && ArgumentName.equal n1 n2 && equal (s1 : signature :> any) (s2 : signature :> any)
+      | `ModuleType (s1,n1), `ModuleType (s2,n2) ->
+        ModuleTypeName.equal n1 n2 && equal (s1 : signature :> any) (s2 : signature :> any)
+      | `Type (s1, n1), `Type (s2, n2) ->
+        TypeName.equal n1 n2 && equal (s1 : signature :> any) (s2 : signature :> any)
+      | `CoreType n1, `CoreType n2 ->
+        TypeName.equal n1 n2
+      | `Class (s1, n1), `Class (s2, n2) ->
+        ClassName.equal n1 n2 && equal (s1 : signature :> any) (s2 : signature :> any)
+      | `ClassType (s1, n1), `ClassType (s2, n2) ->
+        ClassTypeName.equal n1 n2 && equal (s1 : signature :> any) (s2 : signature :> any)
+      | `Page (r1, n1), `Page (r2, n2) ->
+        PageName.equal n1 n2 && Root.equal r1 r2
+      | `Constructor(t1, n1), `Constructor(t2, n2) ->
+        ConstructorName.equal n1 n2 && equal (t1 : type_ :> any) (t2 : type_ :> any)
+      | `Field(s1, n1), `Field(s2, n2) ->
+        FieldName.equal n1 n2 && equal (s1 : parent :> any) (s2 : parent :> any)
+      | `Extension(s1, n1), `Extension(s2, n2) ->
+        ExtensionName.equal n1 n2 && equal (s1 : signature :> any) (s2 : signature :> any)
+      | `Exception(s1, n1), `Exception(s2, n2) ->
+        ExceptionName.equal n1 n2 && equal (s1 : signature :> any) (s2 : signature :> any)
+      | `CoreException n1, `CoreException n2 ->
+        ExceptionName.equal n1 n2
+      | `Value(s1, n1), `Value(s2, n2) ->
+        ValueName.equal n1 n2 && equal (s1 : signature :> any) (s2 : signature :> any)
+      | `Method(s1, n1), `Method(s2, n2) ->
+        MethodName.equal n1 n2 && equal (s1 : class_signature :> any) (s2 : class_signature :> any)
+      | `InstanceVariable(s1, n1), `InstanceVariable(s2, n2) ->
+        InstanceVariableName.equal n1 n2 && equal (s1 : class_signature :> any) (s2 : class_signature :> any)
+      | `Label(s1, n1), `Label(s2, n2) ->
+        LabelName.equal n1 n2 && equal (s1 : label_parent :> any) (s2 : label_parent :> any)
+      | _, _ -> false
 
-  let class_signature_of_class : class_ -> _ = function
-    | Class _ as x -> x
+  let rec hash (id : Paths_types.Identifier.any) =
+    let open Paths_types.Identifier in
+    match id with
+    | `Root(r, s) ->
+      Hashtbl.hash (1, Root.hash r, s)
+    | `Page(r, s) ->
+      Hashtbl.hash (2, Root.hash r, s)
+    | `Module(id, s) ->
+      Hashtbl.hash (3, hash (id : signature :> any), s)
+    | `Argument(id, n, s) ->
+      Hashtbl.hash (4, hash (id : signature :> any), n, s)
+    | `ModuleType(id, s) ->
+      Hashtbl.hash (5, hash (id : signature :> any), s)
+    | `Type(id, s) ->
+      Hashtbl.hash (6, hash (id : signature :> any), s)
+    | `CoreType s ->
+      Hashtbl.hash (7, s)
+    | `Constructor(id, s) ->
+      Hashtbl.hash (8, hash (id : type_ :> any), s)
+    | `Field(id, s) ->
+      Hashtbl.hash (9, hash (id : parent :> any), s)
+    | `Extension(id, s) ->
+      Hashtbl.hash (10, hash (id : signature :> any), s)
+    | `Exception(id, s) ->
+      Hashtbl.hash (11, hash (id : signature :> any), s)
+    | `CoreException s ->
+      Hashtbl.hash (12, s)
+    | `Value(id, s) ->
+      Hashtbl.hash (13, hash (id : signature :> any), s)
+    | `Class(id, s) ->
+      Hashtbl.hash (14, hash (id : signature :> any), s)
+    | `ClassType(id, s) ->
+      Hashtbl.hash (15, hash (id : signature :> any), s)
+    | `Method(id, s) ->
+      Hashtbl.hash (16, hash (id : class_signature :> any), s)
+    | `InstanceVariable(id, s) ->
+      Hashtbl.hash (17, hash (id : class_signature :> any), s)
+    | `Label(id, s) ->
+      Hashtbl.hash (18, hash (id : label_parent :> any ), s)
 
-  let class_signature_of_class_type : class_type -> _ = function
-    | ClassType _ as x -> x
+  module Signature =
+  struct
+    type t = Paths_types.Identifier.signature 
 
-  let datatype_of_type : type_ -> datatype = function
-    | x -> x
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
 
-  let parent_of_signature : signature -> parent = function
-    | Root _ | Module _ | Argument _ | ModuleType _ as x -> x
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
 
-  let parent_of_class_signature : class_signature -> parent =
-    function Class _ | ClassType _ as x -> x
+    let rec root = function
+      | `Root(r, _) -> r
+      | `Module(id, _)
+      | `Argument(id, _, _)
+      | `ModuleType(id, _) -> root id
+  end
 
-  let parent_of_datatype : datatype -> parent =
-    function Type _ | CoreType _ as x -> x
+  module ClassSignature =
+  struct
+    type t = Paths_types.Identifier.class_signature 
 
-  let label_parent_of_parent : parent -> label_parent =
-    function Root _ | Module _ | Argument _ | ModuleType _ | Type _
-           | CoreType _ | Class _ | ClassType _ as x -> x
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
 
-  let label_parent_of_page : page -> label_parent =
-    function Page _ as x -> x
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
 
-  let any : type k. k t -> any = function
-    | Root _ as x -> x
-    | Page _ as x -> x
-    | Module _ as x -> x
-    | Argument _ as x -> x
-    | ModuleType _ as x -> x
-    | Type _ as x -> x
-    | CoreType _ as x -> x
-    | Constructor _ as x -> x
-    | Field _ as x -> x
-    | Extension _ as x -> x
-    | Exception _ as x -> x
-    | CoreException _ as x -> x
-    | Value _ as x -> x
-    | Class _ as x -> x
-    | ClassType _ as x -> x
-    | Method _ as x -> x
-    | InstanceVariable _ as x -> x
-    | Label _ as x -> x
+    let root = function
+      | `Class (s, _) -> Signature.root s
+      | `ClassType (s, _) -> Signature.root s
+  end
 
-  let name : type k. k t -> string = function
-    | Root(_, name) -> name
-    | Page(_, name) -> name
-    | Module(_, name) -> name
-    | Argument(_, _, name) -> name
-    | ModuleType(_, name) -> name
-    | Type(_, name) -> name
-    | CoreType name -> name
-    | Constructor(_, name) -> name
-    | Field(_, name) -> name
-    | Extension(_, name) -> name
-    | Exception(_, name) -> name
-    | CoreException name -> name
-    | Value(_, name) -> name
-    | Class(_, name) -> name
-    | ClassType(_, name) -> name
-    | Method(_, name) -> name
-    | InstanceVariable(_, name) -> name
-    | Label(_, name) -> name
+  module DataType =
+  struct
+    type t = Paths_types.Identifier.datatype
 
-  let equal id1 id2 =
-    let rec loop : type k. k t -> k t -> bool =
-      fun id1 id2 ->
-        match id1, id2 with
-        | Root(r1, s1), Root(r2, s2) ->
-            s1 = s2 && Root.equal r1 r2
-        | Module(id1, s1), Module(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | Argument(id1, n1, s1), Argument(id2, n2, s2) ->
-            n1 = n2 && s1 = s2 && loop id1 id2
-        | ModuleType(id1, s1), ModuleType(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | Type(id1, s1), Type(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | CoreType s1, CoreType s2 ->
-            s1 = s2
-        | Constructor(id1, s1), Constructor(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | Field(id1, s1), Field(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | Extension(id1, s1), Extension(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | Exception(id1, s1), Exception(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | CoreException s1, CoreException s2 ->
-            s1 = s2
-        | Value(id1, s1), Value(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | Class(id1, s1), Class(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | ClassType(id1, s1), ClassType(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | Method(id1, s1), Method(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | InstanceVariable(id1, s1), InstanceVariable(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | Label(id1, s1), Label(id2, s2) ->
-            s1 = s2 && loop id1 id2
-        | _, _ -> false
-    in
-      loop id1 id2
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
 
-  let hash id =
-    let rec loop : type k. k t -> int =
-      fun id ->
-        match id with
-        | Root(r, s) ->
-            Hashtbl.hash (1, Root.hash r, s)
-        | Page(r, s) ->
-            Hashtbl.hash (2, Root.hash r, s)
-        | Module(id, s) ->
-            Hashtbl.hash (3, loop id, s)
-        | Argument(id, n, s) ->
-            Hashtbl.hash (4, loop id, n, s)
-        | ModuleType(id, s) ->
-            Hashtbl.hash (5, loop id, s)
-        | Type(id, s) ->
-            Hashtbl.hash (6, loop id, s)
-        | CoreType s ->
-            Hashtbl.hash (7, s)
-        | Constructor(id, s) ->
-            Hashtbl.hash (8, loop id, s)
-        | Field(id, s) ->
-            Hashtbl.hash (9, loop id, s)
-        | Extension(id, s) ->
-            Hashtbl.hash (10, loop id, s)
-        | Exception(id, s) ->
-            Hashtbl.hash (11, loop id, s)
-        | CoreException s ->
-            Hashtbl.hash (12, s)
-        | Value(id, s) ->
-            Hashtbl.hash (13, loop id, s)
-        | Class(id, s) ->
-            Hashtbl.hash (14, loop id, s)
-        | ClassType(id, s) ->
-            Hashtbl.hash (15, loop id, s)
-        | Method(id, s) ->
-            Hashtbl.hash (16, loop id, s)
-        | InstanceVariable(id, s) ->
-            Hashtbl.hash (17, loop id, s)
-        | Label(id, s) ->
-            Hashtbl.hash (18, loop id, s)
-    in
-      loop id
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
 
-  let rec signature_root : signature -> Root.t = function
-    | Root(r, _) -> r
-    | Module(id, _) -> signature_root id
-    | Argument(id, _, _) -> signature_root id
-    | ModuleType(id, _) -> signature_root id
+  module Parent =
+  struct
+    type t = Paths_types.Identifier.parent
 
-  let module_root : module_ -> Root.t = function
-    | Root(r, _) -> r
-    | Module(id, _) -> signature_root id
-    | Argument(id, _, _) -> signature_root id
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
 
-  let module_type_root : module_type -> Root.t = function
-    | ModuleType(id, _) -> signature_root id
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
 
-  let class_signature_root : class_signature -> Root.t = function
-    | Class(id, _)
-    | ClassType(id, _) -> signature_root id
+  module LabelParent =
+  struct
+    type t = Paths_types.Identifier.label_parent
 
-  let label_parent_root : label_parent -> Root.t = function
-    | Root (r, _) -> r
-    | Page (r, _) -> r
-    | Module (s, _) -> signature_root s
-    | Argument (s, _, _) -> signature_root s
-    | ModuleType (s, _) -> signature_root s
-    | Type (s, _) -> signature_root s
-    | CoreType _ -> assert false
-    | Class (s, _) -> signature_root s
-    | ClassType (s, _) -> signature_root s
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+
+    let root : t -> Root.t = function
+      | `Root(r, _) -> r
+      | `Module(id, _)
+      | `Argument(id, _, _)
+      | `ModuleType(id, _) -> Signature.root id
+      | `Type(id,_) -> Signature.root id
+      | `CoreType _ -> assert false
+      | `Class (s, _) -> Signature.root s
+      | `ClassType (s, _) -> Signature.root s
+      | `Page (r, _) -> r
+  end
+
+  module Module =
+  struct
+    type t = Paths_types.Identifier.module_
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+
+    let root = function
+      | `Root(r, _) -> r
+      | `Module(id, _)
+      | `Argument(id, _, _) -> Signature.root id
+
+  end
+
+  module ModuleType =
+  struct
+    type t = Paths_types.Identifier.module_type
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+
+    let root : t -> Root.t = function
+      | `ModuleType(id, _) -> Signature.root id
+
+  end
+
+  module Type =
+  struct
+    type t = Paths_types.Identifier.type_
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module Constructor =
+  struct
+    type t = Paths_types.Identifier.constructor
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module Field =
+  struct
+    type t = Paths_types.Identifier.field
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module Extension =
+  struct
+    type t = Paths_types.Identifier.extension
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module Exception =
+  struct
+    type t = Paths_types.Identifier.exception_
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module Value =
+  struct
+    type t = Paths_types.Identifier.value
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module Class =
+  struct
+    type t = Paths_types.Identifier.class_
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module ClassType =
+  struct
+    type t = Paths_types.Identifier.class_type
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module Method =
+  struct
+    type t = Paths_types.Identifier.method_
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module InstanceVariable =
+  struct
+    type t = Paths_types.Identifier.instance_variable
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module Label =
+  struct
+    type t = Paths_types.Identifier.label
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module Page =
+  struct
+    type t = Paths_types.Identifier.page
+
+    let equal : t -> t -> bool =
+      fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+    let hash : t -> int =
+      fun t -> hash (t : t :> Paths_types.Identifier.any)
+  end
+
+  module Path =
+  struct
+    module Module =
+    struct
+      type t = Paths_types.Identifier.path_module
+
+      let equal : t -> t -> bool =
+        fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+      let hash : t -> int =
+        fun t -> hash (t : t :> Paths_types.Identifier.any)
+    end
+
+    module ModuleType =
+    struct
+      type t = Paths_types.Identifier.path_module_type
+
+      let equal : t -> t -> bool =
+        fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+      let hash : t -> int =
+        fun t -> hash (t : t :> Paths_types.Identifier.any)
+    end
+
+    module Type =
+    struct
+      type t = Paths_types.Identifier.path_type
+
+      let equal : t -> t -> bool =
+        fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+      let hash : t -> int =
+        fun t -> hash (t : t :> Paths_types.Identifier.any)
+    end
+
+    module ClassType =
+    struct
+      type t = Paths_types.Identifier.path_class_type
+
+      let equal : t -> t -> bool =
+        fun t1 t2 -> equal (t1 : t :> Paths_types.Identifier.any) (t2 : t :> Paths_types.Identifier.any)
+
+      let hash : t -> int =
+        fun t -> hash (t : t :> Paths_types.Identifier.any)
+    end
+
+    type t = Paths_types.Identifier.path_any
+  end
 
   let to_reversed i =
-    let rec loop acc : signature -> Reversed.t = function
-      | Root (_, s) -> Reversed.Root s :: acc
-      | Module (i, s) -> loop (Reversed.Module s :: acc) i
-      | ModuleType (i, s) -> loop (Reversed.ModuleType s :: acc) i
-      | Argument (i, d, s) -> loop (Reversed.Argument (d, s) :: acc) i
+    let rec loop acc : Signature.t -> Reversed.t = function
+      | `Root (_, s) -> Reversed.Root s :: acc
+      | `Module (i, s) -> loop (Reversed.Module s :: acc) i
+      | `ModuleType (i, s) -> loop (Reversed.ModuleType s :: acc) i
+      | `Argument (i, d, s) -> loop (Reversed.Argument (d, s) :: acc) i
     in
     loop [] i
+
+  let signature_of_module m = (m : Module.t :> Signature.t)
+
+  let page_of_t : t -> Page.t = function
+    | #Page.t as result -> result
+    | _ -> assert false
+
+  let signature_of_t : t -> Signature.t = function
+      | #Signature.t as result -> result
+      | _ -> assert false
+
+  let class_signature_of_t : t -> ClassSignature.t = function
+      | #ClassSignature.t as result -> result
+      | _ -> assert false
+
+  let datatype_of_t : t -> DataType.t = function
+      | #DataType.t as result -> result
+      | _ -> assert false
+
+  let module_of_t : t -> Module.t = function
+      | #Module.t as result -> result
+      | _ -> assert false
+
+  let module_type_of_t : t -> ModuleType.t = function
+      | #ModuleType.t as result -> result
+      | _ -> assert false
+
+  let type_of_t : t -> Type.t = function
+      | #Type.t as result -> result
+      | _ -> assert false
+
+  let constructor_of_t : t -> Constructor.t = function
+      | #Constructor.t as result -> result
+      | _ -> assert false
+
+  let field_of_t : t -> Field.t = function
+      | #Field.t as result -> result
+      | _ -> assert false
+
+  let extension_of_t : t -> Extension.t = function
+      | #Extension.t as result -> result
+      | _ -> assert false
+
+  let exception_of_t : t -> Exception.t = function
+      | #Exception.t as result -> result
+      | _ -> assert false
+
+  let value_of_t : t -> Value.t = function
+      | #Value.t as result -> result
+      | _ -> assert false
+
+  let class_of_t : t -> Class.t = function
+      | #Class.t as result -> result
+      | _ -> assert false
+
+  let class_type_of_t : t -> ClassType.t = function
+      | #ClassType.t as result -> result
+      | _ -> assert false
+
+  let method_of_t : t -> Method.t = function
+      | #Method.t as result -> result
+      | _ -> assert false
+
+  let instance_variable_of_t : t -> InstanceVariable.t = function
+      | #InstanceVariable.t as result -> result
+      | _ -> assert false
+
+  let label_of_t : t -> Label.t = function
+      | #Label.t as result -> result
+      | _ -> assert false
+
+  let parent_of_t : t -> Parent.t = function
+      | #Parent.t as result -> result
+      | _ -> assert false
+
 end
 
 
 
 module Path = struct
 
-  (* Separate types module to avoid repeating type definitions *)
-  module rec Types : sig
+  type t = Paths_types.Path.any
 
-    module Resolved = Paths_types.Resolved_path
-
-    module Path = Paths_types.Path
-
-  end = Types
-
-  let rec equal_resolved_path : type k. k Types.Resolved.t -> k Types.Resolved.t -> bool =
+  let rec equal_resolved_path : Paths_types.Resolved_path.any -> Paths_types.Resolved_path.any -> bool =
+    let open Paths_types.Resolved_path in
     fun p1 p2 ->
-      let open Types.Resolved in
-        match p1, p2 with
-        | Identifier id1, Identifier id2 ->
-            Identifier.equal id1 id2
-        | Subst(sub1, p1), Subst(sub2, p2) ->
-            equal_resolved_path p1 p2
-            && equal_resolved_path sub1 sub2
-        | SubstAlias(sub1, p1), SubstAlias(sub2, p2) ->
-            equal_resolved_path p1 p2
-            && equal_resolved_path sub1 sub2
-        | Module(p1, s1), Module(p2, s2) ->
-            s1 = s2 && equal_resolved_path p1 p2
-        | Apply(p1, arg1), Apply(p2, arg2) ->
-            equal_path arg1 arg2
-            && equal_resolved_path p1 p2
-        | ModuleType(p1, s1), ModuleType(p2, s2) ->
-            s1 = s2 && equal_resolved_path p1 p2
-        | Type(p1, s1), Type(p2, s2) ->
-            s1 = s2 && equal_resolved_path p1 p2
-        | Class(p1, s1), Class(p2, s2) ->
-            s1 = s2 && equal_resolved_path p1 p2
-        | ClassType(p1, s1), ClassType(p2, s2) ->
-            s1 = s2 && equal_resolved_path p1 p2
-        | _, _ -> false
+      match p1, p2 with
+      | `Identifier id1, `Identifier id2 ->
+        Identifier.equal id1 id2
+      | `Subst(sub1, p1), `Subst(sub2, p2) ->
+        equal_resolved_path (p1 : module_ :> any) (p2 : module_ :> any)
+        && equal_resolved_path (sub1 : module_type :> any) (sub2 : module_type :> any)
+      | `SubstAlias(sub1, p1), `SubstAlias(sub2, p2) ->
+        equal_resolved_path (p1 : module_ :> any) (p2 : module_ :> any)
+        && equal_resolved_path (sub1 : module_ :> any) (sub2 : module_ :> any)
+      | `Module(p1, s1), `Module(p2, s2) ->
+        s1 = s2 && equal_resolved_path (p1 : module_ :> any) (p2 : module_ :> any)
+      | `Apply(p1, arg1), `Apply(p2, arg2) ->
+        equal_path
+          (arg1 : Paths_types.Path.module_ :> Paths_types.Path.any)
+          (arg2 : Paths_types.Path.module_ :> Paths_types.Path.any)
+        && equal_resolved_path (p1 : module_ :> any) (p2 : module_ :> any)
+      | `ModuleType(p1, s1), `ModuleType(p2, s2) ->
+        s1 = s2 && equal_resolved_path (p1 : module_ :> any) (p2 : module_ :> any)
+      | `Type(p1, s1), `Type(p2, s2) ->
+        s1 = s2 && equal_resolved_path (p1 : module_ :> any) (p2 : module_ :> any)
+      | `Class(p1, s1), `Class(p2, s2) ->
+        s1 = s2 && equal_resolved_path (p1 : module_ :> any) (p2 : module_ :> any)
+      | `ClassType(p1, s1), `ClassType(p2, s2) ->
+        s1 = s2 && equal_resolved_path (p1 : module_ :> any) (p2 : module_ :> any)
+      | _, _ -> false
 
-  and equal_path : type k. k Types.Path.t -> k Types.Path.t -> bool =
+  and equal_path : Paths_types.Path.any -> Paths_types.Path.any -> bool =
+    let open Paths_types.Path in
     fun p1 p2 ->
-      let open Types.Path in
-        match p1, p2 with
-        | Resolved p1, Resolved p2 ->
-            equal_resolved_path p1 p2
-        | Root s1, Root s2 ->
-            s1 = s2
-        | Dot(p1, s1), Dot(p2, s2) ->
-            s1 = s2 && equal_path p1 p2
-        | Apply(p1, arg1), Apply(p2, arg2) ->
-            equal_path arg1 arg2 && equal_path p1 p2
-        | _, _ -> false
+      match p1, p2 with
+      | `Resolved p1, `Resolved p2 ->
+        equal_resolved_path p1 p2
+      | `Root s1, `Root s2 ->
+        s1 = s2
+      | `Dot(p1, s1), `Dot(p2, s2) ->
+        s1 = s2 && equal_path (p1 : module_ :> any) (p2 : module_ :> any)
+      | `Apply(p1, arg1), `Apply(p2, arg2) ->
+        equal_path (arg1 : module_ :> any) (arg2 : module_ :> any)
+        && equal_path (p1 : module_ :> any) (p2 : module_ :> any)
+      | _, _ -> false
 
-  let rec hash_resolved_path : type k. k Types.Resolved.t -> int =
+  let rec hash_resolved_path : Paths_types.Resolved_path.any -> int =
     fun p ->
-      let open Types.Resolved in
-        match p with
-        | Identifier id ->
-            Identifier.hash id
-        | Subst(sub, p) ->
-            Hashtbl.hash (19, hash_resolved_path sub,
-                          hash_resolved_path p)
-        | SubstAlias(sub, p) ->
-            Hashtbl.hash (20, hash_resolved_path sub,
-                          hash_resolved_path p)
-        | Hidden p -> Hashtbl.hash (21, hash_resolved_path p)
-        | Module(p, s) ->
-            Hashtbl.hash (22, hash_resolved_path p, s)
-        | Canonical(p, canonical) ->
-          Hashtbl.hash (23, hash_resolved_path p, hash_path canonical)
-        | Apply(p, arg) ->
-            Hashtbl.hash (24, hash_resolved_path p, hash_path arg)
-        | ModuleType(p, s) ->
-            Hashtbl.hash (25, hash_resolved_path p, s)
-        | Type(p, s) ->
-            Hashtbl.hash (26, hash_resolved_path p, s)
-        | Class(p, s) ->
-            Hashtbl.hash (27, hash_resolved_path p, s)
-        | ClassType(p, s) ->
-            Hashtbl.hash (28, hash_resolved_path p, s)
+    let open Paths_types.Resolved_path in
+    match p with
+    | `Identifier id ->
+      Identifier.hash id
+    | `Subst(sub, p) ->
+      Hashtbl.hash (19, hash_resolved_path (sub : module_type :> any),
+                    hash_resolved_path (p : module_ :> any))
+    | `SubstAlias(sub, p) ->
+      Hashtbl.hash (20, hash_resolved_path (sub : module_ :> any),
+                    hash_resolved_path (p : module_ :> any))
+    | `Hidden p -> Hashtbl.hash (21, hash_resolved_path (p : module_ :> any))
+    | `Module(p, s) ->
+      Hashtbl.hash (22, hash_resolved_path (p : module_ :> any), s)
+    | `Canonical(p, canonical) ->
+      Hashtbl.hash (23, hash_resolved_path (p : module_ :> any),
+                    hash_path (canonical : Paths_types.Path.module_ :> Paths_types.Path.any))
+    | `Apply(p, arg) ->
+      Hashtbl.hash (24, hash_resolved_path (p : module_ :> any),
+                    hash_path (arg : Paths_types.Path.module_ :> Paths_types.Path.any))
+    | `ModuleType(p, s) ->
+      Hashtbl.hash (25, hash_resolved_path (p : module_ :> any), s)
+    | `Type(p, s) ->
+      Hashtbl.hash (26, hash_resolved_path (p : module_ :> any), s)
+    | `Class(p, s) ->
+      Hashtbl.hash (27, hash_resolved_path (p : module_ :> any), s)
+    | `ClassType(p, s) ->
+      Hashtbl.hash (28, hash_resolved_path (p : module_ :> any), s)
 
-  and hash_path : type k. k Types.Path.t -> int =
+  and hash_path : Paths_types.Path.any -> int =
     fun p ->
-      let open Types.Path in
-        match p with
-        | Resolved p -> hash_resolved_path p
-        | Root s ->
-            Hashtbl.hash (29, s)
-        | Forward s ->
-            Hashtbl.hash (30, s)
-        | Dot(p, s) ->
-            Hashtbl.hash (31, hash_path p, s)
-        | Apply(p, arg) ->
-            Hashtbl.hash (32, hash_path p, hash_path arg)
+    let open Paths_types.Path in
+    match p with
+    | `Resolved p -> hash_resolved_path p
+    | `Root s ->
+      Hashtbl.hash (29, s)
+    | `Forward s ->
+      Hashtbl.hash (30, s)
+    | `Dot(p, s) ->
+      Hashtbl.hash (31, hash_path (p : module_ :> any), s)
+    | `Apply(p, arg) ->
+      Hashtbl.hash (32, hash_path (p : module_ :> any), hash_path (arg : module_ :> any))
 
-  let equal p1 p2 = equal_path p1 p2
-
-  let hash p = hash_path p
-
-  let rec is_resolved_hidden : type k. k Types.Resolved.t -> bool =
-    let open Types.Resolved in
+  let rec is_resolved_hidden : Paths_types.Resolved_path.any -> bool =
+    let open Paths_types.Resolved_path in
     function
-    | Identifier _ -> false
-    | Canonical (_, _) -> false
-    | Hidden _ -> true
-    | Subst(p1, p2) -> is_resolved_hidden p1 || is_resolved_hidden p2
-    | SubstAlias(p1, p2) -> is_resolved_hidden p1 || is_resolved_hidden p2
-    | Module (p, _) -> is_resolved_hidden p
-    | Apply (p, _) -> is_resolved_hidden p
-    | ModuleType (p, _) -> is_resolved_hidden p
-    | Type (p, _) -> is_resolved_hidden p
-    | Class (p, _) -> is_resolved_hidden p
-    | ClassType (p, _) -> is_resolved_hidden p
+    | `Identifier _ -> false
+    | `Canonical (_, _) -> false
+    | `Hidden _ -> true
+    | `Subst(p1, p2) -> is_resolved_hidden (p1 : module_type :> any) || is_resolved_hidden (p2 : module_ :> any)
+    | `SubstAlias(p1, p2) -> is_resolved_hidden (p1 : module_ :> any) || is_resolved_hidden (p2 : module_ :> any)
+    | `Module (p, _) -> is_resolved_hidden (p : module_ :> any)
+    | `Apply (p, _) -> is_resolved_hidden (p : module_ :> any)
+    | `ModuleType (p, _) -> is_resolved_hidden (p : module_ :> any)
+    | `Type (p, _) -> is_resolved_hidden (p : module_ :> any)
+    | `Class (p, _) -> is_resolved_hidden (p : module_ :> any)
+    | `ClassType (p, _) -> is_resolved_hidden (p : module_ :> any)
 
-  and is_path_hidden : type k. k Types.Path.t -> bool =
-    let open Types.Path in
+  and is_path_hidden : Paths_types.Path.any -> bool =
+    let open Paths_types.Path in
     function
-    | Resolved r -> is_resolved_hidden r
-    | Root _ -> false
-    | Forward _ -> false
-    | Dot(p, _) -> is_path_hidden p
-    | Apply(p1, p2) -> is_path_hidden p1 || is_path_hidden p2
+    | `Resolved r -> is_resolved_hidden r
+    | `Root _ -> false
+    | `Forward _ -> false
+    | `Dot(p, _) -> is_path_hidden (p : module_ :> any)
+    | `Apply(p1, p2) -> is_path_hidden (p1 : module_ :> any) || is_path_hidden (p2 : module_ :> any)
 
   module Resolved = struct
 
-    open Identifier
 
-    include Types.Resolved
+    type t = Paths_types.Resolved_path.any
 
-    let ident_module : Identifier.module_ -> _ = function
-      | Root _ | Module _ | Argument _ as x -> Identifier x
+    let rec parent_module_type_identifier : Paths_types.Resolved_path.module_type -> Identifier.Signature.t = function
+      | `Identifier id -> (id : Identifier.ModuleType.t :> Identifier.Signature.t) 
+      | `ModuleType(m, n) -> `ModuleType(parent_module_identifier m, n)
 
-    let ident_module_type : Identifier.module_type -> _ = function
-      | ModuleType _ as x -> Identifier x
-
-    let ident_type : Identifier.type_ -> _ = function
-      | Type _ | CoreType _ as x -> Identifier x
-
-    let ident_class : Identifier.class_ -> _ = function
-      | Class _ as x -> Identifier x
-
-    let ident_class_type : Identifier.class_type -> _ = function
-      | ClassType _ as x -> Identifier x
-
-    let any : type k. k t -> any = function
-      | Identifier (Root _) as x -> x
-      | Identifier (Module _) as x -> x
-      | Identifier (Argument _) as x -> x
-      | Identifier (ModuleType _) as x -> x
-      | Identifier (Type _) as x -> x
-      | Identifier (CoreType _) as x -> x
-      | Identifier (Class _) as x -> x
-      | Identifier (ClassType _) as x -> x
-      | Subst _ as x -> x
-      | SubstAlias _ as x -> x
-      | Hidden _ as x -> x
-      | Module _ as x -> x
-      | Canonical _ as x -> x
-      | Apply _ as x -> x
-      | ModuleType _ as x -> x
-      | Type _ as x -> x
-      | Class _ as x -> x
-      | ClassType _ as x -> x
-
-    let open_module : 'k. module_ -> ([< kind > `Module ] as 'k) t = function
-      | Identifier (Root _ | Module _ | Argument _) | Subst _ | SubstAlias _
-      | Hidden _ | Module _ | Canonical _ | Apply _ as x -> x
-
-    let rec parent_module_type_identifier : module_type -> Identifier.signature = function
-      | Identifier id -> Identifier.signature_of_module_type id
-      | ModuleType(m, n) -> ModuleType(parent_module_identifier m, n)
-
-    and parent_module_identifier : module_ -> Identifier.signature = function
-      | Identifier id -> Identifier.signature_of_module id
-      | Subst(sub, _) -> parent_module_type_identifier sub
-      | SubstAlias(sub, _) -> parent_module_identifier sub
-      | Hidden p -> parent_module_identifier p
-      | Module(m, n) -> Module(parent_module_identifier m, n)
-      | Canonical(_, Types.Path.Resolved p) -> parent_module_identifier p
-      | Canonical(p, _) -> parent_module_identifier p
-      | Apply(m, _) -> parent_module_identifier m
-
-    let rec identifier : type k. k t -> k Identifier.t = function
-      | Identifier id -> id
-      | Subst(_, p) -> identifier (open_module p)
-      | SubstAlias(_, p) -> identifier (open_module p)
-      | Hidden p -> identifier (open_module p)
-      | Module(m, n) -> Module(parent_module_identifier m, n)
-      | Canonical(_, Types.Path.Resolved p) -> begin
-          match identifier p with
-          | Root _ | Module _ | Argument _ as x -> x
-        end
-      | Canonical(p, _) -> begin
-          match identifier p with
-          | Root _ | Module _ | Argument _ as x -> x
-        end
-      | Apply(m, _) -> begin
-          match identifier m with
-          | Root _ | Module _ | Argument _ as x -> x
-        end
-      | ModuleType(m, n) -> ModuleType(parent_module_identifier m, n)
-      | Type(m, n) -> Type(parent_module_identifier m, n)
-      | Class(m, n) -> Class(parent_module_identifier m, n)
-      | ClassType(m, n) -> ClassType(parent_module_identifier m, n)
+    and parent_module_identifier : Paths_types.Resolved_path.module_ -> Identifier.Signature.t = function
+      | `Identifier id -> (id : Identifier.Module.t :> Identifier.Signature.t)
+      | `Subst(sub, _) -> parent_module_type_identifier sub
+      | `SubstAlias(sub, _) -> parent_module_identifier sub
+      | `Hidden p -> parent_module_identifier p
+      | `Module(m, n) -> `Module(parent_module_identifier m, n)
+      | `Canonical(_, `Resolved p) -> parent_module_identifier p
+      | `Canonical(p, _) -> parent_module_identifier p
+      | `Apply(m, _) -> parent_module_identifier m
 
     let equal p1 p2 = equal_resolved_path p1 p2
 
     let hash p = hash_resolved_path p
 
-    type 'kind rebase_result =
-      | Stop of 'kind t
-      | Continue of 'kind Identifier.t * Reversed.t
+    type rebase_result =
+      | Stop of Paths_types.Resolved_path.module_
+      | Continue of Paths_types.Identifier.path_module * Reversed.t
 
-    let rec rebase_module_path : Reversed.t -> module_ -> Kind.path_module rebase_result =
+    let rec rebase_module_path : Reversed.t -> Paths_types.Resolved_path.module_ -> rebase_result =
       fun new_base t ->
-        match t with
-        | Identifier id ->
-          let rev = Identifier.(to_reversed @@ signature_of_module id) in
-          let new_base' = Reversed.remove_prefix rev ~of_:new_base in
-          if new_base == new_base' then
-            Stop t
-          else
-            Continue (id, new_base')
-        | Subst (_, p)
-        | SubstAlias (_, p)
-        | Hidden p -> begin
-            match rebase_module_path new_base p with
-            | Stop p' when p == p' -> Stop t
-            | otherwise -> otherwise
-          end
-        | Module (m, s) ->
-          begin match rebase_module_path new_base m with
-          | Stop m' -> if m == m' then Stop t else Stop (Module (m', s))
+      match t with
+      | `Identifier id ->
+        let rev = Identifier.(to_reversed @@ signature_of_module id) in
+        let new_base' = Reversed.remove_prefix rev ~of_:new_base in
+        if new_base == new_base' then
+          Stop t
+        else
+          Continue (id, new_base')
+      | `Subst (_, p)
+      | `SubstAlias (_, p)
+      | `Hidden p -> begin
+          match rebase_module_path new_base p with
+          | Stop p' when p == p' -> Stop t
+          | otherwise -> otherwise
+        end
+      | `Module (m, s) ->
+        begin match rebase_module_path new_base m with
+          | Stop m' -> if m == m' then Stop t else Stop (`Module (m', s))
           | Continue (id, new_base) ->
-            let id = Identifier.Module(Identifier.signature_of_module id, s) in
+            let id = `Module (Identifier.signature_of_module id, s) in
             match new_base with
             | Reversed.Module s' :: rest when s = s' ->
               Continue (id, rest)
             | _ ->
-                Stop (Identifier id)
-          end
-        | Canonical (_, Types.Path.Resolved p) ->
-          (* We only care about printing at this point, so let's drop the lhs. *)
-          rebase_module_path new_base p
-        | Canonical (rp, p) ->
-          begin match rebase_module_path new_base rp with
-          | Stop rp' -> Stop (Canonical (rp', p))
+              Stop (`Identifier id)
+        end
+      | `Canonical (_, `Resolved p) ->
+        (* We only care about printing at this point, so let's drop the lhs. *)
+        rebase_module_path new_base p
+      | `Canonical (rp, p) ->
+        begin match rebase_module_path new_base rp with
+          | Stop rp' -> Stop (`Canonical (rp', p))
           | _ ->
             (* We might come back at some point with a resolved rhs? So we don't want to
                drop it. *)
             Stop t
-          end
-        | Apply _ -> Stop t
-        (* TODO: rewrite which side? *)
-
-    let rebase : type k. Reversed.t -> k t -> k t =
-      fun new_base t ->
-        match t with
-        | Identifier _ -> t
-        | Subst _ -> t (* TODO: rewrite which side? *)
-        | SubstAlias _ -> t (* TODO: rewrite which side? *)
-        | Hidden p  -> begin
-            match rebase_module_path new_base p with
-            | Stop p' ->
-              if p == p' then t else open_module p'
-            | Continue (id, _) -> open_module (Identifier id)
-          end
-        | Module (mp, s) ->
-          begin match rebase_module_path new_base mp with
-          | Continue (id, _) ->
-            Identifier Identifier.(Module (signature_of_module id, s))
-          | Stop mp' -> Module (mp', s)
-          end
-        | Canonical (p, Types.Path.Resolved rp) ->
-          begin match rebase_module_path new_base rp with
-          | Continue (id, _) -> ident_module id
-          | Stop rp ->
-            (* Easier to reexport a canonical than get the type for rp right... *)
-            Canonical (p, Types.Path.Resolved rp)
-          end
-        | Canonical (rp, p) ->
-          begin match rebase_module_path new_base rp with
-          | Stop rp' -> Canonical (rp', p)
-          | _ ->
-            (* We might come back at some point with a resolved rhs? So we don't want to
-               drop it. *)
-            t
-          end
-        | Apply (mp, arg) ->
-          begin match rebase_module_path new_base mp with
-          | Continue (id, _) -> Apply (Identifier id, arg)
-          | Stop mp' -> Apply (mp', arg)
-          end
-        | ModuleType (mp, s) ->
-          begin match rebase_module_path new_base mp with
-          | Continue (id, _) ->
-            Identifier Identifier.(ModuleType (signature_of_module id, s))
-          | Stop mp' -> ModuleType (mp', s)
-          end
-        | Type (mp, s) ->
-          begin match rebase_module_path new_base mp with
-          | Continue (id, _) ->
-            Identifier Identifier.(Type (signature_of_module id, s))
-          | Stop mp' -> Type (mp', s)
-          end
-        | Class (mp, s) ->
-          begin match rebase_module_path new_base mp with
-          | Continue (id, _) ->
-            Identifier Identifier.(Class (signature_of_module id, s))
-          | Stop mp' -> Class (mp', s)
-          end
-        | ClassType (mp, s) ->
-          begin match rebase_module_path new_base mp with
-          | Continue (id, _) ->
-            Identifier Identifier.(ClassType (signature_of_module id, s))
-          | Stop mp' -> ClassType (mp', s)
-          end
-
-    let rebase id t =
-      let rev = Identifier.to_reversed id in
-      rebase rev t
-
-    let signature_of_module : module_ -> Kind.signature t = function
-      | Identifier (Root _) as x -> x
-      | Identifier (Module _) as x -> x
-      | Identifier (Argument _) as x -> x
-      | Module _ as x -> x
-      | Canonical _ as x -> x
-      | Apply _ as x -> x
-      | Hidden _ as x -> x
-      | Subst _ as x -> x
-      | SubstAlias _ as x -> x
+        end
+      | `Apply _ -> Stop t
+    (* TODO: rewrite which side? *)
 
     let rec equal_identifier :
-      type k. k Identifier.t -> k t -> bool =
+      Identifier.t -> t -> bool =
       fun id p ->
-        match id, p with
-        | _, Identifier id' -> Identifier.equal id id'
-        | Module (id, s1), Module (p, s2) when s1 = s2 ->
-          equal_identifier id (signature_of_module p)
-        | ModuleType (id, s1), ModuleType (p, s2) when s1 = s2 ->
-          equal_identifier id (signature_of_module p)
-        | _, _ ->
-          false
+      match id, p with
+      | _, `Identifier id' -> Identifier.equal id id'
+      | `Module (id, s1), `Module (p, s2) when s1 = s2 ->
+        equal_identifier
+          (id : Paths_types.Identifier.signature :> Paths_types.Identifier.any)
+          (p : Paths_types.Resolved_path.module_ :> Paths_types.Resolved_path.any)
+      | `ModuleType (id, s1), `ModuleType (p, s2) when s1 = s2 ->
+        equal_identifier
+          (id : Paths_types.Identifier.signature :> Paths_types.Identifier.any)
+          (p : Paths_types.Resolved_path.module_ :> Paths_types.Resolved_path.any)
+      | _, _ ->
+        false
+
+    module Module = struct
+
+      type t = Paths_types.Resolved_path.module_
+
+      let of_ident id = `Identifier id
+
+      let equal m1 m2 = equal_resolved_path (m1 : t :> Paths_types.Resolved_path.any) (m2 : t :> Paths_types.Resolved_path.any)
+
+      let hash m = hash (m : t :> Paths_types.Resolved_path.any)
+
+      let is_hidden m = is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
+
+        let rec identifier = function
+        | `Identifier id -> id
+        | `Subst(_, p) -> identifier p
+        | `SubstAlias(_, p) -> identifier p
+        | `Hidden p -> identifier p
+        | `Module(m, n) -> `Module(parent_module_identifier m, n)
+        | `Canonical(_, `Resolved p) -> identifier p
+        | `Canonical(p, _) -> identifier p
+        | `Apply(m, _) -> identifier m
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `Subst _ -> t (* TODO: rewrite which side? *)
+        | `SubstAlias _ -> t (* TODO: rewrite which side? *)
+        | `Hidden p  -> begin
+            match rebase_module_path new_base p with
+            | Stop p' ->
+              if p == p' then t else p'
+            | Continue (id, _) -> `Identifier id
+          end
+        | `Module (mp, s) ->
+          begin match rebase_module_path new_base mp with
+            | Continue (id, _) ->
+              `Identifier (`Module (Identifier.signature_of_module id, s))
+            | Stop mp' -> `Module (mp', s)
+          end
+        | `Canonical (p, `Resolved rp) ->
+          begin match rebase_module_path new_base rp with
+            | Continue (id, _) -> `Identifier id
+            | Stop rp ->
+              (* Easier to reexport a canonical than get the type for rp right... *)
+              `Canonical (p, `Resolved rp)
+          end
+        | `Canonical (rp, p) ->
+          begin match rebase_module_path new_base rp with
+            | Stop rp' -> `Canonical (rp', p)
+            | _ ->
+              (* We might come back at some point with a resolved rhs? So we don't want to
+                 drop it. *)
+              t
+          end
+        | `Apply (mp, arg) ->
+          begin match rebase_module_path new_base mp with
+            | Continue (id, _) -> `Apply (`Identifier id, arg)
+            | Stop mp' -> `Apply (mp', arg)
+          end
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+
+      let equal_identifier :
+        Identifier.Path.Module.t -> t -> bool =
+        fun id t ->
+        equal_identifier
+          (id : Identifier.Path.Module.t :> Identifier.t)
+          (t : t :> Paths_types.Resolved_path.any)
+    end
+
+    module ModuleType = struct
+
+      type t = Paths_types.Resolved_path.module_type
+
+      let of_ident id = `Identifier id
+
+      let equal m1 m2 = equal_resolved_path (m1 : t :> Paths_types.Resolved_path.any) (m2 : t :> Paths_types.Resolved_path.any)
+
+      let hash m = hash (m : t :> Paths_types.Resolved_path.any)
+
+      let is_hidden m = is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
+
+      let identifier = function
+        | `Identifier id -> id
+        | `ModuleType(m, n) -> `ModuleType(parent_module_identifier m, n)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `ModuleType (mp, s) ->
+          begin match rebase_module_path new_base mp with
+            | Continue (id, _) ->
+              `Identifier (`ModuleType (Identifier.signature_of_module id, s))
+            | Stop mp' -> `ModuleType (mp', s)
+          end
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+
+      let equal_identifier :
+        Identifier.Path.ModuleType.t -> t -> bool =
+        fun id t ->
+        equal_identifier
+          (id : Identifier.Path.ModuleType.t :> Identifier.t)
+          (t : t :> Paths_types.Resolved_path.any)
+    end
+
+    module Type = struct
+
+      type t = Paths_types.Resolved_path.type_
+
+      let of_ident id = `Identifier id
+
+      let equal m1 m2 = equal_resolved_path (m1 : t :> Paths_types.Resolved_path.any) (m2 : t :> Paths_types.Resolved_path.any)
+
+      let hash m = hash (m : t :> Paths_types.Resolved_path.any)
+
+      let is_hidden m = is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
+
+      let identifier = function
+        | `Identifier id -> id
+        | `Type(m, n) -> `Type(parent_module_identifier m, n)
+        | `Class(m, n) -> `Class(parent_module_identifier m, n)
+        | `ClassType(m, n) -> `ClassType(parent_module_identifier m, n)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `Type (mp, s) ->
+          begin match rebase_module_path new_base mp with
+            | Continue (id, _) ->
+              `Identifier (`Type (Identifier.signature_of_module id, s))
+            | Stop mp' -> `Type (mp', s)
+          end
+        | `Class (mp, s) ->
+          begin match rebase_module_path new_base mp with
+            | Continue (id, _) ->
+              `Identifier (`Class (Identifier.signature_of_module id, s))
+            | Stop mp' -> `Class (mp', s)
+          end
+        | `ClassType (mp, s) ->
+          begin match rebase_module_path new_base mp with
+            | Continue (id, _) ->
+              `Identifier (`ClassType (Identifier.signature_of_module id, s))
+            | Stop mp' -> `ClassType (mp', s)
+          end
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+
+      let equal_identifier :
+        Identifier.Path.Type.t -> t -> bool =
+        fun id t ->
+        equal_identifier
+          (id : Identifier.Path.Type.t :> Identifier.t)
+          (t : t :> Paths_types.Resolved_path.any)
+
+    end
+
+    module ClassType = struct
+
+      type t = Paths_types.Resolved_path.class_type
+
+      let of_ident id = `Identifier id
+
+      let equal m1 m2 = equal_resolved_path (m1 : t :> Paths_types.Resolved_path.any) (m2 : t :> Paths_types.Resolved_path.any)
+
+      let hash m = hash (m : t :> Paths_types.Resolved_path.any)
+
+      let is_hidden m = is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
+
+      let identifier = function
+        | `Identifier id -> id
+        | `Class(m, n) -> `Class(parent_module_identifier m, n)
+        | `ClassType(m, n) -> `ClassType(parent_module_identifier m, n)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `Class (mp, s) ->
+          begin match rebase_module_path new_base mp with
+            | Continue (id, _) ->
+              `Identifier (`Class (Identifier.signature_of_module id, s))
+            | Stop mp' -> `Class (mp', s)
+          end
+        | `ClassType (mp, s) ->
+          begin match rebase_module_path new_base mp with
+            | Continue (id, _) ->
+              `Identifier (`ClassType (Identifier.signature_of_module id, s))
+            | Stop mp' -> `ClassType (mp', s)
+          end
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+
+      let equal_identifier :
+        Identifier.Path.ClassType.t -> t -> bool =
+        fun id t ->
+        equal_identifier
+          (id : Identifier.Path.ClassType.t :> Identifier.t)
+          (t : t :> Paths_types.Resolved_path.any)
+    end
+
+    let module_of_t : t -> Module.t = function
+        | `Identifier (#Identifier.Path.Module.t)
+        | #Paths_types.Resolved_path.module_no_id as x -> x
+        | _ -> assert false
+
+    let module_type_of_t : t -> ModuleType.t = function
+        | `Identifier (#Identifier.Path.ModuleType.t)
+        | #Paths_types.Resolved_path.module_type_no_id as x -> x
+        | _ -> assert false
+
+    let type_of_t : t -> Type.t = function
+        | `Identifier (#Identifier.Path.Type.t)
+        | #Paths_types.Resolved_path.type_no_id as x -> x
+        | _ -> assert false
+
+    let class_type_of_t : t -> ClassType.t = function
+        | `Identifier (#Identifier.Path.ClassType.t)
+        | #Paths_types.Resolved_path.class_type_no_id as x -> x
+        | _ -> assert false
 
 
-    let is_hidden = is_resolved_hidden
+    let rec identifier : t -> Identifier.t = function
+      | `Identifier id -> id
+      | `Subst(_, p) -> identifier (p :> t)
+      | `SubstAlias(_, p) -> identifier (p :> t)
+      | `Hidden p -> identifier (p :> t)
+      | `Module(m, n) -> `Module(parent_module_identifier m, n)
+      | `Canonical(_, `Resolved p) -> identifier (p :> t)
+      | `Canonical(p, _) -> identifier (p :> t)
+      | `Apply(m, _) -> identifier (m :> t)
+      | `Type(m, n) -> `Type(parent_module_identifier m, n)
+      | `ModuleType(m, n) -> `ModuleType(parent_module_identifier m, n)
+      | `Class(m, n) -> `Class(parent_module_identifier m, n)
+      | `ClassType(m, n) -> `ClassType(parent_module_identifier m, n)
+
   end
 
-  open Identifier
-  open Resolved
+  module Module =
+  struct
+    type t = Paths_types.Path.module_
 
-  include Types.Path
+    let equal : t -> t -> bool =
+      fun p1 p2 ->
+      equal_path (p1 : t :> Paths_types.Path.any) (p2 : t :> Paths_types.Path.any)
 
-  let ident_module : Identifier.module_ -> _ = function
-    | Root _ | Module _ | Argument _ as x -> Resolved (Identifier x)
+    let hash : t -> int =
+      fun t ->
+      hash_path (t : t :> Paths_types.Path.any)
 
-  let ident_module_type : Identifier.module_type -> _ = function
-    | ModuleType _ as x -> Resolved (Identifier x)
+    let is_hidden : t -> bool =
+      fun t ->
+      is_path_hidden (t : t :> Paths_types.Path.any)
+  end
 
-  let ident_type : Identifier.type_ -> _ = function
-    | Type _ | CoreType _ as x -> Resolved (Identifier x)
+  module ModuleType =
+  struct
+    type t = Paths_types.Path.module_type
 
-  let ident_class : Identifier.class_ -> _ = function
-    | Class _ as x -> Resolved (Identifier x)
+    let equal : t -> t -> bool =
+      fun p1 p2 ->
+      equal_path (p1 : t :> Paths_types.Path.any) (p2 : t :> Paths_types.Path.any)
 
-  let ident_class_type : Identifier.class_type -> _ = function
-    | ClassType _ as x -> Resolved (Identifier x)
+    let hash : t -> int =
+      fun t ->
+      hash_path (t : t :> Paths_types.Path.any)
 
-  let any : type k. k t -> any = function
-    | Resolved (Identifier (Root _)) as x -> x
-    | Resolved (Identifier (Module _)) as x -> x
-    | Resolved (Identifier (Argument _)) as x -> x
-    | Resolved (Identifier (ModuleType _)) as x -> x
-    | Resolved (Identifier (Type _)) as x -> x
-    | Resolved (Identifier (CoreType _)) as x -> x
-    | Resolved (Identifier (Class _)) as x -> x
-    | Resolved (Identifier (ClassType _)) as x -> x
-    | Resolved (Hidden _) as x -> x
-    | Resolved (Module _) as x -> x
-    | Resolved (Canonical _) as x -> x
-    | Resolved (Apply _) as x -> x
-    | Resolved (ModuleType _) as x -> x
-    | Resolved (Type _) as x -> x
-    | Resolved (Class _) as x -> x
-    | Resolved (ClassType _) as x -> x
-    | Resolved (Subst _) as x -> x
-    | Resolved (SubstAlias _) as x -> x
-    | Root _ as x -> x
-    | Forward _ as x -> x
-    | Dot _ as x -> x
-    | Apply _ as x -> x
+    let is_hidden : t -> bool =
+      fun t ->
+      is_path_hidden (t : t :> Paths_types.Path.any)
+  end
 
-  let module_ p name =
+  module Type =
+  struct
+    type t = Paths_types.Path.type_
+
+    let equal : t -> t -> bool =
+      fun p1 p2 ->
+      equal_path (p1 : t :> Paths_types.Path.any) (p2 : t :> Paths_types.Path.any)
+
+    let hash : t -> int =
+      fun t ->
+      hash_path (t : t :> Paths_types.Path.any)
+
+    let is_hidden : t -> bool =
+      fun t ->
+      is_path_hidden (t : t :> Paths_types.Path.any)
+  end
+
+  module ClassType =
+  struct
+    type t = Paths_types.Path.class_type
+
+    let equal : t -> t -> bool =
+      fun p1 p2 ->
+      equal_path (p1 : t :> Paths_types.Path.any) (p2 : t :> Paths_types.Path.any)
+
+    let hash : t -> int =
+      fun t ->
+      hash_path (t : t :> Paths_types.Path.any)
+
+    let is_hidden : t -> bool =
+      fun t ->
+      is_path_hidden (t : t :> Paths_types.Path.any)
+  end
+
+  let module_of_t : t -> Module.t = function
+    | `Resolved (`Identifier (#Paths_types.Identifier.path_module))
+    | `Resolved (#Paths_types.Resolved_path.module_no_id)
+    | `Root _
+    | `Forward _
+    | `Dot (_,_)
+    | `Apply (_,_) as x -> x
+    | _ -> assert false
+
+  let module_type_of_t : t -> ModuleType.t = function
+    | `Resolved (`Identifier (#Paths_types.Identifier.path_module_type))
+    | `Resolved (#Paths_types.Resolved_path.module_type_no_id)
+    | `Dot (_,_) as x -> x
+    | _ -> assert false
+
+  let type_of_t : t -> Type.t = function
+    | `Resolved (`Identifier (#Paths_types.Identifier.path_type))
+    | `Resolved (#Paths_types.Resolved_path.type_no_id)
+    | `Dot (_,_) as x -> x
+    | _ -> assert false
+
+  let class_type_of_t : t -> ClassType.t = function
+    | `Resolved (`Identifier (#Paths_types.Identifier.path_class_type))
+    | `Resolved (#Paths_types.Resolved_path.class_type_no_id)
+    | `Dot (_,_) as x -> x
+    | _ -> assert false
+
+  let module_ : Module.t -> ModuleName.t -> Module.t = fun p name ->
     match p with
-    | Resolved p -> Resolved (Module(p, name))
-    | p -> Dot(p, name)
+    | `Resolved p -> `Resolved (`Module(p, name))
+    | p -> `Dot(p, ModuleName.to_string name)
 
   let apply p arg =
     match p with
-    | Resolved p -> Resolved (Apply(p, arg))
-    | p -> Apply(p, arg)
+    | `Resolved p -> `Resolved (`Apply(p, arg))
+    | p -> `Apply(p, arg)
 
   let module_type p name =
     match p with
-    | Resolved p -> Resolved (ModuleType(p, name))
-    | p -> Dot(p, name)
-
-  let type_ p name =
-    match p with
-    | Resolved p -> Resolved (Type(p, name))
-    | p -> Dot(p, name)
-
-  let class_ p name =
-    match p with
-    | Resolved p -> Resolved (Class(p, name))
-    | p -> Dot(p, name)
-
-  let class_type_ p name =
-    match p with
-    | Resolved p -> Resolved (ClassType(p, name))
-    | p -> Dot(p, name)
-
-  let type_of_class_type : class_type -> type_ = function
-    | Resolved (Identifier (Class _)) as x -> x
-    | Resolved (Identifier (ClassType _)) as x -> x
-    | Resolved (Class _) as x -> x
-    | Resolved (ClassType _) as x -> x
-    | Dot _ as x -> x
+    | `Resolved p -> `Resolved (`ModuleType(p, name))
+    | p -> `Dot(p, ModuleTypeName.to_string name)
 
   let is_hidden = is_path_hidden
+
+  let equal = equal_path
+
+  let hash = hash_path
 end
 
 
@@ -673,999 +1087,1735 @@ module Fragment = struct
 
   module Resolved = struct
 
-    include Paths_types.Resolved_fragment
+    type t = Paths_types.Resolved_fragment.any
 
-    let signature_of_module : module_ -> signature = function
-      | Subst _ | SubstAlias _ | Module _ as x -> x
+    let t_of_module m = (m : Paths_types.Resolved_fragment.module_ :> t)
+    let t_of_signature s = (s : Paths_types.Resolved_fragment.signature :> t)
 
-    let any_sort : type b c. (b, c) raw -> (b, sort) raw =
+    let equal p1 p2 =
+      let rec loop : t -> t -> bool =
+        fun p1 p2 ->
+          match p1, p2 with
+          | `Root, `Root -> true
+          | `Subst(sub1, p1), `Subst(sub2, p2) ->
+            Path.Resolved.ModuleType.equal sub1 sub2
+            && loop (t_of_module p1) (t_of_module p2)
+          | `SubstAlias(sub1, p1), `SubstAlias(sub2, p2) ->
+            Path.Resolved.Module.equal sub1 sub2
+            && loop (t_of_module p1) (t_of_module p2)
+          | `Module(p1, s1), `Module(p2, s2) ->
+            s1 = s2 && loop (t_of_signature p1) (t_of_signature p2)
+          | `Type(p1, s1), `Type(p2, s2) ->
+            s1 = s2 && loop (t_of_signature p1) (t_of_signature p2)
+          | `Class(p1, s1), `Class(p2, s2) ->
+            s1 = s2 && loop (t_of_signature p1) (t_of_signature p2)
+          | `ClassType(p1, s1), `ClassType(p2, s2) ->
+            s1 = s2 && loop (t_of_signature p1) (t_of_signature p2)
+          | _, _ -> false
+      in
+      loop p1 p2
+
+    let hash p =
+      let rec loop : t -> int =
+        fun p ->
+          match p with
+          | `Root -> Hashtbl.hash 32
+          | `Subst(sub, p) ->
+            Hashtbl.hash (34, Path.Resolved.ModuleType.hash sub, loop (t_of_module p))
+          | `SubstAlias(sub, p) ->
+            Hashtbl.hash (35, Path.Resolved.Module.hash sub, loop (t_of_module p))
+          | `Module(p, s) ->
+            Hashtbl.hash (36, loop (t_of_signature p), s)
+          | `Type(p, s) ->
+            Hashtbl.hash (37, loop (t_of_signature p), s)
+          | `Class(p, s) ->
+            Hashtbl.hash (38, loop (t_of_signature p), s)
+          | `ClassType(p, s) ->
+            Hashtbl.hash (39, loop (t_of_signature p), s)
+      in
+      loop p
+
+    let sig_of_mod m =
+      let open Paths_types.Resolved_fragment in 
+      (m : module_ :> signature)
+
+    let rec parent_resolved_path : Path.Resolved.Module.t -> Paths_types.Resolved_fragment.signature -> Path.Resolved.Module.t = fun root -> 
       function
-      | Root as x -> x
-      | Subst _ as x -> x
-      | SubstAlias _ as x -> x
-      | Module (_,_) as x -> x
-      | Type (_,_) as x -> x
-      | Class (_,_) as x -> x
-      | ClassType (_,_) as x -> x
+      | `Root -> root
+      | `Subst(sub, p) ->
+        `Subst(sub, parent_resolved_path root (sig_of_mod p))
+      | `SubstAlias(sub, p) ->
+        `SubstAlias(sub, parent_resolved_path root (sig_of_mod p))
+      | `Module(m, n) ->
+        `Module(parent_resolved_path root m, n)
 
-    let open_sort : module_ -> (Kind.fragment_module, [< sort > `Branch ]) raw =
-      function
-      | Module _ | Subst _ | SubstAlias _ as x -> x
-
-    let open_module : module_ -> ([< kind > `Module ]) t =
-      function
-      | Module _ | Subst _ | SubstAlias _ as x -> x
-
-    let any : type k. k t -> any = function
-      | Subst _ as x -> x
-      | SubstAlias _ as x -> x
-      | Module _ as x -> x
-      | Type _ as x -> x
-      | Class _ as x -> x
-      | ClassType _ as x -> x
-
-    let rec parent_resolved_path root = function
-      | Root -> root
-      | Subst(sub, p) ->
-          Path.Resolved.Subst(sub, parent_resolved_path root (open_sort p))
-      | SubstAlias(sub, p) ->
-          Path.Resolved.SubstAlias(sub, parent_resolved_path root (open_sort p))
-      | Module(m, n) ->
-          Path.Resolved.Module(parent_resolved_path root m, n)
-
-    let rec resolved_path
-        : type k. Path.Resolved.module_ ->
-               k t -> k Path.Resolved.t =
-      fun root frag ->
-        match frag with
-        | Subst(sub, p) ->
-            Path.Resolved.Subst(sub, resolved_path root p)
-        | SubstAlias(sub, p) ->
-            Path.Resolved.SubstAlias(sub, resolved_path root p)
-        | Module(m, n) ->
-            Path.Resolved.Module(parent_resolved_path root m, n)
-        | Type( m, n) ->
-            Path.Resolved.Type(parent_resolved_path root m, n)
-        | Class( m, n) ->
-            Path.Resolved.Class(parent_resolved_path root m, n)
-        | ClassType( m, n) ->
-            Path.Resolved.ClassType(parent_resolved_path root m, n)
-
-    let rec parent_unresolved_path root = function
-      | Root -> root
-      | Subst(_, p) -> parent_unresolved_path root (open_sort p)
-      | SubstAlias(_, p) -> parent_unresolved_path root (open_sort p)
-      | Module(m, n) -> Path.Dot(parent_unresolved_path root m, n)
-
-    let rec unresolved_path
-        : type k. Path.module_ -> k t -> k Path.t =
-      fun root -> function
-        | Subst(_, p) -> unresolved_path root (open_module p)
-        | SubstAlias(_, p) -> unresolved_path root (open_module p)
-        | Module(m, n) -> Path.Dot(parent_unresolved_path root m, n)
-        | Type( m, n) -> Path.Dot(parent_unresolved_path root m, n)
-        | Class( m, n) -> Path.Dot(parent_unresolved_path root m, n)
-        | ClassType( m, n) -> Path.Dot(parent_unresolved_path root m, n)
+    let rec parent_unresolved_path : Path.Module.t -> Paths_types.Resolved_fragment.signature -> Path.Module.t = fun root -> function
+      | `Root -> root
+      | `Subst(_, p) -> parent_unresolved_path root (sig_of_mod p)
+      | `SubstAlias(_, p) -> parent_unresolved_path root (sig_of_mod p)
+      | `Module(m, n) -> `Dot(parent_unresolved_path root m, (ModuleName.to_string n))
 
     let parent_path root frag =
       match root with
-      | Path.Resolved root -> Path.Resolved (parent_resolved_path root frag)
+      | `Resolved root -> `Resolved (parent_resolved_path root frag)
       | _ -> parent_unresolved_path root frag
 
-    let path (root : Path.module_) frag =
-      match root with
-      | Path.Resolved root -> Path.Resolved (resolved_path root frag)
-      | _ -> unresolved_path root frag
+    type base_name =
+      | Base
+      | Branch of ModuleName.t * Paths_types.Resolved_fragment.signature
 
-    let rec parent_identifier root = function
-      | Root -> root
-      | Subst(sub, _) -> Path.Resolved.parent_module_type_identifier sub
-      | SubstAlias(sub, _) -> Path.Resolved.parent_module_identifier sub
-      | Module(m, n) -> Identifier.Module(parent_identifier root m, n)
+    let rec split_parent : Paths_types.Resolved_fragment.signature -> base_name = function
+      | `Root -> Base
+      | `Subst(_, p) -> split_parent (sig_of_mod p)
+      | `SubstAlias(_, p) -> split_parent (sig_of_mod p)
+      | `Module(p, name) ->
+        match split_parent p with
+        | Base -> Branch(name, `Root)
+        | Branch(base, m) -> Branch(base, `Module(m, name))
 
-    let rec identifier :
-      type k. Identifier.signature -> k t -> k Identifier.t =
-        fun root -> function
-          | Subst(_, p) -> identifier root (open_module p)
-          | SubstAlias(_, p) -> identifier root (open_module p)
-          | Module(m, n) -> Identifier.Module(parent_identifier root m, n)
-          | Type(m, n) -> Identifier.Type(parent_identifier root m, n)
-          | Class(m, n) -> Identifier.Class(parent_identifier root m, n)
-          | ClassType(m, n) ->
-              Identifier.ClassType(parent_identifier root m, n)
 
-    type ('a, 'b) base_name =
-      | Base : ('a, [< sort > `Root]) base_name
-      | Branch : string * signature -> ('a, [< sort > `Branch]) base_name
+    module Signature =
+    struct
+      type t = Paths_types.Resolved_fragment.signature
 
-    let rec split_parent
-            : type s . (fragment_module, s) raw -> ('a, s) base_name =
-      function
-        | Root -> Base
-        | Subst(_, p) -> split_parent (open_sort p)
-        | SubstAlias(_, p) -> split_parent (open_sort p)
-        | Module(m, name) ->
+      let equal s1 s2 =
+        equal (s1 : t :> Paths_types.Resolved_fragment.any) (s2 : t :> Paths_types.Resolved_fragment.any)
+
+      let hash s =
+        hash (s : t :> Paths_types.Resolved_fragment.any)
+
+      let rec resolved_path : Path.Resolved.Module.t -> t -> Path.Resolved.Module.t =
+        fun root frag ->
+        match frag with
+        | `Root -> root
+        | `Subst(sub, p) ->
+          `Subst(sub, resolved_path root (sig_of_mod p))
+        | `SubstAlias(sub, p) ->
+          `SubstAlias(sub, resolved_path root (sig_of_mod p))
+        | `Module(m, n) ->
+          `Module(parent_resolved_path root m, n)
+
+      let rec unresolved_path : Path.Module.t -> t -> Path.Module.t =
+        fun root frag ->
+        match frag with
+        | `Root -> root
+        | `Subst(_, p) -> unresolved_path root (sig_of_mod p)
+        | `SubstAlias(_, p) -> unresolved_path root (sig_of_mod p)
+        | `Module(m, n) -> `Dot(parent_unresolved_path root m, ModuleName.to_string n)
+
+      let path : Path.Module.t -> t -> Path.Module.t =
+        fun root frag ->
+        match root with
+        | `Resolved root -> `Resolved (resolved_path root frag)
+        | _ -> unresolved_path root frag
+
+      let rec split : t -> string * t option = function
+        | `Root -> "", None
+        | `Subst(_,p) -> split (sig_of_mod p)
+        | `SubstAlias(_,p) -> split (sig_of_mod p)
+        | `Module (m, name) -> begin
             match split_parent m with
-            | Base -> Branch(name, Root)
-            | Branch(base, m) -> Branch(base, Module(m, name))
+            | Base -> (ModuleName.to_string name, None)
+            | Branch(base,m) -> ModuleName.to_string base, Some (`Module(m,name))
+          end
 
-    let rec split : type k . k t -> string * k t option = function
-      | Subst(_, p) -> split (open_module p)
-      | SubstAlias(_, p) -> split (open_module p)
-      | Module(m, name) -> begin
-          match split_parent m with
-          | Base -> name, None
-          | Branch(base, m)-> base, Some (Module(m, name))
-        end
-      | Type(m, name) -> begin
-          match split_parent m with
-          | Base -> name, None
-          | Branch(base, m)-> base, Some (Type(m, name))
-        end
-      | Class(m, name) -> begin
-          match split_parent m with
-          | Base -> name, None
-          | Branch(base, m)-> base, Some (Class(m, name))
-        end
-      | ClassType(m, name) -> begin
-          match split_parent m with
-          | Base -> name, None
-          | Branch(base, m)-> base, Some (ClassType(m, name))
-        end
+      let rec identifier : Identifier.Signature.t -> t -> Identifier.Signature.t =
+        fun root -> function
+          | `Root -> root
+          | `Subst(_, p) -> identifier root (sig_of_mod p)
+          | `SubstAlias(_, p) -> identifier root (sig_of_mod p)
+          | `Module(m, n) -> `Module (identifier root m, n)
 
-    let equal p1 p2 =
-      let rec loop : type k s. (k, s) raw -> (k, s) raw -> bool =
-        fun p1 p2 ->
-          match p1, p2 with
-          | Root, Root -> true
-          | Subst(sub1, p1), Subst(sub2, p2) ->
-              Path.Resolved.equal sub1 sub2
-              && loop p1 p2
-          | SubstAlias(sub1, p1), SubstAlias(sub2, p2) ->
-              Path.Resolved.equal sub1 sub2
-              && loop p1 p2
-          | Module(p1, s1), Module(p2, s2) ->
-              s1 = s2 && loop p1 p2
-          | Type(p1, s1), Type(p2, s2) ->
-              s1 = s2 && loop p1 p2
-          | Class(p1, s1), Class(p2, s2) ->
-              s1 = s2 && loop p1 p2
-          | ClassType(p1, s1), ClassType(p2, s2) ->
-              s1 = s2 && loop p1 p2
-          | _, _ -> false
-      in
-        loop p1 p2
+    end
 
-    let hash p =
-      let rec loop : type k s. (k, s) raw -> int =
-        fun p ->
-          match p with
-          | Root -> Hashtbl.hash 32
-          | Subst(sub, p) ->
-              Hashtbl.hash (34, Path.Resolved.hash sub, loop p)
-          | SubstAlias(sub, p) ->
-              Hashtbl.hash (35, Path.Resolved.hash sub, loop p)
-          | Module(p, s) ->
-              Hashtbl.hash (36, loop p, s)
-          | Type(p, s) ->
-              Hashtbl.hash (37, loop p, s)
-          | Class(p, s) ->
-              Hashtbl.hash (38, loop p, s)
-          | ClassType(p, s) ->
-              Hashtbl.hash (39, loop p, s)
-      in
-        loop p
+    module Module =
+    struct
+      type t = Paths_types.Resolved_fragment.module_
+
+      let equal s1 s2 =
+        equal (s1 : t :> Paths_types.Resolved_fragment.any) (s2 : t :> Paths_types.Resolved_fragment.any)
+
+      let hash s =
+        hash (s : t :> Paths_types.Resolved_fragment.any)
+
+      let resolved_path : Path.Resolved.Module.t -> t -> Path.Resolved.Module.t =
+        fun root frag ->
+        match frag with
+        | `Subst(sub, p) ->
+          `Subst(sub, Signature.resolved_path root (sig_of_mod p))
+        | `SubstAlias(sub, p) ->
+          `SubstAlias(sub, Signature.resolved_path root (sig_of_mod p))
+        | `Module(m, n) ->
+          `Module(parent_resolved_path root m, n)
+
+      let unresolved_path : Path.Module.t -> t -> Path.Module.t =
+        fun root frag ->
+        match frag with
+        | `Subst(_, p) -> Signature.unresolved_path root (sig_of_mod p)
+        | `SubstAlias(_, p) -> Signature.unresolved_path root (sig_of_mod p)
+        | `Module(m, n) -> `Dot(parent_unresolved_path root m, ModuleName.to_string n)
+
+      let path : Path.Module.t -> t -> Path.Module.t =
+        fun root frag ->
+        match root with
+        | `Resolved root -> `Resolved (resolved_path root frag)
+        | _ -> unresolved_path root frag
+
+      let rec split : t -> string * t option = function
+        | `Subst(_,p) -> split p
+        | `SubstAlias(_,p) -> split p
+        | `Module (m, name) -> begin
+            match split_parent m with
+            | Base -> (ModuleName.to_string name, None)
+            | Branch(base,m) -> ModuleName.to_string base, Some (`Module(m,name))
+          end
+
+      let rec identifier : Identifier.Signature.t -> t -> Identifier.Path.Module.t =
+        fun root -> function
+          | `Subst(_, p) -> identifier root p
+          | `SubstAlias(_, p) -> identifier root p
+          | `Module(m, n) -> `Module (Signature.identifier root m, n)
+
+    end
+
+    module Type =
+    struct
+      type t = Paths_types.Resolved_fragment.type_
+
+      let equal s1 s2 =
+        equal (s1 : t :> Paths_types.Resolved_fragment.any) (s2 : t :> Paths_types.Resolved_fragment.any)
+
+      let hash s =
+        hash (s : t :> Paths_types.Resolved_fragment.any)
+
+      let resolved_path : Path.Resolved.Module.t -> t -> Path.Resolved.Type.t = fun root ->
+        function
+        | `Type(m,n) -> `Type (Signature.resolved_path root m, n)
+        | `Class(m,n) -> `Class (Signature.resolved_path root m, n)
+        | `ClassType(m,n) -> `ClassType (Signature.resolved_path root m, n)
+
+      let unresolved_path : Path.Module.t -> t -> Path.Type.t = fun root ->
+        function
+        | `Type(m,n) -> `Dot (Signature.unresolved_path root m, TypeName.to_string n)
+        | `Class(m,n) -> `Dot (Signature.unresolved_path root m, ClassName.to_string n)
+        | `ClassType(m,n) -> `Dot (Signature.unresolved_path root m, ClassTypeName.to_string n)
+
+      let path :  Path.Module.t -> t -> Path.Type.t = fun root frag ->
+        match root with
+        | `Resolved root -> `Resolved (resolved_path root frag)
+        | _ -> unresolved_path root frag
+
+      let split : t -> string * t option =
+        function
+        | `Type (m,name) -> begin
+            match split_parent m with
+            | Base -> TypeName.to_string name, None
+            | Branch(base, m) -> ModuleName.to_string base, Some (`Type(m, name))
+          end
+        | `Class(m, name) -> begin
+            match split_parent m with
+            | Base -> ClassName.to_string name, None
+            | Branch(base, m) -> ModuleName.to_string base, Some (`Class(m, name))
+          end
+        | `ClassType(m, name) -> begin
+            match split_parent m with
+            | Base -> ClassTypeName.to_string name, None
+            | Branch(base, m) -> ModuleName.to_string base, Some (`ClassType(m, name))
+          end
+
+      let identifier : Identifier.Signature.t -> t -> Identifier.Path.Type.t =
+        fun root -> function
+          | `Type(m, n) -> `Type(Signature.identifier root m, n)
+          | `Class(m, n) -> `Class(Signature.identifier root m, n)
+          | `ClassType(m, n) -> `ClassType(Signature.identifier root m, n)
+
+    end
+
+    let signature_of_t : t -> Signature.t = function
+      | #Signature.t as x -> x
+      | _ -> assert false
+
+    let module_of_t : t -> Module.t = function
+      | #Module.t as x -> x
+      | _ -> assert false
+
+    let type_of_t : t -> Type.t = function
+      | #Type.t as x -> x
+      | _ -> assert false
+
+    let rec identifier : Identifier.Signature.t -> t -> Identifier.t =
+      fun root -> function
+        | `Root -> (root :> Identifier.t)
+        | `Subst(_, p) -> identifier root (p :> t)
+        | `SubstAlias(_, p) -> identifier root (p :> t)
+        | `Module(m, n) -> `Module (Signature.identifier root m, n)
+        | `Type(m, n) -> `Type(Signature.identifier root m, n)
+        | `Class(m, n) -> `Class(Signature.identifier root m, n)
+        | `ClassType(m, n) -> `ClassType(Signature.identifier root m, n)
+
 
   end
 
-  open Resolved
+  type t = Paths_types.Fragment.any
 
-  include Paths_types.Fragment
+  let rec parent_path : Path.Module.t -> Paths_types.Fragment.signature -> Path.Module.t = fun root -> function
+    | `Resolved r -> Resolved.parent_path root r
+    | `Dot(m, n) -> `Dot(parent_path root m, n)
 
-  let signature_of_module : module_ -> signature = function
-    | Resolved(Subst _ | SubstAlias _ | Module _) | Dot _ as x -> x
+  type base_name =
+    | Base
+    | Branch of ModuleName.t * Paths_types.Fragment.signature
 
-  let any_sort : type b c. (b, c) raw -> (b, sort) raw = function
-    | Resolved r -> Resolved (any_sort r)
-    | Dot _ as x -> x
-
-  let any : type k. k t -> any = function
-    | Resolved (Subst _) as x -> x
-    | Resolved (SubstAlias _) as x -> x
-    | Resolved (Module _) as x -> x
-    | Resolved (Type _) as x -> x
-    | Resolved (Class _) as x -> x
-    | Resolved (ClassType _) as x -> x
-    | Dot _ as x -> x
-
-  let rec parent_path root = function
-    | Resolved r -> Resolved.parent_path root r
-    | Dot(m, n) -> Path.Dot(parent_path root m, n)
-
-  let path : type k. Path.module_ -> k t -> k Path.t =
-   fun root -> function
-    | Resolved r -> Resolved.path root r
-    | Dot(m, s) -> Path.Dot(parent_path root m, s)
-
-  type ('a, 'b) base_name =
-    | Base : ('a, [< sort > `Root]) base_name
-    | Branch : string * signature -> ('a, [< sort > `Branch]) base_name
-
-  let rec split_parent
-          : type s . (fragment_module, s) raw -> ('a, s) base_name =
+  let rec split_parent : Paths_types.Fragment.signature -> base_name =
     function
-      | Resolved r -> begin
-          match Resolved.split_parent r with
-          | Base -> Base
-          | Branch(base, m) -> Branch(base, Resolved m)
-        end
-      | Dot(m, name) -> begin
-          match split_parent m with
-          | Base -> Branch(name, Resolved Root)
-          | Branch(base, m) -> Branch(base, Dot(m, name))
-        end
+    | `Resolved r -> begin
+        match Resolved.split_parent r with
+        | Resolved.Base -> Base
+        | Resolved.Branch(base, m) -> Branch(base, `Resolved m)
+      end
+    | `Dot(m,name) -> begin
+        match split_parent m with
+        | Base -> Branch(ModuleName.of_string name,`Resolved `Root)
+        | Branch(base,m) -> Branch(base, `Dot(m,name))
+      end
 
-  let split : type k . k t -> string * k t option = function
-    | Resolved r ->
-        let base, m = Resolved.split r in
+  let equal p1 p2 =
+    let rec loop : t -> t -> bool =
+      fun p1 p2 ->
+        match p1, p2 with
+        | `Resolved p1, `Resolved p2 ->
+          Resolved.equal p1 p2
+        | `Dot(p1, s1), `Dot(p2, s2) ->
+          s1 = s2 && loop (p1 : Paths_types.Fragment.signature :> t) (p2 : Paths_types.Fragment.signature :> t)
+        | _, _ -> false
+    in
+    loop p1 p2
+
+  let hash p =
+    let rec loop : t -> int =
+      fun p ->
+        match p with
+        | `Resolved p -> Resolved.hash p
+        | `Dot(p, s) ->
+          Hashtbl.hash (40, loop (p : Paths_types.Fragment.signature :> t), s)
+    in
+    loop p
+
+  module Signature = struct
+    type t = Paths_types.Fragment.signature
+
+    let equal t1 t2 =
+      equal (t1 : t :> Paths_types.Fragment.any) (t2 : t :> Paths_types.Fragment.any)
+
+    let hash t =
+      hash (t : t :> Paths_types.Fragment.any)
+
+    let split : t -> string * t option = function
+      | `Resolved r ->
+        let base, m = Resolved.Signature.split r in
         let m =
           match m with
           | None -> None
-          | Some m -> Some (Resolved m)
+          | Some m -> Some (`Resolved m)
         in
-          base, m
-    | Dot(m, name) ->
+        base, m
+      | `Dot(m, name) ->
         match split_parent m with
         | Base -> name, None
-        | Branch(base, m) -> base, Some(Dot(m, name))
+        | Branch(base, m) -> ModuleName.to_string base, Some(`Dot(m, name))
 
-  let equal p1 p2 =
-    let rec loop : type k s. (k, s) raw -> (k, s) raw -> bool =
-      fun p1 p2 ->
-        match p1, p2 with
-        | Resolved p1, Resolved p2 ->
-            Resolved.equal p1 p2
-        | Dot(p1, s1), Dot(p2, s2) ->
-            s1 = s2 && loop p1 p2
-        | _, _ -> false
-    in
-      loop p1 p2
+    let path : Path.Module.t -> t -> Path.Module.t =
+      fun root -> function
+        | `Resolved r -> Resolved.Signature.path root r
+        | `Dot(m, s) -> `Dot(parent_path root m, s)
 
-  let hash p =
-    let rec loop : type k s. (k, s) raw -> int =
-      fun p ->
-        match p with
-        | Resolved p -> Resolved.hash p
-        | Dot(p, s) ->
-            Hashtbl.hash (40, loop p, s)
-    in
-      loop p
+  end
+
+  module Module = struct
+    type t = Paths_types.Fragment.module_
+
+    let equal t1 t2 =
+      equal (t1 : t :> Paths_types.Fragment.any) (t2 : t :> Paths_types.Fragment.any)
+
+    let hash t =
+      hash (t : t :> Paths_types.Fragment.any)
+
+    let split : t -> string * t option = function
+      | `Resolved r ->
+        let base, m = Resolved.Module.split r in
+        let m =
+          match m with
+          | None -> None
+          | Some m -> Some (`Resolved m)
+        in
+        base, m
+      | `Dot(m, name) ->
+        match split_parent m with
+        | Base -> name, None
+        | Branch(base, m) -> ModuleName.to_string base, Some(`Dot(m, name))
+
+    let path : Path.Module.t -> t -> Path.Module.t =
+      fun root -> function
+        | `Resolved r -> Resolved.Module.path root r
+        | `Dot(m, s) -> `Dot(parent_path root m, s)
+  end
+
+  module Type = struct
+    type t = Paths_types.Fragment.type_
+
+    let equal t1 t2 =
+      equal (t1 : t :> Paths_types.Fragment.any) (t2 : t :> Paths_types.Fragment.any)
+
+    let hash t =
+      hash (t : t :> Paths_types.Fragment.any)
+
+    let split : t -> string * t option = function
+      | `Resolved r ->
+        let base, m = Resolved.Type.split r in
+        let m =
+          match m with
+          | None -> None
+          | Some m -> Some (`Resolved m)
+        in
+        base, m
+      | `Dot(m, name) ->
+        match split_parent m with
+        | Base -> name, None
+        | Branch(base, m) -> ModuleName.to_string base, Some(`Dot(m, name))
+
+    let path : Path.Module.t -> t -> Path.Type.t =
+      fun root -> function
+        | `Resolved r -> Resolved.Type.path root r
+        | `Dot(m, s) -> `Dot(parent_path root m, s)
+
+  end
+
+  let signature_of_t : t -> Signature.t = function
+    | `Resolved (#Resolved.Signature.t) 
+    | `Dot (_,_) as x -> x
+    | _ -> assert false
+
+  let module_of_t : t -> Module.t = function
+    | `Resolved (#Resolved.Module.t) 
+    | `Dot (_,_) as x -> x
+    | _ -> assert false
+
+  let type_of_t : t -> Type.t = function
+    | `Resolved (#Resolved.Type.t) 
+    | `Dot (_,_) as x -> x
+    | _ -> assert false
 
 end
 
+
 module Reference = struct
-  module rec Types : sig
-    module Resolved = Paths_types.Resolved_reference
 
-    module Reference = Paths_types.Reference
-  end = Types
-
-  let rec hash_resolved : type k. k Types.Resolved.t -> int =
+  let rec hash_resolved : Paths_types.Resolved_reference.any -> int =
     fun p ->
-      let open Types.Resolved in
+      let open Paths_types.Resolved_reference in
       match p with
-      | Identifier id ->
+      | `Identifier id ->
         Identifier.hash id
-      | SubstAlias (r1, r2) ->
-        Hashtbl.hash (41, Path.Resolved.hash r1, hash_resolved r2)
-      | Module(p, s) ->
-        Hashtbl.hash (42, hash_resolved p, s)
-      | Canonical (rp, p) ->
-        Hashtbl.hash (43, hash_resolved rp, hash_reference p)
-      | ModuleType(p, s) ->
-        Hashtbl.hash (44, hash_resolved p, s)
-      | Type(p, s) ->
-        Hashtbl.hash (45, hash_resolved p, s)
-      | Constructor(p, s) ->
-        Hashtbl.hash (46, hash_resolved p, s)
-      | Field(p, s) ->
-        Hashtbl.hash (47, hash_resolved p, s)
-      | Extension(p, s) ->
-        Hashtbl.hash (48, hash_resolved p, s)
-      | Exception(p, s) ->
-        Hashtbl.hash (49, hash_resolved p, s)
-      | Value(p, s) ->
-        Hashtbl.hash (50, hash_resolved p, s)
-      | Class(p, s) ->
-        Hashtbl.hash (51, hash_resolved p, s)
-      | ClassType(p, s) ->
-        Hashtbl.hash (52, hash_resolved p, s)
-      | Method(p, s) ->
-        Hashtbl.hash (53, hash_resolved p, s)
-      | InstanceVariable(p, s) ->
-        Hashtbl.hash (54, hash_resolved p, s)
-      | Label(p, s) ->
-        Hashtbl.hash (55, hash_resolved p, s)
+      | `SubstAlias (r1, r2) ->
+        Hashtbl.hash (41, Path.Resolved.Module.hash r1, hash_resolved (r2 : module_ :> any ))
+      | `Module(p, s) ->
+        Hashtbl.hash (42, hash_resolved (p : signature :> any), s)
+      | `Canonical (rp, p) ->
+        Hashtbl.hash (43, hash_resolved (rp : module_ :> any), hash_reference (p : Paths_types.Reference.module_ :> Paths_types.Reference.any))
+      | `ModuleType(p, s) ->
+        Hashtbl.hash (44, hash_resolved (p : signature :> any), s)
+      | `Type(p, s) ->
+        Hashtbl.hash (45, hash_resolved (p : signature :> any), s)
+      | `Constructor(p, s) ->
+        Hashtbl.hash (46, hash_resolved (p : datatype :> any), s)
+      | `Field(p, s) ->
+        Hashtbl.hash (47, hash_resolved (p : parent :> any), s)
+      | `Extension(p, s) ->
+        Hashtbl.hash (48, hash_resolved (p : signature :> any), s)
+      | `Exception(p, s) ->
+        Hashtbl.hash (49, hash_resolved (p : signature :> any), s)
+      | `Value(p, s) ->
+        Hashtbl.hash (50, hash_resolved (p : signature :> any), s)
+      | `Class(p, s) ->
+        Hashtbl.hash (51, hash_resolved (p : signature :> any), s)
+      | `ClassType(p, s) ->
+        Hashtbl.hash (52, hash_resolved (p : signature :> any), s)
+      | `Method(p, s) ->
+        Hashtbl.hash (53, hash_resolved (p : class_signature :> any), s)
+      | `InstanceVariable(p, s) ->
+        Hashtbl.hash (54, hash_resolved (p : class_signature :> any), s)
+      | `Label(p, s) ->
+        Hashtbl.hash (55, hash_resolved (p : label_parent :> any), s)
 
-  and hash_reference : type k. k Types.Reference.t -> int =
+  and hash_reference : Paths_types.Reference.any -> int =
     fun p ->
-      let open Types.Reference in
+      let open Paths_types.Reference in
       match p with
-      | Resolved p -> hash_resolved p
-      | Root (s, k) -> Hashtbl.hash (56, s, k)
-      | Dot (p,s) -> Hashtbl.hash (57, hash_reference p, s)
-      | Module (p,s) -> Hashtbl.hash (58, hash_reference p, s)
-      | ModuleType (p,s) -> Hashtbl.hash (59, hash_reference p, s)
-      | Type (p,s) -> Hashtbl.hash (60, hash_reference p, s)
-      | Constructor (p,s) -> Hashtbl.hash (61, hash_reference p, s)
-      | Field (p,s) -> Hashtbl.hash (62, hash_reference p, s)
-      | Extension (p,s) -> Hashtbl.hash (63, hash_reference p, s)
-      | Exception (p,s) -> Hashtbl.hash (64, hash_reference p, s)
-      | Value (p,s) -> Hashtbl.hash (65, hash_reference p, s)
-      | Class (p,s) -> Hashtbl.hash (66, hash_reference p, s)
-      | ClassType (p,s) -> Hashtbl.hash (67, hash_reference p, s)
-      | Method (p,s) -> Hashtbl.hash (68, hash_reference p, s)
-      | InstanceVariable (p,s) -> Hashtbl.hash (69, hash_reference p, s)
-      | Label (p,s) -> Hashtbl.hash (70, hash_reference p, s)
+      | `Resolved p -> hash_resolved p
+      | `Root (s, k) -> Hashtbl.hash (56, s, k)
+      | `Dot (p,s) -> Hashtbl.hash (57, hash_reference (p : label_parent :> any), s)
+      | `Module (p,s) -> Hashtbl.hash (58, hash_reference (p : signature :> any), s)
+      | `ModuleType (p,s) -> Hashtbl.hash (59, hash_reference (p : signature :> any), s)
+      | `Type (p,s) -> Hashtbl.hash (60, hash_reference (p : signature :> any), s)
+      | `Constructor (p,s) -> Hashtbl.hash (61, hash_reference (p : datatype :> any), s)
+      | `Field (p,s) -> Hashtbl.hash (62, hash_reference (p : parent :> any), s)
+      | `Extension (p,s) -> Hashtbl.hash (63, hash_reference (p : signature :> any), s)
+      | `Exception (p,s) -> Hashtbl.hash (64, hash_reference (p : signature :> any), s)
+      | `Value (p,s) -> Hashtbl.hash (65, hash_reference (p : signature :> any), s)
+      | `Class (p,s) -> Hashtbl.hash (66, hash_reference (p : signature :> any), s)
+      | `ClassType (p,s) -> Hashtbl.hash (67, hash_reference (p : signature :> any), s)
+      | `Method (p,s) -> Hashtbl.hash (68, hash_reference (p : class_signature :> any), s)
+      | `InstanceVariable (p,s) -> Hashtbl.hash (69, hash_reference (p : class_signature :> any), s)
+      | `Label (p,s) -> Hashtbl.hash (70, hash_reference (p : label_parent :> any), s)
+
+  let rec resolved_equal : Paths_types.Resolved_reference.any -> Paths_types.Resolved_reference.any -> bool = 
+    let open Paths_types.Resolved_reference in
+    fun id1 id2 ->
+      match id1, id2 with
+      | `Identifier id1, `Identifier id2 ->
+        Identifier.equal id1 id2
+      | `SubstAlias (r1, m1), `SubstAlias (r2, m2) ->
+        Path.Resolved.equal
+          (r1 : Path.Resolved.Module.t :> Path.Resolved.t)
+          (r2 : Path.Resolved.Module.t :> Path.Resolved.t)
+        && resolved_equal (m1 : module_ :> any) (m2 : module_ :> any)
+      | `Module(r1, s1), `Module(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Canonical(m1, r1), `Canonical(m2, r2) ->
+        equal
+          (r1 : Paths_types.Reference.module_ :> Paths_types.Reference.any)
+          (r2 : Paths_types.Reference.module_ :> Paths_types.Reference.any)
+        && resolved_equal (m1 : module_ :> any) (m2 : module_ :> any)
+      | `ModuleType(r1, s1), `ModuleType(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Type(r1, s1), `Type(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Constructor(r1, s1), `Constructor(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : datatype :> any) (r2 : datatype :> any)
+      | `Field(r1, s1), `Field(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : parent :> any) (r2 : parent :> any)
+      | `Extension(r1, s1), `Extension(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Exception(r1, s1), `Exception(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Value(r1, s1), `Value(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Class(r1, s1), `Class(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : signature :> any) (r2 : signature :> any)
+      | `ClassType(r1, s1), `ClassType(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Method(r1, s1), `Method(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : class_signature :> any) (r2 : class_signature :> any)
+      | `InstanceVariable(r1, s1), `InstanceVariable(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : class_signature :> any) (r2 : class_signature :> any)
+      | `Label(r1, s1), `Label(r2, s2) ->
+        s1 = s2 && resolved_equal (r1 : label_parent :> any) (r2 : label_parent :> any)
+      | _, _ -> false
+
+  and equal : Paths_types.Reference.any -> Paths_types.Reference.any -> bool = 
+    let open Paths_types.Reference in
+    fun r1 r2 ->
+      match r1, r2 with
+      | `Resolved r1, `Resolved r2 ->
+        resolved_equal r1 r2
+      | `Root (s1, k1), `Root (s2, k2) ->
+        s1 = s2 && k1 = k2
+      | `Dot(r1, s1), `Dot(r2, s2) ->
+        s1 = s2 && equal (r1 : label_parent :> any) (r2 : label_parent :> any)
+      | `Module(r1, s1), `Module(r2, s2) ->
+        s1 = s2 && equal (r1 : signature :> any) (r2 : signature :> any)
+      | `ModuleType(r1, s1), `ModuleType(r2, s2) ->
+        s1 = s2 && equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Type(r1, s1), `Type(r2, s2) ->
+        s1 = s2 && equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Constructor(r1, s1), `Constructor(r2, s2) ->
+        s1 = s2 && equal (r1 : datatype :> any) (r2 : datatype :> any)
+      | `Field(r1, s1), `Field(r2, s2) ->
+        s1 = s2 && equal (r1 : parent :> any) (r2 : parent :> any)
+      | `Extension(r1, s1), `Extension(r2, s2) ->
+        s1 = s2 && equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Exception(r1, s1), `Exception(r2, s2) ->
+        s1 = s2 && equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Class(r1, s1), `Class(r2, s2) ->
+        s1 = s2 && equal (r1 : signature :> any) (r2 : signature :> any)
+      | `ClassType(r1, s1), `ClassType(r2, s2) ->
+        s1 = s2 && equal (r1 : signature :> any) (r2 : signature :> any)
+      | `Method(r1, s1), `Method(r2, s2) ->
+        s1 = s2 && equal (r1 : class_signature :> any) (r2 : class_signature :> any)
+      | `InstanceVariable(r1, s1), `InstanceVariable(r2, s2) ->
+        s1 = s2 && equal (r1 : class_signature :> any) (r2 : class_signature :> any)
+      | `Label(r1, s1), `Label(r2, s2) ->
+        s1 = s2 && equal (r1 : label_parent :> any) (r2 : label_parent :> any)
+      | _, _ -> false
 
   module Resolved = struct
-    open Identifier
+    open Paths_types.Resolved_reference
 
-    include Types.Resolved
-
-    let ident_module : Identifier.module_ -> _ = function
-      | Root _ | Module _ | Argument _ as x -> Identifier x
-
-    let ident_module_type : Identifier.module_type -> _ = function
-      | ModuleType _ as x -> Identifier x
-
-    let ident_type : Identifier.type_ -> _ = function
-      | Type _ | CoreType _ as x -> Identifier x
-
-    let ident_constructor : Identifier.constructor -> _ = function
-      | Constructor _ as x -> Identifier x
-
-    let ident_field : Identifier.field -> _ = function
-      | Field _ as x -> Identifier x
-
-    let ident_extension : Identifier.extension -> _ = function
-      | Extension _ as x -> Identifier x
-
-    let ident_exception : Identifier.exception_ -> _ = function
-      | Exception _ | CoreException _ as x -> Identifier x
-
-    let ident_value : Identifier.value -> _ = function
-      | Value _ as x -> Identifier x
-
-    let ident_class : Identifier.class_ -> _ = function
-      | Class _ as x -> Identifier x
-
-    let ident_class_type : Identifier.class_type -> _ = function
-      | ClassType _ as x -> Identifier x
-
-    let ident_method : Identifier.method_ -> _ = function
-      | Method _ as x -> Identifier x
-
-    let ident_instance_variable : Identifier.instance_variable -> _ =
-      function InstanceVariable _ as x -> Identifier x
-
-    let ident_label : Identifier.label -> _ = function
-      | Label _ as x -> Identifier x
-
-    let ident_page : Identifier.page -> _ = function
-      | Page _ as x -> Identifier x
-
-    let signature_of_module : module_ -> _ = function
-      | Identifier (Root _ | Module _ | Argument _)
-      | SubstAlias _
-      | Module _
-      | Canonical _ as x -> x
-
-    let signature_of_module_type : module_type -> _ = function
-      | Identifier (ModuleType _) | ModuleType _ as x -> x
-
-    let class_signature_of_class : class_ -> _ = function
-      | Identifier (Class _) | Class _ as x -> x
-
-    let class_signature_of_class_type : class_type -> _ = function
-      | Identifier (Class _ | ClassType _) | Class _ | ClassType _ as x -> x
-
-    let parent_of_signature : signature -> _ = function
-      | Identifier (Root _ | Module _ | Argument _ | ModuleType _)
-      | SubstAlias _ | Module _ | ModuleType _ | Canonical _ as x -> x
-
-    let parent_of_class_signature : class_signature -> _ =
+    let rec parent_signature_identifier : Paths_types.Resolved_reference.signature -> Identifier.Signature.t =
       function
-      | Identifier (Class _ | ClassType _) | Class _ | ClassType _ as x -> x
+      | `Identifier id -> id
+      | `SubstAlias(sub, _) -> Path.Resolved.parent_module_identifier sub
+      | `Module(m, n) -> `Module(parent_signature_identifier m, n)
+      | `Canonical(_, `Resolved r) ->
+        parent_signature_identifier (r : module_ :> signature)
+      | `Canonical (r, _) -> parent_signature_identifier (r : module_ :> signature)
+      | `ModuleType(m, s) -> `ModuleType(parent_signature_identifier m, s)
 
-    let parent_of_datatype : datatype -> _ = function
-      | Identifier (Type _ |CoreType _) | Type _ as x -> x
-
-    let label_parent_of_parent : parent -> label_parent = function
-      | Identifier (Root _ | Module _ | Argument _ | ModuleType _
-                   |Type _ | CoreType _ | Class _ | ClassType _)
-      | SubstAlias _ | Module _ | ModuleType _ | Canonical _
-      | Type _ | Class _ | ClassType _ as x -> x
-
-    let label_parent_of_page : page -> label_parent = function
-      | Identifier Page _ as x -> x
-
-    let any : type k. k t -> any = function
-      | Identifier (Root _ ) as x -> x
-      | Identifier (Page _ ) as x -> x
-      | Identifier (Module _) as x -> x
-      | Identifier (Argument _ ) as x -> x
-      | Identifier (ModuleType _) as x -> x
-      | Identifier (Type _) as x -> x
-      | Identifier (CoreType _) as x -> x
-      | Identifier (Constructor _) as x -> x
-      | Identifier (Field _) as x -> x
-      | Identifier (Extension _) as x -> x
-      | Identifier (Exception _) as x -> x
-      | Identifier (CoreException _) as x -> x
-      | Identifier (Value _) as x -> x
-      | Identifier (Class _) as x -> x
-      | Identifier (ClassType _) as x -> x
-      | Identifier (Method _) as x -> x
-      | Identifier (InstanceVariable _) as x -> x
-      | Identifier (Label _) as x -> x
-      | SubstAlias _ as x -> x
-      | Module _ as x -> x
-      | Canonical _ as x -> x
-      | ModuleType _ as x -> x
-      | Type _ as x -> x
-      | Constructor _ as x -> x
-      | Field _ as x -> x
-      | Extension _ as x -> x
-      | Exception _ as x -> x
-      | Value _ as x -> x
-      | Class _ as x -> x
-      | ClassType _ as x -> x
-      | Method _ as x -> x
-      | InstanceVariable _ as x -> x
-      | Label _ as x -> x
-
-    let open_module : 'b. module_ -> ([< kind > `Module ] as 'b) t =
+    let parent_type_identifier : datatype -> Identifier.DataType.t =
       function
-      | Identifier (Root _ | Module _ | Argument _) | SubstAlias _
-      | Module _ | Canonical _ as x -> x
-
-    let rec parent_signature_identifier : signature -> Identifier.signature =
-      function
-      | Identifier id -> id
-      | SubstAlias(sub, _) -> Path.Resolved.parent_module_identifier sub
-      | Module(m, n) -> Module(parent_signature_identifier m, n)
-      | Canonical(_, Types.Reference.Resolved r) ->
-        parent_signature_identifier (open_module r)
-      | Canonical (r, _) -> parent_signature_identifier (open_module r)
-      | ModuleType(m, s) -> ModuleType(parent_signature_identifier m, s)
-
-    let parent_type_identifier : datatype -> Identifier.datatype =
-      function
-      | Identifier id -> id
-      | Type(sg, s) -> Type(parent_signature_identifier sg, s)
+      | `Identifier id -> id
+      | `Type(sg, s) -> `Type(parent_signature_identifier sg, s)
 
     let parent_class_signature_identifier :
-      class_signature -> Identifier.class_signature =
+      class_signature -> Identifier.ClassSignature.t =
       function
-      | Identifier id -> id
-      | Class(sg, s) -> Class(parent_signature_identifier sg, s)
-      | ClassType(sg, s) -> ClassType(parent_signature_identifier sg, s)
+      | `Identifier id -> id
+      | `Class(sg, s) -> `Class(parent_signature_identifier sg, s)
+      | `ClassType(sg, s) -> `ClassType(parent_signature_identifier sg, s)
 
-    let rec parent_identifier : parent -> Identifier.parent =
+    let rec parent_identifier : parent -> Identifier.Parent.t =
       function
-      | Identifier id -> id
-      | SubstAlias(sub, _) ->
-        Identifier.parent_of_signature
-          (Path.Resolved.parent_module_identifier sub)
-      | Module(m, n) -> Module(parent_signature_identifier m, n)
-      | Canonical(_, Types.Reference.Resolved r) ->
-        parent_identifier (open_module r)
-      | Canonical (r, _) -> parent_identifier (open_module r)
-      | ModuleType(m, s) -> ModuleType(parent_signature_identifier m, s)
-      | Type(sg, s) -> Type(parent_signature_identifier sg, s)
-      | Class(sg, s) -> Class(parent_signature_identifier sg, s)
-      | ClassType(sg, s) -> ClassType(parent_signature_identifier sg, s)
+      | `Identifier id -> id
+      | `SubstAlias(sub, _) ->
+        let id = Path.Resolved.parent_module_identifier sub in
+        (id : Identifier.Signature.t :> Identifier.Parent.t)
+      | `Module(m, n) -> `Module(parent_signature_identifier m, n)
+      | `Canonical(_, `Resolved r) ->
+        parent_identifier (r : module_ :> parent)
+      | `Canonical (r, _) -> parent_identifier (r : module_ :> parent)
+      | `ModuleType(m, s) -> `ModuleType(parent_signature_identifier m, s)
+      | `Type(sg, s) -> `Type(parent_signature_identifier sg, s)
+      | `Class(sg, s) -> `Class(parent_signature_identifier sg, s)
+      | `ClassType(sg, s) -> `ClassType(parent_signature_identifier sg, s)
 
-    let rec label_parent_identifier : label_parent -> Identifier.label_parent =
+    let rec label_parent_identifier : label_parent -> Identifier.LabelParent.t =
       function
-      | Identifier id -> id
-      | SubstAlias(sub, _) ->
-        Identifier.label_parent_of_parent (
-          Identifier.parent_of_signature
-            (Path.Resolved.parent_module_identifier sub))
-      | Module(m, n) -> Module(parent_signature_identifier m, n)
-      | Canonical(_, Types.Reference.Resolved r) ->
-        label_parent_identifier (open_module r)
-      | Canonical (r, _) -> label_parent_identifier (open_module r)
-      | ModuleType(m, s) -> ModuleType(parent_signature_identifier m, s)
-      | Type(sg, s) -> Type(parent_signature_identifier sg, s)
-      | Class(sg, s) -> Class(parent_signature_identifier sg, s)
-      | ClassType(sg, s) -> ClassType(parent_signature_identifier sg, s)
+      | `Identifier id -> id
+      | `SubstAlias(sub, _) ->
+        let id = Path.Resolved.parent_module_identifier sub in
+        (id : Identifier.Signature.t :> Identifier.LabelParent.t)
+      | `Module(m, n) -> `Module(parent_signature_identifier m, n)
+      | `Canonical(_, `Resolved r) ->
+        label_parent_identifier (r : module_ :> label_parent)
+      | `Canonical (r, _) -> label_parent_identifier (r : module_ :> label_parent)
+      | `ModuleType(m, s) -> `ModuleType(parent_signature_identifier m, s)
+      | `Type(sg, s) -> `Type(parent_signature_identifier sg, s)
+      | `Class(sg, s) -> `Class(parent_signature_identifier sg, s)
+      | `ClassType(sg, s) -> `ClassType(parent_signature_identifier sg, s)
 
-    let rec identifier: type k. k t -> k Identifier.t = function
-      | Identifier id -> id
-      | SubstAlias(_, p) -> identifier (open_module p)
-      | Module(s, n) -> Module(parent_signature_identifier s, n)
-      | Canonical(_, Types.Reference.Resolved p) -> begin
-          match identifier p with
-          | Root _ | Module _ | Argument _ as x -> x
-        end
-      | Canonical(p, _) -> begin
-          match identifier p with
-          | Root _ | Module _ | Argument _ as x -> x
-        end
-      | ModuleType(s, n) -> ModuleType(parent_signature_identifier s, n)
-      | Type(s, n) -> Type(parent_signature_identifier s, n)
-      | Constructor(s, n) -> Constructor(parent_type_identifier s, n)
-      | Field(s, n) -> Field(parent_identifier s, n)
-      | Extension(s, n) -> Extension(parent_signature_identifier s, n)
-      | Exception(s, n) -> Exception(parent_signature_identifier s, n)
-      | Value(s, n) -> Value(parent_signature_identifier s, n)
-      | Class(s, n) -> Class(parent_signature_identifier s, n)
-      | ClassType(s, n) -> ClassType(parent_signature_identifier s, n)
-      | Method(s, n) -> Method(parent_class_signature_identifier s, n)
-      | InstanceVariable(s, n) ->
-        InstanceVariable(parent_class_signature_identifier s, n)
-      | Label(s, n) -> Label (label_parent_identifier s, n)
 
-    let equal r1 r2 =
-      let rec loop : type k. k t -> k t -> bool =
-        fun id1 id2 ->
-          match id1, id2 with
-          | Identifier id1, Identifier id2 ->
-              Identifier.equal id1 id2
-          | Module(r1, s1), Module(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | ModuleType(r1, s1), ModuleType(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | Type(r1, s1), Type(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | Constructor(r1, s1), Constructor(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | Field(r1, s1), Field(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | Extension(r1, s1), Extension(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | Exception(r1, s1), Exception(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | Value(r1, s1), Value(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | Class(r1, s1), Class(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | ClassType(r1, s1), ClassType(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | Method(r1, s1), Method(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | InstanceVariable(r1, s1), InstanceVariable(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | Label(r1, s1), Label(r2, s2) ->
-              s1 = s2 && loop r1 r2
-          | _, _ -> false
-      in
-        loop r1 r2
+    type mod_rebase_result =
+      | MStop of Paths_types.Resolved_reference.module_
+      | MContinue of Identifier.Module.t * Reversed.t
 
-    let hash p = hash_resolved p
-
-    type 'kind rebase_result =
-      | Stop of 'kind t
-      | Continue of 'kind Identifier.t * Reversed.t
+    type sig_rebase_result =
+      | SStop of Paths_types.Resolved_reference.signature
+      | SContinue of Identifier.Signature.t * Reversed.t
 
     let rec rebase_module_reference :
-      Reversed.t -> module_ -> Kind.reference_module rebase_result =
+      Reversed.t -> Paths_types.Resolved_reference.module_ -> mod_rebase_result =
       fun new_base t ->
-        match t with
-        | Identifier id ->
-          let rev = Identifier.(to_reversed @@ signature_of_module id) in
-          let new_base = Reversed.remove_prefix rev ~of_:new_base in
-          Continue (id, new_base)
-        | SubstAlias _ -> Stop t (* FIXME? *)
-        | Module (m, s) ->
-          begin match rebase_signature_reference new_base m with
-          | Stop m' -> if m == m' then Stop t else Stop (Module (m', s))
-          | Continue (id, new_base) ->
-            let id = Identifier.Module(id, s) in
+      match t with
+      | `Identifier id ->
+        let rev = Identifier.(to_reversed @@ signature_of_module id) in
+        let new_base = Reversed.remove_prefix rev ~of_:new_base in
+        MContinue (id, new_base)
+      | `SubstAlias _ -> MStop t (* FIXME? *)
+      | `Module (m, s) ->
+        begin match rebase_signature_reference new_base m with
+          | SStop m' -> if m == m' then MStop t else MStop (`Module (m', s))
+          | SContinue (id, new_base) ->
+            let id = `Module(id, s) in
             match new_base with
             | Reversed.Module s' :: rest when s = s' ->
-              Continue (id, rest)
+              MContinue (id, rest)
             | _ ->
-              Stop (Identifier id)
-          end
-        | Canonical (_, Types.Reference.Resolved p) ->
-          (* We only care about printing at this point, so let's drop the lhs. *)
-          rebase_module_reference new_base (signature_of_module p)
-        | Canonical (rp, p) ->
-          begin match rebase_module_reference new_base (signature_of_module rp) with
-          | Stop rp' -> Stop (Canonical (rp', p))
+              MStop (`Identifier id)
+        end
+      | `Canonical (_, `Resolved p) ->
+        (* We only care about printing at this point, so let's drop the lhs. *)
+        rebase_module_reference new_base p
+      | `Canonical (rp, p) ->
+        begin match rebase_module_reference new_base (rp) with
+          | MStop rp' -> MStop (`Canonical (rp', p))
           | _ ->
             (* We might come back at some point with a resolved rhs? So we don't want to
                drop it. *)
-            Stop t
-          end
+            MStop t
+        end
 
     and rebase_signature_reference :
-      Reversed.t -> signature -> Kind.signature rebase_result =
+      Reversed.t -> Paths_types.Resolved_reference.signature -> sig_rebase_result =
       fun new_base t ->
-        match t with
-        | Identifier id ->
-          let rev = Identifier.(to_reversed id) in
-          let new_base = Reversed.remove_prefix rev ~of_:new_base in
-          Continue (id, new_base)
-        | ModuleType (m, s) ->
-          begin match rebase_signature_reference new_base m with
-          | Stop m' -> if m == m' then Stop t else Stop (Module (m', s))
-          | Continue (id, new_base) ->
-            let id = Identifier.ModuleType(id, s) in
+      match t with
+      | `Identifier id ->
+        let rev = Identifier.(to_reversed id) in
+        let new_base = Reversed.remove_prefix rev ~of_:new_base in
+        SContinue (id, new_base)
+      | `ModuleType (m, s) ->
+        begin match rebase_signature_reference new_base m with
+          | SStop m' -> if m == m' then SStop t else SStop (`ModuleType(m', s))
+          | SContinue (id, new_base) ->
+            let id = `ModuleType(id, s) in
             match new_base with
             | Reversed.ModuleType s' :: rest when s = s' ->
-              Continue (id, rest)
+              SContinue (id, rest)
             | _ ->
-              Stop (Identifier id)
-          end
-        | Module _ | Canonical _ as x ->
-          begin match rebase_module_reference new_base x with
-          | Stop rp -> Stop (signature_of_module rp)
-          | Continue (id, rev) ->
-            Continue (Identifier.signature_of_module id, rev)
-          end
-        | SubstAlias _ -> Stop t (* FIXME? *)
+              SStop (`Identifier id)
+        end
+      | `Module _ | `Canonical _ as x ->
+        begin match rebase_module_reference new_base x with
+          | MStop rp -> SStop (rp : module_ :> signature)
+          | MContinue (id, rev) ->
+            SContinue (Identifier.signature_of_module id, rev)
+        end
+      | `SubstAlias _ -> SStop t (* FIXME? *)
 
-    let rec rebase : type k. Reversed.t -> k t -> k t =
-      fun new_base t ->
-        match t with
-        | Identifier _ -> t
-        | SubstAlias _ -> t (* TODO: rewrite necessary? *)
-        | Module (mp, s) ->
-          begin match rebase_signature_reference new_base mp with
-          | Continue (id, _) ->
-            Identifier (Identifier.Module(id, s))
-          | Stop mp' -> Module (mp', s)
-          end
-        | Canonical (p, Types.Reference.Resolved rp) ->
-          begin match rebase_module_reference new_base (signature_of_module rp) with
-          | Continue (id, _) -> ident_module id
-          | Stop rp ->
+    let rebase_single_module = fun
+      new_base t ->
+      match t with
+      | `Module (mp, s) ->
+        begin match rebase_signature_reference new_base mp with
+          | SContinue (id, _) ->
+            `Identifier (`Module(id, s))
+          | SStop mp' -> `Module (mp', s)
+        end
+
+    type module_id = [  
+      | `Identifier of Identifier.Module.t
+    ]
+
+    let rebase_single_canonical : Reversed.t -> s_canonical -> [ s_canonical | module_id ] = fun
+      new_base t ->
+      match t with
+      | `Canonical (p, `Resolved rp) ->
+        begin match rebase_module_reference new_base rp with
+          | MContinue (id, _) -> `Identifier id
+          | MStop rp ->
             (* Easier to reexport a canonical than get the type for rp right... *)
-            Canonical (p, Types.Reference.Resolved rp)
-          end
-        | Canonical (rp, p) ->
-          begin match rebase_module_reference new_base rp with
-          | Stop rp' -> Canonical (rp', p)
+            `Canonical (p, `Resolved rp)
+        end
+      | `Canonical (rp, p) ->
+        begin match rebase_module_reference new_base rp with
+          | MStop rp' -> `Canonical (rp', p)
           | _ ->
             (* We might come back at some point with a resolved rhs? So we don't want to
                drop it. *)
-            t
-          end
-        | ModuleType (mp, s) ->
-          begin match rebase_signature_reference new_base mp with
-          | Continue (id, _) ->
-            Identifier (Identifier.ModuleType (id, s))
-          | Stop mp' -> ModuleType (mp', s)
-          end
-        | Type (mp, s) ->
-          begin match rebase_signature_reference new_base mp with
-          | Continue (id, _) ->
-            Identifier (Identifier.Type (id, s))
-          | Stop mp' -> Type (mp', s)
-          end
-        | Constructor (parent, s) ->
-          Constructor(rebase new_base parent, s)
-        | Field (parent, s) ->
-          Field(rebase new_base parent, s)
-        | Extension (mp, s) ->
-          begin match rebase_signature_reference new_base mp with
-          | Continue (id, _) ->
-            Identifier (Identifier.Extension (id, s))
-          | Stop mp' -> Extension (mp', s)
-          end
-        | Exception (mp, s) ->
-          begin match rebase_signature_reference new_base mp with
-          | Continue (id, _) ->
-            Identifier (Identifier.Exception (id, s))
-          | Stop mp' -> Exception (mp', s)
-          end
-        | Value (mp, s) ->
-          begin match rebase_signature_reference new_base mp with
-          | Continue (id, _) ->
-            Identifier (Identifier.Value (id, s))
-          | Stop mp' -> Value (mp', s)
-          end
-        | Class (mp, s) ->
-          begin match rebase_signature_reference new_base mp with
-          | Continue (id, _) ->
-            Identifier (Identifier.Class (id, s))
-          | Stop mp' -> Class (mp', s)
-          end
-        | ClassType (mp, s) ->
-          begin match rebase_signature_reference new_base mp with
-          | Continue (id, _) ->
-            Identifier (Identifier.ClassType (id, s))
-          | Stop mp' -> ClassType (mp', s)
-          end
-        | Method (mp, s) ->
-            Method (rebase new_base mp, s)
-        | InstanceVariable (mp, s) ->
-            InstanceVariable (rebase new_base mp, s)
-        | Label (mp, s) ->
-            Label (rebase new_base mp, s)
+            (t :> [s_canonical | module_id ])
+        end
 
-    let rebase id t =
-      let rev = Identifier.to_reversed id in
-      rebase rev t
+    let rebase_single_module_type : Reversed.t -> s_module_type -> module_type = fun
+      new_base t ->
+      match t with
+      | `ModuleType (mp, s) ->
+        begin match rebase_signature_reference new_base mp with
+          | SContinue (id, _) ->
+            `Identifier (`ModuleType (id, s))
+          | SStop mp' -> `ModuleType (mp', s)
+        end
+
+    let rebase_single_module : Reversed.t -> s_module -> [ s_module | `Identifier of Identifier.Module.t ] = fun
+      new_base t ->
+      match t with
+      | `Module (x,y) -> (rebase_single_module new_base (`Module (x,y)))
+
+    let rebase_single_class : Reversed.t -> s_class -> class_ = fun
+      new_base t ->
+      match t with
+      | `Class (mp, s) ->
+        begin match rebase_signature_reference new_base mp with
+          | SContinue (id, _) -> `Identifier (`Class (id, s))
+          | SStop mp' -> `Class (mp', s)
+        end
+
+    let rebase_single_value : Reversed.t -> s_value -> [s_value | `Identifier of Identifier.Value.t] = fun
+      new_base t ->
+      match t with
+      | `Value (mp, s) ->
+        begin match rebase_signature_reference new_base mp with
+          | SContinue (id, _) -> `Identifier (`Value (id, s))
+          | SStop mp' -> `Value (mp', s)
+        end
+
+    let rebase_single_class_type : Reversed.t -> s_class_type -> class_type = fun
+      new_base t ->
+      match t with
+      | `ClassType (mp, s) ->
+        begin match rebase_signature_reference new_base mp with
+          | SContinue (id, _) -> `Identifier (`ClassType (id, s))
+          | SStop mp' -> `ClassType (mp', s)
+        end
+
+    let rebase_single_type : Reversed.t -> s_type -> [s_type | `Identifier of Paths_types.Identifier.type_] = fun
+      new_base t ->
+      match t with
+      | `Type (mp, s) ->
+        begin match rebase_signature_reference new_base mp with
+          | SContinue (id, _) -> `Identifier (`Type (id, s))
+          | SStop mp' -> `Type (mp', s)
+        end
+
+    let rebase_single_extension : Reversed.t -> s_extension -> [s_extension | `Identifier of Paths_types.Identifier.reference_extension] = fun
+      new_base t ->
+      match t with 
+      | `Extension (mp, s) ->
+        begin match rebase_signature_reference new_base mp with
+        | SContinue (id, _) ->
+          `Identifier (`Extension (id, s))
+        | SStop mp' -> `Extension (mp', s)
+        end
+
+    let rebase_single_exception : Reversed.t -> s_exception -> exception_ = fun
+      new_base t ->
+      match t with
+      | `Exception (mp, s) ->
+        begin match rebase_signature_reference new_base mp with
+        | SContinue (id, _) ->
+          `Identifier (`Exception (id, s))
+        | SStop mp' -> `Exception (mp', s)
+        end
+
+
+    module Signature =
+    struct
+      type t = Paths_types.Resolved_reference.signature
+
+      let equal t1 t2 =
+        resolved_equal (t1 : t :> any) (t2 : t :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let rec identifier : t -> Identifier.Signature.t = function
+        | `Identifier id -> id
+        | `SubstAlias(_, p) -> identifier (p : module_ :> signature)
+        | `Module(s, n) -> `Module(parent_signature_identifier s, n)
+        | `Canonical(_, `Resolved p) -> identifier (p : module_ :> signature)
+        | `Canonical(p, _) -> identifier (p : module_ :> signature)
+        | `ModuleType(s, n) -> `ModuleType(parent_signature_identifier s, n)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `SubstAlias _ -> t (* TODO: rewrite necessary? *)
+        | `Canonical (x, y) -> (rebase_single_canonical new_base (`Canonical (x,y)) :> t)
+        | `Module (x,y) -> (rebase_single_module new_base (`Module (x,y)) :> t)
+        | `ModuleType (x,y) -> (rebase_single_module_type new_base (`ModuleType (x,y)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module ClassSignature =
+    struct
+      type t = Paths_types.Resolved_reference.class_signature
+
+      let equal t1 t2 =
+        resolved_equal (t1 : t :> any) (t2 : t :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Identifier.ClassSignature.t = function
+        | `Identifier id -> id
+        | `Class(s, n) -> `Class(parent_signature_identifier s, n)
+        | `ClassType(s, n) -> `ClassType(parent_signature_identifier s, n)
+
+      let rebase' : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `Class (mp, s) -> (rebase_single_class new_base (`Class (mp, s)) :> t)
+        | `ClassType (x, y) -> (rebase_single_class_type new_base (`ClassType (x, y)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase' rev t
+
+    end
+
+
+    module DataType =
+    struct
+      type t = Paths_types.Resolved_reference.datatype
+
+      let equal t1 t2 =
+        resolved_equal (t1 : t :> any) (t2 : t :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Identifier.DataType.t = function 
+        | `Identifier id -> id
+        | `Type(s, n) -> `Type(parent_signature_identifier s, n)
+
+      let rebase' : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `Type (s, n) -> (rebase_single_type new_base (`Type (s, n)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase' rev t
+    end
+
+    let rebase_single_constructor : Reversed.t -> s_constructor -> s_constructor = fun
+      new_base t ->
+      match t with
+      | `Constructor (parent, s) ->
+          `Constructor(DataType.rebase' new_base parent, s)
+
+    module Parent =
+    struct
+      type t = Paths_types.Resolved_reference.parent
+
+      let equal t1 t2 =
+        resolved_equal (t1 : t :> any) (t2 : t :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let rec identifier : t -> Identifier.Parent.t = function
+        | `Identifier id -> id
+        | `SubstAlias(_, p) -> identifier (p : module_ :> t)
+        | `Module(s, n) -> `Module(parent_signature_identifier s, n)
+        | `Canonical(_, `Resolved p) -> identifier (p : module_ :> t)
+        | `Canonical(p, _) -> identifier (p : module_ :> t)
+        | `ModuleType(s, n) -> `ModuleType(parent_signature_identifier s, n)
+        | `Class(s, n) -> `Class(parent_signature_identifier s, n)
+        | `ClassType(s, n) -> `ClassType(parent_signature_identifier s, n)
+        | `Type(s, n) -> `Type(parent_signature_identifier s, n)
+
+      let rebase' : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `SubstAlias _ -> t (* TODO: rewrite necessary? *)
+        | `Canonical (x, y) -> (rebase_single_canonical new_base (`Canonical (x,y)) :> t)
+        | `Module (x,y) -> (rebase_single_module new_base (`Module (x,y)) :> t)
+        | `ModuleType (x,y) -> (rebase_single_module_type new_base (`ModuleType (x,y)) :> t)
+        | `Type (mp, s) -> (rebase_single_type new_base (`Type (mp, s)) :> t)
+        | `Class (mp, s) -> (rebase_single_class new_base (`Class (mp, s)) :> t)
+        | `ClassType (x, y) -> (rebase_single_class_type new_base (`ClassType (x, y)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase' rev t
+    end
+
+    let rebase_single_field : Reversed.t -> s_field -> s_field = fun
+      new_base t ->
+      match t with
+      | `Field (parent, s) ->
+          `Field(Parent.rebase' new_base parent, s)
+
+    module LabelParent =
+    struct
+      type t = Paths_types.Resolved_reference.label_parent
+
+      let equal t1 t2 =
+        resolved_equal (t1 : t :> any) (t2 : t :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let rec identifier : t -> Identifier.LabelParent.t = function
+        | `Identifier id -> id
+        | `SubstAlias(_, p) -> identifier (p : module_ :> t)
+        | `Module(s, n) -> `Module(parent_signature_identifier s, n)
+        | `Canonical(_, `Resolved p) -> identifier (p : module_ :> t)
+        | `Canonical(p, _) -> identifier (p : module_ :> t)
+        | `ModuleType(s, n) -> `ModuleType(parent_signature_identifier s, n)
+        | `Class(s, n) -> `Class(parent_signature_identifier s, n)
+        | `ClassType(s, n) -> `ClassType(parent_signature_identifier s, n)
+        | `Type(s, n) -> `Type(parent_signature_identifier s, n)
+
+      let rebase' : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `SubstAlias _ -> t (* TODO: rewrite necessary? *)
+        | `Canonical (x, y) -> (rebase_single_canonical new_base (`Canonical (x,y)) :> t)
+        | `Module (x,y) -> (rebase_single_module new_base (`Module (x,y)) :> t)
+        | `ModuleType (x,y) -> (rebase_single_module_type new_base (`ModuleType (x,y)) :> t)
+        | `Type (mp, s) -> (rebase_single_type new_base (`Type (mp, s)) :> t)
+        | `Class (mp, s) -> (rebase_single_class new_base (`Class (mp, s)) :> t)
+        | `ClassType (x, y) -> (rebase_single_class_type new_base (`ClassType (x, y)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase' rev t
+    end
+
+    module Module =
+    struct
+      type t = Paths_types.Resolved_reference.module_
+
+      let equal t1 t2 =
+        resolved_equal (t1 : t :> any) (t2 : t :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let rec identifier : t -> Identifier.Module.t = function
+        | `Identifier id -> id
+        | `SubstAlias(_, p) -> identifier (p : module_ :> t)
+        | `Module(s, n) -> `Module(parent_signature_identifier s, n)
+        | `Canonical(_, `Resolved p) -> identifier (p : module_ :> t)
+        | `Canonical(p, _) -> identifier (p : module_ :> t)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `SubstAlias _ -> t (* TODO: rewrite necessary? *)
+        | `Canonical (x, y) -> (rebase_single_canonical new_base (`Canonical (x,y)) :> t)
+        | `Module (x,y) -> (rebase_single_module new_base (`Module (x,y)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+  module ModuleType =
+    struct
+      type t = Paths_types.Resolved_reference.module_type
+
+      let equal t1 t2 =
+        resolved_equal (t1 : t :> any) (t2 : t :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Identifier.ModuleType.t = function
+        | `Identifier id -> id
+        | `ModuleType(s, n) -> `ModuleType(parent_signature_identifier s, n)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `ModuleType (x,y) -> (rebase_single_module_type new_base (`ModuleType (x,y)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module Type =
+    struct
+      type t = Paths_types.Resolved_reference.type_
+
+      let equal t1 t2 =
+        resolved_equal (t1 : t :> any) (t2 : t :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Identifier.Path.Type.t = function
+        | `Identifier id -> id
+        | `Type(s, n) -> `Type(parent_signature_identifier s, n)
+        | `Class(s,n) -> `Class(parent_signature_identifier s, n)
+        | `ClassType(s,n) -> `ClassType(parent_signature_identifier s, n)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `Type (mp, s) -> (rebase_single_type new_base (`Type (mp, s)) :> t)
+        | `Class (s, n) -> (rebase_single_class new_base (`Class (s, n)) :> t)
+        | `ClassType (s, n) -> (rebase_single_class_type new_base (`ClassType (s, n)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module Constructor =
+    struct
+      type t = Paths_types.Resolved_reference.constructor
+
+      let equal t1 t2 =
+        resolved_equal (t1 : t :> any) (t2 : t :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Paths_types.Identifier.reference_constructor = function
+        | `Identifier id -> id
+        | `Constructor(s, n) -> `Constructor(parent_type_identifier s, n)
+        | `Extension(s, n) -> `Extension(parent_signature_identifier s, n)
+        | `Exception(s, n) -> `Exception(parent_signature_identifier s, n)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+        match t with
+        | `Identifier _ -> t
+        | `Constructor (p,q) -> (rebase_single_constructor new_base (`Constructor (p,q)) :> t)
+        | `Extension (p,q) -> (rebase_single_extension new_base (`Extension (p,q)) :> t)
+        | `Exception (p,q) -> (rebase_single_exception new_base (`Exception (p,q)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module Field =
+    struct
+      type t = Paths_types.Resolved_reference.field
+
+      let equal t1 t2 =
+        resolved_equal (t1 :> any) (t2 :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Identifier.Field.t = function
+        | `Identifier id -> id
+        | `Field(p, n) -> `Field(parent_identifier p, n)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+          match t with
+          | `Identifier _ -> t
+          | `Field (p,q) -> (rebase_single_field new_base (`Field (p,q)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module Extension =
+    struct
+      type t = Paths_types.Resolved_reference.extension
+
+      let equal t1 t2 =
+        resolved_equal (t1 :> any) (t2 :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Paths_types.Identifier.reference_extension  = function
+        | `Identifier id -> id
+        | `Extension(p,q) -> `Extension(parent_signature_identifier p, q)
+        | `Exception(p,q) -> `Exception(parent_signature_identifier p, q)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+          match t with
+          | `Identifier _ -> t
+          | `Extension(p,q) -> (rebase_single_extension new_base (`Extension (p,q)) :> t)
+          | `Exception(p,q) -> (rebase_single_exception new_base (`Exception (p,q)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module Exception =
+    struct
+      type t = Paths_types.Resolved_reference.exception_
+
+      let equal t1 t2 =
+        resolved_equal (t1 :> any) (t2 :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Paths_types.Identifier.reference_exception  = function
+        | `Identifier id -> id
+        | `Exception(p,q) -> `Exception(parent_signature_identifier p, q)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+          match t with
+          | `Identifier _ -> t
+          | `Exception(p,q) -> (rebase_single_exception new_base (`Exception (p,q)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module Value =
+    struct
+      type t = Paths_types.Resolved_reference.value
+
+      let equal t1 t2 =
+        resolved_equal (t1 :> any) (t2 :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Paths_types.Identifier.reference_value  = function
+        | `Identifier id -> id
+        | `Value(p,q) -> `Value(parent_signature_identifier p, q)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+          match t with
+          | `Identifier _ -> t
+          | `Value(p,q) -> (rebase_single_value new_base (`Value (p,q)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module Class =
+    struct
+      type t = Paths_types.Resolved_reference.class_
+
+      let equal t1 t2 =
+        resolved_equal (t1 :> any) (t2 :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Paths_types.Identifier.reference_class  = function
+        | `Identifier id -> id
+        | `Class(p,q) -> `Class(parent_signature_identifier p, q)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+          match t with
+          | `Identifier _ -> t
+          | `Class(p,q) -> (rebase_single_class new_base (`Class (p,q)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module ClassType =
+    struct
+      type t = Paths_types.Resolved_reference.class_type
+
+      let equal t1 t2 =
+        resolved_equal (t1 :> any) (t2 :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Paths_types.Identifier.reference_class_type  = function
+        | `Identifier id -> id
+        | `Class(p,q) -> `Class(parent_signature_identifier p, q)
+        | `ClassType(p,q) -> `ClassType(parent_signature_identifier p, q)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+          match t with
+          | `Identifier _ -> t
+          | `Class(p,q) -> (rebase_single_class new_base (`Class (p,q)) :> t)
+          | `ClassType(p,q) -> (rebase_single_class_type new_base (`ClassType(p,q)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    let rebase_single_method : Reversed.t -> s_method -> s_method = fun
+      new_base t ->
+      match t with
+      | `Method (parent, s) ->
+          `Method(ClassSignature.rebase' new_base parent, s)
+
+    let rebase_single_instance_variable : Reversed.t -> s_instance_variable -> s_instance_variable = fun
+      new_base t ->
+      match t with
+      | `InstanceVariable (parent, s) ->
+          `InstanceVariable(ClassSignature.rebase' new_base parent, s)
+
+    module Method =
+    struct
+      type t = Paths_types.Resolved_reference.method_
+
+      let equal t1 t2 =
+        resolved_equal (t1 :> any) (t2 :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Paths_types.Identifier.reference_method  = function
+        | `Identifier id -> id
+        | `Method(p,q) -> `Method(parent_class_signature_identifier p, q)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+          match t with
+          | `Identifier _ -> t
+          | `Method(p,q) -> (rebase_single_method new_base (`Method (p,q)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module InstanceVariable =
+    struct
+      type t = Paths_types.Resolved_reference.instance_variable
+
+      let equal t1 t2 =
+        resolved_equal (t1 :> any) (t2 :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Paths_types.Identifier.reference_instance_variable  = function
+        | `Identifier id -> id
+        | `InstanceVariable(p,q) -> `InstanceVariable(parent_class_signature_identifier p, q)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+          match t with
+          | `Identifier _ -> t
+          | `InstanceVariable(p,q) -> (rebase_single_instance_variable new_base (`InstanceVariable(p,q)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    let rebase_single_label : Reversed.t -> s_label -> s_label = fun
+      new_base t ->
+      match t with
+      | `Label (parent, s) ->
+          `Label(LabelParent.rebase' new_base parent, s)
+
+    module Label =
+    struct
+      type t = Paths_types.Resolved_reference.label
+
+      let equal t1 t2 =
+        resolved_equal (t1 :> any) (t2 :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Paths_types.Identifier.reference_label  = function
+        | `Identifier id -> id
+        | `Label(p,q) -> `Label(label_parent_identifier p, q)
+
+      let rebase : Reversed.t -> t -> t =
+        fun new_base t ->
+          match t with
+          | `Identifier _ -> t
+          | `Label(p,q) -> (rebase_single_label new_base (`Label(p,q)) :> t)
+
+      let rebase id t =
+        let rev = Identifier.to_reversed id in
+        rebase rev t
+    end
+
+    module Page =
+    struct
+      type t = Paths_types.Resolved_reference.page
+
+      let equal t1 t2 =
+        resolved_equal (t1 :> any) (t2 :> any)
+
+      let hash t = hash_resolved (t : t :> any)
+
+      let identifier : t -> Paths_types.Identifier.reference_page  = function
+        | `Identifier id -> id
+
+      let rebase _id t = t
+    end
+
+    type t = Paths_types.Resolved_reference.any
+
+    let rec identifier : t -> Identifier.t = function
+      | `Identifier id -> id
+      | `SubstAlias(_, p) -> identifier (p :> t)
+      | `Module(s, n) -> `Module(parent_signature_identifier s, n)
+      | `Canonical(_, `Resolved p) -> identifier (p :> t)
+      | `Canonical(p, _) -> identifier (p :> t)
+      | `ModuleType(s, n) -> `ModuleType(parent_signature_identifier s, n)
+      | `Field(p, n) -> `Field(parent_identifier p, n)
+      | `Type(s, n) -> `Type(parent_signature_identifier s, n)
+      | `Constructor(s, n) -> `Constructor(parent_type_identifier s, n)
+      | `Extension(p,q) -> `Extension(parent_signature_identifier p, q)
+      | `Exception(p,q) -> `Exception(parent_signature_identifier p, q)
+      | `Value(p,q) -> `Value(parent_signature_identifier p, q)
+      | `Class(p,q) -> `Class(parent_signature_identifier p, q)
+      | `ClassType(p,q) -> `ClassType(parent_signature_identifier p, q)
+      | `Method(p,q) -> `Method(parent_class_signature_identifier p, q)
+      | `InstanceVariable(p,q) -> `InstanceVariable(parent_class_signature_identifier p, q)
+      | `Label(p,q) -> `Label(label_parent_identifier p, q)
+
+    let module_of_t : t -> Module.t = function
+      | `Identifier (#Identifier.Module.t)
+      | #Paths_types.Resolved_reference.module_no_id as x -> x
+      | _ -> assert false
+
+    let module_type_of_t : t -> ModuleType.t = function
+      | `Identifier (#Identifier.ModuleType.t)
+      | #Paths_types.Resolved_reference.s_module_type as x -> x
+      | _ -> assert false
+
+    let signature_of_t : t -> Signature.t = function
+      | `Identifier (#Identifier.Signature.t)
+      | #Paths_types.Resolved_reference.signature_no_id as x -> x
+      | _ -> assert false
+
+    let class_signature_of_t : t -> ClassSignature.t = function
+      | `Identifier (#Identifier.ClassSignature.t)
+      | #Paths_types.Resolved_reference.class_signature_no_id as x -> x
+      | _ -> assert false
+
+    let parent_of_t : t -> Parent.t = function
+      | `Identifier (#Identifier.Parent.t)
+      | #Paths_types.Resolved_reference.parent_no_id as x -> x
+      | _ -> assert false
+
+    let label_parent_of_t : t -> LabelParent.t = function
+      | `Identifier (#Identifier.LabelParent.t)
+      | #Paths_types.Resolved_reference.parent_no_id as x -> x
+      | _ -> assert false
+
+    let type_of_t : t -> Type.t = function
+      | `Identifier (#Identifier.Type.t)
+      | #Paths_types.Resolved_reference.s_type as x -> x
+      | _ -> assert false
+
+    let datatype_of_t : t -> DataType.t = function
+      | `Identifier (#Identifier.DataType.t)
+      | #Paths_types.Resolved_reference.s_type as x -> x
+      | _ -> assert false
+
+    let constructor_of_t : t -> Constructor.t = function
+      | `Identifier (#Identifier.Constructor.t)
+      | #Paths_types.Resolved_reference.s_constructor
+      | #Paths_types.Resolved_reference.s_extension
+      | #Paths_types.Resolved_reference.s_exception as x -> x
+      | _ -> assert false
+
+    let field_of_t : t -> Field.t = function
+      | `Identifier (#Identifier.Field.t)
+      | #Paths_types.Resolved_reference.s_field as x -> x
+      | _ -> assert false
+
+    let extension_of_t : t -> Extension.t = function
+      | `Identifier (#Paths_types.Identifier.reference_extension)
+      | #Paths_types.Resolved_reference.s_extension
+      | #Paths_types.Resolved_reference.s_exception as x -> x
+      | _ -> assert false
+
+    let exception_of_t : t -> Exception.t = function
+      | `Identifier (#Paths_types.Identifier.reference_exception)
+      | #Paths_types.Resolved_reference.s_exception as x -> x
+      | _ -> assert false
+
+    let value_of_t : t -> Value.t = function
+      | `Identifier (#Paths_types.Identifier.reference_value)
+      | #Paths_types.Resolved_reference.s_value as x -> x
+      | _ -> assert false
+
+    let class_of_t : t -> Class.t = function
+      | `Identifier (#Paths_types.Identifier.reference_class)
+      | #Paths_types.Resolved_reference.s_class as x -> x
+      | _ -> assert false
+
+    let class_type_of_t : t -> ClassType.t = function
+      | `Identifier (#Paths_types.Identifier.reference_class_type)
+      | #Paths_types.Resolved_reference.s_class_type as x -> x
+      | _ -> assert false
+
+    let method_of_t : t -> Method.t = function
+      | `Identifier (#Paths_types.Identifier.reference_method)
+      | #Paths_types.Resolved_reference.s_method as x -> x
+      | _ -> assert false
+
+    let instance_variable_of_t : t -> InstanceVariable.t = function
+      | `Identifier (#Paths_types.Identifier.reference_instance_variable)
+      | #Paths_types.Resolved_reference.s_instance_variable as x -> x
+      | _ -> assert false
+
+    let label_of_t : t -> Label.t = function
+      | `Identifier (#Paths_types.Identifier.reference_label)
+      | #Paths_types.Resolved_reference.s_label as x -> x
+      | _ -> assert false
+
   end
+  type t = Paths_types.Reference.any
 
-  open Identifier
-  open Resolved
-
-  include Types.Reference
-
-  let ident_module : Identifier.module_ -> _ = function
-    | Root _ | Module _ | Argument _ as x -> Resolved (Identifier x)
-
-  let ident_module_type : Identifier.module_type -> _ = function
-    | ModuleType _ as x -> Resolved (Identifier x)
-
-  let ident_type : Identifier.type_ -> _ = function
-    | Type _ | CoreType _ as x -> Resolved (Identifier x)
-
-  let ident_constructor : Identifier.constructor -> _ = function
-    | Constructor _ as x -> Resolved (Identifier x)
-
-  let ident_field : Identifier.field -> _ = function
-    | Field _ as x -> Resolved (Identifier x)
-
-  let ident_extension : Identifier.extension -> _ = function
-    | Extension _ as x -> Resolved (Identifier x)
-
-  let ident_exception : Identifier.exception_ -> _ = function
-    | Exception _ | CoreException _ as x -> Resolved (Identifier x)
-
-  let ident_value : Identifier.value -> _ = function
-    | Value _ as x -> Resolved (Identifier x)
-
-  let ident_class : Identifier.class_ -> _ = function
-    | Class _ as x -> Resolved (Identifier x)
-
-  let ident_class_type : Identifier.class_type -> _ = function
-    | ClassType _ as x -> Resolved (Identifier x)
-
-  let ident_method : Identifier.method_ -> _ = function
-    | Method _ as x -> Resolved (Identifier x)
-
-  let ident_instance_variable : Identifier.instance_variable -> _ =
-    function InstanceVariable _ as x -> Resolved (Identifier x)
-
-  let ident_label : Identifier.label -> _ = function
-    | Label _ as x -> Resolved (Identifier x)
-
-  let signature_of_module : module_ -> signature = function
-    | Resolved (Identifier (Root _ | Module _ | Argument _)
-               | SubstAlias _ | Module _ | Canonical _)
-    | Root (_, (TUnknown | TModule))
-    | Dot (_, _)
-    | Module (_,_) as x -> x
-
-  let signature_of_module_type : module_type -> signature = function
-    | Resolved (Identifier (ModuleType _) | ModuleType _)
-    | Root (_, (TUnknown | TModuleType))
-    | Dot (_, _)
-    | ModuleType (_,_) as x -> x
-
-  let class_signature_of_class : class_ -> class_signature = function
-    | Resolved (Identifier (Class _) | Class _)
-    | Root (_, (TUnknown | TClass))
-    | Dot (_, _)
-    | Class (_,_) as x -> x
-
-  let class_signature_of_class_type : class_type -> class_signature = function
-    | Resolved (Identifier (Class _ | ClassType _) | Class _ | ClassType _)
-    | Root (_, (TUnknown | TClass | TClassType))
-    | Dot (_, _)
-    | Class (_,_)
-    | ClassType (_,_) as x -> x
-
-  let parent_of_signature : signature -> parent = function
-    | Resolved (Identifier (Root _ | Module _ | Argument _ | ModuleType _)
-               | SubstAlias _ | Module _ | ModuleType _ | Canonical _)
-    | Root (_, (TUnknown | TModule | TModuleType))
-    | Dot (_, _)
-    | Module (_,_)
-    | ModuleType (_,_) as x -> x
-
-  let parent_of_class_signature : class_signature -> parent = function
-    | Resolved (Identifier (Class _ | ClassType _) | Class _ | ClassType _)
-    | Root  (_, (TUnknown | TClass | TClassType))
-    | Dot (_, _)
-    | Class (_,_)
-    | ClassType (_,_) as x -> x
-
-  let parent_of_datatype : datatype -> parent = function
-    | Resolved (Identifier (Type _ | CoreType _) | Type _)
-    | Root (_, (TUnknown | TType))
-    | Dot (_, _)
-    | Type (_,_) as x -> x
-
-  let label_parent_of_parent : parent -> label_parent = function
-    | Resolved (Identifier (Root _ | Module _ | Argument _ | ModuleType _
-                           |Type _ | CoreType _ | Class _ | ClassType _)
-               | SubstAlias _ | Module _ | ModuleType _ | Canonical _
-               | Type _ | Class _ | ClassType _)
-    | Root (_, (TUnknown | TModule | TModuleType | TType | TClass | TClassType))
-    | Dot (_, _)
-    | Module (_,_)
-    | ModuleType (_,_)
-    | Type (_,_)
-    | Class (_,_)
-    | ClassType (_,_)
-      as x -> x
-
-  let any : type k. k t -> any = function
-    | Resolved (Identifier (Root _)) as x -> x
-    | Resolved (Identifier (Page _)) as x -> x
-    | Resolved (Identifier (Module _)) as x -> x
-    | Resolved (Identifier (Argument _)) as x -> x
-    | Resolved (Identifier (ModuleType _)) as x -> x
-    | Resolved (Identifier (Type _)) as x -> x
-    | Resolved (Identifier (CoreType _)) as x -> x
-    | Resolved (Identifier (Constructor _)) as x -> x
-    | Resolved (Identifier (Field _)) as x -> x
-    | Resolved (Identifier (Extension _)) as x -> x
-    | Resolved (Identifier (Exception _)) as x -> x
-    | Resolved (Identifier (CoreException _)) as x -> x
-    | Resolved (Identifier (Value _)) as x -> x
-    | Resolved (Identifier (Class _)) as x -> x
-    | Resolved (Identifier (ClassType _)) as x -> x
-    | Resolved (Identifier (Method _)) as x -> x
-    | Resolved (Identifier (InstanceVariable _)) as x -> x
-    | Resolved (Identifier (Label _)) as x -> x
-    | Resolved (SubstAlias _) as x -> x
-    | Resolved (Module _) as x -> x
-    | Resolved (Canonical _) as x -> x
-    | Resolved (ModuleType _) as x -> x
-    | Resolved (Type _) as x -> x
-    | Resolved (Constructor _) as x -> x
-    | Resolved (Field _) as x -> x
-    | Resolved (Extension _) as x -> x
-    | Resolved (Exception _) as x -> x
-    | Resolved (Value _) as x -> x
-    | Resolved (Class _) as x -> x
-    | Resolved (ClassType _) as x -> x
-    | Resolved (Method _) as x -> x
-    | Resolved (InstanceVariable _) as x -> x
-    | Resolved (Label _) as x -> x
-    | Root (_, TUnknown) as x -> x
-    | Root (_, TModule) as x -> x
-    | Root (_, TModuleType) as x -> x
-    | Root (_, TType) as x -> x
-    | Root (_, TConstructor) as x -> x
-    | Root (_, TField) as x -> x
-    | Root (_, TExtension) as x -> x
-    | Root (_, TException) as x -> x
-    | Root (_, TClass) as x -> x
-    | Root (_, TClassType) as x -> x
-    | Root (_, TValue) as x -> x
-    | Root (_, TMethod) as x -> x
-    | Root (_, TInstanceVariable) as x -> x
-    | Root (_, TLabel) as x -> x
-    | Root (_, TPage) as x -> x
-    | Dot (_, _) as x -> x
-    | Module (_,_) as x -> x
-    | ModuleType (_,_) as x -> x
-    | Type (_,_) as x -> x
-    | Constructor (_,_) as x -> x
-    | Field (_,_) as x -> x
-    | Extension (_,_) as x -> x
-    | Exception (_,_) as x -> x
-    | Class (_,_) as x -> x
-    | ClassType (_,_) as x -> x
-    | Value (_,_) as x -> x
-    | Method (_,_) as x -> x
-    | InstanceVariable (_,_) as x -> x
-    | Label (_,_) as x -> x
-
-  let module_ p name =
-    match p with
-    | Resolved p -> Resolved (Module(p, name))
-    | p -> Module(p, name)
-
-  let module_type p name =
-    match p with
-    | Resolved p -> Resolved (ModuleType(p, name))
-    | p -> ModuleType(p, name)
-
-  let type_ p name =
-    match p with
-    | Resolved p -> Resolved (Type(p, name))
-    | p -> Type(p, name)
-
-  let constructor p arg =
-    match p with
-    | Resolved p -> Resolved (Constructor(p, arg))
-    | p -> Constructor(p, arg)
-
-  let field p arg =
-    match p with
-    | Resolved p -> Resolved (Field(p, arg))
-    | p -> Field(p, arg)
-
-  let extension p arg =
-    match p with
-    | Resolved p -> Resolved (Extension(p, arg))
-    | p -> Extension(p, arg)
-
-  let exception_ p arg =
-    match p with
-    | Resolved p -> Resolved (Exception(p, arg))
-    | p -> Exception(p, arg)
-
-  let value p arg =
-    match p with
-    | Resolved p -> Resolved (Value(p, arg))
-    | p -> Value(p, arg)
-
-  let class_ p name =
-    match p with
-    | Resolved p -> Resolved (Class(p, name))
-    | p -> Class(p, name)
-
-  let class_type p name =
-    match p with
-    | Resolved p -> Resolved (ClassType(p, name))
-    | p -> ClassType(p, name)
-
-  let method_ p arg =
-    match p with
-    | Resolved p -> Resolved (Method(p, arg))
-    | p -> Method(p, arg)
-
-  let instance_variable p arg =
-    match p with
-    | Resolved p -> Resolved (InstanceVariable(p, arg))
-    | p -> InstanceVariable(p, arg)
-
-  let label p arg =
-    match p with
-    | Resolved p -> Resolved (Label(p, arg))
-    | p -> Label(p, arg)
-
-  let equal r1 r2 =
-    let rec loop : type k. k t -> k t -> bool =
-      fun r1 r2 ->
-        match r1, r2 with
-        | Resolved r1, Resolved r2 ->
-            Resolved.equal r1 r2
-        | Root (s1, k1), Root (s2, k2) ->
-            s1 = s2 && k1 = k2
-        | Dot(r1, s1), Dot(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | Module(r1, s1), Module(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | ModuleType(r1, s1), ModuleType(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | Type(r1, s1), Type(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | Constructor(r1, s1), Constructor(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | Field(r1, s1), Field(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | Extension(r1, s1), Extension(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | Exception(r1, s1), Exception(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | Class(r1, s1), Class(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | ClassType(r1, s1), ClassType(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | Method(r1, s1), Method(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | InstanceVariable(r1, s1), InstanceVariable(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | Label(r1, s1), Label(r2, s2) ->
-            s1 = s2 && loop r1 r2
-        | _, _ -> false
-    in
-      loop r1 r2
+  let equal : t -> t -> bool = equal
 
   let hash p = hash_reference p
 
+  module Signature =
+  struct
+    type t = Paths_types.Reference.signature
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module ClassSignature =
+  struct
+    type t = Paths_types.Reference.class_signature
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module DataType =
+  struct
+    type t = Paths_types.Reference.datatype
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Parent =
+  struct
+    type t = Paths_types.Reference.parent
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module LabelParent =
+  struct
+    type t = Paths_types.Reference.label_parent
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Module =
+  struct
+    type t = Paths_types.Reference.module_
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module ModuleType =
+  struct
+    type t = Paths_types.Reference.module_type
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Type =
+  struct
+    type t = Paths_types.Reference.type_
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Constructor =
+  struct
+    type t = Paths_types.Reference.constructor
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Field =
+  struct
+    type t = Paths_types.Reference.field
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Extension =
+  struct
+    type t = Paths_types.Reference.extension
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Exception =
+  struct
+    type t = Paths_types.Reference.exception_
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Value =
+  struct
+    type t = Paths_types.Reference.value
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Class =
+  struct
+    type t = Paths_types.Reference.class_
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module ClassType =
+  struct
+    type t = Paths_types.Reference.class_type
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Method =
+  struct
+    type t = Paths_types.Reference.method_
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module InstanceVariable =
+  struct
+    type t = Paths_types.Reference.instance_variable
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Label =
+  struct
+    type t = Paths_types.Reference.label
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  module Page =
+  struct
+    type t = Paths_types.Reference.page
+    let equal : t -> t -> bool = fun t1 t2 -> equal (t1 :> Paths_types.Reference.any) (t2 :> Paths_types.Reference.any)
+    let hash : t -> int = fun t -> hash (t :> Paths_types.Reference.any)
+  end
+
+  let module_of_t : t -> Module.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.module_))
+  | `Resolved (#Paths_types.Resolved_reference.module_no_id)
+  | `Root (_,#Paths_types.Reference.tag_module)
+  | `Dot (_,_)
+  | `Module (_, _) as x -> x
+  | _ -> assert false
+
+let module_type_of_t : t -> ModuleType.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.module_type))
+  | `Resolved (#Paths_types.Resolved_reference.s_module_type)
+  | `Root (_,#Paths_types.Reference.tag_module_type)
+  | `Dot (_,_)
+  | `ModuleType (_, _) as x -> x
+  | _ -> assert false
+
+let signature_of_t : t -> Signature.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.signature))
+  | `Resolved (#Paths_types.Resolved_reference.signature_no_id)
+  | `Root (_,#Paths_types.Reference.tag_signature)
+  | `Dot (_,_)
+  | `ModuleType (_,_)
+  | `Module (_, _) as x -> x
+  | _ -> assert false
+
+let class_signature_of_t : t -> ClassSignature.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.class_signature))
+  | `Resolved (#Paths_types.Resolved_reference.class_signature_no_id)
+  | `Root (_,#Paths_types.Reference.tag_class_signature)
+  | `Dot (_,_)
+  | `ClassType (_,_)
+  | `Class (_, _) as x -> x
+  | _ -> assert false
+
+let parent_of_t : t -> Parent.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.parent))
+  | `Resolved (#Paths_types.Resolved_reference.parent_no_id)
+  | `Root (_,#Paths_types.Reference.tag_parent)
+  | `Dot (_,_)
+  | `ClassType (_,_)
+  | `ModuleType (_,_)
+  | `Module (_, _)
+  | `Type (_,_)
+  | `Class (_, _) as x -> x
+  | _ -> assert false
+
+let label_parent_of_t : t -> LabelParent.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.label_parent))
+  | `Resolved (#Paths_types.Resolved_reference.parent_no_id) (* Nb, parent_no_id would be equal to label_parent_no_id if it existed! *)
+  | `Root (_,#Paths_types.Reference.tag_label_parent)
+  | `Dot (_,_)
+  | `ClassType (_,_)
+  | `ModuleType (_,_)
+  | `Module (_, _)
+  | `Type (_,_)
+  | `Class (_, _) as x -> x
+  | _ -> assert false
+
+let type_of_t : t -> Type.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.type_))
+  | `Resolved (#Paths_types.Resolved_reference.s_type)
+  | `Root (_,#Paths_types.Reference.tag_type)
+  | `Dot (_,_)
+  | `Type (_,_) as x -> x
+  | _ -> assert false
+
+let datatype_of_t : t -> DataType.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.datatype))
+  | `Resolved (#Paths_types.Resolved_reference.s_type)
+  | `Root (_,#Paths_types.Reference.tag_datatype)
+  | `Dot (_,_)
+  | `Type (_,_) as x -> x
+  | _ -> assert false
+
+let constructor_of_t : t -> Constructor.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.reference_constructor))
+  | `Resolved (#Paths_types.Resolved_reference.constructor_no_id)
+  | `Root (_,#Paths_types.Reference.tag_constructor)
+  | `Dot (_,_)
+  | `Constructor (_,_)
+  | `Extension (_,_)
+  | `Exception (_,_) as x -> x
+  | _ -> assert false
+
+let field_of_t : t -> Field.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.reference_field))
+  | `Resolved (#Paths_types.Resolved_reference.s_field)
+  | `Root (_,#Paths_types.Reference.tag_field)
+  | `Dot (_,_)
+  | `Field (_,_) as x -> x
+  | _ -> assert false
+
+let extension_of_t : t -> Extension.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.reference_extension))
+  | `Resolved (#Paths_types.Resolved_reference.extension_no_id)
+  | `Root (_,#Paths_types.Reference.tag_extension)
+  | `Dot (_,_)
+  | `Extension (_,_)
+  | `Exception (_,_) as x -> x
+  | _ -> assert false
+
+let exception_of_t : t -> Exception.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.reference_exception))
+  | `Resolved (#Paths_types.Resolved_reference.s_exception)
+  | `Root (_,#Paths_types.Reference.tag_exception)
+  | `Dot (_,_)
+  | `Exception (_,_) as x -> x
+  | _ -> assert false
+
+let value_of_t : t -> Value.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.reference_value))
+  | `Resolved (#Paths_types.Resolved_reference.s_value)
+  | `Root (_,#Paths_types.Reference.tag_value)
+  | `Dot (_,_)
+  | `Value (_,_) as x -> x
+  | _ -> assert false
+
+let class_of_t : t -> Class.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.reference_class))
+  | `Resolved (#Paths_types.Resolved_reference.s_class)
+  | `Root (_,#Paths_types.Reference.tag_class)
+  | `Dot (_,_)
+  | `Class (_,_) as x -> x
+  | _ -> assert false
+
+let class_type_of_t : t -> ClassType.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.reference_class_type))
+  | `Resolved (#Paths_types.Resolved_reference.class_type_no_id)
+  | `Root (_,#Paths_types.Reference.tag_class_type)
+  | `Dot (_,_)
+  | `Class (_,_) 
+  | `ClassType (_,_) as x -> x 
+  | _ -> assert false
+
+let method_of_t : t -> Method.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.reference_method))
+  | `Resolved (#Paths_types.Resolved_reference.s_method)
+  | `Root (_,#Paths_types.Reference.tag_method)
+  | `Dot (_,_)
+  | `Method (_,_) as x -> x 
+  | _ -> assert false
+
+let instance_variable_of_t : t -> InstanceVariable.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.reference_instance_variable))
+  | `Resolved (#Paths_types.Resolved_reference.s_instance_variable)
+  | `Root (_,#Paths_types.Reference.tag_instance_variable)
+  | `Dot (_,_)
+  | `InstanceVariable (_,_) as x -> x 
+  | _ -> assert false
+
+let label_of_t : t -> Label.t = function
+  | `Resolved (`Identifier (#Paths_types.Identifier.reference_label))
+  | `Resolved (#Paths_types.Resolved_reference.s_label)
+  | `Root (_,#Paths_types.Reference.tag_label)
+  | `Dot (_,_)
+  | `Label (_,_) as x -> x 
+  | _ -> assert false
 end

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -438,6 +438,8 @@ module Identifier = struct
 
   let signature_of_module m = (m : Module.t :> Signature.t)
 
+  (* It would be much nicer not to have to have these functions *)
+
   let page_of_t : t -> Page.t = function
     | #Page.t as result -> result
     | _ -> assert false

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -19,33 +19,6 @@
 open Names
 
 module Identifier : sig
-
-  (** {2 Explicit coercions} *)
-
-  (*
-  val signature_of_module : module_ -> signature
-
-  val signature_of_module_type : module_type -> signature
-
-  val class_signature_of_class : class_ -> class_signature
-
-  val class_signature_of_class_type : class_type -> class_signature
-
-  val datatype_of_type : type_ -> datatype
-
-  val parent_of_signature : signature -> parent
-
-  val parent_of_class_signature : class_signature -> parent
-
-  val parent_of_datatype : datatype -> parent
-
-  val label_parent_of_parent : parent -> label_parent
-
-  val label_parent_of_page : page -> label_parent
-
-  val any : 'kind t -> any
-*)
-
   (** {2 Generic operations} *)
 
   module Signature : sig

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -14,17 +14,15 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(** Paths of documentation *)
-
-module Kind = Paths_types.Kind
-
 (** Identifiers for definitions *)
-module Identifier : sig
 
-  include module type of Paths_types.Identifier
+open Names
+
+module Identifier : sig
 
   (** {2 Explicit coercions} *)
 
+  (*
   val signature_of_module : module_ -> signature
 
   val signature_of_module_type : module_type -> signature
@@ -46,28 +44,252 @@ module Identifier : sig
   val label_parent_of_page : page -> label_parent
 
   val any : 'kind t -> any
+*)
 
   (** {2 Generic operations} *)
 
-  val equal : 'kind t -> 'kind t -> bool
+  module Signature : sig
+    type t = Paths_types.Identifier.signature
 
-  val hash : 'kind t -> int
+    val equal : t -> t -> bool
+    
+    val hash : t -> int
+ 
+    val root : t -> Root.t
+  end
 
-  (** {3 Printing} *)
+  module ClassSignature : sig
+    type t = Paths_types.Identifier.class_signature
 
-  val name : 'kind t -> string
+    val equal : t -> t -> bool
 
-  (** {2 Root retrieval} *)
+    val hash : t -> int
 
-  val signature_root : signature -> Root.t
+    val root : t -> Root.t
+  end
 
-  val module_root : module_ -> Root.t
+  module DataType : sig
+    type t = Paths_types.Identifier.datatype
 
-  val module_type_root : module_type -> Root.t
+    val equal : t -> t -> bool
 
-  val class_signature_root : class_signature -> Root.t
+    val hash : t -> int
+  end
 
-  val label_parent_root : label_parent -> Root.t
+  module Parent : sig
+    type t = Paths_types.Identifier.parent
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module LabelParent : sig
+    type t = Paths_types.Identifier.label_parent
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+
+    val root : t -> Root.t
+  end
+
+  module Module : sig
+    type t = Paths_types.Identifier.module_
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+
+    val root : t -> Root.t
+  end
+
+  module ModuleType : sig
+    type t = Paths_types.Identifier.module_type
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+
+    val root : t -> Root.t
+  end
+
+  module Type : sig
+    type t = Paths_types.Identifier.type_
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module Constructor : sig
+    type t = Paths_types.Identifier.constructor
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module Field : sig
+    type t = Paths_types.Identifier.field
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module Extension : sig
+    type t = Paths_types.Identifier.extension
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module Exception : sig
+    type t = Paths_types.Identifier.exception_
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module Value : sig
+    type t = Paths_types.Identifier.value
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module Class : sig
+    type t = Paths_types.Identifier.class_
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module ClassType : sig
+    type t = Paths_types.Identifier.class_type
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module Method : sig
+    type t = Paths_types.Identifier.method_
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module InstanceVariable : sig
+    type t = Paths_types.Identifier.instance_variable
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module Label : sig
+    type t = Paths_types.Identifier.label
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module Page : sig
+    type t = Paths_types.Identifier.page
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+  end
+
+  module Path : sig
+    
+    module Module : sig
+      type t = Paths_types.Identifier.path_module
+
+      val equal : t -> t -> bool 
+      
+      val hash : t -> int
+    end
+
+    module ModuleType : sig
+      type t = Paths_types.Identifier.path_module_type
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+    end
+
+    module Type : sig
+      type t = Paths_types.Identifier.path_type
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+    end
+
+    module ClassType : sig
+      type t = Paths_types.Identifier.path_class_type
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+    end
+
+    type t = Paths_types.Identifier.path_any
+  end
+
+  type t = Paths_types.Identifier.any
+
+  val page_of_t : t -> Page.t
+
+  val signature_of_t : t -> Signature.t
+
+  val class_signature_of_t : t -> ClassSignature.t
+
+  val datatype_of_t : t -> DataType.t
+
+  val module_of_t : t -> Module.t
+
+  val module_type_of_t : t -> ModuleType.t
+
+  val type_of_t : t -> Type.t
+
+  val constructor_of_t : t -> Constructor.t
+
+  val field_of_t : t -> Field.t
+
+  val extension_of_t : t -> Extension.t
+
+  val exception_of_t : t -> Exception.t
+
+  val value_of_t : t -> Value.t
+
+  val class_of_t : t -> Class.t
+
+  val class_type_of_t : t -> ClassType.t
+
+  val method_of_t : t -> Method.t
+
+  val instance_variable_of_t : t -> InstanceVariable.t
+
+  val label_of_t : t -> Label.t
+
+  val parent_of_t : t -> Parent.t
+
+  val equal : t -> t -> bool
+
+  val hash : t -> int
+  
+  val name : [< t] -> string
 end
 
 (** Normal OCaml paths (i.e. the ones present in types) *)
@@ -75,85 +297,156 @@ module rec Path : sig
 
   module Resolved : sig
 
-    include module type of Paths_types.Resolved_path
+    module Module : sig
+      type t = Paths_types.Resolved_path.module_
 
-    (** {2 Creators} *)
+      val of_ident : Identifier.Path.Module.t -> t
 
-    val ident_module : Identifier.module_ -> [< kind > `Module] t
+      val equal : t -> t -> bool
 
-    val ident_module_type : Identifier.module_type -> [< kind > `ModuleType] t
+      val hash : t -> int
 
-    val ident_type : Identifier.type_ -> [< kind > `Type] t
+      val is_hidden : t -> bool
 
-    val ident_class : Identifier.class_ -> [< kind > `Class] t
+      val identifier : t -> Identifier.Path.Module.t
 
-    val ident_class_type : Identifier.class_type -> [< kind > `ClassType] t
+      val rebase : Identifier.Signature.t -> t -> t
 
-    (** {2 Explicit coercion} *)
+      val equal_identifier : Identifier.Path.Module.t -> t -> bool
+    end
 
-    val any : 'kind t -> any
+    module ModuleType : sig
+      type t = Paths_types.Resolved_path.module_type
 
-    (** {2 Generic operations} *)
+      val of_ident : Identifier.Path.ModuleType.t -> t
 
-    val equal : 'kind t -> 'kind t -> bool
+      val equal : t -> t -> bool
 
-    val hash : 'kind t -> int
+      val hash : t -> int
 
-    val identifier: 'kind t -> 'kind Identifier.t
-    (** [identifier rp] extracts the identifier present at the "root" of [rp]. *)
+      val is_hidden : t -> bool
 
-    val is_hidden : 'kind t -> bool
-    (** [is_hidden rp] is [true] when some prefix of [rp] (which is not under a
-        [Canonical]) is the [Hidden] constructor.
+      val identifier : t -> Identifier.Path.ModuleType.t
 
-        [Canonical] are treated specialy because we expect them to rewrite a
-        hidden path to a non-hidden one. *)
+      val rebase : Identifier.Signature.t -> t -> t
 
-    val rebase : Identifier.signature -> 'kind t -> 'kind t
+      val equal_identifier : Identifier.Path.ModuleType.t -> t -> bool
+    end
 
-    val equal_identifier : 'kind Identifier.t -> 'kind t -> bool
+    module Type : sig
+      type t = Paths_types.Resolved_path.type_
+
+      val of_ident : Identifier.Path.Type.t -> t
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val is_hidden : t -> bool
+
+      val identifier : t -> Identifier.Path.Type.t
+
+      val rebase : Identifier.Signature.t -> t -> t
+
+      val equal_identifier : Identifier.Path.Type.t -> t -> bool
+    end
+
+    module ClassType : sig
+      type t = Paths_types.Resolved_path.class_type
+
+      val of_ident : Identifier.Path.ClassType.t -> t
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val is_hidden : t -> bool
+
+      val identifier : t -> Identifier.Path.ClassType.t
+
+      val rebase : Identifier.Signature.t -> t -> t
+
+      val equal_identifier : Identifier.Path.ClassType.t -> t -> bool
+    end
+
+    type t = Paths_types.Resolved_path.any
+
+    val module_of_t : t -> Module.t
+
+    val module_type_of_t : t -> ModuleType.t
+
+    val type_of_t : t -> Type.t
+
+    val class_type_of_t : t -> ClassType.t
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+
+    val identifier : t -> Identifier.t
   end
 
-  include module type of Paths_types.Path
+  module Module : sig
+    type t = Paths_types.Path.module_
 
-  (** {2 Creators} *)
+    val equal : t -> t -> bool
 
-  val ident_module : Identifier.module_ -> [< kind > `Module] t
+    val hash : t -> int
 
-  val ident_module_type : Identifier.module_type -> [< kind > `ModuleType] t
+    val is_hidden : t -> bool    
+  end
 
-  val ident_type : Identifier.type_ -> [< kind > `Type] t
+  module ModuleType : sig
+    type t = Paths_types.Path.module_type
 
-  val ident_class : Identifier.class_ -> [< kind > `Class] t
+    val equal : t -> t -> bool
 
-  val ident_class_type : Identifier.class_type -> [< kind > `ClassType] t
+    val hash : t -> int
 
-  val module_ : module_ -> string -> [< kind > `Module] t
+    val is_hidden : t -> bool    
+  end
 
-  val apply : module_ -> module_ -> [< kind > `Module] t
+  module Type : sig
+    type t = Paths_types.Path.type_
 
-  val module_type : module_ -> string -> [< kind > `ModuleType] t
+    val equal : t -> t -> bool
 
-  val type_ : module_ -> string -> [< kind > `Type] t
+    val hash : t -> int
 
-  val class_ : module_ -> string -> [< kind > `Class] t
+    val is_hidden : t -> bool    
+  end
 
-  val class_type_ : module_ -> string -> [< kind > `ClassType] t
+  module ClassType : sig
+    type t = Paths_types.Path.class_type
 
-  (** {2 Explicit coercions} *)
+    val equal : t -> t -> bool
 
-  val any : 'kind t -> any
+    val hash : t -> int
 
-  val type_of_class_type : class_type -> type_
+    val is_hidden : t -> bool    
+  end
 
-  (** {2 Generic operations} *)
+  type t = Paths_types.Path.any
 
-  val equal : 'kind t -> 'kind t -> bool
+  val module_of_t : t -> Module.t
 
-  val hash : 'kind t -> int
+  val module_type_of_t : t -> ModuleType.t
 
-  val is_hidden : 'kind t -> bool
-  (** cf. {!Resolved.is_hidden} *)
+  val type_of_t : t -> Type.t
+
+  val class_type_of_t : t -> ClassType.t
+
+  val module_ : Module.t -> ModuleName.t -> Module.t
+
+  val apply : Module.t -> Module.t -> Module.t
+
+  val module_type : Module.t -> ModuleTypeName.t -> ModuleType.t
+
+  val is_hidden : t -> bool
+
+  val equal : t -> t -> bool
+
+  val hash : t -> int
 end
 
 (** OCaml path fragments for specifying module substitutions *)
@@ -161,211 +454,577 @@ module Fragment : sig
 
   module Resolved : sig
 
-    include module type of Paths_types.Resolved_fragment
+    module Signature : sig
+      type t = Paths_types.Resolved_fragment.signature
+
+      val path : Path.Module.t -> t -> Path.Module.t
+
+      val identifier : Identifier.Signature.t -> t -> Identifier.Signature.t
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val split : t -> string * t option
+    end
+
+    module Module : sig
+      type t = Paths_types.Resolved_fragment.module_
+
+      val path : Path.Module.t -> t -> Path.Module.t
+
+      val identifier : Identifier.Signature.t -> t -> Identifier.Path.Module.t
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val split : t -> string * t option
+    end
+
+    module Type : sig
+      type t = Paths_types.Resolved_fragment.type_
+
+      val path : Path.Module.t -> t -> Path.Type.t
+
+      val identifier : Identifier.Signature.t -> t -> Identifier.Path.Type.t
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val split : t -> string * t option
+
+    end
 
     (** {2 Explicit coercions} *)
 
-    val signature_of_module : module_ -> signature
+    type t = Paths_types.Resolved_fragment.any
 
-    val any : 'b t -> any
+    val identifier : Identifier.Signature.t -> t -> Identifier.t
 
-    val any_sort : ('b, 'c) raw -> ('b, sort) raw
+    val signature_of_t : t -> Signature.t
 
-    (** {2 Attaching fragments to valid paths} *)
+    val module_of_t : t -> Module.t
 
-    val path: Path.module_ -> 'b t -> 'b Path.t
-
-    val identifier: Identifier.signature -> 'b t -> 'b Identifier.t
-
-    (** {2 Generic operations} *)
-
-    val equal : 'b t -> 'b t -> bool
-
-    val hash : 'b t -> int
-
-    val split : 'b t -> string * 'b t option
+    val type_of_t : t -> Type.t
 
   end
 
-  include module type of Paths_types.Fragment
+  module Signature : sig
+    type t = Paths_types.Fragment.signature
 
-  (** {2 Explicit coercions} *)
+    val equal : t -> t ->  bool
 
-  val signature_of_module : module_ -> signature
+    val hash : t -> int
 
-  val any_sort : ('b, 'c) raw -> ('b, sort) raw
+    val split : t -> string * t option
 
-  val any : 'b t -> any
+    val path : Path.Module.t -> t -> Path.Module.t
+  end
 
-  (** {2 Attaching fragments to valid paths} *)
+  module Module : sig
+    type t = Paths_types.Fragment.module_
 
-  val path: Path.module_ -> 'b t -> 'b Path.t
+    val equal : t -> t ->  bool
 
-  (** {2 Generic operations} *)
+    val hash : t -> int
 
-  val equal : 'b t -> 'b t -> bool
+    val split : t -> string * t option
 
-  val hash : 'b t -> int
+    val path : Path.Module.t -> t -> Path.Module.t
+  end
 
-  val split: 'b t -> string * 'b t option
+  module Type : sig
+    type t = Paths_types.Fragment.type_
+
+    val equal : t -> t ->  bool
+
+    val hash : t -> int
+
+    val split : t -> string * t option
+
+    val path : Path.Module.t -> t -> Path.Type.t
+  end
+
+  type t = Paths_types.Fragment.any
+
+  val signature_of_t : t -> Signature.t
+
+  val module_of_t : t -> Module.t
+
+  val type_of_t : t -> Type.t
 
 end
+
 
 (** References present in documentation comments ([{!Foo.Bar}]) *)
 module rec Reference : sig
 
   module Resolved : sig
+    module Signature : sig 
+      type t = Paths_types.Resolved_reference.signature
 
-    include module type of Paths_types.Resolved_reference
+      val equal : t -> t -> bool
 
-    (** {2 Creators} *)
+      val hash : t -> int
 
-    val ident_module : Identifier.module_ -> [< kind > `Module] t
+      val identifier : t -> Identifier.Signature.t
 
-    val ident_module_type : Identifier.module_type -> [< kind > `ModuleType] t
+      val rebase : Identifier.Signature.t -> t -> t
+    end
 
-    val ident_type : Identifier.type_ -> [< kind > `Type] t
+    module ClassSignature : sig 
+      type t = Paths_types.Resolved_reference.class_signature
 
-    val ident_constructor : Identifier.constructor -> [< kind > `Constructor] t
+      val equal : t -> t -> bool
 
-    val ident_field : Identifier.field -> [< kind > `Field] t
+      val hash : t -> int
 
-    val ident_extension : Identifier.extension -> [< kind > `Extension] t
+      val identifier : t -> Identifier.ClassSignature.t
 
-    val ident_exception : Identifier.exception_ -> [< kind > `Exception] t
+      val rebase : Identifier.Signature.t -> t -> t
+    end
 
-    val ident_value : Identifier.value -> [< kind > `Value] t
+    module DataType : sig 
+      type t = Paths_types.Resolved_reference.datatype
 
-    val ident_class : Identifier.class_ -> [< kind > `Class] t
+      val equal : t -> t -> bool
 
-    val ident_class_type : Identifier.class_type -> [< kind > `ClassType] t
+      val hash : t -> int
 
-    val ident_method : Identifier.method_ -> [< kind > `Method] t
+      val identifier : t -> Identifier.DataType.t
 
-    val ident_instance_variable : Identifier.instance_variable ->
-          [< kind > `InstanceVariable] t
+      val rebase : Identifier.Signature.t -> t -> t
+    end
 
-    val ident_label : Identifier.label -> [< kind > `Label] t
+    module Parent : sig 
+      type t = Paths_types.Resolved_reference.parent
 
-    val ident_page : Identifier.page -> [< kind > `Page] t
+      val equal : t -> t -> bool
 
-    (** {2 Explicit coercions} *)
+      val hash : t -> int
 
-    val signature_of_module : module_ -> signature
+      val identifier : t -> Identifier.Parent.t
 
-    val signature_of_module_type : module_type -> signature
+      val rebase : Identifier.Signature.t -> t -> t
+    end
 
-    val class_signature_of_class : class_ -> class_signature
+    module LabelParent : sig 
+      type t = Paths_types.Resolved_reference.label_parent
 
-    val class_signature_of_class_type : class_type -> class_signature
+      val equal : t -> t -> bool
 
-    val parent_of_signature : signature -> parent
+      val hash : t -> int
 
-    val parent_of_class_signature : class_signature -> parent
+      val identifier : t -> Identifier.LabelParent.t
 
-    val parent_of_datatype : datatype -> parent
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+    module Module : sig 
+      type t = Paths_types.Resolved_reference.module_
 
-    val label_parent_of_parent : parent -> label_parent
+      val equal : t -> t -> bool
 
-    val label_parent_of_page : page -> label_parent
+      val hash : t -> int
 
-    val any : 'kind t -> any
+      val identifier : t -> Identifier.Module.t
 
-    (** {2 Generic operations} *)
+      val rebase : Identifier.Signature.t -> t -> t
+    end
 
-    val equal : 'kind t -> 'kind t -> bool
+    module ModuleType : sig 
+      type t = Paths_types.Resolved_reference.module_type
 
-    val hash : 'kind t -> int
+      val equal : t -> t -> bool
 
-    val identifier: 'kind t -> 'kind Identifier.t
-    (** [identifier rr] extracts the identifier present at the "root" of [rr]. *)
+      val hash : t -> int
 
-    val rebase : Identifier.signature -> 'kind t -> 'kind t
+      val identifier : t -> Identifier.ModuleType.t
 
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module Type : sig 
+      type t = Paths_types.Resolved_reference.type_
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Identifier.Path.Type.t
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module Constructor : sig 
+      type t = Paths_types.Resolved_reference.constructor
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Paths_types.Identifier.reference_constructor
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module Field : sig 
+      type t = Paths_types.Resolved_reference.field
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Paths_types.Identifier.reference_field
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module Extension : sig 
+      type t = Paths_types.Resolved_reference.extension
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Paths_types.Identifier.reference_extension
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module Exception : sig 
+      type t = Paths_types.Resolved_reference.exception_
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Identifier.Exception.t
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module Value : sig 
+      type t = Paths_types.Resolved_reference.value
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Identifier.Value.t
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module Class : sig 
+      type t = Paths_types.Resolved_reference.class_
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Identifier.Class.t
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module ClassType : sig 
+      type t = Paths_types.Resolved_reference.class_type
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Paths_types.Identifier.reference_class_type
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module Method : sig 
+      type t = Paths_types.Resolved_reference.method_
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Identifier.Method.t
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module InstanceVariable : sig 
+      type t = Paths_types.Resolved_reference.instance_variable
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Identifier.InstanceVariable.t
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module Label : sig 
+      type t = Paths_types.Resolved_reference.label
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Identifier.Label.t
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    module Page : sig 
+      type t = Paths_types.Resolved_reference.page
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      val identifier : t -> Identifier.Page.t
+
+      val rebase : Identifier.Signature.t -> t -> t
+    end
+
+    type t = Paths_types.Resolved_reference.any
+
+    val module_of_t : t -> Module.t
+
+    val module_type_of_t : t -> ModuleType.t
+
+    val signature_of_t : t -> Signature.t
+
+    val class_signature_of_t : t -> ClassSignature.t
+
+    val parent_of_t : t -> Parent.t
+
+    val label_parent_of_t : t -> LabelParent.t
+
+    val type_of_t : t -> Type.t
+
+    val datatype_of_t : t -> DataType.t
+
+    val constructor_of_t : t -> Constructor.t
+
+    val field_of_t : t -> Field.t
+
+    val extension_of_t : t -> Extension.t
+
+    val exception_of_t : t -> Exception.t
+
+    val value_of_t : t -> Value.t
+  
+    val class_of_t : t -> Class.t
+
+    val class_type_of_t : t -> ClassType.t
+
+    val method_of_t : t -> Method.t
+
+    val instance_variable_of_t : t -> InstanceVariable.t
+
+    val label_of_t : t -> Label.t
+
+    val identifier : t -> Identifier.t
   end
 
-  include module type of Paths_types.Reference
 
   (** {2 Creators} *)
 
-  val ident_module : Identifier.module_ -> [< kind > `Module] t
+    module Signature : sig 
+      type t = Paths_types.Reference.signature
 
-  val ident_module_type : Identifier.module_type -> [< kind > `ModuleType] t
+      val equal : t -> t -> bool
 
-  val ident_type : Identifier.type_ -> [< kind > `Type] t
+      val hash : t -> int
+    end
 
-  val ident_constructor : Identifier.constructor -> [< kind > `Constructor] t
+    module ClassSignature : sig 
+      type t = Paths_types.Reference.class_signature
 
-  val ident_field : Identifier.field -> [< kind > `Field] t
+      val equal : t -> t -> bool
 
-  val ident_extension : Identifier.extension -> [< kind > `Extension] t
+      val hash : t -> int
+    end
 
-  val ident_exception : Identifier.exception_ -> [< kind > `Exception] t
+    module DataType : sig 
+      type t = Paths_types.Reference.datatype
 
-  val ident_value : Identifier.value -> [< kind > `Value] t
+      val equal : t -> t -> bool
 
-  val ident_class : Identifier.class_ -> [< kind > `Class] t
+      val hash : t -> int
+    end
 
-  val ident_class_type : Identifier.class_type -> [< kind > `ClassType] t
+    module Parent : sig 
+      type t = Paths_types.Reference.parent
 
-  val ident_method : Identifier.method_ -> [< kind > `Method] t
+      val equal : t -> t -> bool
 
-  val ident_instance_variable : Identifier.instance_variable ->
-        [< kind > `InstanceVariable] t
+      val hash : t -> int
+    end
 
-  val ident_label : Identifier.label -> [< kind > `Label] t
+    module LabelParent : sig 
+      type t = Paths_types.Reference.label_parent
 
-  val module_ : signature -> string -> [< kind > `Module] t
+      val equal : t -> t -> bool
 
-  val module_type : signature -> string ->
-        [< kind > `ModuleType] t
+      val hash : t -> int
+    end
+    module Module : sig 
+      type t = Paths_types.Reference.module_
 
-  val type_ : signature -> string -> [< kind > `Type] t
+      val equal : t -> t -> bool
 
-  val constructor : datatype -> string -> [< kind > `Constructor] t
+      val hash : t -> int
+    end
 
-  val field : parent -> string -> [< kind > `Field] t
+    module ModuleType : sig 
+      type t = Paths_types.Reference.module_type
 
-  val extension : signature -> string -> [< kind > `Extension] t
+      val equal : t -> t -> bool
 
-  val exception_ : signature -> string -> [< kind > `Exception] t
+      val hash : t -> int
+    end
 
-  val value : signature -> string -> [< kind > `Value] t
+    module Type : sig 
+      type t = Paths_types.Reference.type_
 
-  val class_ : signature -> string -> [< kind > `Class] t
+      val equal : t -> t -> bool
 
-  val class_type : signature -> string -> [< kind > `ClassType] t
+      val hash : t -> int
+    end
 
-  val method_ : class_signature -> string -> [< kind > `Method] t
+    module Constructor : sig 
+      type t = Paths_types.Reference.constructor
 
-  val instance_variable : class_signature -> string ->
-        [< kind > `InstanceVariable] t
+      val equal : t -> t -> bool
 
-  val label : label_parent -> string -> [< kind > `Label] t
+      val hash : t -> int
+    end
 
-  (** {2 Explicit coercions} *)
+    module Field : sig 
+      type t = Paths_types.Reference.field
 
-  val signature_of_module : module_ -> signature
+      val equal : t -> t -> bool
 
-  val signature_of_module_type : module_type -> signature
+      val hash : t -> int
 
-  val class_signature_of_class : class_ -> class_signature
+    end
 
-  val class_signature_of_class_type : class_type -> class_signature
+    module Extension : sig 
+      type t = Paths_types.Reference.extension
 
-  val parent_of_signature : signature -> parent
+      val equal : t -> t -> bool
 
-  val parent_of_class_signature : class_signature -> parent
+      val hash : t -> int
+    end
 
-  val parent_of_datatype : datatype -> parent
+    module Exception : sig 
+      type t = Paths_types.Reference.exception_
 
-  val label_parent_of_parent : parent -> label_parent
+      val equal : t -> t -> bool
 
-  val any : 'kind t -> any
+      val hash : t -> int
+    end
 
-  (** {2 Generic operations} *)
+    module Value : sig 
+      type t = Paths_types.Reference.value
 
-  val equal : 'kind t -> 'kind t -> bool
+      val equal : t -> t -> bool
 
-  val hash : 'kind t -> int
+      val hash : t -> int
+    end
+
+    module Class : sig 
+      type t = Paths_types.Reference.class_
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+    end
+
+    module ClassType : sig 
+      type t = Paths_types.Reference.class_type
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+    end
+
+    module Method : sig 
+      type t = Paths_types.Reference.method_
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+    end
+
+    module InstanceVariable : sig 
+      type t = Paths_types.Reference.instance_variable
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+    end
+
+    module Label : sig 
+      type t = Paths_types.Reference.label
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+    end
+
+    module Page : sig 
+      type t = Paths_types.Reference.page
+
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+    end
+
+    type t = Paths_types.Reference.any
+
+    val module_of_t : t -> Module.t
+
+    val module_type_of_t : t -> ModuleType.t
+
+    val signature_of_t : t -> Signature.t
+
+    val class_signature_of_t : t -> ClassSignature.t
+
+    val parent_of_t : t -> Parent.t
+
+    val label_parent_of_t : t -> LabelParent.t
+
+    val type_of_t : t -> Type.t
+
+    val datatype_of_t : t -> DataType.t
+
+    val constructor_of_t : t -> Constructor.t
+
+    val field_of_t : t -> Field.t
+
+    val extension_of_t : t -> Extension.t
+
+    val exception_of_t : t -> Exception.t
+
+    val value_of_t : t -> Value.t
+  
+    val class_of_t : t -> Class.t
+
+    val class_type_of_t : t -> ClassType.t
+
+    val method_of_t : t -> Method.t
+
+    val instance_variable_of_t : t -> InstanceVariable.t
+
+    val label_of_t : t -> Label.t
+
+    val hash : t -> int
+
+    val equal : t -> t -> bool
 end
+

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -1,383 +1,835 @@
 (** {1 Paths} *)
-
-(** Every path is annotated with its kind. *)
-module Kind =
-struct
-  (** {4 General purpose kinds} *)
-
-  (** Any possible referent *)
-  type any =
-    [ `Module | `ModuleType | `Type
-    | `Constructor | `Field | `Extension
-    | `Exception | `Value | `Class | `ClassType
-    | `Method | `InstanceVariable | `Label | `Page ]
-
-  (** A referent that can contain signature items *)
-  type signature = [ `Module | `ModuleType ]
-
-  (** A referent that can contain class signature items *)
-  type class_signature = [ `Class | `ClassType ]
-
-  (** A referent that can contain datatype items *)
-  type datatype = [ `Type ]
-
-  (** A referent that can contain page items *)
-  type page = [ `Page ]
-
-  (** A referent that can contain other items *)
-  type parent = [ signature | class_signature | datatype ]
-
-  type label_parent = [ parent | page ]
-
-  (** {4 Identifier kinds}
-
-      The kind of an identifier directly corresponds to the kind of its
-      referent. *)
-
-  type identifier = any
-
-  type identifier_module = [ `Module ]
-  type identifier_module_type = [ `ModuleType ]
-  type identifier_type =  [ `Type ]
-  type identifier_constructor = [ `Constructor ]
-  type identifier_field = [ `Field ]
-  type identifier_extension = [ `Extension ]
-  type identifier_exception = [ `Exception ]
-  type identifier_value = [ `Value ]
-  type identifier_class = [ `Class ]
-  type identifier_class_type = [ `ClassType ]
-  type identifier_method = [ `Method ]
-  type identifier_instance_variable = [ `InstanceVariable ]
-  type identifier_label = [ `Label ]
-  type identifier_page = [ `Page ]
-
-  (** {4 Path kinds}
-
-      There are four kinds of OCaml path:
-
-        - module
-        - module type
-        - type
-        - class type
-
-      These kinds do not directly correspond to the kind of their
-      referent (e.g. a type path may refer to a class definition). *)
-
-  type path = [ `Module | `ModuleType | `Type | `Class | `ClassType ]
-
-  type path_module = [ `Module ]
-  type path_module_type = [ `ModuleType ]
-  type path_type = [ `Type | `Class | `ClassType ]
-  type path_class_type = [ `Class | `ClassType ]
-
-  (** {4 Fragment kinds}
-
-      There are two kinds of OCaml path fragment:
-
-        - module
-        - type
-
-      These kinds do not directly correspond to the kind of their
-      referent (e.g. a type path fragment may refer to a class
-      definition). *)
-
-  type fragment = [ `Module | `Type | `Class | `ClassType ]
-
-  type fragment_module = [ `Module ]
-  type fragment_type = [ `Type | `Class | `ClassType ]
-
-  (** {4 Reference kinds}
-
-      There is one reference kind for each kind of referent. However,
-      the kind of a reference does not refer to the kind of its
-      referent, but to the kind with which the reference was annotated.
-
-      This means that reference kinds do not correspond directly to the
-      kind of their referent because we used more relaxed rules when
-      resolving a reference. For example, a reference annotated as being
-      to a constructor can be resolved to the definition of an exception
-      (which is a sort of constructor). *)
-
-  type reference = any
-
-  type reference_module = [ `Module ]
-  type reference_module_type = [ `ModuleType ]
-  type reference_type = [ `Type | `Class | `ClassType ]
-  type reference_constructor = [ `Constructor | `Extension | `Exception ]
-  type reference_field = [ `Field ]
-  type reference_extension = [ `Extension | `Exception ]
-  type reference_exception = [ `Exception ]
-  type reference_value = [ `Value ]
-  type reference_class = [ `Class ]
-  type reference_class_type = [ `Class | `ClassType ]
-  type reference_method = [ `Method ]
-  type reference_instance_variable = [ `InstanceVariable ]
-  type reference_label = [ `Label ]
-  type reference_page = [ `Page ]
-end
+open Names
 
 module Identifier =
 struct
-  type kind = Kind.identifier
 
-  type 'kind t =
-    | Root : Root.t * string -> [< kind > `Module] t
-    | Page : Root.t * string -> [< kind > `Page] t
-    | Module : signature * string -> [< kind > `Module] t
-    | Argument : signature * int * string -> [< kind > `Module] t
-    | ModuleType : signature * string -> [< kind > `ModuleType] t
-    | Type : signature * string -> [< kind > `Type] t
-    | CoreType : string -> [< kind > `Type] t
-    | Constructor : datatype * string -> [< kind > `Constructor] t
-    | Field : parent * string -> [< kind > `Field] t
-    | Extension : signature * string -> [< kind > `Extension] t
-    | Exception : signature * string -> [< kind > `Exception] t
-    | CoreException : string -> [< kind > `Exception] t
-    | Value : signature * string -> [< kind > `Value] t
-    | Class : signature * string -> [< kind > `Class] t
-    | ClassType : signature * string -> [< kind > `ClassType] t
-    | Method : class_signature * string -> [< kind > `Method] t
-    | InstanceVariable : class_signature * string ->
-        [< kind > `InstanceVariable] t
-    | Label : label_parent * string -> [< kind > `Label] t
+  type signature = [
+    | `Root of Root.t * UnitName.t
+    | `Module of signature * ModuleName.t
+    | `Argument of signature * int * ArgumentName.t
+    | `ModuleType of signature * ModuleTypeName.t
+  ]
 
-  and any = kind t
-  and signature = Kind.signature t
-  and class_signature = Kind.class_signature t
-  and datatype = Kind.datatype t
-  and parent = Kind.parent t
-  and label_parent = Kind.label_parent t
+  type class_signature = [
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+  ]
 
-  type module_ = Kind.identifier_module t
-  type module_type = Kind.identifier_module_type t
-  type type_ = Kind.identifier_type t
-  type constructor = Kind.identifier_constructor t
-  type field = Kind.identifier_field t
-  type extension = Kind.identifier_extension t
-  type exception_ = Kind.identifier_exception t
-  type value = Kind.identifier_value t
-  type class_ = Kind.identifier_class t
-  type class_type = Kind.identifier_class_type t
-  type method_ = Kind.identifier_method t
-  type instance_variable = Kind.identifier_instance_variable t
-  type label = Kind.identifier_label t
-  type page = Kind.identifier_page t
+  type datatype = [
+    | `Type of signature * TypeName.t
+    | `CoreType of TypeName.t
+  ]
 
-  type path_module = Kind.path_module t
-  type path_module_type = Kind.path_module_type t
-  type path_type = Kind.path_type t
-  type path_class_type = Kind.path_class_type t
+  type parent = [
+    | `Root of Root.t * UnitName.t
+    | `Module of signature * ModuleName.t
+    | `Argument of signature * int * ArgumentName.t
+    | `ModuleType of signature * ModuleTypeName.t
+    | `Type of signature * TypeName.t
+    | `CoreType of TypeName.t
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+  ]
 
-  type fragment_module = Kind.fragment_module t
-  type fragment_type = Kind.fragment_type t
+  type label_parent = [
+    | `Root of Root.t * UnitName.t
+    | `Module of signature * ModuleName.t
+    | `Argument of signature * int * ArgumentName.t
+    | `ModuleType of signature * ModuleTypeName.t
+    | `Type of signature * TypeName.t
+    | `CoreType of TypeName.t
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+    | `Page of Root.t * PageName.t
+  ]
 
-  type reference_module = Kind.reference_module t
-  type reference_module_type = Kind.reference_module_type t
-  type reference_type =  Kind.reference_type t
-  type reference_constructor = Kind.reference_constructor t
-  type reference_field = Kind.reference_field t
-  type reference_extension = Kind.reference_extension t
-  type reference_exception = Kind.reference_exception t
-  type reference_value = Kind.reference_value t
-  type reference_class = Kind.reference_class t
-  type reference_class_type = Kind.reference_class_type t
-  type reference_method = Kind.reference_method t
-  type reference_instance_variable = Kind.reference_instance_variable t
-  type reference_label = Kind.reference_label t
-  type reference_page = Kind.reference_page t
+  type module_ = [
+    | `Root of Root.t * UnitName.t
+    | `Module of signature * ModuleName.t
+    | `Argument of signature * int * ArgumentName.t
+  ]
+
+  type module_type = [
+    | `ModuleType of signature * ModuleTypeName.t
+  ]
+
+  type type_ = [
+    | `Type of signature * TypeName.t
+    | `CoreType of TypeName.t
+  ]
+
+  type constructor = [
+    | `Constructor of type_ * ConstructorName.t
+  ]
+
+  type field = [
+    | `Field of parent * FieldName.t
+  ]
+
+  type extension = [
+    | `Extension of signature * ExtensionName.t
+  ]
+
+  type exception_ = [
+    | `Exception of signature * ExceptionName.t
+    | `CoreException of ExceptionName.t
+  ]
+
+  type value = [
+    | `Value of signature * ValueName.t
+  ]
+
+  type class_ = [
+    | `Class of signature * ClassName.t
+  ]
+
+  type class_type = [
+    | `ClassType of signature * ClassTypeName.t
+  ]
+
+  type method_ = [
+    | `Method of class_signature * MethodName.t
+  ]
+
+  type instance_variable = [
+    | `InstanceVariable of class_signature * InstanceVariableName.t
+  ]
+
+  type label = [
+    | `Label of label_parent * LabelName.t
+  ]
+
+  type page = [
+    | `Page of Root.t * PageName.t
+  ]
+
+  type any = [
+    | signature
+    | class_signature
+    | datatype
+    | parent
+    | label_parent
+    | module_
+    | module_type
+    | type_
+    | constructor
+    | field
+    | extension
+    | exception_
+    | value
+    | class_
+    | class_type
+    | method_
+    | instance_variable
+    | label
+    | page
+  ]
+
+  type path_module = module_
+
+  type path_module_type = module_type
+
+  type path_type = [
+    | type_
+    | class_
+    | class_type
+  ]
+
+  type path_class_type = [
+    | class_
+    | class_type
+  ]
+
+  type path_any = [
+    | path_module
+    | path_module_type
+    | path_type
+    | path_class_type
+  ]
+
+  type fragment_module = path_module
+  type fragment_type = path_type
+
+  type reference_module = path_module
+  type reference_module_type = path_module_type
+  type reference_type = path_type
+  type reference_constructor = [
+    | constructor
+    | extension
+    | exception_
+  ]
+  type reference_field = field
+  type reference_extension = [
+    | extension
+    | exception_
+  ]
+  type reference_exception = exception_
+  type reference_value = value
+  type reference_class = class_
+  type reference_class_type = [
+    | class_
+    | class_type
+  ]
+  type reference_method = method_
+  type reference_instance_variable = instance_variable
+  type reference_label = label
+  type reference_page = page
 end
 
 module rec Path :
 sig
-  type kind = Kind.path
-
-  type 'kind t =
-    | Resolved : 'kind Resolved_path.t -> 'kind t
-    | Root : string -> [< kind > `Module] t
-    | Forward : string -> [< kind > `Module] t
-    | Dot : module_ * string -> [< kind] t
-    | Apply : module_ * module_ -> [< kind > `Module] t
-
-  and any = kind t
-  and module_ = Kind.path_module t
-  and module_type = Kind.path_module_type t
-  and type_ = Kind.path_type t
-  and class_type = Kind.path_class_type t
+  type module_ = [
+    | `Resolved of Resolved_path.module_
+    | `Root of string
+    | `Forward of string
+    | `Dot of module_ * string
+    | `Apply of module_ * module_
+  ]
+  type module_type = [
+    | `Resolved of Resolved_path.module_type
+    | `Dot of module_ * string
+  ]
+  type type_ = [
+    | `Resolved of Resolved_path.type_
+    | `Dot of module_ * string
+  ]
+  type class_type = [
+    | `Resolved of Resolved_path.class_type
+    | `Dot of module_ * string
+  ]
+  type any = [
+    | `Resolved of Resolved_path.any
+    | `Root of string
+    | `Forward of string
+    | `Dot of module_ * string
+    | `Apply of module_ * module_
+  ]
 end = Path
 
 and Resolved_path :
 sig
-  type kind = Kind.path
+  type module_ = [
+    | `Identifier of Identifier.path_module
+    | `Subst of module_type * module_
+    | `SubstAlias of module_ * module_
+    | `Hidden of module_
+    | `Module of module_ * ModuleName.t
+    (* TODO: The canonical path should be a reference not a path *)
+    | `Canonical of module_ * Path.module_
+    | `Apply of module_ * Path.module_
+    ]
 
-  type 'kind t =
-    | Identifier : 'kind Identifier.t -> ([< kind] as 'kind) t
-    | Subst : module_type * module_ -> [< kind > `Module] t
-    | SubstAlias : module_ * module_ -> [< kind > `Module] t
-    | Hidden : module_ -> [< kind > `Module ] t
-    | Module : module_ * string -> [< kind > `Module] t
-      (* TODO: The canonical path should be a reference not a path *)
-    | Canonical : module_ * Path.module_ -> [< kind > `Module] t
-    | Apply : module_ * Path.module_ -> [< kind > `Module] t
-    | ModuleType : module_ * string -> [< kind > `ModuleType] t
-    | Type : module_ * string -> [< kind > `Type] t
-    | Class : module_ * string -> [< kind > `Class] t
-    | ClassType : module_ * string -> [< kind > `ClassType] t
+  and module_type = [
+    | `Identifier of Identifier.path_module_type
+    | `ModuleType of module_ * ModuleTypeName.t
+  ]
 
-  and any = kind t
-  and module_ = Kind.path_module t
-  and module_type = Kind.path_module_type t
-  and type_ = Kind.path_type t
-  and class_type = Kind.path_class_type t
+  type module_no_id = [
+    | `Subst of module_type * module_
+    | `SubstAlias of module_ * module_
+    | `Hidden of module_
+    | `Module of module_ * ModuleName.t
+    | `Canonical of module_ * Path.module_
+    | `Apply of module_ * Path.module_
+    ]
+
+  type module_type_no_id = [
+    | `ModuleType of module_ * ModuleTypeName.t
+  ]
+
+  type type_ = [
+    | `Identifier of Identifier.path_type
+    | `Type of module_ * TypeName.t
+    | `Class of module_ * ClassName.t
+    | `ClassType of module_ * ClassTypeName.t
+  ]
+
+  type type_no_id = [
+    | `Type of module_ * TypeName.t
+    | `Class of module_ * ClassName.t
+    | `ClassType of module_ * ClassTypeName.t
+  ]
+
+  type class_type = [
+    | `Identifier of Identifier.path_class_type
+    | `Class of module_ * ClassName.t
+    | `ClassType of module_ * ClassTypeName.t
+  ]
+
+  type class_type_no_id = [
+    | `Class of module_ * ClassName.t
+    | `ClassType of module_ * ClassTypeName.t
+  ]
+
+  type any = [
+    | `Identifier of Identifier.any
+    | module_no_id
+    | module_type_no_id
+    | type_no_id
+    | class_type_no_id
+  ]
 end = Resolved_path
 
 module rec Fragment :
 sig
-  type kind = Kind.fragment
+  type signature = [
+    | `Resolved of Resolved_fragment.signature
+    | `Dot of signature * string
+  ]
 
-  type sort = [ `Root | `Branch ]
+  type module_ = [
+    | `Resolved of Resolved_fragment.module_
+    | `Dot of signature * string
+  ]
 
-  type ('b, 'c) raw =
-    | Resolved : ('b, 'c) Resolved_fragment.raw -> ('b, 'c) raw
-    | Dot : signature * string -> ([< kind], [< sort > `Branch]) raw
+  type type_ = [
+    | `Resolved of Resolved_fragment.type_
+    | `Dot of signature * string
+  ]
 
-  and 'b t = ('b, [`Branch]) raw
-  and any = kind t
-  and signature = (Kind.fragment_module, [`Root | `Branch]) raw
-
-  type module_ = Kind.fragment_module t
-  type type_ = Kind.fragment_type t
+  type any = [
+    | `Resolved of Resolved_fragment.any
+    | `Dot of signature * string
+  ]
 end = Fragment
 
 and Resolved_fragment :
 sig
-  type kind = Kind.fragment
 
-  type sort = [ `Root | `Branch ]
+  type signature = [
+    | `Root
+    | `Subst of Resolved_path.module_type * module_
+    | `SubstAlias of Resolved_path.module_ * module_
+    | `Module of signature * ModuleName.t
+  ]
+  and module_ = [
+    | `Subst of Resolved_path.module_type * module_
+    | `SubstAlias of Resolved_path.module_ * module_
+    | `Module of signature * ModuleName.t
+  ]
 
-  type ('b, 'c) raw =
-    | Root : ('b, [< sort > `Root]) raw
-    | Subst : Resolved_path.module_type * module_ ->
-              ([< kind > `Module] as 'b, [< sort > `Branch] as 'c) raw
-    | SubstAlias : Resolved_path.module_ * module_ ->
-              ([< kind > `Module] as 'b, [< sort > `Branch] as 'c) raw
-    | Module : signature * string -> ([< kind > `Module], [< sort > `Branch]) raw
-    | Type : signature * string -> ([< kind > `Type], [< sort > `Branch]) raw
-    | Class : signature * string -> ([< kind > `Class], [< sort > `Branch]) raw
-    | ClassType : signature * string -> ([< kind > `ClassType], [< sort > `Branch]) raw
+  type type_ = [
+    | `Type of signature * TypeName.t
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+  ]
 
-  and 'b t = ('b, [`Branch]) raw
-  and any = kind t
-  and signature = (Kind.fragment_module, [`Root | `Branch]) raw
-  and module_ = Kind.fragment_module t
-
-  type type_ = Kind.fragment_type t
+  (* Absence of `Root here might make coersions annoying *)
+  type any = [
+    | `Root
+    | `Subst of Resolved_path.module_type * module_
+    | `SubstAlias of Resolved_path.module_ * module_
+    | `Module of signature * ModuleName.t
+    | `Type of signature * TypeName.t
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+  ]
 end = Resolved_fragment
 
 module rec Reference :
 sig
-  type kind = Kind.reference
 
-  type _ tag =
-    | TUnknown : [< kind ] tag
-    | TModule : [< kind > `Module ] tag
-    | TModuleType : [< kind > `ModuleType ] tag
-    | TType : [< kind > `Type ] tag
-    | TConstructor : [< kind > `Constructor ] tag
-    | TField : [< kind > `Field ] tag
-    | TExtension : [< kind > `Extension ] tag
-    | TException : [< kind > `Exception ] tag
-    | TValue : [< kind > `Value ] tag
-    | TClass : [< kind > `Class ] tag
-    | TClassType : [< kind > `ClassType ] tag
-    | TMethod : [< kind > `Method ] tag
-    | TInstanceVariable : [< kind > `InstanceVariable ] tag
-    | TLabel : [< kind > `Label ] tag
-    | TPage : [< kind > `Page ] tag
+  type tag_module = [
+    | `TModule
+   ]
 
-  type 'kind t =
-    | Resolved : 'kind Resolved_reference.t -> 'kind t
-    | Root : string * 'kind tag -> 'kind t
-    | Dot : label_parent * string -> [< kind ] t
-    | Module : signature * string -> [< kind > `Module] t
-    | ModuleType : signature * string -> [< kind > `ModuleType] t
-    | Type : signature * string -> [< kind > `Type] t
-    | Constructor : datatype * string -> [< kind > `Constructor] t
-    | Field : parent * string -> [< kind > `Field] t
-    | Extension : signature * string -> [< kind > `Extension] t
-    | Exception : signature * string -> [< kind > `Exception] t
-    | Value : signature * string -> [< kind > `Value] t
-    | Class : signature * string -> [< kind > `Class] t
-    | ClassType : signature * string -> [< kind > `ClassType] t
-    | Method : class_signature * string -> [< kind > `Method] t
-    | InstanceVariable : class_signature * string ->
-        [< kind > `InstanceVariable] t
-    | Label : label_parent * string -> [< kind > `Label] t
+  type tag_module_type = [
+    | `TModuleType
+  ]
 
-  and any = kind t
-  and signature = Kind.signature t
-  and class_signature = Kind.class_signature t
-  and datatype = Kind.datatype t
-  and parent = Kind.parent t
-  and label_parent = [ Kind.parent | Kind.page ] t
+  type tag_type = [
+    | `TType
+  ]
 
-  type module_ = Kind.reference_module t
-  type module_type = Kind.reference_module_type t
-  type type_ = Kind.reference_type t
-  type constructor = Kind.reference_constructor t
-  type field = Kind.reference_field t
-  type extension = Kind.reference_extension t
-  type exception_ = Kind.reference_exception t
-  type value = Kind.reference_value t
-  type class_ = Kind.reference_class t
-  type class_type = Kind.reference_class_type t
-  type method_ = Kind.reference_method t
-  type instance_variable = Kind.reference_instance_variable t
-  type label = Kind.reference_label t
-  type page = Kind.reference_page t
+  type tag_constructor = [
+    | `TConstructor
+  ]
+
+  type tag_field = [
+    | `TField
+  ]
+
+  type tag_extension = [
+    | `TExtension
+  ]
+
+  type tag_exception = [
+    | `TException
+  ]
+
+  type tag_value = [
+    | `TValue
+  ]
+
+  type tag_class = [
+    | `TClass
+  ]
+
+  type tag_class_type = [
+    | `TClassType
+  ]
+
+  type tag_method = [
+    | `TMethod
+  ]
+
+  type tag_instance_variable = [
+    | `TInstanceVariable
+  ]
+
+  type tag_label = [
+    | `TLabel
+  ]
+
+  type tag_page = [
+    | `TPage
+  ]
+
+  type tag_unknown = [
+    `TUnknown
+  ]
+
+  type tag_any = [
+    | tag_module
+    | tag_module_type
+    | tag_type
+    | tag_constructor
+    | tag_field
+    | tag_extension
+    | tag_exception
+    | tag_value
+    | tag_class
+    | tag_class_type
+    | tag_method
+    | tag_instance_variable
+    | tag_label
+    | tag_page
+    | tag_unknown
+  ]
+
+  type tag_signature = [
+    | tag_unknown
+    | tag_module
+    | tag_module_type
+  ]
+
+  type tag_class_signature = [
+    | tag_unknown
+    | tag_class
+    | tag_class_type
+  ]
+
+  type tag_datatype = [
+    | tag_unknown
+    | tag_type
+  ]
+
+  type tag_parent = [
+    | tag_unknown
+    | tag_module
+    | tag_module_type
+    | tag_class
+    | tag_class_type
+    | tag_type
+  ]
+
+  type tag_label_parent = [
+    | tag_unknown
+    | tag_module
+    | tag_module_type
+    | tag_class
+    | tag_class_type
+    | tag_type
+    | tag_page
+  ]
+
+  type signature = [
+    | `Resolved of Resolved_reference.signature
+    | `Root of UnitName.t * tag_signature
+    | `Dot of label_parent * string
+    | `Module of signature * ModuleName.t
+    | `ModuleType of signature * ModuleTypeName.t
+  ]
+
+  and class_signature = [
+    | `Resolved of Resolved_reference.class_signature
+    | `Root of UnitName.t * tag_class_signature
+    | `Dot of label_parent * string
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+  ]
+
+  and datatype = [
+    | `Resolved of Resolved_reference.datatype
+    | `Root of UnitName.t * tag_datatype
+    | `Dot of label_parent * string
+    | `Type of signature * TypeName.t
+  ]
+
+  and parent = [
+    | `Resolved of Resolved_reference.parent
+    | `Root of UnitName.t * tag_parent
+    | `Dot of label_parent * string
+    | `Module of signature * ModuleName.t
+    | `ModuleType of signature * ModuleTypeName.t
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+    | `Type of signature * TypeName.t
+  ]
+
+  and label_parent = [
+    | `Resolved of Resolved_reference.label_parent
+    | `Root of UnitName.t * tag_label_parent
+    | `Dot of label_parent * string
+    | `Module of signature * ModuleName.t
+    | `ModuleType of signature * ModuleTypeName.t
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+    | `Type of signature * TypeName.t
+  ]
+
+  type module_ = [
+    | `Resolved of Resolved_reference.module_
+    | `Root of UnitName.t * [ tag_module | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Module of signature * ModuleName.t
+  ]
+
+  type module_type = [
+    | `Resolved of Resolved_reference.module_type
+    | `Root of UnitName.t * [tag_module_type | tag_unknown ]
+    | `Dot of label_parent * string
+    | `ModuleType of signature * ModuleTypeName.t
+  ]
+
+  type type_ = [
+    | `Resolved of Resolved_reference.type_
+    | `Root of UnitName.t * [ tag_type | tag_class | tag_class_type | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+    | `Type of signature * TypeName.t
+  ]
+
+  type constructor = [
+    | `Resolved of Resolved_reference.constructor
+    | `Root of UnitName.t * [ tag_constructor | tag_extension | tag_exception | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Constructor of datatype * ConstructorName.t
+    | `Extension of signature * ExtensionName.t
+    | `Exception of signature * ExceptionName.t
+  ]
+
+  type field = [
+    | `Resolved of Resolved_reference.field
+    | `Root of UnitName.t * [ tag_field | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Field of parent * FieldName.t
+  ]
+
+  type extension = [
+    | `Resolved of Resolved_reference.extension
+    | `Root of UnitName.t * [ tag_extension | tag_exception | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Extension of signature * ExtensionName.t
+    | `Exception of signature * ExceptionName.t
+  ]
+
+  type exception_ = [
+    | `Resolved of Resolved_reference.exception_
+    | `Root of UnitName.t * [ tag_exception | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Exception of signature * ExceptionName.t
+  ]
+
+  type value = [
+    | `Resolved of Resolved_reference.value
+    | `Root of UnitName.t * [ tag_value | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Value of signature * ValueName.t
+  ]
+
+  type class_ = [
+    | `Resolved of Resolved_reference.class_
+    | `Root of UnitName.t * [ tag_class | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Class of signature * ClassName.t
+  ]
+
+  type class_type = [
+    | `Resolved of Resolved_reference.class_type
+    | `Root of UnitName.t * [ tag_class | tag_class_type | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+  ]
+
+  type method_ = [
+    | `Resolved of Resolved_reference.method_
+    | `Root of UnitName.t * [ tag_method | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Method of class_signature * MethodName.t
+  ]
+
+  type instance_variable = [
+    | `Resolved of Resolved_reference.instance_variable
+    | `Root of UnitName.t * [ tag_instance_variable | tag_unknown ]
+    | `Dot of label_parent * string
+    | `InstanceVariable of class_signature * InstanceVariableName.t
+  ]
+
+  type label = [
+    | `Resolved of Resolved_reference.label
+    | `Root of UnitName.t * [ tag_label | tag_unknown ]
+    | `Dot of label_parent * string
+    | `Label of label_parent * LabelName.t
+  ]
+
+  type page = [
+    | `Resolved of Resolved_reference.page
+    | `Root of UnitName.t * [ tag_page | tag_unknown ]
+    | `Dot of label_parent * string
+  ]
+
+  type any = [
+    | `Resolved of Resolved_reference.any
+    | `Root of UnitName.t * tag_any
+    | `Dot of label_parent * string
+    | `Module of signature * ModuleName.t
+    | `ModuleType of signature * ModuleTypeName.t
+    | `Type of signature * TypeName.t
+    | `Constructor of datatype * ConstructorName.t
+    | `Field of parent * FieldName.t
+    | `Extension of signature * ExtensionName.t
+    | `Exception of signature * ExceptionName.t
+    | `Value of signature * ValueName.t
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+    | `Method of class_signature * MethodName.t
+    | `InstanceVariable of class_signature * InstanceVariableName.t
+    | `Label of label_parent * LabelName.t
+  ]
 end = Reference
 
 and Resolved_reference :
 sig
-  type kind = Kind.reference
 
-  type 'kind t =
-    | Identifier : 'kind Identifier.t -> 'kind t
-    | SubstAlias : Resolved_path.module_ * module_ -> [< kind > `Module ] t
-    | Module : signature * string -> [< kind > `Module] t
-    | Canonical : module_ * Reference.module_ -> [< kind > `Module] t
-    | ModuleType : signature * string -> [< kind > `ModuleType] t
-    | Type : signature * string -> [< kind > `Type] t
-    | Constructor : datatype * string -> [< kind > `Constructor] t
-    | Field : parent * string -> [< kind > `Field] t
-    | Extension : signature * string -> [< kind > `Extension] t
-    | Exception : signature * string -> [< kind > `Exception] t
-    | Value : signature * string -> [< kind > `Value] t
-    | Class : signature * string -> [< kind > `Class] t
-    | ClassType : signature * string -> [< kind > `ClassType] t
-    | Method : class_signature * string -> [< kind > `Method] t
-    | InstanceVariable : class_signature * string ->
-        [< kind > `InstanceVariable] t
-    | Label : label_parent * string -> [< kind > `Label] t
+  (* Note - many of these are effectively unions of previous types,
+    but they are declared here explicitly because OCaml isn't yet
+    smart enough to accept the more natural expression of this. Hence
+    we define here all those types that ever appear on the right hand
+    side of the constructors and then below we redefine many with
+    the actual hierarchy made more explicit. *)
+  type datatype = [
+    | `Identifier of Identifier.datatype
 
-  and any = kind t
-  and signature = Kind.signature t
-  and class_signature = Kind.class_signature t
-  and datatype = Kind.datatype t
-  and parent = Kind.parent t
-  and module_ = Kind.reference_module t
-  and label_parent = Kind.label_parent t
+    | `Type of signature * TypeName.t
+  ]
 
-  type module_type = Kind.reference_module_type t
-  type type_ = Kind.reference_type t
-  type constructor = Kind.reference_constructor t
-  type field = Kind.reference_field t
-  type extension = Kind.reference_extension t
-  type exception_ = Kind.reference_exception t
-  type value = Kind.reference_value t
-  type class_ = Kind.reference_class t
-  type class_type = Kind.reference_class_type t
-  type method_ = Kind.reference_method t
-  type instance_variable = Kind.reference_instance_variable t
-  type label = Kind.reference_label t
-  type page = Kind.reference_page t
+  and module_ = [
+    | `Identifier of Identifier.module_
+
+    | `SubstAlias of Resolved_path.module_ * module_
+    | `Module of signature * ModuleName.t
+    | `Canonical of module_ * Reference.module_
+  ]
+
+  (* Signature is [ module | datatype] *)
+  and signature = [
+    | `Identifier of Identifier.signature
+
+    | `SubstAlias of Resolved_path.module_ * module_
+    | `Module of signature * ModuleName.t
+    | `Canonical of module_ * Reference.module_
+
+    | `ModuleType of signature * ModuleTypeName.t
+  ]
+
+  and class_signature = [
+    | `Identifier of Identifier.class_signature
+
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+  ]
+
+  (* parent is [ signature | class_signature ] *)
+  and parent = [
+    | `Identifier of Identifier.parent
+
+    | `SubstAlias of Resolved_path.module_ * module_
+    | `Module of signature * ModuleName.t
+    | `Canonical of module_ * Reference.module_
+
+    | `ModuleType of signature * ModuleTypeName.t
+
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+
+    | `Type of signature * TypeName.t
+  ]
+
+  (* The only difference between parent and label_parent
+     is that the Identifier allows more types *)
+  and label_parent = [
+    | `Identifier of Identifier.label_parent
+
+    | `SubstAlias of Resolved_path.module_ * module_
+    | `Module of signature * ModuleName.t
+    | `Canonical of module_ * Reference.module_
+
+    | `ModuleType of signature * ModuleTypeName.t
+
+    | `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t
+
+    | `Type of signature * TypeName.t
+  ]
+
+  type s_substalias = [ `SubstAlias of Resolved_path.module_ * module_ ]
+  type s_module = [ `Module of signature * ModuleName.t ]
+  type s_canonical = [ `Canonical of module_ * Reference.module_ ]
+  type s_module_type = [ `ModuleType of signature * ModuleTypeName.t ]
+  type s_type =[ `Type of signature * TypeName.t ]
+  type s_constructor = [ `Constructor of datatype * ConstructorName.t ]
+  type s_field = [ `Field of parent * FieldName.t ]
+  type s_extension = [ `Extension of signature * ExtensionName.t ]
+  type s_exception = [ `Exception of signature * ExceptionName.t ]
+  type s_value = [ `Value of signature * ValueName.t ]
+  type s_class = [ `Class of signature * ClassName.t ]
+  type s_class_type = [ `ClassType of signature * ClassTypeName.t ]
+  type s_method = [ `Method of class_signature * MethodName.t ]
+  type s_instance_variable = [ `InstanceVariable of class_signature * InstanceVariableName.t ]
+  type s_label = [ `Label of label_parent * LabelName.t ]
+
+  type module_no_id = [
+    | s_substalias
+    | s_module
+    | s_canonical
+  ]
+
+  type signature_no_id = [
+    | module_no_id
+    | s_module_type
+  ]
+
+  type class_signature_no_id = [
+    | s_class
+    | s_class_type
+  ]
+
+  type datatype_no_id = [
+    | s_type
+  ]
+
+  type parent_no_id = [
+    | signature_no_id
+    | class_signature_no_id
+    | datatype_no_id
+  ]
+
+  type module_type = [
+    | `Identifier of Identifier.reference_module_type
+    | s_module_type
+  ]
+
+  type type_ = [
+    | `Identifier of Identifier.reference_type
+    | s_type
+    | s_class
+    | s_class_type
+  ]
+
+  type constructor = [
+    | `Identifier of Identifier.reference_constructor
+    | s_constructor
+    | s_extension
+    | s_exception
+  ]
+
+  type constructor_no_id = [
+    | s_constructor
+    | s_extension
+    | s_exception
+  ]
+
+  type field = [
+    | `Identifier of Identifier.reference_field
+    | s_field
+  ]
+
+  type extension = [
+    | `Identifier of Identifier.reference_extension
+    | s_exception
+    | s_extension
+  ]
+
+  type extension_no_id = [
+    | s_exception
+    | s_extension
+  ]
+
+  type exception_ = [
+    | `Identifier of Identifier.reference_exception
+    | s_exception
+  ]
+
+  type value = [
+    | `Identifier of Identifier.reference_value
+    | s_value
+  ]
+
+  type class_ = [
+    | `Identifier of Identifier.reference_class
+    | s_class
+  ]
+
+  type class_type = [
+    | `Identifier of Identifier.reference_class_type
+    | s_class
+    | s_class_type
+  ]
+
+  type class_type_no_id = [
+    | s_class
+    | s_class_type
+  ]
+
+  type method_ = [
+    | `Identifier of Identifier.reference_method
+    | s_method
+  ]
+
+  type instance_variable = [
+    | `Identifier of Identifier.reference_instance_variable
+    | s_instance_variable
+  ]
+
+  type label = [
+    | `Identifier of Identifier.reference_label
+    | s_label
+  ]
+
+  type page = [
+    | `Identifier of Identifier.reference_page
+  ]
+
+  type any = [
+    | `Identifier of Identifier.any
+    | s_substalias
+    | s_module
+    | s_canonical
+    | s_module_type
+    | s_type
+    | s_constructor
+    | s_field
+    | s_extension
+    | s_exception
+    | s_value
+    | s_class
+    | s_class_type
+    | s_method
+    | s_instance_variable
+    | s_label
+  ]
 end = Resolved_reference

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -238,28 +238,25 @@ sig
     | `ModuleType of module_ * ModuleTypeName.t
   ]
 
-  type type_ = [
-    | `Identifier of Identifier.path_type
-    | `Type of module_ * TypeName.t
-    | `Class of module_ * ClassName.t
-    | `ClassType of module_ * ClassTypeName.t
-  ]
-
   type type_no_id = [
     | `Type of module_ * TypeName.t
     | `Class of module_ * ClassName.t
     | `ClassType of module_ * ClassTypeName.t
   ]
 
-  type class_type = [
-    | `Identifier of Identifier.path_class_type
-    | `Class of module_ * ClassName.t
-    | `ClassType of module_ * ClassTypeName.t
+  type type_ = [
+    | `Identifier of Identifier.path_type
+    | type_no_id
   ]
 
   type class_type_no_id = [
     | `Class of module_ * ClassName.t
     | `ClassType of module_ * ClassTypeName.t
+  ]
+
+  type class_type = [
+    | `Identifier of Identifier.path_class_type
+    | class_type_no_id
   ]
 
   type any = [
@@ -709,7 +706,7 @@ sig
     | `Canonical of module_ * Reference.module_
   ]
 
-  (* Signature is [ module | datatype] *)
+  (* Signature is [ module | moduletype ] *)
   and signature = [
     | `Identifier of Identifier.signature
 

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -330,59 +330,59 @@ end = Resolved_fragment
 module rec Reference :
 sig
 
-  type tag_module = [
+  type tag_only_module = [
     | `TModule
    ]
 
-  type tag_module_type = [
+  type tag_only_module_type = [
     | `TModuleType
   ]
 
-  type tag_type = [
+  type tag_only_type = [
     | `TType
   ]
 
-  type tag_constructor = [
+  type tag_only_constructor = [
     | `TConstructor
   ]
 
-  type tag_field = [
+  type tag_only_field = [
     | `TField
   ]
 
-  type tag_extension = [
+  type tag_only_extension = [
     | `TExtension
   ]
 
-  type tag_exception = [
+  type tag_only_exception = [
     | `TException
   ]
 
-  type tag_value = [
+  type tag_only_value = [
     | `TValue
   ]
 
-  type tag_class = [
+  type tag_only_class = [
     | `TClass
   ]
 
-  type tag_class_type = [
+  type tag_only_class_type = [
     | `TClassType
   ]
 
-  type tag_method = [
+  type tag_only_method = [
     | `TMethod
   ]
 
-  type tag_instance_variable = [
+  type tag_only_instance_variable = [
     | `TInstanceVariable
   ]
 
-  type tag_label = [
+  type tag_only_label = [
     | `TLabel
   ]
 
-  type tag_page = [
+  type tag_only_page = [
     | `TPage
   ]
 
@@ -391,57 +391,57 @@ sig
   ]
 
   type tag_any = [
-    | tag_module
-    | tag_module_type
-    | tag_type
-    | tag_constructor
-    | tag_field
-    | tag_extension
-    | tag_exception
-    | tag_value
-    | tag_class
-    | tag_class_type
-    | tag_method
-    | tag_instance_variable
-    | tag_label
-    | tag_page
+    | tag_only_module
+    | tag_only_module_type
+    | tag_only_type
+    | tag_only_constructor
+    | tag_only_field
+    | tag_only_extension
+    | tag_only_exception
+    | tag_only_value 
+    | tag_only_class
+    | tag_only_class_type
+    | tag_only_method
+    | tag_only_instance_variable
+    | tag_only_label
+    | tag_only_page
     | tag_unknown
   ]
 
   type tag_signature = [
     | tag_unknown
-    | tag_module
-    | tag_module_type
+    | tag_only_module
+    | tag_only_module_type
   ]
 
   type tag_class_signature = [
     | tag_unknown
-    | tag_class
-    | tag_class_type
+    | tag_only_class
+    | tag_only_class_type
   ]
 
   type tag_datatype = [
     | tag_unknown
-    | tag_type
+    | tag_only_type
   ]
 
   type tag_parent = [
     | tag_unknown
-    | tag_module
-    | tag_module_type
-    | tag_class
-    | tag_class_type
-    | tag_type
+    | tag_only_module
+    | tag_only_module_type
+    | tag_only_class
+    | tag_only_class_type
+    | tag_only_type
   ]
 
   type tag_label_parent = [
     | tag_unknown
-    | tag_module
-    | tag_module_type
-    | tag_class
-    | tag_class_type
-    | tag_type
-    | tag_page
+    | tag_only_module
+    | tag_only_module_type
+    | tag_only_class
+    | tag_only_class_type
+    | tag_only_type
+    | tag_only_page
   ]
 
   type signature = [
@@ -489,106 +489,180 @@ sig
     | `Type of signature * TypeName.t
   ]
 
+  type tag_module = [
+    | tag_only_module
+    | tag_unknown
+  ]
+
   type module_ = [
     | `Resolved of Resolved_reference.module_
-    | `Root of UnitName.t * [ tag_module | tag_unknown ]
+    | `Root of UnitName.t * tag_module
     | `Dot of label_parent * string
     | `Module of signature * ModuleName.t
   ]
 
+  type tag_module_type = [
+    | tag_only_module_type
+    | tag_unknown
+  ]
   type module_type = [
     | `Resolved of Resolved_reference.module_type
-    | `Root of UnitName.t * [tag_module_type | tag_unknown ]
+    | `Root of UnitName.t * tag_module_type
     | `Dot of label_parent * string
     | `ModuleType of signature * ModuleTypeName.t
   ]
 
+  type tag_type = [
+    | tag_only_type
+    | tag_only_class
+    | tag_only_class_type
+    | tag_unknown
+  ]
+
   type type_ = [
     | `Resolved of Resolved_reference.type_
-    | `Root of UnitName.t * [ tag_type | tag_class | tag_class_type | tag_unknown ]
+    | `Root of UnitName.t * tag_type
     | `Dot of label_parent * string
     | `Class of signature * ClassName.t
     | `ClassType of signature * ClassTypeName.t
     | `Type of signature * TypeName.t
   ]
 
+  type tag_constructor = [
+    | tag_only_constructor
+    | tag_only_extension
+    | tag_only_exception
+    | tag_unknown
+  ]
+
   type constructor = [
     | `Resolved of Resolved_reference.constructor
-    | `Root of UnitName.t * [ tag_constructor | tag_extension | tag_exception | tag_unknown ]
+    | `Root of UnitName.t * tag_constructor
     | `Dot of label_parent * string
     | `Constructor of datatype * ConstructorName.t
     | `Extension of signature * ExtensionName.t
     | `Exception of signature * ExceptionName.t
   ]
 
+  type tag_field = [
+    | tag_only_field
+    | tag_unknown
+  ]
+
   type field = [
     | `Resolved of Resolved_reference.field
-    | `Root of UnitName.t * [ tag_field | tag_unknown ]
+    | `Root of UnitName.t * tag_field
     | `Dot of label_parent * string
     | `Field of parent * FieldName.t
   ]
 
+  type tag_extension = [
+    | tag_only_extension
+    | tag_only_exception
+    | tag_unknown
+  ]
   type extension = [
     | `Resolved of Resolved_reference.extension
-    | `Root of UnitName.t * [ tag_extension | tag_exception | tag_unknown ]
+    | `Root of UnitName.t * tag_extension
     | `Dot of label_parent * string
     | `Extension of signature * ExtensionName.t
     | `Exception of signature * ExceptionName.t
   ]
 
+  type tag_exception = [
+    | tag_only_exception
+    | tag_unknown
+  ]
+
   type exception_ = [
     | `Resolved of Resolved_reference.exception_
-    | `Root of UnitName.t * [ tag_exception | tag_unknown ]
+    | `Root of UnitName.t * tag_exception
     | `Dot of label_parent * string
     | `Exception of signature * ExceptionName.t
   ]
 
+  type tag_value = [
+    | tag_only_value
+    | tag_unknown
+  ]
+
   type value = [
     | `Resolved of Resolved_reference.value
-    | `Root of UnitName.t * [ tag_value | tag_unknown ]
+    | `Root of UnitName.t * tag_value
     | `Dot of label_parent * string
     | `Value of signature * ValueName.t
   ]
 
+  type tag_class = [
+    | tag_only_class
+    | tag_unknown
+  ]
+
   type class_ = [
     | `Resolved of Resolved_reference.class_
-    | `Root of UnitName.t * [ tag_class | tag_unknown ]
+    | `Root of UnitName.t * tag_class
     | `Dot of label_parent * string
     | `Class of signature * ClassName.t
   ]
 
+  type tag_class_type = [
+    | tag_only_class
+    | tag_only_class_type
+    | tag_unknown
+  ]
+
   type class_type = [
     | `Resolved of Resolved_reference.class_type
-    | `Root of UnitName.t * [ tag_class | tag_class_type | tag_unknown ]
+    | `Root of UnitName.t * tag_class_type
     | `Dot of label_parent * string
     | `Class of signature * ClassName.t
     | `ClassType of signature * ClassTypeName.t
   ]
 
+  type tag_method = [
+    | tag_only_method
+    | tag_unknown
+  ]
+
   type method_ = [
     | `Resolved of Resolved_reference.method_
-    | `Root of UnitName.t * [ tag_method | tag_unknown ]
+    | `Root of UnitName.t * tag_method
     | `Dot of label_parent * string
     | `Method of class_signature * MethodName.t
   ]
 
+  type tag_instance_variable = [
+    | tag_only_instance_variable
+    | tag_unknown
+  ]
+
   type instance_variable = [
     | `Resolved of Resolved_reference.instance_variable
-    | `Root of UnitName.t * [ tag_instance_variable | tag_unknown ]
+    | `Root of UnitName.t * tag_instance_variable
     | `Dot of label_parent * string
     | `InstanceVariable of class_signature * InstanceVariableName.t
   ]
 
+  type tag_label = [
+    | tag_only_label
+    | tag_unknown
+  ]
+
   type label = [
     | `Resolved of Resolved_reference.label
-    | `Root of UnitName.t * [ tag_label | tag_unknown ]
+    | `Root of UnitName.t * tag_label
     | `Dot of label_parent * string
     | `Label of label_parent * LabelName.t
   ]
 
+  type tag_page = [
+    | tag_only_page
+    | tag_unknown
+  ]
+
   type page = [
     | `Resolved of Resolved_reference.page
-    | `Root of UnitName.t * [ tag_page | tag_unknown ]
+    | `Root of UnitName.t * tag_page
     | `Dot of label_parent * string
   ]
 

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -22,25 +22,13 @@ struct
   ]
 
   type parent = [
-    | `Root of Root.t * UnitName.t
-    | `Module of signature * ModuleName.t
-    | `Argument of signature * int * ArgumentName.t
-    | `ModuleType of signature * ModuleTypeName.t
-    | `Type of signature * TypeName.t
-    | `CoreType of TypeName.t
-    | `Class of signature * ClassName.t
-    | `ClassType of signature * ClassTypeName.t
+    | signature
+    | datatype
+    | class_signature
   ]
 
   type label_parent = [
-    | `Root of Root.t * UnitName.t
-    | `Module of signature * ModuleName.t
-    | `Argument of signature * int * ArgumentName.t
-    | `ModuleType of signature * ModuleTypeName.t
-    | `Type of signature * TypeName.t
-    | `CoreType of TypeName.t
-    | `Class of signature * ClassName.t
-    | `ClassType of signature * ClassTypeName.t
+    | parent
     | `Page of Root.t * PageName.t
   ]
 

--- a/src/model/predefined.ml
+++ b/src/model/predefined.ml
@@ -14,8 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Paths
 open Lang
+open Names
 
 let predefined_location =
   let point =
@@ -59,48 +59,46 @@ let invariant_equation =
   let constraints = [] in
     {params; private_; manifest; constraints}
 
-open Identifier
-
-let bool_identifier = CoreType "bool"
-let int_identifier = CoreType "int"
-let char_identifier = CoreType "char"
-let bytes_identifier = CoreType "bytes"
-let string_identifier = CoreType "string"
-let float_identifier = CoreType "float"
-let unit_identifier = CoreType "unit"
-let exn_identifier = CoreType "exn"
-let array_identifier = CoreType "array"
-let list_identifier = CoreType "list"
-let option_identifier = CoreType "option"
-let int32_identifier = CoreType "int32"
-let int64_identifier = CoreType "int64"
-let nativeint_identifier = CoreType "nativeint"
-let lazy_t_identifier = CoreType "lazy_t"
-let extension_constructor_identifier = CoreType "extension_constructor"
-let floatarray_identifier = CoreType "floatarray"
+let bool_identifier = `CoreType (TypeName.of_string "bool")
+let int_identifier = `CoreType (TypeName.of_string "int")
+let char_identifier = `CoreType (TypeName.of_string "char")
+let bytes_identifier = `CoreType (TypeName.of_string "bytes")
+let string_identifier = `CoreType (TypeName.of_string "string")
+let float_identifier = `CoreType (TypeName.of_string "float")
+let unit_identifier = `CoreType (TypeName.of_string "unit")
+let exn_identifier = `CoreType (TypeName.of_string "exn")
+let array_identifier = `CoreType (TypeName.of_string "array")
+let list_identifier = `CoreType (TypeName.of_string "list")
+let option_identifier = `CoreType (TypeName.of_string "option")
+let int32_identifier = `CoreType (TypeName.of_string "int32")
+let int64_identifier = `CoreType (TypeName.of_string "int64")
+let nativeint_identifier = `CoreType (TypeName.of_string "nativeint")
+let lazy_t_identifier = `CoreType (TypeName.of_string "lazy_t")
+let extension_constructor_identifier = `CoreType (TypeName.of_string "extension_constructor")
+let floatarray_identifier = `CoreType (TypeName.of_string "floatarray")
 
 
-let false_identifier = Constructor(bool_identifier, "false")
-let true_identifier = Constructor(bool_identifier, "true")
-let void_identifier = Constructor(unit_identifier, "()")
-let nil_identifier = Constructor(list_identifier, "([])")
-let cons_identifier = Constructor(list_identifier, "(::)")
-let none_identifier = Constructor(option_identifier, "None")
-let some_identifier = Constructor(option_identifier, "Some")
+let false_identifier = `Constructor(bool_identifier, ConstructorName.of_string "false")
+let true_identifier = `Constructor(bool_identifier, ConstructorName.of_string "true")
+let void_identifier = `Constructor(unit_identifier, ConstructorName.of_string "()")
+let nil_identifier = `Constructor(list_identifier, ConstructorName.of_string "([])")
+let cons_identifier = `Constructor(list_identifier, ConstructorName.of_string "(::)")
+let none_identifier = `Constructor(option_identifier, ConstructorName.of_string "None")
+let some_identifier = `Constructor(option_identifier, ConstructorName.of_string "Some")
 
-let match_failure_identifier = CoreException "Match_failure"
-let assert_failure_identifier = CoreException "Assert_failure"
-let invalid_argument_identifier = CoreException "Invalid_argument"
-let failure_identifier = CoreException "Failure"
-let not_found_identifier = CoreException "Not_found"
-let out_of_memory_identifier = CoreException "Out_of_memory"
-let stack_overflow_identifier = CoreException "Stack_overflow"
-let sys_error_identifier = CoreException "Sys_error"
-let end_of_file_identifier = CoreException "End_of_file"
-let division_by_zero_identifier = CoreException "Division_by_zero"
-let sys_blocked_io_identifier = CoreException "Sys_blocked_io"
+let match_failure_identifier = `CoreException (ExceptionName.of_string "Match_failure")
+let assert_failure_identifier = `CoreException (ExceptionName.of_string "Assert_failure")
+let invalid_argument_identifier = `CoreException (ExceptionName.of_string "Invalid_argument")
+let failure_identifier = `CoreException (ExceptionName.of_string "Failure")
+let not_found_identifier = `CoreException (ExceptionName.of_string "Not_found")
+let out_of_memory_identifier = `CoreException (ExceptionName.of_string "Out_of_memory")
+let stack_overflow_identifier = `CoreException (ExceptionName.of_string "Stack_overflow")
+let sys_error_identifier = `CoreException (ExceptionName.of_string "Sys_error")
+let end_of_file_identifier = `CoreException (ExceptionName.of_string "End_of_file")
+let division_by_zero_identifier = `CoreException (ExceptionName.of_string "Division_by_zero")
+let sys_blocked_io_identifier = `CoreException (ExceptionName.of_string "Sys_blocked_io")
 let undefined_recursive_module_identifier =
-  CoreException "Undefined_recursive_module"
+  `CoreException (ExceptionName.of_string "Undefined_recursive_module")
 
 let core_type_identifier = function
   | "int" -> Some int_identifier
@@ -149,71 +147,66 @@ let core_constructor_identifier = function
   | "Some" -> Some some_identifier
   | _ -> None
 
-open Path.Resolved
-open Path
 
-let bool_path = Resolved (Identifier bool_identifier)
-let int_path = Resolved (Identifier int_identifier)
-let char_path = Resolved (Identifier char_identifier)
-let bytes_path = Resolved (Identifier bytes_identifier)
-let string_path = Resolved (Identifier string_identifier)
-let float_path = Resolved (Identifier float_identifier)
-let unit_path = Resolved (Identifier unit_identifier)
-let exn_path = Resolved (Identifier exn_identifier)
-let array_path = Resolved (Identifier array_identifier)
-let list_path = Resolved (Identifier list_identifier)
-let option_path = Resolved (Identifier option_identifier)
-let int32_path = Resolved (Identifier int32_identifier)
-let int64_path = Resolved (Identifier int64_identifier)
-let nativeint_path = Resolved (Identifier nativeint_identifier)
-let lazy_t_path = Resolved (Identifier lazy_t_identifier)
+let bool_path = `Resolved (`Identifier bool_identifier)
+let int_path = `Resolved (`Identifier int_identifier)
+let char_path = `Resolved (`Identifier char_identifier)
+let bytes_path = `Resolved (`Identifier bytes_identifier)
+let string_path = `Resolved (`Identifier string_identifier)
+let float_path = `Resolved (`Identifier float_identifier)
+let unit_path = `Resolved (`Identifier unit_identifier)
+let exn_path = `Resolved (`Identifier exn_identifier)
+let array_path = `Resolved (`Identifier array_identifier)
+let list_path = `Resolved (`Identifier list_identifier)
+let option_path = `Resolved (`Identifier option_identifier)
+let int32_path = `Resolved (`Identifier int32_identifier)
+let int64_path = `Resolved (`Identifier int64_identifier)
+let nativeint_path = `Resolved (`Identifier nativeint_identifier)
+let lazy_t_path = `Resolved (`Identifier lazy_t_identifier)
 let extension_constructor_path =
-  Resolved (Identifier extension_constructor_identifier)
-let _floatarray_path = Resolved (Identifier floatarray_identifier)
+  `Resolved (`Identifier extension_constructor_identifier)
+let _floatarray_path = `Resolved (`Identifier floatarray_identifier)
 
-open Reference.Resolved
-open Reference
-
-let bool_reference = Resolved (Identifier bool_identifier)
-let int_reference = Resolved (Identifier int_identifier)
-let char_reference = Resolved (Identifier char_identifier)
-let bytes_reference = Resolved (Identifier bytes_identifier)
-let string_reference = Resolved (Identifier string_identifier)
-let float_reference = Resolved (Identifier float_identifier)
-let unit_reference = Resolved (Identifier unit_identifier)
-let exn_reference = Resolved (Identifier exn_identifier)
-let array_reference = Resolved (Identifier array_identifier)
-let list_reference = Resolved (Identifier list_identifier)
-let option_reference = Resolved (Identifier option_identifier)
-let int32_reference = Resolved (Identifier int32_identifier)
-let int64_reference = Resolved (Identifier int64_identifier)
-let nativeint_reference = Resolved (Identifier nativeint_identifier)
-let lazy_t_reference = Resolved (Identifier lazy_t_identifier)
+let bool_reference = `Resolved (`Identifier bool_identifier)
+let int_reference = `Resolved (`Identifier int_identifier)
+let char_reference = `Resolved (`Identifier char_identifier)
+let bytes_reference = `Resolved (`Identifier bytes_identifier)
+let string_reference = `Resolved (`Identifier string_identifier)
+let float_reference = `Resolved (`Identifier float_identifier)
+let unit_reference = `Resolved (`Identifier unit_identifier)
+let exn_reference = `Resolved (`Identifier exn_identifier)
+let array_reference = `Resolved (`Identifier array_identifier)
+let list_reference = `Resolved (`Identifier list_identifier)
+let option_reference = `Resolved (`Identifier option_identifier)
+let int32_reference = `Resolved (`Identifier int32_identifier)
+let int64_reference = `Resolved (`Identifier int64_identifier)
+let nativeint_reference = `Resolved (`Identifier nativeint_identifier)
+let lazy_t_reference = `Resolved (`Identifier lazy_t_identifier)
 let extension_constructor_reference =
-  Resolved (Identifier extension_constructor_identifier)
-let _floatarray_reference = Resolved (Identifier floatarray_identifier)
+  `Resolved (`Identifier extension_constructor_identifier)
+let _floatarray_reference = `Resolved (`Identifier floatarray_identifier)
 
-let false_reference = Resolved (Identifier false_identifier)
-let true_reference = Resolved (Identifier true_identifier)
-let void_reference = Resolved (Identifier void_identifier)
-let nil_reference = Resolved (Identifier nil_identifier)
-let cons_reference = Resolved (Identifier cons_identifier)
-let none_reference = Resolved (Identifier none_identifier)
-let some_reference = Resolved (Identifier some_identifier)
+let false_reference = `Resolved (`Identifier false_identifier)
+let true_reference = `Resolved (`Identifier true_identifier)
+let void_reference = `Resolved (`Identifier void_identifier)
+let nil_reference = `Resolved (`Identifier nil_identifier)
+let cons_reference = `Resolved (`Identifier cons_identifier)
+let none_reference = `Resolved (`Identifier none_identifier)
+let some_reference = `Resolved (`Identifier some_identifier)
 
-let match_failure_reference = Resolved(Identifier match_failure_identifier)
-let assert_failure_reference = Resolved(Identifier assert_failure_identifier)
-let invalid_argument_reference = Resolved(Identifier invalid_argument_identifier)
-let failure_reference = Resolved(Identifier failure_identifier)
-let not_found_reference = Resolved(Identifier not_found_identifier)
-let out_of_memory_reference = Resolved(Identifier out_of_memory_identifier)
-let stack_overflow_reference = Resolved(Identifier stack_overflow_identifier)
-let sys_error_reference = Resolved(Identifier sys_error_identifier)
-let end_of_file_reference = Resolved(Identifier end_of_file_identifier)
-let division_by_zero_reference = Resolved(Identifier division_by_zero_identifier)
-let sys_blocked_io_reference = Resolved(Identifier sys_blocked_io_identifier)
+let match_failure_reference = `Resolved (`Identifier match_failure_identifier)
+let assert_failure_reference = `Resolved (`Identifier assert_failure_identifier)
+let invalid_argument_reference = `Resolved (`Identifier invalid_argument_identifier)
+let failure_reference = `Resolved (`Identifier failure_identifier)
+let not_found_reference = `Resolved (`Identifier not_found_identifier)
+let out_of_memory_reference = `Resolved (`Identifier out_of_memory_identifier)
+let stack_overflow_reference = `Resolved (`Identifier stack_overflow_identifier)
+let sys_error_reference = `Resolved (`Identifier sys_error_identifier)
+let end_of_file_reference = `Resolved (`Identifier end_of_file_identifier)
+let division_by_zero_reference = `Resolved (`Identifier division_by_zero_identifier)
+let sys_blocked_io_reference = `Resolved (`Identifier sys_blocked_io_identifier)
 let undefined_recursive_module_reference =
-  Resolved(Identifier undefined_recursive_module_identifier)
+  `Resolved (`Identifier undefined_recursive_module_identifier)
 
 let false_decl =
   let open TypeDecl.Constructor in
@@ -498,7 +491,7 @@ let floatarray_decl =
     [`Paragraph (
       words ["This"; "type"; "is"; "used"; "to"; "implement"; "the"] @
       [`Space;
-       `Reference (Module (Root ("Array", TModule), "Floatarray"), []);
+       `Reference (`Module (`Root (UnitName.of_string "Array", `TModule), ModuleName.of_string "Floatarray"), []);
        `Space] @
       words ["module."; "It"; "should"; "not"; "be"; "used"; "directly."]
       |> List.map (Location_.at predefined_location)
@@ -510,7 +503,7 @@ let floatarray_decl =
     {id; doc; equation; representation}
 
 let match_failure_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = match_failure_identifier in
   (* let text =
@@ -530,7 +523,7 @@ let match_failure_decl =
     {id; doc; args; res}
 
 let assert_failure_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = assert_failure_identifier in
   (* let text =
@@ -550,7 +543,7 @@ let assert_failure_decl =
     {id; doc; args; res}
 
 let invalid_argument_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = invalid_argument_identifier in
   (* let text =
@@ -564,7 +557,7 @@ let invalid_argument_decl =
     {id; doc; args; res}
 
 let failure_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = failure_identifier in
   (* let text =
@@ -578,7 +571,7 @@ let failure_decl =
     {id; doc; args; res}
 
 let not_found_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = not_found_identifier in
   (* let text =
@@ -592,7 +585,7 @@ let not_found_decl =
     {id; doc; args; res}
 
 let out_of_memory_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = out_of_memory_identifier in
   (* let text =
@@ -607,7 +600,7 @@ let out_of_memory_decl =
 
 (* TODO: Provide reference to the OCaml manual *)
 let stack_overflow_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = stack_overflow_identifier in
   (* let text =
@@ -624,7 +617,7 @@ let stack_overflow_decl =
     {id; doc; args; res}
 
 let sys_error_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = sys_error_identifier in
   (* let text =
@@ -638,7 +631,7 @@ let sys_error_decl =
     {id; doc; args; res}
 
 let end_of_file_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = end_of_file_identifier in
   (* let text =
@@ -652,7 +645,7 @@ let end_of_file_decl =
     {id; doc; args; res}
 
 let division_by_zero_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = division_by_zero_identifier in
   (* let text =
@@ -666,7 +659,7 @@ let division_by_zero_decl =
     {id; doc; args; res}
 
 let sys_blocked_io_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = sys_blocked_io_identifier in
   (* let text =
@@ -682,7 +675,7 @@ let sys_blocked_io_decl =
 
 (* TODO: Provide reference to the OCaml manual *)
 let undefined_recursive_module_decl =
-  let open Exception in
+  let open Lang.Exception in
   (* let open Model.Comment in *)
   let id = undefined_recursive_module_identifier in
   (* let text =

--- a/src/model/predefined.mli
+++ b/src/model/predefined.mli
@@ -18,109 +18,106 @@ open Paths
 
 (** {3 Identifiers} *)
 
-val bool_identifier : Identifier.type_
-val int_identifier : Identifier.type_
-val char_identifier : Identifier.type_
-val bytes_identifier : Identifier.type_
-val string_identifier : Identifier.type_
-val float_identifier : Identifier.type_
-val unit_identifier : Identifier.type_
-val exn_identifier : Identifier.type_
-val array_identifier : Identifier.type_
-val list_identifier : Identifier.type_
-val option_identifier : Identifier.type_
-val int32_identifier : Identifier.type_
-val int64_identifier : Identifier.type_
-val nativeint_identifier : Identifier.type_
-val lazy_t_identifier : Identifier.type_
-val extension_constructor_identifier : Identifier.type_
+val bool_identifier : Identifier.Type.t
+val int_identifier : Identifier.Type.t
+val char_identifier : Identifier.Type.t
+val bytes_identifier : Identifier.Type.t
+val string_identifier : Identifier.Type.t
+val float_identifier : Identifier.Type.t
+val unit_identifier : Identifier.Type.t
+val exn_identifier : Identifier.Type.t
+val array_identifier : Identifier.Type.t
+val list_identifier : Identifier.Type.t
+val option_identifier : Identifier.Type.t
+val int32_identifier : Identifier.Type.t
+val int64_identifier : Identifier.Type.t
+val nativeint_identifier : Identifier.Type.t
+val lazy_t_identifier : Identifier.Type.t
+val extension_constructor_identifier : Identifier.Type.t
 
-val false_identifier : Identifier.constructor
-val true_identifier : Identifier.constructor
-val void_identifier : Identifier.constructor
-val nil_identifier : Identifier.constructor
-val cons_identifier : Identifier.constructor
-val none_identifier : Identifier.constructor
-val some_identifier : Identifier.constructor
+val false_identifier : Identifier.Constructor.t
+val true_identifier : Identifier.Constructor.t
+val void_identifier : Identifier.Constructor.t
+val nil_identifier : Identifier.Constructor.t
+val cons_identifier : Identifier.Constructor.t
+val none_identifier : Identifier.Constructor.t
+val some_identifier : Identifier.Constructor.t
 
-val match_failure_identifier : Identifier.exception_
-val assert_failure_identifier : Identifier.exception_
-val invalid_argument_identifier : Identifier.exception_
-val failure_identifier : Identifier.exception_
-val not_found_identifier : Identifier.exception_
-val out_of_memory_identifier : Identifier.exception_
-val stack_overflow_identifier : Identifier.exception_
-val sys_error_identifier : Identifier.exception_
-val end_of_file_identifier : Identifier.exception_
-val division_by_zero_identifier : Identifier.exception_
-val sys_blocked_io_identifier : Identifier.exception_
-val undefined_recursive_module_identifier : Identifier.exception_
+val match_failure_identifier : Identifier.Exception.t
+val assert_failure_identifier : Identifier.Exception.t
+val invalid_argument_identifier : Identifier.Exception.t
+val failure_identifier : Identifier.Exception.t
+val not_found_identifier : Identifier.Exception.t
+val out_of_memory_identifier : Identifier.Exception.t
+val stack_overflow_identifier : Identifier.Exception.t
+val sys_error_identifier : Identifier.Exception.t
+val end_of_file_identifier : Identifier.Exception.t
+val division_by_zero_identifier : Identifier.Exception.t
+val sys_blocked_io_identifier : Identifier.Exception.t
+val undefined_recursive_module_identifier : Identifier.Exception.t
 
-val core_type_identifier : string ->
-      [< Identifier.kind > `Type] Identifier.t option
-val core_exception_identifier : string ->
-      [< Identifier.kind > `Exception] Identifier.t option
-val core_constructor_identifier : string ->
-      [< Identifier.kind > `Constructor] Identifier.t option
+val core_type_identifier : string -> Identifier.Type.t option
+val core_exception_identifier : string -> Identifier.Exception.t option
+val core_constructor_identifier : string -> Identifier.Constructor.t option
 
 (** {3 Paths} *)
 
-val bool_path : Path.type_
-val int_path : Path.type_
-val char_path : Path.type_
-val bytes_path : Path.type_
-val string_path : Path.type_
-val float_path : Path.type_
-val unit_path : Path.type_
-val exn_path : Path.type_
-val array_path : Path.type_
-val list_path : Path.type_
-val option_path : Path.type_
-val int32_path : Path.type_
-val int64_path : Path.type_
-val nativeint_path : Path.type_
-val lazy_t_path : Path.type_
-val extension_constructor_path : Path.type_
+val bool_path : Path.Type.t
+val int_path : Path.Type.t
+val char_path : Path.Type.t
+val bytes_path : Path.Type.t
+val string_path : Path.Type.t
+val float_path : Path.Type.t
+val unit_path : Path.Type.t
+val exn_path : Path.Type.t
+val array_path : Path.Type.t
+val list_path : Path.Type.t
+val option_path : Path.Type.t
+val int32_path : Path.Type.t
+val int64_path : Path.Type.t
+val nativeint_path : Path.Type.t
+val lazy_t_path : Path.Type.t
+val extension_constructor_path : Path.Type.t
 
 (** {3 References} *)
 
-val bool_reference : Reference.type_
-val int_reference : Reference.type_
-val char_reference : Reference.type_
-val bytes_reference : Reference.type_
-val string_reference : Reference.type_
-val float_reference : Reference.type_
-val unit_reference : Reference.type_
-val exn_reference : Reference.type_
-val array_reference : Reference.type_
-val list_reference : Reference.type_
-val option_reference : Reference.type_
-val int32_reference : Reference.type_
-val int64_reference : Reference.type_
-val nativeint_reference : Reference.type_
-val lazy_t_reference : Reference.type_
-val extension_constructor_reference : Reference.type_
+val bool_reference : Reference.Type.t
+val int_reference : Reference.Type.t
+val char_reference : Reference.Type.t
+val bytes_reference : Reference.Type.t
+val string_reference : Reference.Type.t
+val float_reference : Reference.Type.t
+val unit_reference : Reference.Type.t
+val exn_reference : Reference.Type.t
+val array_reference : Reference.Type.t
+val list_reference : Reference.Type.t
+val option_reference : Reference.Type.t
+val int32_reference : Reference.Type.t
+val int64_reference : Reference.Type.t
+val nativeint_reference : Reference.Type.t
+val lazy_t_reference : Reference.Type.t
+val extension_constructor_reference : Reference.Type.t
 
-val false_reference : Reference.constructor
-val true_reference : Reference.constructor
-val void_reference : Reference.constructor
-val nil_reference : Reference.constructor
-val cons_reference : Reference.constructor
-val none_reference : Reference.constructor
-val some_reference : Reference.constructor
+val false_reference : Reference.Constructor.t
+val true_reference : Reference.Constructor.t
+val void_reference : Reference.Constructor.t
+val nil_reference : Reference.Constructor.t
+val cons_reference : Reference.Constructor.t
+val none_reference : Reference.Constructor.t
+val some_reference : Reference.Constructor.t
 
-val match_failure_reference : Reference.exception_
-val assert_failure_reference : Reference.exception_
-val invalid_argument_reference : Reference.exception_
-val failure_reference : Reference.exception_
-val not_found_reference : Reference.exception_
-val out_of_memory_reference : Reference.exception_
-val stack_overflow_reference : Reference.exception_
-val sys_error_reference : Reference.exception_
-val end_of_file_reference : Reference.exception_
-val division_by_zero_reference : Reference.exception_
-val sys_blocked_io_reference : Reference.exception_
-val undefined_recursive_module_reference : Reference.exception_
+val match_failure_reference : Reference.Exception.t
+val assert_failure_reference : Reference.Exception.t
+val invalid_argument_reference : Reference.Exception.t
+val failure_reference : Reference.Exception.t
+val not_found_reference : Reference.Exception.t
+val out_of_memory_reference : Reference.Exception.t
+val stack_overflow_reference : Reference.Exception.t
+val sys_error_reference : Reference.Exception.t
+val end_of_file_reference : Reference.Exception.t
+val division_by_zero_reference : Reference.Exception.t
+val sys_blocked_io_reference : Reference.Exception.t
+val undefined_recursive_module_reference : Reference.Exception.t
 
 (** {3 Declarations} *)
 

--- a/src/odoc/compilation_unit.ml
+++ b/src/odoc/compilation_unit.ml
@@ -20,7 +20,7 @@ type t = Model.Lang.Compilation_unit.t
 
 let root (t : Model.Lang.Compilation_unit.t) =
   match t.Model.Lang.Compilation_unit.id with
-  | Model.Paths.Identifier.Root (root, _) -> root
+  | `Root (root, _) -> root
   | _ -> assert false
 
 let save file t =

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -76,7 +76,7 @@ let mld ~env ~package ~output input =
     let file = Model.Root.Odoc_file.create_page root_name in
     {Model.Root.package; file; digest}
   in
-  let name = Model.Paths.Identifier.Page (root, root_name) in
+  let name = `Page (root, Model.Names.PageName.of_string root_name) in
   let location =
     let pos =
       Lexing.{

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -8,7 +8,7 @@ let from_mld ~xref_base_uri ~env ~output input =
     let file = Model.Root.Odoc_file.create_page page_name in
     {Model.Root.package; file; digest}
   in
-  let name = Model.Paths.Identifier.Page (root, page_name) in
+  let name = `Page (root, Model.Names.PageName.of_string page_name) in
   let location =
     let pos =
       Lexing.{

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -96,7 +96,7 @@ let from_mld ~env ?(syntax=Html.Tree.OCaml) ~package ~output:root_dir input =
     let file = Model.Root.Odoc_file.create_page root_name in
     {Model.Root.package; file; digest}
   in
-  let name = Model.Paths.Identifier.Page (root, root_name) in
+  let name = `Page (root, Model.Names.PageName.of_string root_name) in
   let location =
     let pos =
       Lexing.{

--- a/src/odoc/page.ml
+++ b/src/odoc/page.ml
@@ -20,7 +20,7 @@ type t = Model.Lang.Page.t
 
 let root (t : Model.Lang.Page.t) =
   match t.Model.Lang.Page.name with
-  | Model.Paths.Identifier.Page (root, _) -> root
+  | `Page (root, _) -> root
 
 let save file t =
   let dir = Fs.File.dirname file in

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -16,7 +16,7 @@ type inline_element = [
   | `Raw_markup of Comment.raw_markup_target * string
   | `Styled of Comment.style * (inline_element with_location) list
   | `Reference of
-      reference_kind * Reference.any * (inline_element with_location) list
+      reference_kind * Reference.t * (inline_element with_location) list
   | `Link of string * (inline_element with_location) list
 ]
 
@@ -24,7 +24,7 @@ type nestable_block_element = [
   | `Paragraph of (inline_element with_location) list
   | `Code_block of string
   | `Verbatim of string
-  | `Modules of Reference.module_ list
+  | `Modules of Reference.Module.t list
   | `List of
     [ `Unordered | `Ordered ] *
     ((nestable_block_element with_location) list) list
@@ -43,7 +43,7 @@ type tag = [
   | `Since of string
   | `Before of string * (nestable_block_element with_location) list
   | `Version of string
-  | `Canonical of Path.module_ * Reference.module_
+  | `Canonical of Path.Module.t * Reference.Module.t
   | `Inline
   | `Open
   | `Closed

--- a/src/parser/odoc__parser.mli
+++ b/src/parser/odoc__parser.mli
@@ -1,6 +1,6 @@
 val parse_comment :
   sections_allowed:Ast.sections_allowed ->
-  containing_definition:Model.Paths.Identifier.label_parent ->
+  containing_definition:Model.Paths.Identifier.LabelParent.t ->
   location:Lexing.position ->
   text:string ->
     Model.Comment.docs Model.Error.with_warnings

--- a/src/parser/reference.ml
+++ b/src/parser/reference.ml
@@ -364,7 +364,7 @@ let read_path_longident location s =
   | Some r -> Result.Ok r
   | None -> Result.Error (Parse_error.expected "a valid path" location)
 
-let read_mod_longident warnings location lid : (Paths.Reference.Module.t, Error.t) result =
+let read_mod_longident warnings location lid : (Paths.Reference.Module.t, Error.t) Result.result =
   let (>>=) = Rresult.(>>=) in
 
   parse warnings location lid >>= function

--- a/src/parser/reference.mli
+++ b/src/parser/reference.mli
@@ -4,12 +4,12 @@ module Paths = Model.Paths
 
 val parse :
   Error.warning_accumulator -> Location_.span -> string ->
-    (Paths.Reference.any, Error.t) Result.result
+    (Paths.Reference.t, Error.t) Result.result
 
 val read_path_longident :
   Location_.span -> string ->
-    ([< Paths.Path.kind > `Module ] Paths.Path.t, Error.t) Result.result
+    (Paths.Path.Module.t, Error.t) Result.result
 
 val read_mod_longident :
   Error.warning_accumulator -> Location_.span -> string ->
-    (Paths.Reference.module_, Error.t) Result.result
+    (Paths.Reference.Module.t, Error.t) Result.result

--- a/src/parser/semantics.ml
+++ b/src/parser/semantics.ml
@@ -11,7 +11,7 @@ type 'a with_location = 'a Location.with_location
 type status = {
   warnings : Error.warning_accumulator;
   sections_allowed : Ast.sections_allowed;
-  parent_of_sections : Model.Paths.Identifier.label_parent;
+  parent_of_sections : Model.Paths.Identifier.LabelParent.t;
 }
 
 
@@ -206,7 +206,7 @@ let section_heading
     | Some label -> label
     | None -> generate_heading_label content
   in
-  let label = Model.Paths.Identifier.Label (status.parent_of_sections, label) in
+  let label = `Label (status.parent_of_sections, Model.Names.LabelName.of_string label) in
 
   match status.sections_allowed, level with
   | `None, _any_level ->
@@ -265,7 +265,7 @@ let section_heading
 
 let validate_first_page_heading status ast_element =
   match status.parent_of_sections with
-  | Model.Paths.Identifier.Page ({file; _}, _) ->
+  | `Page ({file; _}, _) ->
     begin match ast_element with
       | {Location.value = `Heading (_, _, _); _} -> ()
       | _invalid_ast_element ->
@@ -321,7 +321,7 @@ let top_level_block_elements
   let top_heading_level =
     (* Non-page documents have a generated title. *)
     match status.parent_of_sections with
-    | Model.Paths.Identifier.Page _ -> None
+    | `Page _ -> None
     | _parent_with_generated_title -> Some 0
   in
   traverse ~top_heading_level [] ast_elements

--- a/src/parser/semantics.mli
+++ b/src/parser/semantics.mli
@@ -1,6 +1,6 @@
 val ast_to_comment :
   Model.Error.warning_accumulator ->
   sections_allowed:Ast.sections_allowed ->
-  parent_of_sections:Model.Paths.Identifier.label_parent ->
+  parent_of_sections:Model.Paths.Identifier.LabelParent.t ->
   Ast.docs ->
     Model.Comment.docs

--- a/src/xref/component_table.ml
+++ b/src/xref/component_table.ml
@@ -18,6 +18,7 @@ open Model
 open Paths
 open Model.Lang
 open Components
+open Model.Names
 
 type ('a, 'b) tbl =
   { fresh: int -> ('a, 'b) tbl;
@@ -81,19 +82,19 @@ let create ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
 
 type local =
   { t : t;
-    local : (Identifier.signature, Sig.t) tbl option;
-    base : Identifier.signature option; }
+    local : (Identifier.Signature.t, Sig.t) tbl option;
+    base : Identifier.Signature.t option; }
 
 let create_local t base =
   let equal =
     match t.equal with
     | None -> None
-    | Some _equal -> Some Identifier.equal
+    | Some _equal -> Some Identifier.Signature.equal
   in
   let hash =
     match t.hash with
     | None -> None
-    | Some _hash -> Some Identifier.hash
+    | Some _hash -> Some Identifier.Signature.hash
   in
   let local =
     match base with
@@ -103,86 +104,79 @@ let create_local t base =
     { t; local; base; }
 
 let add_local_module_identifier (local : local) id sg =
-  let open Identifier in
     match local.local with
     | None -> ()
-    | Some tbl -> tbl.add (signature_of_module id) sg
+    | Some tbl -> tbl.add (id : Identifier.Module.t :> Identifier.Signature.t) sg
 
 let add_local_module_type_identifier (local : local) id sg =
-  let open Identifier in
     match local.local with
     | None -> ()
-    | Some tbl -> tbl.add (signature_of_module_type id) sg
+    | Some tbl -> tbl.add (id : Identifier.ModuleType.t :> Identifier.Signature.t) sg
 
 let add_local_modules (local : local) id mds =
-  let open Identifier in
     match local.local with
     | None -> ()
     | Some tbl ->
         List.iter
-          (fun (name, sg) -> tbl.add (Module(id, name)) sg)
+          (fun (name, sg) -> tbl.add (`Module(id, name)) sg)
           mds
 
 let add_local_module_types (local : local) id mtys =
-  let open Identifier in
     match local.local with
     | None -> ()
     | Some tbl ->
         List.iter
-          (fun (name, sg) -> tbl.add (ModuleType(id, name)) sg)
+          (fun (name, sg) -> tbl.add (`ModuleType(id, name)) sg)
           mtys
 
-let equals_signature (type k) _eq
-      (base : Identifier.signature) (id : k Identifier.t) =
-  let open Identifier in
+let equals_signature _eq (base : Identifier.Signature.t) (id : Identifier.t) =
     match id with
-    | Root _ as id ->
-        Identifier.equal base id
-    | Module _ as id ->
-        Identifier.equal base id
-    | Argument _ as id ->
-        Identifier.equal base id
-    | ModuleType _ as id ->
-        Identifier.equal base id
-    | Page _ -> false
-    | Type _ -> false
-    | CoreType _ -> false
-    | Constructor _ -> false
-    | Field _ -> false
-    | Extension _ -> false
-    | Exception _ -> false
-    | CoreException _ -> false
-    | Value _ -> false
-    | Class _ -> false
-    | ClassType _ -> false
-    | Method _ -> false
-    | InstanceVariable _ -> false
-    | Label _ -> false
+    | `Root _ as id ->
+        Identifier.Signature.equal base id
+    | `Module _ as id ->
+        Identifier.Signature.equal base id
+    | `Argument _ as id ->
+        Identifier.Signature.equal base (id :> Identifier.Signature.t)
+    | `ModuleType _ as id ->
+        Identifier.Signature.equal base (id :> Identifier.Signature.t)
+    | `Page _ -> false
+    | `Type _ -> false
+    | `CoreType _ -> false
+    | `Constructor _ -> false
+    | `Field _ -> false
+    | `Extension _ -> false
+    | `Exception _ -> false
+    | `CoreException _ -> false
+    | `Value _ -> false
+    | `Class _ -> false
+    | `ClassType _ -> false
+    | `Method _ -> false
+    | `InstanceVariable _ -> false
+    | `Label _ -> false
 
-let rec is_parent_local : type k . _ -> _ -> k Identifier.t -> bool =
+let rec is_parent_local : _ -> _ -> Identifier.t -> bool =
   fun eq base id ->
-    let open Identifier in
       match id with
-      | Root _  -> false
-      | Page _ -> false
-      | Module(parent, _) -> is_local eq base parent
-      | Argument(parent, _, _) -> is_local eq base parent
-      | ModuleType(parent, _) -> is_local eq base parent
-      | Type(parent, _) -> is_local eq base parent
-      | CoreType _ -> false
-      | Constructor(parent, _) -> is_local eq base parent
-      | Field(parent, _) -> is_local eq base parent
-      | Extension(parent, _) -> is_local eq base parent
-      | Exception(parent, _) -> is_local eq base parent
-      | CoreException _ -> false
-      | Value(parent, _) -> is_local eq base parent
-      | Class(parent, _) -> is_local eq base parent
-      | ClassType(parent, _) -> is_local eq base parent
-      | Method(parent, _) -> is_local eq base parent
-      | InstanceVariable(parent, _) -> is_local eq base parent
-      | Label(parent, _) -> is_local eq base parent
+      | `Root _  -> false
+      | `Page _ -> false
+      | `Module(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `Argument(parent, _, _) -> is_local eq base (parent :> Identifier.t)
+      | `ModuleType(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `Type(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `CoreType _ -> false
+      | `Constructor(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `Field(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `Extension(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `Exception(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `CoreException _ -> false
+      | `Value(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `Class(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `ClassType(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `Method(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `InstanceVariable(parent, _) -> is_local eq base (parent :> Identifier.t)
+      | `Label(parent, _) -> is_local eq base (parent :> Identifier.t)
 
-and is_local : type k ._ -> _ -> k Identifier.t -> bool =
+and is_local : _ -> _ -> Identifier.t -> bool =
   fun eq base id ->
     is_parent_local eq base id
     || equals_signature eq base id
@@ -199,21 +193,19 @@ let is_local local id =
     is_local eq base id
 
 let local_module_identifier (local : local) id =
-  let open Identifier in
     match local.local with
     | None -> Sig.unresolved
     | Some tbl ->
         try
-          tbl.find (signature_of_module id)
+          tbl.find (id : Identifier.Module.t :> Identifier.Signature.t)
         with Not_found -> Sig.unresolved
 
 let local_module_type_identifier (local : local) id =
-  let open Identifier in
     match local.local with
     | None -> Sig.unresolved
     | Some tbl ->
         try
-          tbl.find (signature_of_module_type id)
+          tbl.find (id : Identifier.ModuleType.t :> Identifier.Signature.t)
         with Not_found -> Sig.unresolved
 
 let datatype decl =
@@ -266,9 +258,8 @@ let page tbl base =
     tbl.page_tbl.add base t;
     t
 
-let page_identifier tbl : Identifier.page -> _ =
-  let open Identifier in function
-  | Page(base, _) -> page tbl base
+let page_identifier tbl : Identifier.Page.t -> _ = function
+  | `Page(base, _) -> page tbl base
 
 let rec unit tbl base =
     try
@@ -276,7 +267,7 @@ let rec unit tbl base =
     with Not_found ->
       let open Compilation_unit in
       let unt = tbl.fetch_unit base in
-      let id = Identifier.signature_of_module unt.id in
+      let id = (unt.id : Identifier.Module.t :> Identifier.Signature.t) in
       let local = create_local tbl (Some id) in
       let t =
         match unt.content with
@@ -297,83 +288,89 @@ let rec unit tbl base =
         tbl.tbl.add base t;
         t
 
-and signature_identifier tbl =
-  let open Identifier in function
-  | (Root(base, _) : signature) -> unit tbl base
-  | Module(id, name) ->
+and signature_identifier tbl (i : Identifier.Signature.t) =
+  match i with 
+  | `Root(base, _) -> unit tbl base
+  | `Module(id, name) ->
       let parent = signature_identifier tbl id in
-        Sig.lookup_module name parent
-  | Argument(id, pos, _) ->
-      let parent = signature_identifier tbl id in
-        Sig.lookup_argument pos parent
-  | ModuleType(id, name) ->
-      let parent = signature_identifier tbl id in
-        Sig.lookup_module_type name parent
-
-and module_identifier tbl =
-  let open Identifier in function
-  | (Root(base, _) : module_) -> unit tbl base
-  | Module(id, name) ->
-      let parent = signature_identifier tbl id in
-        Sig.lookup_module name parent
-  | Argument(id, pos, _) ->
+        Sig.lookup_module (ModuleName.to_string name) parent
+  | `Argument(id, pos, _) ->
       let parent = signature_identifier tbl id in
         Sig.lookup_argument pos parent
-
-and module_type_identifier tbl =
-  let open Identifier in function
-  | (ModuleType(id, name) : module_type) ->
+  | `ModuleType(id, name) ->
       let parent = signature_identifier tbl id in
-        Sig.lookup_module_type name parent
+        Sig.lookup_module_type (ModuleTypeName.to_string name) parent
 
-and datatype_identifier tbl =
-  let open Identifier in function
-  | (Type(id, name) : Identifier.type_)->
+and module_identifier tbl (i : Identifier.Module.t) =
+  match i with
+  | `Root(base, _) -> unit tbl base
+  | `Module(id, name) ->
       let parent = signature_identifier tbl id in
-        Sig.lookup_datatype name parent
-  | CoreType name -> List.assoc name core_types
+        Sig.lookup_module (ModuleName.to_string name) parent
+  | `Argument(id, pos, _) ->
+      let parent = signature_identifier tbl id in
+        Sig.lookup_argument pos parent
 
-and class_signature_identifier tbl =
-  let open Identifier in function
-    | (Class(id, name) | ClassType(id, name) : path_class_type) ->
+and module_type_identifier tbl (i : Identifier.ModuleType.t) =
+  match i with
+    | `ModuleType(id, name) ->
+      let parent = signature_identifier tbl id in
+        Sig.lookup_module_type (ModuleTypeName.to_string name) parent
+
+and datatype_identifier tbl (i : Identifier.DataType.t) =
+  match i with
+  | (`Type(id, name) : Identifier.Type.t)->
+      let parent = signature_identifier tbl id in
+        Sig.lookup_datatype (TypeName.to_string name) parent
+  | `CoreType name -> List.assoc (TypeName.to_string name) core_types
+
+and class_signature_identifier tbl (p : Identifier.ClassSignature.t) =
+  match p with
+    | `Class(id, name) ->
         let parent = signature_identifier tbl id in
-          Sig.lookup_class_type name parent
+          Sig.lookup_class_type (ClassName.to_string name) parent
+    | `ClassType(id, name) ->
+        let parent = signature_identifier tbl id in
+          Sig.lookup_class_type (ClassTypeName.to_string name) parent
 
-and resolved_module_path local =
-  let open Path.Resolved in function
-  | Identifier (id : Identifier.module_) ->
-      if is_local local id then local_module_identifier local id
+and resolved_module_path local (p : Path.Resolved.Module.t) =
+  match p with
+  | `Identifier (id : Identifier.Module.t) ->
+      if is_local local (id :> Identifier.t) then local_module_identifier local id
       else module_identifier local.t id
-  | Subst(sub, _) -> resolved_module_type_path local sub
-  | SubstAlias(sub, _) -> resolved_module_path local sub
-  | Hidden p -> resolved_module_path local p
-  | Module(p, name) ->
+  | `Subst(sub, _) -> resolved_module_type_path local sub
+  | `SubstAlias(sub, _) -> resolved_module_path local sub
+  | `Hidden p -> resolved_module_path local p
+  | `Module(p, name) ->
       let parent = resolved_module_path local p in
-        Sig.lookup_module name parent
-  | Canonical (p, _) -> resolved_module_path local p
-  | Apply(p, arg) ->
+        Sig.lookup_module (ModuleName.to_string name) parent
+  | `Canonical (p, _) -> resolved_module_path local p
+  | `Apply(p, arg) ->
       let parent = resolved_module_path local p in
         Sig.lookup_apply (module_path local) arg parent
 
-and resolved_module_type_path local =
-  let open Path.Resolved in function
-  | Identifier (id : Identifier.module_type) ->
-      if is_local local id then local_module_type_identifier local id
+and resolved_module_type_path local (p : Path.Resolved.ModuleType.t) =
+  match p with
+  | `Identifier (id : Identifier.ModuleType.t) ->
+      if is_local local (id :> Identifier.t) then local_module_type_identifier local id
       else module_type_identifier local.t id
-  | ModuleType(p, name) ->
+  | `ModuleType(p, name) ->
       let parent = resolved_module_path local p in
-        Sig.lookup_module_type name parent
+        Sig.lookup_module_type (ModuleTypeName.to_string name) parent
 
-and resolved_class_type_path local =
-  let open Path.Resolved in function
-    | Identifier id -> class_signature_identifier local.t id
-    | Class(p, name) | ClassType(p, name) ->
+and resolved_class_type_path local (p : Path.Resolved.ClassType.t) =
+    match p with
+    | `Identifier id -> class_signature_identifier local.t id
+    | `Class(p, name) ->
         let parent = resolved_module_path local p in
-          Sig.lookup_class_type name parent
+          Sig.lookup_class_type (ClassName.to_string name) parent
+    | `ClassType(p, name) ->
+        let parent = resolved_module_path local p in
+          Sig.lookup_class_type (ClassTypeName.to_string name) parent
 
-and module_path local =
-  let open Path in function
-  | Root s -> begin
+and module_path local (p : Path.Module.t) =
+  match p with
+  | `Root s -> begin
       match local.t.lookup_unit s with
       | Not_found ->
         let sg = Sig.unresolved in
@@ -383,7 +380,7 @@ and module_path local =
         let sg = Sig.abstract in
         Sig.set_hidden sg (Root.contains_double_underscore s)
     end
-  | Forward s -> begin (* FIXME? *)
+  | `Forward s -> begin (* FIXME? *)
       match local.t.lookup_unit s with
       | Not_found ->
         let sg = Sig.unresolved in
@@ -393,25 +390,23 @@ and module_path local =
         let sg = Sig.abstract in
         Sig.set_hidden sg (Root.contains_double_underscore s)
     end
-  | Resolved r -> resolved_module_path local r
-  | Dot(p, name) ->
+  | `Resolved r -> resolved_module_path local r
+  | `Dot(p, name) ->
       let parent = module_path local p in
         Sig.lookup_module name parent
-  | Apply(p, arg) ->
+  | `Apply(p, arg) ->
       let parent = module_path local p in
         Sig.lookup_apply (module_path local) arg parent
 
-and module_type_path local =
-  let open Path in function
-  | Resolved r -> resolved_module_type_path local r
-  | Dot(p, name) ->
+and module_type_path local = function
+  | `Resolved r -> resolved_module_type_path local r
+  | `Dot(p, name) ->
       let parent = module_path local p in
         Sig.lookup_module_type name parent
 
-and class_signature_path local =
-  let open Path in function
-    | Resolved p -> resolved_class_type_path local p
-    | Dot(p, name) ->
+and class_signature_path local = function
+    | `Resolved p -> resolved_class_type_path local p
+    | `Dot(p, name) ->
         let parent = module_path local p in
           Sig.lookup_class_type name parent
 
@@ -423,13 +418,13 @@ and class_signature_items local =
         let csig = class_signature_items local rest in
         let csig = add_documentation ivar.doc csig in
         let name = Identifier.name ivar.id in
-          add_element name Element.InstanceVariable csig
+          add_element name `InstanceVariable csig
     | Method meth :: rest ->
         let open Method in
         let csig = class_signature_items local rest in
         let csig = add_documentation meth.doc csig in
         let name = Identifier.name meth.id in
-          add_element name Element.Method csig
+          add_element name `Method csig
     | Constraint _ :: rest ->
         class_signature_items local rest
     | Inherit expr :: rest ->
@@ -496,26 +491,26 @@ and signature_items local =
                let open Constructor in
                let name = Identifier.name cstr.id in
                let acc = add_documentation cstr.doc acc in
-                 add_element name Element.Extension acc)
+                 add_element name `Extension acc)
             ext.constructors sg
     | Exception exn :: rest ->
         let open Exception in
         let sg = signature_items local rest in
         let sg = add_documentation exn.doc sg in
         let name = Identifier.name exn.id in
-          add_element name Element.Exception sg
+          add_element name `Exception sg
     | Value v :: rest ->
         let open Value in
         let sg = signature_items local rest in
         let sg = add_documentation v.doc sg in
         let name = Identifier.name v.id in
-          add_element name Element.Value sg
+          add_element name `Value sg
     | External ev :: rest ->
         let open External in
         let sg = signature_items local rest in
         let sg = add_documentation ev.doc sg in
         let name = Identifier.name ev.id in
-          add_element name Element.Value sg
+          add_element name `Value sg
     | Class (_, cl)::rest ->
         let open Class in
         let sg = signature_items local rest in
@@ -623,48 +618,50 @@ let module_type_path_with tbl path =
   let base = module_type_path local path in
     { base; tbl }
 
-let rec resolved_signature_fragment wth =
-  let open Fragment.Resolved in function
-  | Root -> wth.base
-  | Subst(sub, _) -> resolved_module_type_path wth.tbl sub
-  | SubstAlias(sub, _) -> resolved_module_path wth.tbl sub
-  | Module(p, name) ->
+let rec resolved_signature_fragment wth (f : Fragment.Resolved.Signature.t) =
+  match f with
+  | `Root -> wth.base
+  | `Subst(sub, _) -> resolved_module_type_path wth.tbl sub
+  | `SubstAlias(sub, _) -> resolved_module_path wth.tbl sub
+  | `Module(p, name) ->
       let parent = resolved_signature_fragment wth p in
-        Sig.lookup_module name parent
+        Sig.lookup_module (ModuleName.to_string name) parent
 
-let rec resolved_signature_reference tbl =
-  let open Reference.Resolved in function
-  | Identifier (id : Identifier.signature) ->
+let rec resolved_signature_reference tbl (r : Reference.Resolved.Signature.t) =
+  match r with 
+  | `Identifier id ->
       signature_identifier tbl id
-  | SubstAlias(sub, _) ->
+  | `SubstAlias(sub, _) ->
       resolved_module_path tbl sub
-  | Module(p, name) ->
+  | `Module(p, name) ->
       let parent = resolved_signature_reference tbl p in
-        Sig.lookup_module name parent
-  | Canonical (p, _) ->
-    resolved_signature_reference tbl (signature_of_module p)
-  | ModuleType(p, name) ->
+        Sig.lookup_module (ModuleName.to_string name) parent
+  | `Canonical (p, _) ->
+    resolved_signature_reference tbl (p : Reference.Resolved.Module.t :> Reference.Resolved.Signature.t)
+  | `ModuleType(p, name) ->
       let parent = resolved_signature_reference tbl p in
-        Sig.lookup_module_type name parent
+        Sig.lookup_module_type (ModuleTypeName.to_string name) parent
 
-and resolved_class_signature_reference tbl =
-  let open Reference.Resolved in function
-    | Identifier id -> class_signature_identifier tbl id
-    | Class(p, name) | ClassType(p, name) ->
+and resolved_class_signature_reference tbl (r : Reference.Resolved.ClassSignature.t) =
+  match r with
+    | `Identifier id -> class_signature_identifier tbl id
+    | `Class(p, name) ->
         let parent = resolved_signature_reference tbl p in
-          Sig.lookup_class_type name parent
-
-and resolved_datatype_reference tbl =
-  let open Reference.Resolved in function
-    | Identifier id -> datatype_identifier tbl id
-    | Type(p, name) ->
+          Sig.lookup_class_type (ClassName.to_string name) parent
+    | `ClassType(p, name) ->
         let parent = resolved_signature_reference tbl p in
-          Sig.lookup_datatype name parent
+          Sig.lookup_class_type (ClassTypeName.to_string name) parent
 
-and resolved_page_reference tbl : Reference.Resolved.page -> _ =
-  let open Reference.Resolved in function
-    | Identifier id -> page_identifier tbl id
+and resolved_datatype_reference tbl (r : Reference.Resolved.DataType.t) =
+  match r with
+    | `Identifier id -> datatype_identifier tbl id
+    | `Type(p, name) ->
+        let parent = resolved_signature_reference tbl p in
+          Sig.lookup_datatype (TypeName.to_string name) parent
 
-let base tbl s = tbl.lookup_unit s
+and resolved_page_reference tbl : Reference.Resolved.Page.t -> _ = function
+    | `Identifier id -> page_identifier tbl id
+
+let base tbl s = tbl.lookup_unit s  
 
 let page_base tbl s = tbl.lookup_page s

--- a/src/xref/component_table.mli
+++ b/src/xref/component_table.mli
@@ -42,30 +42,30 @@ open Components
 (** {3 Identifier Lookup} *)
 
 (** Lookup the components of a signature identifier *)
-val signature_identifier : t -> Identifier.signature -> Sig.t
+val signature_identifier : t -> Identifier.Signature.t -> Sig.t
 
 (** Lookup the components of a class signature identifier *)
-val class_signature_identifier : t -> Identifier.class_signature ->
+val class_signature_identifier : t -> Identifier.ClassSignature.t ->
       ClassSig.t
 
 (** Lookup the components of a datatype identifier *)
-val datatype_identifier : t -> Identifier.type_ -> Datatype.t
+val datatype_identifier : t -> Identifier.Type.t -> Datatype.t
 
 (** {3 Path Lookup} *)
 
 (** Lookup the components of a resolved module path *)
-val resolved_module_path : t -> Path.Resolved.module_ -> Sig.t
+val resolved_module_path : t -> Path.Resolved.Module.t -> Sig.t
 
 (** Lookup the components of a resolved module type path *)
-val resolved_module_type_path : t -> Path.Resolved.module_type -> Sig.t
+val resolved_module_type_path : t -> Path.Resolved.ModuleType.t -> Sig.t
 
 (** Lookup the components of a resolved class type path *)
 val resolved_class_type_path : t ->
-      Path.Resolved.class_type -> ClassSig.t
+      Path.Resolved.ClassType.t -> ClassSig.t
 
 (** Lookup the components of a module path, needed for module
     applications. *)
-val module_path : t -> Path.module_ -> Sig.t
+val module_path : t -> Path.Module.t -> Sig.t
 
 (** {3 Fragment Lookup} *)
 
@@ -75,31 +75,31 @@ type with_
 
 (** Create specialised fragment table for a module type expression *)
 val module_type_expr_with : t ->
-      Identifier.signature -> Lang.ModuleType.expr -> with_
+      Identifier.Signature.t -> Lang.ModuleType.expr -> with_
 
 (** Create specialised fragment table for a module path *)
 val module_type_path_with : t ->
-      Path.module_type -> with_
+      Path.ModuleType.t -> with_
 
 (** Lookup the components of a resolved module fragment *)
 val resolved_signature_fragment : with_ ->
-      Fragment.Resolved.signature -> Sig.t
+      Fragment.Resolved.Signature.t -> Sig.t
 
 (** {3 Reference Lookup} *)
 
 (** Lookup the components of a resolved signature reference *)
 val resolved_signature_reference : t ->
-      Reference.Resolved.signature -> Sig.t
+      Reference.Resolved.Signature.t -> Sig.t
 
 (** Lookup the components of a resolved class signature reference *)
 val resolved_class_signature_reference : t ->
-      Reference.Resolved.class_signature -> ClassSig.t
+      Reference.Resolved.ClassSignature.t -> ClassSig.t
 
 (** Lookup the components of a resolved datatype reference *)
 val resolved_datatype_reference : t ->
-  Reference.Resolved.datatype -> Datatype.t
+  Reference.Resolved.DataType.t -> Datatype.t
 
-val resolved_page_reference : t -> Reference.Resolved.page -> Page.t
+val resolved_page_reference : t -> Reference.Resolved.Page.t -> Page.t
 
 (** {3 Root lookup} *)
 

--- a/src/xref/lookup.ml
+++ b/src/xref/lookup.ml
@@ -131,11 +131,9 @@ class lookup = object
 
   method! documentation_reference r =
     let (path, elements) = super#documentation_reference r in
-    let open Model.Paths.Reference in
-    let open Model.Paths.Reference.Resolved in
     match path, elements with
-    | Resolved
-        (Identifier (Model.Paths.Identifier.Label _) | Label _ as rr), [] ->
+    | `Resolved
+        (`Identifier (`Label _) | `Label _ as rr), [] ->
       begin match Name_env.lookup_section_title env rr with
       | None -> (path, elements)
       | Some elements' -> (path, elements')

--- a/src/xref/name_env.ml
+++ b/src/xref/name_env.ml
@@ -17,91 +17,40 @@
 open Model.Paths
 open Model.Lang
 open Model.Predefined
+open Model.Names
 
 open Identifier
 
 module StringTbl = Map.Make(String)
 
-type type_ident =
-  [`Type | `Class | `ClassType] t
+type type_ident = Model.Paths_types.Identifier.path_type
 
-type constructor_ident =
-  [`Constructor|`Extension|`Exception] t
+type constructor_ident = Model.Paths_types.Identifier.reference_constructor
 
-type extension_ident =
-  [`Extension|`Exception] t
+type extension_ident = Model.Paths_types.Identifier.reference_extension
 
-type class_type_ident =
-  [`Class|`ClassType] t
+type class_type_ident = Model.Paths_types.Identifier.reference_class_type
 
-type parent_ident =
-  [`Module|`ModuleType|`Type|`Class|`ClassType|`Page] t
+type parent_ident = [Model.Paths_types.Identifier.path_any | Model.Paths_types.Identifier.page]
 
-type signature_ident =
-  [`Module|`ModuleType] t
-
-let widen_module : module_ -> _ = function
-  | Root _ as id -> id
-  | Module _ as id -> id
-  | Argument _ as id -> id
-
-let widen_module_type : module_type -> _ = function
-  | ModuleType _ as id -> id
-
-let widen_type : type_ -> _ = function
-  | Type _ as id -> id
-  | CoreType _ as id -> id
-
-let widen_constructor : constructor -> _ = function
-  | Constructor _ as id -> id
-
-let widen_field : field -> _ = function
-  | Field _ as id -> id
-
-let widen_extension : extension -> _ = function
-  | Extension _ as id -> id
-
-let widen_exception : exception_ -> _ = function
-  | Exception _ as id -> id
-  | CoreException _ as id -> id
-
-let widen_value : value -> _ = function
-  | Value _ as id -> id
-
-let widen_class : class_ -> _ = function
-  | Class _ as id -> id
-
-let widen_class_type : class_type -> _ = function
-  | ClassType _ as id -> id
-
-let widen_method : method_ -> _ = function
-  | Method _ as id -> id
-
-let widen_instance_variable : instance_variable -> _ = function
-  | InstanceVariable _ as id -> id
-
-let widen_label : label -> _ = function
-  | Label _ as id -> id
-
-let widen_page : page -> _ = function
-  | Page _ as id -> id
+type signature_ident = [Model.Paths_types.Identifier.reference_module | Model.Paths_types.Identifier.reference_module_type]
 
 type t =
-  { modules : module_ StringTbl.t;
-    module_types : module_type StringTbl.t;
+  { modules : Module.t StringTbl.t;
+    module_types : ModuleType.t StringTbl.t;
     types : type_ident StringTbl.t;
     constructors : constructor_ident StringTbl.t;
-    fields : field StringTbl.t;
+    fields : Field.t StringTbl.t;
     extensions : extension_ident StringTbl.t;
-    exceptions : exception_ StringTbl.t;
-    values : value StringTbl.t;
-    classes : class_ StringTbl.t;
+    exceptions : Exception.t StringTbl.t;
+    values : Value.t StringTbl.t;
+    classes : Class.t StringTbl.t;
     class_types : class_type_ident StringTbl.t;
-    methods : method_ StringTbl.t;
-    instance_variables : instance_variable StringTbl.t;
-    labels : label StringTbl.t;
+    methods : Method.t StringTbl.t;
+    instance_variables : InstanceVariable.t StringTbl.t;
+    labels : Label.t StringTbl.t;
     parents : parent_ident StringTbl.t;
-    elements : any StringTbl.t;
+    elements : Identifier.t StringTbl.t;
     titles : Model.Comment.link_content StringTbl.t; (* Hack *)
     signatures : signature_ident StringTbl.t;
   }
@@ -129,7 +78,7 @@ let empty =
 let add_label_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_label id) env.elements
+    StringTbl.add name (id : Identifier.Label.t :> Identifier.t) env.elements
   in
   let labels =
     StringTbl.add name id env.labels
@@ -139,7 +88,7 @@ let add_label_ident id env =
 let add_value_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_value id) env.elements
+    StringTbl.add name (id : Identifier.Value.t :> Identifier.t) env.elements
   in
   let values =
     StringTbl.add name id env.values
@@ -149,7 +98,7 @@ let add_value_ident id env =
 let add_external_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_value id) env.elements
+    StringTbl.add name (id : Identifier.Value.t :> Identifier.t) env.elements
   in
   let values =
     StringTbl.add name id env.values
@@ -159,17 +108,17 @@ let add_external_ident id env =
 let add_constructor_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_constructor id) env.elements
+    StringTbl.add name (id : Identifier.Constructor.t :> Identifier.t) env.elements
   in
   let constructors =
-    StringTbl.add name (widen_constructor id) env.constructors
+    StringTbl.add name (id :> constructor_ident) env.constructors
   in
     { env with elements; constructors }
 
 let add_field_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_field id) env.elements
+    StringTbl.add name (id : Identifier.Field.t :> Identifier.t) env.elements
   in
   let fields =
     StringTbl.add name id env.fields
@@ -179,39 +128,39 @@ let add_field_ident id env =
 let add_type_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_type id) env.elements
+    StringTbl.add name (id : Identifier.Type.t :> Identifier.t) env.elements
   in
   let parents =
-    StringTbl.add name (widen_type id) env.parents
+    StringTbl.add name (id :> parent_ident) env.parents
   in
   let types =
-    StringTbl.add name (widen_type id) env.types
+    StringTbl.add name (id :> type_ident) env.types
   in
     { env with elements; parents; types }
 
 let add_extension_constructor_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_extension id) env.elements
+    StringTbl.add name (id : Extension.t :> Identifier.t) env.elements
   in
   let constructors =
-    StringTbl.add name (widen_extension id) env.constructors
+    StringTbl.add name (id :> constructor_ident) env.constructors
   in
   let extensions =
-    StringTbl.add name (widen_extension id) env.extensions
+    StringTbl.add name (id :> extension_ident) env.extensions
   in
     { env with elements; constructors; extensions }
 
 let add_exception_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_exception id) env.elements
+    StringTbl.add name (id : Exception.t :> Identifier.t) env.elements
   in
   let constructors =
-    StringTbl.add name (widen_exception id) env.constructors
+    StringTbl.add name (id :> constructor_ident) env.constructors
   in
   let extensions =
-    StringTbl.add name (widen_exception id) env.extensions
+    StringTbl.add name (id :> extension_ident) env.extensions
   in
   let exceptions =
     StringTbl.add name id env.exceptions
@@ -221,73 +170,73 @@ let add_exception_ident id env =
 let add_class_type_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_class_type id) env.elements
+    StringTbl.add name (id : ClassType.t :> Identifier.t) env.elements
   in
   let parents =
-    StringTbl.add name (widen_class_type id) env.parents
+    StringTbl.add name (id :> parent_ident) env.parents
   in
   let types =
-    StringTbl.add name (widen_class_type id) env.types
+    StringTbl.add name (id :> type_ident) env.types
   in
   let class_types =
-    StringTbl.add name (widen_class_type id) env.class_types
+    StringTbl.add name (id :> class_type_ident) env.class_types
   in
     { env with elements; parents; types; class_types }
 
 let add_class_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_class id) env.elements
+    StringTbl.add name (id : Class.t :> Identifier.t) env.elements
   in
   let parents =
-    StringTbl.add name (widen_class id) env.parents
+    StringTbl.add name (id :> parent_ident) env.parents
   in
   let types =
-    StringTbl.add name (widen_class id) env.types
+    StringTbl.add name (id :> type_ident) env.types
   in
   let class_types =
-    StringTbl.add name (widen_class id) env.class_types
+    StringTbl.add name (id :> class_type_ident) env.class_types
   in
   let classes =
-    StringTbl.add name (widen_class id) env.classes
+    StringTbl.add name id env.classes
   in
     { env with elements; parents; types; class_types; classes }
 
 let add_module_type_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_module_type id) env.elements
+    StringTbl.add name (id : ModuleType.t :> Identifier.t) env.elements
   in
   let parents =
-    StringTbl.add name (widen_module_type id) env.parents
+    StringTbl.add name (id :> parent_ident) env.parents
   in
   let module_types =
-    StringTbl.add name (widen_module_type id) env.module_types
+    StringTbl.add name id env.module_types
   in
   let signatures =
-    StringTbl.add name (widen_module_type id) env.signatures
+    StringTbl.add name (id :> signature_ident) env.signatures
   in
     { env with elements; parents; module_types; signatures }
 
 let add_module_ident id env =
   let name = Identifier.name id in
   let elements =
-    StringTbl.add name (widen_module id) env.elements
+    StringTbl.add name (id : Module.t :> Identifier.t) env.elements
   in
   let parents =
-    StringTbl.add name (widen_module id) env.parents
+    StringTbl.add name (id :> parent_ident) env.parents
   in
   let modules =
-    StringTbl.add name (widen_module id) env.modules
+    StringTbl.add name (id :> Module.t) env.modules
   in
   let signatures =
-    StringTbl.add name (widen_module id) env.signatures
+    StringTbl.add name (id :> signature_ident) env.signatures
   in
     { env with elements; parents; modules; signatures }
 
 let add_page_ident id env =
   let name = Identifier.name id in
-  let parents = StringTbl.add name (widen_page id) env.parents in
+  let parents = StringTbl.add name (id : Page.t :> parent_ident) env.parents in
     { env with parents }
 
 let opt_fold f o acc =
@@ -318,7 +267,7 @@ let add_comment com env =
   | `Stop -> env
 
 let add_value vl env =
-  let open Value in
+  let open Model.Lang.Value in
   let env = add_documentation vl.doc env in
     add_value_ident vl.id env
 
@@ -351,12 +300,12 @@ let add_type_decl decl env =
     add_type_ident decl.id env
 
 let add_extension_constructor ext env =
-  let open Extension.Constructor in
+  let open Model.Lang.Extension.Constructor in
   let env = add_documentation ext.doc env in
     add_extension_constructor_ident ext.id env
 
 let add_extension tyext env =
-  let open Extension in
+  let open Model.Lang.Extension in
   let env = add_documentation tyext.doc env in
   let env =
     List.fold_right add_extension_constructor
@@ -365,27 +314,27 @@ let add_extension tyext env =
     env
 
 let add_exception exn env =
-  let open Exception in
+  let open Model.Lang.Exception in
   let env = add_documentation exn.doc env in
     add_exception_ident exn.id env
 
 let add_class_type cltyp env =
-  let open ClassType in
+  let open Model.Lang.ClassType in
   let env = add_documentation cltyp.doc env in
     add_class_type_ident cltyp.id env
 
 let add_class cl env =
-  let open Class in
+  let open Model.Lang.Class in
   let env = add_documentation cl.doc env in
     add_class_ident cl.id env
 
 let add_module_type mtyp env =
-  let open ModuleType in
+  let open Model.Lang.ModuleType in
   let env = add_documentation mtyp.doc env in
     add_module_type_ident mtyp.id env
 
 let add_module md env =
-  let open Module in
+  let open Model.Lang.Module in
   let env = add_documentation md.doc env in
     add_module_ident md.id env
 
@@ -395,7 +344,7 @@ let add_unit unit env =
     add_module_ident unit.id env
 
 let add_page page env =
-  let open Page in
+  let open Model.Lang.Page in
   let env = add_documentation page.content env in
     add_page_ident page.name env
 
@@ -405,7 +354,7 @@ let rec add_include incl env =
   add_signature_items incl.expansion.content env
 
 and add_signature_item item env =
-  let open Signature in
+  let open Model.Lang.Signature in
   match item with
   | Module (_, md) -> add_module md env
   | ModuleType mtyp -> add_module_type mtyp env
@@ -423,7 +372,7 @@ and add_signature_items sg env =
   List.fold_right add_signature_item sg env
 
 let rec add_module_type_expr_items expr env =
-  let open ModuleType in
+  let open Model.Lang.ModuleType in
     match expr with
     | Path _ -> env
     | Signature sg -> add_signature_items sg env
@@ -435,38 +384,37 @@ let rec add_module_type_expr_items expr env =
     | TypeOf decl -> add_module_decl_items decl env
 
 and add_module_decl_items decl env =
-  let open Module in
+  let open Model.Lang.Module in
     match decl with
     | Alias _ -> env
     | ModuleType expr -> add_module_type_expr_items expr env
 
 let add_method meth env =
-  let open Method in
+  let open Model.Lang.Method in
   let env = add_documentation meth.doc env in
   let name = Identifier.name meth.id in
   let elements =
-    StringTbl.add name (widen_method meth.id) env.elements
+    StringTbl.add name (meth.id :> Identifier.t) env.elements
   in
   let methods =
-    StringTbl.add name (widen_method meth.id) env.methods
+    StringTbl.add name meth.id env.methods
   in
     { env with elements; methods }
 
 let add_instance_variable inst env =
-  let open InstanceVariable in
+  let open Model.Lang.InstanceVariable in
   let env = add_documentation inst.doc env in
   let name = Identifier.name inst.id in
   let elements =
-    StringTbl.add name (widen_instance_variable inst.id) env.elements
+    StringTbl.add name (inst.id :> Identifier.t) env.elements
   in
   let instance_variables =
-    StringTbl.add name (widen_instance_variable inst.id)
-      env.instance_variables
+    StringTbl.add name inst.id env.instance_variables
   in
     { env with elements; instance_variables }
 
 let add_class_signature_item item env =
-  let open ClassSignature in
+  let open Model.Lang.ClassSignature in
     match item with
     | Method meth -> add_method meth env
     | InstanceVariable inst -> add_instance_variable inst env
@@ -475,391 +423,368 @@ let add_class_signature_item item env =
     | Comment com -> add_comment com env
 
 let add_class_signature_items clsig env =
-  let open ClassSignature in
+  let open Model.Lang.ClassSignature in
     List.fold_right
       add_class_signature_item
       clsig.items env
 
 let add_class_type_expr_items expr env =
-  let open ClassType in
+  let open Model.Lang.ClassType in
     match expr with
     | Constr _ -> env
     | Signature clsig -> add_class_signature_items clsig env
 
 let rec add_class_decl_items decl env =
-  let open Class in
+  let open Model.Lang.Class in
     match decl with
     | ClassType expr -> add_class_type_expr_items expr env
     | Arrow(_, _, decl) -> add_class_decl_items decl env
 
-open Model.Paths.Reference.Resolved
 open Model.Paths.Reference
 
-let lookup_signature_ident env name =
+let lookup_signature_ident env name : Signature.t =
   try
     let id = StringTbl.find name env.signatures in
-      Resolved (Identifier id)
-  with Not_found -> Root (name, TUnknown)
+      `Resolved (`Identifier id)
+  with Not_found -> `Root (UnitName.of_string name, `TUnknown)
 
-let lookup_module_ident env name =
+let lookup_module_ident env name : Module.t =
   try
     let id = StringTbl.find name env.modules in
-      Resolved (Identifier id)
-  with Not_found -> Root (name, TModule)
+      `Resolved (`Identifier id)
+  with Not_found -> `Root (UnitName.of_string name, `TModule)
 
-let lookup_module_type_ident env name =
+let lookup_module_type_ident env name : ModuleType.t =
   try
     let id = StringTbl.find name env.module_types in
-      Resolved (Identifier id)
-  with Not_found -> Root (name, TModuleType)
+      `Resolved (`Identifier id)
+  with Not_found -> `Root (UnitName.of_string name, `TModuleType)
 
-let lookup_type_ident env name =
+let lookup_type_ident env name : Type.t =
   try
     let id = StringTbl.find name env.types in
-      Resolved (Identifier id)
+      `Resolved (`Identifier id)
   with Not_found ->
     match core_type_identifier name with
-    | Some id -> Resolved (Identifier id)
-    | None -> Root (name, TType)
+    | Some id -> `Resolved (`Identifier (id :> type_ident))
+    | None -> `Root (UnitName.of_string name, `TType)
 
-let lookup_constructor_ident env name =
+let lookup_constructor_ident env name : Constructor.t =
   try
     let id = StringTbl.find name env.constructors in
-      Resolved (Identifier id)
+      `Resolved (`Identifier id)
   with Not_found ->
     match core_constructor_identifier name with
-    | Some id -> Resolved (Identifier id)
+    | Some id -> `Resolved (`Identifier (id :> Model.Paths_types.Identifier.reference_constructor))
     | None ->
         match core_exception_identifier name with
-        | Some id -> Resolved (Identifier id)
-        | None -> Root (name, TConstructor)
+        | Some id -> `Resolved (`Identifier (id :> Model.Paths_types.Identifier.reference_constructor))
+        | None -> `Root (UnitName.of_string name, `TConstructor)
 
-let lookup_field_ident env name =
+let lookup_field_ident env name : Field.t =
   try
     let id = StringTbl.find name env.fields in
-      Resolved (Identifier id)
-  with Not_found -> Root (name, TField)
+      `Resolved (`Identifier id)
+  with Not_found -> `Root (UnitName.of_string name, `TField)
 
-let lookup_extension_ident env name =
+let lookup_extension_ident env name : Extension.t =
   try
     let id = StringTbl.find name env.extensions in
-      Resolved (Identifier id)
+      `Resolved (`Identifier id)
   with Not_found ->
     match core_exception_identifier name with
-    | Some id -> Resolved (Identifier id)
-    | None -> Root (name, TExtension)
+    | Some id -> `Resolved (`Identifier (id :> extension_ident))
+    | None -> `Root (UnitName.of_string name, `TExtension)
 
-let lookup_exception_ident env name =
+let lookup_exception_ident env name : Exception.t =
   try
     let id = StringTbl.find name env.exceptions in
-      Resolved (Identifier id)
+      `Resolved (`Identifier id)
   with Not_found ->
     match core_exception_identifier name with
-    | Some id -> Resolved (Identifier id)
-    | None -> Root (name, TException)
+    | Some id -> `Resolved (`Identifier id)
+    | None -> `Root (UnitName.of_string name, `TException)
 
-let lookup_value_ident env name =
+let lookup_value_ident env name : Value.t =
   try
     let id = StringTbl.find name env.values in
-      Resolved (Identifier id)
-  with Not_found -> Root (name, TValue)
+      `Resolved (`Identifier id)
+  with Not_found -> `Root (UnitName.of_string name, `TValue)
 
-let lookup_class_ident env name =
+let lookup_class_ident env name : Class.t =
   try
     let id = StringTbl.find name env.classes in
-      Resolved (Identifier id)
-  with Not_found -> Root (name, TClass)
+      `Resolved (`Identifier id)
+  with Not_found -> `Root (UnitName.of_string name, `TClass)
 
-let lookup_class_type_ident env name =
+let lookup_class_type_ident env name : ClassType.t =
   try
     let id = StringTbl.find name env.class_types in
-      Resolved (Identifier id)
-  with Not_found -> Root (name, TClassType)
+      `Resolved (`Identifier id)
+  with Not_found -> `Root (UnitName.of_string name, `TClassType)
 
-let lookup_method_ident env name =
+let lookup_method_ident env name : Method.t =
   try
     let id = StringTbl.find name env.methods in
-    Resolved (Identifier id)
-  with Not_found -> Root (name, TMethod)
+    `Resolved (`Identifier id)
+  with Not_found -> `Root (UnitName.of_string name, `TMethod)
 
-let lookup_instance_variable_ident env name =
+let lookup_instance_variable_ident env name : InstanceVariable.t =
   try
     let id = StringTbl.find name env.instance_variables in
-      Resolved (Identifier id)
-  with Not_found -> Root (name, TInstanceVariable)
+      `Resolved (`Identifier id)
+  with Not_found -> `Root (UnitName.of_string name, `TInstanceVariable)
 
-let lookup_label_ident env name =
+let lookup_label_ident env name : Label.t =
   try
     let id = StringTbl.find name env.labels in
-      Resolved (Identifier id)
-  with Not_found -> Root (name, TLabel)
+      `Resolved (`Identifier id)
+  with Not_found -> `Root (UnitName.of_string name, `TLabel)
 
-let lookup_parent_ident env name : Reference.parent =
+let lookup_parent_ident env name : Reference.Parent.t =
   match StringTbl.find name env.parents with
-  | Page _ ->
+  | `Page _ ->
     assert false
-  | Root _ | Module _ | Argument _ | ModuleType _ | Type _ | CoreType _
-  | Class _ | ClassType _ as id ->
-    Resolved (Identifier id)
+  | `Root _ | `Module _ | `Argument _ | `ModuleType _ | `Type _ | `CoreType _
+  | `Class _ | `ClassType _ as id ->
+    `Resolved (`Identifier id)
   | exception Not_found ->
     match core_type_identifier name with
-    | Some id -> Resolved (Identifier id)
-    | None -> Root (name, TUnknown)
+    | Some id -> `Resolved (`Identifier (id :> Identifier.Parent.t))
+    | None -> `Root (UnitName.of_string name, `TUnknown)
 
-let lookup_label_parent_ident env name : Reference.label_parent =
+let lookup_label_parent_ident env name : Reference.LabelParent.t =
   try
     let id = StringTbl.find name env.parents in
-      Resolved (Identifier id)
+      `Resolved (`Identifier id)
   with Not_found ->
     match core_type_identifier name with
-    | Some id -> Resolved (Identifier id)
-    | None -> Root (name, TUnknown)
+    | Some id -> `Resolved (`Identifier (id :> Identifier.LabelParent.t))
+    | None -> `Root (UnitName.of_string name, `TUnknown)
 
 let lookup_element_ident env name =
   try
     let id = StringTbl.find name env.elements in
-      Resolved (Identifier id)
+      `Resolved (`Identifier id)
   with Not_found ->
     match core_type_identifier name with
-    | Some id -> Resolved (Identifier id)
+    | Some id -> `Resolved (`Identifier (id :> Identifier.t))
     | None ->
         match core_constructor_identifier name with
-        | Some id -> Resolved (Identifier id)
+        | Some id -> `Resolved (`Identifier (id :> Identifier.t))
         | None ->
             match core_exception_identifier name with
-            | Some id -> Resolved (Identifier id)
-            | None -> Root (name, TUnknown)
+            | Some id -> `Resolved (`Identifier (id :> Identifier.t))
+            | None -> `Root (UnitName.of_string name, `TUnknown)
 
-let rec lookup_parent env : Reference.parent -> Reference.parent =
+let rec lookup_parent env : Reference.Parent.t -> Reference.Parent.t =
   function
-  | Resolved _ as r -> r
-  | Root (s, TUnknown) -> lookup_parent_ident env s
-  | Root (s, TModule) ->
-    lookup_module_ident env s
-    |> signature_of_module
-    |> parent_of_signature
-  | Root (s,TModuleType) ->
-    lookup_module_type_ident env s
-    |> signature_of_module_type
-    |> parent_of_signature
-  | Root (s,TType) as r ->
-    begin match lookup_type_ident env s with
-    | Type _ | Class _ | ClassType _ | Dot _ ->
+  | `Resolved _ as r -> r
+  | `Root (s, `TUnknown) -> lookup_parent_ident env (UnitName.to_string s)
+  | `Root (s, `TModule) ->
+    (lookup_module_ident env (UnitName.to_string s) :> Reference.Parent.t)
+  | `Root (s, `TModuleType) ->
+    (lookup_module_type_ident env (UnitName.to_string s) :> Reference.Parent.t)
+  | `Root (s, `TType) as r ->
+    begin match lookup_type_ident env (UnitName.to_string s) with
+    | `Type _ | `Class _ | `ClassType _ | `Dot _ ->
       (* can't go from Root to any of these. *)
       assert false
-    | Root _ -> r
-    | Resolved (Identifier (CoreType _ | Type _) | Type _) as resolved ->
-      parent_of_datatype resolved
-    | Resolved (Identifier (Class _ | ClassType _) | Class _ | ClassType _) as r
-      -> parent_of_class_signature r
+    | `Root _ -> r
+    | `Resolved (`Identifier (`CoreType _ | `Type _) | `Type _) as resolved ->
+      (resolved :> Reference.Parent.t)
+    | `Resolved (`Identifier (`Class _ | `ClassType _) | `Class _ | `ClassType _) as r
+      -> r
     end
-  | Root (s,TClass) ->
-    lookup_class_ident env s
-    |> class_signature_of_class
-    |> parent_of_class_signature
-  | Root (s,TClassType) ->
-    lookup_class_type_ident env s
-    |> class_signature_of_class_type
-    |> parent_of_class_signature
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Module(r, s) -> Module(lookup_signature env r, s)
-  | ModuleType(r, s) -> ModuleType(lookup_signature env r, s)
-  | Type(r, s) -> Type(lookup_signature env r, s)
-  | Class(r, s) -> Class(lookup_signature env r, s)
-  | ClassType(r, s) -> ClassType(lookup_signature env r, s)
+  | `Root (s, `TClass) ->
+    (lookup_class_ident env (UnitName.to_string s) :> Reference.Parent.t)
+  | `Root (s, `TClassType) ->
+    (lookup_class_type_ident env (UnitName.to_string s) :> Reference.Parent.t)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Module(r, s) -> `Module(lookup_signature env r, s)
+  | `ModuleType(r, s) -> `ModuleType(lookup_signature env r, s)
+  | `Type(r, s) -> `Type(lookup_signature env r, s)
+  | `Class(r, s) -> `Class(lookup_signature env r, s)
+  | `ClassType(r, s) -> `ClassType(lookup_signature env r, s)
 
 and lookup_label_parent env :
-  Reference.label_parent -> Reference.label_parent =
+  Reference.LabelParent.t -> Reference.LabelParent.t =
   function
-  | Resolved _ as r -> r
-  | Root (s, TUnknown) -> lookup_label_parent_ident env s
-  | Root (_, TPage) as r -> r (* there are no local pages. *)
-  | Root (s, TModule) ->
-    lookup_module_ident env s
-    |> signature_of_module
-    |> parent_of_signature
-    |> label_parent_of_parent
-  | Root (s,TModuleType) ->
-    lookup_module_type_ident env s
-    |> signature_of_module_type
-    |> parent_of_signature
-    |> label_parent_of_parent
-  | Root (s,TType) as r ->
-    begin match lookup_type_ident env s with
-    | Type _ | Class _ | ClassType _ | Dot _ ->
+  | `Resolved _ as r -> r
+  | `Root (s, `TUnknown) -> lookup_label_parent_ident env (UnitName.to_string s)
+  | `Root (_, `TPage) as r -> r (* there are no local pages. *)
+  | `Root (s, `TModule) ->
+    (lookup_module_ident env (UnitName.to_string s) :> LabelParent.t)
+  | `Root (s, `TModuleType) ->
+    (lookup_module_type_ident env (UnitName.to_string s) :> LabelParent.t)
+  | `Root (s, `TType) as r ->
+    begin match lookup_type_ident env (UnitName.to_string s) with
+    | `Type _ | `Class _ | `ClassType _ | `Dot _ ->
       (* can't go from Root to any of these. *)
       assert false
-    | Root _ -> r
-    | Resolved (Identifier (CoreType _ | Type _) | Type _) as resolved ->
-      parent_of_datatype resolved
-    | Resolved (Identifier (Class _ | ClassType _) | Class _ | ClassType _) as r
-      -> parent_of_class_signature r
+    | `Root _ -> r
+    | `Resolved (`Identifier (`CoreType _ | `Type _ | `Class _ | `ClassType _) | `Type _ | `Class _ | `ClassType _ ) as resolved ->
+      (resolved :> LabelParent.t)
     end
-    |> label_parent_of_parent
-  | Root (s,TClass) ->
-    lookup_class_ident env s
-    |> class_signature_of_class
-    |> parent_of_class_signature
-    |> label_parent_of_parent
-  | Root (s,TClassType) ->
-    lookup_class_type_ident env s
-    |> class_signature_of_class_type
-    |> parent_of_class_signature
-    |> label_parent_of_parent
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Module(r, s) -> Module(lookup_signature env r, s)
-  | ModuleType(r, s) -> ModuleType(lookup_signature env r, s)
-  | Type(r, s) -> Type(lookup_signature env r, s)
-  | Class(r, s) -> Class(lookup_signature env r, s)
-  | ClassType(r, s) -> ClassType(lookup_signature env r, s)
+  | `Root (s, `TClass) ->
+    (lookup_class_ident env (UnitName.to_string s) :> LabelParent.t)
+  | `Root (s, `TClassType) ->
+    (lookup_class_type_ident env (UnitName.to_string s) :> LabelParent.t)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Module(r, s) -> `Module(lookup_signature env r, s)
+  | `ModuleType(r, s) -> `ModuleType(lookup_signature env r, s)
+  | `Type(r, s) -> `Type(lookup_signature env r, s)
+  | `Class(r, s) -> `Class(lookup_signature env r, s)
+  | `ClassType(r, s) -> `ClassType(lookup_signature env r, s)
 
 and lookup_signature env :
-  Reference.signature -> Reference.signature = function
-  | Resolved _ as r -> r
-  | Root (s, TUnknown)    -> lookup_signature_ident env s
-  | Root (s, TModule)     -> signature_of_module (lookup_module_ident env s)
-  | Root (s, TModuleType) ->
-    signature_of_module_type (lookup_module_type_ident env s)
-  | Dot (p, s) -> Dot (lookup_label_parent env p, s)
-  | Module (p,s) -> Module (lookup_signature env p, s)
-  | ModuleType (p,s) -> ModuleType(lookup_signature env p, s)
+  Reference.Signature.t -> Reference.Signature.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, `TUnknown) -> lookup_signature_ident env (UnitName.to_string s)
+  | `Root (s, `TModule) ->
+    (lookup_module_ident env (UnitName.to_string s) :> Reference.Signature.t)
+  | `Root (s, `TModuleType) ->
+    (lookup_module_type_ident env (UnitName.to_string s) :> Reference.Signature.t)
+  | `Dot (p, s) -> `Dot (lookup_label_parent env p, s)
+  | `Module (p,s) -> `Module (lookup_signature env p, s)
+  | `ModuleType (p,s) -> `ModuleType(lookup_signature env p, s)
 
-let lookup_module env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_module_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Module(p, s) -> Module(lookup_signature env p, s)
+let lookup_module env : Reference.Module.t -> Reference.Module.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_module_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Module(p, s) -> `Module(lookup_signature env p, s)
 
-let lookup_module_type env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_module_type_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | ModuleType(p, s) -> ModuleType(lookup_signature env p, s)
+let lookup_module_type env : Reference.ModuleType.t -> Reference.ModuleType.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_module_type_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `ModuleType(p, s) -> `ModuleType(lookup_signature env p, s)
 
-let lookup_type env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_type_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Type(r, s) -> Type(lookup_signature env r, s)
-  | Class(r, s) -> Class(lookup_signature env r, s)
-  | ClassType(r, s) -> ClassType(lookup_signature env r, s)
+let lookup_type env : Reference.Type.t -> Reference.Type.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_type_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Type(r, s) -> `Type(lookup_signature env r, s)
+  | `Class(r, s) -> `Class(lookup_signature env r, s)
+  | `ClassType(r, s) -> `ClassType(lookup_signature env r, s)
 
-let lookup_datatype env : Reference.datatype -> Reference.datatype = function
-  | Resolved _ as r -> r
-  | Root (s, _) as r -> begin
-      match lookup_type_ident env s with
-      | Type _ | Class _ | ClassType _ | Dot _ ->
+let lookup_datatype env : Reference.DataType.t -> Reference.DataType.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) as r -> begin
+      match lookup_type_ident env (UnitName.to_string s) with
+      | `Type _ | `Class _ | `ClassType _ | `Dot _ ->
         (* can't go from Root to any of these. *)
         assert false
-      | Root _ -> r
-      | Resolved (Identifier (CoreType _ | Type _) | Type _) as resolved ->
+      | `Root _ -> r
+      | `Resolved (`Identifier (`CoreType _ | `Type _) | `Type _) as resolved ->
         resolved
-      | Resolved (Identifier (Class _ | ClassType _) | Class _ | ClassType _) ->
+      | `Resolved (`Identifier (`Class _ | `ClassType _) | `Class _ | `ClassType _) ->
         r
     end
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Type(r, s) -> Type(lookup_signature env r, s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Type(r, s) -> `Type(lookup_signature env r, s)
 
-let lookup_constructor env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_constructor_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Constructor(r, s) -> Constructor(lookup_datatype env r, s)
-  | Extension(r, s) -> Extension(lookup_signature env r, s)
-  | Exception(r, s) -> Exception(lookup_signature env r, s)
+let lookup_constructor env : Reference.Constructor.t -> Reference.Constructor.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_constructor_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Constructor(r, s) -> `Constructor(lookup_datatype env r, s)
+  | `Extension(r, s) -> `Extension(lookup_signature env r, s)
+  | `Exception(r, s) -> `Exception(lookup_signature env r, s)
 
-let lookup_field env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_field_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Field(r, s) -> Field(lookup_parent env r, s)
+let lookup_field env : Reference.Field.t -> Reference.Field.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_field_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Field(r, s) -> `Field(lookup_parent env r, s)
 
-let lookup_extension env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_extension_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Extension(r, s) -> Extension(lookup_signature env r, s)
-  | Exception(r, s) -> Exception(lookup_signature env r, s)
+let lookup_extension env : Reference.Extension.t -> Reference.Extension.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_extension_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Extension(r, s) -> `Extension(lookup_signature env r, s)
+  | `Exception(r, s) -> `Exception(lookup_signature env r, s)
 
-let lookup_exception env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_exception_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Exception(r, s) -> Exception(lookup_signature env r, s)
+let lookup_exception env : Reference.Exception.t -> Reference.Exception.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_exception_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Exception(r, s) -> `Exception(lookup_signature env r, s)
 
-let lookup_value env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_value_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Value(r, s) -> Value(lookup_signature env r, s)
+let lookup_value env : Reference.Value.t -> Reference.Value.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_value_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Value(r, s) -> `Value(lookup_signature env r, s)
 
-let lookup_class env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_class_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Class(r, s) -> Class(lookup_signature env r, s)
+let lookup_class env : Reference.Class.t -> Reference.Class.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_class_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Class(r, s) -> `Class(lookup_signature env r, s)
 
-let lookup_class_type env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_class_type_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Class(r, s) -> Class(lookup_signature env r, s)
-  | ClassType(r, s) -> ClassType(lookup_signature env r, s)
+let lookup_class_type env : Reference.ClassType.t -> Reference.ClassType.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_class_type_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Class(r, s) -> `Class(lookup_signature env r, s)
+  | `ClassType(r, s) -> `ClassType(lookup_signature env r, s)
 
-let lookup_method env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_method_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Method(r, s) -> Method(lookup_class_type env r, s)
+let lookup_method env : Reference.Method.t -> Reference.Method.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_method_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Method(r, s) -> `Method(lookup_class_type env r, s)
 
-let lookup_instance_variable env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_instance_variable_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | InstanceVariable(r, s) -> InstanceVariable(lookup_class_type env r, s)
+let lookup_instance_variable env : Reference.InstanceVariable.t -> Reference.InstanceVariable.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_instance_variable_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `InstanceVariable(r, s) -> `InstanceVariable(lookup_class_type env r, s)
 
-let lookup_label env = function
-  | Resolved _ as r -> r
-  | Root (s, _) -> lookup_label_ident env s
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Label(r, s) -> Label(lookup_label_parent env r, s)
+let lookup_label env : Reference.Label.t -> Reference.Label.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, _) -> lookup_label_ident env (UnitName.to_string s)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Label(r, s) -> `Label(lookup_label_parent env r, s)
 
-let lookup_element env = function
-  | Resolved _ as r -> r
-  | Root (s, TUnknown) -> Reference.any (lookup_element_ident env s)
-  | Root (_, TPage) as r -> r (* there are no local pages. *)
-  | Root (s, TModule) -> Reference.any (lookup_module_ident env s)
-  | Root (s, TModuleType) -> Reference.any (lookup_module_type_ident env s)
-  | Root (s, TType) -> Reference.any (lookup_type_ident env s)
-  | Root (s, TConstructor) -> Reference.any (lookup_constructor_ident env s)
-  | Root (s, TField) -> Reference.any (lookup_field_ident env s)
-  | Root (s, TExtension) -> Reference.any (lookup_extension_ident env s)
-  | Root (s, TException) -> Reference.any (lookup_exception_ident env s)
-  | Root (s, TValue) -> Reference.any (lookup_value_ident env s)
-  | Root (s, TClass) -> Reference.any (lookup_class_ident env s)
-  | Root (s, TClassType) -> Reference.any (lookup_class_type_ident env s)
-  | Root (s, TMethod) -> Reference.any (lookup_method_ident env s)
-  | Root (s, TInstanceVariable) -> Reference.any (lookup_instance_variable_ident env s)
-  | Root (s, TLabel) -> Reference.any (lookup_label_ident env s)
-  | Dot(r, s) -> Dot(lookup_label_parent env r, s)
-  | Module _ as r -> Reference.any @@ lookup_module env r
-  | ModuleType _ as r -> Reference.any @@ lookup_module_type env r
-  | Type _ as r -> Reference.any @@ lookup_type env r
-  | Constructor _ as r -> Reference.any @@ lookup_constructor env r
-  | Field _ as r -> Reference.any @@ lookup_field env r
-  | Extension _ as r -> Reference.any @@ lookup_extension env r
-  | Exception _ as r -> Reference.any @@ lookup_exception env r
-  | Value _ as r -> Reference.any @@ lookup_value env r
-  | Class _ as r -> Reference.any @@ lookup_class env r
-  | ClassType _ as r -> Reference.any @@ lookup_class_type env r
-  | Method _ as r -> Reference.any @@ lookup_method env r
-  | InstanceVariable _ as r -> Reference.any @@ lookup_instance_variable env r
-  | Label _ as r -> Reference.any @@ lookup_label env r
+let lookup_element env : Reference.t -> Reference.t = function
+  | `Resolved _ as r -> r
+  | `Root (s, `TUnknown) -> (lookup_element_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (_, `TPage) as r -> r (* there are no local pages. *)
+  | `Root (s, `TModule) -> (lookup_module_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TModuleType) -> (lookup_module_type_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TType) -> (lookup_type_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TConstructor) -> (lookup_constructor_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TField) -> (lookup_field_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TExtension) -> (lookup_extension_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TException) -> (lookup_exception_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TValue) -> (lookup_value_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TClass) -> (lookup_class_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TClassType) -> (lookup_class_type_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TMethod) -> (lookup_method_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TInstanceVariable) -> (lookup_instance_variable_ident env (UnitName.to_string s) :> Reference.t)
+  | `Root (s, `TLabel) -> (lookup_label_ident env (UnitName.to_string s) :> Reference.t)
+  | `Dot(r, s) -> `Dot(lookup_label_parent env r, s)
+  | `Module _ as r -> (lookup_module env r :> Reference.t)
+  | `ModuleType _ as r -> (lookup_module_type env r :> Reference.t)
+  | `Type _ as r -> (lookup_type env r :> Reference.t)
+  | `Constructor _ as r -> (lookup_constructor env r :> Reference.t)
+  | `Field _ as r -> (lookup_field env r :> Reference.t)
+  | `Extension _ as r -> (lookup_extension env r :> Reference.t)
+  | `Exception _ as r -> (lookup_exception env r :> Reference.t)
+  | `Value _ as r -> (lookup_value env r :> Reference.t)
+  | `Class _ as r -> (lookup_class env r :> Reference.t)
+  | `ClassType _ as r -> (lookup_class_type env r :> Reference.t)
+  | `Method _ as r -> (lookup_method env r :> Reference.t)
+  | `InstanceVariable _ as r -> (lookup_instance_variable env r :> Reference.t)
+  | `Label _ as r -> (lookup_label env r :> Reference.t)
 
 
 let lookup_section_title env lbl =
   match lbl with
-  | Identifier id ->
+  | `Identifier id ->
     let lbl = Identifier.name id in
     begin match StringTbl.find lbl env.titles with
     | txt -> Some txt

--- a/src/xref/name_env.mli
+++ b/src/xref/name_env.mli
@@ -37,34 +37,34 @@ val add_class_type_expr_items : Lang.ClassType.expr -> t -> t
 
 val add_class_decl_items : Lang.Class.decl -> t -> t
 
-val lookup_module : t -> Reference.module_ -> Reference.module_
+val lookup_module : t -> Reference.Module.t -> Reference.Module.t
 
-val lookup_module_type : t -> Reference.module_type -> Reference.module_type
+val lookup_module_type : t -> Reference.ModuleType.t -> Reference.ModuleType.t
 
-val lookup_type : t -> Reference.type_ -> Reference.type_
+val lookup_type : t -> Reference.Type.t -> Reference.Type.t
 
-val lookup_constructor : t -> Reference.constructor -> Reference.constructor
+val lookup_constructor : t -> Reference.Constructor.t -> Reference.Constructor.t
 
-val lookup_field : t -> Reference.field -> Reference.field
+val lookup_field : t -> Reference.Field.t -> Reference.Field.t
 
-val lookup_extension : t -> Reference.extension -> Reference.extension
+val lookup_extension : t -> Reference.Extension.t -> Reference.Extension.t
 
-val lookup_exception : t -> Reference.exception_ -> Reference.exception_
+val lookup_exception : t -> Reference.Exception.t -> Reference.Exception.t
 
-val lookup_value : t -> Reference.value -> Reference.value
+val lookup_value : t -> Reference.Value.t -> Reference.Value.t
 
-val lookup_class : t -> Reference.class_ -> Reference.class_
+val lookup_class : t -> Reference.Class.t -> Reference.Class.t
 
-val lookup_class_type : t -> Reference.class_type -> Reference.class_type
+val lookup_class_type : t -> Reference.ClassType.t -> Reference.ClassType.t
 
-val lookup_method : t -> Reference.method_ -> Reference.method_
+val lookup_method : t -> Reference.Method.t -> Reference.Method.t
 
-val lookup_instance_variable : t -> Reference.instance_variable ->
-  Reference.instance_variable
+val lookup_instance_variable : t -> Reference.InstanceVariable.t ->
+  Reference.InstanceVariable.t
 
-val lookup_label : t -> Reference.label -> Reference.label
+val lookup_label : t -> Reference.Label.t -> Reference.Label.t
 
-val lookup_element : t -> Reference.any -> Reference.any
+val lookup_element : t -> Reference.t -> Reference.t
 
-val lookup_section_title : t -> Reference.Resolved.label ->
+val lookup_section_title : t -> Reference.Resolved.Label.t ->
   Model.Comment.link_content option

--- a/src/xref/resolve.ml
+++ b/src/xref/resolve.ml
@@ -15,52 +15,52 @@
  *)
 
 open Model
+open Names
 open Paths
 open Components
 module CTbl = Component_table
 
-let lpop = Reference.label_parent_of_parent
-let rlpop = Reference.Resolved.label_parent_of_parent
+let lpop x = (x : Reference.Parent.t :> Reference.LabelParent.t)
+let rlpop x = (x : Reference.Resolved.Parent.t :> Reference.Resolved.LabelParent.t)
 
 type parent_module_path =
-  | Resolved of Path.Resolved.module_ * Sig.t
-  | Unresolved of Path.module_
+  | Resolved of Path.Resolved.Module.t * Sig.t
+  | Unresolved of Path.Module.t
 
 type parent_module_type_path =
-  | Resolved of Path.Resolved.module_type * Sig.t
-  | Unresolved of Path.module_type
+  | Resolved of Path.Resolved.ModuleType.t * Sig.t
+  | Unresolved of Path.ModuleType.t
 
 let rec add_subst_alias :
-  Path.Resolved.module_ ->
-  subp:Path.Resolved.module_ ->
-  Path.Resolved.module_ = fun orig ~subp ->
-  let open Path.Resolved in
-  if equal orig subp then orig else
+  Path.Resolved.Module.t ->
+  subp:Path.Resolved.Module.t ->
+  Path.Resolved.Module.t = fun orig ~subp ->
+  if Path.Resolved.Module.equal orig subp then orig else
   match orig with
-  | Canonical (_, Path.Resolved rp) ->
+  | `Canonical (_, `Resolved rp) ->
     add_subst_alias rp ~subp
-  | Canonical (rp, p) ->
+  | `Canonical (rp, p) ->
     let rp' = add_subst_alias rp ~subp in
-    if rp == rp' then orig else Canonical (rp', p)
-  | Module (p1, s1) -> begin
+    if rp == rp' then orig else `Canonical (rp', p)
+  | `Module (p1, s1) -> begin
       match subp with
-      | Module (subp, s2) when s1 = s2 ->
+      | `Module (subp, s2) when s1 = s2 ->
         let p1' = add_subst_alias p1 ~subp in
-        if p1 == p1' then orig else Module (p1', s1)
+        if p1 == p1' then orig else `Module (p1', s1)
       | _ ->
-        SubstAlias(subp, orig)
+        `SubstAlias(subp, orig)
     end
-  | SubstAlias (subst, printing) ->
-    if equal subst subp then orig else
-      SubstAlias (subp, printing)
+  | `SubstAlias (subst, printing) ->
+    if Path.Resolved.Module.equal subst subp then orig else
+      `SubstAlias (subp, printing)
   (* Not trying to be smart in these cases, let's just subst... *)
   | _ ->
-    SubstAlias(subp, orig)
+    `SubstAlias(subp, orig)
 
 let rec find_with_path_substs
-  : 'b 'c. (Sig.t -> 'b) -> (Path.Resolved.module_ -> 'b -> 'c)
-    -> (Path.Resolved.module_ -> 'c) -> Identifier.signature option
-    -> CTbl.t -> Path.Resolved.module_ -> Sig.t
+  : 'b 'c. (Sig.t -> 'b) -> (Path.Resolved.Module.t -> 'b -> 'c)
+    -> (Path.Resolved.Module.t -> 'c) -> Identifier.Signature.t option
+    -> CTbl.t -> Path.Resolved.Module.t -> Sig.t
     -> 'c =
   fun find resolved unresolved ident tbl pr parent ->
     try
@@ -73,14 +73,13 @@ let rec find_with_path_substs
             | Unresolved _ -> unresolved pr
             | Resolved(subpr, parent) ->
               let pr' =
-                let open Path.Resolved in
                 match pr with
-                | Canonical (_, Path.Resolved _) ->
-                  Path.Resolved.Subst(subpr, pr)
-                | Canonical (p1, p2) ->
-                  Path.Resolved.Canonical(Subst(subpr, p1), p2)
+                | `Canonical (_, `Resolved _) ->
+                  `Subst(subpr, pr)
+                | `Canonical (p1, p2) ->
+                  `Canonical(`Subst(subpr, p1), p2)
                 | _ ->
-                  Path.Resolved.Subst(subpr, pr)
+                  `Subst(subpr, pr)
               in
                 find_with_path_substs
                   find resolved unresolved ident tbl
@@ -97,102 +96,96 @@ let rec find_with_path_substs
           end
       with Not_found -> unresolved pr
 
-and resolve_canonical_path :
-  type k. Identifier.signature option -> _ -> k Path.Resolved.t ->
-  k Path.Resolved.t =
+and resolve_canonical_path_module :
+  Identifier.Signature.t option -> _ -> Path.Resolved.Module.t -> Path.Resolved.Module.t =
   fun ident tbl p ->
-    let open Path.Resolved in
-    let open Path in
     match p with
-    | Canonical(orig, cano) ->
+    | `Canonical (orig, cano) ->
       let orig' = resolve_resolved_module_path ident tbl orig in
       let cano' = resolve_module_path ident tbl cano in
-      if orig == orig' && cano == cano' then p
+      if orig == orig' && cano == cano' then (p :> Path.Resolved.Module.t)
       else (
         let cano' =
           match ident, cano' with
-          | Some ident, Resolved rp ->
-            let rp' = rebase ident rp in
-            if rp != rp' then Resolved rp' else cano'
+          | Some ident, `Resolved rp ->
+            let rp' = Path.Resolved.Module.rebase ident rp in
+            if rp != rp' then `Resolved rp' else cano'
           | _ -> cano'
         in
-        let c = Canonical(orig, cano') in
+        let c = `Canonical(orig, cano') in
         match ident, cano' with
-        | Some ident, Path.Resolved (Identifier id)
-          when Identifier.equal ident
-                 (Identifier.signature_of_module id) ->
-          Hidden c
+        | Some ident, `Resolved (`Identifier id)
+          when Identifier.Signature.equal ident (id :> Identifier.Signature.t) ->
+          `Hidden c
         | _, _ -> c
       )
     | _ -> p
 
-and resolve_parent_module_path ident tbl p : parent_module_path =
-  let open Path.Resolved in
-  let open Path in
+and resolve_parent_module_path ident tbl (p : Path.Module.t) : parent_module_path =
     match p with
-    | Root s -> begin
+    | `Root s -> begin
         match CTbl.base tbl s with
         | CTbl.Not_found -> Unresolved p
         | CTbl.Forward_reference ->
             (* We can't have a forward ref as parent. *)
             Unresolved p
         | CTbl.Found { root ; hidden } ->
-            let p = Identifier (Identifier.Root(root, s)) in
-            let p = if hidden then Hidden p else p in
+            let p = `Identifier (`Root(root, UnitName.of_string s)) in
+            let p = if hidden then `Hidden p else p in
               Resolved(p, CTbl.resolved_module_path tbl p)
       end
-    | Forward s -> begin
+    | `Forward s -> begin
         match CTbl.base tbl s with
         | CTbl.Not_found -> Unresolved p
         | CTbl.Forward_reference ->
             (* We can't have a forward ref as parent. *)
             Unresolved p
         | CTbl.Found { root ; hidden } ->
-            let p = Identifier (Identifier.Root(root, s)) in
-            let p = if hidden then Hidden p else p in
+            let p = `Identifier (`Root(root, UnitName.of_string s)) in
+            let p = if hidden then `Hidden p else p in
               Resolved(p, CTbl.resolved_module_path tbl p)
       end
-    | Resolved r -> Resolved(r, CTbl.resolved_module_path tbl r)
-    | Dot(pr, name) -> begin
+    | `Resolved r -> Resolved(r, CTbl.resolved_module_path tbl r)
+    | `Dot(pr, name) -> begin
         match resolve_parent_module_path ident tbl pr with
-        | Unresolved pr -> Unresolved(Dot(pr, name))
+        | Unresolved pr -> Unresolved(`Dot(pr, name))
         | Resolved(pr, parent) ->
-            let resolved pr (Parent.Module md : Parent.module_) =
-              let pr = Module (pr, name) in
-              let pr = if Sig.get_hidden md then Hidden pr else pr in
+            let resolved pr (`Module md : Parent.module_) =
+              let pr = `Module (pr, ModuleName.of_string name) in
+              let pr = if Sig.get_hidden md then `Hidden pr else pr in
               let pr =
                 match Sig.get_canonical md with
                 | None -> pr
                 | Some (p, _) ->
-                  resolve_canonical_path ident tbl (Canonical(pr, p))
+                  resolve_canonical_path_module ident tbl (`Canonical(pr, p))
               in
               (Resolved(pr, md) : parent_module_path)
             in
             let unresolved pr =
-              (Unresolved(Dot(Resolved pr, name)) : parent_module_path)
+              (Unresolved(`Dot(`Resolved pr, name)) : parent_module_path)
             in
               find_with_path_substs
                 (Sig.find_parent_module name)
                 resolved unresolved ident tbl pr parent
       end
-    | Apply(pr, arg) -> begin
+    | `Apply(pr, arg) -> begin
         let arg = resolve_module_path ident tbl arg in
         match resolve_parent_module_path ident tbl pr with
-        | Unresolved pr -> Unresolved(Apply(pr, arg))
+        | Unresolved pr -> Unresolved(`Apply(pr, arg))
         | Resolved(pr, parent) ->
-            let resolved pr (Parent.Module md : Parent.module_) =
-              let pr = Resolved.Apply(pr, arg) in
-              let pr = if Sig.get_hidden md then Hidden pr else pr in
+            let resolved pr (`Module md : Parent.module_) =
+              let pr = `Apply(pr, arg) in
+              let pr = if Sig.get_hidden md then `Hidden pr else pr in
               let pr =
                 match Sig.get_canonical md with
                 | None -> pr
                 | Some (p, _) ->
-                  resolve_canonical_path ident tbl (Canonical(pr, p))
+                  resolve_canonical_path_module ident tbl (`Canonical(pr, p))
               in
               (Resolved(pr, md) : parent_module_path)
             in
             let unresolved pr =
-              (Unresolved(Apply(Resolved pr, arg)) : parent_module_path)
+              (Unresolved(`Apply(`Resolved pr, arg)) : parent_module_path)
             in
               find_with_path_substs
                 (Sig.find_parent_apply (CTbl.module_path tbl) arg)
@@ -200,226 +193,279 @@ and resolve_parent_module_path ident tbl p : parent_module_path =
       end
 
 and resolve_parent_module_type_path ident tbl p : parent_module_type_path =
-  let open Path.Resolved in
-  let open Path in
     match p with
-    | Resolved r -> Resolved(r, CTbl.resolved_module_type_path tbl r)
-    | Dot(pr, name) -> begin
+    | `Resolved r -> Resolved(r, CTbl.resolved_module_type_path tbl r)
+    | `Dot(pr, name) -> begin
         match resolve_parent_module_path ident tbl pr with
-        | Unresolved pr -> Unresolved(Dot(pr, name))
+        | Unresolved pr -> Unresolved(`Dot(pr, name))
         | Resolved(pr, parent) ->
-            let resolved pr (Parent.ModuleType md : Parent.module_type) =
-              (Resolved(ModuleType(pr, name), md) : parent_module_type_path)
+            let resolved pr (`ModuleType md : Parent.module_type) =
+              (Resolved(`ModuleType(pr, ModuleTypeName.of_string name), md) : parent_module_type_path)
             in
             let unresolved pr =
-              Unresolved(Dot(Resolved pr, name))
+              Unresolved(`Dot(`Resolved pr, name))
             in
               find_with_path_substs
                 (Sig.find_parent_module_type name)
                 resolved unresolved ident tbl pr parent
       end
 
-and resolve_module_path ident tbl =
-  let open Path.Resolved in
-  let open Path in function
-  | Root s as p -> begin
+and resolve_module_path ident tbl : Path.Module.t -> Path.Module.t =
+  function
+  | `Root s as p -> begin
       match CTbl.base tbl s with
       | CTbl.Not_found -> p
-      | CTbl.Forward_reference -> Forward s
+      | CTbl.Forward_reference -> `Forward s
       | CTbl.Found { root ; hidden } ->
-        let p = Identifier (Identifier.Root(root, s)) in
-        Resolved (if hidden then Hidden p else p)
+        let p = `Identifier (`Root(root, UnitName.of_string s)) in
+        `Resolved (if hidden then `Hidden p else p)
     end
-  | Forward s as p -> begin
+  | `Forward s as p -> begin
       match CTbl.base tbl s with
       | CTbl.Not_found -> p
-      | CTbl.Forward_reference -> Forward s
+      | CTbl.Forward_reference -> `Forward s
       | CTbl.Found { root ; hidden } ->
-        let p = Identifier (Identifier.Root(root, s)) in
-        Resolved (if hidden then Hidden p else p)
+        let p = `Identifier (`Root(root, UnitName.of_string s)) in
+        `Resolved (if hidden then `Hidden p else p)
     end
-  | Resolved r as p ->
-    let r' = resolve_resolved_module_path ident tbl r in
-    if r != r' then Resolved r' else p
-  | Dot(p, name) -> begin
+  | `Resolved r as p ->
+    let r' = resolve_resolved_path ident tbl (r :> Path.Resolved.t) |> Path.Resolved.module_of_t in
+    if r != r' then `Resolved r' else p
+  | `Dot(p, name) -> begin
       match resolve_parent_module_path ident tbl p with
-      | Unresolved p -> Dot(p, name)
+      | Unresolved p -> `Dot(p, name)
       | Resolved(p, parent) ->
           let resolved p (elem : Element.signature_module) =
-            let Element.Module {canonical; hidden} = elem in
-            let pr = Resolved.Module(p, name) in
-            let pr = if hidden then Resolved.Hidden pr else pr in
+            let `Module {Element.canonical; hidden} = elem in
+            let pr = `Module(p, ModuleName.of_string name) in
+            let pr = if hidden then `Hidden pr else pr in
             let pr =
               match canonical with
               | None -> pr
-              | Some (p, _) -> Canonical(pr, p)
+              | Some (p, _) -> `Canonical(pr, p)
             in
-            Resolved pr
+            `Resolved pr
           in
           let unresolved p =
-            Dot(Resolved p, name)
+            `Dot(`Resolved p, name)
           in
             find_with_path_substs
               (Sig.find_module_element name)
               resolved unresolved ident tbl p parent
     end
-  | Apply(p, arg) -> begin
+  | `Apply(p, arg) -> begin
       let arg = resolve_module_path ident tbl arg in
         match resolve_parent_module_path ident tbl p with
-        | Unresolved p -> Apply(p, arg)
+        | Unresolved p -> `Apply(p, arg)
         | Resolved(p, parent) ->
           let resolved p (elem : Element.signature_module) =
-            let Element.Module {canonical; hidden} = elem in
-            let pr = Resolved.Apply (p, arg) in
-            let pr = if hidden then Resolved.Hidden pr else pr in
+            let `Module {Element.canonical; hidden} = elem in
+            let pr = `Apply (p, arg) in
+            let pr = if hidden then `Hidden pr else pr in
             let pr =
               match canonical with
               | None -> pr
-              | Some (p, _) -> Canonical(pr, p)
+              | Some (p, _) -> `Canonical(pr, p)
             in
-            Resolved pr
+            `Resolved pr
           in
           let unresolved p =
-            Apply(Resolved p, arg)
+            `Apply(`Resolved p, arg)
           in
             find_with_path_substs
               Sig.find_apply_element
               resolved unresolved ident tbl p parent
     end
 
-and resolve_resolved_module_path :
-  type a. _ -> _ -> a Path.Resolved.t -> a Path.Resolved.t =
+and resolve_resolved_module_type_path_no_id : _ -> _ ->
+  Paths_types.Resolved_path.module_type_no_id ->
+  Paths_types.Resolved_path.module_type =
   fun ident tbl p ->
-  let open Path.Resolved in
   match p with
-  | Identifier _ -> p
-  | Subst(sub, orig) ->
-    let sub' = resolve_resolved_module_path ident tbl sub in
-    let orig' = resolve_resolved_module_path ident tbl orig in
-    if sub != sub' || orig != orig' then Subst(sub', orig')
-    else p
-  | SubstAlias(sub, orig) ->
-    let sub'  = resolve_resolved_module_path ident tbl sub in
-    let orig' = resolve_resolved_module_path ident tbl orig in
-    if sub != sub' || orig != orig' then SubstAlias(sub', orig')
-    else p
-  | Hidden hp ->
-    let hp'  = resolve_resolved_module_path ident tbl hp in
-    if hp != hp' then Hidden hp'
-    else p
-  | Module(parent, name) ->
-    let parent' = resolve_resolved_module_path ident tbl parent in
+  | `ModuleType(parent, name) ->
+    let parent' = resolve_resolved_path ident tbl (parent :> Path.Resolved.t) |> Path.Resolved.module_of_t in
     if parent != parent' then
-      Module(parent', name)
-    else p
-  | Canonical(_, _) ->
-    resolve_canonical_path ident tbl p
-  | Apply(fn, arg) ->
-    let fn' = resolve_resolved_module_path ident tbl fn in
-    if fn != fn' then Apply(fn', arg)
-    else p
-  | ModuleType(parent, name) ->
-    let parent' = resolve_resolved_module_path ident tbl parent in
-    if parent != parent' then
-      ModuleType(parent', name)
-    else p
-  | Type(parent, name) ->
-    let parent' = resolve_resolved_module_path ident tbl parent in
-    if parent != parent' then Type(parent', name)
-    else p
-  | Class(parent, name) ->
-    let parent' = resolve_resolved_module_path ident tbl parent in
-    if parent != parent' then Class(parent', name)
-    else p
-  | ClassType(parent, name) ->
-    let parent' = resolve_resolved_module_path ident tbl parent in
-    if parent != parent' then
-      ClassType(parent', name)
-    else p
+      `ModuleType(parent', name)
+    else (p :> Path.Resolved.ModuleType.t)
 
-and resolve_module_type_path ident tbl =
-  let open Path.Resolved in
-  let open Path in function
-  | (Resolved r : Path.module_type) as p ->
-    let r' = resolve_resolved_module_path ident tbl r in
-    if r != r' then Resolved r' else p
-  | Dot(p, name) -> begin
+and resolve_resolved_module_type_path : _ -> _ -> Path.Resolved.ModuleType.t -> Path.Resolved.ModuleType.t =
+  fun ident tbl p ->
+  match p with
+  | `Identifier _ -> p
+  | `ModuleType(_parent, _name) as p' -> resolve_resolved_module_type_path_no_id ident tbl p'
+
+and resolve_resolved_module_path_no_id : _ -> _ -> Paths_types.Resolved_path.module_no_id -> Paths_types.Resolved_path.module_ =
+  fun ident tbl p ->
+  match p with
+  | `Subst(sub, orig) ->
+    let sub' = resolve_resolved_module_type_path ident tbl sub in
+    let orig' = resolve_resolved_module_path ident tbl orig in
+    if sub != sub' || orig != orig' then `Subst(sub', orig')
+    else (p :> Path.Resolved.Module.t)
+  | `SubstAlias(sub, orig) ->
+    let sub'  = resolve_resolved_module_path ident tbl sub in 
+    let orig' = resolve_resolved_module_path ident tbl orig in 
+    if sub != sub' || orig != orig' then `SubstAlias(sub', orig')
+    else (p :> Path.Resolved.Module.t)
+  | `Hidden hp ->
+    let hp'  = resolve_resolved_module_path ident tbl hp in
+    if hp != hp' then `Hidden hp'
+    else (p :> Path.Resolved.Module.t)
+  | `Module(parent, name) ->
+    let parent' = resolve_resolved_module_path ident tbl parent in
+    if parent != parent' then
+      `Module(parent', name)
+    else (p :> Path.Resolved.Module.t)
+  | `Canonical(_, _) as p ->
+    resolve_canonical_path_module ident tbl p
+  | `Apply(fn, arg) ->
+    let fn' = resolve_resolved_module_path ident tbl fn in
+    if fn != fn' then `Apply(fn', arg)
+    else (p :> Path.Resolved.Module.t)
+
+and resolve_resolved_module_path : _ -> _ ->
+  Path.Resolved.Module.t -> Path.Resolved.Module.t =
+  fun ident tbl p ->
+  match p with
+  | `Identifier _ -> p
+  | `Subst(_,_)
+  | `SubstAlias(_,_)
+  | `Hidden(_)
+  | `Module(_,_)
+  | `Canonical(_,_)
+  | `Apply(_,_) as p' -> resolve_resolved_module_path_no_id ident tbl p'
+
+and resolve_resolved_type_class_path_no_id : _ -> _ ->
+  Paths_types.Resolved_path.class_type_no_id -> Path.Resolved.ClassType.t =
+  fun ident tbl p ->
+  match p with
+  | `Class(parent, name) ->
+    let parent' = resolve_resolved_module_path ident tbl parent in
+    if parent != parent' then `Class(parent', name)
+    else (p :> Path.Resolved.ClassType.t)
+  | `ClassType(parent, name) ->
+    let parent' = resolve_resolved_module_path ident tbl parent in
+    if parent != parent' then `ClassType(parent', name)
+    else (p :> Path.Resolved.ClassType.t)
+
+and resolve_resolved_type_class_path : _ -> _ ->
+  Path.Resolved.ClassType.t -> Path.Resolved.ClassType.t =
+  fun ident tbl p ->
+  match p with
+  | `Identifier _ -> p
+  | `Class _ | `ClassType _ as p' -> resolve_resolved_type_class_path_no_id ident tbl p'
+
+and resolve_resolved_type_path_no_id : _ -> _ ->
+  Paths_types.Resolved_path.type_no_id -> Path.Resolved.Type.t =
+  fun ident tbl p ->
+  match p with
+  | `Type(parent, name) ->
+    let parent' = resolve_resolved_module_path ident tbl parent in
+    if parent != parent' then `Type(parent', name)
+    else (p :> Path.Resolved.Type.t)
+  | `Class _ | `ClassType _ as p' ->
+    (resolve_resolved_type_class_path_no_id ident tbl p' :> Path.Resolved.Type.t)
+
+and resolve_resolved_type_path : _ -> _ ->
+  Path.Resolved.Type.t -> Path.Resolved.Type.t =
+  fun ident tbl p ->
+  match p with
+  | `Identifier _ -> p
+  | `Type _ | `Class _ | `ClassType _ as p' -> resolve_resolved_type_path_no_id ident tbl p'
+
+and resolve_resolved_path :
+  _ -> _ -> Path.Resolved.t -> Path.Resolved.t =
+  fun ident tbl p ->
+  match p with
+  | `Identifier _ -> p
+  | `Subst _ | `SubstAlias _ | `Hidden _
+  | `Module _ | `Canonical _ | `Apply _ as p' ->
+    (resolve_resolved_module_path_no_id ident tbl p' :> Path.Resolved.t)
+  | `ModuleType _ as p' ->
+    (resolve_resolved_module_type_path_no_id ident tbl p' :> Path.Resolved.t)
+  | `Type _ | `Class _ | `ClassType _ as p' ->
+    (resolve_resolved_type_path_no_id ident tbl p' :> Path.Resolved.t)
+
+and resolve_path_module_type ident tbl (p : Path.ModuleType.t) =
+  match p with
+  | `Resolved r ->
+    let r' = resolve_resolved_module_type_path ident tbl r in
+    if r != r' then `Resolved r' else p
+  | `Dot(p, name) -> begin
       match resolve_parent_module_path ident tbl p with
-      | Unresolved p -> Dot(p, name)
+      | Unresolved p -> `Dot(p, name)
       | Resolved(p, parent) ->
-          let resolved p (Element.ModuleType : Element.signature_module_type) =
-            Resolved (ModuleType(p, name))
+          let resolved p (`ModuleType : Element.signature_module_type) =
+            `Resolved (`ModuleType(p, ModuleTypeName.of_string name))
           in
           let unresolved p =
-            Dot(Resolved p, name)
+            `Dot(`Resolved p, name)
           in
             find_with_path_substs
               (Sig.find_module_type_element name)
               resolved unresolved ident tbl p parent
     end
 
-and resolve_type_path ident tbl =
-  let open Path.Resolved in
-  let open Path in function
-  | (Resolved r : Path.type_) as p ->
-    let r' = resolve_resolved_module_path ident tbl r in
-    if r != r' then Resolved r' else p
-  | Dot(p, name) -> begin
+and resolve_type_path ident tbl (p : Path.Type.t) =
+  match p with
+  | `Resolved r ->
+    let r' = resolve_resolved_type_path ident tbl r in
+    if r != r' then `Resolved r' else p
+  | `Dot(p, name) -> begin
       match resolve_parent_module_path ident tbl p with
-      | Unresolved p -> Dot(p, name)
+      | Unresolved p -> `Dot(p, name)
       | Resolved(p, parent) ->
           let resolved p : Element.signature_type -> _ = function
-            | Element.Type -> Resolved (Type(p, name))
-            | Element.Class -> Resolved (Class(p, name))
-            | Element.ClassType -> Resolved (ClassType(p, name))
+            | `Type -> `Resolved (`Type(p, TypeName.of_string name))
+            | `Class -> `Resolved (`Class(p, ClassName.of_string name))
+            | `ClassType -> `Resolved (`ClassType(p, ClassTypeName.of_string name))
           in
           let unresolved p =
-            Dot(Resolved p, name)
+            `Dot(`Resolved p, name)
           in
             find_with_path_substs
               (Sig.find_type_element name)
               resolved unresolved ident tbl p parent
     end
 
-and resolve_class_type_path ident tbl =
-  let open Path.Resolved in
-  let open Path in function
-  | (Resolved r : Path.class_type) as p ->
-    let r' = resolve_resolved_module_path ident tbl r in
-    if r != r' then Resolved r' else p
-  | Dot(p, name) -> begin
+and resolve_class_type_path ident tbl (p : Path.ClassType.t) =
+  match p with
+  | `Resolved r ->
+    let r' = resolve_resolved_type_class_path ident tbl r in
+    if r != r' then `Resolved r' else p
+  | `Dot(p, name) -> begin
       match resolve_parent_module_path ident tbl p with
-      | Unresolved p -> Dot(p, name)
+      | Unresolved p -> `Dot(p, name)
       | Resolved(p, parent) ->
           let resolved p : Element.signature_class_type -> _ = function
-            | Element.Class -> Resolved (Class(p, name))
-            | Element.ClassType -> Resolved (ClassType(p, name))
+            | `Class -> `Resolved (`Class(p, ClassName.of_string name))
+            | `ClassType -> `Resolved (`ClassType(p, ClassTypeName.of_string name))
           in
           let unresolved p =
-            Dot(Resolved p, name)
+            `Dot(`Resolved p, name)
           in
             find_with_path_substs
               (Sig.find_class_type_element name)
               resolved unresolved ident tbl p parent
     end
 
+
 type parent_fragment =
-  | Resolved of Fragment.Resolved.signature * Sig.t
-  | Unresolved of Fragment.signature
+  | Resolved of Fragment.Resolved.Signature.t * Sig.t
+  | Unresolved of Fragment.Signature.t
 
 let rec find_with_fragment_substs
         : 'b 'c. (Sig.t -> 'b) ->
-                   (Fragment.Resolved.signature -> 'b -> 'c) ->
-                     (Fragment.Resolved.signature -> 'c) ->
+                   (Fragment.Resolved.Signature.t -> 'b -> 'c) ->
+                     (Fragment.Resolved.Signature.t -> 'c) ->
                        _ -> CTbl.t ->
-                         Fragment.Resolved.signature -> Sig.t -> 'c =
+                         Fragment.Resolved.Signature.t -> Sig.t -> 'c =
   fun find resolved unresolved ident tbl pr parent ->
     try
       resolved pr (find parent)
     with Not_found ->
-      let open Fragment.Resolved in
       match pr with
-      | Subst _ | SubstAlias _ | Module _ as pr -> begin
+      | `Subst _ | `SubstAlias _ | `Module _ as pr -> begin
           try
             match Sig.find_parent_subst parent with
             | Parent.Subst subp -> begin
@@ -428,7 +474,7 @@ let rec find_with_fragment_substs
                 | Resolved(subpr, parent) ->
                   find_with_fragment_substs
                     find resolved unresolved ident tbl
-                    (Fragment.Resolved.Subst(subpr, pr)) parent
+                    (`Subst(subpr, pr)) parent
               end
             | Parent.SubstAlias subp -> begin
                 match resolve_parent_module_path ident tbl subp with
@@ -436,178 +482,168 @@ let rec find_with_fragment_substs
                 | Resolved(subpr, parent) ->
                   find_with_fragment_substs
                     find resolved unresolved ident tbl
-                    (Fragment.Resolved.SubstAlias(subpr, pr)) parent
+                    (`SubstAlias(subpr, pr)) parent
               end
           with Not_found -> unresolved pr
         end
       | _ -> unresolved pr (* we can find substs only for modules. *)
 
-let rec resolve_parent_fragment ident tbl base p : parent_fragment =
-  let open Fragment.Resolved in
-  let open Fragment in
+let rec resolve_parent_fragment ident tbl base (p : Fragment.Signature.t) : parent_fragment =
     match p with
-    | (Resolved r : signature) ->
+    | `Resolved r ->
           Resolved(r, CTbl.resolved_signature_fragment base r)
-    | Dot(pr, name) -> begin
+    | `Dot(pr, name) -> begin
         match resolve_parent_fragment ident tbl base pr with
-        | Unresolved pr -> Unresolved(Dot(pr, name))
+        | Unresolved pr -> Unresolved(`Dot(pr, name))
         | Resolved(pr, parent) ->
-            let resolved pr (Parent.Module md : Parent.module_) =
-              (Resolved(Module(pr, name), md) : parent_fragment)
+            let resolved pr (`Module md : Parent.module_) =
+              (Resolved(`Module(pr, ModuleName.of_string name), md) : parent_fragment)
             in
             let unresolved pr =
-              (Unresolved(Dot(Resolved pr, name)) : parent_fragment)
+              (Unresolved(`Dot(`Resolved pr, name)) : parent_fragment)
             in
               find_with_fragment_substs
                 (Sig.find_parent_module name)
                 resolved unresolved ident tbl pr parent
       end
 
-and resolve_module_fragment ident tbl base =
-  let open Fragment.Resolved in
-  let open Fragment in function
-  | Resolved _ as p -> p
-  | Dot(p, name) -> begin
+and resolve_module_fragment ident tbl base (p : Fragment.Module.t) =
+  match p with
+  | `Resolved _ as p -> p
+  | `Dot(p, name) -> begin
       match resolve_parent_fragment ident tbl base p with
-      | Unresolved p -> Dot(p, name)
+      | Unresolved p -> `Dot(p, name)
       | Resolved(p, parent) ->
-          let resolved p (Element.Module _ : Element.signature_module) =
+          let resolved p (`Module _ : Element.signature_module) =
             (* Handle canonical path here? *)
-            Resolved (Module(p, name))
+            `Resolved (`Module(p, ModuleName.of_string name))
           in
           let unresolved p =
-            Dot(Resolved p, name)
+            `Dot(`Resolved p, name)
           in
             find_with_fragment_substs
               (Sig.find_module_element name)
               resolved unresolved ident tbl p parent
     end
 
-and resolve_type_fragment ident tbl base =
-  let open Fragment.Resolved in
-  let open Fragment in function
-  | (Resolved _ : Fragment.type_) as p -> p
-  | Dot(p, name) -> begin
+and resolve_type_fragment ident tbl base (p : Fragment.Type.t) =
+  match p with
+  | `Resolved _ -> p
+  | `Dot(p, name) -> begin
       match resolve_parent_fragment ident tbl base p with
-      | Unresolved p -> Dot(p, name)
+      | Unresolved p -> `Dot(p, name)
       | Resolved(p, parent) ->
           let resolved p : Element.signature_type -> _ = function
-            | Element.Type -> Resolved (Type(p, name))
-            | Element.Class -> Resolved (Class(p, name))
-            | Element.ClassType -> Resolved (ClassType(p, name))
+            | `Type -> `Resolved (`Type(p, TypeName.of_string name))
+            | `Class -> `Resolved (`Class(p, ClassName.of_string name))
+            | `ClassType -> `Resolved (`ClassType(p, ClassTypeName.of_string name))
           in
           let unresolved p =
-            Dot(Resolved p, name)
+            `Dot(`Resolved p, name)
           in
             find_with_fragment_substs
               (Sig.find_type_element name)
               resolved unresolved ident tbl p parent
     end
 
-type 'kind parent_reference =
-  | ResolvedSig : Reference.Resolved.signature * Sig.t ->
-                  [> `Module | `ModuleType] parent_reference
-  | ResolvedDatatype : Reference.Resolved.datatype * Datatype.t ->
-                   [> `Type] parent_reference
-  | ResolvedClassSig : Reference.Resolved.class_signature * ClassSig.t ->
-                   [> `Class | `ClassType] parent_reference
-  | ResolvedPage : Reference.Resolved.page * Page.t ->
-                  [> `Page ] parent_reference
-  | Unresolved of Reference.label_parent
+type parent_reference =
+  | ResolvedSig of Reference.Resolved.Signature.t * Sig.t
+  | ResolvedDatatype of Reference.Resolved.DataType.t * Datatype.t
+  | ResolvedClassSig of Reference.Resolved.ClassSignature.t * ClassSig.t
+  | ResolvedPage of Reference.Resolved.Page.t * Page.t
+  | Unresolved of Reference.LabelParent.t
 
-type 'kind parent_kind =
-  | PParent : Kind.parent parent_kind
-  | PSig : Kind.signature parent_kind
-  | PClassSig : Kind.class_signature parent_kind
-  | PSigOrType : [Kind.signature | Kind.datatype] parent_kind
-  | PLabelParent : [Kind.page | Kind.parent] parent_kind
+type parent_kind =
+  | PParent
+  | PSig
+  | PClassSig
+  | PSigOrType
+  | PLabelParent
 
-let find_parent_reference (type k) (kind : k parent_kind) r name parent
-    : k parent_reference =
-  let open Reference.Resolved in
+let find_parent_reference (kind : parent_kind) r name parent
+    : parent_reference =
     match kind with
     | PParent -> begin
         match Sig.find_parent name parent with
-        | Parent.Module md ->
-          let pr = Module (r, name) in
+        | `Module md ->
+          let pr = `Module (r, ModuleName.of_string name) in
           let pr =
             match Sig.get_canonical md with
             | None -> pr
-            | Some (_, r) -> Canonical(pr, r)
+            | Some (_, r) -> `Canonical(pr, r)
           in
           ResolvedSig(pr, md)
-        | Parent.ModuleType md -> ResolvedSig(ModuleType(r, name), md)
-        | Parent.Datatype t -> ResolvedDatatype(Type(r, name), t)
-        | Parent.Class cls -> ResolvedClassSig(Class(r, name), cls)
-        | Parent.ClassType cls -> ResolvedClassSig(ClassType(r, name), cls)
+        | `ModuleType md -> ResolvedSig(`ModuleType(r, ModuleTypeName.of_string name), md)
+        | `Datatype t -> ResolvedDatatype(`Type(r, TypeName.of_string name), t)
+        | `Class cls -> ResolvedClassSig(`Class(r, ClassName.of_string name), cls)
+        | `ClassType cls -> ResolvedClassSig(`ClassType(r, ClassTypeName.of_string name), cls)
       end
     | PSig -> begin
         match Sig.find_parent_signature name parent with
-        | Parent.Module md ->
-          let pr = Module (r, name) in
+        | `Module md ->
+          let pr = `Module (r, ModuleName.of_string name) in
           let pr =
             match Sig.get_canonical md with
             | None -> pr
-            | Some (_, r) -> Canonical(pr, r)
+            | Some (_, r) -> `Canonical(pr, r)
           in
           ResolvedSig(pr, md)
-        | Parent.ModuleType md -> ResolvedSig(ModuleType(r, name), md)
+        | `ModuleType md -> ResolvedSig(`ModuleType(r, ModuleTypeName.of_string name), md)
       end
     | PClassSig -> begin
         match Sig.find_parent_class_signature name parent with
-        | Parent.Class cls -> ResolvedClassSig(Class(r, name), cls)
-        | Parent.ClassType cls -> ResolvedClassSig(ClassType(r, name), cls)
+        | `Class cls -> ResolvedClassSig(`Class(r, ClassName.of_string name), cls)
+        | `ClassType cls -> ResolvedClassSig(`ClassType(r, ClassTypeName.of_string name), cls)
       end
     | PSigOrType -> begin
         match Sig.find_parent_sig_or_type name parent with
-        | Parent.Module md ->
-          let pr = Module (r, name) in
+        | `Module md ->
+          let pr = `Module (r, ModuleName.of_string name) in
           let pr =
             match Sig.get_canonical md with
             | None -> pr
-            | Some (_, r) -> Canonical(pr, r)
+            | Some (_, r) -> `Canonical(pr, r)
           in
           ResolvedSig(pr, md)
-        | Parent.ModuleType md -> ResolvedSig(ModuleType(r, name), md)
-        | Parent.Datatype t -> ResolvedDatatype(Type(r, name), t)
+        | `ModuleType md -> ResolvedSig(`ModuleType(r, ModuleTypeName.of_string name), md)
+        | `Datatype t -> ResolvedDatatype(`Type(r, TypeName.of_string name), t)
       end
     | PLabelParent ->  begin
         match Sig.find_parent name parent with
-        | Parent.Module md ->
-          let pr = Module (r, name) in
+        | `Module md ->
+          let pr = `Module (r, ModuleName.of_string name) in
           let pr =
             match Sig.get_canonical md with
             | None -> pr
-            | Some (_, r) -> Canonical(pr, r)
+            | Some (_, r) -> `Canonical(pr, r)
           in
           ResolvedSig(pr, md)
-        | Parent.ModuleType md -> ResolvedSig(ModuleType(r, name), md)
-        | Parent.Datatype t -> ResolvedDatatype(Type(r, name), t)
-        | Parent.Class cls -> ResolvedClassSig(Class(r, name), cls)
-        | Parent.ClassType cls -> ResolvedClassSig(ClassType(r, name), cls)
+        | `ModuleType md -> ResolvedSig(`ModuleType(r, ModuleTypeName.of_string name), md)
+        | `Datatype t -> ResolvedDatatype(`Type(r, TypeName.of_string name), t)
+        | `Class cls -> ResolvedClassSig(`Class(r, ClassName.of_string name), cls)
+        | `ClassType cls -> ResolvedClassSig(`ClassType(r, ClassTypeName.of_string name), cls)
       end
 
 let rec find_with_reference_substs
    : 'b 'c. (Sig.t -> 'b)
-  -> (Reference.Resolved.signature -> 'b -> 'c)
-  -> (Reference.Resolved.signature -> 'c)
-  -> Identifier.signature option -> CTbl.t
-  -> Reference.Resolved.signature -> Sig.t
+  -> (Reference.Resolved.Signature.t -> 'b -> 'c)
+  -> (Reference.Resolved.Signature.t -> 'c)
+  -> Identifier.Signature.t option -> CTbl.t
+  -> Reference.Resolved.Signature.t -> Sig.t
   -> 'c
   = fun find resolved unresolved ident tbl pr parent ->
     try resolved pr (find parent)
     with Not_found ->
-      let open Reference.Resolved in
       match pr with
-      | Identifier (Identifier.Root _ | Identifier.Module _ | Identifier.Argument _)
-      | SubstAlias _ | Module _ | Canonical _ as pr -> begin
+      | `Identifier (`Root _ | `Module _ | `Argument _)
+      | `SubstAlias _ | `Module _ | `Canonical _ as pr -> begin
           match Sig.find_parent_subst parent with
           | Parent.SubstAlias subp -> begin
               match resolve_parent_module_path ident tbl subp with
               | Unresolved _ -> unresolved pr
               | Resolved(subpr, parent) ->
                 find_with_reference_substs find resolved unresolved ident tbl
-                  (SubstAlias(subpr, pr)) parent
+                  (`SubstAlias(subpr, pr)) parent
             end
           | _ -> unresolved pr
           | exception Not_found -> unresolved pr
@@ -615,21 +651,18 @@ let rec find_with_reference_substs
       | _ -> unresolved pr (* we can find substs only for modules *)
 
 let rec resolve_parent_reference :
-  type k . k parent_kind -> Identifier.signature option -> CTbl.t ->
-       Reference.parent -> k parent_reference =
+  parent_kind -> Identifier.Signature.t option -> CTbl.t ->
+       Reference.Parent.t -> parent_reference =
     fun kind ident tbl r ->
-      let open Identifier in
-      let open Reference.Resolved in
-      let open Reference in
         match r with
-        | Root (s, _) -> begin
-            match CTbl.base tbl s with
+        | `Root (s, _) -> begin
+            match CTbl.base tbl (UnitName.to_string s) with
             | CTbl.Not_found -> Unresolved (lpop r)
             | CTbl.Forward_reference ->
                 (* TODO: fail? *)
                 Unresolved (lpop r)
             | CTbl.Found {root;_} ->
-                let root = Identifier (Identifier.Root(root, s)) in
+                let root = `Identifier (`Root(root, s)) in
                   match kind with
                   | PParent ->
                       ResolvedSig(root, CTbl.resolved_signature_reference tbl root)
@@ -641,9 +674,9 @@ let rec resolve_parent_reference :
                       ResolvedSig(root, CTbl.resolved_signature_reference tbl root)
                   | _ -> Unresolved (lpop r)
           end
-        | Resolved
-            (Identifier (Root _ | Module _ | Argument _ | ModuleType _)
-             | SubstAlias _ | Module _ | Canonical _ | ModuleType _ as rr) -> begin
+        | `Resolved
+            (`Identifier (`Root _ | `Module _ | `Argument _ | `ModuleType _)
+             | `SubstAlias _ | `Module _ | `Canonical _ | `ModuleType _ as rr) -> begin
             match kind with
             | PParent ->
                 ResolvedSig(rr, CTbl.resolved_signature_reference tbl rr)
@@ -655,9 +688,9 @@ let rec resolve_parent_reference :
                 ResolvedSig(rr, CTbl.resolved_signature_reference tbl rr)
             | _ -> Unresolved (lpop r)
           end
-        | Resolved
-            (Identifier (Class _ | ClassType _)
-            | Class _ | ClassType _ as rr) -> begin
+        | `Resolved
+            (`Identifier (`Class _ | `ClassType _)
+            | `Class _ | `ClassType _ as rr) -> begin
             match kind with
             | PParent ->
                 ResolvedClassSig(rr, CTbl.resolved_class_signature_reference tbl rr)
@@ -667,7 +700,7 @@ let rec resolve_parent_reference :
                 ResolvedClassSig(rr, CTbl.resolved_class_signature_reference tbl rr)
             | _ -> Unresolved (lpop r)
           end
-        | Resolved (Identifier (Type _ | CoreType _) | Type _ as rr) -> begin
+        | `Resolved (`Identifier (`Type _ | `CoreType _) | `Type _ as rr) -> begin
             match kind with
             | PParent ->
                 ResolvedDatatype(rr, CTbl.resolved_datatype_reference tbl rr)
@@ -677,14 +710,14 @@ let rec resolve_parent_reference :
                 ResolvedDatatype(rr, CTbl.resolved_datatype_reference tbl rr)
             | _ -> Unresolved (lpop r)
           end
-        | Dot(pr, name) -> begin
+        | `Dot(pr, name) -> begin
             match resolve_label_parent_reference PParent ident tbl pr with
             | Unresolved _ -> Unresolved (lpop r)
             | ResolvedSig(rr, parent) ->
               let resolved _ pr = pr in
               let unresolved pr =
                 Unresolved(
-                  Dot(Resolved (rlpop (Resolved.parent_of_signature pr)), name)
+                  `Dot(`Resolved (pr :> Reference.Resolved.LabelParent.t), name)
                 )
               in
               find_with_reference_substs (find_parent_reference kind rr name)
@@ -692,410 +725,644 @@ let rec resolve_parent_reference :
             | _ ->
               Unresolved (lpop r)
           end
-        | Module(pr, name) -> begin
+        | `Module(pr, name) -> begin
             match
               resolve_parent_reference PSig ident tbl
-                (Reference.parent_of_signature pr)
+                (pr : Reference.Signature.t :> Reference.Parent.t)
             with
             | Unresolved _ -> Unresolved (lpop r)
             | ResolvedSig(rr, parent) ->
               let resolved _ pr = pr in
               let unresolved pr =
                 Unresolved(
-                  Module(Resolved pr, name)
+                  `Module(`Resolved pr, name)
                 )
               in
-              find_with_reference_substs (find_parent_reference kind rr name)
+              find_with_reference_substs (find_parent_reference kind rr (ModuleName.to_string name))
                 resolved unresolved ident tbl rr parent
+            | _ -> assert false
           end
-        | ModuleType(pr, name) -> begin
+        | `ModuleType(pr, name) -> begin
             match
               resolve_parent_reference PSig ident tbl
-                (Reference.parent_of_signature pr)
+                (pr : Reference.Signature.t :> Reference.Parent.t)
             with
             | Unresolved _ -> Unresolved (lpop r)
             | ResolvedSig(rr, parent) ->
               let resolved _ pr = pr in
               let unresolved pr =
                 Unresolved(
-                  ModuleType(Resolved pr, name)
+                  `ModuleType(`Resolved pr, name)
                 )
               in
-              find_with_reference_substs (find_parent_reference kind rr name)
+              find_with_reference_substs (find_parent_reference kind rr (ModuleTypeName.to_string name))
                 resolved unresolved ident tbl rr parent
+            | _ -> assert false
           end
-        | Type(pr, name) -> begin
+        | `Type(pr, name) -> begin
             match
               resolve_parent_reference PSig ident tbl
-                (Reference.parent_of_signature pr)
+                (pr : Reference.Signature.t :> Reference.Parent.t)
             with
             | Unresolved _ -> Unresolved (lpop r)
             | ResolvedSig(rr, parent) ->
               let resolved _ pr = pr in
               let unresolved pr =
                 Unresolved(
-                  Type(Resolved pr, name)
+                  `Type(`Resolved pr, name)
                 )
               in
-              find_with_reference_substs (find_parent_reference kind rr name)
+              find_with_reference_substs (find_parent_reference kind rr (TypeName.to_string name))
                 resolved unresolved ident tbl rr parent
+            | _ -> assert false
           end
-        | Class(pr, name) -> begin
+        | `Class(pr, name) -> begin
             match
               resolve_parent_reference PSig ident tbl
-                (Reference.parent_of_signature pr)
+                (pr : Reference.Signature.t :> Reference.Parent.t)
             with
             | Unresolved _ -> Unresolved (lpop r)
             | ResolvedSig(rr, parent) ->
               let resolved _ pr = pr in
               let unresolved pr =
                 Unresolved(
-                  Class(Resolved pr, name)
+                  `Class(`Resolved pr, name)
                 )
               in
-              find_with_reference_substs (find_parent_reference kind rr name)
+              find_with_reference_substs (find_parent_reference kind rr (ClassName.to_string name))
                 resolved unresolved ident tbl rr parent
+            | _ -> assert false
           end
-        | ClassType(pr, name) -> begin
+        | `ClassType(pr, name) -> begin
             match
               resolve_parent_reference PSig ident tbl
-                (Reference.parent_of_signature pr)
+                (pr : Reference.Signature.t :> Reference.Parent.t)
             with
             | Unresolved _ -> Unresolved (lpop r)
             | ResolvedSig(rr, parent) ->
               let resolved _ pr = pr in
               let unresolved pr =
                 Unresolved(
-                  ClassType(Resolved pr, name)
+                  `ClassType(`Resolved pr, name)
                 )
               in
-              find_with_reference_substs (find_parent_reference kind rr name)
+              find_with_reference_substs (find_parent_reference kind rr (ClassTypeName.to_string name))
                 resolved unresolved ident tbl rr parent
+            | _ -> assert false
           end
 
 and resolve_label_parent_reference :
-  type k . k parent_kind -> Identifier.signature option -> CTbl.t ->
-       Reference.label_parent -> k parent_reference =
+  parent_kind -> Identifier.Signature.t option -> CTbl.t ->
+       Reference.LabelParent.t -> parent_reference =
   fun kind ident tbl r ->
-    let handle_root s : k parent_reference =
+    let handle_root s : parent_reference =
       match CTbl.page_base tbl s with
       | None -> Unresolved r
       | Some root ->
-        let root = Reference.Resolved.Identifier (Identifier.Page(root, s)) in
+        let root = `Identifier (`Page(root, PageName.of_string s)) in
         match kind with
         | PLabelParent ->
           ResolvedPage(root, CTbl.resolved_page_reference tbl root)
         | _ -> Unresolved r
     in
-    let open Reference.Resolved in
-    let open Reference in
       match r with
-      | Root (s, TPage) -> handle_root s
-      | Root (s, TUnknown) as r -> begin
+      | `Root (s, `TPage) -> handle_root (UnitName.to_string s)
+      | `Root (s, `TUnknown) as r -> begin
           match resolve_parent_reference kind ident tbl r with
-          | Unresolved _ -> handle_root s
+          | Unresolved _ -> handle_root (UnitName.to_string s)
           | otherwise -> otherwise
         end
-      | Resolved (Identifier Identifier.Page _ as root) -> begin
+      | `Resolved (`Identifier `Page _ as root) -> begin
           match kind with
           | PLabelParent ->
             ResolvedPage(root, CTbl.resolved_page_reference tbl root)
           | _ -> Unresolved r
         end
-      | Root (_, (TModule | TModuleType | TType | TClass | TClassType))
-      | Resolved (Identifier ( Identifier.Root _ | Identifier.Module _
-                             | Identifier.Argument _ | Identifier.ModuleType _
-                             | Identifier.Type _ | Identifier.CoreType _
-                             | Identifier.Class _ | Identifier.ClassType _)
-                 | SubstAlias _ | Module _ | Canonical _
-                 | ModuleType _ | Type _ | Class _ | ClassType _)
-      | Dot _ | Module _ | ModuleType _ | Type _ | Class _ | ClassType _ as r ->
+      | `Root (_, (`TModule | `TModuleType | `TType | `TClass | `TClassType))
+      | `Resolved (`Identifier ( `Root _ | `Module _
+                             | `Argument _ | `ModuleType _
+                             | `Type _ | `CoreType _
+                             | `Class _ | `ClassType _)
+                 | `SubstAlias _ | `Module _ | `Canonical _
+                 | `ModuleType _ | `Type _ | `Class _ | `ClassType _)
+      | `Dot _ | `Module _ | `ModuleType _ | `Type _ | `Class _ | `ClassType _ as r ->
         resolve_parent_reference kind ident tbl r
 
-and resolve_resolved_reference :
-  type k. _ -> _ -> k Reference.Resolved.t -> k Reference.Resolved.t =
+and resolve_resolved_reference_signature_no_id : _ -> _ ->
+  Paths_types.Resolved_reference.signature_no_id -> Reference.Resolved.Signature.t =
   fun ident tbl r ->
-    let open Reference.Resolved in
-        match r with
-        | Identifier _ -> r
-        | SubstAlias(sub, orig) ->
-          let sub' = resolve_resolved_module_path ident tbl sub in
-          let orig' = resolve_resolved_reference ident tbl orig in
-          if sub != sub' || orig != orig' then
-            SubstAlias(sub', orig')
-          else r
-        | Module(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            Module(parent', name)
-          else r
-        | Canonical(orig, cano) ->
-          let orig' = resolve_resolved_reference ident tbl orig in
-          let cano' = resolve_module_reference ident tbl cano in
-          if orig != orig' || cano != cano' then
-            let cano' =
-              match ident, cano' with
-              | Some ident, Reference.Resolved rp ->
-                  let rp' = Reference.Resolved.rebase ident rp in
-                  if rp != rp' then Reference.Resolved rp' else cano'
-              | _, _ -> cano'
-            in
-            Canonical(orig', cano')
-          else r
-        | ModuleType(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            ModuleType(parent', name)
-          else r
-        | Type(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            Type(parent', name)
-          else r
-        | Constructor(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            Constructor(parent', name)
-          else r
-        | Field(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            Field(parent', name)
-          else r
-        | Extension(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            Extension(parent', name)
-          else r
-        | Exception(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            Exception(parent', name)
-          else r
-        | Value(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            Value(parent', name)
-          else r
-        | Class(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            Class(parent', name)
-          else r
-        | ClassType(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            ClassType(parent', name)
-          else r
-        | Method(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            Method(parent', name)
-          else r
-        | InstanceVariable(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            InstanceVariable(parent', name)
-          else r
-        | Label(parent, name) ->
-          let parent' = resolve_resolved_reference ident tbl parent in
-          if parent != parent' then
-            Label(parent', name)
-          else r
-
-and resolve_module_reference ident tbl (r : Reference.module_)
-  : Reference.module_ =
-  let open Reference.Resolved in
-  let open Reference in
     match r with
-    | Root (s, _) -> begin
-        match CTbl.base tbl s with
+    | `SubstAlias _
+    | `Module _ 
+    | `Canonical _ as r' ->
+      (resolve_resolved_reference_module_no_id ident tbl r' :> Reference.Resolved.Signature.t)
+    | `ModuleType(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `ModuleType(parent', name)
+      else (r :> Reference.Resolved.Signature.t)
+
+and resolve_resolved_reference_signature : _ -> _ ->
+  Reference.Resolved.Signature.t -> Reference.Resolved.Signature.t =
+  fun ident tbl r ->
+    match r with
+    | `Identifier _ -> r
+    | `SubstAlias _ | `Module _ | `Canonical _ | `ModuleType _ as r' ->
+      resolve_resolved_reference_signature_no_id ident tbl r' 
+
+and resolve_resolved_reference_module_no_id : _ -> _ ->
+  Paths_types.Resolved_reference.module_no_id -> Reference.Resolved.Module.t =
+  fun ident tbl r ->
+    match r with
+    | `SubstAlias(sub, orig) ->
+      let sub' = resolve_resolved_module_path ident tbl sub in
+      let orig' = resolve_resolved_reference_module ident tbl orig in
+      if sub != sub' || orig != orig' then
+        `SubstAlias(sub', orig')
+      else (r :> Reference.Resolved.Module.t)
+    | `Module(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Module(parent', name)
+      else (r :> Reference.Resolved.Module.t)
+    | `Canonical(orig, cano) ->
+      let orig' = resolve_resolved_reference_module ident tbl orig in
+      let cano' = resolve_module_reference ident tbl cano in
+      if orig != orig' || cano != cano' then
+        let cano' =
+          match ident, cano' with
+          | Some ident, `Resolved rp ->
+              let rp' = Reference.Resolved.Module.rebase ident rp in
+              if rp != rp' then `Resolved rp' else cano'
+          | _, _ -> cano'
+        in
+        `Canonical(orig', cano')
+      else (r :> Reference.Resolved.Module.t)
+
+and resolve_resolved_reference_module : _ -> _ ->
+  Reference.Resolved.Module.t -> Reference.Resolved.Module.t =
+  fun ident tbl r ->
+    match r with
+    | `Identifier _ -> r
+    | `SubstAlias _ | `Module _ | `Canonical _ as r' ->
+      resolve_resolved_reference_module_no_id ident tbl r' 
+
+and resolve_resolved_reference_class_signature_no_id : _ -> _ ->
+  Paths_types.Resolved_reference.class_signature_no_id -> Reference.Resolved.ClassSignature.t =
+  fun ident tbl r ->
+    match r with
+    | `Class(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Class(parent', name)
+      else (r :> Reference.Resolved.ClassSignature.t)
+    | `ClassType(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `ClassType(parent', name)
+      else (r :> Reference.Resolved.ClassSignature.t)
+
+and resolve_resolved_reference_class_signature : _ -> _ ->
+  Reference.Resolved.ClassSignature.t -> Reference.Resolved.ClassSignature.t =
+  fun ident tbl r ->
+    match r with
+    | `Identifier _ -> r
+    | `Class _ | `ClassType _ as r' ->
+      resolve_resolved_reference_class_signature_no_id ident tbl r' 
+
+and resolve_resolved_reference_datatype_no_id : _ -> _ ->
+  Paths_types.Resolved_reference.datatype_no_id -> Reference.Resolved.DataType.t =
+  fun ident tbl r ->
+    match r with
+    | `Type(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Type(parent', name)
+      else (r :> Reference.Resolved.DataType.t)
+
+and resolve_resolved_reference_datatype : _ -> _ ->
+  Reference.Resolved.DataType.t -> Reference.Resolved.DataType.t =
+  fun ident tbl r ->
+    match r with
+    | `Identifier _ -> r
+    | `Type _ as r' ->
+      resolve_resolved_reference_datatype_no_id ident tbl r'
+
+and resolve_resolved_reference_parent_no_id : _ -> _ ->
+  Paths_types.Resolved_reference.parent_no_id -> Reference.Resolved.Parent.t =
+  fun ident tbl r ->
+    match r with
+    | `SubstAlias _ | `Module _ | `Canonical _ | `ModuleType _ as r' ->
+      (resolve_resolved_reference_signature_no_id ident tbl r' :> Reference.Resolved.Parent.t)
+    | `Class _ | `ClassType _ as r' ->
+      (resolve_resolved_reference_class_signature_no_id ident tbl r' :> Reference.Resolved.Parent.t)
+    | `Type _ as r' ->
+      (resolve_resolved_reference_datatype_no_id ident tbl r' :> Reference.Resolved.Parent.t)
+
+and resolve_resolved_reference_parent : _ -> _ ->
+  Reference.Resolved.Parent.t -> Reference.Resolved.Parent.t =
+  fun ident tbl r ->
+    match r with
+    | `Identifier _ -> r
+    | `SubstAlias _ | `Module _ | `Canonical _ | `ModuleType _ 
+    | `Class _ | `ClassType _ | `Type _  as r' ->
+      resolve_resolved_reference_parent_no_id ident tbl r'
+
+and resolve_resolved_reference_label_parent : _ -> _ ->
+  Reference.Resolved.LabelParent.t -> Reference.Resolved.LabelParent.t =
+  fun ident tbl r ->
+    match r with
+    | `Identifier _ -> r
+    | `SubstAlias _ | `Module _ | `Canonical _ | `ModuleType _ 
+    | `Class _ | `ClassType _ | `Type _  as r' ->
+      (resolve_resolved_reference_parent_no_id ident tbl r' :> Reference.Resolved.LabelParent.t)
+
+and resolve_resolved_reference_type : _ -> _ ->
+  Reference.Resolved.Type.t -> Reference.Resolved.Type.t =
+  fun ident tbl r ->
+    match r with
+    | `Identifier _ -> r
+    | `Type _ as r' ->
+      (resolve_resolved_reference_datatype_no_id ident tbl r' :> Reference.Resolved.Type.t)
+    | `Class _ | `ClassType _ as r' ->
+      (resolve_resolved_reference_class_signature_no_id ident tbl r' :> Reference.Resolved.Type.t)
+
+and resolve_resolved_reference_module_type : _ -> _ ->
+  Reference.Resolved.ModuleType.t -> Reference.Resolved.ModuleType.t =
+  fun ident tbl r ->
+    match r with
+    | `ModuleType(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `ModuleType(parent', name)
+      else (r :> Reference.Resolved.ModuleType.t)
+    | `Identifier _ -> r
+
+and resolve_resolved_reference_constructor : _ -> _ ->
+  Reference.Resolved.Constructor.t -> Reference.Resolved.Constructor.t =
+  fun ident tbl r ->
+    match r with
+    | `Extension(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Extension(parent', name)
+      else r
+    | `Exception(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Exception(parent', name)
+      else r
+    | `Constructor(parent, name) ->
+      let parent' = resolve_resolved_reference_datatype ident tbl parent in
+      if parent != parent' then
+        `Constructor(parent', name)
+      else (r :> Reference.Resolved.Constructor.t)
+    | `Identifier _ -> r
+
+and resolve_resolved_reference_field : _ -> _ ->
+  Reference.Resolved.Field.t -> Reference.Resolved.Field.t =
+  fun ident tbl r ->
+    match r with
+    | `Field(parent, name) ->
+      let parent' = resolve_resolved_reference_parent ident tbl parent in
+      if parent != parent' then
+        `Field(parent', name)
+      else r
+    | `Identifier _ -> r
+
+and resolve_resolved_reference_extension : _ -> _ ->
+  Reference.Resolved.Extension.t -> Reference.Resolved.Extension.t =
+  fun ident tbl r ->
+    match r with
+    | `Extension(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Extension(parent', name)
+      else r
+    | `Exception(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Exception(parent', name)
+      else r
+    | `Identifier _ -> r
+
+and resolve_resolved_reference_exception : _ -> _ ->
+  Reference.Resolved.Exception.t -> Reference.Resolved.Exception.t =
+  fun ident tbl r ->
+    match r with
+    | `Exception(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Exception(parent', name)
+      else r
+    | `Identifier _ -> r
+
+and resolve_resolved_reference_value : _ -> _ ->
+  Reference.Resolved.Value.t -> Reference.Resolved.Value.t =
+  fun ident tbl r ->
+    match r with
+    | `Value(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Value(parent', name)
+      else r
+    | `Identifier _ -> r
+
+and resolve_resolved_reference_class : _ -> _ ->
+  Reference.Resolved.Class.t -> Reference.Resolved.Class.t =
+  fun ident tbl r ->
+    match r with
+    | `Class(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Class(parent', name)
+      else (r :> Reference.Resolved.Class.t)
+    | `Identifier _ -> r
+
+and resolve_resolved_reference_class_type : _ -> _ ->
+  Reference.Resolved.ClassType.t -> Reference.Resolved.ClassType.t =
+  fun ident tbl r ->
+    match r with
+    | `Class _ | `ClassType _ as r'->
+      (resolve_resolved_reference_class_signature_no_id ident tbl r' :> Reference.Resolved.ClassType.t)
+    | `Identifier _ -> r
+
+and resolve_resolved_reference_method : _ -> _ ->
+  Reference.Resolved.Method.t -> Reference.Resolved.Method.t =
+  fun ident tbl r ->
+    match r with
+    | `Method (parent, name) ->
+      let parent' = resolve_resolved_reference_class_signature ident tbl parent in
+      if parent != parent' then
+        `Method(parent', name)
+      else r
+    | `Identifier _ -> r
+
+and resolve_resolved_reference_instance_variable : _ -> _ ->
+  Reference.Resolved.InstanceVariable.t -> Reference.Resolved.InstanceVariable.t =
+  fun ident tbl r ->
+    match r with
+    | `InstanceVariable(parent, name) ->
+      let parent' = resolve_resolved_reference_class_signature ident tbl parent in
+      if parent != parent' then
+        `InstanceVariable(parent', name)
+      else r
+    | `Identifier _ -> r
+
+and resolve_resolved_reference_label : _ -> _ ->
+  Reference.Resolved.Label.t -> Reference.Resolved.Label.t =
+  fun ident tbl r ->
+    match r with
+    | `Label(parent, name) ->
+      let parent' = resolve_resolved_reference_label_parent ident tbl parent in
+      if parent != parent' then
+        `Label(parent', name)
+      else r
+    | `Identifier _ -> r
+
+and resolve_resolved_reference :
+   _ -> _ -> Reference.Resolved.t -> Reference.Resolved.t =
+  fun ident tbl r ->
+    match r with
+    | `Identifier _ -> r
+    | `SubstAlias _ | `Module _ | `Canonical _ | `ModuleType _ 
+    | `Class _ | `ClassType _ | `Type _  as r' ->
+      (resolve_resolved_reference_parent_no_id ident tbl r' :> Reference.Resolved.t)
+    | `Constructor(parent, name) ->
+      let parent' = resolve_resolved_reference_datatype ident tbl parent in
+      if parent != parent' then
+        `Constructor(parent', name)
+      else r
+    | `Field(parent, name) ->
+      let parent' = resolve_resolved_reference_parent ident tbl parent in
+      if parent != parent' then
+        `Field(parent', name)
+      else r
+    | `Extension(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Extension(parent', name)
+      else r
+    | `Exception(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Exception(parent', name)
+      else r
+    | `Value(parent, name) ->
+      let parent' = resolve_resolved_reference_signature ident tbl parent in
+      if parent != parent' then
+        `Value(parent', name)
+      else r
+    | `Method(parent, name) ->
+      let parent' = resolve_resolved_reference_class_signature ident tbl parent in
+      if parent != parent' then
+        `Method(parent', name)
+      else r
+    | `InstanceVariable(parent, name) ->
+      let parent' = resolve_resolved_reference_class_signature ident tbl parent in
+      if parent != parent' then
+        `InstanceVariable(parent', name)
+      else r
+    | `Label(parent, name) ->
+      let parent' = resolve_resolved_reference_label_parent ident tbl parent in
+      if parent != parent' then
+        `Label(parent', name)
+      else r
+
+and resolve_module_reference ident tbl (r : Reference.Module.t)
+  : Reference.Module.t =
+    match r with
+    | `Root (s, _) -> begin
+        match CTbl.base tbl (UnitName.to_string s) with
         | CTbl.Not_found -> r
         | CTbl.Forward_reference -> r (* TODO *)
-        | CTbl.Found {root; _} -> Resolved (Identifier (Identifier.Root(root, s)))
+        | CTbl.Found {root; _} -> `Resolved (`Identifier (`Root(root, s)))
       end
-    | Resolved rr as r ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Resolved rr as r ->
+      let rr' = resolve_resolved_reference_module ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PSig ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_module) =
-            let Element.Module {canonical; hidden = _} = elem in
-            let rr : Reference.Resolved.module_ = Module(r, name) in
-            let rr : Reference.Resolved.module_ =
+            let `Module {Element.canonical; hidden = _} = elem in
+            let rr : Reference.Resolved.Module.t = `Module(r, ModuleName.of_string name) in
+            let rr : Reference.Resolved.Module.t =
               match canonical with
               | None -> rr
-              | Some (_, r) -> Canonical(rr, r)
+              | Some (_, r) -> `Canonical(rr, r)
             in
-              Resolved rr
+              `Resolved rr
           in
           let unresolved r =
-            let r = rlpop (Resolved.parent_of_signature r) in
-              Dot(Resolved r, name)
+            let r = rlpop (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved r, name)
           in
             find_with_reference_substs (Sig.find_module_element name)
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | Module(r, name) -> begin
+    | `Module(r, name) -> begin
         match
           resolve_parent_reference PSig ident tbl
-            (Reference.parent_of_signature r)
+            (r : Reference.Signature.t :> Reference.Parent.t)
         with
-        | Unresolved _ -> Module(r, name)
+        | Unresolved _ -> `Module(r, name)
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_module) =
-            let Element.Module {canonical; hidden = _} = elem in
-            let rr : Reference.Resolved.module_ = Module(r, name) in
-            let rr : Reference.Resolved.module_ =
+            let `Module {Element.canonical; hidden = _} = elem in
+            let rr : Reference.Resolved.Module.t = `Module(r, name) in
+            let rr : Reference.Resolved.Module.t =
               match canonical with
               | None -> rr
-              | Some (_, r) -> Canonical(rr, r)
+              | Some (_, r) -> `Canonical(rr, r)
             in
-              Resolved rr
+              `Resolved rr
           in
-          let unresolved r = Module(Resolved r, name) in
-            find_with_reference_substs (Sig.find_module_element name)
+          let unresolved r = `Module(`Resolved r, name) in
+            find_with_reference_substs (Sig.find_module_element (ModuleName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
+
+        
       end
 
-and resolve_module_type_reference ident tbl (r : Reference.module_type)
-  : Reference.module_type =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_module_type_reference ident tbl (r : Reference.ModuleType.t)
+  : Reference.ModuleType.t =
     match r with
-    | Root _ -> r
-    | Resolved rr as r ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr as r ->
+      let rr' = resolve_resolved_reference_module_type ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PSig ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
-          let resolved r (Element.ModuleType : Element.signature_module_type) =
-            Resolved(ModuleType(r, name))
+          let resolved r (`ModuleType : Element.signature_module_type) =
+            `Resolved(`ModuleType(r, ModuleTypeName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_module_type_element name)
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | ModuleType(r, name) -> begin
+    | `ModuleType(r, name) -> begin
         match
-          resolve_parent_reference PSig ident tbl
-            (Reference.parent_of_signature r)
+          (resolve_parent_reference PSig ident tbl (r :> Reference.Parent.t))
         with
-        | Unresolved _ -> ModuleType(r, name)
+        | Unresolved _ -> `ModuleType(r, name)
         | ResolvedSig(r, parent) ->
-          let resolved r (Element.ModuleType : Element.signature_module_type) =
-            Resolved(ModuleType(r, name))
+          let resolved r (`ModuleType : Element.signature_module_type) =
+            `Resolved(`ModuleType(r, name))
           in
-          let unresolved r = ModuleType(Resolved r, name) in
-            find_with_reference_substs (Sig.find_module_type_element name)
+          let unresolved r = `ModuleType(`Resolved r, name) in
+            find_with_reference_substs (Sig.find_module_type_element (ModuleTypeName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
 
-and resolve_type_reference ident tbl (r : Reference.type_)
-  : Reference.type_ =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_type_reference ident tbl (r : Reference.Type.t)
+  : Reference.Type.t =
     match r with
-    | Root _ -> r
-    | Resolved rr as r ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr as r ->
+      let rr' = resolve_resolved_reference_type ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PSig ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_type) =
             match elem with
-            | Element.Type -> Resolved (Type(r, name))
-            | Element.Class -> Resolved (Class(r, name))
-            | Element.ClassType -> Resolved (ClassType(r, name))
+            | `Type -> `Resolved (`Type(r, TypeName.of_string name))
+            | `Class -> `Resolved (`Class(r, ClassName.of_string name))
+            | `ClassType -> `Resolved (`ClassType(r, ClassTypeName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_type_element name)
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | Type(r, name) as typ -> begin
+    | `Type(r, name) as typ -> begin
         match
-          resolve_parent_reference PSig ident tbl (parent_of_signature r)
+          resolve_parent_reference PSig ident tbl (r :> Reference.Parent.t)
         with
         | Unresolved _ -> typ
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_type) =
             match elem with
-            | Element.Type -> Resolved (Type(r, name))
-            | Element.Class -> typ
-            | Element.ClassType -> typ
+            | `Type -> `Resolved (`Type(r, name))
+            | `Class -> typ
+            | `ClassType -> typ
           in
-          let unresolved r = Type(Resolved r, name) in
-            find_with_reference_substs (Sig.find_type_element name)
+          let unresolved r = `Type(`Resolved r, name) in
+            find_with_reference_substs (Sig.find_type_element (TypeName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | Class(r, name) as cls -> begin
+    | `Class(r, name) as cls -> begin
         match
-          resolve_parent_reference PSig ident tbl (parent_of_signature r)
+          resolve_parent_reference PSig ident tbl (r :> Reference.Parent.t)
         with
         | Unresolved _ -> cls
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_type) =
             match elem with
-            | Element.Type -> cls
-            | Element.Class -> Resolved (Class(r, name))
-            | Element.ClassType -> cls
+            | `Type -> cls
+            | `Class -> `Resolved (`Class(r, name))
+            | `ClassType -> cls
           in
-          let unresolved r = Class(Resolved r, name) in
-            find_with_reference_substs (Sig.find_type_element name)
+          let unresolved r = `Class(`Resolved r, name) in
+            find_with_reference_substs (Sig.find_type_element (ClassName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | ClassType(r, name) as cls -> begin
+    | `ClassType(r, name) as cls -> begin
         match
-          resolve_parent_reference PSig ident tbl (parent_of_signature r)
+          resolve_parent_reference PSig ident tbl (r :> Reference.Parent.t)
         with
         | Unresolved _ -> cls
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_type) =
             match elem with
-            | Element.Type -> cls
-            | Element.Class -> Resolved (Class(r, name))
-            | Element.ClassType -> Resolved (ClassType(r, name))
+            | `Type -> cls
+            | `Class -> `Resolved (`Class(r, (ClassName.of_string (ClassTypeName.to_string name))))
+            | `ClassType -> `Resolved (`ClassType(r, name))
           in
-          let unresolved r = ClassType(Resolved r, name) in
-            find_with_reference_substs (Sig.find_type_element name)
+          let unresolved r = `ClassType(`Resolved r, name) in
+            find_with_reference_substs (Sig.find_type_element (ClassTypeName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
 
-and resolve_constructor_reference ident tbl (r : Reference.constructor)
-  : Reference.constructor =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_constructor_reference ident tbl (r : Reference.Constructor.t)
+  : Reference.Constructor.t =
     match r with
-    | Root _ -> r
-    | Resolved rr as r ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr as r ->
+      let rr' = resolve_resolved_reference_constructor ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PSigOrType ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_constructor) =
             match elem with
-            | Element.Constructor type_name ->
-              Resolved (Constructor(Type(r, type_name), name))
-            | Element.Extension -> Resolved (Extension(r, name))
-            | Element.Exception -> Resolved (Exception(r, name))
+            | `Constructor type_name ->
+              `Resolved (`Constructor(`Type(r, TypeName.of_string type_name), ConstructorName.of_string name))
+            | `Extension -> `Resolved (`Extension(r, ExtensionName.of_string name))
+            | `Exception -> `Resolved (`Exception(r, ExceptionName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_constructor_element name)
               resolved unresolved ident tbl r parent
@@ -1103,105 +1370,107 @@ and resolve_constructor_reference ident tbl (r : Reference.constructor)
             (* Not calling [find_with_reference_substs] here since the parent is
                not a Sig, i.e. there won't be any subst. *)
             try
-              let Element.Constructor _ =
+              let `Constructor _ =
                 Datatype.find_constructor_element name parent
               in
-                Resolved (Constructor(r, name))
+                `Resolved (`Constructor(r, ConstructorName.of_string name))
             with Not_found ->
-              let r = Resolved.parent_of_datatype r in
-                Dot(Resolved (rlpop r), name)
+              let r = (r :> Reference.Resolved.Parent.t) in
+                `Dot(`Resolved (rlpop r), name)
           end
+        | _ -> assert false
       end
-    | Constructor(r, name) -> begin
+    | `Constructor(r, name) -> begin
         match
           resolve_parent_reference PSigOrType ident tbl
-            (parent_of_datatype r)
+            (r :> Reference.Parent.t)
         with
-        | Unresolved _ -> Constructor(r, name)
+        | Unresolved _ -> `Constructor(r, name)
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_constructor) =
             match elem with
-            | Element.Constructor type_name ->
-              Resolved (Constructor(Type(r, type_name), name))
-            | Element.Extension -> Resolved (Extension(r, name))
-            | Element.Exception -> Resolved (Exception(r, name))
+            | `Constructor type_name ->
+              `Resolved (`Constructor(`Type(r, TypeName.of_string type_name), name))
+            | `Extension -> `Resolved (`Extension(r, (ExtensionName.of_string (ConstructorName.to_string name))))
+            | `Exception -> `Resolved (`Exception(r, (ExceptionName.of_string (ConstructorName.to_string name))))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), ConstructorName.to_string name)
           in
-            find_with_reference_substs (Sig.find_constructor_element name)
+            find_with_reference_substs (Sig.find_constructor_element (ConstructorName.to_string name))
               resolved unresolved ident tbl r parent
         | ResolvedDatatype(r, parent) -> begin
             (* Not calling [find_with_reference_substs] here since the parent is
                not a Sig, i.e. there won't be any subst. *)
             try
-              let Element.Constructor _ =
-                Datatype.find_constructor_element name parent
+              let `Constructor _ =
+                Datatype.find_constructor_element (ConstructorName.to_string name) parent
               in
-                Resolved (Constructor(r, name))
+                `Resolved (`Constructor(r, name))
             with Not_found ->
-                Constructor(Resolved r, name)
+                `Constructor(`Resolved r, name)
           end
+        | _ -> assert false
       end
-    | Extension(r, name) as ext -> begin
+    | `Extension(r, name) as ext -> begin
         match
           resolve_parent_reference PSig ident tbl
-            (parent_of_signature r)
+            (r :> Reference.Parent.t)
         with
         | Unresolved _ -> ext
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_constructor) =
             match elem with
-            | Element.Constructor _ -> ext
-            | Element.Extension -> Resolved (Extension(r, name))
-            | Element.Exception -> Resolved (Exception(r, name))
+            | `Constructor _ -> ext
+            | `Extension -> `Resolved (`Extension(r, name))
+            | `Exception -> `Resolved (`Exception(r, (ExceptionName.of_string (ExtensionName.to_string name))))
           in
           let unresolved r =
-              Extension(Resolved r, name)
+              `Extension(`Resolved r, name)
           in
-            find_with_reference_substs (Sig.find_constructor_element name)
+            find_with_reference_substs (Sig.find_constructor_element (ExtensionName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | Exception(r, name) as ext -> begin
+    | `Exception(r, name) as ext -> begin
         match
           resolve_parent_reference PSig ident tbl
-            (parent_of_signature r)
+            (r :> Reference.Parent.t)
         with
         | Unresolved _ -> ext
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_constructor) =
             match elem with
-            | Element.Constructor _ -> ext
-            | Element.Extension -> ext
-            | Element.Exception -> Resolved (Exception(r, name))
+            | `Constructor _ -> ext
+            | `Extension -> ext
+            | `Exception -> `Resolved (`Exception(r, name))
           in
           let unresolved r =
-              Exception(Resolved r, name)
+              `Exception(`Resolved r, name)
           in
-            find_with_reference_substs (Sig.find_constructor_element name)
+            find_with_reference_substs (Sig.find_constructor_element (ExceptionName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
 
-and resolve_field_reference ident tbl (r : Reference.field)
-  : Reference.field =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_field_reference ident tbl (r : Reference.Field.t)
+  : Reference.Field.t =
     match r with
-    | Root _ -> r
-    | Resolved rr as r ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr as r ->
+      let rr' = resolve_resolved_reference_field ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PSigOrType ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
-          let resolved r (Element.Field type_name : Element.signature_field) =
-            Resolved (Field(Type(r, type_name), name))
+          let resolved r (`Field type_name : Element.signature_field) =
+            `Resolved (`Field(`Type(r, TypeName.of_string type_name), FieldName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_field_element name)
               resolved unresolved ident tbl r parent
@@ -1209,602 +1478,603 @@ and resolve_field_reference ident tbl (r : Reference.field)
             (* Not calling [find_with_reference_substs] here since the parent is
                not a Sig, i.e. there won't be any subst. *)
             try
-              let Element.Field _ =
+              let `Field _ =
                 Datatype.find_field_element name parent
               in
-                Resolved (Field(Reference.Resolved.parent_of_datatype r, name))
+                `Resolved (`Field((r :> Reference.Resolved.Parent.t), FieldName.of_string name))
             with Not_found ->
-              let r = Resolved.parent_of_datatype r in
-                Dot(Resolved (rlpop r), name)
+              let r = (r :> Reference.Resolved.Parent.t) in
+                `Dot(`Resolved (rlpop r), name)
           end
+        | _ -> assert false
       end
-    | Field(r, name) -> begin
+    | `Field(r, name) -> begin
         match resolve_parent_reference PSigOrType ident tbl r with
-        | Unresolved _ -> Field(r, name)
+        | Unresolved _ -> `Field(r, name)
         | ResolvedSig(r, parent) ->
-          let resolved r (Element.Field type_name : Element.signature_field) =
-            Resolved (Field(Type(r, type_name), name))
+          let resolved r (`Field type_name : Element.signature_field) =
+            `Resolved (`Field(`Type(r, TypeName.of_string type_name), name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Field(Resolved r, name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Field(`Resolved r, name)
           in
-            find_with_reference_substs (Sig.find_field_element name)
+            find_with_reference_substs (Sig.find_field_element (FieldName.to_string name))
               resolved unresolved ident tbl r parent
         | ResolvedDatatype(r, parent) -> begin
             (* Not calling [find_with_reference_substs] here since the parent is
                not a Sig, i.e. there won't be any subst. *)
             try
-              let Element.Field _ =
-                Datatype.find_field_element name parent
+              let `Field _ =
+                Datatype.find_field_element (FieldName.to_string name) parent
               in
-                Resolved (Field(Reference.Resolved.parent_of_datatype r, name))
+                `Resolved (`Field((r :> Reference.Resolved.Parent.t), name))
             with Not_found ->
-              let r = Resolved.parent_of_datatype r in
-                Field(Resolved r, name)
+              let r = (r :> Reference.Resolved.Parent.t) in
+                `Field(`Resolved r, name)
           end
+        | _ -> assert false
       end
 
-and resolve_extension_reference ident tbl (r : Reference.extension)
-  : Reference.extension =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_extension_reference ident tbl (r : Reference.Extension.t)
+  : Reference.Extension.t =
     match r with
-    | Root _ -> r
-    | Resolved rr as r ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr as r ->
+      let rr' = resolve_resolved_reference_extension ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PSig ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_extension) =
             match elem with
-            | Element.Extension -> Resolved (Extension(r, name))
-            | Element.Exception -> Resolved (Exception(r, name))
+            | `Extension -> `Resolved (`Extension(r, ExtensionName.of_string name))
+            | `Exception -> `Resolved (`Exception(r, ExceptionName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_extension_element name)
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | Extension(r, name) as ext -> begin
+    | `Extension(r, name) as ext -> begin
         match
           resolve_parent_reference PSig ident tbl
-            (parent_of_signature r)
+            (r :> Reference.Parent.t)
         with
         | Unresolved _ -> ext
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_constructor) =
             match elem with
-            | Element.Constructor _ -> ext
-            | Element.Extension -> Resolved (Extension(r, name))
-            | Element.Exception -> Resolved (Exception(r, name))
+            | `Constructor _ -> ext
+            | `Extension -> `Resolved (`Extension(r, name))
+            | `Exception -> `Resolved (`Exception(r, (ExceptionName.of_string (ExtensionName.to_string name))))
           in
           let unresolved r =
-              Extension(Resolved r, name)
+              `Extension(`Resolved r, name)
           in
-            find_with_reference_substs (Sig.find_constructor_element name)
+            find_with_reference_substs (Sig.find_constructor_element (ExtensionName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | Exception(r, name) as ext -> begin
+    | `Exception(r, name) as ext -> begin
         match
           resolve_parent_reference PSig ident tbl
-            (parent_of_signature r)
+            (r :> Reference.Parent.t)
         with
         | Unresolved _ -> ext
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_constructor) =
             match elem with
-            | Element.Constructor _ -> ext
-            | Element.Extension -> ext
-            | Element.Exception -> Resolved (Exception(r, name))
+            | `Constructor _ -> ext
+            | `Extension -> ext
+            | `Exception -> `Resolved (`Exception(r, name))
           in
           let unresolved r =
-              Exception(Resolved r, name)
+              `Exception(`Resolved r, name)
           in
-            find_with_reference_substs (Sig.find_constructor_element name)
+            find_with_reference_substs (Sig.find_constructor_element (ExceptionName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
 
-and resolve_exception_reference ident tbl (r : Reference.exception_)
-  : Reference.exception_ =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_exception_reference ident tbl (r : Reference.Exception.t)
+  : Reference.Exception.t =
     match r with
-    | Root _ -> r
-    | Resolved rr ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr ->
+      let rr' = resolve_resolved_reference_exception ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PSig ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
-          let resolved r (Element.Exception : Element.signature_exception) =
-            Resolved (Exception(r, name))
+          let resolved r (`Exception : Element.signature_exception) =
+            `Resolved (`Exception(r, ExceptionName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_exception_element name)
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | Exception(r, name) as ext -> begin
+    | `Exception(r, name) as ext -> begin
         match
           resolve_parent_reference PSig ident tbl
-            (parent_of_signature r)
+            (r :> Reference.Parent.t)
         with
         | Unresolved _ -> ext
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_constructor) =
             match elem with
-            | Element.Constructor _ -> ext
-            | Element.Extension -> ext
-            | Element.Exception -> Resolved (Exception(r, name))
+            | `Constructor _ -> ext
+            | `Extension -> ext
+            | `Exception -> `Resolved (`Exception(r, name))
           in
           let unresolved r =
-              Exception(Resolved r, name)
+              `Exception(`Resolved r, name)
           in
-            find_with_reference_substs (Sig.find_constructor_element name)
+            find_with_reference_substs (Sig.find_constructor_element (ExceptionName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
 
-and resolve_value_reference ident tbl (r : Reference.value)
-  : Reference.value =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_value_reference ident tbl (r : Reference.Value.t)
+  : Reference.Value.t =
     match r with
-    | Root _ -> r
-    | Resolved rr ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr ->
+      let rr' = resolve_resolved_reference_value ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PSig ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
-          let resolved r (Element.Value : Element.signature_value) =
-            Resolved (Value(r, name))
+          let resolved r (`Value : Element.signature_value) =
+            `Resolved (`Value(r, ValueName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_value_element name)
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | Value(r, name) -> begin
+    | `Value(r, name) -> begin
         match
-          resolve_parent_reference PSig ident tbl (parent_of_signature r)
+          resolve_parent_reference PSig ident tbl (r :> Reference.Parent.t)
         with
-        | Unresolved _ -> Value(r, name)
+        | Unresolved _ -> `Value(r, name)
         | ResolvedSig(r, parent) ->
-          let resolved r (Element.Value : Element.signature_value) =
-            Resolved (Value(r, name))
+          let resolved r (`Value : Element.signature_value) =
+            `Resolved (`Value(r, name))
           in
           let unresolved r =
-            Value(Resolved r, name)
+            `Value(`Resolved r, name)
           in
-            find_with_reference_substs (Sig.find_value_element name)
+            find_with_reference_substs (Sig.find_value_element (ValueName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
 
-and resolve_class_reference ident tbl (r : Reference.class_)
-  : Reference.class_ =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_class_reference ident tbl (r : Reference.Class.t)
+  : Reference.Class.t =
     match r with
-    | Root _ -> r
-    | Resolved rr ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr ->
+      let rr' = resolve_resolved_reference_class ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PSig ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
-          let resolved r (Element.Class : Element.signature_class) =
-            Resolved (Class(r, name))
+          let resolved r (`Class : Element.signature_class) =
+            `Resolved (`Class(r, ClassName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_class_element name)
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | Class(r, name) as cls -> begin
+    | `Class(r, name) as cls -> begin
         match
-          resolve_parent_reference PSig ident tbl (parent_of_signature r)
+          resolve_parent_reference PSig ident tbl (r :> Reference.Parent.t)
         with
         | Unresolved _ -> cls
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_type) =
             match elem with
-            | Element.Type -> cls
-            | Element.Class -> Resolved (Class(r, name))
-            | Element.ClassType -> cls
+            | `Type -> cls
+            | `Class -> `Resolved (`Class(r, name))
+            | `ClassType -> cls
           in
-          let unresolved r = Class(Resolved r, name) in
-            find_with_reference_substs (Sig.find_type_element name)
+          let unresolved r = `Class(`Resolved r, name) in
+            find_with_reference_substs (Sig.find_type_element (ClassName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
 
-and resolve_class_type_reference ident tbl (r : Reference.class_type)
-  : Reference.class_type =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_class_type_reference ident tbl (r : Reference.ClassType.t)
+  : Reference.ClassType.t =
     match r with
-    | Root _ -> r
-    | Resolved rr ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr ->
+      let rr' = resolve_resolved_reference_class_type ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PSig ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
           let resolved r : Element.signature_class_type -> _ = function
-            | Element.Class -> Resolved (Class(r, name))
-            | Element.ClassType -> Resolved (ClassType(r, name))
+            | `Class -> `Resolved (`Class(r, ClassName.of_string name))
+            | `ClassType -> `Resolved (`ClassType(r, ClassTypeName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_class_type_element name)
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | Class(r, name) as cls -> begin
+    | `Class(r, name) as cls -> begin
         match
-          resolve_parent_reference PSig ident tbl (parent_of_signature r)
+          resolve_parent_reference PSig ident tbl (r :> Reference.Parent.t)
         with
         | Unresolved _ -> cls
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_type) =
             match elem with
-            | Element.Type -> cls
-            | Element.Class -> Resolved (Class(r, name))
-            | Element.ClassType -> cls
+            | `Type -> cls
+            | `Class -> `Resolved (`Class(r, name))
+            | `ClassType -> cls
           in
-          let unresolved r = Class(Resolved r, name) in
-            find_with_reference_substs (Sig.find_type_element name)
+          let unresolved r = `Class(`Resolved r, name) in
+            find_with_reference_substs (Sig.find_type_element (ClassName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
-    | ClassType(r, name) as cls -> begin
+    | `ClassType(r, name) as cls -> begin
         match
-          resolve_parent_reference PSig ident tbl (parent_of_signature r)
+          resolve_parent_reference PSig ident tbl (r :> Reference.Parent.t)
         with
         | Unresolved _ -> cls
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_type) =
             match elem with
-            | Element.Type -> cls
-            | Element.Class -> Resolved (Class(r, name))
-            | Element.ClassType -> Resolved (ClassType(r, name))
+            | `Type -> cls
+            | `Class -> `Resolved (`Class(r, (ClassName.of_string (ClassTypeName.to_string name))))
+            | `ClassType -> `Resolved (`ClassType(r, name))
           in
-          let unresolved r = ClassType(Resolved r, name) in
-            find_with_reference_substs (Sig.find_type_element name)
+          let unresolved r = `ClassType(`Resolved r, name) in
+            find_with_reference_substs (Sig.find_type_element (ClassTypeName.to_string name))
               resolved unresolved ident tbl r parent
+        | _ -> assert false
       end
 
-and resolve_method_reference ident tbl (r : Reference.method_)
-  : Reference.method_ =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_method_reference ident tbl (r : Reference.Method.t)
+  : Reference.Method.t =
     match r with
-    | Root _ -> r
-    | Resolved rr ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr ->
+      let rr' = resolve_resolved_reference_method ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PClassSig ident tbl r with
-        | Unresolved r -> Dot(r, name)
-        | ResolvedClassSig(r, parent) ->
+        | Unresolved r -> `Dot(r, name)
+        | ResolvedClassSig(r, parent) -> begin
             try
-              let Element.Method =
+              let `Method =
                 ClassSig.find_method_element name parent
               in
-                Resolved (Method(r, name))
+                `Resolved (`Method(r, MethodName.of_string name))
             with Not_found ->
-              let r = Resolved.parent_of_class_signature r in
-                Dot(Resolved (rlpop r), name)
+              let r = (r :> Reference.Resolved.Parent.t) in
+                `Dot(`Resolved (rlpop r), name)
+          end
+        | _ -> assert false
       end
-    | Method(r, name) -> begin
+    | `Method(r, name) -> begin
         match
           resolve_parent_reference PClassSig ident tbl
-            (parent_of_class_signature r)
+            (r :> Reference.Parent.t)
         with
-        | Unresolved _ -> Method(r, name)
-        | ResolvedClassSig(r, parent) ->
+        | Unresolved _ -> `Method(r, name)
+        | ResolvedClassSig(r, parent) -> begin
             try
-              let Element.Method =
-                ClassSig.find_method_element name parent
+              let `Method =
+                ClassSig.find_method_element (MethodName.to_string name) parent
               in
-                Resolved (Method(r, name))
+                `Resolved (`Method(r, name))
             with Not_found ->
-              Method(Resolved r, name)
+              `Method(`Resolved r, name)
+          end
+        | _ -> assert false
       end
 
 and resolve_instance_variable_reference ident tbl
-      (r : Reference.instance_variable) : Reference.instance_variable =
-  let open Reference.Resolved in
-  let open Reference in
+      (r : Reference.InstanceVariable.t) : Reference.InstanceVariable.t =
     match r with
-    | Root _ -> r
-    | Resolved rr ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr ->
+      let rr' = resolve_resolved_reference_instance_variable ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PClassSig ident tbl r with
-        | Unresolved r -> Dot(r, name)
-        | ResolvedClassSig(r, parent) ->
+        | Unresolved r -> `Dot(r, name)
+        | ResolvedClassSig(r, parent) -> begin
             try
-              let Element.InstanceVariable =
+              let `InstanceVariable =
                 ClassSig.find_instance_variable_element name parent
               in
-                Resolved (InstanceVariable(r, name))
+                `Resolved (`InstanceVariable(r, InstanceVariableName.of_string name))
             with Not_found ->
-              let r = Resolved.parent_of_class_signature r in
-                Dot(Resolved (rlpop r), name)
+              let r = (r :> Reference.Resolved.Parent.t) in
+                `Dot(`Resolved (rlpop r), name)
+          end
+        | _ -> assert false
       end
-    | InstanceVariable(r, name) -> begin
+    | `InstanceVariable(r, name) -> begin
         match
           resolve_parent_reference PClassSig ident tbl
-            (parent_of_class_signature r)
+            (r :> Reference.Parent.t)
         with
-        | Unresolved _ -> InstanceVariable(r, name)
-        | ResolvedClassSig(r, parent) ->
+        | Unresolved _ -> `InstanceVariable(r, name)
+        | ResolvedClassSig(r, parent) -> begin
             try
-              let Element.InstanceVariable =
-                ClassSig.find_instance_variable_element name parent
+              let `InstanceVariable =
+                ClassSig.find_instance_variable_element (InstanceVariableName.to_string name) parent
               in
-                Resolved (InstanceVariable(r, name))
+                `Resolved (`InstanceVariable(r, name))
             with Not_found ->
-              InstanceVariable(Resolved r, name)
+              `InstanceVariable(`Resolved r, name)
+          end
+        | _ -> assert false
       end
 
-and resolve_label_reference ident tbl (r : Reference.label)
-  : Reference.label =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_label_reference ident tbl (r : Reference.Label.t)
+  : Reference.Label.t =
     match r with
-    | Root _ -> r
-    | Resolved rr ->
-      let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+    | `Root _ -> r
+    | `Resolved rr ->
+      let rr' = resolve_resolved_reference_label ident tbl rr in
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PLabelParent ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_label) =
             match elem with
-            | Element.Label (Some type_name) ->
-                Resolved (Label(Type(r, type_name), name))
-            | Element.Label None ->
-                Resolved (Label(rlpop (Resolved.parent_of_signature r), name))
+            | `Label (Some type_name) ->
+                `Resolved (`Label(`Type(r, TypeName.of_string type_name), LabelName.of_string name))
+            | `Label None ->
+                `Resolved (`Label((r :> Reference.Resolved.LabelParent.t), LabelName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_label_element name)
               resolved unresolved ident tbl r parent
         | ResolvedDatatype(r, parent) -> begin
-            let r = Resolved.parent_of_datatype r in
+            let r = (r :> Reference.Resolved.Parent.t) in
               try
-                let Element.Label _ =
+                let `Label _ =
                   Datatype.find_label_element name parent
                 in
-                  Resolved (Label(rlpop r, name))
+                  `Resolved (`Label(rlpop r, LabelName.of_string name))
               with Not_found ->
-                  Dot(Resolved (rlpop r), name)
+                  `Dot(`Resolved (rlpop r), name)
           end
         | ResolvedClassSig(r, parent) -> begin
-            let r = Resolved.parent_of_class_signature r in
+            let r = (r :> Reference.Resolved.Parent.t) in
               try
-                let Element.Label _ =
+                let `Label _ =
                   ClassSig.find_label_element name parent
                 in
-                  Resolved (Label((rlpop r), name))
+                  `Resolved (`Label((rlpop r), LabelName.of_string name))
               with Not_found ->
-                  Dot(Resolved (rlpop r), name)
+                  `Dot(`Resolved (rlpop r), name)
           end
         | ResolvedPage(r, page) -> begin
             match Page.find_label_element name page with
             | exception Not_found ->
-              Dot(Resolved (Resolved.label_parent_of_page r), name)
-            | Element.Label None ->
-              Resolved (Label (Resolved.label_parent_of_page r, name))
-            | Element.Label (Some _) -> assert false
+              `Dot(`Resolved (r :> Reference.Resolved.LabelParent.t), name)
+            | `Label None ->
+              `Resolved (`Label ((r :> Reference.Resolved.LabelParent.t), LabelName.of_string name))
+            | `Label (Some _) -> assert false
           end
       end
-    | Label(r, name) -> begin
+    | `Label(r, name) -> begin
         match resolve_label_parent_reference PLabelParent ident tbl r with
-        | Unresolved r -> Label(r, name)
+        | Unresolved r -> `Label(r, name)
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature_label) =
             match elem with
-            | Element.Label (Some type_name) ->
-                Resolved (Label(Type(r, type_name), name))
-            | Element.Label None ->
-                Resolved (Label(rlpop (Resolved.parent_of_signature r), name))
+            | `Label (Some type_name) ->
+                `Resolved (`Label(`Type(r, TypeName.of_string type_name), name))
+            | `Label None ->
+                `Resolved (`Label((r :> Reference.Resolved.LabelParent.t), name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Label(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Label(`Resolved (rlpop r), name)
           in
-            find_with_reference_substs (Sig.find_label_element name)
+            find_with_reference_substs (Sig.find_label_element (LabelName.to_string name))
               resolved unresolved ident tbl r parent
         | ResolvedDatatype(r, parent) -> begin
-            let r = Resolved.parent_of_datatype r in
+            let r = (r :> Reference.Resolved.Parent.t) in
               try
-                let Element.Label _ =
-                  Datatype.find_label_element name parent
+                let `Label _ =
+                  Datatype.find_label_element (LabelName.to_string name) parent
                 in
-                  Resolved (Label(rlpop r, name))
+                  `Resolved (`Label(rlpop r, name))
               with Not_found ->
-                  Label(Resolved (rlpop r), name)
+                  `Label(`Resolved (rlpop r), name)
           end
         | ResolvedClassSig(r, parent) -> begin
-            let r = Resolved.parent_of_class_signature r in
+            let r = (r :> Reference.Resolved.Parent.t) in
               try
-                let Element.Label _ =
-                  ClassSig.find_label_element name parent
+                let `Label _ =
+                  ClassSig.find_label_element (LabelName.to_string name) parent
                 in
-                  Resolved (Label(rlpop r, name))
+                  `Resolved (`Label(rlpop r, name))
               with Not_found ->
-                  Label(Resolved (rlpop r), name)
+                  `Label(`Resolved (rlpop r), name)
           end
         | ResolvedPage(r, page) -> begin
-              match Page.find_label_element name page with
+              match Page.find_label_element (LabelName.to_string name) page with
               | exception Not_found ->
-                Label(Resolved (Resolved.label_parent_of_page r), name)
-              | Element.Label None ->
-                Resolved (Label (Resolved.label_parent_of_page r, name))
-              | Element.Label (Some _) -> assert false
+                `Label(`Resolved (r :> Reference.Resolved.LabelParent.t), name)
+              | `Label None ->
+                `Resolved (`Label ((r :> Reference.Resolved.LabelParent.t), name))
+              | `Label (Some _) -> assert false
           end
       end
 
-and resolve_element_reference ident tbl (r : Reference.any)
-  : Reference.any =
-  let open Reference.Resolved in
-  let open Reference in
+and resolve_element_reference ident tbl (r : Reference.t)
+  : Reference.t =
     let find_root_page s =
         match CTbl.page_base tbl s with
         | None -> r
-        | Some root -> Resolved (Identifier (Identifier.Page(root, s)))
+        | Some root -> `Resolved (`Identifier (`Page(root, (PageName.of_string s))))
     in
     match r with
-    | Root (s, TPage) -> find_root_page s
-    | Root (s, TUnknown) -> begin
-        match CTbl.base tbl s with
-        | CTbl.Not_found -> find_root_page s
+    | `Root (s, `TPage) -> find_root_page (UnitName.to_string s)
+    | `Root (s, `TUnknown) -> begin
+        match CTbl.base tbl (UnitName.to_string s) with
+        | CTbl.Not_found -> find_root_page (UnitName.to_string s)
         | CTbl.Forward_reference ->
           r (* not looking for a page since [s] "exists". *)
-        | CTbl.Found {root;_} -> Resolved (Identifier (Identifier.Root(root, s)))
+        | CTbl.Found {root;_} -> `Resolved (`Identifier (`Root(root, s)))
       end
-    | Root (s, _) -> begin
-        match CTbl.base tbl s with
+    | `Root (s, _) -> begin
+        match CTbl.base tbl (UnitName.to_string s) with
         | CTbl.Not_found -> r
         | CTbl.Forward_reference -> r
-        | CTbl.Found {root;_} -> Resolved (Identifier (Identifier.Root(root, s)))
+        | CTbl.Found {root;_} -> `Resolved (`Identifier (`Root(root, s)))
       end
-    | Resolved rr ->
+    | `Resolved rr ->
       let rr' = resolve_resolved_reference ident tbl rr in
-      if rr != rr' then Resolved rr' else r
-    | Dot(r, name) -> begin
+      if rr != rr' then `Resolved rr' else r
+    | `Dot(r, name) -> begin
         match resolve_label_parent_reference PLabelParent ident tbl r with
-        | Unresolved r -> Dot(r, name)
+        | Unresolved r -> `Dot(r, name)
         | ResolvedSig(r, parent) ->
           let resolved r (elem : Element.signature) =
             match elem with
-            | Element.Module {canonical; hidden = _} ->
-              let rr = Resolved.Module(r, name) in
+            | `Module {canonical; hidden = _} ->
+              let rr = `Module(r, ModuleName.of_string name) in
               let rr =
                 match canonical with
                 | None -> rr
-                | Some (_, r) -> Resolved.Canonical(rr, r)
+                | Some (_, r) -> `Canonical(rr, r)
               in
-              Resolved rr
-            | Element.ModuleType -> Resolved (ModuleType(r, name))
-            | Element.Type -> Resolved (Type(r, name))
-            | Element.Constructor type_name ->
-                Resolved (Constructor(Type(r, type_name) , name))
-            | Element.Field type_name ->
-                Resolved (Field(Type(r, type_name) , name))
-            | Element.Extension -> Resolved (Extension(r, name))
-            | Element.Exception -> Resolved (Exception(r, name))
-            | Element.Value -> Resolved (Value(r, name))
-            | Element.Class -> Resolved (Class(r, name))
-            | Element.ClassType -> Resolved (ClassType(r, name))
-            | Element.Label (Some type_name) ->
-                Resolved (Label(Type(r, type_name), name))
-            | Element.Label None ->
-                Resolved (Label(rlpop (Resolved.parent_of_signature r), name))
+              `Resolved rr
+            | `ModuleType -> `Resolved (`ModuleType(r, ModuleTypeName.of_string name))
+            | `Type -> `Resolved (`Type(r, TypeName.of_string name))
+            | `Constructor type_name ->
+                `Resolved (`Constructor(`Type(r, TypeName.of_string type_name) , ConstructorName.of_string name))
+            | `Field type_name ->
+                `Resolved (`Field(`Type(r, TypeName.of_string type_name) , FieldName.of_string name))
+            | `Extension -> `Resolved (`Extension(r, ExtensionName.of_string name))
+            | `Exception -> `Resolved (`Exception(r, ExceptionName.of_string name))
+            | `Value -> `Resolved (`Value(r, ValueName.of_string name))
+            | `Class -> `Resolved (`Class(r, ClassName.of_string name))
+            | `ClassType -> `Resolved (`ClassType(r, ClassTypeName.of_string name))
+            | `Label (Some type_name) ->
+                `Resolved (`Label(`Type(r, TypeName.of_string type_name), LabelName.of_string name))
+            | `Label None ->
+                `Resolved (`Label((r :> Reference.Resolved.LabelParent.t), LabelName.of_string name))
           in
           let unresolved r =
-            let r = Resolved.parent_of_signature r in
-              Dot(Resolved (rlpop r), name)
+            let r = (r :> Reference.Resolved.Parent.t) in
+              `Dot(`Resolved (rlpop r), name)
           in
             find_with_reference_substs (Sig.find_element name)
               resolved unresolved ident tbl r parent
         | ResolvedDatatype(r, parent) -> begin
             try
               match Datatype.find_element name parent with
-              | Element.Constructor _ -> Resolved (Constructor(r , name))
-              | Element.Field _ ->
-                  Resolved (Field(Reference.Resolved.parent_of_datatype r , name))
-              | Element.Label _ ->
-                  Resolved (Label(rlpop (Resolved.parent_of_datatype r), name))
+              | `Constructor _ -> `Resolved (`Constructor(r , ConstructorName.of_string name))
+              | `Field _ ->
+                  `Resolved (`Field((r :> Reference.Resolved.Parent.t) , FieldName.of_string name))
+              | `Label _ ->
+                  `Resolved (`Label((r :> Reference.Resolved.LabelParent.t), LabelName.of_string name))
             with Not_found ->
-              let r = Resolved.parent_of_datatype r in
-                Dot(Resolved (rlpop r), name)
+              let r = (r :> Reference.Resolved.Parent.t) in
+                `Dot(`Resolved (rlpop r), name)
           end
         | ResolvedClassSig(r, parent) -> begin
             try
               match ClassSig.find_element name parent with
-              | Element.Method -> Resolved (Method(r, name))
-              | Element.InstanceVariable -> Resolved (InstanceVariable(r, name))
-              | Element.Label _ ->
-                  Resolved (Label(rlpop (Resolved.parent_of_class_signature r), name))
+              | `Method -> `Resolved (`Method(r, MethodName.of_string name))
+              | `InstanceVariable -> `Resolved (`InstanceVariable(r, InstanceVariableName.of_string name))
+              | `Label _ ->
+                  `Resolved (`Label((r :> Reference.Resolved.LabelParent.t), LabelName.of_string name))
             with Not_found ->
-              let r = Resolved.parent_of_class_signature r in
-                Dot(Resolved (rlpop r), name)
+              let r = (r :> Reference.Resolved.Parent.t) in
+                `Dot(`Resolved (rlpop r), name)
           end
         | ResolvedPage(r, page) -> begin
               match Page.find_label_element name page with
               | exception Not_found ->
-                Dot(Resolved (Resolved.label_parent_of_page r), name)
-              | Element.Label None ->
-                Resolved (Label (Resolved.label_parent_of_page r, name))
-              | Element.Label (Some _) -> assert false
+                `Dot(`Resolved (r :> Reference.Resolved.LabelParent.t), name)
+              | `Label None ->
+                `Resolved (`Label ((r :> Reference.Resolved.LabelParent.t), LabelName.of_string name))
+              | `Label (Some _) -> assert false
           end
       end
-    | Module _ as r -> any (resolve_module_reference ident tbl r)
-    | ModuleType _ as r -> any (resolve_module_type_reference ident tbl r)
-    | Type _ as r -> any (resolve_type_reference ident tbl r)
-    | Constructor _ as r -> any (resolve_constructor_reference ident tbl r)
-    | Field _ as r -> any (resolve_field_reference ident tbl r)
-    | Extension _ as r -> any (resolve_extension_reference ident tbl r)
-    | Exception _ as r -> any (resolve_exception_reference ident tbl r)
-    | Value _ as r -> any (resolve_value_reference ident tbl r)
-    | Class _ as r -> any (resolve_class_reference ident tbl r)
-    | ClassType _ as r -> any (resolve_class_type_reference ident tbl r)
-    | Method _ as r -> any (resolve_method_reference ident tbl r)
-    | InstanceVariable _ as r -> any (resolve_instance_variable_reference ident tbl r)
-    | Label _ as r -> any (resolve_label_reference ident tbl r)
+    | `Module _ as r -> (resolve_module_reference ident tbl r :> Reference.t)
+    | `ModuleType _ as r -> (resolve_module_type_reference ident tbl r :> Reference.t)
+    | `Type _ as r -> (resolve_type_reference ident tbl r :> Reference.t)
+    | `Constructor _ as r -> (resolve_constructor_reference ident tbl r :> Reference.t)
+    | `Field _ as r -> (resolve_field_reference ident tbl r :> Reference.t)
+    | `Extension _ as r -> (resolve_extension_reference ident tbl r :> Reference.t)
+    | `Exception _ as r -> (resolve_exception_reference ident tbl r :> Reference.t)
+    | `Value _ as r -> (resolve_value_reference ident tbl r :> Reference.t)
+    | `Class _ as r -> (resolve_class_reference ident tbl r :> Reference.t)
+    | `ClassType _ as r -> (resolve_class_type_reference ident tbl r :> Reference.t)
+    | `Method _ as r -> (resolve_method_reference ident tbl r :> Reference.t)
+    | `InstanceVariable _ as r -> (resolve_instance_variable_reference ident tbl r :> Reference.t)
+    | `Label _ as r -> (resolve_label_reference ident tbl r :> Reference.t)
 
 let splice_section_title tbl path elements =
-  let open Reference in
   let title_of_parent =
-    let open Resolved in
-    let open Identifier in
     fun name parent_ref ->
       match parent_ref with
-      | (Identifier (Root _ | Module _ | Argument _ | ModuleType _)
-        | SubstAlias _ | Module _ | Canonical _ | ModuleType _ as rr) ->
+      | (`Identifier (`Root _ | `Module _ | `Argument _ | `ModuleType _)
+        | `SubstAlias _ | `Module _ | `Canonical _ | `ModuleType _ as rr) ->
           Some (Sig.find_section_title name
                   (CTbl.resolved_signature_reference tbl rr))
-      | Identifier Page _ as rr->
+      | `Identifier `Page _ as rr ->
         Some (Page.find_section_title name
                 (CTbl.resolved_page_reference tbl rr))
       | _ -> None
   in
   let find_section_title :
-    Resolved.label -> Model.Comment.link_content option =
+    Reference.Resolved.Label.t -> Model.Comment.link_content option =
     function
-    | Resolved.Identifier Identifier.Label (parent, str) ->
-      let parent_ref = Resolved.Identifier parent in
-      title_of_parent str parent_ref
-    | Resolved.Label (parent_ref, str) ->
-      title_of_parent str parent_ref
+    | `Identifier `Label (parent, str) ->
+      let parent_ref = `Identifier parent in
+      title_of_parent (LabelName.to_string str) parent_ref
+    | `Label (parent_ref, str) ->
+      title_of_parent (LabelName.to_string str) parent_ref
   in
   match (path, elements) with
   | (r, []) ->
     begin match r with
-    | Resolved (Resolved.Label _
-                       |Resolved.Identifier (Identifier.Label _) as rr) ->
+    | `Resolved (`Label _
+                       | `Identifier (`Label _) as rr) ->
       begin match find_section_title rr with
       | None -> (path, elements)
       | Some txt -> (r, txt)
@@ -1817,7 +2087,7 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
   object (self)
     val tbl =
       CTbl.create ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page
-    val where_am_i : Identifier.signature option = None
+    val where_am_i : Identifier.Signature.t option = None
 
     inherit Maps.types as super
     method root x = x
@@ -1840,7 +2110,7 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
     method identifier x = x
 
     method path_module x = resolve_module_path where_am_i tbl x
-    method path_module_type x = resolve_module_type_path where_am_i tbl x
+    method path_module_type x = resolve_path_module_type where_am_i tbl x
     method path_type x = resolve_type_path where_am_i tbl x
     method path_class_type x = resolve_class_type_path where_am_i tbl x
 
@@ -1848,7 +2118,7 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
       let open Lang.Module in
       let {id; doc; type_; expansion; canonical;display_type;hidden} = md in
       let id' = self#identifier_module id in
-      let sig_id = Identifier.signature_of_module id' in
+      let sig_id = (id' :> Identifier.Signature.t) in
       let self = {< where_am_i = Some sig_id >} in
       let doc' = self#documentation doc in
       let type' = self#module_decl_with_id sig_id type_ in
@@ -1875,7 +2145,7 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
       let open Lang.ModuleType in
       let {id; doc; expr; expansion} = mty in
       let id' = self#identifier_module_type id in
-      let sig_id = Identifier.signature_of_module_type id' in
+      let sig_id = (id' :> Identifier.Signature.t) in
       let self = {< where_am_i = Some sig_id >} in
       let doc' = self#documentation doc in
       let expr' =
@@ -1908,7 +2178,7 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
       | None -> arg
       | Some{ id; expr; expansion } ->
           let id' = self#identifier_module id in
-          let sig_id = Identifier.signature_of_module id' in
+          let sig_id = (id' :> Identifier.Signature.t) in
           let expr' = self#module_type_expr_with_id sig_id expr in
           let expansion' =
             Maps.option_map self#module_expansion expansion
@@ -1974,7 +2244,7 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
 
     method! type_expr_package pkg =
       let open Lang.TypeExpr.Package in
-      let path = resolve_module_type_path where_am_i tbl pkg.path in
+      let path = resolve_path_module_type where_am_i tbl pkg.path in
       let base = CTbl.module_type_path_with tbl path in
       let substitutions =
         List.map
@@ -2040,7 +2310,7 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
     method resolve_unit unit =
       let this =
         {< where_am_i =
-          Some (Identifier.signature_of_module unit.Lang.Compilation_unit.id) >}
+          Some (unit.Lang.Compilation_unit.id :> Identifier.Signature.t) >}
       in
         this#unit unit
 

--- a/src/xref/subst.mli
+++ b/src/xref/subst.mli
@@ -56,40 +56,40 @@ val comment : t -> Model.Comment.docs_or_stop -> Model.Comment.docs_or_stop
 
 val documentation : t -> Model.Comment.docs -> Model.Comment.docs
 
-val identifier_module : t -> Identifier.module_ ->
-                        Identifier.module_
+val identifier_module : t -> Identifier.Module.t ->
+                        Identifier.Module.t
 
-val identifier_signature : t -> Identifier.signature ->
-                        Identifier.signature
+val identifier_signature : t -> Identifier.Signature.t ->
+                        Identifier.Signature.t
 
-val offset_identifier_signature : t -> Identifier.signature * int ->
-                                  Identifier.signature * int
+val offset_identifier_signature : t -> Identifier.Signature.t * int ->
+                                  Identifier.Signature.t * int
 
 val module_type_expr : t -> Lang.ModuleType.expr -> Lang.ModuleType.expr
 
 val module_expansion : t -> Lang.Module.expansion -> Lang.Module.expansion
 
 val rename_signature : equal:(Root.t -> Root.t -> bool) ->
-                       Identifier.signature ->
-                       Identifier.signature ->
+                       Identifier.Signature.t ->
+                       Identifier.Signature.t ->
                        int -> t
 
 val rename_class_signature : equal:(Root.t -> Root.t -> bool) ->
-                             Identifier.class_signature ->
-                             Identifier.class_signature ->
+                             Identifier.ClassSignature.t ->
+                             Identifier.ClassSignature.t ->
                              t
 
 val rename_datatype : equal:(Root.t -> Root.t -> bool) ->
-                      Identifier.datatype ->
-                      Identifier.datatype ->
+                      Identifier.DataType.t ->
+                      Identifier.DataType.t ->
                       t
 
 val prefix : equal:(Root.t -> Root.t -> bool) ->
-             canonical:(Path.module_ * Reference.module_) option ->
-             Identifier.module_ ->
+             canonical:(Path.Module.t * Reference.Module.t) option ->
+             Identifier.Module.t ->
              t
 
-val strengthen : Path.Resolved.module_ -> t
+val strengthen : Path.Resolved.Module.t -> t
 
 val pack : equal:(Root.t -> Root.t -> bool) -> hash:(Root.t -> int) ->
-           (Identifier.module_ * Identifier.module_) list -> t
+           (Identifier.Module.t * Identifier.Module.t) list -> t

--- a/test/parser/test.ml
+++ b/test/parser/test.ml
@@ -1132,7 +1132,7 @@ let () =
             digest = String.make 16 '\000';
           }
           in
-          Model.Paths.Identifier.Page (root, dummy_filename)
+          `Page (root, Model.Names.PageName.of_string dummy_filename)
         in
 
         let location =


### PR DESCRIPTION
Warning: this is a large patch.

This patch replaces the GADTs in Paths/Paths_types with polymorphic
variants. The resulting code is more verbose, but significantly easier
to understand. Additionally a few instances of `Obj.magic` were removed
where OCaml wasn't _quite_ smart enough to figure out that types
were actually OK.

Previously we had a GADT whose type index was a set of polymorphic
variants. This allowed us to define subsets of the constructors to use
in different contexts and also to declare functions that were polymorphic
on the index and could be guaranteed to return the same subset that
were passed in.

What we now have are sets of polymorphic variants, many of which
contain identically typed constructors and can be viewed as having
subset-superset relations. To replace the functions that were
polymorphic on the index we have to write multiple functions, though
these can use pattern matching to coerce to the smaller type and hence
the superset functions can simply call the subset functions.

This PR has been tested by running `odig odoc` over my installed opam
switch and diffing the results. I saw nothing other than hash differences
in the resulting docs.

There is one area that still needs some thought - the 'maps.ml' module.
It currently allows the same overriding that was possible before, but
the typing is now more permissive. In the vast majority of cases this
will be fine, but it would be nice to close this particular hole.

Signed-off-by: Jon Ludlam <jon@recoil.org>