### PR TITLE
Add `modules` class to the ul generated by {!modules: ...} directive.

### DIFF
--- a/src/html/comment.ml
+++ b/src/html/comment.ml
@@ -280,7 +280,7 @@ let rec nestable_block_element
     let items = List.map (Reference.to_html ?xref_base_uri ~stop_before:false) ms in
     let items = (items :> (Html_types.li_content Html.elt) list) in
     let items = List.map (fun e -> Html.li [e]) items in
-    Html.ul items
+    Html.ul ~a:[Html.a_class ["modules"]] items
   | `List (kind, items) ->
     let items =
       items

--- a/test/html/cases/markup.mli
+++ b/test/html/cases/markup.mli
@@ -148,6 +148,13 @@ v}
     %}
 
 
+    {1 Modules}
+
+    {!modules: }
+    {!modules: X}
+    {!modules: X Y Z}
+
+
     {1 Tags}
 
     Each comment can end with zero or more tags. Here are some examples:

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -70,6 +70,9 @@
        <a href="#raw-html">Raw HTML</a>
       </li>
       <li>
+       <a href="#modules">Modules</a>
+      </li>
+      <li>
        <a href="#tags">Tags</a>
       </li>
      </ul>
@@ -296,6 +299,30 @@ let bar =
       If the raw HTML is the only thing in a paragraph, it is treated as a block
       element, and won't be wrapped in paragraph tags by the HTML generator.
      </blockquote>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="modules">
+      <a href="#modules" class="anchor"></a>Modules
+     </h2>
+     <ul class="modules"></ul>
+     <ul class="modules">
+      <li>
+       <code>X</code>
+      </li>
+     </ul>
+     <ul class="modules">
+      <li>
+       <code>X</code>
+      </li>
+      <li>
+       <code>Y</code>
+      </li>
+      <li>
+       <code>Z</code>
+      </li>
+     </ul>
     </header>
    </section>
    <section>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -70,6 +70,9 @@
        <a href="#raw-html">Raw HTML</a>
       </li>
       <li>
+       <a href="#modules">Modules</a>
+      </li>
+      <li>
        <a href="#tags">Tags</a>
       </li>
      </ul>
@@ -296,6 +299,30 @@ let bar =
       If the raw HTML is the only thing in a paragraph, it is treated as a block
       element, and won't be wrapped in paragraph tags by the HTML generator.
      </blockquote>
+    </header>
+   </section>
+   <section>
+    <header>
+     <h2 id="modules">
+      <a href="#modules" class="anchor"></a>Modules
+     </h2>
+     <ul class="modules"></ul>
+     <ul class="modules">
+      <li>
+       <code>X</code>
+      </li>
+     </ul>
+     <ul class="modules">
+      <li>
+       <code>X</code>
+      </li>
+      <li>
+       <code>Y</code>
+      </li>
+      <li>
+       <code>Z</code>
+      </li>
+     </ul>
     </header>
    </section>
    <section>


### PR DESCRIPTION
See https://github.com/ocaml/odoc/issues/297.