### PR TITLE
Remove dependency on bos.

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -18,7 +18,6 @@ synopsis: "OCaml documentation generator"
 
 depends: [
   "astring" {build}
-  "bos" {build}
   "cmdliner" {build & >= "1.0.0"}
   "cppo" {build}
   "dune" {build}

--- a/src/odoc/dune
+++ b/src/odoc/dune
@@ -2,7 +2,6 @@
  (name odoc__odoc)
  (public_name odoc.odoc)
  (libraries
-  bos
   compiler-libs.common
   fpath
   odoc__alias


### PR DESCRIPTION
Tools like odoc at the roots of the eco-system should be lean on deps. This removes one of them.

In this case it seems only `Bos.File.read` was being used. I added something that is functionally equivalent.