### PR TITLE
html-deps: Fix package flatness assumption.

### DIFF
--- a/src/odoc/depends.ml
+++ b/src/odoc/depends.ml
@@ -77,8 +77,6 @@ let deps_of_odoc_file ~deps input = match (Root.read input).file with
 
 let for_html_step pkg_dir =
   let deps = Hash_set.create () in
-  List.iter (Fs.Directory.ls pkg_dir) ~f:(fun file ->
-    if Fs.File.has_ext "odoc" file then
-      deps_of_odoc_file ~deps file
-  );
+  let add_deps () file = deps_of_odoc_file ~deps file in
+  Fs.Directory.fold_files_rec ~ext:".odoc" add_deps () pkg_dir;
   Hash_set.elements deps

--- a/src/odoc/fs.ml
+++ b/src/odoc/fs.ml
@@ -89,12 +89,25 @@ module Directory = struct
     | Error (`Msg e) -> invalid_arg ("Odoc.Fs.Directory.of_string: " ^ e)
     | Ok p -> Fpath.to_dir_path p
 
-  let ls t =
-    let elts = Sys.readdir (to_string t) |> Array.to_list in
-    List.fold_left elts ~init:[] ~f:(fun acc elt ->
-      let file = File.create ~directory:t ~name:elt in
-      if Fpath.is_file_path file then file :: acc else acc
-    )
+  let fold_files_rec ?(ext = "") f acc d =
+    let fold_non_dirs ext f acc files =
+      let is_dir d = try Sys.is_directory d with Sys_error _ -> false in
+      let has_ext ext file = Filename.check_suffix file ext in
+      let dirs, files = List.partition ~f:is_dir files in
+      let files = List.find_all ~f:(has_ext ext) files in
+      let f acc fn = f acc (Fpath.v fn) in
+      List.fold_left ~f ~init:acc files, dirs
+    in
+    let rec loop ext f acc = function
+    | (d :: ds) :: up ->
+        let rdir d = try Array.to_list (Sys.readdir d) with Sys_error _ -> [] in
+        let files = List.rev (List.rev_map ~f:(Filename.concat d) (rdir d)) in
+        let acc, dirs = fold_non_dirs ext f acc files in
+        loop ext f acc (dirs :: ds :: up)
+    | [] :: up -> loop ext f acc up
+    | [] -> acc
+    in
+    loop ext f acc ([Fpath.to_string d] :: []);;
 
   module Table = Hashtbl.Make(struct
       type nonrec t = t

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -39,7 +39,10 @@ module Directory : sig
   val of_string : string -> t
   val to_string : t -> string
 
-  val ls : t -> file list
+  val fold_files_rec : ?ext:string -> ('a -> file -> 'a) -> 'a -> t -> 'a
+  (** [fold_files_rec ~ext f acc d] recursively folds [f] over the files
+      with extension matching [ext] (defaults to [""]) contained in [d]
+      and its sub directories. *)
 
   module Table : Hashtbl.S with type key = t
 end


### PR DESCRIPTION
Make `html-deps` look recursively in the package directory for odoc files. Before this patch it only looked at the first level of the given package directory which is not what you want in practice. 

A lot of packages have a hierarchy in their install libdir (try e.g. `ls $(opam var odoc:lib)`). When you generate the `odoc` files you copycat that hierarchy. As mentioned `html-deps` would not lookup the hierarchy but only the first level of the hierarchy. For a package like `odoc` itself this would return an empty set of deps, which would then result in failures further down the pipeline.

