### PR TITLE
Remove make from esy build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odoc",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "The OCaml/Reason Documentation Generator",
   "repository": "https://github.com/ocaml/odoc",
   "authors": [
@@ -9,7 +9,7 @@
     "Leo White <leo@lpw25.net>"
   ],
   "esy": {
-    "build": "make build",
+    "build": "dune build",
     "release": {
       "releasedBinaries": [
         "odoc"


### PR DESCRIPTION
As @ulrikstrid mentioned before, depending on `make` hinders
the build on Windows.

Also bump version number from 1.2.0 to match current tag 1.3.0