### PR TITLE
Make bisect_ppx a build-time dependency

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -18,6 +18,7 @@ synopsis: "OCaml documentation generator"
 
 depends: [
   "astring" {build}
+  "bisect_ppx"  {build & >= "1.3.0"}
   "cmdliner" {build & >= "1.0.0"}
   "cppo" {build}
   "dune" {build}
@@ -27,7 +28,6 @@ depends: [
   "tyxml" {build & >= "4.3.0"}
 
   "alcotest" {dev & >= "0.8.3"}
-  "bisect_ppx"  {dev & >= "1.3.0"}
   "markup" {dev & >= "0.8.0"}
   "ocamlfind" {dev}
   "sexplib" {dev & >= "113.33.00"}


### PR DESCRIPTION
I was trying to update the version of `odoc` being used in [an effort to build BuckleScript documentation with it](https://github.com/BuckleScript/bucklescript/pull/3379) and I ran into the following issue:

```
λ esy build
info esy build 0.5.6 (using package.json)
info building @opam/odoc@github:ocaml/odoc:odoc.opam#eea456edb503ca259718c745233fa4054ad185c5@d41d8cd9
error: build failed with exit code: 1
  build log:
    # esy-build-package: building: @opam/odoc@github:ocaml/odoc:odoc.opam#eea456edb503ca259718c745233fa4054ad185c5
    # esy-build-package: pwd: /Users/ostera/.esy/3__________________________________________________________________/b/opam__s__odoc-11be51b8
    # esy-build-package: running: 'dune' 'build' '-p' 'odoc' '-j' '4'
    File "test/inactive/core/jbuild", line 1, characters 0-0:
    Warning: jbuild files are deprecated, please convert this file to a dune file instead.
    Note: You can use "dune upgrade" to convert your project to dune.
    File "src/html/dune", line 4, characters 18-28:
    4 |  (preprocess (pps bisect_ppx -conditional))
                          ^^^^^^^^^^
    Error: Library "bisect_ppx" not found.
    Hint: try: dune external-lib-deps --missing -j 4 -p odoc @@default
    File "src/model/dune", line 14, characters 18-28:
    14 |  (preprocess (pps bisect_ppx -conditional))
                           ^^^^^^^^^^
    Error: Library "bisect_ppx" not found.
    Hint: try: dune external-lib-deps --missing -j 4 -p odoc @@default
    File "src/parser/dune", line 6, characters 18-28:
    6 |  (preprocess (pps bisect_ppx -conditional))
                          ^^^^^^^^^^
    Error: Library "bisect_ppx" not found.
    Hint: try: dune external-lib-deps --missing -j 4 -p odoc @@default
    File "src/xref/dune", line 4, characters 18-28:
    4 |  (preprocess (pps bisect_ppx -conditional))
                          ^^^^^^^^^^
    Error: Library "bisect_ppx" not found.
    Hint: try: dune external-lib-deps --missing -j 4 -p odoc @@default
    error: command failed: 'dune' 'build' '-p' 'odoc' '-j' '4' (exited with 1)
    esy-build-package: exiting with errors above...

  building @opam/odoc@github:ocaml/odoc:odoc.opam#eea456edb503ca259718c745233fa4054ad185c5
esy: exiting due to errors above
```

I noticed that this change https://github.com/ocaml/odoc/commit/eea456edb503ca259718c745233fa4054ad185c5#diff-be686d4352ebd00cf2bdeae00bcd6070L4 changed `bisect_ppx` to be used during build time instead of being just a development dependency.

So here's a PR to change it into a build dependency that makes `odoc` build again as a direct esy dependency.