### PR TITLE
HTML: clean up keyword markup

### DIFF
--- a/src/html/ML.ml
+++ b/src/html/ML.ml
@@ -68,8 +68,8 @@ module ML = Generator.Make (struct
 
   module Mod =
   struct
-    let open_tag = "sig"
-    let close_tag = "end"
+    let open_tag = Generator.keyword "sig"
+    let close_tag = Generator.keyword "end"
     let close_tag_semicolon = false
     let include_semicolon = false
     let functor_keyword = true
@@ -77,8 +77,8 @@ module ML = Generator.Make (struct
 
   module Class =
   struct
-    let open_tag = "object"
-    let close_tag = "end"
+    let open_tag = Generator.keyword "object"
+    let close_tag = Generator.keyword "end"
   end
 
   module Value =

--- a/src/html/generator.mli
+++ b/src/html/generator.mli
@@ -1,2 +1,4 @@
+val keyword : string -> [> Html_types.span ] Tyxml.Html.elt
+
 include module type of Generator_signatures
 module Make (Syntax : SYNTAX) : GENERATOR

--- a/src/html/generator_signatures.ml
+++ b/src/html/generator_signatures.ml
@@ -99,8 +99,8 @@ sig
 
   module Mod :
   sig
-    val open_tag : string
-    val close_tag : string
+    val open_tag : [> Html_types.span | Html_types.pcdata ] Html.elt
+    val close_tag : [> Html_types.span | Html_types.pcdata ] Html.elt
     val close_tag_semicolon : bool
     val include_semicolon : bool
     val functor_keyword : bool
@@ -108,8 +108,8 @@ sig
 
   module Class :
   sig
-    val open_tag : string
-    val close_tag : string
+    val open_tag : [> Html_types.span | Html_types.pcdata ] Html.elt
+    val close_tag : [> Html_types.span | Html_types.pcdata ] Html.elt
   end
 
   module Value :

--- a/src/html/reason.ml
+++ b/src/html/reason.ml
@@ -69,8 +69,8 @@ module Reason = Generator.Make (struct
 
   module Mod =
   struct
-    let open_tag = "{"
-    let close_tag = "}"
+    let open_tag = Html.txt "{"
+    let close_tag = Html.txt "}"
     let close_tag_semicolon = true
     let include_semicolon = true
     let functor_keyword = false
@@ -78,8 +78,8 @@ module Reason = Generator.Make (struct
 
   module Class =
   struct
-    let open_tag = "{"
-    let close_tag = "}"
+    let open_tag = Html.txt "{"
+    let close_tag = Html.txt "}"
   end
 
   module Value =

--- a/src/html/utils.ml
+++ b/src/html/utils.ml
@@ -12,6 +12,14 @@ let rec list_concat_map ?sep ~f = function
     | None -> hd @ tl
     | Some sep -> hd @ sep :: tl
 
+let rec list_concat_map_list_sep ~sep ~f = function
+  | [] -> []
+  | [x] -> f x
+  | x :: xs ->
+    let hd = f x in
+    let tl = list_concat_map_list_sep ~sep ~f xs in
+    hd @ sep @ tl
+
 let optional_code children =
   match children with
   | [] -> []

--- a/test/html/cases/class.mli
+++ b/test/html/cases/class.mli
@@ -12,3 +12,9 @@ end
 
 class mutually' : mutually
 and recursive' : recursive
+
+class type virtual empty_virtual =
+object
+end
+
+class virtual empty_virtual' : empty

--- a/test/html/cases/nested.mli
+++ b/test/html/cases/nested.mli
@@ -63,11 +63,22 @@ end
 (** This is class z.
 
     Some additional comments. *)
-class z : object
+class virtual z : object
+
+  val y : int
+  (** Some value. *)
+
+  val mutable virtual y' : int
 
   (** {1 Methods} *)
 
   method z : int
   (** Some method. *)
+
+  method private virtual z' : int
 end
 
+
+class virtual inherits : object
+  inherit z
+end

--- a/test/html/cases/recent.mli
+++ b/test/html/cases/recent.mli
@@ -24,3 +24,5 @@ type polymorphic_variant = [
   | `C (** foo *)
   | `D (** bar *)
 ]
+
+type nonrec nonrec_ = int

--- a/test/html/cases/type.mli
+++ b/test/html/cases/type.mli
@@ -60,7 +60,7 @@ type record = {
 type polymorphic_variant = [
   | `A
   | `B of int
-  | `C
+  | `C of int * unit
   | `D
 ]
 
@@ -73,17 +73,19 @@ type nested_polymorphic_variant = [
   | `A of [ `B | `C ]
 ]
 
+type private_extenion = private [> polymorphic_variant ]
+
 type object_ = <
   a : int;
   b : int; (** foo *)
   c : int; (** {e bar} *)
 >
 
-module type X = sig type t end
+module type X = sig type t type u end
 
 type module_ = (module X)
 
-type module_substitution = (module X with type t = int)
+type module_substitution = (module X with type t = int and type u = unit)
 
 type +'a covariant
 
@@ -115,11 +117,15 @@ type 'a lower_object = 'a constraint 'a = <a : int; b : int; ..>
 
 type 'a poly_object = 'a constraint 'a = <a : 'a. 'a>
 
+type ('a, 'b) double_constrained = 'a * 'b
+  constraint 'a = int
+  constraint 'b = unit
+
 type as_ = (int as 'a) * 'a
 
 type extensible = ..
 
-type extensible += Extension
+type extensible += Extension | Another_extension
 
 type mutually = A of recursive
 and recursive = B of mutually

--- a/test/html/expect/test_package+custom_theme,ml/Include/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Include/index.html
@@ -22,18 +22,18 @@
     </h1>
    </header>
    <div class="spec module-type" id="module-type-Not_inlined">
-    <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined">Not_inlined</a></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Not_inlined">Not_inlined</a></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+         <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
         </dt>
        </dl>
       </details>
@@ -41,32 +41,32 @@
     </div>
    </div>
    <div class="spec module-type" id="module-type-Inlined">
-    <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <dl>
        <dt class="spec type" id="type-u">
-        <a href="#type-u" class="anchor"></a><code><span class="keyword">type </span>u</code>
+        <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code>
        </dt>
       </dl>
      </div>
     </div>
    </div>
    <div class="spec module-type" id="module-type-Not_inlined_and_closed">
-    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <details>
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-v">
-         <a href="#type-v" class="anchor"></a><code><span class="keyword">type </span>v</code>
+         <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v</code>
         </dt>
        </dl>
       </details>
@@ -74,18 +74,18 @@
     </div>
    </div>
    <div class="spec module-type" id="module-type-Not_inlined_and_opened">
-    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-w">
-         <a href="#type-w" class="anchor"></a><code><span class="keyword">type </span>w</code>
+         <a href="#type-w" class="anchor"></a><code><span class="keyword">type</span> w</code>
         </dt>
        </dl>
       </details>

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -26,7 +26,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
     </dt>
     <dd>
      <p>
@@ -35,48 +35,48 @@
     </dd>
    </dl>
    <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a></code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a></code>
    </div>
    <div class="spec module-type" id="module-type-S2">
-    <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code>
+    <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code>
    </div>
    <div class="spec module-type" id="module-type-S3">
-    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string</code>
+    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-u">u</a> = string</code>
    </div>
    <div class="spec module-type" id="module-type-S4">
-    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int</code>
+    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int</code>
    </div>
    <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> 'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
    </div>
    <dl>
     <dt class="spec type" id="type-result">
-     <a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) result</code>
+     <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) result</code>
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
    </div>
    <div class="spec module" id="module-M'">
-    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-S7">
-    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module-type" id="module-type-S8">
-    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module-type" id="module-type-S9">
-    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S9/index.html">S9</a> : <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module" id="module-Mutually">
-    <a href="#module-Mutually" class="anchor"></a><code><span class="keyword">module rec </span><a href="Mutually/index.html">Mutually</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-Mutually" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">rec</span> <a href="Mutually/index.html">Mutually</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-Recursive">
-    <a href="#module-Recursive" class="anchor"></a><code><span class="keyword">and </span><a href="Recursive/index.html">Recursive</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-Recursive" class="anchor"></a><code><span class="keyword">and</span> <a href="Recursive/index.html">Recursive</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+custom_theme,ml/Section/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Section/index.html
@@ -91,7 +91,7 @@
     </header>
     <dl>
      <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
      </dt>
     </dl>
    </section>

--- a/test/html/expect/test_package+custom_theme,ml/Val/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Val/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-documented">
-     <a href="#val-documented" class="anchor"></a><code><span class="keyword">val </span>documented : unit</code>
+     <a href="#val-documented" class="anchor"></a><code><span class="keyword">val</span> documented : unit</code>
     </dt>
     <dd>
      <p>
@@ -33,10 +33,10 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-undocumented">
-     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val </span>undocumented : unit</code>
+     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val</span> undocumented : unit</code>
     </dt>
     <dt class="spec value" id="val-documented_above">
-     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">val </span>documented_above : unit</code>
+     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">val</span> documented_above : unit</code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+ml/Alias/X/index.html
+++ b/test/html/expect/test_package+ml/Alias/X/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec type" id="type-t">
-     <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><code><span class="keyword"> = </span>int</code>
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code><code> = int</code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+ml/Alias/index.html
+++ b/test/html/expect/test_package+ml/Alias/index.html
@@ -22,10 +22,10 @@
     </h1>
    </header>
    <div class="spec module" id="module-Foo__X">
-    <a href="#module-Foo__X" class="anchor"></a><code><span class="keyword">module </span><a href="Foo__X/index.html">Foo__X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-Foo__X" class="anchor"></a><code><span class="keyword">module</span> <a href="Foo__X/index.html">Foo__X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-X">
-    <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -23,12 +23,12 @@
    </header>
    <dl>
     <dt class="spec type" id="type-opt">
-     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type </span>'a opt</code><code><span class="keyword"> = </span><span class="type-var">'a</span> option</code>
+     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> 'a opt</code><code> = <span class="type-var">'a</span> option</code>
     </dt>
    </dl>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : ?⁠bar:<span class="type-var">'a</span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : ?⁠bar:<span class="type-var">'a</span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
     </dt>
     <dd>
      <p>
@@ -38,12 +38,12 @@
    </dl>
    <dl>
     <dt class="spec type" id="type-opt'">
-     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type </span>'a opt'</code><code><span class="keyword"> = </span>int option</code>
+     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> 'a opt'</code><code> = int option</code>
     </dt>
    </dl>
    <dl>
     <dt class="spec value" id="val-foo'">
-     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">val </span>foo' : ?⁠bar:<span class="type-var">'a</span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
+     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">val</span> foo' : ?⁠bar:<span class="type-var">'a</span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -36,6 +36,12 @@
    <div class="spec class" id="class-recursive'">
     <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and </span><a href="class-recursive'/index.html">recursive'</a> : <a href="class-type-recursive/index.html">recursive</a></code>
    </div>
+   <div class="spec class-type" id="class-type-empty_virtual">
+    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class type </span><span class="keyword">virtual </span><a href="class-type-empty_virtual/index.html">empty_virtual</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+   </div>
+   <div class="spec class" id="class-empty_virtual'">
+    <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-empty_virtual'/index.html">empty_virtual'</a> : <a href="class-type-empty/index.html">empty</a></code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -22,25 +22,25 @@
     </h1>
    </header>
    <div class="spec class-type" id="class-type-empty">
-    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class type </span><a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class-type" id="class-type-mutually">
-    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class type </span><a href="class-type-mutually/index.html">mutually</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <a href="class-type-mutually/index.html">mutually</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class-type" id="class-type-recursive">
-    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and </span><a href="class-type-recursive/index.html">recursive</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span> <a href="class-type-recursive/index.html">recursive</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-mutually'">
-    <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class </span><a href="class-mutually'/index.html">mutually'</a> : <a href="class-type-mutually/index.html">mutually</a></code>
+    <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class</span> <a href="class-mutually'/index.html">mutually'</a> : <a href="class-type-mutually/index.html">mutually</a></code>
    </div>
    <div class="spec class" id="class-recursive'">
-    <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and </span><a href="class-recursive'/index.html">recursive'</a> : <a href="class-type-recursive/index.html">recursive</a></code>
+    <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and</span> <a href="class-recursive'/index.html">recursive'</a> : <a href="class-type-recursive/index.html">recursive</a></code>
    </div>
    <div class="spec class-type" id="class-type-empty_virtual">
-    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class type </span><span class="keyword">virtual </span><a href="class-type-empty_virtual/index.html">empty_virtual</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span> <a href="class-type-empty_virtual/index.html">empty_virtual</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-empty_virtual'">
-    <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-empty_virtual'/index.html">empty_virtual'</a> : <a href="class-type-empty/index.html">empty</a></code>
+    <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-empty_virtual'/index.html">empty_virtual'</a> : <a href="class-type-empty/index.html">empty</a></code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/External/index.html
+++ b/test/html/expect/test_package+ml/External/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec external" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit <span>-&gt;</span> unit</code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit <span>-&gt;</span> unit</code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+ml/Functor/index.html
+++ b/test/html/expect/test_package+ml/Functor/index.html
@@ -22,22 +22,22 @@
     </h1>
    </header>
    <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a> : <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> : <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
    </div>
    <div class="spec module" id="module-F1">
-    <a href="#module-F1" class="anchor"></a><code><span class="keyword">module </span><a href="F1/index.html">F1</a> : <span class="keyword">functor</span> (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
+    <a href="#module-F1" class="anchor"></a><code><span class="keyword">module</span> <a href="F1/index.html">F1</a> : <span class="keyword">functor</span> (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
    </div>
    <div class="spec module" id="module-F2">
-    <a href="#module-F2" class="anchor"></a><code><span class="keyword">module </span><a href="F2/index.html">F2</a> : <span class="keyword">functor</span> (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="F2/index.html#type-t">t</a><span class="keyword"> = </span><a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></code>
+    <a href="#module-F2" class="anchor"></a><code><span class="keyword">module</span> <a href="F2/index.html">F2</a> : <span class="keyword">functor</span> (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="F2/index.html#type-t">t</a> = <a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></code>
    </div>
    <div class="spec module" id="module-F3">
-    <a href="#module-F3" class="anchor"></a><code><span class="keyword">module </span><a href="F3/index.html">F3</a> : <span class="keyword">functor</span> (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-F3" class="anchor"></a><code><span class="keyword">module</span> <a href="F3/index.html">F3</a> : <span class="keyword">functor</span> (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-F4">
-    <a href="#module-F4" class="anchor"></a><code><span class="keyword">module </span><a href="F4/index.html">F4</a> : <span class="keyword">functor</span> (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
+    <a href="#module-F4" class="anchor"></a><code><span class="keyword">module</span> <a href="F4/index.html">F4</a> : <span class="keyword">functor</span> (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Include/index.html
+++ b/test/html/expect/test_package+ml/Include/index.html
@@ -22,18 +22,18 @@
     </h1>
    </header>
    <div class="spec module-type" id="module-type-Not_inlined">
-    <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined">Not_inlined</a></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Not_inlined">Not_inlined</a></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+         <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
         </dt>
        </dl>
       </details>
@@ -41,32 +41,32 @@
     </div>
    </div>
    <div class="spec module-type" id="module-type-Inlined">
-    <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <dl>
        <dt class="spec type" id="type-u">
-        <a href="#type-u" class="anchor"></a><code><span class="keyword">type </span>u</code>
+        <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code>
        </dt>
       </dl>
      </div>
     </div>
    </div>
    <div class="spec module-type" id="module-type-Not_inlined_and_closed">
-    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <details>
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-v">
-         <a href="#type-v" class="anchor"></a><code><span class="keyword">type </span>v</code>
+         <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v</code>
         </dt>
        </dl>
       </details>
@@ -74,18 +74,18 @@
     </div>
    </div>
    <div class="spec module-type" id="module-type-Not_inlined_and_opened">
-    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-w">
-         <a href="#type-w" class="anchor"></a><code><span class="keyword">type </span>w</code>
+         <a href="#type-w" class="anchor"></a><code><span class="keyword">type</span> w</code>
         </dt>
        </dl>
       </details>

--- a/test/html/expect/test_package+ml/Include2/index.html
+++ b/test/html/expect/test_package+ml/Include2/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec module" id="module-X">
-     <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+     <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
     </dt>
     <dd>
      <p>
@@ -36,11 +36,11 @@
      <div class="doc">
       <details open="open">
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-X">X</a></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-X">X</a></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><code><span class="keyword"> = </span>int</code>
+         <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code><code> = int</code>
         </dt>
        </dl>
       </details>

--- a/test/html/expect/test_package+ml/Interlude/index.html
+++ b/test/html/expect/test_package+ml/Interlude/index.html
@@ -31,7 +31,7 @@
    </aside>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
     </dt>
     <dd>
      <p>
@@ -54,7 +54,7 @@
    </aside>
    <dl>
     <dt class="spec value" id="val-bar">
-     <a href="#val-bar" class="anchor"></a><code><span class="keyword">val </span>bar : unit</code>
+     <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
     </dt>
     <dd>
      <p>
@@ -64,13 +64,13 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-multiple">
-     <a href="#val-multiple" class="anchor"></a><code><span class="keyword">val </span>multiple : unit</code>
+     <a href="#val-multiple" class="anchor"></a><code><span class="keyword">val</span> multiple : unit</code>
     </dt>
     <dt class="spec value" id="val-signature">
-     <a href="#val-signature" class="anchor"></a><code><span class="keyword">val </span>signature : unit</code>
+     <a href="#val-signature" class="anchor"></a><code><span class="keyword">val</span> signature : unit</code>
     </dt>
     <dt class="spec value" id="val-items">
-     <a href="#val-items" class="anchor"></a><code><span class="keyword">val </span>items : unit</code>
+     <a href="#val-items" class="anchor"></a><code><span class="keyword">val</span> items : unit</code>
     </dt>
    </dl>
    <aside>

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -440,7 +440,7 @@ let bar =
     </header>
     <dl>
      <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -26,7 +26,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
     </dt>
     <dd>
      <p>
@@ -35,48 +35,48 @@
     </dd>
    </dl>
    <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a></code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a></code>
    </div>
    <div class="spec module-type" id="module-type-S2">
-    <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code>
+    <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code>
    </div>
    <div class="spec module-type" id="module-type-S3">
-    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string</code>
+    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-u">u</a> = string</code>
    </div>
    <div class="spec module-type" id="module-type-S4">
-    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int</code>
+    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int</code>
    </div>
    <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> 'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
    </div>
    <dl>
     <dt class="spec type" id="type-result">
-     <a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) result</code>
+     <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) result</code>
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span>('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
    </div>
    <div class="spec module" id="module-M'">
-    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-S7">
-    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module-type" id="module-type-S8">
-    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module-type" id="module-type-S9">
-    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a> : <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S9/index.html">S9</a> : <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module" id="module-Mutually">
-    <a href="#module-Mutually" class="anchor"></a><code><span class="keyword">module rec </span><a href="Mutually/index.html">Mutually</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-Mutually" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">rec</span> <a href="Mutually/index.html">Mutually</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-Recursive">
-    <a href="#module-Recursive" class="anchor"></a><code><span class="keyword">and </span><a href="Recursive/index.html">Recursive</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-Recursive" class="anchor"></a><code><span class="keyword">and</span> <a href="Recursive/index.html">Recursive</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
@@ -39,7 +39,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
      </dt>
      <dd>
       <p>
@@ -56,7 +56,7 @@
     </header>
     <dl>
      <dt class="spec value" id="val-y">
-      <a href="#val-y" class="anchor"></a><code><span class="keyword">val </span>y : <a href="index.html#type-t">t</a></code>
+      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : <a href="index.html#type-t">t</a></code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
@@ -36,7 +36,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -56,7 +56,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><code><span class="keyword"> = </span><a href="argument-1-Arg1/index.html#type-t">Arg1.t</a><span class="keyword"> * </span><a href="argument-2-Arg2/index.html#type-t">Arg2.t</a></code>
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code><code> = <a href="argument-1-Arg1/index.html#type-t">Arg1.t</a> * <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a></code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -45,7 +45,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
      </dt>
      <dd>
       <p>
@@ -62,7 +62,7 @@
     </header>
     <dl>
      <dt class="spec value" id="val-x">
-      <a href="#val-x" class="anchor"></a><code><span class="keyword">val </span>x : <a href="index.html#type-t">t</a></code>
+      <a href="#val-x" class="anchor"></a><code><span class="keyword">val</span> x : <a href="index.html#type-t">t</a></code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+ml/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-inherits/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt>
-     <span class="keyword">inherit </span><a href="../class-z/index.html">z</a>
+     <code><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></code>
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+ml/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-inherits/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   inherits (test_package+ml.Nested.inherits)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » inherits
+    </nav>
+    <h1>
+     Class <code>Nested.inherits</code>
+    </h1>
+   </header>
+   <dl>
+    <dt>
+     <span class="keyword">inherit </span><a href="../class-z/index.html">z</a>
+    </dt>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Nested/class-z/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-z/index.html
@@ -34,6 +34,21 @@
      </ul>
     </nav>
    </header>
+   <dl>
+    <dt class="spec instance-variable" id="val-y">
+     <a href="#val-y" class="anchor"></a><code><span class="keyword">val </span>y : int</code>
+    </dt>
+    <dd>
+     <p>
+      Some value.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec instance-variable" id="val-y'">
+     <a href="#val-y'" class="anchor"></a><code><span class="keyword">val </span><span class="keyword">mutable </span><span class="keyword">virtual </span>y' : int</code>
+    </dt>
+   </dl>
    <section>
     <header>
      <h2 id="methods">
@@ -49,6 +64,11 @@
        Some method.
       </p>
      </dd>
+    </dl>
+    <dl>
+     <dt class="spec method" id="method-z'">
+      <a href="#method-z'" class="anchor"></a><code><span class="keyword">method </span><span class="keyword">private </span><span class="keyword">virtual </span>z' : int</code>
+     </dt>
     </dl>
    </section>
   </div>

--- a/test/html/expect/test_package+ml/Nested/class-z/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-z/index.html
@@ -36,7 +36,7 @@
    </header>
    <dl>
     <dt class="spec instance-variable" id="val-y">
-     <a href="#val-y" class="anchor"></a><code><span class="keyword">val </span>y : int</code>
+     <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : int</code>
     </dt>
     <dd>
      <p>
@@ -46,7 +46,7 @@
    </dl>
    <dl>
     <dt class="spec instance-variable" id="val-y'">
-     <a href="#val-y'" class="anchor"></a><code><span class="keyword">val </span><span class="keyword">mutable </span><span class="keyword">virtual </span>y' : int</code>
+     <a href="#val-y'" class="anchor"></a><code><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y' : int</code>
     </dt>
    </dl>
    <section>
@@ -57,7 +57,7 @@
     </header>
     <dl>
      <dt class="spec method" id="method-z">
-      <a href="#method-z" class="anchor"></a><code><span class="keyword">method </span>z : int</code>
+      <a href="#method-z" class="anchor"></a><code><span class="keyword">method</span> z : int</code>
      </dt>
      <dd>
       <p>
@@ -67,7 +67,7 @@
     </dl>
     <dl>
      <dt class="spec method" id="method-z'">
-      <a href="#method-z'" class="anchor"></a><code><span class="keyword">method </span><span class="keyword">private </span><span class="keyword">virtual </span>z' : int</code>
+      <a href="#method-z'" class="anchor"></a><code><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z' : int</code>
      </dt>
     </dl>
    </section>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -99,7 +99,7 @@
     </header>
     <dl>
      <dt class="spec class" id="class-z">
-      <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+      <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
      </dt>
      <dd>
       <p>
@@ -107,6 +107,9 @@
       </p>
      </dd>
     </dl>
+    <div class="spec class" id="class-inherits">
+     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-inherits/index.html">inherits</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    </div>
    </section>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -48,7 +48,7 @@
     </header>
     <dl>
      <dt class="spec module" id="module-X">
-      <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
      </dt>
      <dd>
       <p>
@@ -65,7 +65,7 @@
     </header>
     <dl>
      <dt class="spec module-type" id="module-type-Y">
-      <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Y/index.html">Y</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+      <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Y/index.html">Y</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
      </dt>
      <dd>
       <p>
@@ -82,7 +82,7 @@
     </header>
     <dl>
      <dt class="spec module" id="module-F">
-      <a href="#module-F" class="anchor"></a><code><span class="keyword">module </span><a href="F/index.html">F</a> : <span class="keyword">functor</span> (<a href="F/argument-1-Arg1/index.html">Arg1</a> : <a href="index.html#module-type-Y">Y</a>) <span>-&gt;</span> <span class="keyword">functor</span> (<a href="F/argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+      <a href="#module-F" class="anchor"></a><code><span class="keyword">module</span> <a href="F/index.html">F</a> : <span class="keyword">functor</span> (<a href="F/argument-1-Arg1/index.html">Arg1</a> : <a href="index.html#module-type-Y">Y</a>) <span>-&gt;</span> <span class="keyword">functor</span> (<a href="F/argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
      </dt>
      <dd>
       <p>
@@ -99,7 +99,7 @@
     </header>
     <dl>
      <dt class="spec class" id="class-z">
-      <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+      <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
      </dt>
      <dd>
       <p>
@@ -108,7 +108,7 @@
      </dd>
     </dl>
     <div class="spec class" id="class-inherits">
-     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-inherits/index.html">inherits</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-inherits/index.html">inherits</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
     </div>
    </section>
   </div>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -45,7 +45,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code>
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
      </dt>
      <dd>
       <p>
@@ -62,7 +62,7 @@
     </header>
     <dl>
      <dt class="spec value" id="val-y">
-      <a href="#val-y" class="anchor"></a><code><span class="keyword">val </span>y : <a href="index.html#type-t">t</a></code>
+      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : <a href="index.html#type-t">t</a></code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -155,6 +155,9 @@
      </table>
      <code> ]</code>
     </dt>
+    <dt class="spec type" id="type-nonrec_">
+     <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type nonrec </span>nonrec_</code><code><span class="keyword"> = </span>int</code>
+    </dt>
    </dl>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -22,29 +22,29 @@
     </h1>
    </header>
    <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a> : <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> : <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
    </div>
    <dl>
     <dt class="spec type" id="type-variant">
-     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type </span>variant</code><code><span class="keyword"> = </span></code>
+     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code>
+         <a href="#type-variant.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span></code>
         </td>
        </tr>
        <tr id="type-variant.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span><span class="keyword"> of </span>int</code>
+         <a href="#type-variant.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span> <span class="keyword">of</span> int</code>
         </td>
        </tr>
        <tr id="type-variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span></code>
+         <a href="#type-variant.C" class="anchor"></a><code>| </code><code><span class="constructor">C</span></code>
         </td>
         <td class="doc">
          <p>
@@ -54,7 +54,7 @@
        </tr>
        <tr id="type-variant.D" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">D</span></code>
+         <a href="#type-variant.D" class="anchor"></a><code>| </code><code><span class="constructor">D</span></code>
         </td>
         <td class="doc">
          <p>
@@ -64,7 +64,7 @@
        </tr>
        <tr id="type-variant.E" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.E" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">E</span><span class="keyword"> of </span></code><code>{</code>
+         <a href="#type-variant.E" class="anchor"></a><code>| </code><code><span class="constructor">E</span> <span class="keyword">of</span> </code><code>{</code>
          <table class="record">
           <tbody>
            <tr id="type-variant.a" class="anchored">
@@ -81,17 +81,17 @@
      </table>
     </dt>
     <dt class="spec type" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type </span>_ gadt</code><code><span class="keyword"> = </span></code>
+     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> _ gadt</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-gadt.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> int <a href="index.html#type-gadt">gadt</a></code>
+         <a href="#type-gadt.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> : int <a href="index.html#type-gadt">gadt</a></code>
         </td>
        </tr>
        <tr id="type-gadt.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span><span class="keyword"> : </span>int <span>-&gt;</span> string <a href="index.html#type-gadt">gadt</a></code>
+         <a href="#type-gadt.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span> : int <span>-&gt;</span> string <a href="index.html#type-gadt">gadt</a></code>
         </td>
         <td class="doc">
          <p>
@@ -101,7 +101,7 @@
        </tr>
        <tr id="type-gadt.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span><span class="keyword"> : </span></code><code>{</code>
+         <a href="#type-gadt.C" class="anchor"></a><code>| </code><code><span class="constructor">C</span> : </code><code>{</code>
          <table class="record">
           <tbody>
            <tr id="type-gadt.a" class="anchored">
@@ -118,22 +118,22 @@
      </table>
     </dt>
     <dt class="spec type" id="type-polymorphic_variant">
-     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant</code><span class="keyword"> = </span><code>[ </code>
+     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant</code> = <code>[ </code>
      <table class="variant">
       <tbody>
        <tr id="type-polymorphic_variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A</code>
+         <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code>`B<span class="keyword"> of </span>int</code>
+         <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B <span class="keyword">of</span> int</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C</code>
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C</code>
         </td>
         <td class="doc">
          <p>
@@ -143,7 +143,7 @@
        </tr>
        <tr id="type-polymorphic_variant.D" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code>`D</code>
+         <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
         </td>
         <td class="doc">
          <p>
@@ -156,7 +156,7 @@
      <code> ]</code>
     </dt>
     <dt class="spec type" id="type-nonrec_">
-     <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type nonrec </span>nonrec_</code><code><span class="keyword"> = </span>int</code>
+     <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_</code><code> = int</code>
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+ml/Section/index.html
+++ b/test/html/expect/test_package+ml/Section/index.html
@@ -91,7 +91,7 @@
     </header>
     <dl>
      <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : unit</code>
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
      </dt>
     </dl>
    </section>

--- a/test/html/expect/test_package+ml/Stop/index.html
+++ b/test/html/expect/test_package+ml/Stop/index.html
@@ -26,7 +26,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val </span>foo : int</code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : int</code>
     </dt>
     <dd>
      <p>
@@ -48,11 +48,11 @@
     </p>
    </aside>
    <div class="spec module" id="module-N">
-    <a href="#module-N" class="anchor"></a><code><span class="keyword">module </span><a href="N/index.html">N</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-N" class="anchor"></a><code><span class="keyword">module</span> <a href="N/index.html">N</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <dl>
     <dt class="spec value" id="val-lol">
-     <a href="#val-lol" class="anchor"></a><code><span class="keyword">val </span>lol : int</code>
+     <a href="#val-lol" class="anchor"></a><code><span class="keyword">val</span> lol : int</code>
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec type" id="type-abstract">
-     <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type </span>abstract</code>
+     <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type</span> abstract</code>
     </dt>
     <dd>
      <p>
@@ -33,46 +33,46 @@
    </dl>
    <dl>
     <dt class="spec type" id="type-alias">
-     <a href="#type-alias" class="anchor"></a><code><span class="keyword">type </span>alias</code><code><span class="keyword"> = </span>int</code>
+     <a href="#type-alias" class="anchor"></a><code><span class="keyword">type</span> alias</code><code> = int</code>
     </dt>
     <dt class="spec type" id="type-private_">
-     <a href="#type-private_" class="anchor"></a><code><span class="keyword">type </span>private_</code><code><span class="keyword"> = </span><span class="keyword">private </span>int</code>
+     <a href="#type-private_" class="anchor"></a><code><span class="keyword">type</span> private_</code><code> = <span class="keyword">private</span> int</code>
     </dt>
     <dt class="spec type" id="type-constructor">
-     <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type </span>'a constructor</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code>
+     <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type</span> 'a constructor</code><code> = <span class="type-var">'a</span></code>
     </dt>
     <dt class="spec type" id="type-arrow">
-     <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type </span>arrow</code><code><span class="keyword"> = </span>int <span>-&gt;</span> int</code>
+     <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type</span> arrow</code><code> = int <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-higher_order">
-     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type </span>higher_order</code><code><span class="keyword"> = </span>(int <span>-&gt;</span> int) <span>-&gt;</span> int</code>
+     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order</code><code> = (int <span>-&gt;</span> int) <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-labeled">
-     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type </span>labeled</code><code><span class="keyword"> = </span>l:int <span>-&gt;</span> int</code>
+     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled</code><code> = l:int <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-optional">
-     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type </span>optional</code><code><span class="keyword"> = </span>?⁠l:int <span>-&gt;</span> int</code>
+     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional</code><code> = ?⁠l:int <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-labeled_higher_order">
-     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type </span>labeled_higher_order</code><code><span class="keyword"> = </span>(l:int <span>-&gt;</span> int) <span>-&gt;</span> (?⁠l:int <span>-&gt;</span> int) <span>-&gt;</span> int</code>
+     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order</code><code> = (l:int <span>-&gt;</span> int) <span>-&gt;</span> (?⁠l:int <span>-&gt;</span> int) <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-pair">
-     <a href="#type-pair" class="anchor"></a><code><span class="keyword">type </span>pair</code><code><span class="keyword"> = </span>int<span class="keyword"> * </span>int</code>
+     <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair</code><code> = int * int</code>
     </dt>
     <dt class="spec type" id="type-parens_dropped">
-     <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type </span>parens_dropped</code><code><span class="keyword"> = </span>int<span class="keyword"> * </span>int</code>
+     <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type</span> parens_dropped</code><code> = int * int</code>
     </dt>
     <dt class="spec type" id="type-triple">
-     <a href="#type-triple" class="anchor"></a><code><span class="keyword">type </span>triple</code><code><span class="keyword"> = </span>int<span class="keyword"> * </span>int<span class="keyword"> * </span>int</code>
+     <a href="#type-triple" class="anchor"></a><code><span class="keyword">type</span> triple</code><code> = int * int * int</code>
     </dt>
     <dt class="spec type" id="type-nested_pair">
-     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type </span>nested_pair</code><code><span class="keyword"> = </span>(int<span class="keyword"> * </span>int)<span class="keyword"> * </span>int</code>
+     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair</code><code> = (int * int) * int</code>
     </dt>
     <dt class="spec type" id="type-instance">
-     <a href="#type-instance" class="anchor"></a><code><span class="keyword">type </span>instance</code><code><span class="keyword"> = </span>int <a href="index.html#type-constructor">constructor</a></code>
+     <a href="#type-instance" class="anchor"></a><code><span class="keyword">type</span> instance</code><code> = int <a href="index.html#type-constructor">constructor</a></code>
     </dt>
     <dt class="spec type" id="type-variant_e">
-     <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type </span>variant_e</code><code><span class="keyword"> = </span></code><code>{</code>
+     <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type</span> variant_e</code><code> = </code><code>{</code>
      <table class="record">
       <tbody>
        <tr id="type-variant_e.a" class="anchored">
@@ -85,22 +85,22 @@
      <code>}</code>
     </dt>
     <dt class="spec type" id="type-variant">
-     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type </span>variant</code><code><span class="keyword"> = </span></code>
+     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code>
+         <a href="#type-variant.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span></code>
         </td>
        </tr>
        <tr id="type-variant.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span><span class="keyword"> of </span>int</code>
+         <a href="#type-variant.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span> <span class="keyword">of</span> int</code>
         </td>
        </tr>
        <tr id="type-variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span></code>
+         <a href="#type-variant.C" class="anchor"></a><code>| </code><code><span class="constructor">C</span></code>
         </td>
         <td class="doc">
          <p>
@@ -110,7 +110,7 @@
        </tr>
        <tr id="type-variant.D" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">D</span></code>
+         <a href="#type-variant.D" class="anchor"></a><code>| </code><code><span class="constructor">D</span></code>
         </td>
         <td class="doc">
          <p>
@@ -120,14 +120,14 @@
        </tr>
        <tr id="type-variant.E" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.E" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">E</span><span class="keyword"> of </span><a href="index.html#type-variant_e">variant_e</a></code>
+         <a href="#type-variant.E" class="anchor"></a><code>| </code><code><span class="constructor">E</span> <span class="keyword">of</span> <a href="index.html#type-variant_e">variant_e</a></code>
         </td>
        </tr>
       </tbody>
      </table>
     </dt>
     <dt class="spec type" id="type-variant_c">
-     <a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type </span>variant_c</code><code><span class="keyword"> = </span></code><code>{</code>
+     <a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type</span> variant_c</code><code> = </code><code>{</code>
      <table class="record">
       <tbody>
        <tr id="type-variant_c.a" class="anchored">
@@ -140,53 +140,53 @@
      <code>}</code>
     </dt>
     <dt class="spec type" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type </span>_ gadt</code><code><span class="keyword"> = </span></code>
+     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> _ gadt</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-gadt.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> int <a href="index.html#type-gadt">gadt</a></code>
+         <a href="#type-gadt.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> : int <a href="index.html#type-gadt">gadt</a></code>
         </td>
        </tr>
        <tr id="type-gadt.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span><span class="keyword"> : </span>int <span>-&gt;</span> string <a href="index.html#type-gadt">gadt</a></code>
+         <a href="#type-gadt.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span> : int <span>-&gt;</span> string <a href="index.html#type-gadt">gadt</a></code>
         </td>
        </tr>
        <tr id="type-gadt.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span><span class="keyword"> : </span><a href="index.html#type-variant_c">variant_c</a> <span>-&gt;</span> unit <a href="index.html#type-gadt">gadt</a></code>
+         <a href="#type-gadt.C" class="anchor"></a><code>| </code><code><span class="constructor">C</span> : <a href="index.html#type-variant_c">variant_c</a> <span>-&gt;</span> unit <a href="index.html#type-gadt">gadt</a></code>
         </td>
        </tr>
       </tbody>
      </table>
     </dt>
     <dt class="spec type" id="type-degenerate_gadt">
-     <a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type </span>degenerate_gadt</code><code><span class="keyword"> = </span></code>
+     <a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type</span> degenerate_gadt</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-degenerate_gadt.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code>
+         <a href="#type-degenerate_gadt.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> : <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code>
         </td>
        </tr>
       </tbody>
      </table>
     </dt>
     <dt class="spec type" id="type-private_variant">
-     <a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type </span>private_variant</code><code><span class="keyword"> = </span><span class="keyword">private </span></code>
+     <a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type</span> private_variant</code><code> = <span class="keyword">private</span> </code>
      <table class="variant">
       <tbody>
        <tr id="type-private_variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-private_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code>
+         <a href="#type-private_variant.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span></code>
         </td>
        </tr>
       </tbody>
      </table>
     </dt>
     <dt class="spec type" id="type-record">
-     <a href="#type-record" class="anchor"></a><code><span class="keyword">type </span>record</code><code><span class="keyword"> = </span></code><code>{</code>
+     <a href="#type-record" class="anchor"></a><code><span class="keyword">type</span> record</code><code> = </code><code>{</code>
      <table class="record">
       <tbody>
        <tr id="type-record.a" class="anchored">
@@ -196,7 +196,7 @@
        </tr>
        <tr id="type-record.b" class="anchored">
         <td class="def field">
-         <a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable </span>b : int;</code>
+         <a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable</span> b : int;</code>
         </td>
        </tr>
        <tr id="type-record.c" class="anchored">
@@ -229,27 +229,27 @@
      <code>}</code>
     </dt>
     <dt class="spec type" id="type-polymorphic_variant">
-     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant</code><span class="keyword"> = </span><code>[ </code>
+     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant</code> = <code>[ </code>
      <table class="variant">
       <tbody>
        <tr id="type-polymorphic_variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A</code>
+         <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code>`B<span class="keyword"> of </span>int</code>
+         <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B <span class="keyword">of</span> int</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C<span class="keyword"> of </span>int<span class="keyword"> * </span>unit</code>
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C <span class="keyword">of</span> int * unit</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.D" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code>`D</code>
+         <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
         </td>
        </tr>
       </tbody>
@@ -257,17 +257,17 @@
      <code> ]</code>
     </dt>
     <dt class="spec type" id="type-polymorphic_variant_extension">
-     <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant_extension</code><span class="keyword"> = </span><code>[ </code>
+     <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant_extension</code> = <code>[ </code>
      <table class="variant">
       <tbody>
        <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
         <td class="def type">
-         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span class="keyword">| </span></code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant_extension.E" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span class="keyword">| </span></code><code>`E</code>
+         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code>| </code><code>`E</code>
         </td>
        </tr>
       </tbody>
@@ -275,12 +275,12 @@
      <code> ]</code>
     </dt>
     <dt class="spec type" id="type-nested_polymorphic_variant">
-     <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>nested_polymorphic_variant</code><span class="keyword"> = </span><code>[ </code>
+     <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> nested_polymorphic_variant</code> = <code>[ </code>
      <table class="variant">
       <tbody>
        <tr id="type-nested_polymorphic_variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A<span class="keyword"> of </span>[ `B<span class="keyword"> | </span>`C ]</code>
+         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A <span class="keyword">of</span> [ `B | `C ]</code>
         </td>
        </tr>
       </tbody>
@@ -288,15 +288,15 @@
      <code> ]</code>
     </dt>
     <dt class="spec type" id="type-private_extenion#row">
-     <a href="#type-private_extenion#row" class="anchor"></a><code><span class="keyword">type </span>private_extenion#row</code>
+     <a href="#type-private_extenion#row" class="anchor"></a><code><span class="keyword">type</span> private_extenion#row</code>
     </dt>
     <dt class="spec type" id="type-private_extenion">
-     <a href="#type-private_extenion" class="anchor"></a><code><span class="keyword">and </span>private_extenion</code><span class="keyword"> = </span><span class="keyword">private </span><code>[&gt; </code>
+     <a href="#type-private_extenion" class="anchor"></a><code><span class="keyword">and</span> private_extenion</code> = <span class="keyword">private</span> <code>[&gt; </code>
      <table class="variant">
       <tbody>
        <tr id="type-private_extenion.polymorphic_variant" class="anchored">
         <td class="def type">
-         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span class="keyword">| </span></code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
         </td>
        </tr>
       </tbody>
@@ -304,99 +304,99 @@
      <code> ]</code>
     </dt>
     <dt class="spec type" id="type-object_">
-     <a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>&lt; a : int; b : int; c : int; &gt;</code>
+     <a href="#type-object_" class="anchor"></a><code><span class="keyword">type</span> object_</code><code> = &lt; a : int; b : int; c : int; &gt;</code>
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-X">
-    <a href="#module-type-X" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-X/index.html">X</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-type-X" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-X/index.html">X</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <dl>
     <dt class="spec type" id="type-module_">
-     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type </span>module_</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a>)</code>
+     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type</span> module_</code><code> = (<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</code>
     </dt>
     <dt class="spec type" id="type-module_substitution">
-     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type </span>module_substitution</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type </span><a href="module-type-X/index.html#type-t">t</a> <span class="keyword">=</span> int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-X/index.html#type-u">u</a> <span class="keyword">=</span> unit)</code>
+     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution</code><code> = (<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</code>
     </dt>
     <dt class="spec type" id="type-covariant">
-     <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type </span>+'a covariant</code>
+     <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type</span> +'a covariant</code>
     </dt>
     <dt class="spec type" id="type-contravariant">
-     <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type </span>-'a contravariant</code>
+     <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type</span> -'a contravariant</code>
     </dt>
     <dt class="spec type" id="type-bivariant">
-     <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type </span>_ bivariant</code><code><span class="keyword"> = </span>int</code>
+     <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type</span> _ bivariant</code><code> = int</code>
     </dt>
     <dt class="spec type" id="type-binary">
-     <a href="#type-binary" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) binary</code>
+     <a href="#type-binary" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) binary</code>
     </dt>
     <dt class="spec type" id="type-using_binary">
-     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type </span>using_binary</code><code><span class="keyword"> = </span>(int,&nbsp;int) <a href="index.html#type-binary">binary</a></code>
+     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary</code><code> = (int,&nbsp;int) <a href="index.html#type-binary">binary</a></code>
     </dt>
     <dt class="spec type" id="type-name">
-     <a href="#type-name" class="anchor"></a><code><span class="keyword">type </span>'custom name</code>
+     <a href="#type-name" class="anchor"></a><code><span class="keyword">type</span> 'custom name</code>
     </dt>
     <dt class="spec type" id="type-constrained">
-     <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type </span>'a constrained</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = int</code>
+     <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type</span> 'a constrained</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</code>
     </dt>
     <dt class="spec type" id="type-exact_variant">
-     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type </span>'a exact_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [ `A<span class="keyword"> | </span>`B of int ]</code>
+     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> 'a exact_variant</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [ `A | `B of int ]</code>
     </dt>
     <dt class="spec type" id="type-lower_variant">
-     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type </span>'a lower_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt; `A<span class="keyword"> | </span>`B of int ]</code>
+     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> 'a lower_variant</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt; `A | `B of int ]</code>
     </dt>
     <dt class="spec type" id="type-any_variant">
-     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type </span>'a any_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt;  ]</code>
+     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> 'a any_variant</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt;  ]</code>
     </dt>
     <dt class="spec type" id="type-upper_variant">
-     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type </span>'a upper_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; `A<span class="keyword"> | </span>`B of int ]</code>
+     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> 'a upper_variant</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; `A | `B of int ]</code>
     </dt>
     <dt class="spec type" id="type-named_variant">
-     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type </span>'a named_variant</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code>
+     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> 'a named_variant</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code>
     </dt>
     <dt class="spec type" id="type-exact_object">
-     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type </span>'a exact_object</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = &lt; a : int; b : int; &gt;</code>
+     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type</span> 'a exact_object</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; &gt;</code>
     </dt>
     <dt class="spec type" id="type-lower_object">
-     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type </span>'a lower_object</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = &lt; a : int; b : int; .. &gt;</code>
+     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type</span> 'a lower_object</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; .. &gt;</code>
     </dt>
     <dt class="spec type" id="type-poly_object">
-     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type </span>'a poly_object</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = &lt; a : a. <span class="type-var">'a</span>; &gt;</code>
+     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> 'a poly_object</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : a. <span class="type-var">'a</span>; &gt;</code>
     </dt>
     <dt class="spec type" id="type-double_constrained">
-     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) double_constrained</code><code><span class="keyword"> = </span><span class="type-var">'a</span><span class="keyword"> * </span><span class="type-var">'b</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = int<span class="keyword"> and </span><span class="type-var">'b</span> = unit</code>
+     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) double_constrained</code><code> = <span class="type-var">'a</span> * <span class="type-var">'b</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">and</span> <span class="type-var">'b</span> = unit</code>
     </dt>
     <dt class="spec type" id="type-as_">
-     <a href="#type-as_" class="anchor"></a><code><span class="keyword">type </span>as_</code><code><span class="keyword"> = </span>int<span class="keyword"> as </span>a<span class="keyword"> * </span><span class="type-var">'a</span></code>
+     <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_</code><code> = int <span class="keyword">as</span> a * <span class="type-var">'a</span></code>
     </dt>
     <dt class="spec type" id="type-extensible">
-     <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type </span>extensible</code><code><span class="keyword"> = </span></code><code><span class="keyword">..</span></code>
+     <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type</span> extensible</code><code> = </code><code>..</code>
     </dt>
    </dl>
    <dl>
     <dt>
-     <code><span class="keyword">type </span><a href="index.html#type-extensible">extensible</a><span class="keyword"> += </span></code><code><span class="extension">Extension</span></code><code><span class="keyword"> | </span></code><code><span class="extension">Another_extension</span></code>
+     <code><span class="keyword">type</span> <a href="index.html#type-extensible">extensible</a> += </code><code><span class="extension">Extension</span></code><code> | </code><code><span class="extension">Another_extension</span></code>
     </dt>
    </dl>
    <dl>
     <dt class="spec type" id="type-mutually">
-     <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type </span>mutually</code><code><span class="keyword"> = </span></code>
+     <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type</span> mutually</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-mutually.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-mutually.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span><span class="keyword"> of </span><a href="index.html#type-recursive">recursive</a></code>
+         <a href="#type-mutually.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> <span class="keyword">of</span> <a href="index.html#type-recursive">recursive</a></code>
         </td>
        </tr>
       </tbody>
      </table>
     </dt>
     <dt class="spec type" id="type-recursive">
-     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">and </span>recursive</code><code><span class="keyword"> = </span></code>
+     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">and</span> recursive</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-recursive.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-recursive.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span><span class="keyword"> of </span><a href="index.html#type-mutually">mutually</a></code>
+         <a href="#type-recursive.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span> <span class="keyword">of</span> <a href="index.html#type-mutually">mutually</a></code>
         </td>
        </tr>
       </tbody>
@@ -405,7 +405,7 @@
    </dl>
    <dl>
     <dt class="spec exception" id="exception-Foo">
-     <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception </span></code><code><span class="exception">Foo</span><span class="keyword"> of </span>int<span class="keyword"> * </span>int</code>
+     <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception</span> </code><code><span class="exception">Foo</span> <span class="keyword">of</span> int * int</code>
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -244,7 +244,7 @@
        </tr>
        <tr id="type-polymorphic_variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C</code>
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C<span class="keyword"> of </span>int<span class="keyword"> * </span>unit</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.D" class="anchored">
@@ -287,6 +287,22 @@
      </table>
      <code> ]</code>
     </dt>
+    <dt class="spec type" id="type-private_extenion#row">
+     <a href="#type-private_extenion#row" class="anchor"></a><code><span class="keyword">type </span>private_extenion#row</code>
+    </dt>
+    <dt class="spec type" id="type-private_extenion">
+     <a href="#type-private_extenion" class="anchor"></a><code><span class="keyword">and </span>private_extenion</code><span class="keyword"> = </span><span class="keyword">private </span><code>[&gt; </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-private_extenion.polymorphic_variant" class="anchored">
+        <td class="def type">
+         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span class="keyword">| </span></code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code> ]</code>
+    </dt>
     <dt class="spec type" id="type-object_">
      <a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>&lt; a : int; b : int; c : int; &gt;</code>
     </dt>
@@ -299,7 +315,7 @@
      <a href="#type-module_" class="anchor"></a><code><span class="keyword">type </span>module_</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a>)</code>
     </dt>
     <dt class="spec type" id="type-module_substitution">
-     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type </span>module_substitution</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type </span><a href="module-type-X/index.html#type-t">t</a> <span class="keyword">=</span> int)</code>
+     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type </span>module_substitution</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type </span><a href="module-type-X/index.html#type-t">t</a> <span class="keyword">=</span> int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-X/index.html#type-u">u</a> <span class="keyword">=</span> unit)</code>
     </dt>
     <dt class="spec type" id="type-covariant">
      <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type </span>+'a covariant</code>
@@ -346,6 +362,9 @@
     <dt class="spec type" id="type-poly_object">
      <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type </span>'a poly_object</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = &lt; a : a. <span class="type-var">'a</span>; &gt;</code>
     </dt>
+    <dt class="spec type" id="type-double_constrained">
+     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type </span>('a, 'b) double_constrained</code><code><span class="keyword"> = </span><span class="type-var">'a</span><span class="keyword"> * </span><span class="type-var">'b</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = int<span class="keyword"> and </span><span class="type-var">'b</span> = unit</code>
+    </dt>
     <dt class="spec type" id="type-as_">
      <a href="#type-as_" class="anchor"></a><code><span class="keyword">type </span>as_</code><code><span class="keyword"> = </span>int<span class="keyword"> as </span>a<span class="keyword"> * </span><span class="type-var">'a</span></code>
     </dt>
@@ -355,7 +374,7 @@
    </dl>
    <dl>
     <dt>
-     <code><span class="keyword">type </span><a href="index.html#type-extensible">extensible</a><span class="keyword"> += </span></code><code><span class="extension">Extension</span></code>
+     <code><span class="keyword">type </span><a href="index.html#type-extensible">extensible</a><span class="keyword"> += </span></code><code><span class="extension">Extension</span></code><code><span class="keyword"> | </span></code><code><span class="extension">Another_extension</span></code>
     </dt>
    </dl>
    <dl>

--- a/test/html/expect/test_package+ml/Val/index.html
+++ b/test/html/expect/test_package+ml/Val/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-documented">
-     <a href="#val-documented" class="anchor"></a><code><span class="keyword">val </span>documented : unit</code>
+     <a href="#val-documented" class="anchor"></a><code><span class="keyword">val</span> documented : unit</code>
     </dt>
     <dd>
      <p>
@@ -33,10 +33,10 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-undocumented">
-     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val </span>undocumented : unit</code>
+     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val</span> undocumented : unit</code>
     </dt>
     <dt class="spec value" id="val-documented_above">
-     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">val </span>documented_above : unit</code>
+     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">val</span> documented_above : unit</code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+re/Alias/X/index.html
+++ b/test/html/expect/test_package+re/Alias/X/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec type" id="type-t">
-     <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><code><span class="keyword"> = </span>int</code><span class="keyword">;</span>
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code><code> = int</code>;
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+re/Alias/index.html
+++ b/test/html/expect/test_package+re/Alias/index.html
@@ -22,10 +22,10 @@
     </h1>
    </header>
    <div class="spec module" id="module-Foo__X">
-    <a href="#module-Foo__X" class="anchor"></a><code><span class="keyword">module </span><a href="Foo__X/index.html">Foo__X</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-Foo__X" class="anchor"></a><code><span class="keyword">module</span> <a href="Foo__X/index.html">Foo__X</a>: { ... };</code>
    </div>
    <div class="spec module" id="module-X">
-    <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a>: { ... };</code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Bugs/index.html
+++ b/test/html/expect/test_package+re/Bugs/index.html
@@ -23,12 +23,12 @@
    </header>
    <dl>
     <dt class="spec type" id="type-opt">
-     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type </span>opt('a)</code><code><span class="keyword"> = </span>option(<span class="type-var">'a</span>)</code><span class="keyword">;</span>
+     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> opt('a)</code><code> = option(<span class="type-var">'a</span>)</code>;
     </dt>
    </dl>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: ?⁠bar:<span class="type-var">'a</span> <span>=&gt;</span> unit <span>=&gt;</span> unit<span class="keyword">;</span></code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: ?⁠bar:<span class="type-var">'a</span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
     </dt>
     <dd>
      <p>
@@ -38,12 +38,12 @@
    </dl>
    <dl>
     <dt class="spec type" id="type-opt'">
-     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type </span>opt'('a)</code><code><span class="keyword"> = </span>option(int)</code><span class="keyword">;</span>
+     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> opt'('a)</code><code> = option(int)</code>;
     </dt>
    </dl>
    <dl>
     <dt class="spec value" id="val-foo'">
-     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">let </span>foo': ?⁠bar:<span class="type-var">'a</span> <span>=&gt;</span> unit <span>=&gt;</span> unit<span class="keyword">;</span></code>
+     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">let</span> foo': ?⁠bar:<span class="type-var">'a</span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -22,25 +22,25 @@
     </h1>
    </header>
    <div class="spec class-type" id="class-type-empty">
-    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class type </span><a href="class-type-empty/index.html">empty</a> = <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <a href="class-type-empty/index.html">empty</a> = { ... }</code>
    </div>
    <div class="spec class-type" id="class-type-mutually">
-    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class type </span><a href="class-type-mutually/index.html">mutually</a> = <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <a href="class-type-mutually/index.html">mutually</a> = { ... }</code>
    </div>
    <div class="spec class-type" id="class-type-recursive">
-    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and </span><a href="class-type-recursive/index.html">recursive</a> = <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span> <a href="class-type-recursive/index.html">recursive</a> = { ... }</code>
    </div>
    <div class="spec class" id="class-mutually'">
-    <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class </span><a href="class-mutually'/index.html">mutually'</a>: <a href="class-type-mutually/index.html">mutually</a></code>
+    <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class</span> <a href="class-mutually'/index.html">mutually'</a>: <a href="class-type-mutually/index.html">mutually</a></code>
    </div>
    <div class="spec class" id="class-recursive'">
-    <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and </span><a href="class-recursive'/index.html">recursive'</a>: <a href="class-type-recursive/index.html">recursive</a></code>
+    <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and</span> <a href="class-recursive'/index.html">recursive'</a>: <a href="class-type-recursive/index.html">recursive</a></code>
    </div>
    <div class="spec class-type" id="class-type-empty_virtual">
-    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class type </span><span class="keyword">virtual </span><a href="class-type-empty_virtual/index.html">empty_virtual</a> = <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span> <a href="class-type-empty_virtual/index.html">empty_virtual</a> = { ... }</code>
    </div>
    <div class="spec class" id="class-empty_virtual'">
-    <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-empty_virtual'/index.html">empty_virtual'</a>: <a href="class-type-empty/index.html">empty</a></code>
+    <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-empty_virtual'/index.html">empty_virtual'</a>: <a href="class-type-empty/index.html">empty</a></code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -36,6 +36,12 @@
    <div class="spec class" id="class-recursive'">
     <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and </span><a href="class-recursive'/index.html">recursive'</a>: <a href="class-type-recursive/index.html">recursive</a></code>
    </div>
+   <div class="spec class-type" id="class-type-empty_virtual">
+    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class type </span><span class="keyword">virtual </span><a href="class-type-empty_virtual/index.html">empty_virtual</a> = <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+   </div>
+   <div class="spec class" id="class-empty_virtual'">
+    <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-empty_virtual'/index.html">empty_virtual'</a>: <a href="class-type-empty/index.html">empty</a></code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/External/index.html
+++ b/test/html/expect/test_package+re/External/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec external" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: unit <span>=&gt;</span> unit<span class="keyword">;</span></code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit <span>=&gt;</span> unit;</code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+re/Functor/index.html
+++ b/test/html/expect/test_package+re/Functor/index.html
@@ -22,22 +22,22 @@
     </h1>
    </header>
    <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a>:  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a>:  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a>;</code>
    </div>
    <div class="spec module" id="module-F1">
-    <a href="#module-F1" class="anchor"></a><code><span class="keyword">module </span><a href="F1/index.html">F1</a>:  (<a href="F1/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+    <a href="#module-F1" class="anchor"></a><code><span class="keyword">module</span> <a href="F1/index.html">F1</a>:  (<a href="F1/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a>;</code>
    </div>
    <div class="spec module" id="module-F2">
-    <a href="#module-F2" class="anchor"></a><code><span class="keyword">module </span><a href="F2/index.html">F2</a>:  (<a href="F2/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="F2/index.html#type-t">t</a><span class="keyword"> = </span><a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a><span class="keyword">;</span></code>
+    <a href="#module-F2" class="anchor"></a><code><span class="keyword">module</span> <a href="F2/index.html">F2</a>:  (<a href="F2/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="F2/index.html#type-t">t</a> = <a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a>;</code>
    </div>
    <div class="spec module" id="module-F3">
-    <a href="#module-F3" class="anchor"></a><code><span class="keyword">module </span><a href="F3/index.html">F3</a>:  (<a href="F3/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-F3" class="anchor"></a><code><span class="keyword">module</span> <a href="F3/index.html">F3</a>:  (<a href="F3/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> { ... };</code>
    </div>
    <div class="spec module" id="module-F4">
-    <a href="#module-F4" class="anchor"></a><code><span class="keyword">module </span><a href="F4/index.html">F4</a>:  (<a href="F4/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+    <a href="#module-F4" class="anchor"></a><code><span class="keyword">module</span> <a href="F4/index.html">F4</a>:  (<a href="F4/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a>;</code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Include/index.html
+++ b/test/html/expect/test_package+re/Include/index.html
@@ -22,18 +22,18 @@
     </h1>
    </header>
    <div class="spec module-type" id="module-type-Not_inlined">
-    <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a> = { ... };</code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined">Not_inlined</a><span class="keyword">;</span></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Not_inlined">Not_inlined</a><span class="keyword">;</span></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span>
+         <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>;
         </dt>
        </dl>
       </details>
@@ -41,32 +41,32 @@
     </div>
    </div>
    <div class="spec module-type" id="module-type-Inlined">
-    <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Inlined/index.html">Inlined</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-type-Inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Inlined/index.html">Inlined</a> = { ... };</code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <dl>
        <dt class="spec type" id="type-u">
-        <a href="#type-u" class="anchor"></a><code><span class="keyword">type </span>u</code><span class="keyword">;</span>
+        <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code>;
        </dt>
       </dl>
      </div>
     </div>
    </div>
    <div class="spec module-type" id="module-type-Not_inlined_and_closed">
-    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a> = { ... };</code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <details>
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a><span class="keyword">;</span></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Not_inlined_and_closed">Not_inlined_and_closed</a><span class="keyword">;</span></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-v">
-         <a href="#type-v" class="anchor"></a><code><span class="keyword">type </span>v</code><span class="keyword">;</span>
+         <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v</code>;
         </dt>
        </dl>
       </details>
@@ -74,18 +74,18 @@
     </div>
    </div>
    <div class="spec module-type" id="module-type-Not_inlined_and_opened">
-    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a> = { ... };</code>
    </div>
    <div>
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a><span class="keyword">;</span></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Not_inlined_and_opened">Not_inlined_and_opened</a><span class="keyword">;</span></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-w">
-         <a href="#type-w" class="anchor"></a><code><span class="keyword">type </span>w</code><span class="keyword">;</span>
+         <a href="#type-w" class="anchor"></a><code><span class="keyword">type</span> w</code>;
         </dt>
        </dl>
       </details>

--- a/test/html/expect/test_package+re/Include2/index.html
+++ b/test/html/expect/test_package+re/Include2/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec module" id="module-X">
-     <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+     <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a>: { ... };</code>
     </dt>
     <dd>
      <p>
@@ -36,11 +36,11 @@
      <div class="doc">
       <details open="open">
        <summary>
-        <span class="def"><code><span class="keyword">include </span><a href="index.html#module-X">X</a><span class="keyword">;</span></code></span>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-X">X</a><span class="keyword">;</span></code></span>
        </summary>
        <dl>
         <dt class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><code><span class="keyword"> = </span>int</code><span class="keyword">;</span>
+         <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code><code> = int</code>;
         </dt>
        </dl>
       </details>

--- a/test/html/expect/test_package+re/Interlude/index.html
+++ b/test/html/expect/test_package+re/Interlude/index.html
@@ -31,7 +31,7 @@
    </aside>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: unit<span class="keyword">;</span></code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
     </dt>
     <dd>
      <p>
@@ -54,7 +54,7 @@
    </aside>
    <dl>
     <dt class="spec value" id="val-bar">
-     <a href="#val-bar" class="anchor"></a><code><span class="keyword">let </span>bar: unit<span class="keyword">;</span></code>
+     <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
     </dt>
     <dd>
      <p>
@@ -64,13 +64,13 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-multiple">
-     <a href="#val-multiple" class="anchor"></a><code><span class="keyword">let </span>multiple: unit<span class="keyword">;</span></code>
+     <a href="#val-multiple" class="anchor"></a><code><span class="keyword">let</span> multiple: unit;</code>
     </dt>
     <dt class="spec value" id="val-signature">
-     <a href="#val-signature" class="anchor"></a><code><span class="keyword">let </span>signature: unit<span class="keyword">;</span></code>
+     <a href="#val-signature" class="anchor"></a><code><span class="keyword">let</span> signature: unit;</code>
     </dt>
     <dt class="spec value" id="val-items">
-     <a href="#val-items" class="anchor"></a><code><span class="keyword">let </span>items: unit<span class="keyword">;</span></code>
+     <a href="#val-items" class="anchor"></a><code><span class="keyword">let</span> items: unit;</code>
     </dt>
    </dl>
    <aside>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -440,7 +440,7 @@ let bar =
     </header>
     <dl>
      <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: unit<span class="keyword">;</span></code>
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -26,7 +26,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: unit<span class="keyword">;</span></code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
     </dt>
     <dd>
      <p>
@@ -35,48 +35,48 @@
     </dd>
    </dl>
    <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a><span class="keyword">;</span></code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a>;</code>
    </div>
    <div class="spec module-type" id="module-type-S2">
-    <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+    <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a>;</code>
    </div>
    <div class="spec module-type" id="module-type-S3">
-    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S3/index.html">S3</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-t">t</a><span class="keyword"> = </span>int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-S3/index.html#type-u">u</a><span class="keyword"> = </span>string<span class="keyword">;</span></code>
+    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S3/index.html">S3</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-u">u</a> = string;</code>
    </div>
    <div class="spec module-type" id="module-type-S4">
-    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S4/index.html">S4</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S4/index.html#type-t">t</a> := int<span class="keyword">;</span></code>
+    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int;</code>
    </div>
    <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S5/index.html">S5</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S5/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>)<span class="keyword">;</span></code>
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S5/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>);</code>
    </div>
    <dl>
     <dt class="spec type" id="type-result">
-     <a href="#type-result" class="anchor"></a><code><span class="keyword">type </span>result('a, 'b)</code><span class="keyword">;</span>
+     <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> result('a, 'b)</code>;
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S6/index.html">S6</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">type </span><a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)<span class="keyword">;</span></code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>);</code>
    </div>
    <div class="spec module" id="module-M'">
-    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module </span><a href="M'/index.html">M'</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a>: { ... };</code>
    </div>
    <div class="spec module-type" id="module-type-S7">
-    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S7/index.html">S7</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
+    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S7/index.html">S7</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a>;</code>
    </div>
    <div class="spec module-type" id="module-type-S8">
-    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S8/index.html">S8</a>: <a href="index.html#module-type-S">S</a><span class="keyword"> with </span><span class="keyword">module </span><a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
+    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S8/index.html">S8</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a>;</code>
    </div>
    <div class="spec module-type" id="module-type-S9">
-    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S9/index.html">S9</a>: <span class="keyword">module type of </span><a href="index.html#module-M'">M'</a><span class="keyword">;</span></code>
+    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S9/index.html">S9</a>: <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="index.html#module-M'">M'</a>;</code>
    </div>
    <div class="spec module" id="module-Mutually">
-    <a href="#module-Mutually" class="anchor"></a><code><span class="keyword">module rec </span><a href="Mutually/index.html">Mutually</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-Mutually" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">rec</span> <a href="Mutually/index.html">Mutually</a>: { ... };</code>
    </div>
    <div class="spec module" id="module-Recursive">
-    <a href="#module-Recursive" class="anchor"></a><code><span class="keyword">and </span><a href="Recursive/index.html">Recursive</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-Recursive" class="anchor"></a><code><span class="keyword">and</span> <a href="Recursive/index.html">Recursive</a>: { ... };</code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
@@ -39,7 +39,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span>
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>;
      </dt>
      <dd>
       <p>
@@ -56,7 +56,7 @@
     </header>
     <dl>
      <dt class="spec value" id="val-y">
-      <a href="#val-y" class="anchor"></a><code><span class="keyword">let </span>y: <a href="index.html#type-t">t</a><span class="keyword">;</span></code>
+      <a href="#val-y" class="anchor"></a><code><span class="keyword">let</span> y: <a href="index.html#type-t">t</a>;</code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
@@ -36,7 +36,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span>
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>;
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -42,7 +42,7 @@
      <code><a href="argument-1-Arg1/index.html">Arg1</a>: <a href="../index.html#module-type-Y">Y</a></code>
     </li>
     <li>
-     <code><a href="argument-2-Arg2/index.html">Arg2</a>: <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+     <code><a href="argument-2-Arg2/index.html">Arg2</a>: { ... }</code>
     </li>
    </ul>
    <h3 class="heading">
@@ -56,7 +56,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><code><span class="keyword"> = </span>(<a href="argument-1-Arg1/index.html#type-t">Arg1.t</a><span class="keyword">, </span><a href="argument-2-Arg2/index.html#type-t">Arg2.t</a>)</code><span class="keyword">;</span>
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code><code> = (<a href="argument-1-Arg1/index.html#type-t">Arg1.t</a>, <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a>)</code>;
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -45,7 +45,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span>
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>;
      </dt>
      <dd>
       <p>
@@ -62,7 +62,7 @@
     </header>
     <dl>
      <dt class="spec value" id="val-x">
-      <a href="#val-x" class="anchor"></a><code><span class="keyword">let </span>x: <a href="index.html#type-t">t</a><span class="keyword">;</span></code>
+      <a href="#val-x" class="anchor"></a><code><span class="keyword">let</span> x: <a href="index.html#type-t">t</a>;</code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+re/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+re/Nested/class-inherits/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt>
-     <span class="keyword">inherit </span><a href="../class-z/index.html">z</a>
+     <code><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></code>
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+re/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+re/Nested/class-inherits/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   inherits (test_package+re.Nested.inherits)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » inherits
+    </nav>
+    <h1>
+     Class <code>Nested.inherits</code>
+    </h1>
+   </header>
+   <dl>
+    <dt>
+     <span class="keyword">inherit </span><a href="../class-z/index.html">z</a>
+    </dt>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Nested/class-z/index.html
+++ b/test/html/expect/test_package+re/Nested/class-z/index.html
@@ -36,7 +36,7 @@
    </header>
    <dl>
     <dt class="spec instance-variable" id="val-y">
-     <a href="#val-y" class="anchor"></a><code><span class="keyword">val </span>y: int</code>
+     <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y: int</code>
     </dt>
     <dd>
      <p>
@@ -46,7 +46,7 @@
    </dl>
    <dl>
     <dt class="spec instance-variable" id="val-y'">
-     <a href="#val-y'" class="anchor"></a><code><span class="keyword">val </span><span class="keyword">mutable </span><span class="keyword">virtual </span>y': int</code>
+     <a href="#val-y'" class="anchor"></a><code><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y': int</code>
     </dt>
    </dl>
    <section>
@@ -57,7 +57,7 @@
     </header>
     <dl>
      <dt class="spec method" id="method-z">
-      <a href="#method-z" class="anchor"></a><code><span class="keyword">method </span>z: int</code>
+      <a href="#method-z" class="anchor"></a><code><span class="keyword">method</span> z: int</code>
      </dt>
      <dd>
       <p>
@@ -67,7 +67,7 @@
     </dl>
     <dl>
      <dt class="spec method" id="method-z'">
-      <a href="#method-z'" class="anchor"></a><code><span class="keyword">method </span><span class="keyword">private </span><span class="keyword">virtual </span>z': int</code>
+      <a href="#method-z'" class="anchor"></a><code><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z': int</code>
      </dt>
     </dl>
    </section>

--- a/test/html/expect/test_package+re/Nested/class-z/index.html
+++ b/test/html/expect/test_package+re/Nested/class-z/index.html
@@ -34,6 +34,21 @@
      </ul>
     </nav>
    </header>
+   <dl>
+    <dt class="spec instance-variable" id="val-y">
+     <a href="#val-y" class="anchor"></a><code><span class="keyword">val </span>y: int</code>
+    </dt>
+    <dd>
+     <p>
+      Some value.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec instance-variable" id="val-y'">
+     <a href="#val-y'" class="anchor"></a><code><span class="keyword">val </span><span class="keyword">mutable </span><span class="keyword">virtual </span>y': int</code>
+    </dt>
+   </dl>
    <section>
     <header>
      <h2 id="methods">
@@ -49,6 +64,11 @@
        Some method.
       </p>
      </dd>
+    </dl>
+    <dl>
+     <dt class="spec method" id="method-z'">
+      <a href="#method-z'" class="anchor"></a><code><span class="keyword">method </span><span class="keyword">private </span><span class="keyword">virtual </span>z': int</code>
+     </dt>
     </dl>
    </section>
   </div>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -48,7 +48,7 @@
     </header>
     <dl>
      <dt class="spec module" id="module-X">
-      <a href="#module-X" class="anchor"></a><code><span class="keyword">module </span><a href="X/index.html">X</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a>: { ... };</code>
      </dt>
      <dd>
       <p>
@@ -65,7 +65,7 @@
     </header>
     <dl>
      <dt class="spec module-type" id="module-type-Y">
-      <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-Y/index.html">Y</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+      <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Y/index.html">Y</a> = { ... };</code>
      </dt>
      <dd>
       <p>
@@ -82,7 +82,7 @@
     </header>
     <dl>
      <dt class="spec module" id="module-F">
-      <a href="#module-F" class="anchor"></a><code><span class="keyword">module </span><a href="F/index.html">F</a>:  (<a href="F/argument-1-Arg1/index.html">Arg1</a>: <a href="index.html#module-type-Y">Y</a>) <span>=&gt;</span>  (<a href="F/argument-2-Arg2/index.html">Arg2</a>: <span class="keyword">{</span> ... <span class="keyword">}</span>) <span>=&gt;</span> <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+      <a href="#module-F" class="anchor"></a><code><span class="keyword">module</span> <a href="F/index.html">F</a>:  (<a href="F/argument-1-Arg1/index.html">Arg1</a>: <a href="index.html#module-type-Y">Y</a>) <span>=&gt;</span>  (<a href="F/argument-2-Arg2/index.html">Arg2</a>: { ... }) <span>=&gt;</span> { ... };</code>
      </dt>
      <dd>
       <p>
@@ -99,7 +99,7 @@
     </header>
     <dl>
      <dt class="spec class" id="class-z">
-      <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-z/index.html">z</a>: <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+      <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-z/index.html">z</a>: { ... }</code>
      </dt>
      <dd>
       <p>
@@ -108,7 +108,7 @@
      </dd>
     </dl>
     <div class="spec class" id="class-inherits">
-     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-inherits/index.html">inherits</a>: <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-inherits/index.html">inherits</a>: { ... }</code>
     </div>
    </section>
   </div>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -99,7 +99,7 @@
     </header>
     <dl>
      <dt class="spec class" id="class-z">
-      <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><a href="class-z/index.html">z</a>: <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+      <a href="#class-z" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-z/index.html">z</a>: <span class="keyword">{</span> ... <span class="keyword">}</span></code>
      </dt>
      <dd>
       <p>
@@ -107,6 +107,9 @@
       </p>
      </dd>
     </dl>
+    <div class="spec class" id="class-inherits">
+     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class </span><span class="keyword">virtual </span><a href="class-inherits/index.html">inherits</a>: <span class="keyword">{</span> ... <span class="keyword">}</span></code>
+    </div>
    </section>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -45,7 +45,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type </span>t</code><span class="keyword">;</span>
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>;
      </dt>
      <dd>
       <p>
@@ -62,7 +62,7 @@
     </header>
     <dl>
      <dt class="spec value" id="val-y">
-      <a href="#val-y" class="anchor"></a><code><span class="keyword">let </span>y: <a href="index.html#type-t">t</a><span class="keyword">;</span></code>
+      <a href="#val-y" class="anchor"></a><code><span class="keyword">let</span> y: <a href="index.html#type-t">t</a>;</code>
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -157,6 +157,9 @@
      </table>
      <code> ]</code><span class="keyword">;</span>
     </dt>
+    <dt class="spec type" id="type-nonrec_">
+     <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type nonrec </span>nonrec_</code><code><span class="keyword"> = </span>int</code><span class="keyword">;</span>
+    </dt>
    </dl>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -22,29 +22,29 @@
     </h1>
    </header>
    <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S/index.html">S</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-S1/index.html">S1</a>:  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a><span class="keyword">;</span></code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a>:  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a>;</code>
    </div>
    <dl>
     <dt class="spec type" id="type-variant">
-     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type </span>variant</code><code><span class="keyword"> = </span></code>
+     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code>
+         <a href="#type-variant.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span></code>
         </td>
        </tr>
        <tr id="type-variant.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span>(int)</code>
+         <a href="#type-variant.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span>(int)</code>
         </td>
        </tr>
        <tr id="type-variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span></code>
+         <a href="#type-variant.C" class="anchor"></a><code>| </code><code><span class="constructor">C</span></code>
         </td>
         <td class="doc">
          <p>
@@ -54,7 +54,7 @@
        </tr>
        <tr id="type-variant.D" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">D</span></code>
+         <a href="#type-variant.D" class="anchor"></a><code>| </code><code><span class="constructor">D</span></code>
         </td>
         <td class="doc">
          <p>
@@ -64,7 +64,7 @@
        </tr>
        <tr id="type-variant.E" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.E" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">E</span><span class="keyword"> of </span></code><code>{</code>
+         <a href="#type-variant.E" class="anchor"></a><code>| </code><code><span class="constructor">E</span> <span class="keyword">of</span> </code><code>{</code>
          <table class="record">
           <tbody>
            <tr id="type-variant.a" class="anchored">
@@ -79,20 +79,20 @@
        </tr>
       </tbody>
      </table>
-     <span class="keyword">;</span>
+     ;
     </dt>
     <dt class="spec type" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type </span>gadt(_)</code><code><span class="keyword"> = </span></code>
+     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> gadt(_)</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-gadt.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> <a href="index.html#type-gadt">gadt</a>(int)</code>
+         <a href="#type-gadt.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> : <a href="index.html#type-gadt">gadt</a>(int)</code>
         </td>
        </tr>
        <tr id="type-gadt.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span>(int) : <a href="index.html#type-gadt">gadt</a>(string)</code>
+         <a href="#type-gadt.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span>(int) : <a href="index.html#type-gadt">gadt</a>(string)</code>
         </td>
         <td class="doc">
          <p>
@@ -102,7 +102,7 @@
        </tr>
        <tr id="type-gadt.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span><span class="keyword">: </span></code><code>{</code>
+         <a href="#type-gadt.C" class="anchor"></a><code>| </code><code><span class="constructor">C</span>: </code><code>{</code>
          <table class="record">
           <tbody>
            <tr id="type-gadt.a" class="anchored">
@@ -117,25 +117,25 @@
        </tr>
       </tbody>
      </table>
-     <span class="keyword">;</span>
+     ;
     </dt>
     <dt class="spec type" id="type-polymorphic_variant">
-     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant</code><span class="keyword"> = </span><code>[ </code>
+     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant</code> = <code>[ </code>
      <table class="variant">
       <tbody>
        <tr id="type-polymorphic_variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A</code>
+         <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code>`B(int)</code>
+         <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B(int)</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C</code>
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C</code>
         </td>
         <td class="doc">
          <p>
@@ -145,7 +145,7 @@
        </tr>
        <tr id="type-polymorphic_variant.D" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code>`D</code>
+         <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
         </td>
         <td class="doc">
          <p>
@@ -155,10 +155,10 @@
        </tr>
       </tbody>
      </table>
-     <code> ]</code><span class="keyword">;</span>
+     <code> ]</code>;
     </dt>
     <dt class="spec type" id="type-nonrec_">
-     <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type nonrec </span>nonrec_</code><code><span class="keyword"> = </span>int</code><span class="keyword">;</span>
+     <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_</code><code> = int</code>;
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+re/Section/index.html
+++ b/test/html/expect/test_package+re/Section/index.html
@@ -91,7 +91,7 @@
     </header>
     <dl>
      <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: unit<span class="keyword">;</span></code>
+      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
      </dt>
     </dl>
    </section>

--- a/test/html/expect/test_package+re/Stop/index.html
+++ b/test/html/expect/test_package+re/Stop/index.html
@@ -26,7 +26,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let </span>foo: int<span class="keyword">;</span></code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: int;</code>
     </dt>
     <dd>
      <p>
@@ -48,11 +48,11 @@
     </p>
    </aside>
    <div class="spec module" id="module-N">
-    <a href="#module-N" class="anchor"></a><code><span class="keyword">module </span><a href="N/index.html">N</a>: <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-N" class="anchor"></a><code><span class="keyword">module</span> <a href="N/index.html">N</a>: { ... };</code>
    </div>
    <dl>
     <dt class="spec value" id="val-lol">
-     <a href="#val-lol" class="anchor"></a><code><span class="keyword">let </span>lol: int<span class="keyword">;</span></code>
+     <a href="#val-lol" class="anchor"></a><code><span class="keyword">let</span> lol: int;</code>
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -248,7 +248,7 @@
        </tr>
        <tr id="type-polymorphic_variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C</code>
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C((int<span class="keyword">, </span>unit))</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.D" class="anchored">
@@ -291,6 +291,22 @@
      </table>
      <code> ]</code><span class="keyword">;</span>
     </dt>
+    <dt class="spec type" id="type-private_extenion#row">
+     <a href="#type-private_extenion#row" class="anchor"></a><code><span class="keyword">type </span>private_extenion#row</code><span class="keyword">;</span>
+    </dt>
+    <dt class="spec type" id="type-private_extenion">
+     <a href="#type-private_extenion" class="anchor"></a><code><span class="keyword">and </span>private_extenion</code><span class="keyword"> = </span><span class="keyword">pri </span><code>[&gt; </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-private_extenion.polymorphic_variant" class="anchored">
+        <td class="def type">
+         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span class="keyword">| </span></code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code> ]</code><span class="keyword">;</span>
+    </dt>
     <dt class="spec type" id="type-object_">
      <a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>{. a: int, b: int, c: int, }</code><span class="keyword">;</span>
     </dt>
@@ -303,7 +319,7 @@
      <a href="#type-module_" class="anchor"></a><code><span class="keyword">type </span>module_</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a>)</code><span class="keyword">;</span>
     </dt>
     <dt class="spec type" id="type-module_substitution">
-     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type </span>module_substitution</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type </span><a href="module-type-X/index.html#type-t">t</a> <span class="keyword">=</span> int)</code><span class="keyword">;</span>
+     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type </span>module_substitution</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type </span><a href="module-type-X/index.html#type-t">t</a> <span class="keyword">=</span> int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-X/index.html#type-u">u</a> <span class="keyword">=</span> unit)</code><span class="keyword">;</span>
     </dt>
     <dt class="spec type" id="type-covariant">
      <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type </span>covariant(+'a)</code><span class="keyword">;</span>
@@ -350,6 +366,9 @@
     <dt class="spec type" id="type-poly_object">
      <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type </span>poly_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a: a. <span class="type-var">'a</span>, }</code><span class="keyword">;</span>
     </dt>
+    <dt class="spec type" id="type-double_constrained">
+     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type </span>double_constrained('a, 'b)</code><code><span class="keyword"> = </span>(<span class="type-var">'a</span><span class="keyword">, </span><span class="type-var">'b</span>)</code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = int<span class="keyword"> and </span><span class="type-var">'b</span> = unit</code><span class="keyword">;</span>
+    </dt>
     <dt class="spec type" id="type-as_">
      <a href="#type-as_" class="anchor"></a><code><span class="keyword">type </span>as_</code><code><span class="keyword"> = </span>(int<span class="keyword"> as </span>a<span class="keyword">, </span><span class="type-var">'a</span>)</code><span class="keyword">;</span>
     </dt>
@@ -359,7 +378,7 @@
    </dl>
    <dl>
     <dt>
-     <code><span class="keyword">type </span><a href="index.html#type-extensible">extensible</a><span class="keyword"> += </span></code><code><span class="extension">Extension</span></code><span class="keyword">;</span>
+     <code><span class="keyword">type </span><a href="index.html#type-extensible">extensible</a><span class="keyword"> += </span></code><code><span class="extension">Extension</span></code><code><span class="keyword"> | </span></code><code><span class="extension">Another_extension</span></code><span class="keyword">;</span>
     </dt>
    </dl>
    <dl>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec type" id="type-abstract">
-     <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type </span>abstract</code><span class="keyword">;</span>
+     <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type</span> abstract</code>;
     </dt>
     <dd>
      <p>
@@ -33,46 +33,46 @@
    </dl>
    <dl>
     <dt class="spec type" id="type-alias">
-     <a href="#type-alias" class="anchor"></a><code><span class="keyword">type </span>alias</code><code><span class="keyword"> = </span>int</code><span class="keyword">;</span>
+     <a href="#type-alias" class="anchor"></a><code><span class="keyword">type</span> alias</code><code> = int</code>;
     </dt>
     <dt class="spec type" id="type-private_">
-     <a href="#type-private_" class="anchor"></a><code><span class="keyword">type </span>private_</code><code><span class="keyword"> = </span><span class="keyword">pri </span>int</code><span class="keyword">;</span>
+     <a href="#type-private_" class="anchor"></a><code><span class="keyword">type</span> private_</code><code> = <span class="keyword">pri</span> int</code>;
     </dt>
     <dt class="spec type" id="type-constructor">
-     <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type </span>constructor('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><span class="keyword">;</span>
+     <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type</span> constructor('a)</code><code> = <span class="type-var">'a</span></code>;
     </dt>
     <dt class="spec type" id="type-arrow">
-     <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type </span>arrow</code><code><span class="keyword"> = </span>int <span>=&gt;</span> int</code><span class="keyword">;</span>
+     <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type</span> arrow</code><code> = int <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-higher_order">
-     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type </span>higher_order</code><code><span class="keyword"> = </span>(int <span>=&gt;</span> int) <span>=&gt;</span> int</code><span class="keyword">;</span>
+     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order</code><code> = (int <span>=&gt;</span> int) <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-labeled">
-     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type </span>labeled</code><code><span class="keyword"> = </span>l:int <span>=&gt;</span> int</code><span class="keyword">;</span>
+     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled</code><code> = l:int <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-optional">
-     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type </span>optional</code><code><span class="keyword"> = </span>?⁠l:int <span>=&gt;</span> int</code><span class="keyword">;</span>
+     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional</code><code> = ?⁠l:int <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-labeled_higher_order">
-     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type </span>labeled_higher_order</code><code><span class="keyword"> = </span>(l:int <span>=&gt;</span> int) <span>=&gt;</span> (?⁠l:int <span>=&gt;</span> int) <span>=&gt;</span> int</code><span class="keyword">;</span>
+     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order</code><code> = (l:int <span>=&gt;</span> int) <span>=&gt;</span> (?⁠l:int <span>=&gt;</span> int) <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-pair">
-     <a href="#type-pair" class="anchor"></a><code><span class="keyword">type </span>pair</code><code><span class="keyword"> = </span>(int<span class="keyword">, </span>int)</code><span class="keyword">;</span>
+     <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair</code><code> = (int, int)</code>;
     </dt>
     <dt class="spec type" id="type-parens_dropped">
-     <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type </span>parens_dropped</code><code><span class="keyword"> = </span>(int<span class="keyword">, </span>int)</code><span class="keyword">;</span>
+     <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type</span> parens_dropped</code><code> = (int, int)</code>;
     </dt>
     <dt class="spec type" id="type-triple">
-     <a href="#type-triple" class="anchor"></a><code><span class="keyword">type </span>triple</code><code><span class="keyword"> = </span>(int<span class="keyword">, </span>int<span class="keyword">, </span>int)</code><span class="keyword">;</span>
+     <a href="#type-triple" class="anchor"></a><code><span class="keyword">type</span> triple</code><code> = (int, int, int)</code>;
     </dt>
     <dt class="spec type" id="type-nested_pair">
-     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type </span>nested_pair</code><code><span class="keyword"> = </span>((int<span class="keyword">, </span>int)<span class="keyword">, </span>int)</code><span class="keyword">;</span>
+     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair</code><code> = ((int, int), int)</code>;
     </dt>
     <dt class="spec type" id="type-instance">
-     <a href="#type-instance" class="anchor"></a><code><span class="keyword">type </span>instance</code><code><span class="keyword"> = </span><a href="index.html#type-constructor">constructor</a>(int)</code><span class="keyword">;</span>
+     <a href="#type-instance" class="anchor"></a><code><span class="keyword">type</span> instance</code><code> = <a href="index.html#type-constructor">constructor</a>(int)</code>;
     </dt>
     <dt class="spec type" id="type-variant_e">
-     <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type </span>variant_e</code><code><span class="keyword"> = </span></code><code>{</code>
+     <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type</span> variant_e</code><code> = </code><code>{</code>
      <table class="record">
       <tbody>
        <tr id="type-variant_e.a" class="anchored">
@@ -82,25 +82,25 @@
        </tr>
       </tbody>
      </table>
-     <code>}</code><span class="keyword">;</span>
+     <code>}</code>;
     </dt>
     <dt class="spec type" id="type-variant">
-     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type </span>variant</code><code><span class="keyword"> = </span></code>
+     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code>
+         <a href="#type-variant.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span></code>
         </td>
        </tr>
        <tr id="type-variant.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span>(int)</code>
+         <a href="#type-variant.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span>(int)</code>
         </td>
        </tr>
        <tr id="type-variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span></code>
+         <a href="#type-variant.C" class="anchor"></a><code>| </code><code><span class="constructor">C</span></code>
         </td>
         <td class="doc">
          <p>
@@ -110,7 +110,7 @@
        </tr>
        <tr id="type-variant.D" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">D</span></code>
+         <a href="#type-variant.D" class="anchor"></a><code>| </code><code><span class="constructor">D</span></code>
         </td>
         <td class="doc">
          <p>
@@ -120,15 +120,15 @@
        </tr>
        <tr id="type-variant.E" class="anchored">
         <td class="def constructor">
-         <a href="#type-variant.E" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">E</span>(<a href="index.html#type-variant_e">variant_e</a>)</code>
+         <a href="#type-variant.E" class="anchor"></a><code>| </code><code><span class="constructor">E</span>(<a href="index.html#type-variant_e">variant_e</a>)</code>
         </td>
        </tr>
       </tbody>
      </table>
-     <span class="keyword">;</span>
+     ;
     </dt>
     <dt class="spec type" id="type-variant_c">
-     <a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type </span>variant_c</code><code><span class="keyword"> = </span></code><code>{</code>
+     <a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type</span> variant_c</code><code> = </code><code>{</code>
      <table class="record">
       <tbody>
        <tr id="type-variant_c.a" class="anchored">
@@ -138,59 +138,59 @@
        </tr>
       </tbody>
      </table>
-     <code>}</code><span class="keyword">;</span>
+     <code>}</code>;
     </dt>
     <dt class="spec type" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type </span>gadt(_)</code><code><span class="keyword"> = </span></code>
+     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> gadt(_)</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-gadt.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> <a href="index.html#type-gadt">gadt</a>(int)</code>
+         <a href="#type-gadt.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> : <a href="index.html#type-gadt">gadt</a>(int)</code>
         </td>
        </tr>
        <tr id="type-gadt.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span>(int) : <a href="index.html#type-gadt">gadt</a>(string)</code>
+         <a href="#type-gadt.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span>(int) : <a href="index.html#type-gadt">gadt</a>(string)</code>
         </td>
        </tr>
        <tr id="type-gadt.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">C</span>(<a href="index.html#type-variant_c">variant_c</a>) : <a href="index.html#type-gadt">gadt</a>(unit)</code>
+         <a href="#type-gadt.C" class="anchor"></a><code>| </code><code><span class="constructor">C</span>(<a href="index.html#type-variant_c">variant_c</a>) : <a href="index.html#type-gadt">gadt</a>(unit)</code>
         </td>
        </tr>
       </tbody>
      </table>
-     <span class="keyword">;</span>
+     ;
     </dt>
     <dt class="spec type" id="type-degenerate_gadt">
-     <a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type </span>degenerate_gadt</code><code><span class="keyword"> = </span></code>
+     <a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type</span> degenerate_gadt</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-degenerate_gadt.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span> <span class="keyword">:</span> <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code>
+         <a href="#type-degenerate_gadt.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> : <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code>
         </td>
        </tr>
       </tbody>
      </table>
-     <span class="keyword">;</span>
+     ;
     </dt>
     <dt class="spec type" id="type-private_variant">
-     <a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type </span>private_variant</code><code><span class="keyword"> = </span><span class="keyword">pri </span></code>
+     <a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type</span> private_variant</code><code> = <span class="keyword">pri</span> </code>
      <table class="variant">
       <tbody>
        <tr id="type-private_variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-private_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span></code>
+         <a href="#type-private_variant.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span></code>
         </td>
        </tr>
       </tbody>
      </table>
-     <span class="keyword">;</span>
+     ;
     </dt>
     <dt class="spec type" id="type-record">
-     <a href="#type-record" class="anchor"></a><code><span class="keyword">type </span>record</code><code><span class="keyword"> = </span></code><code>{</code>
+     <a href="#type-record" class="anchor"></a><code><span class="keyword">type</span> record</code><code> = </code><code>{</code>
      <table class="record">
       <tbody>
        <tr id="type-record.a" class="anchored">
@@ -200,7 +200,7 @@
        </tr>
        <tr id="type-record.b" class="anchored">
         <td class="def field">
-         <a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable </span>b: int,</code>
+         <a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable</span> b: int,</code>
         </td>
        </tr>
        <tr id="type-record.c" class="anchored">
@@ -230,188 +230,188 @@
        </tr>
       </tbody>
      </table>
-     <code>}</code><span class="keyword">;</span>
+     <code>}</code>;
     </dt>
     <dt class="spec type" id="type-polymorphic_variant">
-     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant</code><span class="keyword"> = </span><code>[ </code>
+     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant</code> = <code>[ </code>
      <table class="variant">
       <tbody>
        <tr id="type-polymorphic_variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A</code>
+         <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span class="keyword">| </span></code><code>`B(int)</code>
+         <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B(int)</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span class="keyword">| </span></code><code>`C((int<span class="keyword">, </span>unit))</code>
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C((int, unit))</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.D" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span class="keyword">| </span></code><code>`D</code>
+         <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
         </td>
        </tr>
       </tbody>
      </table>
-     <code> ]</code><span class="keyword">;</span>
+     <code> ]</code>;
     </dt>
     <dt class="spec type" id="type-polymorphic_variant_extension">
-     <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type </span>polymorphic_variant_extension</code><span class="keyword"> = </span><code>[ </code>
+     <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant_extension</code> = <code>[ </code>
      <table class="variant">
       <tbody>
        <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
         <td class="def type">
-         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span class="keyword">| </span></code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant_extension.E" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span class="keyword">| </span></code><code>`E</code>
+         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code>| </code><code>`E</code>
         </td>
        </tr>
       </tbody>
      </table>
-     <code> ]</code><span class="keyword">;</span>
+     <code> ]</code>;
     </dt>
     <dt class="spec type" id="type-nested_polymorphic_variant">
-     <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type </span>nested_polymorphic_variant</code><span class="keyword"> = </span><code>[ </code>
+     <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> nested_polymorphic_variant</code> = <code>[ </code>
      <table class="variant">
       <tbody>
        <tr id="type-nested_polymorphic_variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span class="keyword">| </span></code><code>`A([ `B<span class="keyword"> | </span>`C ])</code>
+         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A([ `B | `C ])</code>
         </td>
        </tr>
       </tbody>
      </table>
-     <code> ]</code><span class="keyword">;</span>
+     <code> ]</code>;
     </dt>
     <dt class="spec type" id="type-private_extenion#row">
-     <a href="#type-private_extenion#row" class="anchor"></a><code><span class="keyword">type </span>private_extenion#row</code><span class="keyword">;</span>
+     <a href="#type-private_extenion#row" class="anchor"></a><code><span class="keyword">type</span> private_extenion#row</code>;
     </dt>
     <dt class="spec type" id="type-private_extenion">
-     <a href="#type-private_extenion" class="anchor"></a><code><span class="keyword">and </span>private_extenion</code><span class="keyword"> = </span><span class="keyword">pri </span><code>[&gt; </code>
+     <a href="#type-private_extenion" class="anchor"></a><code><span class="keyword">and</span> private_extenion</code> = <span class="keyword">pri</span> <code>[&gt; </code>
      <table class="variant">
       <tbody>
        <tr id="type-private_extenion.polymorphic_variant" class="anchored">
         <td class="def type">
-         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span class="keyword">| </span></code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
         </td>
        </tr>
       </tbody>
      </table>
-     <code> ]</code><span class="keyword">;</span>
+     <code> ]</code>;
     </dt>
     <dt class="spec type" id="type-object_">
-     <a href="#type-object_" class="anchor"></a><code><span class="keyword">type </span>object_</code><code><span class="keyword"> = </span>{. a: int, b: int, c: int, }</code><span class="keyword">;</span>
+     <a href="#type-object_" class="anchor"></a><code><span class="keyword">type</span> object_</code><code> = {. a: int, b: int, c: int, }</code>;
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-X">
-    <a href="#module-type-X" class="anchor"></a><code><span class="keyword">module type </span><a href="module-type-X/index.html">X</a> = <span class="keyword">{</span> ... <span class="keyword">}</span><span class="keyword">;</span></code>
+    <a href="#module-type-X" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-X/index.html">X</a> = { ... };</code>
    </div>
    <dl>
     <dt class="spec type" id="type-module_">
-     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type </span>module_</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a>)</code><span class="keyword">;</span>
+     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type</span> module_</code><code> = (<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</code>;
     </dt>
     <dt class="spec type" id="type-module_substitution">
-     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type </span>module_substitution</code><code><span class="keyword"> = </span>(<span class="keyword">module </span><a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type </span><a href="module-type-X/index.html#type-t">t</a> <span class="keyword">=</span> int<span class="keyword"> and </span><span class="keyword">type </span><a href="module-type-X/index.html#type-u">u</a> <span class="keyword">=</span> unit)</code><span class="keyword">;</span>
+     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution</code><code> = (<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</code>;
     </dt>
     <dt class="spec type" id="type-covariant">
-     <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type </span>covariant(+'a)</code><span class="keyword">;</span>
+     <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type</span> covariant(+'a)</code>;
     </dt>
     <dt class="spec type" id="type-contravariant">
-     <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type </span>contravariant(-'a)</code><span class="keyword">;</span>
+     <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type</span> contravariant(-'a)</code>;
     </dt>
     <dt class="spec type" id="type-bivariant">
-     <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type </span>bivariant(_)</code><code><span class="keyword"> = </span>int</code><span class="keyword">;</span>
+     <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type</span> bivariant(_)</code><code> = int</code>;
     </dt>
     <dt class="spec type" id="type-binary">
-     <a href="#type-binary" class="anchor"></a><code><span class="keyword">type </span>binary('a, 'b)</code><span class="keyword">;</span>
+     <a href="#type-binary" class="anchor"></a><code><span class="keyword">type</span> binary('a, 'b)</code>;
     </dt>
     <dt class="spec type" id="type-using_binary">
-     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type </span>using_binary</code><code><span class="keyword"> = </span><a href="index.html#type-binary">binary</a>(int,&nbsp;int)</code><span class="keyword">;</span>
+     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary</code><code> = <a href="index.html#type-binary">binary</a>(int,&nbsp;int)</code>;
     </dt>
     <dt class="spec type" id="type-name">
-     <a href="#type-name" class="anchor"></a><code><span class="keyword">type </span>name('custom)</code><span class="keyword">;</span>
+     <a href="#type-name" class="anchor"></a><code><span class="keyword">type</span> name('custom)</code>;
     </dt>
     <dt class="spec type" id="type-constrained">
-     <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type </span>constrained('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = int</code><span class="keyword">;</span>
+     <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type</span> constrained('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</code>;
     </dt>
     <dt class="spec type" id="type-exact_variant">
-     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type </span>exact_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [ `A<span class="keyword"> | </span>`B(int) ]</code><span class="keyword">;</span>
+     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> exact_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [ `A | `B(int) ]</code>;
     </dt>
     <dt class="spec type" id="type-lower_variant">
-     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type </span>lower_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt; `A<span class="keyword"> | </span>`B(int) ]</code><span class="keyword">;</span>
+     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> lower_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt; `A | `B(int) ]</code>;
     </dt>
     <dt class="spec type" id="type-any_variant">
-     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type </span>any_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&gt;  ]</code><span class="keyword">;</span>
+     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> any_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt;  ]</code>;
     </dt>
     <dt class="spec type" id="type-upper_variant">
-     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type </span>upper_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; `A<span class="keyword"> | </span>`B(int) ]</code><span class="keyword">;</span>
+     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> upper_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; `A | `B(int) ]</code>;
     </dt>
     <dt class="spec type" id="type-named_variant">
-     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type </span>named_variant('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code><span class="keyword">;</span>
+     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> named_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code>;
     </dt>
     <dt class="spec type" id="type-exact_object">
-     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type </span>exact_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a: int, b: int, }</code><span class="keyword">;</span>
+     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type</span> exact_object('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {. a: int, b: int, }</code>;
     </dt>
     <dt class="spec type" id="type-lower_object">
-     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type </span>lower_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {.. a: int, b: int, }</code><span class="keyword">;</span>
+     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type</span> lower_object('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {.. a: int, b: int, }</code>;
     </dt>
     <dt class="spec type" id="type-poly_object">
-     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type </span>poly_object('a)</code><code><span class="keyword"> = </span><span class="type-var">'a</span></code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = {. a: a. <span class="type-var">'a</span>, }</code><span class="keyword">;</span>
+     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> poly_object('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {. a: a. <span class="type-var">'a</span>, }</code>;
     </dt>
     <dt class="spec type" id="type-double_constrained">
-     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type </span>double_constrained('a, 'b)</code><code><span class="keyword"> = </span>(<span class="type-var">'a</span><span class="keyword">, </span><span class="type-var">'b</span>)</code><code><span class="keyword"> constraint </span><span class="type-var">'a</span> = int<span class="keyword"> and </span><span class="type-var">'b</span> = unit</code><span class="keyword">;</span>
+     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> double_constrained('a, 'b)</code><code> = (<span class="type-var">'a</span>, <span class="type-var">'b</span>)</code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">and</span> <span class="type-var">'b</span> = unit</code>;
     </dt>
     <dt class="spec type" id="type-as_">
-     <a href="#type-as_" class="anchor"></a><code><span class="keyword">type </span>as_</code><code><span class="keyword"> = </span>(int<span class="keyword"> as </span>a<span class="keyword">, </span><span class="type-var">'a</span>)</code><span class="keyword">;</span>
+     <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_</code><code> = (int <span class="keyword">as</span> a, <span class="type-var">'a</span>)</code>;
     </dt>
     <dt class="spec type" id="type-extensible">
-     <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type </span>extensible</code><code><span class="keyword"> = </span></code><code><span class="keyword">..</span></code><span class="keyword">;</span>
+     <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type</span> extensible</code><code> = </code><code>..</code>;
     </dt>
    </dl>
    <dl>
     <dt>
-     <code><span class="keyword">type </span><a href="index.html#type-extensible">extensible</a><span class="keyword"> += </span></code><code><span class="extension">Extension</span></code><code><span class="keyword"> | </span></code><code><span class="extension">Another_extension</span></code><span class="keyword">;</span>
+     <code><span class="keyword">type</span> <a href="index.html#type-extensible">extensible</a> += </code><code><span class="extension">Extension</span></code><code> | </code><code><span class="extension">Another_extension</span></code>;
     </dt>
    </dl>
    <dl>
     <dt class="spec type" id="type-mutually">
-     <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type </span>mutually</code><code><span class="keyword"> = </span></code>
+     <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type</span> mutually</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-mutually.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-mutually.A" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">A</span>(<a href="index.html#type-recursive">recursive</a>)</code>
+         <a href="#type-mutually.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span>(<a href="index.html#type-recursive">recursive</a>)</code>
         </td>
        </tr>
       </tbody>
      </table>
-     <span class="keyword">;</span>
+     ;
     </dt>
     <dt class="spec type" id="type-recursive">
-     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">and </span>recursive</code><code><span class="keyword"> = </span></code>
+     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">and</span> recursive</code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-recursive.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-recursive.B" class="anchor"></a><code><span class="keyword">| </span></code><code><span class="constructor">B</span>(<a href="index.html#type-mutually">mutually</a>)</code>
+         <a href="#type-recursive.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span>(<a href="index.html#type-mutually">mutually</a>)</code>
         </td>
        </tr>
       </tbody>
      </table>
-     <span class="keyword">;</span>
+     ;
     </dt>
    </dl>
    <dl>
     <dt class="spec exception" id="exception-Foo">
-     <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception </span></code><code><span class="exception">Foo</span>(int<span class="keyword">, </span>int)</code><span class="keyword">;</span>
+     <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception</span> </code><code><span class="exception">Foo</span>(int, int)</code>;
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+re/Val/index.html
+++ b/test/html/expect/test_package+re/Val/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec value" id="val-documented">
-     <a href="#val-documented" class="anchor"></a><code><span class="keyword">let </span>documented: unit<span class="keyword">;</span></code>
+     <a href="#val-documented" class="anchor"></a><code><span class="keyword">let</span> documented: unit;</code>
     </dt>
     <dd>
      <p>
@@ -33,10 +33,10 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-undocumented">
-     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">let </span>undocumented: unit<span class="keyword">;</span></code>
+     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">let</span> undocumented: unit;</code>
     </dt>
     <dt class="spec value" id="val-documented_above">
-     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">let </span>documented_above: unit<span class="keyword">;</span></code>
+     <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">let</span> documented_above: unit;</code>
     </dt>
     <dd>
      <p>

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -267,6 +267,7 @@ let source_files = [
       "Nested/F/argument-2-Arg2/index.html";
       "Nested/X/index.html";
       "Nested/class-z/index.html";
+      "Nested/class-inherits/index.html";
       "Nested/module-type-Y/index.html";
     ]);
   ("type.mli", ["Type/index.html"]);


### PR DESCRIPTION
- Move spaces inside keyword `<span>`s to the outside. This makes the markup friendly to stylesheets that use a background color or an underline to highlight keywords.
- Punctuation marks and parentheses are not keywords.

All changes are reflected in the expect files.

This PR is mostly FYI. I'll merge once CI passes.

I spotted several more bugs while doing this. I'll fix them after this PR.