### PR TITLE
Fix output of multiple type constraints

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -525,17 +525,17 @@ struct
   let format_constraints
     : 'inner_row 'outer_row. (_ * _) list ->
     ([> `PCDATA | `Span
-    | `A of ([> `PCDATA ] as 'inner_row) ] as 'outer_row) Html.elt list
-    = function
-    | [] -> []
-    | lst ->
+    | `A of ([> `PCDATA ] as 'inner_row) ] as 'outer_row) Html.elt list =
+      fun constraints ->
+
+    list_concat_map constraints ~f:begin fun (t1, t2) ->
       Html.txt " " ::
       keyword "constraint" ::
       Html.txt " " ::
-      list_concat_map_list_sep ~sep:[Html.txt " "; keyword "and"; Html.txt " "]
-          lst ~f:(fun (t1, t2) ->
-        type_expr t1 @ Html.txt " = " :: type_expr t2
-      )
+      type_expr t1 @
+      Html.txt " = " ::
+      type_expr t2
+    end
 
   let format_manifest
     : 'inner_row 'outer_row. ?compact_variants:bool

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -363,7 +363,7 @@
      <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> 'a poly_object</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : a. <span class="type-var">'a</span>; &gt;</code>
     </dt>
     <dt class="spec type" id="type-double_constrained">
-     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) double_constrained</code><code> = <span class="type-var">'a</span> * <span class="type-var">'b</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">and</span> <span class="type-var">'b</span> = unit</code>
+     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) double_constrained</code><code> = <span class="type-var">'a</span> * <span class="type-var">'b</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</code>
     </dt>
     <dt class="spec type" id="type-as_">
      <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_</code><code> = int <span class="keyword">as</span> a * <span class="type-var">'a</span></code>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -367,7 +367,7 @@
      <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> poly_object('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {. a: a. <span class="type-var">'a</span>, }</code>;
     </dt>
     <dt class="spec type" id="type-double_constrained">
-     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> double_constrained('a, 'b)</code><code> = (<span class="type-var">'a</span>, <span class="type-var">'b</span>)</code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">and</span> <span class="type-var">'b</span> = unit</code>;
+     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> double_constrained('a, 'b)</code><code> = (<span class="type-var">'a</span>, <span class="type-var">'b</span>)</code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</code>;
     </dt>
     <dt class="spec type" id="type-as_">
      <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_</code><code> = (int <span class="keyword">as</span> a, <span class="type-var">'a</span>)</code>;


### PR DESCRIPTION
Before this PR, the code

https://github.com/ocaml/odoc/blob/96a970ce3092d80eaa1ff4ec683288995d4ff419/test/html/cases/type.mli#L120-L122

results in the output

```ocaml
type ('a, 'b) double_constrained = 'a * 'b constraint 'a = int and 'b = unit
```

which does not match the source syntax.

This PR changes the output to match.

In future work, I will (or hope to) add proper pretty-printing with newlines, including for this case.
