### PR TITLE
odoc.css: Change copyright attribution.

### DIFF
--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-/* Copyright (c) 2016 Daniel C. Bünzli. All rights reserved.
+/* Copyright (c) 2016 The odoc contributors. All rights reserved.
    Distributed under the ISC license, see terms at the end of the file.
    %%NAME%% %%VERSION%% */
 
@@ -748,7 +748,7 @@ h1+.modules, h1+.sel {
 }
 
 /*---------------------------------------------------------------------------
-   Copyright (c) 2016 Daniel C. Bünzli
+   Copyright (c) 2016 The odoc contributors
 
    Permission to use, copy, modify, and/or distribute this software for any
    purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
The stylesheet was significantly changed since I created it and no longer represents my original design or one I would author.