### PR TITLE
odoc.css: Update margin to improve centering

### DIFF
--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -46,10 +46,7 @@ body {
 
 .content {
   max-width: 90ex;
-  margin-left: calc(10vw + 20ex);
-  margin-right: 4ex;
-  margin-top: 20px;
-  margin-bottom: 50px;
+  margin: 20px auto 50px;
   font-family: "Noticia Text", Georgia, serif;
   line-height: 1.5;
 }


### PR DESCRIPTION
This seems to make the centering better, except between ~700px and 760px, where the page should probably switch to the smaller layout but sticks with the larger layout. Any improvements are welcome.