### PR TITLE
generator: Add missing space before class name

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -1194,6 +1194,7 @@ struct
       Html.txt " " ::
       virtual_ @
       params ::
+      Html.txt " " ::
       cname ::
       Html.txt Syntax.Type.annotation_separator ::
       cd
@@ -1231,6 +1232,7 @@ struct
       [Html.txt " "] @
       virtual_ @
       params ::
+      Html.txt " " ::
       cname ::
       Html.txt " = " ::
       expr

--- a/test/html/cases/class.mli
+++ b/test/html/cases/class.mli
@@ -18,3 +18,9 @@ object
 end
 
 class virtual empty_virtual' : empty
+
+class type ['a] polymorphic =
+object
+end
+
+class ['a] polymorphic' : ['a] polymorphic

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -22,25 +22,25 @@
     </h1>
    </header>
    <div class="spec class-type" id="class-type-empty">
-    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class-type" id="class-type-mutually">
-    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <a href="class-type-mutually/index.html">mutually</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-mutually/index.html">mutually</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class-type" id="class-type-recursive">
-    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span> <a href="class-type-recursive/index.html">recursive</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-type-recursive/index.html">recursive</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-mutually'">
-    <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class</span> <a href="class-mutually'/index.html">mutually'</a> : <a href="class-type-mutually/index.html">mutually</a></code>
+    <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-mutually'/index.html">mutually'</a> : <a href="class-type-mutually/index.html">mutually</a></code>
    </div>
    <div class="spec class" id="class-recursive'">
-    <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and</span> <a href="class-recursive'/index.html">recursive'</a> : <a href="class-type-recursive/index.html">recursive</a></code>
+    <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-recursive'/index.html">recursive'</a> : <a href="class-type-recursive/index.html">recursive</a></code>
    </div>
    <div class="spec class-type" id="class-type-empty_virtual">
-    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span> <a href="class-type-empty_virtual/index.html">empty_virtual</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  <a href="class-type-empty_virtual/index.html">empty_virtual</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-empty_virtual'">
-    <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-empty_virtual'/index.html">empty_virtual'</a> : <a href="class-type-empty/index.html">empty</a></code>
+    <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-empty_virtual'/index.html">empty_virtual'</a> : <a href="class-type-empty/index.html">empty</a></code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -42,6 +42,12 @@
    <div class="spec class" id="class-empty_virtual'">
     <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-empty_virtual'/index.html">empty_virtual'</a> : <a href="class-type-empty/index.html">empty</a></code>
    </div>
+   <div class="spec class-type" id="class-type-polymorphic">
+    <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> 'a <a href="class-type-polymorphic/index.html">polymorphic</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+   </div>
+   <div class="spec class" id="class-polymorphic'">
+    <a href="#class-polymorphic'" class="anchor"></a><code><span class="keyword">class</span> 'a <a href="class-polymorphic'/index.html">polymorphic'</a> : <span class="type-var">'a</span> <a href="class-type-polymorphic/index.html">polymorphic</a></code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -99,7 +99,7 @@
     </header>
     <dl>
      <dt class="spec class" id="class-z">
-      <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+      <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
      </dt>
      <dd>
       <p>
@@ -108,7 +108,7 @@
      </dd>
     </dl>
     <div class="spec class" id="class-inherits">
-     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-inherits/index.html">inherits</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-inherits/index.html">inherits</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
     </div>
    </section>
   </div>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -22,25 +22,25 @@
     </h1>
    </header>
    <div class="spec class-type" id="class-type-empty">
-    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <a href="class-type-empty/index.html">empty</a> = { ... }</code>
+    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a> = { ... }</code>
    </div>
    <div class="spec class-type" id="class-type-mutually">
-    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <a href="class-type-mutually/index.html">mutually</a> = { ... }</code>
+    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-mutually/index.html">mutually</a> = { ... }</code>
    </div>
    <div class="spec class-type" id="class-type-recursive">
-    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span> <a href="class-type-recursive/index.html">recursive</a> = { ... }</code>
+    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-type-recursive/index.html">recursive</a> = { ... }</code>
    </div>
    <div class="spec class" id="class-mutually'">
-    <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class</span> <a href="class-mutually'/index.html">mutually'</a>: <a href="class-type-mutually/index.html">mutually</a></code>
+    <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-mutually'/index.html">mutually'</a>: <a href="class-type-mutually/index.html">mutually</a></code>
    </div>
    <div class="spec class" id="class-recursive'">
-    <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and</span> <a href="class-recursive'/index.html">recursive'</a>: <a href="class-type-recursive/index.html">recursive</a></code>
+    <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-recursive'/index.html">recursive'</a>: <a href="class-type-recursive/index.html">recursive</a></code>
    </div>
    <div class="spec class-type" id="class-type-empty_virtual">
-    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span> <a href="class-type-empty_virtual/index.html">empty_virtual</a> = { ... }</code>
+    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  <a href="class-type-empty_virtual/index.html">empty_virtual</a> = { ... }</code>
    </div>
    <div class="spec class" id="class-empty_virtual'">
-    <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-empty_virtual'/index.html">empty_virtual'</a>: <a href="class-type-empty/index.html">empty</a></code>
+    <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-empty_virtual'/index.html">empty_virtual'</a>: <a href="class-type-empty/index.html">empty</a></code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -42,6 +42,12 @@
    <div class="spec class" id="class-empty_virtual'">
     <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-empty_virtual'/index.html">empty_virtual'</a>: <a href="class-type-empty/index.html">empty</a></code>
    </div>
+   <div class="spec class-type" id="class-type-polymorphic">
+    <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> ('a) <a href="class-type-polymorphic/index.html">polymorphic</a> = { ... }</code>
+   </div>
+   <div class="spec class" id="class-polymorphic'">
+    <a href="#class-polymorphic'" class="anchor"></a><code><span class="keyword">class</span> ('a) <a href="class-polymorphic'/index.html">polymorphic'</a>: <a href="class-type-polymorphic/index.html">polymorphic</a>(<span class="type-var">'a</span>)</code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -99,7 +99,7 @@
     </header>
     <dl>
      <dt class="spec class" id="class-z">
-      <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-z/index.html">z</a>: { ... }</code>
+      <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-z/index.html">z</a>: { ... }</code>
      </dt>
      <dd>
       <p>
@@ -108,7 +108,7 @@
      </dd>
     </dl>
     <div class="spec class" id="class-inherits">
-     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span> <a href="class-inherits/index.html">inherits</a>: { ... }</code>
+     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-inherits/index.html">inherits</a>: { ... }</code>
     </div>
    </section>
   </div>


### PR DESCRIPTION
Fixes #338. I tested this locally by generating the docs for Ppxlib_traverse_builtins and it seemed to have inserted the space.