### PR TITLE
Always use " = " separator for module type definitions

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -1474,12 +1474,7 @@ struct
       match t.expr with
       | None -> []
       | Some expr ->
-        begin match expr with
-        | Signature _
-        | Path _ -> Html.txt " = "
-        | _ -> Html.txt Syntax.Type.annotation_separator
-        end ::
-        mty (t.id :> Paths.Identifier.Signature.t) expr
+        Html.txt " = " :: mty (t.id :> Paths.Identifier.Signature.t) expr
     in
     let modname, subtree =
       match t.expansion with

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -44,13 +44,13 @@
     <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code>
    </div>
    <div class="spec module-type" id="module-type-S3">
-    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-u">u</a> = string</code>
+    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S3/index.html">S3</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-u">u</a> = string</code>
    </div>
    <div class="spec module-type" id="module-type-S4">
-    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int</code>
+    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int</code>
    </div>
    <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> 'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> 'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
    </div>
    <dl>
     <dt class="spec type" id="type-result">
@@ -58,19 +58,19 @@
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
    </div>
    <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-S7">
-    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S7/index.html">S7</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module-type" id="module-type-S8">
-    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S8/index.html">S8</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module-type" id="module-type-S9">
-    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S9/index.html">S9</a> : <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S9/index.html">S9</a> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module" id="module-Mutually">
     <a href="#module-Mutually" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">rec</span> <a href="Mutually/index.html">Mutually</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>

--- a/test/html/expect/test_package+ml/Functor/index.html
+++ b/test/html/expect/test_package+ml/Functor/index.html
@@ -25,7 +25,7 @@
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> : <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> = <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
    </div>
    <div class="spec module" id="module-F1">
     <a href="#module-F1" class="anchor"></a><code><span class="keyword">module</span> <a href="F1/index.html">F1</a> : <span class="keyword">functor</span> (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -44,13 +44,13 @@
     <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a></code>
    </div>
    <div class="spec module-type" id="module-type-S3">
-    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S3/index.html">S3</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-u">u</a> = string</code>
+    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S3/index.html">S3</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-u">u</a> = string</code>
    </div>
    <div class="spec module-type" id="module-type-S4">
-    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int</code>
+    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int</code>
    </div>
    <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> 'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> 'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
    </div>
    <dl>
     <dt class="spec type" id="type-result">
@@ -58,19 +58,19 @@
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
    </div>
    <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-S7">
-    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S7/index.html">S7</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S7/index.html">S7</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module-type" id="module-type-S8">
-    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S8/index.html">S8</a> : <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S8/index.html">S8</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module-type" id="module-type-S9">
-    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S9/index.html">S9</a> : <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="index.html#module-M'">M'</a></code>
+    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S9/index.html">S9</a> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="index.html#module-M'">M'</a></code>
    </div>
    <div class="spec module" id="module-Mutually">
     <a href="#module-Mutually" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">rec</span> <a href="Mutually/index.html">Mutually</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -25,7 +25,7 @@
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> : <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> = <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="index.html#module-type-S">S</a>) <span>-&gt;</span> <a href="index.html#module-type-S">S</a></code>
    </div>
    <dl>
     <dt class="spec type" id="type-variant">

--- a/test/html/expect/test_package+re/Functor/index.html
+++ b/test/html/expect/test_package+re/Functor/index.html
@@ -25,7 +25,7 @@
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a>:  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a>;</code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> =  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a>;</code>
    </div>
    <div class="spec module" id="module-F1">
     <a href="#module-F1" class="anchor"></a><code><span class="keyword">module</span> <a href="F1/index.html">F1</a>:  (<a href="F1/argument-1-Arg/index.html">Arg</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a>;</code>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -44,13 +44,13 @@
     <a href="#module-type-S2" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S2/index.html">S2</a> = <a href="index.html#module-type-S">S</a>;</code>
    </div>
    <div class="spec module-type" id="module-type-S3">
-    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S3/index.html">S3</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-u">u</a> = string;</code>
+    <a href="#module-type-S3" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S3/index.html">S3</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-S3/index.html#type-u">u</a> = string;</code>
    </div>
    <div class="spec module-type" id="module-type-S4">
-    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int;</code>
+    <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int;</code>
    </div>
    <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S5/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>);</code>
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S5/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>);</code>
    </div>
    <dl>
     <dt class="spec type" id="type-result">
@@ -58,19 +58,19 @@
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>);</code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>);</code>
    </div>
    <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a>: { ... };</code>
    </div>
    <div class="spec module-type" id="module-type-S7">
-    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S7/index.html">S7</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a>;</code>
+    <a href="#module-type-S7" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S7/index.html">S7</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S7/M/index.html">M</a> = <a href="index.html#module-M'">M'</a>;</code>
    </div>
    <div class="spec module-type" id="module-type-S8">
-    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S8/index.html">S8</a>: <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a>;</code>
+    <a href="#module-type-S8" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S8/index.html">S8</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-S8/M/index.html">M</a> := <a href="index.html#module-M'">M'</a>;</code>
    </div>
    <div class="spec module-type" id="module-type-S9">
-    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S9/index.html">S9</a>: <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="index.html#module-M'">M'</a>;</code>
+    <a href="#module-type-S9" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S9/index.html">S9</a> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="index.html#module-M'">M'</a>;</code>
    </div>
    <div class="spec module" id="module-Mutually">
     <a href="#module-Mutually" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">rec</span> <a href="Mutually/index.html">Mutually</a>: { ... };</code>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -25,7 +25,7 @@
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>
    <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a>:  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a>;</code>
+    <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> =  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="index.html#module-type-S">S</a>) <span>=&gt;</span> <a href="index.html#module-type-S">S</a>;</code>
    </div>
    <dl>
     <dt class="spec type" id="type-variant">


### PR DESCRIPTION
All cases of module type definitions in both OCaml and Reason use an
equal sign to separate the identifier from the definitions.