### PR TITLE
Check that tidy supports the mute option

### DIFF
--- a/test/html/tidy.ml
+++ b/test/html/tidy.ml
@@ -13,7 +13,7 @@ let muted_warnings = [
 
 
 let is_present_in_path =
-  Sys.command "which tidy > /dev/null" = 0
+  Sys.command "which tidy > /dev/null" = 0 && Sys.command "tidy -show-config < /dev/null | grep '^mute' > /dev/null" = 0
 
 
 (* Returns a list of errors and warnings. *)


### PR DESCRIPTION
macOS comes with tidy but it is an old version that does not support the `--mute` option. This leads to spurious test failures on macOS.

This adds a check to is_present_in_path that requires the available version of tidy support the mute configuration option before it will be used.