### PR TITLE
Expose parser internals and add Parser.parse_comment_raw

### DIFF
--- a/src/parser/odoc_parser.mli
+++ b/src/parser/odoc_parser.mli
@@ -1,3 +1,10 @@
+module Ast = Ast
+
+val parse_comment_raw :
+  location:Lexing.position ->
+  text:string ->
+    Ast.docs Odoc_model.Error.with_warnings
+
 val parse_comment :
   sections_allowed:Ast.sections_allowed ->
   containing_definition:Odoc_model.Paths.Identifier.LabelParent.t ->


### PR DESCRIPTION
This PR exposes the internal modules of the parser.

I figured that `Parser_.Ast` is a bit simpler than `Model.Comment` and a lot simpler to obtain.
It also contains more informations (eg. heading labels)

I also add `Parser.parse_comment_raw` that returns an `Ast.docs`.