### PR TITLE
Fix generated html for conjunctive types

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -72,19 +72,33 @@ struct
     let elements =
       list_concat_map t.elements ~sep:(Html.txt " | ") ~f:(function
         | Model.Lang.TypeExpr.Polymorphic_variant.Type te -> type_expr te
-        | Constructor {name; arguments; _} ->
+        | Constructor {constant; name; arguments; _} ->
           let constr = "`" ^ name in
           match arguments with
           | [] -> [ Html.txt constr ]
           | _ ->
+            (* Multiple arguments in a polymorphic variant constructor correspond
+               to a conjunction of types, not a product: [`Lbl int&float].
+               If constant is [true], the conjunction starts with an empty type,
+               for instance [`Lbl &int].
+            *)
+            let wrapped_type_expr =
+              (* type conjunction in Reason is printed as `Lbl (t1)&(t2)` *)
+              if Syntax.Type.Variant.parenthesize_params then
+                fun x -> Html.txt "(" :: type_expr x @ [Html.txt ")"]
+              else
+                fun x -> type_expr x
+            in
             let arguments =
               list_concat_map
                 arguments
-                ~sep:(Html.txt Syntax.Type.Tuple.element_separator)
-                ~f:type_expr
+                ~sep:(Html.txt " & ")
+                ~f:wrapped_type_expr
             in
+            let arguments =
+              if constant then Html.txt "& " :: arguments else arguments in
             if Syntax.Type.Variant.parenthesize_params
-            then Html.txt (constr ^ "(") :: arguments @ [ Html.txt ")" ]
+            then Html.txt constr :: arguments
             else Html.txt (constr ^ " of ") :: arguments
       )
     in
@@ -426,21 +440,35 @@ struct
         match item with
         | Model.Lang.TypeExpr.Polymorphic_variant.Type te ->
           "unknown", [Html.code (type_expr te)], None
-        | Constructor {name; arguments; doc; _} ->
+        | Constructor {constant; name; arguments; doc; _} ->
           let cstr = "`" ^ name in
           "constructor",
           begin match arguments with
           | [] -> [Html.code [ Html.txt cstr ]]
           | _ ->
-            let params = list_concat_map arguments
-              ~sep:(Html.txt Syntax.Type.Tuple.element_separator)
-              ~f:type_expr
+            (* Multiple arguments in a polymorphic variant constructor correspond
+               to a conjunction of types, not a product: [`Lbl int&float].
+               If constant is [true], the conjunction starts with an empty type,
+               for instance [`Lbl &int].
+            *)
+            let wrapped_type_expr =
+              (* type conjunction in Reason is printed as `Lbl (t1)&(t2)` *)
+              if Syntax.Type.Variant.parenthesize_params then
+                fun x -> Html.txt "(" :: type_expr x @ [Html.txt ")"]
+              else
+                fun x -> type_expr x
             in
+            let params = list_concat_map arguments
+              ~sep:(Html.txt " & ")
+              ~f:wrapped_type_expr
+            in
+            let params =
+              if constant then Html.txt "& " :: params else params in
             [ Html.code (
                 Html.txt cstr ::
                 (
                 if Syntax.Type.Variant.parenthesize_params
-                then Html.txt "(" :: params @ [ Html.txt ")" ]
+                then params
                 else Html.txt " " :: keyword "of" :: Html.txt " " :: params
                 )
               )

--- a/test/html/cases/recent.mli
+++ b/test/html/cases/recent.mli
@@ -26,3 +26,11 @@ type polymorphic_variant = [
 ]
 
 type nonrec nonrec_ = int
+
+
+(* Conjunctive types: dune compilation scheme exposes a bug in old
+   versions of the compiler *)
+type empty_conj= X: [< `X of & 'a & int * float  ] -> empty_conj
+type conj = X: [< `X of int & [< `B of int & float ] ] -> conj
+val empty_conj: [< `X of & 'a & int * float  ]
+val conj : [< `X of int & [< `B of int & float ] ]

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -158,6 +158,38 @@
     <dt class="spec type" id="type-nonrec_">
      <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_</code><code> = int</code>
     </dt>
+    <dt class="spec type" id="type-empty_conj">
+     <a href="#type-empty_conj" class="anchor"></a><code><span class="keyword">type</span> empty_conj</code><code> = </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-empty_conj.X" class="anchored">
+        <td class="def constructor">
+         <a href="#type-empty_conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span> : [&lt; `X of &amp; <span class="type-var">'a</span> &amp; int * float ] <span>-&gt;</span> <a href="index.html#type-empty_conj">empty_conj</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </dt>
+    <dt class="spec type" id="type-conj">
+     <a href="#type-conj" class="anchor"></a><code><span class="keyword">type</span> conj</code><code> = </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-conj.X" class="anchored">
+        <td class="def constructor">
+         <a href="#type-conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span> : [&lt; `X of int &amp; [&lt; `B of int &amp; float ] ] <span>-&gt;</span> <a href="index.html#type-conj">conj</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-empty_conj">
+     <a href="#val-empty_conj" class="anchor"></a><code><span class="keyword">val</span> empty_conj : [&lt; `X of &amp; <span class="type-var">'a</span> &amp; int * float ]</code>
+    </dt>
+    <dt class="spec value" id="val-conj">
+     <a href="#val-conj" class="anchor"></a><code><span class="keyword">val</span> conj : [&lt; `X of int &amp; [&lt; `B of int &amp; float ] ]</code>
+    </dt>
    </dl>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -160,6 +160,40 @@
     <dt class="spec type" id="type-nonrec_">
      <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_</code><code> = int</code>;
     </dt>
+    <dt class="spec type" id="type-empty_conj">
+     <a href="#type-empty_conj" class="anchor"></a><code><span class="keyword">type</span> empty_conj</code><code> = </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-empty_conj.X" class="anchored">
+        <td class="def constructor">
+         <a href="#type-empty_conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span>([&lt; `X&amp; (<span class="type-var">'a</span>) &amp; ((int, float)) ]) : <a href="index.html#type-empty_conj">empty_conj</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     ;
+    </dt>
+    <dt class="spec type" id="type-conj">
+     <a href="#type-conj" class="anchor"></a><code><span class="keyword">type</span> conj</code><code> = </code>
+     <table class="variant">
+      <tbody>
+       <tr id="type-conj.X" class="anchored">
+        <td class="def constructor">
+         <a href="#type-conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span>([&lt; `X(int) &amp; ([&lt; `B(int) &amp; (float) ]) ]) : <a href="index.html#type-conj">conj</a></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     ;
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-empty_conj">
+     <a href="#val-empty_conj" class="anchor"></a><code><span class="keyword">let</span> empty_conj: [&lt; `X&amp; (<span class="type-var">'a</span>) &amp; ((int, float)) ];</code>
+    </dt>
+    <dt class="spec value" id="val-conj">
+     <a href="#val-conj" class="anchor"></a><code><span class="keyword">let</span> conj: [&lt; `X(int) &amp; ([&lt; `B(int) &amp; (float) ]) ];</code>
+    </dt>
    </dl>
   </div>
  </body>


### PR DESCRIPTION
This PR fixes the html generated for conjunctive types, for instance
```OCaml
type 'a t = [< `X of & int & float ] as 'a
```
which are currently printed as
```OCaml
type 'a t = [< `X of int * float ] as 'a
```
because the list of arguments of the polymorphic variant constructor is interpreted as a product instead of a conjunction. 
