### PR TITLE
Reference.deconstruct

### DIFF
--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -998,6 +998,7 @@ module rec Reference : sig
 
     val label_of_t : t -> Label.t
 
+    (** Returns the string representation of a reference and it's kind *)
     val deconstruct : t -> string * Paths_types.Reference.tag_any
 
     val hash : t -> int

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -801,6 +801,8 @@ module rec Reference : sig
     val label_of_t : t -> Label.t
 
     val identifier : t -> Identifier.t
+
+    val deconstruct : t -> string * Paths_types.Reference.tag_any
   end
 
 
@@ -995,6 +997,8 @@ module rec Reference : sig
     val instance_variable_of_t : t -> InstanceVariable.t
 
     val label_of_t : t -> Label.t
+
+    val deconstruct : t -> string * Paths_types.Reference.tag_any
 
     val hash : t -> int
 

--- a/test/parser/expect/author/followed-by-modules.txt
+++ b/test/parser/expect/author/followed-by-modules.txt
@@ -1,6 +1,6 @@
 ((output
   (((f.ml (1 0) (1 11)) (@author foo))
-   ((f.ml (2 0) (2 14)) (modules ((root Foo unknown))))))
+   ((f.ml (2 0) (2 14)) (modules (((root Foo unknown) (Foo unknown)))))))
  (warnings
   ( "File \"f.ml\", line 2, characters 0-14:\
    \n'{!modules ...}' is not allowed in the tags section.\

--- a/test/parser/expect/canonical/basic.txt
+++ b/test/parser/expect/canonical/basic.txt
@@ -1,2 +1,4 @@
-((output (((f.ml (1 0) (1 14)) (@canonical (root Foo) (root Foo unknown)))))
+((output
+  (((f.ml (1 0) (1 14))
+    (@canonical (root Foo) ((root Foo unknown) (Foo unknown))))))
  (warnings ()))

--- a/test/parser/expect/canonical/extra-whitespace.txt
+++ b/test/parser/expect/canonical/extra-whitespace.txt
@@ -1,2 +1,4 @@
-((output (((f.ml (1 0) (1 16)) (@canonical (root Foo) (root Foo unknown)))))
+((output
+  (((f.ml (1 0) (1 16))
+    (@canonical (root Foo) ((root Foo unknown) (Foo unknown))))))
  (warnings ()))

--- a/test/parser/expect/canonical/with-whitespace.txt
+++ b/test/parser/expect/canonical/with-whitespace.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 18))
-    (@canonical (root "Foo Bar") (root "Foo Bar" unknown)))))
+    (@canonical (root "Foo Bar")
+     ((root "Foo Bar" unknown) ("Foo Bar" unknown))))))
  (warnings ()))

--- a/test/parser/expect/link/nested-in-reference.txt
+++ b/test/parser/expect/link/nested-in-reference.txt
@@ -2,7 +2,7 @@
   (((f.ml (1 0) (1 25))
     (paragraph
      (((f.ml (1 0) (1 25))
-       (reference (root foo unknown)
+       (reference ((root foo unknown) (foo unknown))
         (((f.ml (1 8) (1 24))
           (emphasis
            (((f.ml (1 11) (1 23))

--- a/test/parser/expect/module-list/basic.txt
+++ b/test/parser/expect/module-list/basic.txt
@@ -1,2 +1,3 @@
-((output (((f.ml (1 0) (1 14)) (modules ((root Foo unknown))))))
+((output
+  (((f.ml (1 0) (1 14)) (modules (((root Foo unknown) (Foo unknown)))))))
  (warnings ()))

--- a/test/parser/expect/module-list/cr-lf.txt
+++ b/test/parser/expect/module-list/cr-lf.txt
@@ -1,3 +1,5 @@
 ((output
-  (((f.ml (1 0) (2 4)) (modules ((root Foo unknown) (root Bar unknown))))))
+  (((f.ml (1 0) (2 4))
+    (modules
+     (((root Foo unknown) (Foo unknown)) ((root Bar unknown) (Bar unknown)))))))
  (warnings ()))

--- a/test/parser/expect/module-list/extra-whitespace.txt
+++ b/test/parser/expect/module-list/extra-whitespace.txt
@@ -1,3 +1,5 @@
 ((output
-  (((f.ml (1 0) (1 21)) (modules ((root Foo unknown) (root Bar unknown))))))
+  (((f.ml (1 0) (1 21))
+    (modules
+     (((root Foo unknown) (Foo unknown)) ((root Bar unknown) (Bar unknown)))))))
  (warnings ()))

--- a/test/parser/expect/module-list/followed-by-word.txt
+++ b/test/parser/expect/module-list/followed-by-word.txt
@@ -1,5 +1,5 @@
 ((output
-  (((f.ml (1 0) (1 14)) (modules ((root Foo unknown))))
+  (((f.ml (1 0) (1 14)) (modules (((root Foo unknown) (Foo unknown)))))
    ((f.ml (1 15) (1 18)) (paragraph (((f.ml (1 15) (1 18)) (word foo)))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 15-18:\

--- a/test/parser/expect/module-list/in-list.txt
+++ b/test/parser/expect/module-list/in-list.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 16))
-    (unordered ((((f.ml (1 2) (1 16)) (modules ((root Foo unknown))))))))))
+    (unordered
+     ((((f.ml (1 2) (1 16)) (modules (((root Foo unknown) (Foo unknown)))))))))))
  (warnings ()))

--- a/test/parser/expect/module-list/in-paragraph.txt
+++ b/test/parser/expect/module-list/in-paragraph.txt
@@ -1,7 +1,7 @@
 ((output
   (((f.ml (1 0) (1 4))
     (paragraph (((f.ml (1 0) (1 3)) (word foo)) ((f.ml (1 3) (1 4)) space))))
-   ((f.ml (1 4) (1 18)) (modules ((root Foo unknown))))))
+   ((f.ml (1 4) (1 18)) (modules (((root Foo unknown) (Foo unknown)))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 4-18:\
    \n'{!modules ...}' should begin on its own line.")))

--- a/test/parser/expect/module-list/newline.txt
+++ b/test/parser/expect/module-list/newline.txt
@@ -1,3 +1,5 @@
 ((output
-  (((f.ml (1 0) (2 4)) (modules ((root Foo unknown) (root Bar unknown))))))
+  (((f.ml (1 0) (2 4))
+    (modules
+     (((root Foo unknown) (Foo unknown)) ((root Bar unknown) (Bar unknown)))))))
  (warnings ()))

--- a/test/parser/expect/module-list/two.txt
+++ b/test/parser/expect/module-list/two.txt
@@ -1,3 +1,5 @@
 ((output
-  (((f.ml (1 0) (1 18)) (modules ((root Foo unknown) (root Bar unknown))))))
+  (((f.ml (1 0) (1 18))
+    (modules
+     (((root Foo unknown) (Foo unknown)) ((root Bar unknown) (Bar unknown)))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/canonical-module.txt
+++ b/test/parser/expect/reference-component-kind/canonical-module.txt
@@ -1,3 +1,4 @@
 ((output
-  (((f.ml (1 0) (1 21)) (@canonical (root module-Foo) (root Foo module)))))
+  (((f.ml (1 0) (1 21))
+    (@canonical (root module-Foo) ((root Foo module) (Foo module))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/canonical-path.txt
+++ b/test/parser/expect/reference-component-kind/canonical-path.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 18))
-    (@canonical (dot Bar (root Foo)) (dot Bar (root Foo unknown))))))
+    (@canonical (dot Bar (root Foo))
+     ((dot Bar (root Foo unknown)) (Foo.Bar unknown))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/canonical-something.txt
+++ b/test/parser/expect/reference-component-kind/canonical-something.txt
@@ -1,2 +1,4 @@
-((output (((f.ml (1 0) (1 14)) (@canonical (root Foo) (root Foo unknown)))))
+((output
+  (((f.ml (1 0) (1 14))
+    (@canonical (root Foo) ((root Foo unknown) (Foo unknown))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/class-in-module.txt
+++ b/test/parser/expect/reference-component-kind/class-in-module.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 23))
     (paragraph
-     (((f.ml (1 0) (1 23)) (reference (class bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 23))
+       (reference ((class bar (root Foo module)) (Foo.bar class)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/class-in-something.txt
+++ b/test/parser/expect/reference-component-kind/class-in-something.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 16))
     (paragraph
-     (((f.ml (1 0) (1 16)) (reference (class bar (root Foo unknown)) ())))))))
+     (((f.ml (1 0) (1 16))
+       (reference ((class bar (root Foo unknown)) (Foo.bar class)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/class-type-alt.txt
+++ b/test/parser/expect/reference-component-kind/class-type-alt.txt
@@ -1,6 +1,8 @@
 ((output
   (((f.ml (1 0) (1 16))
-    (paragraph (((f.ml (1 0) (1 16)) (reference (root foo class_type) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 16))
+       (reference ((root foo class_type) (foo class_type)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 2-15:\
    \n'classtype' is deprecated, use 'class-type' instead.")))

--- a/test/parser/expect/reference-component-kind/class-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/class-type-in-module.txt
@@ -1,5 +1,7 @@
 ((output
   (((f.ml (1 0) (1 28))
     (paragraph
-     (((f.ml (1 0) (1 28)) (reference (class_type bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 28))
+       (reference ((class_type bar (root Foo module)) (Foo.bar class_type))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/class-type-in-something.txt
+++ b/test/parser/expect/reference-component-kind/class-type-in-something.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 21))
     (paragraph
      (((f.ml (1 0) (1 21))
-       (reference (class_type bar (root Foo unknown)) ())))))))
+       (reference ((class_type bar (root Foo unknown)) (Foo.bar class_type))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/class-type.txt
+++ b/test/parser/expect/reference-component-kind/class-type.txt
@@ -1,4 +1,6 @@
 ((output
   (((f.ml (1 0) (1 17))
-    (paragraph (((f.ml (1 0) (1 17)) (reference (root foo class_type) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 17))
+       (reference ((root foo class_type) (foo class_type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/class.txt
+++ b/test/parser/expect/reference-component-kind/class.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 12))
-    (paragraph (((f.ml (1 0) (1 12)) (reference (root foo class) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 12)) (reference ((root foo class) (foo class)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/constructor-alt.txt
+++ b/test/parser/expect/reference-component-kind/constructor-alt.txt
@@ -1,6 +1,8 @@
 ((output
   (((f.ml (1 0) (1 12))
-    (paragraph (((f.ml (1 0) (1 12)) (reference (root Foo constructor) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 12))
+       (reference ((root Foo constructor) (Foo constructor)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 2-11:\
    \n'const' is deprecated, use 'constructor' instead.")))

--- a/test/parser/expect/reference-component-kind/constructor-in-something-nested.txt
+++ b/test/parser/expect/reference-component-kind/constructor-in-something-nested.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 26))
     (paragraph
      (((f.ml (1 0) (1 26))
-       (reference (constructor Baz (dot bar (root foo unknown))) ())))))))
+       (reference
+        ((constructor Baz (dot bar (root foo unknown)))
+         (foo.bar.Baz constructor))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/constructor-in-something.txt
+++ b/test/parser/expect/reference-component-kind/constructor-in-something.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 22))
     (paragraph
      (((f.ml (1 0) (1 22))
-       (reference (constructor Bar (root foo unknown)) ())))))))
+       (reference
+        ((constructor Bar (root foo unknown)) (foo.Bar constructor)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/constructor-in-type-nested.txt
+++ b/test/parser/expect/reference-component-kind/constructor-in-type-nested.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 31))
     (paragraph
      (((f.ml (1 0) (1 31))
-       (reference (constructor Baz (type bar (root foo unknown))) ())))))))
+       (reference
+        ((constructor Baz (type bar (root foo unknown)))
+         (foo.bar.Baz constructor))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/constructor-in-type.txt
+++ b/test/parser/expect/reference-component-kind/constructor-in-type.txt
@@ -1,5 +1,7 @@
 ((output
   (((f.ml (1 0) (1 27))
     (paragraph
-     (((f.ml (1 0) (1 27)) (reference (constructor Bar (root foo type)) ())))))))
+     (((f.ml (1 0) (1 27))
+       (reference ((constructor Bar (root foo type)) (foo.Bar constructor))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/constructor.txt
+++ b/test/parser/expect/reference-component-kind/constructor.txt
@@ -1,4 +1,6 @@
 ((output
   (((f.ml (1 0) (1 18))
-    (paragraph (((f.ml (1 0) (1 18)) (reference (root Foo constructor) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 18))
+       (reference ((root Foo constructor) (Foo constructor)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/exception-alt.txt
+++ b/test/parser/expect/reference-component-kind/exception-alt.txt
@@ -1,6 +1,8 @@
 ((output
   (((f.ml (1 0) (1 10))
-    (paragraph (((f.ml (1 0) (1 10)) (reference (root Foo exception) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 10))
+       (reference ((root Foo exception) (Foo exception)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 2-9:\
    \n'exn' is deprecated, use 'exception' instead.")))

--- a/test/parser/expect/reference-component-kind/exception-in-module.txt
+++ b/test/parser/expect/reference-component-kind/exception-in-module.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 27))
     (paragraph
-     (((f.ml (1 0) (1 27)) (reference (exception Bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 27))
+       (reference ((exception Bar (root Foo module)) (Foo.Bar exception)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/exception-in-something.txt
+++ b/test/parser/expect/reference-component-kind/exception-in-something.txt
@@ -1,5 +1,7 @@
 ((output
   (((f.ml (1 0) (1 20))
     (paragraph
-     (((f.ml (1 0) (1 20)) (reference (exception Bar (root Foo unknown)) ())))))))
+     (((f.ml (1 0) (1 20))
+       (reference ((exception Bar (root Foo unknown)) (Foo.Bar exception))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/exception.txt
+++ b/test/parser/expect/reference-component-kind/exception.txt
@@ -1,4 +1,6 @@
 ((output
   (((f.ml (1 0) (1 16))
-    (paragraph (((f.ml (1 0) (1 16)) (reference (root Foo exception) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 16))
+       (reference ((root Foo exception) (Foo exception)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/extension-in-module.txt
+++ b/test/parser/expect/reference-component-kind/extension-in-module.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 27))
     (paragraph
-     (((f.ml (1 0) (1 27)) (reference (extension Bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 27))
+       (reference ((extension Bar (root Foo module)) (Foo.Bar extension)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/extension-in-something.txt
+++ b/test/parser/expect/reference-component-kind/extension-in-something.txt
@@ -1,5 +1,7 @@
 ((output
   (((f.ml (1 0) (1 20))
     (paragraph
-     (((f.ml (1 0) (1 20)) (reference (extension Bar (root Foo unknown)) ())))))))
+     (((f.ml (1 0) (1 20))
+       (reference ((extension Bar (root Foo unknown)) (Foo.Bar extension))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/extension.txt
+++ b/test/parser/expect/reference-component-kind/extension.txt
@@ -1,4 +1,6 @@
 ((output
   (((f.ml (1 0) (1 16))
-    (paragraph (((f.ml (1 0) (1 16)) (reference (root Foo extension) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 16))
+       (reference ((root Foo extension) (Foo extension)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-alt.txt
+++ b/test/parser/expect/reference-component-kind/field-alt.txt
@@ -1,6 +1,7 @@
 ((output
   (((f.ml (1 0) (1 15))
-    (paragraph (((f.ml (1 0) (1 15)) (reference (root foo field) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 15)) (reference ((root foo field) (foo field)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 2-14:\
    \n'recfield' is deprecated, use 'field' instead.")))

--- a/test/parser/expect/reference-component-kind/field-in-class-nested.txt
+++ b/test/parser/expect/reference-component-kind/field-in-class-nested.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 26))
     (paragraph
      (((f.ml (1 0) (1 26))
-       (reference (field baz (class bar (root Foo unknown))) ())))))))
+       (reference
+        ((field baz (class bar (root Foo unknown))) (Foo.bar.baz field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-class-type-nested.txt
+++ b/test/parser/expect/reference-component-kind/field-in-class-type-nested.txt
@@ -2,5 +2,7 @@
   (((f.ml (1 0) (1 31))
     (paragraph
      (((f.ml (1 0) (1 31))
-       (reference (field baz (class_type bar (root Foo unknown))) ())))))))
+       (reference
+        ((field baz (class_type bar (root Foo unknown))) (Foo.bar.baz field))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-class-type.txt
+++ b/test/parser/expect/reference-component-kind/field-in-class-type.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 27))
     (paragraph
-     (((f.ml (1 0) (1 27)) (reference (field bar (root foo class_type)) ())))))))
+     (((f.ml (1 0) (1 27))
+       (reference ((field bar (root foo class_type)) (foo.bar field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-class.txt
+++ b/test/parser/expect/reference-component-kind/field-in-class.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 22))
     (paragraph
-     (((f.ml (1 0) (1 22)) (reference (field bar (root foo class)) ())))))))
+     (((f.ml (1 0) (1 22))
+       (reference ((field bar (root foo class)) (foo.bar field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-module-nested.txt
+++ b/test/parser/expect/reference-component-kind/field-in-module-nested.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 27))
     (paragraph
      (((f.ml (1 0) (1 27))
-       (reference (field baz (module Bar (root Foo unknown))) ())))))))
+       (reference
+        ((field baz (module Bar (root Foo unknown))) (Foo.Bar.baz field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-module-type-nested.txt
+++ b/test/parser/expect/reference-component-kind/field-in-module-type-nested.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 32))
     (paragraph
      (((f.ml (1 0) (1 32))
-       (reference (field baz (module_type Bar (root Foo unknown))) ())))))))
+       (reference
+        ((field baz (module_type Bar (root Foo unknown)))
+         (Foo.Bar.baz field))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-module-type.txt
+++ b/test/parser/expect/reference-component-kind/field-in-module-type.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 28))
     (paragraph
-     (((f.ml (1 0) (1 28)) (reference (field bar (root Foo module_type)) ())))))))
+     (((f.ml (1 0) (1 28))
+       (reference ((field bar (root Foo module_type)) (Foo.bar field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-module.txt
+++ b/test/parser/expect/reference-component-kind/field-in-module.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 23))
     (paragraph
-     (((f.ml (1 0) (1 23)) (reference (field bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 23))
+       (reference ((field bar (root Foo module)) (Foo.bar field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-something-nested.txt
+++ b/test/parser/expect/reference-component-kind/field-in-something-nested.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 20))
     (paragraph
      (((f.ml (1 0) (1 20))
-       (reference (field baz (dot bar (root foo unknown))) ())))))))
+       (reference
+        ((field baz (dot bar (root foo unknown))) (foo.bar.baz field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-something.txt
+++ b/test/parser/expect/reference-component-kind/field-in-something.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 16))
     (paragraph
-     (((f.ml (1 0) (1 16)) (reference (field bar (root foo unknown)) ())))))))
+     (((f.ml (1 0) (1 16))
+       (reference ((field bar (root foo unknown)) (foo.bar field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-type-nested.txt
+++ b/test/parser/expect/reference-component-kind/field-in-type-nested.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 25))
     (paragraph
      (((f.ml (1 0) (1 25))
-       (reference (field baz (type bar (root Foo unknown))) ())))))))
+       (reference
+        ((field baz (type bar (root Foo unknown))) (Foo.bar.baz field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field-in-type.txt
+++ b/test/parser/expect/reference-component-kind/field-in-type.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 21))
     (paragraph
-     (((f.ml (1 0) (1 21)) (reference (field bar (root foo type)) ())))))))
+     (((f.ml (1 0) (1 21))
+       (reference ((field bar (root foo type)) (foo.bar field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/field.txt
+++ b/test/parser/expect/reference-component-kind/field.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 12))
-    (paragraph (((f.ml (1 0) (1 12)) (reference (root foo field) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 12)) (reference ((root foo field) (foo field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/heading-alt.txt
+++ b/test/parser/expect/reference-component-kind/heading-alt.txt
@@ -1,6 +1,7 @@
 ((output
   (((f.ml (1 0) (1 12))
-    (paragraph (((f.ml (1 0) (1 12)) (reference (root foo label) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 12)) (reference ((root foo label) (foo label)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 2-11:\
    \n'label' is deprecated, use 'section' instead.")))

--- a/test/parser/expect/reference-component-kind/heading.txt
+++ b/test/parser/expect/reference-component-kind/heading.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 14))
-    (paragraph (((f.ml (1 0) (1 14)) (reference (root foo label) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 14)) (reference ((root foo label) (foo label)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/hyphenated-kind-longident.txt
+++ b/test/parser/expect/reference-component-kind/hyphenated-kind-longident.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 43))
     (paragraph
      (((f.ml (1 0) (1 43))
-       (reference (type baz (module_type Bar (root Foo module_type))) ())))))))
+       (reference
+        ((type baz (module_type Bar (root Foo module_type)))
+         (Foo.Bar.baz type))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-class-signature-class-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-class-signature-class-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 34))
     (paragraph
      (((f.ml (1 0) (1 34))
-       (reference (method baz (class bar (root Foo module))) ())))))))
+       (reference
+        ((method baz (class bar (root Foo module))) (Foo.bar.baz method)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-class-signature-class-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-class-signature-class-type-in-module.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 39))
     (paragraph
      (((f.ml (1 0) (1 39))
-       (reference (method baz (class_type bar (root Foo module))) ())))))))
+       (reference
+        ((method baz (class_type bar (root Foo module)))
+         (Foo.bar.baz method))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-class-signature-something-in-something.txt
+++ b/test/parser/expect/reference-component-kind/inner-class-signature-something-in-something.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 21))
     (paragraph
      (((f.ml (1 0) (1 21))
-       (reference (method baz (dot bar (root foo unknown))) ())))))))
+       (reference
+        ((method baz (dot bar (root foo unknown))) (foo.bar.baz method)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-datatype-something-in-something.txt
+++ b/test/parser/expect/reference-component-kind/inner-datatype-something-in-something.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 26))
     (paragraph
      (((f.ml (1 0) (1 26))
-       (reference (constructor Baz (dot bar (root foo unknown))) ())))))))
+       (reference
+        ((constructor Baz (dot bar (root foo unknown)))
+         (foo.bar.Baz constructor))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-datatype-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-datatype-type-in-module.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 38))
     (paragraph
      (((f.ml (1 0) (1 38))
-       (reference (constructor Baz (type bar (root Foo module))) ())))))))
+       (reference
+        ((constructor Baz (type bar (root Foo module)))
+         (Foo.bar.Baz constructor))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-label-parent-class-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-label-parent-class-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 27))
     (paragraph
      (((f.ml (1 0) (1 27))
-       (reference (dot baz (class bar (root Foo module))) ())))))))
+       (reference
+        ((dot baz (class bar (root Foo module))) (Foo.bar.baz unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-label-parent-class-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-label-parent-class-type-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 27))
     (paragraph
      (((f.ml (1 0) (1 27))
-       (reference (dot baz (class bar (root Foo module))) ())))))))
+       (reference
+        ((dot baz (class bar (root Foo module))) (Foo.bar.baz unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-label-parent-module-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-label-parent-module-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 28))
     (paragraph
      (((f.ml (1 0) (1 28))
-       (reference (dot baz (module Bar (root Foo module))) ())))))))
+       (reference
+        ((dot baz (module Bar (root Foo module))) (Foo.Bar.baz unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-label-parent-module-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-label-parent-module-type-in-module.txt
@@ -2,5 +2,7 @@
   (((f.ml (1 0) (1 33))
     (paragraph
      (((f.ml (1 0) (1 33))
-       (reference (dot baz (module_type Bar (root Foo module))) ())))))))
+       (reference
+        ((dot baz (module_type Bar (root Foo module))) (Foo.Bar.baz unknown))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-label-parent-something-in-page.txt
+++ b/test/parser/expect/reference-component-kind/inner-label-parent-something-in-page.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 19))
     (paragraph
      (((f.ml (1 0) (1 19))
-       (reference (dot baz (dot bar (root foo page))) ())))))))
+       (reference ((dot baz (dot bar (root foo page))) (foo.bar.baz unknown))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-label-parent-something-in-something.txt
+++ b/test/parser/expect/reference-component-kind/inner-label-parent-something-in-something.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 14))
     (paragraph
      (((f.ml (1 0) (1 14))
-       (reference (dot baz (dot bar (root foo unknown))) ())))))))
+       (reference
+        ((dot baz (dot bar (root foo unknown))) (foo.bar.baz unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-label-parent-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-label-parent-type-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 26))
     (paragraph
      (((f.ml (1 0) (1 26))
-       (reference (dot baz (type bar (root Foo module))) ())))))))
+       (reference
+        ((dot baz (type bar (root Foo module))) (Foo.bar.baz unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-parent-class-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-parent-class-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 33))
     (paragraph
      (((f.ml (1 0) (1 33))
-       (reference (field baz (class bar (root Foo module))) ())))))))
+       (reference
+        ((field baz (class bar (root Foo module))) (Foo.bar.baz field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-parent-class-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-parent-class-type-in-module.txt
@@ -2,5 +2,7 @@
   (((f.ml (1 0) (1 38))
     (paragraph
      (((f.ml (1 0) (1 38))
-       (reference (field baz (class_type bar (root Foo module))) ())))))))
+       (reference
+        ((field baz (class_type bar (root Foo module))) (Foo.bar.baz field))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-parent-module-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-parent-module-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 34))
     (paragraph
      (((f.ml (1 0) (1 34))
-       (reference (field baz (module Bar (root Foo module))) ())))))))
+       (reference
+        ((field baz (module Bar (root Foo module))) (Foo.Bar.baz field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-parent-module-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-parent-module-type-in-module.txt
@@ -2,5 +2,7 @@
   (((f.ml (1 0) (1 39))
     (paragraph
      (((f.ml (1 0) (1 39))
-       (reference (field baz (module_type Bar (root Foo module))) ())))))))
+       (reference
+        ((field baz (module_type Bar (root Foo module))) (Foo.Bar.baz field))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-parent-something-in-class.txt
+++ b/test/parser/expect/reference-component-kind/inner-parent-something-in-class.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 26))
     (paragraph
      (((f.ml (1 0) (1 26))
-       (reference (field baz (dot bar (root foo class))) ())))))))
+       (reference
+        ((field baz (dot bar (root foo class))) (foo.bar.baz field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-parent-something-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-parent-something-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 27))
     (paragraph
      (((f.ml (1 0) (1 27))
-       (reference (field baz (dot bar (root Foo module))) ())))))))
+       (reference
+        ((field baz (dot bar (root Foo module))) (Foo.bar.baz field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-parent-something-in-something.txt
+++ b/test/parser/expect/reference-component-kind/inner-parent-something-in-something.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 20))
     (paragraph
      (((f.ml (1 0) (1 20))
-       (reference (field baz (dot bar (root foo unknown))) ())))))))
+       (reference
+        ((field baz (dot bar (root foo unknown))) (foo.bar.baz field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-parent-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-parent-type-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 32))
     (paragraph
      (((f.ml (1 0) (1 32))
-       (reference (field baz (type bar (root Foo module))) ())))))))
+       (reference
+        ((field baz (type bar (root Foo module))) (Foo.bar.baz field)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-signature-module-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-signature-module-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 33))
     (paragraph
      (((f.ml (1 0) (1 33))
-       (reference (type baz (module Bar (root Foo module))) ())))))))
+       (reference
+        ((type baz (module Bar (root Foo module))) (Foo.Bar.baz type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-signature-module-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/inner-signature-module-type-in-module.txt
@@ -2,5 +2,7 @@
   (((f.ml (1 0) (1 38))
     (paragraph
      (((f.ml (1 0) (1 38))
-       (reference (type baz (module_type Bar (root Foo module))) ())))))))
+       (reference
+        ((type baz (module_type Bar (root Foo module))) (Foo.Bar.baz type))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/inner-signature-something-in-something.txt
+++ b/test/parser/expect/reference-component-kind/inner-signature-something-in-something.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 19))
     (paragraph
      (((f.ml (1 0) (1 19))
-       (reference (type baz (dot bar (root foo unknown))) ())))))))
+       (reference
+        ((type baz (dot bar (root foo unknown))) (foo.bar.baz type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/instance-variable-in-class.txt
+++ b/test/parser/expect/reference-component-kind/instance-variable-in-class.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 34))
     (paragraph
      (((f.ml (1 0) (1 34))
-       (reference (instance_variable bar (root foo class)) ())))))))
+       (reference
+        ((instance_variable bar (root foo class))
+         (foo.bar instance_variable))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/instance-variable-in-something.txt
+++ b/test/parser/expect/reference-component-kind/instance-variable-in-something.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 28))
     (paragraph
      (((f.ml (1 0) (1 28))
-       (reference (instance_variable bar (root Foo unknown)) ())))))))
+       (reference
+        ((instance_variable bar (root Foo unknown))
+         (Foo.bar instance_variable))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/instance-variable.txt
+++ b/test/parser/expect/reference-component-kind/instance-variable.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 24))
     (paragraph
-     (((f.ml (1 0) (1 24)) (reference (root foo instance_variable) ())))))))
+     (((f.ml (1 0) (1 24))
+       (reference ((root foo instance_variable) (foo instance_variable)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/internal-whitespace.txt
+++ b/test/parser/expect/reference-component-kind/internal-whitespace.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 16))
     (paragraph
      (((f.ml (1 0) (1 16))
-       (reference (dot baz (dot bar (root foo unknown))) ())))))))
+       (reference
+        ((dot baz (dot bar (root foo unknown))) (foo.bar.baz unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/kind-agreement-alt.txt
+++ b/test/parser/expect/reference-component-kind/kind-agreement-alt.txt
@@ -1,6 +1,7 @@
 ((output
   (((f.ml (1 0) (1 16))
-    (paragraph (((f.ml (1 0) (1 16)) (reference (root foo value) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 16)) (reference ((root foo value) (foo value)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 2-7:\
    \n'value' is deprecated, use 'val' instead.")))

--- a/test/parser/expect/reference-component-kind/kind-agreement.txt
+++ b/test/parser/expect/reference-component-kind/kind-agreement.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 14))
-    (paragraph (((f.ml (1 0) (1 14)) (reference (root foo value) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 14)) (reference ((root foo value) (foo value)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/kind-conflict.txt
+++ b/test/parser/expect/reference-component-kind/kind-conflict.txt
@@ -1,6 +1,7 @@
 ((output
   (((f.ml (1 0) (1 15))
-    (paragraph (((f.ml (1 0) (1 15)) (reference (root foo type) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 15)) (reference ((root foo type) (foo type)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 2-15:\
    \nOld-style reference kind ('val:') does not match new ('type-').")))

--- a/test/parser/expect/reference-component-kind/longident.txt
+++ b/test/parser/expect/reference-component-kind/longident.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 22))
     (paragraph
-     (((f.ml (1 0) (1 22)) (reference (type bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 22))
+       (reference ((type bar (root Foo module)) (Foo.bar type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/method-in-class-nested.txt
+++ b/test/parser/expect/reference-component-kind/method-in-class-nested.txt
@@ -2,5 +2,7 @@
   (((f.ml (1 0) (1 27))
     (paragraph
      (((f.ml (1 0) (1 27))
-       (reference (method baz (class bar (root Foo unknown))) ())))))))
+       (reference
+        ((method baz (class bar (root Foo unknown))) (Foo.bar.baz method))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/method-in-class-type-nested.txt
+++ b/test/parser/expect/reference-component-kind/method-in-class-type-nested.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 32))
     (paragraph
      (((f.ml (1 0) (1 32))
-       (reference (method baz (class_type bar (root Foo unknown))) ())))))))
+       (reference
+        ((method baz (class_type bar (root Foo unknown)))
+         (Foo.bar.baz method))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/method-in-class-type.txt
+++ b/test/parser/expect/reference-component-kind/method-in-class-type.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 28))
     (paragraph
-     (((f.ml (1 0) (1 28)) (reference (method bar (root foo class_type)) ())))))))
+     (((f.ml (1 0) (1 28))
+       (reference ((method bar (root foo class_type)) (foo.bar method)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/method-in-class.txt
+++ b/test/parser/expect/reference-component-kind/method-in-class.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 23))
     (paragraph
-     (((f.ml (1 0) (1 23)) (reference (method bar (root foo class)) ())))))))
+     (((f.ml (1 0) (1 23))
+       (reference ((method bar (root foo class)) (foo.bar method)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/method-in-something-nested.txt
+++ b/test/parser/expect/reference-component-kind/method-in-something-nested.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 21))
     (paragraph
      (((f.ml (1 0) (1 21))
-       (reference (method baz (dot bar (root foo unknown))) ())))))))
+       (reference
+        ((method baz (dot bar (root foo unknown))) (foo.bar.baz method)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/method-in-something.txt
+++ b/test/parser/expect/reference-component-kind/method-in-something.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 17))
     (paragraph
-     (((f.ml (1 0) (1 17)) (reference (method bar (root foo unknown)) ())))))))
+     (((f.ml (1 0) (1 17))
+       (reference ((method bar (root foo unknown)) (foo.bar method)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/method.txt
+++ b/test/parser/expect/reference-component-kind/method.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 13))
-    (paragraph (((f.ml (1 0) (1 13)) (reference (root foo method) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 13)) (reference ((root foo method) (foo method)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module-in-module-nested.txt
+++ b/test/parser/expect/reference-component-kind/module-in-module-nested.txt
@@ -2,5 +2,7 @@
   (((f.ml (1 0) (1 28))
     (paragraph
      (((f.ml (1 0) (1 28))
-       (reference (module Baz (module Bar (root Foo unknown))) ())))))))
+       (reference
+        ((module Baz (module Bar (root Foo unknown))) (Foo.Bar.Baz module))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module-in-module-type-nested.txt
+++ b/test/parser/expect/reference-component-kind/module-in-module-type-nested.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 33))
     (paragraph
      (((f.ml (1 0) (1 33))
-       (reference (module Baz (module_type Bar (root Foo unknown))) ())))))))
+       (reference
+        ((module Baz (module_type Bar (root Foo unknown)))
+         (Foo.Bar.Baz module))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module-in-module-type.txt
+++ b/test/parser/expect/reference-component-kind/module-in-module-type.txt
@@ -2,5 +2,5 @@
   (((f.ml (1 0) (1 29))
     (paragraph
      (((f.ml (1 0) (1 29))
-       (reference (module Bar (root Foo module_type)) ())))))))
+       (reference ((module Bar (root Foo module_type)) (Foo.Bar module)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module-in-module.txt
+++ b/test/parser/expect/reference-component-kind/module-in-module.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 24))
     (paragraph
-     (((f.ml (1 0) (1 24)) (reference (module Bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 24))
+       (reference ((module Bar (root Foo module)) (Foo.Bar module)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module-in-something-nested.txt
+++ b/test/parser/expect/reference-component-kind/module-in-something-nested.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 21))
     (paragraph
      (((f.ml (1 0) (1 21))
-       (reference (module Baz (dot Bar (root Foo unknown))) ())))))))
+       (reference
+        ((module Baz (dot Bar (root Foo unknown))) (Foo.Bar.Baz module)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module-in-something.txt
+++ b/test/parser/expect/reference-component-kind/module-in-something.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 17))
     (paragraph
-     (((f.ml (1 0) (1 17)) (reference (module Bar (root Foo unknown)) ())))))))
+     (((f.ml (1 0) (1 17))
+       (reference ((module Bar (root Foo unknown)) (Foo.Bar module)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module-type-alt.txt
+++ b/test/parser/expect/reference-component-kind/module-type-alt.txt
@@ -1,6 +1,8 @@
 ((output
   (((f.ml (1 0) (1 14))
-    (paragraph (((f.ml (1 0) (1 14)) (reference (root Foo module_type) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 14))
+       (reference ((root Foo module_type) (Foo module_type)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 2-13:\
    \n'modtype' is deprecated, use 'module-type' instead.")))

--- a/test/parser/expect/reference-component-kind/module-type-in-module-type.txt
+++ b/test/parser/expect/reference-component-kind/module-type-in-module-type.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 34))
     (paragraph
      (((f.ml (1 0) (1 34))
-       (reference (module_type Bar (root Foo module_type)) ())))))))
+       (reference
+        ((module_type Bar (root Foo module_type)) (Foo.Bar module_type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module-type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/module-type-in-module.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 29))
     (paragraph
      (((f.ml (1 0) (1 29))
-       (reference (module_type Bar (root Foo module)) ())))))))
+       (reference ((module_type Bar (root Foo module)) (Foo.Bar module_type))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module-type-in-something.txt
+++ b/test/parser/expect/reference-component-kind/module-type-in-something.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 22))
     (paragraph
      (((f.ml (1 0) (1 22))
-       (reference (module_type Bar (root Foo unknown)) ())))))))
+       (reference
+        ((module_type Bar (root Foo unknown)) (Foo.Bar module_type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module-type.txt
+++ b/test/parser/expect/reference-component-kind/module-type.txt
@@ -1,4 +1,6 @@
 ((output
   (((f.ml (1 0) (1 18))
-    (paragraph (((f.ml (1 0) (1 18)) (reference (root Foo module_type) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 18))
+       (reference ((root Foo module_type) (Foo module_type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/module.txt
+++ b/test/parser/expect/reference-component-kind/module.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 13))
-    (paragraph (((f.ml (1 0) (1 13)) (reference (root Foo module) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 13)) (reference ((root Foo module) (Foo module)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/no-kind.txt
+++ b/test/parser/expect/reference-component-kind/no-kind.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 6))
-    (paragraph (((f.ml (1 0) (1 6)) (reference (root foo unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 6)) (reference ((root foo unknown) (foo unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/page.txt
+++ b/test/parser/expect/reference-component-kind/page.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 11))
-    (paragraph (((f.ml (1 0) (1 11)) (reference (root foo page) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 11)) (reference ((root foo page) (foo page)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/section-in-class.txt
+++ b/test/parser/expect/reference-component-kind/section-in-class.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 24))
     (paragraph
-     (((f.ml (1 0) (1 24)) (reference (label bar (root foo class)) ())))))))
+     (((f.ml (1 0) (1 24))
+       (reference ((label bar (root foo class)) (foo.bar label)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/section-in-module.txt
+++ b/test/parser/expect/reference-component-kind/section-in-module.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 25))
     (paragraph
-     (((f.ml (1 0) (1 25)) (reference (label bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 25))
+       (reference ((label bar (root Foo module)) (Foo.bar label)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/section-in-page.txt
+++ b/test/parser/expect/reference-component-kind/section-in-page.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 23))
     (paragraph
-     (((f.ml (1 0) (1 23)) (reference (label bar (root foo page)) ())))))))
+     (((f.ml (1 0) (1 23))
+       (reference ((label bar (root foo page)) (foo.bar label)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/section-in-something.txt
+++ b/test/parser/expect/reference-component-kind/section-in-something.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 18))
     (paragraph
-     (((f.ml (1 0) (1 18)) (reference (label bar (root Foo unknown)) ())))))))
+     (((f.ml (1 0) (1 18))
+       (reference ((label bar (root Foo unknown)) (Foo.bar label)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-class-nested.txt
+++ b/test/parser/expect/reference-component-kind/something-in-class-nested.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 20))
     (paragraph
      (((f.ml (1 0) (1 20))
-       (reference (dot baz (class bar (root Foo unknown))) ())))))))
+       (reference
+        ((dot baz (class bar (root Foo unknown))) (Foo.bar.baz unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-class-type-nested.txt
+++ b/test/parser/expect/reference-component-kind/something-in-class-type-nested.txt
@@ -2,5 +2,7 @@
   (((f.ml (1 0) (1 25))
     (paragraph
      (((f.ml (1 0) (1 25))
-       (reference (dot baz (class_type bar (root foo unknown))) ())))))))
+       (reference
+        ((dot baz (class_type bar (root foo unknown))) (foo.bar.baz unknown))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-class-type.txt
+++ b/test/parser/expect/reference-component-kind/something-in-class-type.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 21))
     (paragraph
-     (((f.ml (1 0) (1 21)) (reference (dot bar (root foo class_type)) ())))))))
+     (((f.ml (1 0) (1 21))
+       (reference ((dot bar (root foo class_type)) (foo.bar unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-class.txt
+++ b/test/parser/expect/reference-component-kind/something-in-class.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 16))
     (paragraph
-     (((f.ml (1 0) (1 16)) (reference (dot bar (root foo class)) ())))))))
+     (((f.ml (1 0) (1 16))
+       (reference ((dot bar (root foo class)) (foo.bar unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-module-nested.txt
+++ b/test/parser/expect/reference-component-kind/something-in-module-nested.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 21))
     (paragraph
      (((f.ml (1 0) (1 21))
-       (reference (dot baz (module Bar (root Foo unknown))) ())))))))
+       (reference
+        ((dot baz (module Bar (root Foo unknown))) (Foo.Bar.baz unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-module-type-nested.txt
+++ b/test/parser/expect/reference-component-kind/something-in-module-type-nested.txt
@@ -2,5 +2,8 @@
   (((f.ml (1 0) (1 26))
     (paragraph
      (((f.ml (1 0) (1 26))
-       (reference (dot baz (module_type Bar (root Foo unknown))) ())))))))
+       (reference
+        ((dot baz (module_type Bar (root Foo unknown)))
+         (Foo.Bar.baz unknown))
+        ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-module-type.txt
+++ b/test/parser/expect/reference-component-kind/something-in-module-type.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 22))
     (paragraph
-     (((f.ml (1 0) (1 22)) (reference (dot bar (root Foo module_type)) ())))))))
+     (((f.ml (1 0) (1 22))
+       (reference ((dot bar (root Foo module_type)) (Foo.bar unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-module.txt
+++ b/test/parser/expect/reference-component-kind/something-in-module.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 17))
     (paragraph
-     (((f.ml (1 0) (1 17)) (reference (dot bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 17))
+       (reference ((dot bar (root Foo module)) (Foo.bar unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-page.txt
+++ b/test/parser/expect/reference-component-kind/something-in-page.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 15))
     (paragraph
-     (((f.ml (1 0) (1 15)) (reference (dot bar (root foo page)) ())))))))
+     (((f.ml (1 0) (1 15))
+       (reference ((dot bar (root foo page)) (foo.bar unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-something-nested.txt
+++ b/test/parser/expect/reference-component-kind/something-in-something-nested.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 14))
     (paragraph
      (((f.ml (1 0) (1 14))
-       (reference (dot baz (dot bar (root foo unknown))) ())))))))
+       (reference
+        ((dot baz (dot bar (root foo unknown))) (foo.bar.baz unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-something.txt
+++ b/test/parser/expect/reference-component-kind/something-in-something.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 10))
     (paragraph
-     (((f.ml (1 0) (1 10)) (reference (dot bar (root foo unknown)) ())))))))
+     (((f.ml (1 0) (1 10))
+       (reference ((dot bar (root foo unknown)) (foo.bar unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-type-nested.txt
+++ b/test/parser/expect/reference-component-kind/something-in-type-nested.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 19))
     (paragraph
      (((f.ml (1 0) (1 19))
-       (reference (dot baz (type bar (root Foo unknown))) ())))))))
+       (reference
+        ((dot baz (type bar (root Foo unknown))) (Foo.bar.baz unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/something-in-type.txt
+++ b/test/parser/expect/reference-component-kind/something-in-type.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 15))
     (paragraph
-     (((f.ml (1 0) (1 15)) (reference (dot bar (root foo type)) ())))))))
+     (((f.ml (1 0) (1 15))
+       (reference ((dot bar (root foo type)) (foo.bar unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/type-in-module-type.txt
+++ b/test/parser/expect/reference-component-kind/type-in-module-type.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 27))
     (paragraph
-     (((f.ml (1 0) (1 27)) (reference (type bar (root Foo module_type)) ())))))))
+     (((f.ml (1 0) (1 27))
+       (reference ((type bar (root Foo module_type)) (Foo.bar type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/type-in-module.txt
+++ b/test/parser/expect/reference-component-kind/type-in-module.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 22))
     (paragraph
-     (((f.ml (1 0) (1 22)) (reference (type bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 22))
+       (reference ((type bar (root Foo module)) (Foo.bar type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/type-in-something.txt
+++ b/test/parser/expect/reference-component-kind/type-in-something.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 15))
     (paragraph
-     (((f.ml (1 0) (1 15)) (reference (type bar (root Foo unknown)) ())))))))
+     (((f.ml (1 0) (1 15))
+       (reference ((type bar (root Foo unknown)) (Foo.bar type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/type.txt
+++ b/test/parser/expect/reference-component-kind/type.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 11))
-    (paragraph (((f.ml (1 0) (1 11)) (reference (root foo type) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 11)) (reference ((root foo type) (foo type)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/val-alt.txt
+++ b/test/parser/expect/reference-component-kind/val-alt.txt
@@ -1,6 +1,7 @@
 ((output
   (((f.ml (1 0) (1 12))
-    (paragraph (((f.ml (1 0) (1 12)) (reference (root foo value) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 12)) (reference ((root foo value) (foo value)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 2-11:\
    \n'value' is deprecated, use 'val' instead.")))

--- a/test/parser/expect/reference-component-kind/val-in-module.txt
+++ b/test/parser/expect/reference-component-kind/val-in-module.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 21))
     (paragraph
-     (((f.ml (1 0) (1 21)) (reference (value bar (root Foo module)) ())))))))
+     (((f.ml (1 0) (1 21))
+       (reference ((value bar (root Foo module)) (Foo.bar value)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/val-in-something.txt
+++ b/test/parser/expect/reference-component-kind/val-in-something.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 14))
     (paragraph
-     (((f.ml (1 0) (1 14)) (reference (value bar (root Foo unknown)) ())))))))
+     (((f.ml (1 0) (1 14))
+       (reference ((value bar (root Foo unknown)) (Foo.bar value)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-component-kind/val.txt
+++ b/test/parser/expect/reference-component-kind/val.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 10))
-    (paragraph (((f.ml (1 0) (1 10)) (reference (root foo value) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 10)) (reference ((root foo value) (foo value)) ())))))))
  (warnings ()))

--- a/test/parser/expect/reference-with-text/basic.txt
+++ b/test/parser/expect/reference-with-text/basic.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 12))
     (paragraph
      (((f.ml (1 0) (1 12))
-       (reference (root foo unknown) (((f.ml (1 8) (1 11)) (word bar))))))))))
+       (reference ((root foo unknown) (foo unknown))
+        (((f.ml (1 8) (1 11)) (word bar))))))))))
  (warnings ()))

--- a/test/parser/expect/reference-with-text/degenerate.txt
+++ b/test/parser/expect/reference-with-text/degenerate.txt
@@ -1,6 +1,7 @@
 ((output
   (((f.ml (1 0) (1 8))
-    (paragraph (((f.ml (1 0) (1 8)) (reference (root foo unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 8)) (reference ((root foo unknown) (foo unknown)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 0-8:\
    \n'{{!...} ...}' (cross-reference) should not be empty.")))

--- a/test/parser/expect/reference-with-text/empty.txt
+++ b/test/parser/expect/reference-with-text/empty.txt
@@ -1,6 +1,7 @@
 ((output
   (((f.ml (1 0) (1 9))
-    (paragraph (((f.ml (1 0) (1 9)) (reference (root foo unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 9)) (reference ((root foo unknown) (foo unknown)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 0-9:\
    \n'{{!...} ...}' (cross-reference) should not be empty.")))

--- a/test/parser/expect/reference-with-text/in-markup.txt
+++ b/test/parser/expect/reference-with-text/in-markup.txt
@@ -4,5 +4,6 @@
      (((f.ml (1 0) (1 16))
        (emphasis
         (((f.ml (1 3) (1 15))
-          (reference (root foo unknown) (((f.ml (1 11) (1 14)) (word bar)))))))))))))
+          (reference ((root foo unknown) (foo unknown))
+           (((f.ml (1 11) (1 14)) (word bar)))))))))))))
  (warnings ()))

--- a/test/parser/expect/reference-with-text/internal-whitespace.txt
+++ b/test/parser/expect/reference-with-text/internal-whitespace.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 14))
     (paragraph
      (((f.ml (1 0) (1 14))
-       (reference (root "( * )" unknown) (((f.ml (1 10) (1 13)) (word baz))))))))))
+       (reference ((root "( * )" unknown) ("( * )" unknown))
+        (((f.ml (1 10) (1 13)) (word baz))))))))))
  (warnings ()))

--- a/test/parser/expect/reference-with-text/kind.txt
+++ b/test/parser/expect/reference-with-text/kind.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 16))
     (paragraph
      (((f.ml (1 0) (1 16))
-       (reference (root foo value) (((f.ml (1 12) (1 15)) (word bar))))))))))
+       (reference ((root foo value) (foo value))
+        (((f.ml (1 12) (1 15)) (word bar))))))))))
  (warnings ()))

--- a/test/parser/expect/reference-with-text/nested-empty.txt
+++ b/test/parser/expect/reference-with-text/nested-empty.txt
@@ -2,7 +2,8 @@
   (((f.ml (1 0) (1 17))
     (paragraph
      (((f.ml (1 0) (1 17))
-       (reference (root foo unknown) (((f.ml (1 8) (1 16)) (emphasis ()))))))))))
+       (reference ((root foo unknown) (foo unknown))
+        (((f.ml (1 8) (1 16)) (emphasis ()))))))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 8-16:\
    \n'{{!...} ...}' (cross-reference) should not be empty."

--- a/test/parser/expect/reference-with-text/nested-markup.txt
+++ b/test/parser/expect/reference-with-text/nested-markup.txt
@@ -2,6 +2,6 @@
   (((f.ml (1 0) (1 16))
     (paragraph
      (((f.ml (1 0) (1 16))
-       (reference (root foo unknown)
+       (reference ((root foo unknown) (foo unknown))
         (((f.ml (1 8) (1 15)) (bold (((f.ml (1 11) (1 14)) (word bar)))))))))))))
  (warnings ()))

--- a/test/parser/expect/reference-with-text/nested-reference.txt
+++ b/test/parser/expect/reference-with-text/nested-reference.txt
@@ -2,7 +2,8 @@
   (((f.ml (1 0) (1 15))
     (paragraph
      (((f.ml (1 0) (1 15))
-       (reference (root foo unknown) (((f.ml (1 8) (1 14)) (emphasis ()))))))))))
+       (reference ((root foo unknown) (foo unknown))
+        (((f.ml (1 8) (1 14)) (emphasis ()))))))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 8-14:\
    \n'{!...}' (cross-reference) is not allowed in '{{!...} ...}' (cross-reference).")))

--- a/test/parser/expect/reference-with-text/nested-through-emphasis.txt
+++ b/test/parser/expect/reference-with-text/nested-through-emphasis.txt
@@ -2,7 +2,7 @@
   (((f.ml (1 0) (1 25))
     (paragraph
      (((f.ml (1 0) (1 25))
-       (reference (root foo unknown)
+       (reference ((root foo unknown) (foo unknown))
         (((f.ml (1 8) (1 24))
           (emphasis
            (((f.ml (1 11) (1 23))

--- a/test/parser/expect/reference-with-text/no-separating-space.txt
+++ b/test/parser/expect/reference-with-text/no-separating-space.txt
@@ -2,5 +2,6 @@
   (((f.ml (1 0) (1 11))
     (paragraph
      (((f.ml (1 0) (1 11))
-       (reference (root foo unknown) (((f.ml (1 7) (1 10)) (word bar))))))))))
+       (reference ((root foo unknown) (foo unknown))
+        (((f.ml (1 7) (1 10)) (word bar))))))))))
  (warnings ()))

--- a/test/parser/expect/reference-with-text/simple-through-emphasis.txt
+++ b/test/parser/expect/reference-with-text/simple-through-emphasis.txt
@@ -2,7 +2,7 @@
   (((f.ml (1 0) (1 19))
     (paragraph
      (((f.ml (1 0) (1 19))
-       (reference (root foo unknown)
+       (reference ((root foo unknown) (foo unknown))
         (((f.ml (1 8) (1 18))
           (emphasis (((f.ml (1 11) (1 17)) (emphasis ())))))))))))))
  (warnings

--- a/test/parser/expect/reference-with-text/unterminated-content.txt
+++ b/test/parser/expect/reference-with-text/unterminated-content.txt
@@ -2,7 +2,8 @@
   (((f.ml (1 0) (1 11))
     (paragraph
      (((f.ml (1 0) (1 11))
-       (reference (root foo unknown) (((f.ml (1 8) (1 11)) (word bar))))))))))
+       (reference ((root foo unknown) (foo unknown))
+        (((f.ml (1 8) (1 11)) (word bar))))))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 11-11:\
    \nEnd of text is not allowed in '{{!...} ...}' (cross-reference).")))

--- a/test/parser/expect/reference-with-text/unterminated.txt
+++ b/test/parser/expect/reference-with-text/unterminated.txt
@@ -1,6 +1,7 @@
 ((output
   (((f.ml (1 0) (1 6))
-    (paragraph (((f.ml (1 0) (1 6)) (reference (root foo unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 6)) (reference ((root foo unknown) (foo unknown)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 6-6:\
    \nEnd of text is not allowed in '{{!...} ...}' (cross-reference)."

--- a/test/parser/expect/simple-reference/adjacent-word-leading.txt
+++ b/test/parser/expect/simple-reference/adjacent-word-leading.txt
@@ -2,5 +2,5 @@
   (((f.ml (1 0) (1 9))
     (paragraph
      (((f.ml (1 0) (1 3)) (word bar))
-      ((f.ml (1 3) (1 9)) (reference (root foo unknown) ())))))))
+      ((f.ml (1 3) (1 9)) (reference ((root foo unknown) (foo unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/adjacent-word-trailing.txt
+++ b/test/parser/expect/simple-reference/adjacent-word-trailing.txt
@@ -1,6 +1,6 @@
 ((output
   (((f.ml (1 0) (1 9))
     (paragraph
-     (((f.ml (1 0) (1 6)) (reference (root foo unknown) ()))
+     (((f.ml (1 0) (1 6)) (reference ((root foo unknown) (foo unknown)) ()))
       ((f.ml (1 6) (1 9)) (word bar)))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/basic.txt
+++ b/test/parser/expect/simple-reference/basic.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 6))
-    (paragraph (((f.ml (1 0) (1 6)) (reference (root foo unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 6)) (reference ((root foo unknown) (foo unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/explicit-leading-space.txt
+++ b/test/parser/expect/simple-reference/explicit-leading-space.txt
@@ -2,5 +2,5 @@
   (((f.ml (1 0) (1 10))
     (paragraph
      (((f.ml (1 0) (1 3)) (word bar)) ((f.ml (1 3) (1 4)) space)
-      ((f.ml (1 4) (1 10)) (reference (root foo unknown) ())))))))
+      ((f.ml (1 4) (1 10)) (reference ((root foo unknown) (foo unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/explicit-trailing-space.txt
+++ b/test/parser/expect/simple-reference/explicit-trailing-space.txt
@@ -1,6 +1,6 @@
 ((output
   (((f.ml (1 0) (1 10))
     (paragraph
-     (((f.ml (1 0) (1 6)) (reference (root foo unknown) ()))
+     (((f.ml (1 0) (1 6)) (reference ((root foo unknown) (foo unknown)) ()))
       ((f.ml (1 6) (1 7)) space) ((f.ml (1 7) (1 10)) (word bar)))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/internal-whitespace-in-referent.txt
+++ b/test/parser/expect/simple-reference/internal-whitespace-in-referent.txt
@@ -1,4 +1,6 @@
 ((output
   (((f.ml (1 0) (1 12))
-    (paragraph (((f.ml (1 0) (1 12)) (reference (root "( * )" value) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 12))
+       (reference ((root "( * )" value) ("( * )" value)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/internal-whitespace.txt
+++ b/test/parser/expect/simple-reference/internal-whitespace.txt
@@ -1,4 +1,6 @@
 ((output
   (((f.ml (1 0) (1 8))
-    (paragraph (((f.ml (1 0) (1 8)) (reference (root "( * )" unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 8))
+       (reference ((root "( * )" unknown) ("( * )" unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/kind.txt
+++ b/test/parser/expect/simple-reference/kind.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 10))
-    (paragraph (((f.ml (1 0) (1 10)) (reference (root foo value) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 10)) (reference ((root foo value) (foo value)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/leading-whitespace-in-kind.txt
+++ b/test/parser/expect/simple-reference/leading-whitespace-in-kind.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 11))
-    (paragraph (((f.ml (1 0) (1 11)) (reference (root foo value) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 11)) (reference ((root foo value) (foo value)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/leading-whitespace.txt
+++ b/test/parser/expect/simple-reference/leading-whitespace.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 7))
-    (paragraph (((f.ml (1 0) (1 7)) (reference (root foo unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 7)) (reference ((root foo unknown) (foo unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/operator-with-dash.txt
+++ b/test/parser/expect/simple-reference/operator-with-dash.txt
@@ -1,4 +1,6 @@
 ((output
   (((f.ml (1 0) (1 8))
-    (paragraph (((f.ml (1 0) (1 8)) (reference (root "(@->)" unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 8))
+       (reference ((root "(@->)" unknown) ("(@->)" unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/operator-with-dot.txt
+++ b/test/parser/expect/simple-reference/operator-with-dot.txt
@@ -1,4 +1,6 @@
 ((output
   (((f.ml (1 0) (1 7))
-    (paragraph (((f.ml (1 0) (1 7)) (reference (root "(*.)" unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 7))
+       (reference ((root "(*.)" unknown) ("(*.)" unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/operator.txt
+++ b/test/parser/expect/simple-reference/operator.txt
@@ -1,4 +1,6 @@
 ((output
   (((f.ml (1 0) (1 8))
-    (paragraph (((f.ml (1 0) (1 8)) (reference (root "(>>=)" unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 8))
+       (reference ((root "(>>=)" unknown) ("(>>=)" unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/space-after-colon.txt
+++ b/test/parser/expect/simple-reference/space-after-colon.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 11))
-    (paragraph (((f.ml (1 0) (1 11)) (reference (root foo value) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 11)) (reference ((root foo value) (foo value)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/space-before-colon.txt
+++ b/test/parser/expect/simple-reference/space-before-colon.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 11))
-    (paragraph (((f.ml (1 0) (1 11)) (reference (root foo value) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 11)) (reference ((root foo value) (foo value)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/trailing-whitespace.txt
+++ b/test/parser/expect/simple-reference/trailing-whitespace.txt
@@ -1,4 +1,5 @@
 ((output
   (((f.ml (1 0) (1 7))
-    (paragraph (((f.ml (1 0) (1 7)) (reference (root foo unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 7)) (reference ((root foo unknown) (foo unknown)) ())))))))
  (warnings ()))

--- a/test/parser/expect/simple-reference/unterminated-after-kind.txt
+++ b/test/parser/expect/simple-reference/unterminated-after-kind.txt
@@ -1,6 +1,7 @@
 ((output
   (((f.ml (1 0) (1 9))
-    (paragraph (((f.ml (1 0) (1 9)) (reference (root foo value) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 9)) (reference ((root foo value) (foo value)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 9-9:\
    \nEnd of text is not allowed in '{!...}' (cross-reference).")))

--- a/test/parser/expect/simple-reference/unterminated.txt
+++ b/test/parser/expect/simple-reference/unterminated.txt
@@ -1,6 +1,7 @@
 ((output
   (((f.ml (1 0) (1 5))
-    (paragraph (((f.ml (1 0) (1 5)) (reference (root foo unknown) ())))))))
+    (paragraph
+     (((f.ml (1 0) (1 5)) (reference ((root foo unknown) (foo unknown)) ())))))))
  (warnings
   ( "File \"f.ml\", line 1, characters 5-5:\
    \nEnd of text is not allowed in '{!...}' (cross-reference).")))

--- a/test/parser/expect/utf-8/reference-target.txt
+++ b/test/parser/expect/utf-8/reference-target.txt
@@ -1,5 +1,6 @@
 ((output
   (((f.ml (1 0) (1 5))
     (paragraph
-     (((f.ml (1 0) (1 5)) (reference (root "\206\187" unknown) ())))))))
+     (((f.ml (1 0) (1 5))
+       (reference ((root "\206\187" unknown) ("\206\187" unknown)) ())))))))
  (warnings ()))

--- a/test/print/print.ml
+++ b/test/print/print.ml
@@ -206,6 +206,10 @@ struct
       List [Atom "instance_variable"; Atom (InstanceVariableName.to_string s); resolved (parent :> Resolved.t)]
     | `Label (parent, s) ->
       List [Atom "label"; Atom (LabelName.to_string s); resolved (parent :> Resolved.t)]
+
+  let reference t =
+    let ds, dt = Reference.deconstruct t in
+    List [reference t; List [Atom ds; tag dt]]
 end
 
 


### PR DESCRIPTION
Add the `Reference.deconstruct` and `Reference.Resolved.deconstruct` functions to easily print references.

While working with Odoc, I had to write these functions in order to print references.
They are very hard to write and most probably contain bugs. Implementing them in Odoc should solve these problems.

The interface is:

```ocaml
val deconstruct : t -> string * Paths_types.Reference.tag_any
```