### PR TITLE
<span> parentheses

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -69,40 +69,61 @@ struct
     : 'inner 'outer. Odoc_model.Lang.TypeExpr.Polymorphic_variant.t ->
         ('inner, 'outer) text Html.elt
   = fun (t : Odoc_model.Lang.TypeExpr.Polymorphic_variant.t) ->
-    let elements =
-      list_concat_map t.elements ~sep:(Html.txt " | ") ~f:(function
-        | Odoc_model.Lang.TypeExpr.Polymorphic_variant.Type te -> type_expr te
-        | Constructor {constant; name; arguments; _} ->
-          let constr = "`" ^ name in
-          match arguments with
-          | [] -> [ Html.txt constr ]
-          | _ ->
-            (* Multiple arguments in a polymorphic variant constructor correspond
-               to a conjunction of types, not a product: [`Lbl int&float].
-               If constant is [true], the conjunction starts with an empty type,
-               for instance [`Lbl &int].
-            *)
-            let wrapped_type_expr =
-              (* type conjunction in Reason is printed as `Lbl (t1)&(t2)` *)
-              if Syntax.Type.Variant.parenthesize_params then
-                fun x ->
-                  [Html.span (Html.txt "(" :: type_expr x @ [Html.txt ")"])]
-              else
-                fun x -> type_expr x
-            in
-            let arguments =
-              list_concat_map
-                arguments
-                ~sep:(Html.txt " & ")
-                ~f:wrapped_type_expr
-            in
-            let arguments =
-              if constant then Html.txt "& " :: arguments else arguments in
-            if Syntax.Type.Variant.parenthesize_params
-            then Html.txt constr :: arguments
-            else Html.txt (constr ^ " of ") :: arguments
-      )
+    let style_arguments ~constant arguments =
+      (* Multiple arguments in a polymorphic variant constructor correspond
+         to a conjunction of types, not a product: [`Lbl int&float].
+         If constant is [true], the conjunction starts with an empty type,
+         for instance [`Lbl &int].
+      *)
+      let wrapped_type_expr =
+        (* type conjunction in Reason is printed as `Lbl (t1)&(t2)` *)
+        if Syntax.Type.Variant.parenthesize_params then
+          fun x ->
+            [Html.span (Html.txt "(" :: type_expr x @ [Html.txt ")"])]
+        else
+          fun x -> type_expr x
+      in
+      let arguments =
+        list_concat_map
+          arguments
+          ~sep:(Html.txt " & ")
+          ~f:wrapped_type_expr
+      in
+      if constant
+      then Html.txt "& " :: arguments
+      else arguments
     in
+    let rec style_elements ~add_pipe = function
+      | [] -> []
+      | first :: rest ->
+        let first =
+          match first with
+          | Odoc_model.Lang.TypeExpr.Polymorphic_variant.Type te ->
+            let res = type_expr te in
+            if add_pipe
+            then [Html.span (Html.txt " | " :: res)]
+            else res
+          | Constructor {constant; name; arguments; _} ->
+            let constr =
+              let name = "`" ^ name in
+              if add_pipe
+              then Html.span [Html.txt (" | " ^ name)]
+              else Html.txt name
+            in
+            [ match arguments with
+              | [] -> constr
+              | _ ->
+                let arguments = style_arguments ~constant arguments in
+                Html.span (
+                  if Syntax.Type.Variant.parenthesize_params
+                  then constr :: arguments
+                  else constr :: Html.txt  " of " :: arguments
+                )
+            ]
+        in
+        first @ style_elements ~add_pipe:true rest
+    in
+    let elements = style_elements ~add_pipe:false t.elements in
     Html.span (
       match t.kind with
       | Fixed -> Html.txt "[ " :: elements @ [Html.txt " ]"]


### PR DESCRIPTION
As suggested by @dbuenzli (:heart_eyes:) on https://github.com/ocaml/odoc/issues/19#issuecomment-470128041

Before this PR:
![before](https://user-images.githubusercontent.com/118852/58326630-4b13f680-7e25-11e9-8dfa-d21137d67d58.png)

With this PR:
![after](https://user-images.githubusercontent.com/118852/58326649-5a933f80-7e25-11e9-85b8-1de521b85b0d.png)

It's not the cleanest patch, but I encountered some type-checker bug when trying a cleaner version, so this will have to do.