### PR TITLE
Span things

### DIFF
--- a/src/html/ML.ml
+++ b/src/html/ML.ml
@@ -18,7 +18,7 @@ module ML = Generator.Make (struct
 
     let handle_params name args =
       if args <> [ Html.txt "" ]
-      then args @ [ Html.txt " " ] @ name
+      then [Html.span (args @ [ Html.txt " " ] @ name)]
       else name
 
     let handle_constructor_params = handle_params

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -191,9 +191,9 @@ struct
         [enclose ~l:"(" res ~r:")"]
     | Arrow (Some lbl, src, dst) ->
       let res =
-        label lbl @ Html.txt ":" ::
-        type_expr ~needs_parentheses:true src @
-        Html.txt " " :: Syntax.Type.arrow :: Html.txt " " :: type_expr dst
+        Html.span (
+          label lbl @ Html.txt ":" :: type_expr ~needs_parentheses:true src
+        ) :: Html.txt " " :: Syntax.Type.arrow :: Html.txt " " :: type_expr dst
       in
       if not needs_parentheses then
         res

--- a/src/html/generator_signatures.ml
+++ b/src/html/generator_signatures.ml
@@ -5,8 +5,11 @@ module Lang = Odoc_model.Lang
 
 type rendered_item = (Html_types.dt_content Html.elt) list
 
-type ('inner, 'outer) text =
-  [> `PCDATA | `Span | `A of ([> `PCDATA] as 'inner)] as 'outer
+type text =
+  [ `A of Html_types.phrasing_without_interactive
+  | `Code
+  | `PCDATA
+  | `Span ] Html.elt list
 
 type ('item_kind, 'item) tagged_item = [
   | `Leaf_item of 'item_kind * 'item
@@ -41,15 +44,8 @@ sig
   sig
     val annotation_separator : string
 
-    val handle_constructor_params :
-      ('inner, 'outer) text Html.elt list ->
-      ('inner, 'outer) text Html.elt list ->
-        ('inner, 'outer) text Html.elt list
-
-    val handle_substitution_params :
-      ('inner, 'outer) text Html.elt list ->
-      ('inner, 'outer) text Html.elt list ->
-        ('inner, 'outer) text Html.elt list
+    val handle_constructor_params : text -> text -> text
+    val handle_substitution_params : text -> text -> text
 
     val handle_format_params : string -> string
     val type_def_semicolon : bool

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -58,7 +58,7 @@
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := <span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="index.html#type-result">result</a></code>
    </div>
    <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -50,15 +50,15 @@
     <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int</code>
    </div>
    <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> 'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <span>'a <a href="module-type-S5/index.html#type-v">v</a></span> := <span><span class="type-var">'a</span> list</span></code>
    </div>
    <dl>
     <dt class="spec type" id="type-result">
-     <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) result</code>
+     <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) result</span></code>
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := <span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="index.html#type-result">result</a></code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <span>('a, 'b) <a href="module-type-S6/index.html#type-w">w</a></span> := <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="index.html#type-result">result</a></span></code>
    </div>
    <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -28,7 +28,7 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : ?⁠bar:<span class="type-var">'a</span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : <span>?⁠bar:<span class="type-var">'a</span></span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
     </dt>
     <dd>
      <p>
@@ -43,7 +43,7 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-foo'">
-     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">val</span> foo' : ?⁠bar:<span class="type-var">'a</span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
+     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">val</span> foo' : <span>?⁠bar:<span class="type-var">'a</span></span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -23,7 +23,7 @@
    </header>
    <dl>
     <dt class="spec type" id="type-opt">
-     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> 'a opt</code><code> = <span class="type-var">'a</span> option</code>
+     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt</span></code><code> = <span><span class="type-var">'a</span> option</span></code>
     </dt>
    </dl>
    <dl>
@@ -38,7 +38,7 @@
    </dl>
    <dl>
     <dt class="spec type" id="type-opt'">
-     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> 'a opt'</code><code> = int option</code>
+     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt'</span></code><code> = <span>int option</span></code>
     </dt>
    </dl>
    <dl>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -46,7 +46,7 @@
     <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> 'a <a href="class-type-polymorphic/index.html">polymorphic</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-polymorphic'">
-    <a href="#class-polymorphic'" class="anchor"></a><code><span class="keyword">class</span> 'a <a href="class-polymorphic'/index.html">polymorphic'</a> : <span class="type-var">'a</span> <a href="class-type-polymorphic/index.html">polymorphic</a></code>
+    <a href="#class-polymorphic'" class="anchor"></a><code><span class="keyword">class</span> 'a <a href="class-polymorphic'/index.html">polymorphic'</a> : <span><span class="type-var">'a</span> <a href="class-type-polymorphic/index.html">polymorphic</a></span></code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -58,7 +58,7 @@
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := (<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>) <a href="index.html#type-result">result</a></code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := <span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="index.html#type-result">result</a></code>
    </div>
    <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -50,15 +50,15 @@
     <a href="#module-type-S4" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S4/index.html">S4</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S4/index.html#type-t">t</a> := int</code>
    </div>
    <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> 'a <a href="module-type-S5/index.html#type-v">v</a> := <span class="type-var">'a</span> list</code>
+    <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <span>'a <a href="module-type-S5/index.html#type-v">v</a></span> := <span><span class="type-var">'a</span> list</span></code>
    </div>
    <dl>
     <dt class="spec type" id="type-result">
-     <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) result</code>
+     <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) result</span></code>
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> ('a, 'b) <a href="module-type-S6/index.html#type-w">w</a> := <span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="index.html#type-result">result</a></code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <span>('a, 'b) <a href="module-type-S6/index.html#type-w">w</a></span> := <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="index.html#type-result">result</a></span></code>
    </div>
    <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -45,7 +45,7 @@
      <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type</span> arrow</code><code> = int <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-higher_order">
-     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order</code><code> = (int <span>-&gt;</span> int) <span>-&gt;</span> int</code>
+     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order</code><code> = <span>(int <span>-&gt;</span> int)</span> <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-labeled">
      <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled</code><code> = l:int <span>-&gt;</span> int</code>
@@ -54,7 +54,7 @@
      <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional</code><code> = ?⁠l:int <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-labeled_higher_order">
-     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order</code><code> = (l:int <span>-&gt;</span> int) <span>-&gt;</span> (?⁠l:int <span>-&gt;</span> int) <span>-&gt;</span> int</code>
+     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order</code><code> = <span>(l:int <span>-&gt;</span> int)</span> <span>-&gt;</span> <span>(?⁠l:int <span>-&gt;</span> int)</span> <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-pair">
      <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair</code><code> = int * int</code>
@@ -66,7 +66,7 @@
      <a href="#type-triple" class="anchor"></a><code><span class="keyword">type</span> triple</code><code> = int * int * int</code>
     </dt>
     <dt class="spec type" id="type-nested_pair">
-     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair</code><code> = (int * int) * int</code>
+     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair</code><code> = <span>(int * int)</span> * int</code>
     </dt>
     <dt class="spec type" id="type-instance">
      <a href="#type-instance" class="anchor"></a><code><span class="keyword">type</span> instance</code><code> = int <a href="index.html#type-constructor">constructor</a></code>
@@ -312,10 +312,10 @@
    </div>
    <dl>
     <dt class="spec type" id="type-module_">
-     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type</span> module_</code><code> = (<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</code>
+     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type</span> module_</code><code> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</span></code>
     </dt>
     <dt class="spec type" id="type-module_substitution">
-     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution</code><code> = (<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</code>
+     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution</code><code> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span></code>
     </dt>
     <dt class="spec type" id="type-covariant">
      <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type</span> +'a covariant</code>
@@ -330,7 +330,7 @@
      <a href="#type-binary" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) binary</code>
     </dt>
     <dt class="spec type" id="type-using_binary">
-     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary</code><code> = (int,&nbsp;int) <a href="index.html#type-binary">binary</a></code>
+     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary</code><code> = <span>(int,&nbsp;int)</span> <a href="index.html#type-binary">binary</a></code>
     </dt>
     <dt class="spec type" id="type-name">
      <a href="#type-name" class="anchor"></a><code><span class="keyword">type</span> 'custom name</code>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -280,7 +280,7 @@
       <tbody>
        <tr id="type-nested_polymorphic_variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A <span class="keyword">of</span> [ `B | `C ]</code>
+         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A <span class="keyword">of</span> <span>[ `B <span>| `C</span> ]</span></code>
         </td>
        </tr>
       </tbody>
@@ -339,19 +339,19 @@
      <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type</span> <span>'a constrained</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</code>
     </dt>
     <dt class="spec type" id="type-exact_variant">
-     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a exact_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [ `A | `B of int ]</code>
+     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a exact_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[ `A <span><span>| `B</span> of int</span> ]</span></code>
     </dt>
     <dt class="spec type" id="type-lower_variant">
-     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a lower_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt; `A | `B of int ]</code>
+     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a lower_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `A <span><span>| `B</span> of int</span> ]</span></code>
     </dt>
     <dt class="spec type" id="type-any_variant">
-     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a any_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt;  ]</code>
+     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a any_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt;  ]</span></code>
     </dt>
     <dt class="spec type" id="type-upper_variant">
-     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a upper_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; `A | `B of int ]</code>
+     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a upper_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; `A <span><span>| `B</span> of int</span> ]</span></code>
     </dt>
     <dt class="spec type" id="type-named_variant">
-     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a named_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code>
+     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a named_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</span></code>
     </dt>
     <dt class="spec type" id="type-exact_object">
      <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type</span> <span>'a exact_object</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; &gt;</code>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -48,13 +48,13 @@
      <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order</code><code> = <span>(int <span>-&gt;</span> int)</span> <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-labeled">
-     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled</code><code> = l:int <span>-&gt;</span> int</code>
+     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled</code><code> = <span>l:int</span> <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-optional">
-     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional</code><code> = ?⁠l:int <span>-&gt;</span> int</code>
+     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional</code><code> = <span>?⁠l:int</span> <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-labeled_higher_order">
-     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order</code><code> = <span>(l:int <span>-&gt;</span> int)</span> <span>-&gt;</span> <span>(?⁠l:int <span>-&gt;</span> int)</span> <span>-&gt;</span> int</code>
+     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order</code><code> = <span>(<span>l:int</span> <span>-&gt;</span> int)</span> <span>-&gt;</span> <span>(<span>?⁠l:int</span> <span>-&gt;</span> int)</span> <span>-&gt;</span> int</code>
     </dt>
     <dt class="spec type" id="type-pair">
      <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair</code><code> = int * int</code>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -39,7 +39,7 @@
      <a href="#type-private_" class="anchor"></a><code><span class="keyword">type</span> private_</code><code> = <span class="keyword">private</span> int</code>
     </dt>
     <dt class="spec type" id="type-constructor">
-     <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type</span> 'a constructor</code><code> = <span class="type-var">'a</span></code>
+     <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type</span> <span>'a constructor</span></code><code> = <span class="type-var">'a</span></code>
     </dt>
     <dt class="spec type" id="type-arrow">
      <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type</span> arrow</code><code> = int <span>-&gt;</span> int</code>
@@ -69,7 +69,7 @@
      <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair</code><code> = <span>(int * int)</span> * int</code>
     </dt>
     <dt class="spec type" id="type-instance">
-     <a href="#type-instance" class="anchor"></a><code><span class="keyword">type</span> instance</code><code> = int <a href="index.html#type-constructor">constructor</a></code>
+     <a href="#type-instance" class="anchor"></a><code><span class="keyword">type</span> instance</code><code> = <span>int <a href="index.html#type-constructor">constructor</a></span></code>
     </dt>
     <dt class="spec type" id="type-variant_e">
      <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type</span> variant_e</code><code> = </code><code>{</code>
@@ -140,22 +140,22 @@
      <code>}</code>
     </dt>
     <dt class="spec type" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> _ gadt</code><code> = </code>
+     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> <span>_ gadt</span></code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-gadt.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> : int <a href="index.html#type-gadt">gadt</a></code>
+         <a href="#type-gadt.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> : <span>int <a href="index.html#type-gadt">gadt</a></span></code>
         </td>
        </tr>
        <tr id="type-gadt.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span> : int <span>-&gt;</span> string <a href="index.html#type-gadt">gadt</a></code>
+         <a href="#type-gadt.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span> : int <span>-&gt;</span> <span>string <a href="index.html#type-gadt">gadt</a></span></code>
         </td>
        </tr>
        <tr id="type-gadt.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code>| </code><code><span class="constructor">C</span> : <a href="index.html#type-variant_c">variant_c</a> <span>-&gt;</span> unit <a href="index.html#type-gadt">gadt</a></code>
+         <a href="#type-gadt.C" class="anchor"></a><code>| </code><code><span class="constructor">C</span> : <a href="index.html#type-variant_c">variant_c</a> <span>-&gt;</span> <span>unit <a href="index.html#type-gadt">gadt</a></span></code>
         </td>
        </tr>
       </tbody>
@@ -318,52 +318,52 @@
      <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution</code><code> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span></code>
     </dt>
     <dt class="spec type" id="type-covariant">
-     <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type</span> +'a covariant</code>
+     <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type</span> <span>+'a covariant</span></code>
     </dt>
     <dt class="spec type" id="type-contravariant">
-     <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type</span> -'a contravariant</code>
+     <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type</span> <span>-'a contravariant</span></code>
     </dt>
     <dt class="spec type" id="type-bivariant">
-     <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type</span> _ bivariant</code><code> = int</code>
+     <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type</span> <span>_ bivariant</span></code><code> = int</code>
     </dt>
     <dt class="spec type" id="type-binary">
-     <a href="#type-binary" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) binary</code>
+     <a href="#type-binary" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) binary</span></code>
     </dt>
     <dt class="spec type" id="type-using_binary">
-     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary</code><code> = <span>(int,&nbsp;int)</span> <a href="index.html#type-binary">binary</a></code>
+     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary</code><code> = <span><span>(int,&nbsp;int)</span> <a href="index.html#type-binary">binary</a></span></code>
     </dt>
     <dt class="spec type" id="type-name">
-     <a href="#type-name" class="anchor"></a><code><span class="keyword">type</span> 'custom name</code>
+     <a href="#type-name" class="anchor"></a><code><span class="keyword">type</span> <span>'custom name</span></code>
     </dt>
     <dt class="spec type" id="type-constrained">
-     <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type</span> 'a constrained</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</code>
+     <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type</span> <span>'a constrained</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</code>
     </dt>
     <dt class="spec type" id="type-exact_variant">
-     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> 'a exact_variant</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [ `A | `B of int ]</code>
+     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a exact_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [ `A | `B of int ]</code>
     </dt>
     <dt class="spec type" id="type-lower_variant">
-     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> 'a lower_variant</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt; `A | `B of int ]</code>
+     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a lower_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt; `A | `B of int ]</code>
     </dt>
     <dt class="spec type" id="type-any_variant">
-     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> 'a any_variant</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt;  ]</code>
+     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a any_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt;  ]</code>
     </dt>
     <dt class="spec type" id="type-upper_variant">
-     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> 'a upper_variant</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; `A | `B of int ]</code>
+     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a upper_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; `A | `B of int ]</code>
     </dt>
     <dt class="spec type" id="type-named_variant">
-     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> 'a named_variant</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code>
+     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a named_variant</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code>
     </dt>
     <dt class="spec type" id="type-exact_object">
-     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type</span> 'a exact_object</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; &gt;</code>
+     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type</span> <span>'a exact_object</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; &gt;</code>
     </dt>
     <dt class="spec type" id="type-lower_object">
-     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type</span> 'a lower_object</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; .. &gt;</code>
+     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type</span> <span>'a lower_object</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; .. &gt;</code>
     </dt>
     <dt class="spec type" id="type-poly_object">
-     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> 'a poly_object</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : a. <span class="type-var">'a</span>; &gt;</code>
+     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> <span>'a poly_object</span></code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : a. <span class="type-var">'a</span>; &gt;</code>
     </dt>
     <dt class="spec type" id="type-double_constrained">
-     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> ('a, 'b) double_constrained</code><code> = <span class="type-var">'a</span> * <span class="type-var">'b</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</code>
+     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) double_constrained</span></code><code> = <span class="type-var">'a</span> * <span class="type-var">'b</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</code>
     </dt>
     <dt class="spec type" id="type-as_">
      <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_</code><code> = int <span class="keyword">as</span> a * <span class="type-var">'a</span></code>

--- a/test/html/expect/test_package+re/Bugs/index.html
+++ b/test/html/expect/test_package+re/Bugs/index.html
@@ -28,7 +28,7 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: ?⁠bar:<span class="type-var">'a</span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: <span>?⁠bar:<span class="type-var">'a</span></span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
     </dt>
     <dd>
      <p>
@@ -43,7 +43,7 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-foo'">
-     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">let</span> foo': ?⁠bar:<span class="type-var">'a</span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
+     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">let</span> foo': <span>?⁠bar:<span class="type-var">'a</span></span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
     </dt>
     <dd>
      <p>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -58,7 +58,7 @@
     </dt>
    </dl>
    <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>);</code>
+    <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="index.html#module-type-S">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S6/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span>;</code>
    </div>
    <div class="spec module" id="module-M'">
     <a href="#module-M'" class="anchor"></a><code><span class="keyword">module</span> <a href="M'/index.html">M'</a>: { ... };</code>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -56,7 +56,7 @@
     </header>
     <dl>
      <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code><code> = (<a href="argument-1-Arg1/index.html#type-t">Arg1.t</a>, <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a>)</code>;
+      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code><code> = <span>(<a href="argument-1-Arg1/index.html#type-t">Arg1.t</a>, <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a>)</span></code>;
      </dt>
      <dd>
       <p>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -45,7 +45,7 @@
      <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type</span> arrow</code><code> = int <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-higher_order">
-     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order</code><code> = (int <span>=&gt;</span> int) <span>=&gt;</span> int</code>;
+     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order</code><code> = <span>(int <span>=&gt;</span> int)</span> <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-labeled">
      <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled</code><code> = l:int <span>=&gt;</span> int</code>;
@@ -54,19 +54,19 @@
      <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional</code><code> = ?⁠l:int <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-labeled_higher_order">
-     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order</code><code> = (l:int <span>=&gt;</span> int) <span>=&gt;</span> (?⁠l:int <span>=&gt;</span> int) <span>=&gt;</span> int</code>;
+     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order</code><code> = <span>(l:int <span>=&gt;</span> int)</span> <span>=&gt;</span> <span>(?⁠l:int <span>=&gt;</span> int)</span> <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-pair">
-     <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair</code><code> = (int, int)</code>;
+     <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair</code><code> = <span>(int, int)</span></code>;
     </dt>
     <dt class="spec type" id="type-parens_dropped">
-     <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type</span> parens_dropped</code><code> = (int, int)</code>;
+     <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type</span> parens_dropped</code><code> = <span>(int, int)</span></code>;
     </dt>
     <dt class="spec type" id="type-triple">
-     <a href="#type-triple" class="anchor"></a><code><span class="keyword">type</span> triple</code><code> = (int, int, int)</code>;
+     <a href="#type-triple" class="anchor"></a><code><span class="keyword">type</span> triple</code><code> = <span>(int, int, int)</span></code>;
     </dt>
     <dt class="spec type" id="type-nested_pair">
-     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair</code><code> = ((int, int), int)</code>;
+     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair</code><code> = <span>(<span>(int, int)</span>, int)</span></code>;
     </dt>
     <dt class="spec type" id="type-instance">
      <a href="#type-instance" class="anchor"></a><code><span class="keyword">type</span> instance</code><code> = <a href="index.html#type-constructor">constructor</a>(int)</code>;
@@ -248,7 +248,7 @@
        </tr>
        <tr id="type-polymorphic_variant.C" class="anchored">
         <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C((int, unit))</code>
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C(<span>(int, unit)</span>)</code>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.D" class="anchored">
@@ -316,10 +316,10 @@
    </div>
    <dl>
     <dt class="spec type" id="type-module_">
-     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type</span> module_</code><code> = (<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</code>;
+     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type</span> module_</code><code> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</span></code>;
     </dt>
     <dt class="spec type" id="type-module_substitution">
-     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution</code><code> = (<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</code>;
+     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution</code><code> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span></code>;
     </dt>
     <dt class="spec type" id="type-covariant">
      <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type</span> covariant(+'a)</code>;
@@ -334,7 +334,7 @@
      <a href="#type-binary" class="anchor"></a><code><span class="keyword">type</span> binary('a, 'b)</code>;
     </dt>
     <dt class="spec type" id="type-using_binary">
-     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary</code><code> = <a href="index.html#type-binary">binary</a>(int,&nbsp;int)</code>;
+     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary</code><code> = <a href="index.html#type-binary">binary</a><span>(int,&nbsp;int)</span></code>;
     </dt>
     <dt class="spec type" id="type-name">
      <a href="#type-name" class="anchor"></a><code><span class="keyword">type</span> name('custom)</code>;
@@ -367,10 +367,10 @@
      <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> poly_object('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {. a: a. <span class="type-var">'a</span>, }</code>;
     </dt>
     <dt class="spec type" id="type-double_constrained">
-     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> double_constrained('a, 'b)</code><code> = (<span class="type-var">'a</span>, <span class="type-var">'b</span>)</code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</code>;
+     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> double_constrained('a, 'b)</code><code> = <span>(<span class="type-var">'a</span>, <span class="type-var">'b</span>)</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</code>;
     </dt>
     <dt class="spec type" id="type-as_">
-     <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_</code><code> = (int <span class="keyword">as</span> a, <span class="type-var">'a</span>)</code>;
+     <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_</code><code> = <span>(int <span class="keyword">as</span> a, <span class="type-var">'a</span>)</span></code>;
     </dt>
     <dt class="spec type" id="type-extensible">
      <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type</span> extensible</code><code> = </code><code>..</code>;

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -284,7 +284,7 @@
       <tbody>
        <tr id="type-nested_polymorphic_variant.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A([ `B | `C ])</code>
+         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A(<span>[ `B <span>| `C</span> ]</span>)</code>
         </td>
        </tr>
       </tbody>
@@ -343,19 +343,19 @@
      <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type</span> constrained('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</code>;
     </dt>
     <dt class="spec type" id="type-exact_variant">
-     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> exact_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [ `A | `B(int) ]</code>;
+     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> exact_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[ `A <span><span>| `B</span><span>(int)</span></span> ]</span></code>;
     </dt>
     <dt class="spec type" id="type-lower_variant">
-     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> lower_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt; `A | `B(int) ]</code>;
+     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> lower_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `A <span><span>| `B</span><span>(int)</span></span> ]</span></code>;
     </dt>
     <dt class="spec type" id="type-any_variant">
-     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> any_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&gt;  ]</code>;
+     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> any_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt;  ]</span></code>;
     </dt>
     <dt class="spec type" id="type-upper_variant">
-     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> upper_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; `A | `B(int) ]</code>;
+     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> upper_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; `A <span><span>| `B</span><span>(int)</span></span> ]</span></code>;
     </dt>
     <dt class="spec type" id="type-named_variant">
-     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> named_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = [&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</code>;
+     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> named_variant('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</span></code>;
     </dt>
     <dt class="spec type" id="type-exact_object">
      <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type</span> exact_object('a)</code><code> = <span class="type-var">'a</span></code><code> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {. a: int, b: int, }</code>;

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -48,13 +48,13 @@
      <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order</code><code> = <span>(int <span>=&gt;</span> int)</span> <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-labeled">
-     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled</code><code> = l:int <span>=&gt;</span> int</code>;
+     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled</code><code> = <span>l:int</span> <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-optional">
-     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional</code><code> = ?⁠l:int <span>=&gt;</span> int</code>;
+     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional</code><code> = <span>?⁠l:int</span> <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-labeled_higher_order">
-     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order</code><code> = <span>(l:int <span>=&gt;</span> int)</span> <span>=&gt;</span> <span>(?⁠l:int <span>=&gt;</span> int)</span> <span>=&gt;</span> int</code>;
+     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order</code><code> = <span>(<span>l:int</span> <span>=&gt;</span> int)</span> <span>=&gt;</span> <span>(<span>?⁠l:int</span> <span>=&gt;</span> int)</span> <span>=&gt;</span> int</code>;
     </dt>
     <dt class="spec type" id="type-pair">
      <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair</code><code> = <span>(int, int)</span></code>;


### PR DESCRIPTION
#359 reloaded:
- it's closer to @dbuenzli's initial markup
- I also `<span>` type constructors and their parameters together
- the implementation is much cleaner.
- I've updated the testsuite!

The final result for the extreme example I was using doesn't look quite as nice:
![markup](https://user-images.githubusercontent.com/118852/58492322-981b0400-8168-11e9-8f7d-ae16b33a78f3.png)

But it's reasonable, and Daniel seems to thing the markup proposed here will be better in general, which I tend to agree with.
I'm considering including some special handling for extreme cases like the one in the screenshot, but that will wait until a later date.

I think that unlike #359 this is in a reasonable state and is ready for review.