### PR TITLE
Reduce memory usage

### DIFF
--- a/src/xref/subst.ml
+++ b/src/xref/subst.ml
@@ -172,11 +172,13 @@ let rename_datatype ~equal x y =
   let open Path.Resolved in
     (Module(Identifier id, name))*)
 
-class prefix ~equal:_ ~canonical id : t = object (self)
+class prefix ~equal:_ ~canonical id : t = object
 
   inherit Maps.paths as super
 
   method root x = x
+
+  method! identifier x = x
 
   method! path_resolved : Path.Resolved.t -> Path.Resolved.t =
     fun p ->
@@ -258,8 +260,7 @@ class prefix ~equal:_ ~canonical id : t = object (self)
 
   inherit Maps.types
 
-  method offset_identifier_signature (id, offset) =
-    (self#identifier_signature id, offset)
+  method offset_identifier_signature x = x
 
 end
 


### PR DESCRIPTION
We have some files at janestreet where odoc was using over 40G of memory, this series of patch brings that back down to roughly 10G.
On these files odoc is about 5x slower though.

I expect the rewrite that @jonludlam is currently working on to improve the (resulting as well as preexisting) slowness issues.
In the meantime, these patches are necessary because odoc gets reliably OOM killed when ran from a build system.