### PR TITLE
HTML TOC for mld pages

### DIFF
--- a/src/html/generator_signatures.ml
+++ b/src/html/generator_signatures.ml
@@ -134,6 +134,12 @@ sig
       (_, 'item) tagged_item list ->
         (Html_types.div_content Html.elt) list * toc * (Tree.t list)
 
+  val lay_out_page :
+    Odoc_model.Comment.docs ->
+      ((Html_types.div_content Html.elt) list *
+       (Html_types.flow5_without_header_footer Html.elt) list *
+       toc)
+
     val render_toc :
       toc -> [> Html_types.flow5_without_header_footer] Html.elt list
   end

--- a/test/html/cases/mld.mld
+++ b/test/html/cases/mld.mld
@@ -1,4 +1,22 @@
+{0 Mld Page}
+
 This is an [.mld] file. It doesn't have an auto-generated title, like modules
 and other pages generated fully by odoc do.
 
-The whole thing is {b written} {i in}{^ocamldoc}{_syntax}.
+It will have a TOC generated from section headings.
+
+{1 Section}
+
+This is a section.
+
+{1 Another section}
+
+This is another section.
+
+{2 Subsection}
+
+This is a subsection.
+
+{2 Another Subsection}
+
+This is another subsection.

--- a/test/html/expect/test_package+ml/mld.html
+++ b/test/html/expect/test_package+ml/mld.html
@@ -17,12 +17,57 @@
     <nav>
      <a href="index.html">Up</a> – <a href="index.html">test_package+ml</a> » mld
     </nav>
+    <h1 id="mld-page">
+     <a href="#mld-page" class="anchor"></a>Mld Page
+    </h1>
+    <p>
+     This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
+    </p>
+    <p>
+     It will have a TOC generated from section headings.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#section">Section</a>
+      </li>
+      <li>
+       <a href="#another-section">Another section</a>
+       <ul>
+        <li>
+         <a href="#subsection">Subsection</a>
+        </li>
+        <li>
+         <a href="#another-subsection">Another Subsection</a>
+        </li>
+       </ul>
+      </li>
+     </ul>
+    </nav>
    </header>
+   <h2 id="section">
+    <a href="#section" class="anchor"></a>Section
+   </h2>
    <p>
-    This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
+    This is a section.
    </p>
+   <h2 id="another-section">
+    <a href="#another-section" class="anchor"></a>Another section
+   </h2>
    <p>
-    The whole thing is <b>written</b> <i>in</i><sup>ocamldoc</sup><sub>syntax</sub>.
+    This is another section.
+   </p>
+   <h3 id="subsection">
+    <a href="#subsection" class="anchor"></a>Subsection
+   </h3>
+   <p>
+    This is a subsection.
+   </p>
+   <h3 id="another-subsection">
+    <a href="#another-subsection" class="anchor"></a>Another Subsection
+   </h3>
+   <p>
+    This is another subsection.
    </p>
   </div>
  </body>

--- a/test/html/expect/test_package+re/mld.html
+++ b/test/html/expect/test_package+re/mld.html
@@ -17,12 +17,57 @@
     <nav>
      <a href="index.html">Up</a> – <a href="index.html">test_package+re</a> » mld
     </nav>
+    <h1 id="mld-page">
+     <a href="#mld-page" class="anchor"></a>Mld Page
+    </h1>
+    <p>
+     This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
+    </p>
+    <p>
+     It will have a TOC generated from section headings.
+    </p>
+    <nav class="toc">
+     <ul>
+      <li>
+       <a href="#section">Section</a>
+      </li>
+      <li>
+       <a href="#another-section">Another section</a>
+       <ul>
+        <li>
+         <a href="#subsection">Subsection</a>
+        </li>
+        <li>
+         <a href="#another-subsection">Another Subsection</a>
+        </li>
+       </ul>
+      </li>
+     </ul>
+    </nav>
    </header>
+   <h2 id="section">
+    <a href="#section" class="anchor"></a>Section
+   </h2>
    <p>
-    This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
+    This is a section.
    </p>
+   <h2 id="another-section">
+    <a href="#another-section" class="anchor"></a>Another section
+   </h2>
    <p>
-    The whole thing is <b>written</b> <i>in</i><sup>ocamldoc</sup><sub>syntax</sub>.
+    This is another section.
+   </p>
+   <h3 id="subsection">
+    <a href="#subsection" class="anchor"></a>Subsection
+   </h3>
+   <p>
+    This is a subsection.
+   </p>
+   <h3 id="another-subsection">
+    <a href="#another-subsection" class="anchor"></a>Another Subsection
+   </h3>
+   <p>
+    This is another subsection.
    </p>
   </div>
  </body>


### PR DESCRIPTION
Fixes https://github.com/ocaml/odoc/issues/294.

### Notes for Reviewers

- Added `Generator.Top_level_markup.lay_out_page` – an entry point for HTML generation of pages. This function will produce HTML content for pages, the header element and the TOC.
- Introduced the `comment_state` type that is used to track the state for HTML generation of both signatures and mld files.
- `page_section_comment` implements the same logic as `section_comment` with some changes:
  - The title heading is not included in TOC.
  - The title heading and the following content (until the next heading or end) are placed into a header element. This is similar to signatures.
  - The other headings and the following content are _not_ placed into section elements. I find this unnecessary for plain mld files. I also think we should simplify this in signatures (https://github.com/ocaml/odoc/issues/327).
- A potential improvement would be to avoid duplicating the comment traversal logic between signatures and pages, but that would require quite deep changes to the HTML generator.