### PR TITLE
Simpler parser ast

### DIFF
--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -27,6 +27,7 @@ type nestable_block_element = [
   | `Modules of Reference.Module.t list
   | `List of
     [ `Unordered | `Ordered ] *
+    [ `Light | `Heavy ] *
     ((nestable_block_element with_location) list) list
 ]
 

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -24,7 +24,7 @@ type nestable_block_element = [
   | `Paragraph of (inline_element with_location) list
   | `Code_block of string
   | `Verbatim of string
-  | `Modules of Reference.Module.t list
+  | `Modules of string with_location list
   | `List of
     [ `Unordered | `Ordered ] *
     [ `Light | `Heavy ] *

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -16,7 +16,7 @@ type inline_element = [
   | `Raw_markup of string option * string
   | `Styled of Comment.style * (inline_element with_location) list
   | `Reference of
-      reference_kind * Reference.t * (inline_element with_location) list
+      reference_kind * string with_location * (inline_element with_location) list
   | `Link of string * (inline_element with_location) list
 ]
 

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -13,7 +13,7 @@ type inline_element = [
   | `Space
   | `Word of string
   | `Code_span of string
-  | `Raw_markup of Comment.raw_markup_target * string
+  | `Raw_markup of string option * string
   | `Styled of Comment.style * (inline_element with_location) list
   | `Reference of
       reference_kind * Reference.t * (inline_element with_location) list

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -1,8 +1,14 @@
-module Comment = Odoc_model.Comment
-
 type 'a with_location = 'a Odoc_model.Location_.with_location
 
 
+
+type style = [
+  | `Bold
+  | `Italic
+  | `Emphasis
+  | `Superscript
+  | `Subscript
+]
 
 type reference_kind = [ `Simple | `With_text ]
 
@@ -11,7 +17,7 @@ type inline_element = [
   | `Word of string
   | `Code_span of string
   | `Raw_markup of string option * string
-  | `Styled of Comment.style * (inline_element with_location) list
+  | `Styled of style * (inline_element with_location) list
   | `Reference of
       reference_kind * string with_location * (inline_element with_location) list
   | `Link of string * (inline_element with_location) list

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -13,7 +13,7 @@ type style = [
 type reference_kind = [ `Simple | `With_text ]
 
 type inline_element = [
-  | `Space
+  | `Space of string
   | `Word of string
   | `Code_span of string
   | `Raw_markup of string option * string

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -1,6 +1,3 @@
-module Path = Odoc_model.Paths.Path
-module Reference = Odoc_model.Paths.Reference
-module Identifier = Odoc_model.Paths.Identifier
 module Comment = Odoc_model.Comment
 
 type 'a with_location = 'a Odoc_model.Location_.with_location
@@ -44,7 +41,7 @@ type tag = [
   | `Since of string
   | `Before of string * (nestable_block_element with_location) list
   | `Version of string
-  | `Canonical of Path.Module.t * Reference.Module.t
+  | `Canonical of string with_location
   | `Inline
   | `Open
   | `Closed

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -76,7 +76,7 @@ let trim_leading_whitespace : string -> string = fun s ->
       match line.[index] with
       | ' ' | '\t' -> count_leading_whitespace' (index + 1)
       | _ -> `Leading_whitespace index
-      | exception Invalid_argument _ -> `Blank_line
+      | exception Invalid_argument _ -> `Blank_line "\n"
     in
     count_leading_whitespace' 0
   in
@@ -251,15 +251,15 @@ rule token input = parse
   | horizontal_space* eof
     { emit input `End }
 
-  | (horizontal_space* newline as prefix)
-    horizontal_space* ((newline horizontal_space*)+ as suffix)
-    { emit input `Blank_line ~adjust_start_by:prefix ~adjust_end_by:suffix }
+  | ((horizontal_space* newline as prefix)
+    horizontal_space* ((newline horizontal_space*)+ as suffix) as ws)
+    { emit input (`Blank_line ws) ~adjust_start_by:prefix ~adjust_end_by:suffix }
 
-  | horizontal_space* newline horizontal_space*
-    { emit input `Single_newline }
+  | (horizontal_space* newline horizontal_space* as ws)
+    { emit input (`Single_newline ws) }
 
-  | horizontal_space+
-    { emit input `Space }
+  | (horizontal_space+ as ws)
+    { emit input (`Space ws) }
 
   | (horizontal_space* (newline horizontal_space*)? as p) '}'
     { emit input `Right_brace ~adjust_start_by:p }
@@ -474,7 +474,7 @@ and code_span buffer nesting_level start_offset input = parse
     { warning
         input
         (Parse_error.not_allowed
-          ~what:(Token.describe `Blank_line)
+          ~what:(Token.describe (`Blank_line "\n\n"))
           ~in_what:(Token.describe (`Code_span "")));
       Buffer.add_char buffer '\n';
       code_span buffer nesting_level start_offset input lexbuf }

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -308,14 +308,15 @@ rule token input = parse
 
   | "{%" ((raw_markup_target as target) ':')? (raw_markup as s)
     ("%}" | eof as e)
-    { if e <> "%}" then
+    { let token = `Raw_markup (target, s) in
+      if e <> "%}" then
         warning
           input
           ~start_offset:(Lexing.lexeme_end lexbuf)
           (Parse_error.not_allowed
             ~what:(Token.describe `End)
-            ~in_what:(Token.describe (`Raw_markup (None, ""))));
-      emit input (`Raw_markup (target, s)) }
+            ~in_what:(Token.describe token));
+      emit input token }
 
   | "{ul"
     { emit input (`Begin_list `Unordered) }

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -314,21 +314,8 @@ rule token input = parse
           ~start_offset:(Lexing.lexeme_end lexbuf)
           (Parse_error.not_allowed
             ~what:(Token.describe `End)
-            ~in_what:(Token.describe (`Raw_markup (`Html, ""))));
-      let target_is_valid =
-        match target with
-        | Some "html" -> true
-        | Some invalid_target ->
-          warning input (Parse_error.invalid_raw_markup_target invalid_target);
-          false
-        | None ->
-          warning input Parse_error.default_raw_markup_target_not_supported;
-          false
-      in
-      if target_is_valid then
-        emit input (`Raw_markup (`Html, s))
-      else
-        emit input (`Code_span s) }
+            ~in_what:(Token.describe (`Raw_markup (None, ""))));
+      emit input (`Raw_markup (target, s)) }
 
   | "{ul"
     { emit input (`Begin_list `Unordered) }

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -91,15 +91,15 @@ let unpaired_right_bracket : Location.span -> Error.t =
 let invalid_raw_markup_target : string -> Location.span -> Error.t =
   Error.make
     ~suggestion:
-      (Printf.sprintf "try %s." (Token.print (`Raw_markup (`Html, ""))))
+      (Printf.sprintf "try %s." (Token.print (`Raw_markup (Some "html", ""))))
       "'{%%%s:': bad raw markup target."
 
 let default_raw_markup_target_not_supported : Location.span -> Error.t =
   Error.make
     ~suggestion:
-      (Printf.sprintf "try %s." (Token.print (`Raw_markup (`Html, ""))))
+      (Printf.sprintf "try %s." (Token.print (`Raw_markup (Some "html", ""))))
     "%s needs a target language."
-    (Token.describe (`Raw_markup (`Html, "")))
+    (Token.describe (`Raw_markup (None, "")))
 
 let expected : string -> Location.span -> Error.t =
   Error.make "Expected %s."

--- a/src/parser/semantics.ml
+++ b/src/parser/semantics.ml
@@ -111,7 +111,7 @@ let rec inline_element
     |> Location.at location
 
   | {value = `Reference (kind, target, content) as value; location} ->
-    let Location.{value = target; location = target_location} = target in
+    let {Location.value = target; location = target_location} = target in
     begin match Reference.parse status.warnings target_location target with
       | Result.Ok target ->
         let content = non_link_inline_elements status ~surrounding:value content in
@@ -151,7 +151,7 @@ let rec nestable_block_element
 
   | {value = `Modules modules; location} ->
     let modules =
-      List.fold_left (fun acc Location.{value; location} ->
+      List.fold_left (fun acc {Location.value; location} ->
           match Reference.read_mod_longident status.warnings location value with
           | Result.Ok r ->
             r :: acc

--- a/src/parser/semantics.ml
+++ b/src/parser/semantics.ml
@@ -176,7 +176,7 @@ let tag
     : location:Location.span -> status -> Ast.tag ->
         (Comment.block_element with_location, Ast.block_element with_location) Result.result =
     fun ~location status tag ->
-  let ok t = Ok (Location.at location (`Tag t)) in
+  let ok t = Result.Ok (Location.at location (`Tag t)) in
   match tag with
   | `Author _
   | `Since _
@@ -190,10 +190,10 @@ let tag
     let path = Reference.read_path_longident r_location s in
     let module_ = Reference.read_mod_longident status.warnings r_location s in
     begin match path, module_ with
-    | Ok path, Ok module_ ->
+    | Result.Ok path, Result.Ok module_ ->
       ok (`Canonical (path, module_))
-    | Error e, _
-    | Ok _, Error e ->
+    | Result.Error e, _
+    | Result.Ok _, Result.Error e ->
       Error.warning status.warnings e;
       let placeholder = [`Word "@canonical"; `Space " "; `Code_span s] in
       let placeholder = List.map (Location.at location) placeholder in
@@ -387,9 +387,9 @@ let top_level_block_elements
 
       | {value = `Tag the_tag; location} ->
         begin match tag ~location status the_tag with
-          | Ok element ->
+          | Result.Ok element ->
             traverse ~top_heading_level (element::comment_elements_acc) ast_elements
-          | Error placeholder ->
+          | Result.Error placeholder ->
             traverse ~top_heading_level comment_elements_acc (placeholder::ast_elements)
         end
 

--- a/src/parser/semantics.ml
+++ b/src/parser/semantics.ml
@@ -135,7 +135,7 @@ let rec nestable_block_element
   | {value = `Modules _; _} as element ->
     element
 
-  | {value = `List (kind, items); location} ->
+  | {value = `List (kind, _syntax, items); location} ->
     `List (kind, List.map (nestable_block_elements status) items)
     |> Location.at location
 

--- a/src/parser/semantics.ml
+++ b/src/parser/semantics.ml
@@ -9,7 +9,7 @@ type 'a with_location = 'a Location.with_location
 
 
 type ast_leaf_inline_element = [
-  | `Space
+  | `Space of string
   | `Word of string
   | `Code_span of string
   | `Raw_markup of string option * string
@@ -44,8 +44,11 @@ let leaf_inline_element
     fun status element ->
 
   match element with
-  | { value = (`Space | `Word _ | `Code_span _); _ } as element ->
+  | { value = (`Word _ | `Code_span _); _ } as element ->
     element
+
+  | { value = `Space _; _ } ->
+    Location.same element `Space
 
   | { value = `Raw_markup (Some "html", s); _ } ->
     Location.same element (`Raw_markup (`Html, s))
@@ -192,7 +195,7 @@ let tag
     | Error e, _
     | Ok _, Error e ->
       Error.warning status.warnings e;
-      let placeholder = [`Word "@canonical"; `Space; `Code_span s] in
+      let placeholder = [`Word "@canonical"; `Space " "; `Code_span s] in
       let placeholder = List.map (Location.at location) placeholder in
       Error (Location.at location (`Paragraph placeholder))
     end

--- a/src/parser/syntax.ml
+++ b/src/parser/syntax.ml
@@ -90,13 +90,13 @@ let rec inline_element
     fun input location next_token ->
 
   match next_token with
-  | `Space ws ->
+  | `Space _ as token ->
     junk input;
-    Location.at location (`Space ws)
+    Location.at location token
 
-  | `Word w ->
+  | `Word _ as token ->
     junk input;
-    Location.at location (`Word w)
+    Location.at location token
     (* This is actually the same memory representation as the token, complete
        with location, and is probably the most common case. Perhaps the token
        can be reused somehow. The same is true of [`Space], [`Code_span]. *)

--- a/src/parser/syntax.ml
+++ b/src/parser/syntax.ml
@@ -945,7 +945,7 @@ let rec block_element_list
         |> Error.warning input.warnings;
 
       let location = Location.span [location; brace_location] in
-      let block = `List (kind, items) in
+      let block = `List (kind, `Heavy, items) in
       let block = accepted_in_all_contexts context block in
       let block = Location.at location block in
       let acc = block::acc in
@@ -980,7 +980,7 @@ let rec block_element_list
           location::(List.map Location.location (List.flatten items))
           |> Location.span
         in
-        let block = `List (kind, items) in
+        let block = `List (kind, `Light, items) in
         let block = accepted_in_all_contexts context block in
         let block = Location.at location block in
         let acc = block::acc in

--- a/src/parser/syntax.ml
+++ b/src/parser/syntax.ml
@@ -747,38 +747,18 @@ let rec block_element_list
             |> Error.warning input.warnings;
           let tag =
             match tag with
-            | `Author _ -> Result.Ok (`Author s)
-            | `Since _ -> Result.Ok (`Since s)
-            | `Version _ -> Result.Ok (`Version s)
+            | `Author _ -> `Author s
+            | `Since _ -> `Since s
+            | `Version _ -> `Version s
             | `Canonical _ ->
               (* TODO The location is only approximate, as we need lexer
                  cooperation to get the real location. *)
               let r_location =
                 Location.nudge_start (String.length "@canonical ") location in
-              let result = match Reference.read_path_longident r_location s with
-              | Error _ as e -> e
-              | Ok path ->
-                  match
-                    Reference.read_mod_longident input.warnings r_location s
-                  with
-                  | Error _ as e -> e
-                  | Ok module_ ->  Result.Ok (`Canonical (path, module_))
-              in
-              match result with
-              | Result.Ok _ as result -> result
-              | Result.Error error ->
-                Error.warning input.warnings error;
-                Result.Error [`Word "@canonical"; `Space; `Code_span s]
+              `Canonical (Location.at r_location s)
           in
 
-          let tag =
-            match tag with
-            | Result.Ok tag -> Location.at location (`Tag tag)
-            | Result.Error text ->
-              Location.at location (`Paragraph
-                (List.map (Location.at location) text))
-          in
-
+          let tag = Location.at location (`Tag tag) in
           consume_block_elements ~parsed_a_tag:true `After_text (tag::acc)
 
         | `Deprecated | `Return as tag ->

--- a/src/parser/syntax.ml
+++ b/src/parser/syntax.ml
@@ -146,30 +146,15 @@ let rec inline_element
     junk input;
 
     let r_location = Location.nudge_start (String.length "{!") location in
+    let r = Location.at r_location r in
 
-    begin match Reference.parse input.warnings r_location r with
-    | Result.Ok r ->
-      Location.at location (`Reference (`Simple, r, []))
-    | Result.Error error ->
-      Error.warning input.warnings error;
-      Location.at location (`Code_span r)
-    end
+    Location.at location (`Reference (`Simple, r, []))
 
   | `Begin_reference_with_replacement_text r as parent_markup ->
     junk input;
 
     let r_location = Location.nudge_start (String.length "{{!") location in
-
-    (* Parse the reference target immediately, so that any warnings from it are
-       triggered before warnings from the content. *)
-    let make_element =
-      match Reference.parse input.warnings r_location r with
-      | Result.Ok r ->
-        fun content -> `Reference (`With_text, r, content)
-      | Result.Error error ->
-        Error.warning input.warnings error;
-        fun content -> `Styled (`Emphasis, content)
-    in
+    let r = Location.at r_location r in
 
     let content, brace_location =
       delimited_inline_element_list
@@ -186,7 +171,7 @@ let rec inline_element
         ~what:(Token.describe parent_markup) location
       |> Error.warning input.warnings;
 
-    Location.at location (make_element content)
+    Location.at location (`Reference (`With_text, r, content))
 
   | `Simple_link u ->
     junk input;

--- a/src/parser/syntax.ml
+++ b/src/parser/syntax.ml
@@ -897,13 +897,7 @@ let rec block_element_list
          parsing. *)
       let modules =
         split_string " \t\r\n" s
-        |> List.fold_left (fun acc r ->
-          match Reference.read_mod_longident input.warnings location r with
-          | Result.Ok r -> r::acc
-          | Result.Error error ->
-            Error.warning input.warnings error;
-            acc) []
-        |> List.rev
+        |> List.map (fun r -> Location.at location r)
       in
 
       if modules = [] then

--- a/src/parser/syntax.ml
+++ b/src/parser/syntax.ml
@@ -53,7 +53,7 @@ let npeek n input = Stream.npeek n input.tokens
 type token_that_always_begins_an_inline_element = [
   | `Word of string
   | `Code_span of string
-  | `Raw_markup of Comment.raw_markup_target * string
+  | `Raw_markup of string option * string
   | `Begin_style of Comment.style
   | `Simple_reference of string
   | `Begin_reference_with_replacement_text of string

--- a/src/parser/token.ml
+++ b/src/parser/token.ml
@@ -55,7 +55,7 @@ type t = [
      bullets. *)
   | `Word of string
   | `Code_span of string
-  | `Raw_markup of Odoc_model.Comment.raw_markup_target * string
+  | `Raw_markup of string option * string
   | `Begin_style of Odoc_model.Comment.style
 
   (* Other inline element markup. *)
@@ -137,8 +137,10 @@ let print : [< t ] -> string = function
     "'@open'"
   | `Tag `Closed ->
     "'@closed'"
-  | `Raw_markup (`Html, _) ->
-    "'{%html:...%}'"
+  | `Raw_markup (None, _) ->
+    "'{%...%}'"
+  | `Raw_markup (Some target, _) ->
+    "'{%" ^ target ^ ":...%}'"
 
 (* [`Minus] and [`Plus] are interpreted as if they start list items. Therefore,
    for error messages based on [Token.describe] to be accurate, formatted

--- a/src/parser/token.ml
+++ b/src/parser/token.ml
@@ -39,9 +39,9 @@ type t = [
      tokens are emitted by the lexer. Otherwise, there would be the need for
      unbounded lookahead, a (co-?)ambiguity between
      [Single_newline Single_newline] and [Blank_line], and other problems. *)
-  | `Space
-  | `Single_newline
-  | `Blank_line
+  | `Space of string
+  | `Single_newline of string
+  | `Blank_line of string
 
   (* A right curly brace ([}]), i.e. end of markup. *)
   | `Right_brace
@@ -172,11 +172,11 @@ let describe : [< t | `Comment ] -> string = function
     "'{{:...} ...}' (external link)"
   | `End ->
     "end of text"
-  | `Space ->
+  | `Space _ ->
     "whitespace"
-  | `Single_newline ->
+  | `Single_newline _ ->
     "line break"
-  | `Blank_line ->
+  | `Blank_line _ ->
     "blank line"
   | `Right_brace ->
     "'}'"


### PR DESCRIPTION
Hi!

As I explained in ocaml/odoc#355, `Model.Comment` is a bit hard to obtain and understand and too strict and lossy on the input.

Some of this issues could be solved by changing `Model.Comment` with a bit of work. But I think that in the future, this will make similar issues harder to solve as Odoc codebase and language change.

This PR simplifies `Parser.Ast` to make it closer to the concrete syntax and simpler by delaying some parsing to `semantics.ml`:

- References are represented as strings
- `Raw_markup` targets can be any string or none.
- Keep concrete syntax used for lists
- Keep whitespaces (Only when a `Space` element is generated)

This PR also removes some uses of `Model` types, as @lpw25 suggested, but not all yet.

This PR is supposed to follow ocaml/odoc#351 but if this approach is definitively rejected, it should be a good first step at improving `Model.Comment`.

What do you think?

Thanks!