### PR TITLE
Fixes paragraph ordering in HTML for mld pages.

### DIFF
--- a/test/html/cases/mld.mld
+++ b/test/html/cases/mld.mld
@@ -9,14 +9,26 @@ It will have a TOC generated from section headings.
 
 This is a section.
 
+Another paragraph in section.
+
 {1 Another section}
 
 This is another section.
+
+Another paragraph in section 2.
 
 {2 Subsection}
 
 This is a subsection.
 
+Another paragraph in subsection.
+
+Yet another paragraph in subsection.
+
 {2 Another Subsection}
 
 This is another subsection.
+
+Another paragraph in subsection 2.
+
+Yet another paragraph in subsection 2.

--- a/test/html/expect/test_package+ml/mld.html
+++ b/test/html/expect/test_package+ml/mld.html
@@ -51,11 +51,17 @@
    <p>
     This is a section.
    </p>
+   <p>
+    Another paragraph in section.
+   </p>
    <h2 id="another-section">
     <a href="#another-section" class="anchor"></a>Another section
    </h2>
    <p>
     This is another section.
+   </p>
+   <p>
+    Another paragraph in section 2.
    </p>
    <h3 id="subsection">
     <a href="#subsection" class="anchor"></a>Subsection
@@ -63,11 +69,23 @@
    <p>
     This is a subsection.
    </p>
+   <p>
+    Another paragraph in subsection.
+   </p>
+   <p>
+    Yet another paragraph in subsection.
+   </p>
    <h3 id="another-subsection">
     <a href="#another-subsection" class="anchor"></a>Another Subsection
    </h3>
    <p>
     This is another subsection.
+   </p>
+   <p>
+    Another paragraph in subsection 2.
+   </p>
+   <p>
+    Yet another paragraph in subsection 2.
    </p>
   </div>
  </body>

--- a/test/html/expect/test_package+re/mld.html
+++ b/test/html/expect/test_package+re/mld.html
@@ -51,11 +51,17 @@
    <p>
     This is a section.
    </p>
+   <p>
+    Another paragraph in section.
+   </p>
    <h2 id="another-section">
     <a href="#another-section" class="anchor"></a>Another section
    </h2>
    <p>
     This is another section.
+   </p>
+   <p>
+    Another paragraph in section 2.
    </p>
    <h3 id="subsection">
     <a href="#subsection" class="anchor"></a>Subsection
@@ -63,11 +69,23 @@
    <p>
     This is a subsection.
    </p>
+   <p>
+    Another paragraph in subsection.
+   </p>
+   <p>
+    Yet another paragraph in subsection.
+   </p>
    <h3 id="another-subsection">
     <a href="#another-subsection" class="anchor"></a>Another Subsection
    </h3>
    <p>
     This is another subsection.
+   </p>
+   <p>
+    Another paragraph in subsection 2.
+   </p>
+   <p>
+    Yet another paragraph in subsection 2.
    </p>
   </div>
  </body>


### PR DESCRIPTION
Fixes https://github.com/ocaml/odoc/issues/365.

## Notes

* Added paragraphs to the mld test.
* There's no point in using `finish_comment_state` for `acc_html` because without section elements we're appending elements, not consing.