### PR TITLE
Add meta generator

### DIFF
--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -283,6 +283,8 @@ let page_creator ?kind ?(theme_uri = Relative "./") ~path header_docs content =
     Html.head (Html.title (Html.txt title_string)) [
       Html.link ~rel:[`Stylesheet] ~href:odoc_css_uri () ;
       Html.meta ~a:[ Html.a_charset "utf-8" ] () ;
+      Html.meta ~a:[ Html.a_name "generator";
+                     Html.a_content "odoc %%VERSION%%" ] ();
       Html.meta ~a:[ Html.a_name "viewport";
                   Html.a_content "width=device-width,initial-scale=1.0"; ] ();
       Html.script ~a:[Html.a_src highlight_js_uri] (Html.txt "");

--- a/test/html/expect/test_package+custom_theme,ml/Include/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Include/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../b/c/odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="/a/b/c/odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+custom_theme,ml/Section/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Section/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../b/c/odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+custom_theme,ml/Val/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Val/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="https://foo.com/a/b/c/odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Alias/X/index.html
+++ b/test/html/expect/test_package+ml/Alias/X/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Alias/index.html
+++ b/test/html/expect/test_package+ml/Alias/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/External/index.html
+++ b/test/html/expect/test_package+ml/External/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Functor/index.html
+++ b/test/html/expect/test_package+ml/Functor/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Include/index.html
+++ b/test/html/expect/test_package+ml/Include/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Include2/index.html
+++ b/test/html/expect/test_package+ml/Include2/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Interlude/index.html
+++ b/test/html/expect/test_package+ml/Interlude/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-inherits/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Nested/class-z/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-z/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>
@@ -81,17 +82,17 @@
      </table>
     </dt>
     <dt class="spec type" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> _ gadt</code><code> = </code>
+     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> <span>_ gadt</span></code><code> = </code>
      <table class="variant">
       <tbody>
        <tr id="type-gadt.A" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> : int <a href="index.html#type-gadt">gadt</a></code>
+         <a href="#type-gadt.A" class="anchor"></a><code>| </code><code><span class="constructor">A</span> : <span>int <a href="index.html#type-gadt">gadt</a></span></code>
         </td>
        </tr>
        <tr id="type-gadt.B" class="anchored">
         <td class="def constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span> : int <span>-&gt;</span> string <a href="index.html#type-gadt">gadt</a></code>
+         <a href="#type-gadt.B" class="anchor"></a><code>| </code><code><span class="constructor">B</span> : int <span>-&gt;</span> <span>string <a href="index.html#type-gadt">gadt</a></span></code>
         </td>
         <td class="doc">
          <p>
@@ -111,7 +112,7 @@
            </tr>
           </tbody>
          </table>
-         <code>}</code><code> <span>-&gt;</span> unit <a href="index.html#type-gadt">gadt</a></code>
+         <code>}</code><code> <span>-&gt;</span> <span>unit <a href="index.html#type-gadt">gadt</a></span></code>
         </td>
        </tr>
       </tbody>
@@ -164,7 +165,7 @@
       <tbody>
        <tr id="type-empty_conj.X" class="anchored">
         <td class="def constructor">
-         <a href="#type-empty_conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span> : [&lt; `X of &amp; <span class="type-var">'a</span> &amp; int * float ] <span>-&gt;</span> <a href="index.html#type-empty_conj">empty_conj</a></code>
+         <a href="#type-empty_conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span> : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span> <span>-&gt;</span> <a href="index.html#type-empty_conj">empty_conj</a></code>
         </td>
        </tr>
       </tbody>
@@ -176,7 +177,7 @@
       <tbody>
        <tr id="type-conj.X" class="anchored">
         <td class="def constructor">
-         <a href="#type-conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span> : [&lt; `X of int &amp; [&lt; `B of int &amp; float ] ] <span>-&gt;</span> <a href="index.html#type-conj">conj</a></code>
+         <a href="#type-conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span> : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span> <span>-&gt;</span> <a href="index.html#type-conj">conj</a></code>
         </td>
        </tr>
       </tbody>
@@ -185,10 +186,10 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-empty_conj">
-     <a href="#val-empty_conj" class="anchor"></a><code><span class="keyword">val</span> empty_conj : [&lt; `X of &amp; <span class="type-var">'a</span> &amp; int * float ]</code>
+     <a href="#val-empty_conj" class="anchor"></a><code><span class="keyword">val</span> empty_conj : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span></code>
     </dt>
     <dt class="spec value" id="val-conj">
-     <a href="#val-conj" class="anchor"></a><code><span class="keyword">val</span> conj : [&lt; `X of int &amp; [&lt; `B of int &amp; float ] ]</code>
+     <a href="#val-conj" class="anchor"></a><code><span class="keyword">val</span> conj : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span></code>
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+ml/Section/index.html
+++ b/test/html/expect/test_package+ml/Section/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Stop/index.html
+++ b/test/html/expect/test_package+ml/Stop/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/Val/index.html
+++ b/test/html/expect/test_package+ml/Val/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+ml/mld.html
+++ b/test/html/expect/test_package+ml/mld.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Alias/X/index.html
+++ b/test/html/expect/test_package+re/Alias/X/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Alias/index.html
+++ b/test/html/expect/test_package+re/Alias/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Bugs/index.html
+++ b/test/html/expect/test_package+re/Bugs/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/External/index.html
+++ b/test/html/expect/test_package+re/External/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Functor/index.html
+++ b/test/html/expect/test_package+re/Functor/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Include/index.html
+++ b/test/html/expect/test_package+re/Include/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Include2/index.html
+++ b/test/html/expect/test_package+re/Include2/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Interlude/index.html
+++ b/test/html/expect/test_package+re/Interlude/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+re/Nested/class-inherits/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Nested/class-z/index.html
+++ b/test/html/expect/test_package+re/Nested/class-z/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>
@@ -166,7 +167,7 @@
       <tbody>
        <tr id="type-empty_conj.X" class="anchored">
         <td class="def constructor">
-         <a href="#type-empty_conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span>([&lt; `X&amp; (<span class="type-var">'a</span>) &amp; ((int, float)) ]) : <a href="index.html#type-empty_conj">empty_conj</a></code>
+         <a href="#type-empty_conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span>(<span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>) : <a href="index.html#type-empty_conj">empty_conj</a></code>
         </td>
        </tr>
       </tbody>
@@ -179,7 +180,7 @@
       <tbody>
        <tr id="type-conj.X" class="anchored">
         <td class="def constructor">
-         <a href="#type-conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span>([&lt; `X(int) &amp; ([&lt; `B(int) &amp; (float) ]) ]) : <a href="index.html#type-conj">conj</a></code>
+         <a href="#type-conj.X" class="anchor"></a><code>| </code><code><span class="constructor">X</span>(<span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>) : <a href="index.html#type-conj">conj</a></code>
         </td>
        </tr>
       </tbody>
@@ -189,10 +190,10 @@
    </dl>
    <dl>
     <dt class="spec value" id="val-empty_conj">
-     <a href="#val-empty_conj" class="anchor"></a><code><span class="keyword">let</span> empty_conj: [&lt; `X&amp; (<span class="type-var">'a</span>) &amp; ((int, float)) ];</code>
+     <a href="#val-empty_conj" class="anchor"></a><code><span class="keyword">let</span> empty_conj: <span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>;</code>
     </dt>
     <dt class="spec value" id="val-conj">
-     <a href="#val-conj" class="anchor"></a><code><span class="keyword">let</span> conj: [&lt; `X(int) &amp; ([&lt; `B(int) &amp; (float) ]) ];</code>
+     <a href="#val-conj" class="anchor"></a><code><span class="keyword">let</span> conj: <span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>;</code>
     </dt>
    </dl>
   </div>

--- a/test/html/expect/test_package+re/Section/index.html
+++ b/test/html/expect/test_package+re/Section/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Stop/index.html
+++ b/test/html/expect/test_package+re/Stop/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/Val/index.html
+++ b/test/html/expect/test_package+re/Val/index.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../../highlight.pack.js"></script>
   <script>

--- a/test/html/expect/test_package+re/mld.html
+++ b/test/html/expect/test_package+re/mld.html
@@ -5,6 +5,7 @@
   </title>
   <link rel="stylesheet" href="../odoc.css">
   <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script src="../highlight.pack.js"></script>
   <script>


### PR DESCRIPTION
Bring back the versioned meta generator tag (closes #324).

I made the test promotion as a separate commit. Btw. is there a way to promote things via a single diff. I had to run the tests, see one failing, promote, start over, etc. I'm sure I'm missing something.

Also I promoted a few things that seem unrelated to the change but is related to @trefis' spanning of sigs I think. 