### PR TITLE
Fix odoc html-targets (closes #276).

### DIFF
--- a/src/html/targets.ml
+++ b/src/html/targets.ml
@@ -90,18 +90,38 @@ and module_ ~prefix (t : Odoc_model.Lang.Module.t) =
   match t.expansion with
   | None -> []
   | Some expansion ->
-    let page = Printf.sprintf "%s/%s" prefix (Identifier.name t.id) in
-    let subpages = module_expansion ~prefix:page expansion in
-    page :: subpages
+      let expansion =
+        match expansion with
+        | AlreadyASig ->
+            begin match t.type_ with
+            | ModuleType (Odoc_model.Lang.ModuleType.Signature sg) ->
+                Odoc_model.Lang.Module.Signature sg
+            | _ -> assert false
+            end
+        | e -> e
+      in
+      let page = Printf.sprintf "%s/%s" prefix (Identifier.name t.id) in
+      let subpages = module_expansion ~prefix:page expansion in
+      page :: subpages
 
 and module_type ~prefix (t : Odoc_model.Lang.ModuleType.t) =
   match t.expansion with
   | None -> []
   | Some expansion ->
+      let expansion = match expansion with
+      | AlreadyASig ->
+          begin match t.expr with
+          | Some (Signature sg) -> Odoc_model.Lang.Module.Signature sg
+          | _ -> assert false
+          end
+      | e -> e
+      in
     (* FIXME: reuse [Url] somehow. *)
-    let page = Printf.sprintf "%s/module-type-%s" prefix (Identifier.name t.id) in
-    let subpages = module_expansion ~prefix:page expansion in
-    page :: subpages
+      let page =
+        Printf.sprintf "%s/module-type-%s" prefix (Identifier.name t.id)
+      in
+      let subpages = module_expansion ~prefix:page expansion in
+      page :: subpages
 
 
 and include_ ~prefix (t : Odoc_model.Lang.Include.t) =

--- a/src/html/targets.ml
+++ b/src/html/targets.ml
@@ -90,38 +90,36 @@ and module_ ~prefix (t : Odoc_model.Lang.Module.t) =
   match t.expansion with
   | None -> []
   | Some expansion ->
-      let expansion =
-        match expansion with
-        | AlreadyASig ->
-            begin match t.type_ with
-            | ModuleType (Odoc_model.Lang.ModuleType.Signature sg) ->
-                Odoc_model.Lang.Module.Signature sg
-            | _ -> assert false
-            end
-        | e -> e
-      in
-      let page = Printf.sprintf "%s/%s" prefix (Identifier.name t.id) in
-      let subpages = module_expansion ~prefix:page expansion in
-      page :: subpages
+    let expansion =
+      match expansion with
+      | AlreadyASig ->
+          begin match t.type_ with
+          | ModuleType (Odoc_model.Lang.ModuleType.Signature sg) ->
+              Odoc_model.Lang.Module.Signature sg
+          | _ -> assert false
+          end
+      | e -> e
+    in
+    let page = Printf.sprintf "%s/%s" prefix (Identifier.name t.id) in
+    let subpages = module_expansion ~prefix:page expansion in
+    page :: subpages
 
 and module_type ~prefix (t : Odoc_model.Lang.ModuleType.t) =
   match t.expansion with
   | None -> []
   | Some expansion ->
-      let expansion = match expansion with
-      | AlreadyASig ->
-          begin match t.expr with
-          | Some (Signature sg) -> Odoc_model.Lang.Module.Signature sg
-          | _ -> assert false
-          end
-      | e -> e
-      in
+    let expansion = match expansion with
+    | AlreadyASig ->
+        begin match t.expr with
+        | Some (Signature sg) -> Odoc_model.Lang.Module.Signature sg
+        | _ -> assert false
+        end
+    | e -> e
+    in
     (* FIXME: reuse [Url] somehow. *)
-      let page =
-        Printf.sprintf "%s/module-type-%s" prefix (Identifier.name t.id)
-      in
-      let subpages = module_expansion ~prefix:page expansion in
-      page :: subpages
+    let page = Printf.sprintf "%s/module-type-%s" prefix (Identifier.name t.id) in
+    let subpages = module_expansion ~prefix:page expansion in
+    page :: subpages
 
 
 and include_ ~prefix (t : Odoc_model.Lang.Include.t) =


### PR DESCRIPTION
Fixes the fact that generated files for modules beyond one level after the top level were not reported by `html-targets`. A similar fix is applied for module types (not reported in #276).

Please review carefully I don't claim I understand what I'm doing 😅. 

My approach was simply to realize that in subsub modules we would end up in [this `AlreadyASig` case](https://github.com/ocaml/odoc/blob/1843f89f769bd16147802414e1b0bf1d3a87d5ef/src/html/targets.ml#L77) and nothing was then being done. So I went in the `generator.ml` file and made a copy-cat what is being done [there](https://github.com/ocaml/odoc/blob/master/src/html/generator.ml#L1521-L1532) in that case which seems to work... 

Along the way I realized the same may happen for module types (I don't have a report for that though) so I did that them aswell.