### PR TITLE
Handle 4.08 module and type substitutions

### DIFF
--- a/src/html/targets.ml
+++ b/src/html/targets.ml
@@ -49,6 +49,8 @@ and signature ~prefix (t : Odoc_model.Lang.Signature.t) =
           add_items ~don't (module_type ~prefix mty :: acc) is
       | Include incl ->
           add_items ~don't (include_ ~prefix incl :: acc) is
+      | ModuleSubstitution _
+      | TypeSubstitution _
       | Type _
       | TypExt _
       | Exception _

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -622,8 +622,6 @@ and read_signature_item env parent item =
         [ModuleSubstitution (read_module_substitution env parent mst)]
 #endif
 
-(*and read_type_subst _env _parent _tst = []*)
-
 and read_module_substitution env parent ms =
   let open ModuleSubstitution in
   let name = parenthesise (Ident.name ms.ms_id) in

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -273,6 +273,9 @@ let read_type_declarations env parent rec_flag decls =
   in
     List.rev items
 
+let read_type_substitutions env parent decls =
+  List.map (fun decl -> Odoc_model.Lang.Signature.TypeSubstitution (read_type_declaration env parent decl)) decls
+
 let read_extension_constructor env parent ext =
   let open Extension.Constructor in
   let open Odoc_model.Names in
@@ -613,9 +616,22 @@ and read_signature_item env parent item =
           | Some doc -> [Comment doc]
       end
 #if OCAML_MAJOR = 4 && OCAML_MINOR >= 08
-    | Tsig_typesubst _
-    | Tsig_modsubst _ -> []
+    | Tsig_typesubst tst ->
+        read_type_substitutions env parent tst
+    | Tsig_modsubst mst ->
+        [ModuleSubstitution (read_module_substitution env parent mst)]
 #endif
+
+(*and read_type_subst _env _parent _tst = []*)
+
+and read_module_substitution env parent ms =
+  let open ModuleSubstitution in
+  let name = parenthesise (Ident.name ms.ms_id) in
+  let id = `Module(parent, (Odoc_model.Names.ModuleName.of_string name)) in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
+  let doc = Doc_attr.attached container ms.ms_attributes in
+  let manifest = Env.Path.read_module env ms.ms_manifest in
+  { id; doc; manifest }
 
 and read_include env parent incl =
   let open Include in

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -273,8 +273,10 @@ let read_type_declarations env parent rec_flag decls =
   in
     List.rev items
 
+#if OCAML_MAJOR = 4 && OCAML_MINOR >= 08
 let read_type_substitutions env parent decls =
   List.map (fun decl -> Odoc_model.Lang.Signature.TypeSubstitution (read_type_declaration env parent decl)) decls
+#endif
 
 let read_extension_constructor env parent ext =
   let open Extension.Constructor in
@@ -620,7 +622,6 @@ and read_signature_item env parent item =
         read_type_substitutions env parent tst
     | Tsig_modsubst mst ->
         [ModuleSubstitution (read_module_substitution env parent mst)]
-#endif
 
 and read_module_substitution env parent ms =
   let open ModuleSubstitution in
@@ -630,6 +631,7 @@ and read_module_substitution env parent ms =
   let doc = Doc_attr.attached container ms.ms_attributes in
   let manifest = Env.Path.read_module env ms.ms_manifest in
   { id; doc; manifest }
+#endif
 
 and read_include env parent incl =
   let open Include in

--- a/src/model/ident_env.cppo.ml
+++ b/src/model/ident_env.cppo.ml
@@ -175,7 +175,12 @@ let add_signature_tree_item parent item env =
                env)
           cltyps env
 #if OCAML_MAJOR = 4 && OCAML_MINOR >= 08
-    | Tsig_typesubst _ | Tsig_modsubst _
+    | Tsig_modsubst ms ->
+      add_module parent ms.ms_id env
+    | Tsig_typesubst ts ->
+      List.fold_right
+        (fun decl env -> add_type parent decl.typ_id env)
+        ts env
 #endif
     | Tsig_value _ | Tsig_typext _
     | Tsig_exception _ | Tsig_open _

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -81,6 +81,14 @@ and ModuleType : sig
 
 end = ModuleType
 
+and ModuleSubstitution : sig
+  type t =
+    { id: Identifier.Module.t
+    ; doc: Comment.docs
+    ; manifest: Path.Module.t
+    ; }
+end = ModuleSubstitution
+
 (** {3 Signatures} *)
 
 and Signature : sig
@@ -94,7 +102,9 @@ and Signature : sig
   type item =
     | Module of recursive * Module.t
     | ModuleType of ModuleType.t
+    | ModuleSubstitution of ModuleSubstitution.t
     | Type of recursive * TypeDecl.t
+    | TypeSubstitution of TypeDecl.t
     | TypExt of Extension.t
     | Exception of Exception.t
     | Value of Value.t

--- a/src/model/maps.ml
+++ b/src/model/maps.ml
@@ -1175,6 +1175,28 @@ class virtual module_ = object (self)
 
 end
 
+class virtual module_substitution = object (self)
+
+  method virtual identifier_module :
+    Identifier.Module.t -> Identifier.Module.t
+  
+  method virtual documentation :
+    Comment.docs -> Comment.docs
+  
+  method virtual path_module :
+    Path.Module.t -> Path.Module.t
+
+  method module_substitution subst =
+    let open ModuleSubstitution in
+    let {id; doc; manifest} = subst in
+    let id' = self#identifier_module id in
+    let doc' = self#documentation doc in
+    let manifest' = self#path_module manifest in
+    if id != id' || doc != doc' || manifest' != manifest then
+        {id = id'; doc = doc'; manifest = manifest' }
+      else subst
+end
+
 class virtual module_type = object (self)
 
   method virtual identifier_module :
@@ -1328,6 +1350,9 @@ class virtual signature = object (self)
   method virtual include_:
     Include.t -> Include.t
 
+  method virtual module_substitution :
+    ModuleSubstitution.t -> ModuleSubstitution.t
+
   method signature_item item =
     let open Signature in
       match item with
@@ -1367,6 +1392,14 @@ class virtual signature = object (self)
           let mty' = self#module_type mty in
             if mty != mty' then ModuleType mty'
             else item
+      | ModuleSubstitution msub ->
+          let msub' = self#module_substitution msub in
+          if msub' != msub then ModuleSubstitution msub'
+          else item
+      | TypeSubstitution tsub ->
+          let tsub' = self#type_decl tsub in 
+          if tsub' != tsub then TypeSubstitution tsub'
+          else item
       | Include incl ->
           let incl' = self#include_ incl in
             if incl != incl' then Include incl'
@@ -2211,6 +2244,7 @@ end
 class virtual types = object
   inherit documentation
   inherit module_
+  inherit module_substitution
   inherit module_type
   inherit signature
   inherit include_

--- a/src/model/maps.ml
+++ b/src/model/maps.ml
@@ -1192,9 +1192,9 @@ class virtual module_substitution = object (self)
     let id' = self#identifier_module id in
     let doc' = self#documentation doc in
     let manifest' = self#path_module manifest in
-    if id != id' || doc != doc' || manifest' != manifest then
-        {id = id'; doc = doc'; manifest = manifest' }
-      else subst
+    if id != id' || doc != doc' || manifest' != manifest
+    then {id = id'; doc = doc'; manifest = manifest' }
+    else subst
 end
 
 class virtual module_type = object (self)

--- a/src/model/maps.mli
+++ b/src/model/maps.mli
@@ -435,6 +435,17 @@ class virtual module_ : object
   method module_hidden : bool -> bool
 end
 
+class virtual module_substitution : object
+
+  method virtual identifier_module : Identifier.Module.t -> Identifier.Module.t
+
+  method virtual path_module : Path.Module.t -> Path.Module.t
+
+  method virtual documentation : Comment.docs -> Comment.docs
+
+  method module_substitution : ModuleSubstitution.t -> ModuleSubstitution.t
+end
+
 class virtual module_type : object
 
   method virtual identifier_module : Identifier.Module.t -> Identifier.Module.t
@@ -485,6 +496,8 @@ class virtual signature : object
 
   method virtual module_ : Module.t -> Module.t
 
+  method virtual module_substitution : ModuleSubstitution.t -> ModuleSubstitution.t
+  
   method virtual module_type : ModuleType.t -> ModuleType.t
 
   method virtual type_decl : TypeDecl.t -> TypeDecl.t
@@ -857,6 +870,7 @@ end
 class virtual types : object
   inherit documentation
   inherit module_
+  inherit module_substitution
   inherit module_type
   inherit signature
   inherit include_

--- a/src/xref/component_table.ml
+++ b/src/xref/component_table.ml
@@ -536,6 +536,17 @@ and signature_items local =
     | Comment com :: rest ->
         let sg = signature_items local rest in
           add_comment com sg
+    | ModuleSubstitution mst :: rest ->
+        let open ModuleSubstitution in
+        (* Treat it like an alias *)
+        let name = Identifier.name mst.id in
+        let decl = module_decl local (Alias mst.manifest) in
+        add_local_module_identifier local mst.id decl;
+        let sg = signature_items local rest in
+        let sg = add_documentation mst.doc sg in
+          add_module name decl sg
+    | TypeSubstitution _ :: rest ->
+        signature_items local rest
     | [] -> empty
 
 and module_type_expr local expr =

--- a/src/xref/name_env.ml
+++ b/src/xref/name_env.ml
@@ -338,6 +338,11 @@ let add_module md env =
   let env = add_documentation md.doc env in
     add_module_ident md.id env
 
+let add_module_substitution m env =
+  let open Odoc_model.Lang.ModuleSubstitution in
+  let env = add_documentation m.doc env in
+  add_module_ident m.id env
+
 let add_unit unit env =
   let open Compilation_unit in
   let env = add_documentation unit.doc env in
@@ -367,7 +372,9 @@ and add_signature_item item env =
   | ClassType (_, cltyp) -> add_class_type cltyp env
   | Include incl -> add_include incl env
   | Comment com -> add_comment com env
-
+  | ModuleSubstitution m -> add_module_substitution m env
+  | TypeSubstitution t -> add_type_decl t env
+  
 and add_signature_items sg env =
   List.fold_right add_signature_item sg env
 

--- a/test/html/cases/recent.mli
+++ b/test/html/cases/recent.mli
@@ -34,3 +34,21 @@ type empty_conj= X: [< `X of & 'a & int * float  ] -> empty_conj
 type conj = X: [< `X of int & [< `B of int & float ] ] -> conj
 val empty_conj: [< `X of & 'a & int * float  ]
 val conj : [< `X of int & [< `B of int & float ] ]
+
+module Z : sig
+  module Y : sig
+    module X : sig
+      type 'a t
+    end
+  end
+end
+
+module X : sig
+  module L := Z.Y
+  type t = int L.X.t
+  type u := int
+  type v = u L.X.t
+end
+
+
+

--- a/test/html/expect/test_package+ml/Recent/X/index.html
+++ b/test/html/expect/test_package+ml/Recent/X/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   X (test_package+ml.Recent.X)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Recent</a> » X
+    </nav>
+    <h1>
+     Module <code>Recent.X</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec module-substitution" id="module-L">
+     <a href="#module-L" class="anchor"></a><code><span class="keyword">module</span> L := <a href="../Z/index.html#module-Y">Z.Y</a></code>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code><code> = <span>int <a href="../Z/Y/X/index.html#type-t">L.X.t</a></span></code>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec type-subst" id="type-u">
+     <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code><code> := int</code>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec type" id="type-v">
+     <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v</code><code> = <span><a href="index.html#type-u">u</a> <a href="../Z/Y/X/index.html#type-t">L.X.t</a></span></code>
+    </dt>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -192,6 +192,12 @@
      <a href="#val-conj" class="anchor"></a><code><span class="keyword">val</span> conj : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span></code>
     </dt>
    </dl>
+   <div class="spec module" id="module-Z">
+    <a href="#module-Z" class="anchor"></a><code><span class="keyword">module</span> <a href="Z/index.html">Z</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </div>
+   <div class="spec module" id="module-X">
+    <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Recent/X/index.html
+++ b/test/html/expect/test_package+re/Recent/X/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   X (test_package+re.Recent.X)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Recent</a> » X
+    </nav>
+    <h1>
+     Module <code>Recent.X</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec module-substitution" id="module-L">
+     <a href="#module-L" class="anchor"></a><code><span class="keyword">module</span> L := <a href="../Z/index.html#module-Y">Z.Y</a></code>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code><code> = <a href="../Z/Y/X/index.html#type-t">L.X.t</a>(int)</code>;
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec type-subst" id="type-u">
+     <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code><code> := int</code>;
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec type" id="type-v">
+     <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v</code><code> = <a href="../Z/Y/X/index.html#type-t">L.X.t</a>(<a href="index.html#type-u">u</a>)</code>;
+    </dt>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -196,6 +196,12 @@
      <a href="#val-conj" class="anchor"></a><code><span class="keyword">let</span> conj: <span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>;</code>
     </dt>
    </dl>
+   <div class="spec module" id="module-Z">
+    <a href="#module-Z" class="anchor"></a><code><span class="keyword">module</span> <a href="Z/index.html">Z</a>: { ... };</code>
+   </div>
+   <div class="spec module" id="module-X">
+    <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a>: { ... };</code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -285,7 +285,7 @@ let source_files = [
 let source_files =
   let latest_supported = "4.08." in
   match String.sub (Sys.ocaml_version) 0 (String.length latest_supported) with
-  | s when s = latest_supported -> source_files @ [("recent.mli", ["Recent/index.html"])]
+  | s when s = latest_supported -> source_files @ [("recent.mli", ["Recent/index.html"; "Recent/X/index.html"])]
   | _ -> source_files
   | exception _ -> source_files
 


### PR DESCRIPTION
This PR will render the new syntactic elements as written in the mli files. This should fix #350 as it qualifies as 'minimal support'. We might want to consider removing the substituted modules and types entirely, depending on how these features end up being used.