### PR TITLE
Fix compilation on OCaml 4.09.0 beta2

### DIFF
--- a/src/model/compat.cppo.ml
+++ b/src/model/compat.cppo.ml
@@ -67,7 +67,7 @@ and modtype_declaration =
 
 let opt conv = function | None -> None | Some x -> Some (conv x)
 
-#if OCAML_MAJOR = 4 && OCAML_MINOR = 08
+#if OCAML_MAJOR = 4 && OCAML_MINOR >= 08
 
 let rec signature : Types.signature -> signature = fun x -> List.map signature_item x
 


### PR DESCRIPTION
The constraint in the cppo conditional compilation also expands to 4.10.0~dev as well, since it should work there too.

Closes #382
cc @jonludlam 