### PR TITLE
Option to turn warnings into errors

### DIFF
--- a/src/model/error.ml
+++ b/src/model/error.ml
@@ -15,6 +15,7 @@ type filename_only_payload = {
 type t = [
   | `With_full_location of full_location_payload
   | `With_filename_only of filename_only_payload
+  | `Without_location of string
 ]
 
 let full message location =
@@ -22,6 +23,10 @@ let full message location =
 
 let filename_only message file =
   `With_filename_only {file; message}
+
+(** Only used internally *)
+let without_location message =
+  `Without_location message
 
 let make ?suggestion format =
   format |>
@@ -49,6 +54,9 @@ let to_string = function
 
   | `With_filename_only {file; message} ->
     Printf.sprintf "File \"%s\":\n%s" file message
+
+  | `Without_location message ->
+    message
 
 
 
@@ -90,7 +98,7 @@ let shed_warnings with_warnings =
   with_warnings.warnings
   |> List.iter (fun warning -> warning |> to_string |> prerr_endline);
   if !warn_error && with_warnings.warnings <> [] then
-    failwith "Warnings have been generated.";
+    raise_exception (without_location "Warnings have been generated.");
   with_warnings.value
 
 let set_warn_error b = warn_error := b

--- a/src/model/error.ml
+++ b/src/model/error.ml
@@ -82,9 +82,15 @@ let accumulate_warnings f =
 let warning accumulator error =
   accumulator := error::!accumulator
 
+let warn_error = ref false
+
 (* TODO This is a temporary measure until odoc is ported to handle warnings
    throughout. *)
 let shed_warnings with_warnings =
   with_warnings.warnings
   |> List.iter (fun warning -> warning |> to_string |> prerr_endline);
+  if !warn_error && with_warnings.warnings <> [] then
+    failwith "Warnings have been generated.";
   with_warnings.value
+
+let set_warn_error b = warn_error := b

--- a/src/model/error.mli
+++ b/src/model/error.mli
@@ -20,3 +20,7 @@ type warning_accumulator
 val accumulate_warnings : (warning_accumulator -> 'a) -> 'a with_warnings
 val warning : warning_accumulator -> t -> unit
 val shed_warnings : 'a with_warnings -> 'a
+
+(** When set to [true],
+   [shed_warnings] will raise [Failure] if it had to print warnings. *)
+val set_warn_error : bool -> unit

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -51,6 +51,15 @@ let convert_uri : Odoc_html.Tree.uri Arg.converter =
   in
   (parser, printer)
 
+let handle_error = function
+  | Ok () -> ()
+  | Error (`Cli_error msg) ->
+    Printf.eprintf "%s\n%!" msg;
+    exit 2
+  | Error (`Msg msg) ->
+    Printf.eprintf "ERROR: %s\n%!" msg;
+    exit 1
+
 let docs = "ARGUMENTS"
 
 let odoc_file_directories =
@@ -128,10 +137,8 @@ end = struct
       Compile.cmi ~env ~package:package_name ~hidden ~output ~warn_error input
     else if Fs.File.has_ext ".mld" input then
       Compile.mld ~env ~package:package_name ~output ~warn_error input
-    else (
-      Printf.eprintf "Unknown extension, expected one of: cmti, cmt, cmi or mld.\n%!";
-      exit 2
-    )
+    else
+      Error (`Cli_error "Unknown extension, expected one of: cmti, cmt, cmi or mld.\n%!")
 
   let input =
     let doc = "Input cmti, cmt, cmi or mld file" in
@@ -156,8 +163,8 @@ end = struct
       let doc = "Try resolving forward references" in
       Arg.(value & flag & info ~doc ["r";"resolve-fwd-refs"])
     in
-    Term.(const compile $ hidden $ odoc_file_directories $ resolve_fwd_refs $
-          dst $ pkg $ input $ warn_error)
+    Term.(const handle_error $ (const compile $ hidden $ odoc_file_directories $
+          resolve_fwd_refs $ dst $ pkg $ input $ warn_error))
 
   let info =
     Term.info "compile"
@@ -206,7 +213,9 @@ end = struct
     let env = Env.create ~important_digests:false ~directories in
     let file = Fs.File.of_string input_file in
     match index_for with
-    | None -> Html_page.from_odoc ~env ~syntax ~theme_uri ~output:output_dir file
+    | None ->
+      Html_page.from_odoc ~env ~syntax ~theme_uri ~output:output_dir file;
+      Ok ()
     | Some pkg_name ->
       Html_page.from_mld ~env ~syntax ~output:output_dir ~package:pkg_name ~warn_error file
 
@@ -247,9 +256,9 @@ end = struct
       in
       Arg.(value & opt (pconv convert_syntax) (Odoc_html.Tree.OCaml) @@ info ~docv:"SYNTAX" ~doc ~env ["syntax"])
     in
-    Term.(const html $ semantic_uris $ closed_details $ hidden $
+    Term.(const handle_error $ (const html $ semantic_uris $ closed_details $ hidden $
           odoc_file_directories $ dst ~create:true () $ index_for $ syntax $
-          theme_uri $ input $ warn_error)
+          theme_uri $ input $ warn_error))
 
   let info =
     Term.info ~doc:"Generates an html file from an odoc one" "html"
@@ -288,8 +297,8 @@ end = struct
                  `.' is used." in
       Arg.(value & opt string "" & info ~docv:"URI" ~doc ["xref-base-uri"])
     in
-    Term.(const html_fragment $ odoc_file_directories $ xref_base_uri $ output $
-          input $ warn_error)
+    Term.(const handle_error $ (const html_fragment $ odoc_file_directories $
+          xref_base_uri $ output $ input $ warn_error))
 
   let info =
     Term.info ~doc:"Generates an html fragment file from an mld one" "html-fragment"

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -5,6 +5,7 @@
 
 open Odoc_odoc
 open Cmdliner
+open Result
 
 let convert_syntax : Odoc_html.Tree.syntax Arg.converter =
   let syntax_parser str =

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -18,7 +18,8 @@ open Result
 
 
 
-let resolve_and_substitute ~env ~output input_file read_file =
+let resolve_and_substitute ~env ~output ~warn_error input_file read_file =
+  Odoc_model.Error.set_warn_error warn_error;
   let filename = Fs.File.to_string input_file in
   match read_file ~filename:filename with
   | Error e -> failwith (Odoc_model.Error.to_string e)
@@ -47,23 +48,24 @@ let root_of_compilation_unit ~package ~hidden ~module_name ~digest =
     Odoc_model.Root.Odoc_file.create_unit ~force_hidden:hidden module_name in
   {Odoc_model.Root.package; file = file_representation; digest}
 
-let cmti ~env ~package ~hidden ~output input =
+let cmti ~env ~package ~hidden ~output ~warn_error input =
   let make_root = root_of_compilation_unit ~package ~hidden in
   let read_file = Odoc_loader.read_cmti ~make_root in
-  resolve_and_substitute ~env ~output input read_file
+  resolve_and_substitute ~env ~output ~warn_error input read_file
 
-let cmt ~env ~package ~hidden ~output input =
+let cmt ~env ~package ~hidden ~output ~warn_error input =
   let make_root = root_of_compilation_unit ~package ~hidden in
   let read_file = Odoc_loader.read_cmt ~make_root in
-  resolve_and_substitute ~env ~output input read_file
+  resolve_and_substitute ~env ~output ~warn_error input read_file
 
-let cmi ~env ~package ~hidden ~output input =
+let cmi ~env ~package ~hidden ~output ~warn_error input =
   let make_root = root_of_compilation_unit ~package ~hidden in
   let read_file = Odoc_loader.read_cmi ~make_root in
-  resolve_and_substitute ~env ~output input read_file
+  resolve_and_substitute ~env ~output ~warn_error input read_file
 
 (* TODO: move most of this to doc-ock. *)
-let mld ~env ~package ~output input =
+let mld ~env ~package ~output ~warn_error input =
+  Odoc_model.Error.set_warn_error warn_error;
   let root_name =
     let page_dash_root =
       Filename.chop_extension (Fs.File.(to_string @@ basename output))

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -22,7 +22,7 @@ let resolve_and_substitute ~env ~output ~warn_error input_file read_file =
   Odoc_model.Error.set_warn_error warn_error;
   let filename = Fs.File.to_string input_file in
   match read_file ~filename:filename with
-  | Error e -> failwith (Odoc_model.Error.to_string e)
+  | Error e -> Error (`Msg (Odoc_model.Error.to_string e))
   | Ok unit ->
     let unit = Odoc_xref.Lookup.lookup unit in
     if not unit.Odoc_model.Lang.Compilation_unit.interface then (
@@ -41,7 +41,8 @@ let resolve_and_substitute ~env ~output ~warn_error input_file read_file =
        working on. *)
     let expand_env = Env.build env (`Unit resolved) in
     let expanded = Odoc_xref.expand (Env.expander expand_env) resolved in
-    Compilation_unit.save output expanded
+    Compilation_unit.save output expanded;
+    Ok ()
 
 let root_of_compilation_unit ~package ~hidden ~module_name ~digest =
   let file_representation : Odoc_model.Root.Odoc_file.t =
@@ -90,20 +91,19 @@ let mld ~env ~package ~output ~warn_error input =
     in
     Location.{ loc_start = pos; loc_end = pos; loc_ghost = true }
   in
-  match Fs.File.read input with
-  | Error (`Msg s) ->
-    Printf.eprintf "ERROR: %s\n%!" s;
-    exit 1
-  | Ok str ->
-    let content =
-      match Odoc_loader.read_string name location str with
-      | Error e -> failwith (Odoc_model.Error.to_string e)
-      | Ok (`Docs content) -> content
-      | Ok `Stop -> [] (* TODO: Error? *)
-    in
+  let resolve content =
     (* This is a mess. *)
     let page = Odoc_model.Lang.Page.{ name; content; digest } in
     let page = Odoc_xref.Lookup.lookup_page page in
     let env = Env.build env (`Page page) in
     let resolved = Odoc_xref.resolve_page (Env.resolver env) page in
-    Page.save output resolved
+    Page.save output resolved;
+    Ok ()
+  in
+  match Fs.File.read input with
+  | Error _ as e -> e
+  | Ok str ->
+    match Odoc_loader.read_string name location str with
+    | Error e -> Error (`Msg (Odoc_model.Error.to_string e))
+    | Ok `Stop -> resolve [] (* TODO: Error? *)
+    | Ok (`Docs content) -> resolve content

--- a/src/odoc/compile.mli
+++ b/src/odoc/compile.mli
@@ -18,16 +18,16 @@
 
 val cmti :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
-  output:Fs.File.t -> Fs.File.t -> unit
+  output:Fs.File.t -> warn_error:bool -> Fs.File.t -> unit
 
 val cmt :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
-  output:Fs.File.t -> Fs.File.t -> unit
+  output:Fs.File.t -> warn_error:bool -> Fs.File.t -> unit
 
 val cmi :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
-  output:Fs.File.t -> Fs.File.t -> unit
+  output:Fs.File.t -> warn_error:bool -> Fs.File.t -> unit
 
 val mld :
   env:Env.builder -> package:Odoc_model.Root.Package.t ->
-  output:Fs.File.t -> Fs.File.t -> unit
+  output:Fs.File.t -> warn_error:bool -> Fs.File.t -> unit

--- a/src/odoc/compile.mli
+++ b/src/odoc/compile.mli
@@ -18,16 +18,20 @@
 
 val cmti :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
-  output:Fs.File.t -> warn_error:bool -> Fs.File.t -> unit
+  output:Fs.File.t -> warn_error:bool -> Fs.File.t ->
+  (unit, [> `Msg of string ]) Result.result
 
 val cmt :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
-  output:Fs.File.t -> warn_error:bool -> Fs.File.t -> unit
+  output:Fs.File.t -> warn_error:bool -> Fs.File.t ->
+  (unit, [> `Msg of string ]) Result.result
 
 val cmi :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
-  output:Fs.File.t -> warn_error:bool -> Fs.File.t -> unit
+  output:Fs.File.t -> warn_error:bool -> Fs.File.t ->
+  (unit, [> `Msg of string ]) Result.result
 
 val mld :
   env:Env.builder -> package:Odoc_model.Root.Package.t ->
-  output:Fs.File.t -> warn_error:bool -> Fs.File.t -> unit
+  output:Fs.File.t -> warn_error:bool -> Fs.File.t ->
+  (unit, [> `Msg of string ]) Result.result

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -1,3 +1,4 @@
+open Result
 
 let from_mld ~xref_base_uri ~env ~output ~warn_error input =
   Odoc_model.Error.set_warn_error warn_error;

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -1,5 +1,6 @@
 
-let from_mld ~xref_base_uri ~env ~output input =
+let from_mld ~xref_base_uri ~env ~output ~warn_error input =
+  Odoc_model.Error.set_warn_error warn_error;
   (* Internal names, they don't have effect on the output. *)
   let page_name = "__fragment_page__" in
   let package = "__fragment_package__" in

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -21,17 +21,7 @@ let from_mld ~xref_base_uri ~env ~output ~warn_error input =
     in
     Location.{ loc_start = pos; loc_end = pos; loc_ghost = true }
   in
-  match Fs.File.read input with
-  | Error (`Msg s) ->
-    Printf.eprintf "ERROR: %s\n%!" s;
-    exit 1
-  | Ok str ->
-    let content =
-      match Odoc_loader.read_string name location str with
-      | Error e -> failwith (Odoc_model.Error.to_string e)
-      | Ok (`Docs content) -> content
-      | Ok `Stop -> [] (* TODO: Error? *)
-    in
+  let to_html content =
     (* This is a mess. *)
     let page = Odoc_model.Lang.Page.{ name; content; digest } in
     let page = Odoc_xref.Lookup.lookup_page page in
@@ -42,5 +32,13 @@ let from_mld ~xref_base_uri ~env ~output ~warn_error input =
     let oc = open_out (Fs.File.to_string output) in
     let fmt = Format.formatter_of_out_channel oc in
     Format.fprintf fmt "%a@." (Format.pp_print_list (Tyxml.Html.pp_elt ())) content;
-    close_out oc
-
+    close_out oc;
+    Ok ()
+  in
+  match Fs.File.read input with
+  | Error _ as e -> e
+  | Ok str ->
+    match Odoc_loader.read_string name location str with
+    | Error e -> Error (`Msg (Odoc_model.Error.to_string e))
+    | Ok (`Docs content) -> to_html content
+    | Ok `Stop -> to_html [] (* TODO: Error? *)

--- a/src/odoc/html_fragment.mli
+++ b/src/odoc/html_fragment.mli
@@ -17,7 +17,7 @@
 (** Produces html fragment files from a mld file. *)
 
 val from_mld : xref_base_uri:string -> env:Env.builder -> output:Fs.File.t ->
-  warn_error:bool -> Fs.File.t -> unit
+  warn_error:bool -> Fs.File.t -> (unit, [ `Msg of string ]) Result.result
 (** [from_mld ~xref_base_uri ~env ~output input] parses the content of the [input]
     file as a documentation page ({e i.e.} the ocamldoc syntax), generates the
     equivalent HTML representation and writes the result into the [output]

--- a/src/odoc/html_fragment.mli
+++ b/src/odoc/html_fragment.mli
@@ -16,7 +16,8 @@
 
 (** Produces html fragment files from a mld file. *)
 
-val from_mld : xref_base_uri:string -> env:Env.builder -> output:Fs.File.t -> Fs.File.t -> unit
+val from_mld : xref_base_uri:string -> env:Env.builder -> output:Fs.File.t ->
+  warn_error:bool -> Fs.File.t -> unit
 (** [from_mld ~xref_base_uri ~env ~output input] parses the content of the [input]
     file as a documentation page ({e i.e.} the ocamldoc syntax), generates the
     equivalent HTML representation and writes the result into the [output]

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -15,6 +15,7 @@
  *)
 
 open StdLabels
+open Result
 
 let to_html_tree_page ?theme_uri ~syntax v =
   match syntax with

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -87,7 +87,8 @@ let from_odoc ~env ?(syntax=Odoc_html.Tree.OCaml) ?theme_uri ~output:root_dir in
 
 (* Used only for [--index-for] which is deprecated and available only for
    backward compatibility. It should be removed whenever. *)
-let from_mld ~env ?(syntax=Odoc_html.Tree.OCaml) ~package ~output:root_dir input =
+let from_mld ~env ?(syntax=Odoc_html.Tree.OCaml) ~package ~output:root_dir ~warn_error input =
+  Odoc_model.Error.set_warn_error warn_error;
   let root_name = "index" in
   let digest = Digest.file (Fs.File.to_string input) in
   let root =

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -107,17 +107,7 @@ let from_mld ~env ?(syntax=Odoc_html.Tree.OCaml) ~package ~output:root_dir ~warn
     in
     Location.{ loc_start = pos; loc_end = pos; loc_ghost = true }
   in
-  match Fs.File.read input with
-  | Error (`Msg s) ->
-    Printf.eprintf "ERROR: %s\n%!" s;
-    exit 1
-  | Ok str ->
-    let content =
-      match Odoc_loader.read_string name location str with
-      | Error e -> failwith (Odoc_model.Error.to_string e)
-      | Ok (`Docs content) -> content
-      | Ok `Stop -> [] (* TODO: Error? *)
-    in
+  let to_html content =
     (* This is a mess. *)
     let page = Odoc_model.Lang.Page.{ name; content; digest } in
     let page = Odoc_xref.Lookup.lookup_page page in
@@ -135,4 +125,13 @@ let from_mld ~env ?(syntax=Odoc_html.Tree.OCaml) ~package ~output:root_dir ~warn
       let fmt = Format.formatter_of_out_channel oc in
       Format.fprintf fmt "%a@?" (Tyxml.Html.pp ()) content;
       close_out oc
-    )
+    );
+    Ok ()
+  in
+  match Fs.File.read input with
+  | Error _ as e -> e
+  | Ok str ->
+    match Odoc_loader.read_string name location str with
+    | Error e -> Error (`Msg (Odoc_model.Error.to_string e))
+    | Ok (`Docs content) -> to_html content
+    | Ok `Stop -> to_html [] (* TODO: Error? *)

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -22,4 +22,4 @@ val from_odoc :
   Fs.File.t -> unit
 
 val from_mld : env:Env.builder -> ?syntax:Odoc_html.Tree.syntax -> package:Odoc_model.Root.Package.t ->
-  output:Fs.Directory.t -> Fs.File.t -> unit
+  output:Fs.Directory.t -> warn_error:bool -> Fs.File.t -> unit

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -22,4 +22,4 @@ val from_odoc :
   Fs.File.t -> unit
 
 val from_mld : env:Env.builder -> ?syntax:Odoc_html.Tree.syntax -> package:Odoc_model.Root.Package.t ->
-  output:Fs.Directory.t -> warn_error:bool -> Fs.File.t -> unit
+  output:Fs.Directory.t -> warn_error:bool -> Fs.File.t -> (unit, [ `Msg of string ]) Result.result

--- a/test/compile/cases/parser_errors_fatal.mli
+++ b/test/compile/cases/parser_errors_fatal.mli
@@ -1,0 +1,56 @@
+(** {x This is bad markup} *)
+val x : int
+
+(** {9 Bad hading level} *)
+val x : int
+
+(* {4 Heading} this should be on it's own line *)
+val x : int
+
+(** {ul {limust be followed by whitespace}} *)
+val x : int
+
+(** {limust in a ul} *)
+val x : int
+
+(** {vmust be followed by whitespace v} *)
+val x : int
+
+(** {v must be preceded by whitespacev} *)
+val x : int
+
+(** @ stray *)
+val x : int
+
+(** Expect something on the same line: *)
+val x : int
+
+(** @before *)
+val x : int
+
+(** @param *)
+val x : int
+
+(** @raise *)
+val x : int
+
+(** @see *)
+val x : int
+
+(** @UnknownTag *)
+val x : int
+
+(** } unpaired *)
+val x : int
+
+(** ] unpaired *)
+val x : int
+
+(** {%invalid: raw markup target %} *)
+val x : int
+
+(** This comment has bad
+    } markup on the second line. *)
+val x : int
+
+(** {x bad markup} in a standalone comment. *)

--- a/test/compile/dune
+++ b/test/compile/dune
@@ -26,3 +26,18 @@
 (alias
  (name runtest)
  (action (diff expect/parser_errors.txt parser_errors.output)))
+
+;; Test --warn-error
+
+(rule
+ (deps cases/parser_errors_fatal.mli)
+ (targets parser_errors_fatal.output)
+ (action
+  (progn
+   (run %{ocamlc} -bin-annot -o parser_errors_fatal.cmi -c cases/parser_errors_fatal.mli)
+   (with-stderr-to parser_errors_fatal.output
+	  (system "! %{bin:odoc} compile --package foo --warn-error parser_errors_fatal.cmti")))))
+
+(alias
+ (name runtest)
+ (action (diff expect/parser_errors_fatal.txt parser_errors_fatal.output)))

--- a/test/compile/expect/parser_errors_fatal.txt
+++ b/test/compile/expect/parser_errors_fatal.txt
@@ -1,0 +1,20 @@
+File "cases/parser_errors_fatal.mli", line 1, characters 4-26:
+'{x This is bad markup}': bad markup.
+Suggestion: did you mean '{!x This is bad markup}' or '[x This is bad markup]'?
+odoc: internal error, uncaught exception:
+      Failure("Warnings have been generated.")
+      Raised at file "stdlib.ml", line 29, characters 17-33
+      Called from file "src/model/error.ml", line 93, characters 4-44
+      Called from file "src/loader/doc_attr.ml", line 62, characters 14-234
+      Called from file "src/loader/doc_attr.ml", line 80, characters 4-32
+      Called from file "src/loader/cmti.ml", line 163, characters 12-57
+      Called from file "src/loader/cmti.ml", line 596, characters 9-45
+      Called from file "src/loader/cmti.ml", line 674, characters 25-62
+      Called from file "list.ml", line 121, characters 24-34
+      Called from file "src/loader/cmti.ml", line 672, characters 4-135
+      Called from file "src/loader/cmti.ml", line 681, characters 14-46
+      Called from file "src/loader/odoc_loader.ml", line 46, characters 33-67
+      Called from file "src/model/error.ml", line 65, characters 9-15
+      Called from file "src/odoc/compile.ml", line 24, characters 8-36
+      Called from file "cmdliner_term.ml", line 25, characters 19-24
+      Called from file "cmdliner.ml", line 117, characters 32-39

--- a/test/compile/expect/parser_errors_fatal.txt
+++ b/test/compile/expect/parser_errors_fatal.txt
@@ -4,17 +4,5 @@ Suggestion: did you mean '{!x This is bad markup}' or '[x This is bad markup]'?
 odoc: internal error, uncaught exception:
       Failure("Warnings have been generated.")
       Raised at file "stdlib.ml", line 29, characters 17-33
-      Called from file "src/model/error.ml", line 93, characters 4-44
-      Called from file "src/loader/doc_attr.ml", line 62, characters 14-234
-      Called from file "src/loader/doc_attr.ml", line 80, characters 4-32
-      Called from file "src/loader/cmti.ml", line 163, characters 12-57
-      Called from file "src/loader/cmti.ml", line 596, characters 9-45
-      Called from file "src/loader/cmti.ml", line 674, characters 25-62
-      Called from file "list.ml", line 121, characters 24-34
-      Called from file "src/loader/cmti.ml", line 672, characters 4-135
-      Called from file "src/loader/cmti.ml", line 681, characters 14-46
-      Called from file "src/loader/odoc_loader.ml", line 46, characters 33-67
-      Called from file "src/model/error.ml", line 65, characters 9-15
-      Called from file "src/odoc/compile.ml", line 24, characters 8-36
       Called from file "cmdliner_term.ml", line 25, characters 19-24
       Called from file "cmdliner.ml", line 117, characters 32-39

--- a/test/compile/expect/parser_errors_fatal.txt
+++ b/test/compile/expect/parser_errors_fatal.txt
@@ -1,8 +1,4 @@
 File "cases/parser_errors_fatal.mli", line 1, characters 4-26:
 '{x This is bad markup}': bad markup.
 Suggestion: did you mean '{!x This is bad markup}' or '[x This is bad markup]'?
-odoc: internal error, uncaught exception:
-      Failure("Warnings have been generated.")
-      Raised at file "stdlib.ml", line 29, characters 17-33
-      Called from file "cmdliner_term.ml", line 25, characters 19-24
-      Called from file "cmdliner.ml", line 117, characters 32-39
+ERROR: Warnings have been generated.


### PR DESCRIPTION
Closes https://github.com/ocaml/odoc/issues/284

This PR adds the option `--warn-error` to turn warnings into errors.
It is implemented using a global flag and failing after warnings are printed.

This is the easier implementation I found and it has some problems:
- Very few warnings are accumulated before `shed_warnings` is called and the error is raised.
- It's a global variable that is very deep in the dependency chain

I also started looking into other ways that require refactoring:
- Passing the warning accumulator everywhere
  It's how the parser works but makes the code very verbose and introduce a lot of diffs. (~300 adds)
- Change `Error.catch` to also "catch" warnings
  This is also a lot of changes and requires to change the API of `Error` to avoid bad uses, which requires even more refactoring.
- Monad style would drastically change the whole codebase

What do you think?