### PR TITLE
Don't exit in library code

### DIFF
--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -209,8 +209,7 @@ end = struct
     let file = Fs.File.of_string input_file in
     match index_for with
     | None ->
-      Html_page.from_odoc ~env ~syntax ~theme_uri ~output:output_dir file;
-      Ok ()
+      Html_page.from_odoc ~env ~syntax ~theme_uri ~output:output_dir file
     | Some pkg_name ->
       Html_page.from_mld ~env ~syntax ~output:output_dir ~package:pkg_name file
 
@@ -326,20 +325,23 @@ module Depends = struct
 
   module Odoc_html = struct
     let list_dependencies input_file =
-      List.iter (Depends.for_html_step (Fs.Directory.of_string input_file))
+      let open Or_error in
+      Depends.for_html_step (Fs.Directory.of_string input_file) >>= fun depends ->
+      List.iter depends
         ~f:(fun (root : Odoc_model.Root.t) ->
           Printf.printf "%s %s %s\n"
             root.package
             (Odoc_model.Root.Odoc_file.name root.file)
             (Digest.to_hex root.digest)
-        )
+        );
+      Ok ()
 
     let cmd =
       let input =
         let doc = "Input directory" in
         Arg.(required & pos 0 (some file) None & info ~doc ~docv:"PKG_DIR" [])
       in
-      Term.(const list_dependencies $ input)
+      Term.(const handle_error $ (const list_dependencies $ input))
 
   let info =
     Term.info "html-deps"
@@ -365,20 +367,21 @@ module Targets = struct
 
   module Odoc_html = struct
     let list_targets directories output_dir odoc_file =
+      let open Or_error in
       let env = Env.create ~important_digests:false ~directories in
       let odoc_file = Fs.File.of_string odoc_file in
-      let targets =
-        Targets.of_odoc_file ~env ~output:output_dir odoc_file
-        |> List.map ~f:Fs.File.to_string
-      in
-      Printf.printf "%s\n%!" (String.concat ~sep:"\n" targets)
+      Targets.of_odoc_file ~env ~output:output_dir odoc_file >>= fun targets ->
+      let targets = List.map ~f:Fs.File.to_string targets in
+      Printf.printf "%s\n%!" (String.concat ~sep:"\n" targets);
+      Ok ()
 
     let cmd =
       let input =
         let doc = "Input file" in
         Arg.(required & pos 0 (some file) None & info ~doc ~docv:"file.odoc" [])
       in
-      Term.(const list_targets $ odoc_file_directories $ dst () $ input)
+      Term.(const handle_error $ (const list_targets $ odoc_file_directories $
+            dst () $ input))
 
     let info =
       Term.info "html-targets" ~doc:"TODO: Fill in."

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -52,7 +52,7 @@ let convert_uri : Odoc_html.Tree.uri Arg.converter =
   (parser, printer)
 
 let handle_error = function
-  | Ok () -> ()
+  | Result.Ok () -> ()
   | Error (`Cli_error msg) ->
     Printf.eprintf "%s\n%!" msg;
     exit 2

--- a/src/odoc/compilation_unit.ml
+++ b/src/odoc/compilation_unit.ml
@@ -35,7 +35,7 @@ let load =
   fun file ->
     let file = Fs.File.to_string file in
     match Hashtbl.find units file with
-    | unit -> unit
+    | unit -> Ok unit
     | exception Not_found ->
       try
         let ic = open_in_bin file in
@@ -43,10 +43,12 @@ let load =
         let res = Marshal.from_channel ic in
         close_in ic;
         Hashtbl.add units file res;
-        res
+        Ok res
       with exn ->
-        Printf.eprintf "Error while unmarshalling %S: %s\n%!" file
-          (match exn with
-           | Failure s -> s
-           | _ -> Printexc.to_string exn);
-        exit 2
+        let msg =
+          Printf.sprintf "Error while unmarshalling %S: %s\n%!" file
+            (match exn with
+              | Failure s -> s
+              | _ -> Printexc.to_string exn)
+        in
+        Error (`Msg msg)

--- a/src/odoc/compilation_unit.ml
+++ b/src/odoc/compilation_unit.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-
+open Or_error
 
 type t = Odoc_model.Lang.Compilation_unit.t
 

--- a/src/odoc/compilation_unit.mli
+++ b/src/odoc/compilation_unit.mli
@@ -24,4 +24,4 @@ val save : Fs.File.t -> t -> unit
 
 (** {2 Deserialization} *)
 
-val load : Fs.File.t -> t
+val load : Fs.File.t -> t Or_error.or_error

--- a/src/odoc/compilation_unit.mli
+++ b/src/odoc/compilation_unit.mli
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Or_error
+
 type t = Odoc_model.Lang.Compilation_unit.t
 
 val root : t -> Odoc_model.Root.t
@@ -24,4 +26,4 @@ val save : Fs.File.t -> t -> unit
 
 (** {2 Deserialization} *)
 
-val load : Fs.File.t -> t Or_error.or_error
+val load : Fs.File.t -> (t, [> msg]) result

--- a/src/odoc/compile.mli
+++ b/src/odoc/compile.mli
@@ -14,24 +14,26 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Or_error
+
 (** Produces .odoc files out of .cm{i,t,ti} or .mld files. *)
 
 val cmti :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
   output:Fs.File.t -> Fs.File.t ->
-  unit Or_error.or_error
+  (unit, [> msg]) result
 
 val cmt :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
   output:Fs.File.t -> Fs.File.t ->
-  unit Or_error.or_error
+  (unit, [> msg]) result
 
 val cmi :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
   output:Fs.File.t -> Fs.File.t ->
-  unit Or_error.or_error
+  (unit, [> msg]) result
 
 val mld :
   env:Env.builder -> package:Odoc_model.Root.Package.t ->
   output:Fs.File.t -> Fs.File.t ->
-  unit Or_error.or_error
+  (unit, [> msg]) result

--- a/src/odoc/compile.mli
+++ b/src/odoc/compile.mli
@@ -19,19 +19,19 @@
 val cmti :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
   output:Fs.File.t -> Fs.File.t ->
-  (unit, [> `Msg of string ]) Result.result
+  unit Or_error.or_error
 
 val cmt :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
   output:Fs.File.t -> Fs.File.t ->
-  (unit, [> `Msg of string ]) Result.result
+  unit Or_error.or_error
 
 val cmi :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
   output:Fs.File.t -> Fs.File.t ->
-  (unit, [> `Msg of string ]) Result.result
+  unit Or_error.or_error
 
 val mld :
   env:Env.builder -> package:Odoc_model.Root.Package.t ->
   output:Fs.File.t -> Fs.File.t ->
-  (unit, [> `Msg of string ]) Result.result
+  unit Or_error.or_error

--- a/src/odoc/compile.mli
+++ b/src/odoc/compile.mli
@@ -18,16 +18,20 @@
 
 val cmti :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
-  output:Fs.File.t -> Fs.File.t -> unit
+  output:Fs.File.t -> Fs.File.t ->
+  (unit, [> `Msg of string ]) Result.result
 
 val cmt :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
-  output:Fs.File.t -> Fs.File.t -> unit
+  output:Fs.File.t -> Fs.File.t ->
+  (unit, [> `Msg of string ]) Result.result
 
 val cmi :
   env:Env.builder -> package:Odoc_model.Root.Package.t -> hidden:bool ->
-  output:Fs.File.t -> Fs.File.t -> unit
+  output:Fs.File.t -> Fs.File.t ->
+  (unit, [> `Msg of string ]) Result.result
 
 val mld :
   env:Env.builder -> package:Odoc_model.Root.Package.t ->
-  output:Fs.File.t -> Fs.File.t -> unit
+  output:Fs.File.t -> Fs.File.t ->
+  (unit, [> `Msg of string ]) Result.result

--- a/src/odoc/depends.mli
+++ b/src/odoc/depends.mli
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Or_error
+
 (** Computes the dependencies required for each step of the pipeline to work
     correctly on a given input. *)
 
@@ -27,7 +29,7 @@ end
 val for_compile_step : Fs.File.t -> Compile.t list
 (** Takes a .cm{i,t,ti} file and returns the list of its dependencies. *)
 
-val for_html_step : Fs.Directory.t -> Odoc_model.Root.t list Or_error.or_error
+val for_html_step : Fs.Directory.t -> (Odoc_model.Root.t list, [> msg]) result
 (** Takes the directory where the .odoc files of a given package are stored and
     returns the list of roots that need to be in odoc's load path to process
     html from these .odoc files. *)

--- a/src/odoc/depends.mli
+++ b/src/odoc/depends.mli
@@ -27,7 +27,7 @@ end
 val for_compile_step : Fs.File.t -> Compile.t list
 (** Takes a .cm{i,t,ti} file and returns the list of its dependencies. *)
 
-val for_html_step : Fs.Directory.t -> Odoc_model.Root.t list
+val for_html_step : Fs.Directory.t -> Odoc_model.Root.t list Or_error.or_error
 (** Takes the directory where the .odoc files of a given package are stored and
     returns the list of roots that need to be in odoc's load path to process
     html from these .odoc files. *)

--- a/src/odoc/env.ml
+++ b/src/odoc/env.ml
@@ -180,8 +180,10 @@ let fetch_page ap root =
   match Accessible_paths.file_of_root ap root with
   | path -> Page.load path
   | exception Not_found ->
-    Printf.eprintf "No unit for root: %s\n%!" (Odoc_model.Root.to_string root);
-    exit 2
+    let msg =
+      Printf.sprintf "No unit for root: %s\n%!" (Odoc_model.Root.to_string root)
+    in
+    Error (`Msg msg)
 
 let fetch_unit ap root =
   match Accessible_paths.file_of_root ap root with

--- a/src/odoc/fs.ml
+++ b/src/odoc/fs.ml
@@ -15,6 +15,7 @@
  *)
 
 open StdLabels
+open Or_error
 
 type directory = Fpath.t
 type file = Fpath.t
@@ -146,15 +147,16 @@ module Directory = struct
     in
     loop ext f acc ([Fpath.to_string d] :: []);;
 
-  let fold_files_rec_result (type e) ?ext f acc d =
-    let exception Stop_iter of e in
+  exception Stop_iter of msg
+
+  let fold_files_rec_result ?ext f acc d =
     let f acc fn =
       match f acc fn with
       | Ok acc -> acc
       | Error e -> raise (Stop_iter e)
     in
     try Ok (fold_files_rec ?ext f acc d)
-    with Stop_iter e -> Error e
+    with Stop_iter (`Msg _ as e) -> Error e
 
   module Table = Hashtbl.Make(struct
       type nonrec t = t

--- a/src/odoc/fs.ml
+++ b/src/odoc/fs.ml
@@ -146,6 +146,16 @@ module Directory = struct
     in
     loop ext f acc ([Fpath.to_string d] :: []);;
 
+  let fold_files_rec_result (type e) ?ext f acc d =
+    let exception Stop_iter of e in
+    let f acc fn =
+      match f acc fn with
+      | Ok acc -> acc
+      | Error e -> raise (Stop_iter e)
+    in
+    try Ok (fold_files_rec ?ext f acc d)
+    with Stop_iter e -> Error e
+
   module Table = Hashtbl.Make(struct
       type nonrec t = t
       let equal = Fpath.equal

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -24,6 +24,8 @@ type directory
 
 module Directory : sig
 
+  open Or_error
+
   type t = directory
 
   val dirname : t -> t
@@ -40,7 +42,7 @@ module Directory : sig
   val to_string : t -> string
 
   val fold_files_rec_result : ?ext:string ->
-    ('a -> file -> ('a, 'e) Result.result) -> 'a -> t -> ('a, 'e) Result.result
+    ('a -> file -> ('a, msg) result) -> 'a -> t -> ('a, [> msg ]) result
   (** [fold_files_rec_result ~ext f acc d] recursively folds [f] over the files
       with extension matching [ext] (defaults to [""]) contained in [d]
       and its sub directories. Stop as soon as [f] returns [Error _]. *)

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -1,4 +1,4 @@
-open Result
+open Or_error
 
 (*
  * Copyright (c) 2016 Thomas Refis <trefis@janestreet.com>
@@ -63,7 +63,7 @@ module File : sig
   val of_string : string -> t
   val to_string : t -> string
 
-  val read : t -> (string, [> `Msg of string ]) result
+  val read : t -> (string, [> msg ]) result
 
   module Table : Hashtbl.S with type key = t
 end

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -39,10 +39,11 @@ module Directory : sig
   val of_string : string -> t
   val to_string : t -> string
 
-  val fold_files_rec : ?ext:string -> ('a -> file -> 'a) -> 'a -> t -> 'a
-  (** [fold_files_rec ~ext f acc d] recursively folds [f] over the files
+  val fold_files_rec_result : ?ext:string ->
+    ('a -> file -> ('a, 'e) Result.result) -> 'a -> t -> ('a, 'e) Result.result
+  (** [fold_files_rec_result ~ext f acc d] recursively folds [f] over the files
       with extension matching [ext] (defaults to [""]) contained in [d]
-      and its sub directories. *)
+      and its sub directories. Stop as soon as [f] returns [Error _]. *)
 
   module Table : Hashtbl.S with type key = t
 end

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -1,3 +1,4 @@
+open Or_error
 
 let from_mld ~xref_base_uri ~env ~output input =
   (* Internal names, they don't have effect on the output. *)
@@ -25,7 +26,7 @@ let from_mld ~xref_base_uri ~env ~output input =
     let page = Odoc_model.Lang.Page.{ name; content; digest } in
     let page = Odoc_xref.Lookup.lookup_page page in
     let env = Env.build env (`Page page) in
-    let resolved = Odoc_xref.resolve_page (Env.resolver env) page in
+    Odoc_xref.resolve_page (Env.resolver env) page >>= fun resolved ->
 
     let content = Odoc_html.Comment.to_html ~xref_base_uri resolved.content in
     let oc = open_out (Fs.File.to_string output) in

--- a/src/odoc/html_fragment.mli
+++ b/src/odoc/html_fragment.mli
@@ -16,7 +16,8 @@
 
 (** Produces html fragment files from a mld file. *)
 
-val from_mld : xref_base_uri:string -> env:Env.builder -> output:Fs.File.t -> Fs.File.t -> unit
+val from_mld : xref_base_uri:string -> env:Env.builder -> output:Fs.File.t ->
+  Fs.File.t -> (unit, [ `Msg of string ]) Result.result
 (** [from_mld ~xref_base_uri ~env ~output input] parses the content of the [input]
     file as a documentation page ({e i.e.} the ocamldoc syntax), generates the
     equivalent HTML representation and writes the result into the [output]

--- a/src/odoc/html_fragment.mli
+++ b/src/odoc/html_fragment.mli
@@ -14,10 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Or_error
+
 (** Produces html fragment files from a mld file. *)
 
 val from_mld : xref_base_uri:string -> env:Env.builder -> output:Fs.File.t ->
-  Fs.File.t -> unit Or_error.or_error
+  Fs.File.t -> (unit, [> msg]) result
 (** [from_mld ~xref_base_uri ~env ~output input] parses the content of the [input]
     file as a documentation page ({e i.e.} the ocamldoc syntax), generates the
     equivalent HTML representation and writes the result into the [output]

--- a/src/odoc/html_fragment.mli
+++ b/src/odoc/html_fragment.mli
@@ -17,7 +17,7 @@
 (** Produces html fragment files from a mld file. *)
 
 val from_mld : xref_base_uri:string -> env:Env.builder -> output:Fs.File.t ->
-  Fs.File.t -> (unit, [ `Msg of string ]) Result.result
+  Fs.File.t -> unit Or_error.or_error
 (** [from_mld ~xref_base_uri ~env ~output input] parses the content of the [input]
     file as a documentation page ({e i.e.} the ocamldoc syntax), generates the
     equivalent HTML representation and writes the result into the [output]

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -15,6 +15,7 @@
  *)
 
 open StdLabels
+open Or_error
 
 let to_html_tree_page ?theme_uri ~syntax v =
   match syntax with
@@ -27,14 +28,12 @@ let to_html_tree_compilation_unit ?theme_uri ~syntax v =
   | Odoc_html.Tree.OCaml -> Odoc_html.Generator.ML.compilation_unit ?theme_uri v
 
 let from_odoc ~env ?(syntax=Odoc_html.Tree.OCaml) ?theme_uri ~output:root_dir input =
-  let root = Root.read input in
+  Root.read input >>= fun root ->
   match root.file with
   | Page page_name ->
-    let page = Page.load input in
-    let odoctree =
-      let resolve_env = Env.build env (`Page page) in
-      Odoc_xref.resolve_page (Env.resolver resolve_env) page
-    in
+    Page.load input >>= fun page ->
+    let resolve_env = Env.build env (`Page page) in
+    Odoc_xref.resolve_page (Env.resolver resolve_env) page >>= fun odoctree ->
     let pkg_name = root.package in
     let pages = to_html_tree_page ?theme_uri ~syntax odoctree in
     let pkg_dir = Fs.Directory.reach_from ~dir:root_dir pkg_name in
@@ -48,21 +47,22 @@ let from_odoc ~env ?(syntax=Odoc_html.Tree.OCaml) ?theme_uri ~output:root_dir in
       let fmt = Format.formatter_of_out_channel oc in
       Format.fprintf fmt "%a@?" (Tyxml.Html.pp ()) content;
       close_out oc
-    )
+    );
+    Ok ()
   | Compilation_unit {hidden = _; _} ->
     (* If hidden, we should not generate HTML. See
          https://github.com/ocaml/odoc/issues/99. *)
-    let unit = Compilation_unit.load input in
+    Compilation_unit.load input >>= fun unit ->
     let unit = Odoc_xref.Lookup.lookup unit in
-    let odoctree =
+    begin
       (* See comment in compile for explanation regarding the env duplication. *)
       let resolve_env = Env.build env (`Unit unit) in
-      let resolved = Odoc_xref.resolve (Env.resolver resolve_env) unit in
+      Odoc_xref.resolve (Env.resolver resolve_env) unit >>= fun resolved ->
       let expand_env = Env.build env (`Unit resolved) in
-      Odoc_xref.expand (Env.expander expand_env) resolved
-      |> Odoc_xref.Lookup.lookup
+      Odoc_xref.expand (Env.expander expand_env) resolved >>= fun expanded ->
+      Odoc_xref.Lookup.lookup expanded
       |> Odoc_xref.resolve (Env.resolver expand_env) (* Yes, again. *)
-    in
+    end >>= fun odoctree ->
     let pkg_dir =
       Fs.Directory.reach_from ~dir:root_dir root.package
     in
@@ -83,7 +83,8 @@ let from_odoc ~env ?(syntax=Odoc_html.Tree.OCaml) ?theme_uri ~output:root_dir in
       let fmt = Format.formatter_of_out_channel oc in
       Format.fprintf fmt "%a@?" (Tyxml.Html.pp ()) content;
       close_out oc
-    )
+    );
+    Ok ()
 
 (* Used only for [--index-for] which is deprecated and available only for
    backward compatibility. It should be removed whenever. *)
@@ -111,7 +112,7 @@ let from_mld ~env ?(syntax=Odoc_html.Tree.OCaml) ~package ~output:root_dir input
     let page = Odoc_model.Lang.Page.{ name; content; digest } in
     let page = Odoc_xref.Lookup.lookup_page page in
     let env = Env.build env (`Page page) in
-    let resolved = Odoc_xref.resolve_page (Env.resolver env) page in
+    Odoc_xref.resolve_page (Env.resolver env) page >>= fun resolved ->
     let pages = to_html_tree_page ~syntax resolved in
     let pkg_dir = Fs.Directory.reach_from ~dir:root_dir root.package in
     Fs.Directory.mkdir_p pkg_dir;

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -106,17 +106,7 @@ let from_mld ~env ?(syntax=Odoc_html.Tree.OCaml) ~package ~output:root_dir input
     in
     Location.{ loc_start = pos; loc_end = pos; loc_ghost = true }
   in
-  match Fs.File.read input with
-  | Error (`Msg s) ->
-    Printf.eprintf "ERROR: %s\n%!" s;
-    exit 1
-  | Ok str ->
-    let content =
-      match Odoc_loader.read_string name location str with
-      | Error e -> failwith (Odoc_model.Error.to_string e)
-      | Ok (`Docs content) -> content
-      | Ok `Stop -> [] (* TODO: Error? *)
-    in
+  let to_html content =
     (* This is a mess. *)
     let page = Odoc_model.Lang.Page.{ name; content; digest } in
     let page = Odoc_xref.Lookup.lookup_page page in
@@ -134,4 +124,13 @@ let from_mld ~env ?(syntax=Odoc_html.Tree.OCaml) ~package ~output:root_dir input
       let fmt = Format.formatter_of_out_channel oc in
       Format.fprintf fmt "%a@?" (Tyxml.Html.pp ()) content;
       close_out oc
-    )
+    );
+    Ok ()
+  in
+  match Fs.File.read input with
+  | Error _ as e -> e
+  | Ok str ->
+    match Odoc_loader.read_string name location str with
+    | Error e -> Error (`Msg (Odoc_model.Error.to_string e))
+    | Ok (`Docs content) -> to_html content
+    | Ok `Stop -> to_html [] (* TODO: Error? *)

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -22,4 +22,4 @@ val from_odoc :
   Fs.File.t -> unit
 
 val from_mld : env:Env.builder -> ?syntax:Odoc_html.Tree.syntax -> package:Odoc_model.Root.Package.t ->
-  output:Fs.Directory.t -> Fs.File.t -> unit
+  output:Fs.Directory.t -> Fs.File.t -> (unit, [ `Msg of string ]) Result.result

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -19,7 +19,7 @@
 
 val from_odoc :
   env:Env.builder -> ?syntax:Odoc_html.Tree.syntax -> ?theme_uri:Odoc_html.Tree.uri -> output:Fs.Directory.t ->
-  Fs.File.t -> unit
+  Fs.File.t -> unit Or_error.or_error
 
 val from_mld : env:Env.builder -> ?syntax:Odoc_html.Tree.syntax -> package:Odoc_model.Root.Package.t ->
-  output:Fs.Directory.t -> Fs.File.t -> (unit, [ `Msg of string ]) Result.result
+  output:Fs.Directory.t -> Fs.File.t -> unit Or_error.or_error

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -14,12 +14,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Or_error
 
 (** Produces .html files from a .odoc file. *)
 
 val from_odoc :
   env:Env.builder -> ?syntax:Odoc_html.Tree.syntax -> ?theme_uri:Odoc_html.Tree.uri -> output:Fs.Directory.t ->
-  Fs.File.t -> unit Or_error.or_error
+  Fs.File.t -> (unit, [> msg]) result
 
 val from_mld : env:Env.builder -> ?syntax:Odoc_html.Tree.syntax -> package:Odoc_model.Root.Package.t ->
-  output:Fs.Directory.t -> Fs.File.t -> unit Or_error.or_error
+  output:Fs.Directory.t -> Fs.File.t -> (unit, [> msg]) result

--- a/src/odoc/or_error.ml
+++ b/src/odoc/or_error.ml
@@ -1,0 +1,10 @@
+type ('a, 'e) result = ('a, 'e) Result.result =
+  | Ok of 'a
+  | Error of 'e
+
+type 'a or_error = ('a, [ `Msg of string ]) result
+
+let (>>=) r f =
+  match r with
+  | Ok v -> f v
+  | Error _ as e -> e

--- a/src/odoc/or_error.ml
+++ b/src/odoc/or_error.ml
@@ -2,7 +2,7 @@ type ('a, 'e) result = ('a, 'e) Result.result =
   | Ok of 'a
   | Error of 'e
 
-type 'a or_error = ('a, [ `Msg of string ]) result
+type msg = [ `Msg of string ]
 
 let (>>=) r f =
   match r with

--- a/src/odoc/or_error.mli
+++ b/src/odoc/or_error.mli
@@ -3,6 +3,6 @@ type ('a, 'e) result = ('a, 'e) Result.result =
   | Ok of 'a
   | Error of 'e
 
-type 'a or_error = ('a, [ `Msg of string ]) Result.result
+type msg = [ `Msg of string ]
 
-val (>>=) : 'a or_error -> ('a -> 'b or_error) -> 'b or_error
+val (>>=) : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result

--- a/src/odoc/or_error.mli
+++ b/src/odoc/or_error.mli
@@ -1,0 +1,8 @@
+(** Re-export for compatibility with 4.02 *)
+type ('a, 'e) result = ('a, 'e) Result.result =
+  | Ok of 'a
+  | Error of 'e
+
+type 'a or_error = ('a, [ `Msg of string ]) Result.result
+
+val (>>=) : 'a or_error -> ('a -> 'b or_error) -> 'b or_error

--- a/src/odoc/page.mli
+++ b/src/odoc/page.mli
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Or_error
+
 type t = Odoc_model.Lang.Page.t
 
 val root : t -> Odoc_model.Root.t
@@ -24,4 +26,4 @@ val save : Fs.File.t -> t -> unit
 
 (** {2 Deserialization} *)
 
-val load : Fs.File.t -> (t, [ `Msg of string ]) Result.result
+val load : Fs.File.t -> (t, [> msg ]) result

--- a/src/odoc/page.mli
+++ b/src/odoc/page.mli
@@ -24,4 +24,4 @@ val save : Fs.File.t -> t -> unit
 
 (** {2 Deserialization} *)
 
-val load : Fs.File.t -> t
+val load : Fs.File.t -> (t, [ `Msg of string ]) Result.result

--- a/src/odoc/root.ml
+++ b/src/odoc/root.ml
@@ -21,12 +21,13 @@ let magic = "odoc-%%VERSION%%"
 let load file ic =
   let m = really_input_string ic (String.length magic) in
   if m = magic then
-    Marshal.from_channel ic
-  else (
-    Printf.eprintf "%s: invalid magic number %S, expected %S\n%!"
-      file m magic;
-    exit 1
-  )
+    Ok (Marshal.from_channel ic)
+  else
+    let msg =
+      Printf.sprintf "%s: invalid magic number %S, expected %S\n%!"
+        file m magic
+    in
+    Error (`Msg msg)
 
 let save oc t =
   output_string oc magic;

--- a/src/odoc/root.ml
+++ b/src/odoc/root.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-
+open Or_error
 
 let magic = "odoc-%%VERSION%%"
 

--- a/src/odoc/root.mli
+++ b/src/odoc/root.mli
@@ -14,14 +14,15 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Or_error
 
 
-val load : string -> in_channel -> (Odoc_model.Root.t , [ `Msg of string ]) Result.result
+val load : string -> in_channel -> (Odoc_model.Root.t, [> msg ]) result
 (** [load fn ic] reads a {!t} from [ic].
     [fn] is the name of the file [ic] is "watching", and is used for error
     reporting. *)
 
-val read : Fs.File.t -> (Odoc_model.Root.t , [ `Msg of string ]) Result.result
+val read : Fs.File.t -> (Odoc_model.Root.t, [> msg ]) result
 (** [read f] opens [f] for reading and then calls {!load}. *)
 
 val save : out_channel -> Odoc_model.Root.t -> unit

--- a/src/odoc/root.mli
+++ b/src/odoc/root.mli
@@ -16,12 +16,12 @@
 
 
 
-val load : string -> in_channel -> Odoc_model.Root.t
+val load : string -> in_channel -> (Odoc_model.Root.t , [ `Msg of string ]) Result.result
 (** [load fn ic] reads a {!t} from [ic].
     [fn] is the name of the file [ic] is "watching", and is used for error
     reporting. *)
 
-val read : Fs.File.t -> Odoc_model.Root.t
+val read : Fs.File.t -> (Odoc_model.Root.t , [ `Msg of string ]) Result.result
 (** [read f] opens [f] for reading and then calls {!load}. *)
 
 val save : out_channel -> Odoc_model.Root.t -> unit

--- a/src/odoc/targets.mli
+++ b/src/odoc/targets.mli
@@ -14,9 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Or_error
+
 val of_odoc_file :
   env:Env.builder -> output:Fs.Directory.t ->
-  Fs.File.t -> Fs.File.t list Or_error.or_error
+  Fs.File.t -> (Fs.File.t list, [> msg]) result
 
 val index :
   output:Fs.Directory.t -> Fs.File.t list -> Fs.File.t list

--- a/src/odoc/targets.mli
+++ b/src/odoc/targets.mli
@@ -16,7 +16,7 @@
 
 val of_odoc_file :
   env:Env.builder -> output:Fs.Directory.t ->
-  Fs.File.t -> Fs.File.t list
+  Fs.File.t -> Fs.File.t list Or_error.or_error
 
 val index :
   output:Fs.Directory.t -> Fs.File.t list -> Fs.File.t list

--- a/src/xref/odoc_xref.ml
+++ b/src/xref/odoc_xref.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type 'a or_error = ('a, [ `Msg of string ]) Result.result
-
 type lookup_result_found = Component_table.lookup_result_found =
   { root : Odoc_model.Root.t; hidden : bool }
 
@@ -24,8 +22,10 @@ type lookup_result = Component_table.lookup_unit_result =
   | Found of lookup_result_found
   | Not_found
 
+type msg = [ `Msg of string ]
+
 (** Internal. Used to handled errors from [fetch_unit] and [fetch_page] *)
-exception Fetch_failed of [ `Msg of string ]
+exception Fetch_failed of msg
 
 let core_types = Odoc_model.Predefined.core_types
 
@@ -47,11 +47,11 @@ let build_resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
 
 let resolve resolver unit =
   try Ok (Resolve.resolve resolver unit)
-  with Fetch_failed e -> Error e
+  with Fetch_failed (`Msg _ as e) -> Error e
 
 let resolve_page resolver page =
   try Ok (Resolve.resolve_page resolver page)
-  with Fetch_failed e -> Error e
+  with Fetch_failed (`Msg _ as e) -> Error e
 
 type expander = Expand.t
 
@@ -65,6 +65,6 @@ let build_expander ?equal ?hash lookup fetch =
 
 let expand expander unit =
   try Ok (Expand.expand expander unit)
-  with Fetch_failed e -> Error e
+  with Fetch_failed (`Msg _ as e) -> Error e
 
 module Lookup = Lookup

--- a/src/xref/odoc_xref.ml
+++ b/src/xref/odoc_xref.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Result
+
 type lookup_result_found = Component_table.lookup_result_found =
   { root : Odoc_model.Root.t; hidden : bool }
 

--- a/src/xref/odoc_xref.mli
+++ b/src/xref/odoc_xref.mli
@@ -27,18 +27,21 @@ type lookup_result =
   | Found of lookup_result_found
   | Not_found
 
+type 'a or_error = ('a, [ `Msg of string ]) Result.result
+
 (** Build a resolver. Optionally provide equality and hash on ['a]. *)
 val build_resolver :
   ?equal:(Odoc_model.Root.t -> Odoc_model.Root.t -> bool) -> ?hash:(Odoc_model.Root.t -> int)
   -> (string -> lookup_result)
-  -> (Odoc_model.Root.t -> Odoc_model.Lang.Compilation_unit.t)
-  -> (string -> Odoc_model.Root.t option) -> (Odoc_model.Root.t -> Odoc_model.Lang.Page.t)
+  -> (Odoc_model.Root.t -> Odoc_model.Lang.Compilation_unit.t or_error)
+  -> (string -> Odoc_model.Root.t option)
+  -> (Odoc_model.Root.t -> Odoc_model.Lang.Page.t or_error)
   -> resolver
 
 val resolve :
-  resolver -> Odoc_model.Lang.Compilation_unit.t -> Odoc_model.Lang.Compilation_unit.t
+  resolver -> Odoc_model.Lang.Compilation_unit.t -> Odoc_model.Lang.Compilation_unit.t or_error
 
-val resolve_page : resolver -> Odoc_model.Lang.Page.t -> Odoc_model.Lang.Page.t
+val resolve_page : resolver -> Odoc_model.Lang.Page.t -> Odoc_model.Lang.Page.t or_error
 
 (** {2:expansion Expansion}
 
@@ -52,11 +55,11 @@ type expander
 val build_expander :
   ?equal:(Odoc_model.Root.t -> Odoc_model.Root.t -> bool) -> ?hash:(Odoc_model.Root.t -> int)
   -> (string -> lookup_result)
-  -> (root:Odoc_model.Root.t -> Odoc_model.Root.t -> Odoc_model.Lang.Compilation_unit.t)
+  -> (root:Odoc_model.Root.t -> Odoc_model.Root.t -> Odoc_model.Lang.Compilation_unit.t or_error)
   -> expander
 
 val expand :
-  expander -> Odoc_model.Lang.Compilation_unit.t -> Odoc_model.Lang.Compilation_unit.t
+  expander -> Odoc_model.Lang.Compilation_unit.t -> Odoc_model.Lang.Compilation_unit.t or_error
 
 (** {2 Misc.}
 

--- a/src/xref/odoc_xref.mli
+++ b/src/xref/odoc_xref.mli
@@ -27,21 +27,26 @@ type lookup_result =
   | Found of lookup_result_found
   | Not_found
 
-type 'a or_error = ('a, [ `Msg of string ]) Result.result
+type msg = [ `Msg of string ]
 
 (** Build a resolver. Optionally provide equality and hash on ['a]. *)
 val build_resolver :
   ?equal:(Odoc_model.Root.t -> Odoc_model.Root.t -> bool) -> ?hash:(Odoc_model.Root.t -> int)
   -> (string -> lookup_result)
-  -> (Odoc_model.Root.t -> Odoc_model.Lang.Compilation_unit.t or_error)
+  -> (Odoc_model.Root.t -> (Odoc_model.Lang.Compilation_unit.t, msg) Result.result)
   -> (string -> Odoc_model.Root.t option)
-  -> (Odoc_model.Root.t -> Odoc_model.Lang.Page.t or_error)
+  -> (Odoc_model.Root.t -> (Odoc_model.Lang.Page.t, msg) Result.result)
   -> resolver
 
 val resolve :
-  resolver -> Odoc_model.Lang.Compilation_unit.t -> Odoc_model.Lang.Compilation_unit.t or_error
+  resolver
+  -> Odoc_model.Lang.Compilation_unit.t
+  -> (Odoc_model.Lang.Compilation_unit.t, [> msg]) Result.result
 
-val resolve_page : resolver -> Odoc_model.Lang.Page.t -> Odoc_model.Lang.Page.t or_error
+val resolve_page :
+  resolver
+  -> Odoc_model.Lang.Page.t
+  -> (Odoc_model.Lang.Page.t, [> msg]) Result.result
 
 (** {2:expansion Expansion}
 
@@ -55,11 +60,13 @@ type expander
 val build_expander :
   ?equal:(Odoc_model.Root.t -> Odoc_model.Root.t -> bool) -> ?hash:(Odoc_model.Root.t -> int)
   -> (string -> lookup_result)
-  -> (root:Odoc_model.Root.t -> Odoc_model.Root.t -> Odoc_model.Lang.Compilation_unit.t or_error)
+  -> (root:Odoc_model.Root.t -> Odoc_model.Root.t -> (Odoc_model.Lang.Compilation_unit.t, msg) Result.result)
   -> expander
 
 val expand :
-  expander -> Odoc_model.Lang.Compilation_unit.t -> Odoc_model.Lang.Compilation_unit.t or_error
+  expander
+  -> Odoc_model.Lang.Compilation_unit.t
+  -> (Odoc_model.Lang.Compilation_unit.t, [> msg]) Result.result
 
 (** {2 Misc.}
 


### PR DESCRIPTION
Refactor error reporting to avoid exiting the program in library code.
Errors are propagated back to `odoc/bin/main.ml` by value and handled in an unified way.

Most of the changes are trivial but the patch is very invasive, exiting functions were very deep in the program.
Using exceptions can make the patch a little smaller but also harder as all exposed functions would need to catch them and there is a lot of them.

The exit status for some errors (marshalling) is now `1` instead of `2`. Is that an issue ?

I added the `Or_error` module that re-export `result` and define a bind operator. I didn't use `rresult` as it was removed in https://github.com/ocaml/odoc/pull/306.

Only the first commit is required for https://github.com/ocaml/odoc/pull/398
