### PR TITLE
Allow --warn-error to be set by an environment variable

### DIFF
--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -79,7 +79,8 @@ let hidden =
 
 let warn_error =
   let doc = "Turn warnings into errors." in
-  Arg.(value & flag & info ~docs ~doc ["warn-error"])
+  let env = Arg.env_var "ODOC_WARN_ERROR" ~doc:(doc ^ " See option $(opt).") in
+  Arg.(value & flag & info ~docs ~doc ~env ["warn-error"])
 
 let dst ?create () =
   let doc = "Output directory where the HTML tree is expected to be saved." in


### PR DESCRIPTION
I was pleased to see the PR to [add a flag for fatal warnings](https://github.com/ocaml/odoc/pull/398) to `odoc`. This will be really useful for linting documentation in CI. 

For our specific use-case in [`ocaml-ci`](https://github.com/ocurrent/ocaml-ci), it would be great to be able to trigger this feature even if it's not specified in Dune's `documentation` stanza. This PR adds an `ODOC_WARN_ERROR` environment variable to do just that :slightly_smiling_face:

Old API:

```shell
$ odoc compile --help
   ...
       --warn-error
           Turn warnings into errors.
```

New API:

```shell
$ odoc compile --help
   ...
       --warn-error (absent ODOC_WARN_ERROR env)
           Turn warnings into errors.
   ...
ENVIRONMENT
       These environment variables affect the execution of compile:

       ODOC_WARN_ERROR
           Turn warnings into errors. See option --warn-error.
```
