### PR TITLE
4.10 compatibility

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -25,7 +25,7 @@ open Utils
 
 let a_href = Tree.Relative_link.to_sub_element
 
-let functor_arg_pos { Odoc_model.Lang.FunctorArgument.id ; _ } =
+let functor_arg_pos { Odoc_model.Lang.FunctorParameter.id ; _ } =
   match id with
   | `Argument (_, nb, _) -> nb
   | _ ->
@@ -1462,10 +1462,10 @@ struct
       tagged_items
 
   and functor_argument
-    : 'row. ?theme_uri:Tree.uri -> Odoc_model.Lang.FunctorArgument.t
+    : 'row. ?theme_uri:Tree.uri -> Odoc_model.Lang.FunctorParameter.parameter
     -> Html_types.div_content Html.elt list * Tree.t list
   = fun ?theme_uri arg ->
-    let open Odoc_model.Lang.FunctorArgument in
+    let open Odoc_model.Lang.FunctorParameter in
     let name = Paths.Identifier.name arg.id in
     let nb = functor_arg_pos arg in
     let link_name = Printf.sprintf "%d-%s" nb name in
@@ -1515,8 +1515,8 @@ struct
       let params, params_subpages =
         List.fold_left (fun (args, subpages as acc) arg ->
           match arg with
-          | None -> acc
-          | Some arg ->
+          | Odoc_model.Lang.FunctorParameter.Unit -> acc
+          | Named arg ->
             let arg, arg_subpages = functor_argument ?theme_uri arg in
             let arg = Html.li arg in
             (args @ [arg], subpages @ arg_subpages)
@@ -1666,13 +1666,13 @@ struct
         Html.txt " ... ";
         Syntax.Mod.close_tag;
       ]
-    | Functor (None, expr) ->
+    | Functor (Unit, expr) ->
       (if Syntax.Mod.functor_keyword then [keyword "functor"] else []) @
       Html.txt " () " ::
       mty base expr
-    | Functor (Some arg, expr) ->
+    | Functor (Named arg, expr) ->
       let name =
-        let open Odoc_model.Lang.FunctorArgument in
+        let open Odoc_model.Lang.FunctorParameter in
         let to_print = Html.txt @@ Paths.Identifier.name arg.id in
         match
           Tree.Relative_link.Id.href

--- a/src/html/targets.ml
+++ b/src/html/targets.ml
@@ -17,7 +17,7 @@
 open StdLabels
 open Odoc_model.Paths
 
-let functor_arg_pos { Odoc_model.Lang.FunctorArgument.id ; _ } =
+let functor_arg_pos { Odoc_model.Lang.FunctorParameter.id ; _ } =
   match id with
   | `Argument (_, nb, _) -> nb
   | _ ->
@@ -63,7 +63,7 @@ and signature ~prefix (t : Odoc_model.Lang.Signature.t) =
   add_items ~don't:false [] t
 
 and functor_argument ~prefix arg =
-  let open Odoc_model.Lang.FunctorArgument in
+  let open Odoc_model.Lang.FunctorParameter in
   match arg.expansion with
   | None -> []
   | Some expansion ->
@@ -82,8 +82,8 @@ and module_expansion ~prefix (t : Odoc_model.Lang.Module.expansion) =
     let subpages = signature ~prefix sg in
     List.fold_left args ~init:subpages ~f:(fun subpages arg ->
       match arg with
-      | None -> subpages
-      | Some arg ->
+      | Odoc_model.Lang.FunctorParameter.Unit -> subpages
+      | Named arg ->
         let arg_subpages = functor_argument ~prefix arg in
         arg_subpages @ subpages
     )

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -477,6 +477,7 @@ and read_module_type env parent label_parent pos mty =
     match mty.mty_desc with
     | Tmty_ident(p, _) -> Path (Env.Path.read_module_type env p)
     | Tmty_signature sg -> Signature (read_signature env parent sg)
+#if OCAML_MAJOR = 4 && OCAML_MINOR >= 10
     | Tmty_functor(parameter, res) ->
         let parameter, env =
           match parameter with
@@ -499,6 +500,26 @@ and read_module_type env parent label_parent pos mty =
         in
         let res = read_module_type env parent label_parent (pos + 1) res in
         Functor(parameter, res)
+#else
+    | Tmty_functor(id, _, arg, res) ->
+        let arg =
+          match arg with
+          | None -> Odoc_model.Lang.FunctorParameter.Unit
+          | Some arg ->
+              let name = parenthesise (Ident.name id) in
+              let id = `Argument(parent, pos, Odoc_model.Names.ArgumentName.of_string name) in
+              let arg = read_module_type env id label_parent 1 arg in
+              let expansion =
+                match arg with
+                | Signature _ -> Some Module.AlreadyASig
+                | _ -> None
+              in
+              Named { FunctorParameter. id; expr = arg; expansion }
+        in
+        let env = Env.add_argument parent pos id (ArgumentName.of_ident id) env in
+        let res = read_module_type env parent label_parent (pos + 1) res in
+        Functor(arg, res)
+#endif
     | Tmty_with(body, subs) ->
       let body = read_module_type env parent label_parent pos body in
       let subs = List.map (read_with_constraint env label_parent) subs in
@@ -534,12 +555,17 @@ and read_module_type_declaration env parent mtd =
 and read_module_declaration env parent md =
   let open Module in
   let id =
+#if OCAML_MAJOR = 4 && OCAML_MINOR >= 10
     match md.md_id with
     | Some id ->
       let name = parenthesise (Ident.name id) in
       `Module(parent, Odoc_model.Names.ModuleName.of_string name)
     | None ->
       `Module(parent, Odoc_model.Names.ModuleName.of_string "_")
+#else
+    let name = parenthesise (Ident.name md.md_id) in
+    `Module(parent, Odoc_model.Names.ModuleName.of_string name)
+#endif
   in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached container md.md_attributes in
@@ -556,9 +582,15 @@ and read_module_declaration env parent md =
     | _ -> ModuleType (read_module_type env id container 1 md.md_type)
   in
   let hidden =
+#if OCAML_MAJOR=4 && OCAML_MINOR >= 10
     match canonical, md.md_id with
     | None, Some id -> Odoc_model.Root.contains_double_underscore (Ident.name id)
     | _,_ -> false
+#else
+    match canonical with
+    | None -> Odoc_model.Root.contains_double_underscore (Ident.name md.md_id)
+    | _ -> false
+#endif
   in
   let expansion =
     match type_ with

--- a/src/model/compat.cppo.ml
+++ b/src/model/compat.cppo.ml
@@ -132,7 +132,11 @@ and visibility : Types.visibility -> visibility = function
 and module_type : Types.module_type -> module_type = function
   | Types.Mty_ident p -> Mty_ident p
   | Types.Mty_signature s -> Mty_signature (signature s)
-  | Types.Mty_functor (a, b, c) -> Mty_functor(a, opt module_type b, module_type c)
+  | Types.Mty_functor (a, b, c) -> begin
+    match b with
+    | Some m -> Mty_functor(Named(Some a,module_type m),module_type c)
+    | None -> Mty_functor(Unit,module_type c)
+    end
   | Types.Mty_alias p -> Mty_alias p
 
 and module_presence : Types.module_presence -> module_presence = function
@@ -154,7 +158,11 @@ and modtype_declaration : Types.modtype_declaration -> modtype_declaration = fun
   let rec module_type : Types.module_type -> module_type = function
   | Types.Mty_ident p -> Mty_ident p
   | Types.Mty_signature s -> Mty_signature (signature s)
-  | Types.Mty_functor (a, b, c) -> Mty_functor(a, opt module_type b, module_type c)
+  | Types.Mty_functor (a, b, c) -> begin
+    match b with
+    | Some m -> Mty_functor(Named(Some a,module_type m),module_type c)
+    | None -> Mty_functor(Unit,module_type c)
+    end
   | Types.Mty_alias (_,q) -> Mty_alias q
 
   and signature_item : Types.signature_item -> signature_item = function
@@ -185,7 +193,11 @@ and modtype_declaration : Types.modtype_declaration -> modtype_declaration = fun
   let rec module_type : Types.module_type -> module_type = function
   | Types.Mty_ident p -> Mty_ident p
   | Types.Mty_signature s -> Mty_signature (signature s)
-  | Types.Mty_functor (a, b, c) -> Mty_functor(a, opt module_type b, module_type c)
+  | Types.Mty_functor (a, b, c) -> begin
+    match b with
+    | Some m -> Mty_functor(Named(Some a,module_type m),module_type c)
+    | None -> Mty_functor(Unit,module_type c)
+    end
   | Types.Mty_alias q -> Mty_alias q
 
   and signature_item : Types.signature_item -> signature_item = function

--- a/src/model/ident_env.cppo.ml
+++ b/src/model/ident_env.cppo.ml
@@ -185,11 +185,16 @@ let add_signature_tree_item parent item env =
         List.fold_right
           (fun decl env -> add_type parent decl.typ_id (TypeName.of_ident decl.typ_id) env)
           decls env
-    | Tsig_module md ->
-        add_module parent md.md_id (ModuleName.of_ident md.md_id) env
+    | Tsig_module { md_id = Some id; _ } ->
+        add_module parent id (ModuleName.of_ident id) env
+    | Tsig_module _ ->
+        env
     | Tsig_recmodule mds ->
         List.fold_right
-          (fun md env -> add_module parent md.md_id (ModuleName.of_ident md.md_id) env)
+          (fun md env ->
+            match md.md_id with
+            | Some id -> add_module parent id (ModuleName.of_ident id) env
+            | None -> env)
           mds env
     | Tsig_modtype mtd ->
         add_module_type parent mtd.mtd_id (ModuleTypeName.of_ident mtd.mtd_id) env
@@ -250,10 +255,14 @@ let add_structure_tree_item parent item env =
         List.fold_right
           (fun decl env -> add_type parent decl.typ_id (TypeName.of_ident decl.typ_id) env)
           decls env
-    | Tstr_module mb -> add_module parent mb.mb_id (ModuleName.of_ident mb.mb_id) env
+    | Tstr_module { mb_id = Some id; _} -> add_module parent id (ModuleName.of_ident id) env
+    | Tstr_module _ -> env
     | Tstr_recmodule mbs ->
         List.fold_right
-          (fun mb env -> add_module parent mb.mb_id (ModuleName.of_ident mb.mb_id) env)
+          (fun mb env ->
+            match mb.mb_id with
+            | Some id -> add_module parent id (ModuleName.of_ident id) env
+            | None -> env)
           mbs env
     | Tstr_modtype mtd ->
         add_module_type parent mtd.mtd_id (ModuleTypeName.of_ident mtd.mtd_id) env

--- a/src/model/ident_env.cppo.ml
+++ b/src/model/ident_env.cppo.ml
@@ -185,6 +185,7 @@ let add_signature_tree_item parent item env =
         List.fold_right
           (fun decl env -> add_type parent decl.typ_id (TypeName.of_ident decl.typ_id) env)
           decls env
+#if OCAML_MAJOR = 4 && OCAML_MINOR >= 10
     | Tsig_module { md_id = Some id; _ } ->
         add_module parent id (ModuleName.of_ident id) env
     | Tsig_module _ ->
@@ -196,6 +197,15 @@ let add_signature_tree_item parent item env =
             | Some id -> add_module parent id (ModuleName.of_ident id) env
             | None -> env)
           mds env
+#else
+    | Tsig_module { md_id; _ } ->
+        add_module parent md_id (ModuleName.of_ident md_id) env
+    | Tsig_recmodule mds ->
+        List.fold_right
+          (fun md env ->
+            add_module parent md.md_id (ModuleName.of_ident md.md_id) env)
+          mds env
+#endif
     | Tsig_modtype mtd ->
         add_module_type parent mtd.mtd_id (ModuleTypeName.of_ident mtd.mtd_id) env
     | Tsig_include incl ->
@@ -255,6 +265,7 @@ let add_structure_tree_item parent item env =
         List.fold_right
           (fun decl env -> add_type parent decl.typ_id (TypeName.of_ident decl.typ_id) env)
           decls env
+#if OCAML_MAJOR = 4 && OCAML_MINOR >= 10
     | Tstr_module { mb_id = Some id; _} -> add_module parent id (ModuleName.of_ident id) env
     | Tstr_module _ -> env
     | Tstr_recmodule mbs ->
@@ -264,6 +275,13 @@ let add_structure_tree_item parent item env =
             | Some id -> add_module parent id (ModuleName.of_ident id) env
             | None -> env)
           mbs env
+#else
+    | Tstr_module { mb_id; _} -> add_module parent mb_id (ModuleName.of_ident mb_id) env
+    | Tstr_recmodule mbs ->
+        List.fold_right
+          (fun mb env -> add_module parent mb.mb_id (ModuleName.of_ident mb.mb_id) env)
+          mbs env
+#endif
     | Tstr_modtype mtd ->
         add_module_type parent mtd.mtd_id (ModuleTypeName.of_ident mtd.mtd_id) env
     | Tstr_include incl ->

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -23,7 +23,7 @@ module rec Module : sig
   type expansion =
     | AlreadyASig
     | Signature of Signature.t
-    | Functor of FunctorArgument.t option list * Signature.t
+    | Functor of FunctorParameter.t list * Signature.t
 
   type decl =
     | Alias of Path.Module.t
@@ -47,13 +47,17 @@ module rec Module : sig
 
 end = Module
 
-and FunctorArgument : sig
-  type t = {
+and FunctorParameter : sig
+  type parameter = {
     id : Identifier.Module.t;
     expr : ModuleType.expr;
     expansion: Module.expansion option;
   }
-end = FunctorArgument
+
+  type t = 
+    | Unit
+    | Named of parameter
+end = FunctorParameter
 
 (** {3 Modules Types} *)
 
@@ -68,7 +72,7 @@ and ModuleType : sig
   type expr =
     | Path of Path.ModuleType.t
     | Signature of Signature.t
-    | Functor of FunctorArgument.t option * expr
+    | Functor of FunctorParameter.t * expr
     | With of expr * substitution list
     | TypeOf of Module.decl
 

--- a/src/model/maps.ml
+++ b/src/model/maps.ml
@@ -1120,7 +1120,7 @@ class virtual module_ = object (self)
   method virtual signature : Signature.t -> Signature.t
 
   method virtual module_type_functor_arg :
-    FunctorArgument.t option -> FunctorArgument.t option
+    FunctorParameter.t -> FunctorParameter.t
 
   method module_hidden h = h
 
@@ -1294,13 +1294,13 @@ class virtual module_type = object (self)
 
   method module_type_functor_arg arg =
     match arg with
-    | None -> arg
-    | Some { FunctorArgument. id; expr; expansion } ->
+    | Unit -> Unit
+    | Named { FunctorParameter. id; expr; expansion } ->
         let id' = self#identifier_module id in
         let expr' = self#module_type_expr expr in
         let expansion' = option_map self#module_expansion expansion in
           if id != id' || expr != expr' || expansion != expansion' then
-            Some {FunctorArgument. id = id'; expr = expr'; expansion = expansion'}
+            Named {FunctorParameter. id = id'; expr = expr'; expansion = expansion'}
           else arg
 
   method module_type mty =

--- a/src/model/maps.ml
+++ b/src/model/maps.ml
@@ -1119,7 +1119,7 @@ class virtual module_ = object (self)
 
   method virtual signature : Signature.t -> Signature.t
 
-  method virtual module_type_functor_arg :
+  method virtual module_type_functor_param :
     FunctorParameter.t -> FunctorParameter.t
 
   method module_hidden h = h
@@ -1133,7 +1133,7 @@ class virtual module_ = object (self)
         if sg != sg' then Signature sg'
         else expn
     | Functor (args, sg) ->
-        let args' = list_map self#module_type_functor_arg args in
+        let args' = list_map self#module_type_functor_param args in
         let sg' = self#signature sg in
         if args != args' || sg != sg' then Functor(args', sg')
         else expn
@@ -1278,7 +1278,7 @@ class virtual module_type = object (self)
             if sg != sg' then Signature sg'
             else expr
       | Functor(arg, res) ->
-          let arg' = self#module_type_functor_arg arg in
+          let arg' = self#module_type_functor_param arg in
           let res' = self#module_type_expr res in
             if arg != arg' || res != res' then Functor(arg', res')
             else expr
@@ -1292,7 +1292,7 @@ class virtual module_type = object (self)
             if decl != decl' then TypeOf decl'
             else expr
 
-  method module_type_functor_arg arg =
+  method module_type_functor_param arg =
     match arg with
     | Unit -> Unit
     | Named { FunctorParameter. id; expr; expansion } ->

--- a/src/model/maps.mli
+++ b/src/model/maps.mli
@@ -421,7 +421,7 @@ class virtual module_ : object
 
   method virtual signature : Signature.t -> Signature.t
 
-  method virtual module_type_functor_arg :
+  method virtual module_type_functor_param :
     FunctorParameter.t -> FunctorParameter.t
 
   method module_expansion : Module.expansion -> Module.expansion
@@ -482,7 +482,7 @@ class virtual module_type : object
 
   method module_type_expr : ModuleType.expr -> ModuleType.expr
 
-  method module_type_functor_arg :
+  method module_type_functor_param :
     FunctorParameter.t -> FunctorParameter.t
 
   method module_type : ModuleType.t -> ModuleType.t

--- a/src/model/maps.mli
+++ b/src/model/maps.mli
@@ -422,7 +422,7 @@ class virtual module_ : object
   method virtual signature : Signature.t -> Signature.t
 
   method virtual module_type_functor_arg :
-    FunctorArgument.t option -> FunctorArgument.t option
+    FunctorParameter.t -> FunctorParameter.t
 
   method module_expansion : Module.expansion -> Module.expansion
 
@@ -483,7 +483,7 @@ class virtual module_type : object
   method module_type_expr : ModuleType.expr -> ModuleType.expr
 
   method module_type_functor_arg :
-    FunctorArgument.t option -> FunctorArgument.t option
+    FunctorParameter.t -> FunctorParameter.t
 
   method module_type : ModuleType.t -> ModuleType.t
 

--- a/src/xref/component_table.ml
+++ b/src/xref/component_table.ml
@@ -552,15 +552,15 @@ and signature_items local =
 and module_type_expr local expr =
   let open Sig in
   let open ModuleType in
-  let open FunctorArgument in
+  let open FunctorParameter in
     match expr with
     | Path p -> path (module_type_path local) p
     | Signature sg -> signature (signature_items local) sg
-    | Functor(Some{ id; expr = arg; _}, res) ->
+    | Functor(Named { id; expr = arg; _}, res) ->
         let res = module_type_expr local res in
         let arg = module_type_expr local arg in
           functor_ local.t.equal local.t.hash id arg res
-    | Functor(None, res) ->
+    | Functor(Unit, res) ->
         let res = module_type_expr local res in
           generative res
     | With(body, subs) ->

--- a/src/xref/expand.ml
+++ b/src/xref/expand.ml
@@ -1007,9 +1007,9 @@ class t ?equal ?hash lookup fetch = object
     let incl' = expand_include t incl in
     super#include_ incl'
 
-  method! module_type_functor_arg arg =
+  method! module_type_functor_param arg =
     let arg = expand_argument t arg in
-      super#module_type_functor_arg arg
+      super#module_type_functor_param arg
 
   method! class_ c =
     let c' = expand_class t c in

--- a/src/xref/expand.ml
+++ b/src/xref/expand.ml
@@ -21,7 +21,7 @@ open Names
 
 type partial_expansion =
   | Signature of Signature.t
-  | Functor of FunctorArgument.t option *
+  | Functor of FunctorParameter.t *
                Identifier.Signature.t * int *
                ModuleType.expr
 
@@ -30,15 +30,16 @@ let subst_signature sub = function
   | Some sg -> Some (Subst.signature sub sg)
 
 let subst_arg sub arg =
+  let open FunctorParameter in
   match arg with
-  | None -> None
-  | Some {FunctorArgument. id; expr; expansion} ->
+  | Unit -> Unit
+  | Named {id; expr; expansion} ->
       let id' = Subst.identifier_module sub id in
       let expr' = Subst.module_type_expr sub expr in
       let expansion' =
         Maps.option_map (Subst.module_expansion sub) expansion
       in
-        Some {FunctorArgument. id = id'; expr = expr'; expansion = expansion'}
+        Named {id = id'; expr = expr'; expansion = expansion'}
 
 let subst_expansion sub = function
   | None -> None
@@ -349,7 +350,7 @@ let expand_include t root incl =
       | Some (Functor _) -> To_functor (* TODO: Should be an error *)
     end
 
-let expand_argument_ t root {FunctorArgument. id; expr; expansion} =
+let expand_argument_ t root {FunctorParameter. id; expr; expansion} =
   match expansion with
   | None ->
       let id = (id : Identifier.Module.t :> Identifier.Signature.t) in
@@ -416,8 +417,8 @@ let find_argument t root pos ex =
     match ex with
     | None -> raise Not_found
     | Some (Signature _) -> raise Not_found
-    | Some (Functor(None, _, _, _)) when pos = 1 -> raise Not_found
-    | Some (Functor(Some arg, _, _, _)) when pos = 1 -> arg
+    | Some (Functor(Unit, _, _, _)) when pos = 1 -> raise Not_found
+    | Some (Functor(Named arg, _, _, _)) when pos = 1 -> arg
     | Some (Functor(_, dest, offset, expr)) ->
         loop t root (pos - 1) (expand_module_type_expr t root dest offset expr)
   in
@@ -479,9 +480,9 @@ and expand_module_identifier' t root (id : Identifier.Module.t) =
         md.id, md.doc, md.canonical, expand_module t root md, []
   | `Argument(parent, pos, _name) ->
       let ex = t.expand_signature_identifier ~root parent in
-      let {FunctorArgument. id; _} as arg = find_argument t root pos ex in
+      let {FunctorParameter. id; _} as arg = find_argument t root pos ex in
       let doc = [] in
-        id, doc, None, expand_argument_ t root arg, []
+      id, doc, None, expand_argument_ t root arg, []
 
 and expand_module_type_identifier' t root (id : Identifier.ModuleType.t) =
   match id with
@@ -821,16 +822,16 @@ let rec force_expansion t root (ex : partial_expansion option) =
         | Some (Module.Functor(args, sg)) ->
             Some(Module.Functor(arg :: args, sg))
 
-and expand_argument t arg_opt =
-  match arg_opt with
-  | None -> arg_opt
-  | Some ({FunctorArgument. id; expr; expansion} as arg) ->
+and expand_argument t arg =
+  match arg with
+  | Unit -> arg
+  | Named ({FunctorParameter. id; expr; expansion} as a) ->
       match expansion with
-      | Some _ -> arg_opt
+      | Some _ -> arg
       | None ->
           let root = Identifier.Module.root id in
-          let expansion = force_expansion t root (expand_argument_ t root arg) in
-            Some {FunctorArgument. id; expr; expansion}
+          let expansion = force_expansion t root (expand_argument_ t root a) in
+          Named {FunctorParameter. id; expr; expansion}
 
 (** We will always expand modules which are not aliases. For aliases we only
     expand when the thing they point to should be hidden. *)

--- a/src/xref/name_env.ml
+++ b/src/xref/name_env.ml
@@ -383,8 +383,8 @@ let rec add_module_type_expr_items expr env =
     match expr with
     | Path _ -> env
     | Signature sg -> add_signature_items sg env
-    | Functor(None, expr) -> add_module_type_expr_items expr env
-    | Functor(Some{ FunctorArgument. id; _ }, expr) ->
+    | Functor(Unit, expr) -> add_module_type_expr_items expr env
+    | Functor(Named { FunctorParameter. id; _ }, expr) ->
       add_module_ident id
         (add_module_type_expr_items expr env)
     | With(expr, _) -> add_module_type_expr_items expr env

--- a/src/xref/resolve.ml
+++ b/src/xref/resolve.ml
@@ -2172,7 +2172,7 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
           {parent = parent'; doc = doc'; decl = decl'; expansion = expansion'}
         else incl
 
-    method! module_type_functor_arg arg =
+    method! module_type_functor_param arg =
       let open Lang.FunctorParameter in
       match arg with
       | Unit -> arg
@@ -2223,7 +2223,7 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
           in
           With(body, substs)
         | Functor(arg, res) ->
-          let arg' = self#module_type_functor_arg arg in
+          let arg' = self#module_type_functor_param arg in
           let res' = self#module_type_expr_with_id id res in
           if res != res' || arg != arg' then Functor(arg', res')
           else expr

--- a/src/xref/resolve.ml
+++ b/src/xref/resolve.ml
@@ -2173,10 +2173,10 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
         else incl
 
     method! module_type_functor_arg arg =
-      let open Lang.FunctorArgument in
+      let open Lang.FunctorParameter in
       match arg with
-      | None -> arg
-      | Some{ id; expr; expansion } ->
+      | Unit -> arg
+      | Named { id; expr; expansion } ->
           let id' = self#identifier_module id in
           let sig_id = (id' :> Identifier.Signature.t) in
           let expr' = self#module_type_expr_with_id sig_id expr in
@@ -2184,7 +2184,7 @@ class resolver ?equal ?hash lookup_unit fetch_unit lookup_page fetch_page =
             Maps.option_map self#module_expansion expansion
           in
             if id != id' || expr != expr' || expansion != expansion' then
-              Some {id = id'; expr = expr'; expansion = expansion'}
+              Named {id = id'; expr = expr'; expansion = expansion'}
             else arg
 
     method module_type_expr_with_id id expr =

--- a/test/html/cases/bugs.ml
+++ b/test/html/cases/bugs.ml
@@ -2,3 +2,9 @@ type 'a opt = 'a option
 let foo (type a) ?(bar : a opt) () = ()
 (** Triggers an assertion failure when
     {:https://github.com/ocaml/odoc/issues/101} is not fixed. *)
+
+type 'a opt' = int option
+let foo' (type a) ?(bar : a opt') () = ()
+(** Similar to the above, but the printed type of [~bar] should be [int], not
+    ['a]. This probably requires fixing in the compiler. See
+    {:https://github.com/ocaml/odoc/pull/230#issuecomment-433226807}. *)

--- a/test/html/cases/bugs.ml
+++ b/test/html/cases/bugs.ml
@@ -3,8 +3,3 @@ let foo (type a) ?(bar : a opt) () = ()
 (** Triggers an assertion failure when
     {:https://github.com/ocaml/odoc/issues/101} is not fixed. *)
 
-type 'a opt' = int option
-let foo' (type a) ?(bar : a opt') () = ()
-(** Similar to the above, but the printed type of [~bar] should be [int], not
-    ['a]. This probably requires fixing in the compiler. See
-    {:https://github.com/ocaml/odoc/pull/230#issuecomment-433226807}. *)

--- a/test/html/cases/bugs.ml
+++ b/test/html/cases/bugs.ml
@@ -2,9 +2,3 @@ type 'a opt = 'a option
 let foo (type a) ?(bar : a opt) () = ()
 (** Triggers an assertion failure when
     {:https://github.com/ocaml/odoc/issues/101} is not fixed. *)
-
-type 'a opt' = int option
-let foo' (type a) ?(bar : a opt') () = ()
-(** Similar to the above, but the printed type of [~bar] should be [int], not
-    ['a]. This probably requires fixing in the compiler. See
-    {:https://github.com/ocaml/odoc/pull/230#issuecomment-433226807}. *)

--- a/test/html/cases/bugs_pre_410.ml
+++ b/test/html/cases/bugs_pre_410.ml
@@ -1,0 +1,6 @@
+type 'a opt' = int option
+let foo' (type a) ?(bar : a opt') () = ()
+(** Similar to [Bugs], but the printed type of [~bar] should be [int], not
+    ['a]. This probably requires fixing in the compiler. See
+    {:https://github.com/ocaml/odoc/pull/230#issuecomment-433226807}. *)
+

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -37,21 +37,6 @@
      </p>
     </dd>
    </dl>
-   <dl>
-    <dt class="spec type" id="type-opt'">
-     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt'</span></code><code> = <span>int option</span></code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-foo'">
-     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">val</span> foo' : <span>?⁠bar:<span class="type-var">'a</span></span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
-    </dt>
-    <dd>
-     <p>
-      Similar to the above, but the printed type of <code>~bar</code> should be <code>int</code>, not <code>'a</code>. This probably requires fixing in the compiler. See <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">https://github.com/ocaml/odoc/pull/230#issuecomment-433226807</a>.
-     </p>
-    </dd>
-   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -37,6 +37,21 @@
      </p>
     </dd>
    </dl>
+   <dl>
+    <dt class="spec type" id="type-opt'">
+     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt'</span></code><code> = <span>int option</span></code>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-foo'">
+     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">val</span> foo' : <span>?⁠bar:<span class="type-var">'a</span></span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
+    </dt>
+    <dd>
+     <p>
+      Similar to the above, but the printed type of <code>~bar</code> should be <code>int</code>, not <code>'a</code>. This probably requires fixing in the compiler. See <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">https://github.com/ocaml/odoc/pull/230#issuecomment-433226807</a>.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Bugs_pre_410/index.html
+++ b/test/html/expect/test_package+ml/Bugs_pre_410/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Bugs_pre_410 (test_package+ml.Bugs_pre_410)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Bugs_pre_410
+    </nav>
+    <h1>
+     Module <code>Bugs_pre_410</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec type" id="type-opt'">
+     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt'</span></code><code> = <span>int option</span></code>
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-foo'">
+     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">val</span> foo' : <span>?⁠bar:<span class="type-var">'a</span></span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
+    </dt>
+    <dd>
+     <p>
+      Similar to <code>Bugs</code>, but the printed type of <code>~bar</code> should be <code>int</code>, not <code>'a</code>. This probably requires fixing in the compiler. See <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">https://github.com/ocaml/odoc/pull/230#issuecomment-433226807</a>.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Bugs/index.html
+++ b/test/html/expect/test_package+re/Bugs/index.html
@@ -37,21 +37,6 @@
      </p>
     </dd>
    </dl>
-   <dl>
-    <dt class="spec type" id="type-opt'">
-     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> opt'('a)</code><code> = option(int)</code>;
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-foo'">
-     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">let</span> foo': <span>?⁠bar:<span class="type-var">'a</span></span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
-    </dt>
-    <dd>
-     <p>
-      Similar to the above, but the printed type of <code>~bar</code> should be <code>int</code>, not <code>'a</code>. This probably requires fixing in the compiler. See <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">https://github.com/ocaml/odoc/pull/230#issuecomment-433226807</a>.
-     </p>
-    </dd>
-   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Bugs/index.html
+++ b/test/html/expect/test_package+re/Bugs/index.html
@@ -37,6 +37,21 @@
      </p>
     </dd>
    </dl>
+   <dl>
+    <dt class="spec type" id="type-opt'">
+     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> opt'('a)</code><code> = option(int)</code>;
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-foo'">
+     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">let</span> foo': <span>?⁠bar:<span class="type-var">'a</span></span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
+    </dt>
+    <dd>
+     <p>
+      Similar to the above, but the printed type of <code>~bar</code> should be <code>int</code>, not <code>'a</code>. This probably requires fixing in the compiler. See <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">https://github.com/ocaml/odoc/pull/230#issuecomment-433226807</a>.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Bugs_pre_410/index.html
+++ b/test/html/expect/test_package+re/Bugs_pre_410/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Bugs_pre_410 (test_package+re.Bugs_pre_410)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <div class="content">
+   <header>
+    <nav>
+     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Bugs_pre_410
+    </nav>
+    <h1>
+     Module <code>Bugs_pre_410</code>
+    </h1>
+   </header>
+   <dl>
+    <dt class="spec type" id="type-opt'">
+     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> opt'('a)</code><code> = option(int)</code>;
+    </dt>
+   </dl>
+   <dl>
+    <dt class="spec value" id="val-foo'">
+     <a href="#val-foo'" class="anchor"></a><code><span class="keyword">let</span> foo': <span>?⁠bar:<span class="type-var">'a</span></span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
+    </dt>
+    <dd>
+     <p>
+      Similar to <code>Bugs</code>, but the printed type of <code>~bar</code> should be <code>int</code>, not <code>'a</code>. This probably requires fixing in the compiler. See <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">https://github.com/ocaml/odoc/pull/230#issuecomment-433226807</a>.
+     </p>
+    </dd>
+   </dl>
+  </div>
+ </body>
+</html>

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -250,8 +250,7 @@ let make_test_case ?theme_uri ?syntax case =
   in
   Case.name case, `Slow, run
 
-
-let source_files = [
+let source_files_all = [
   ("val.mli", ["Val/index.html"]);
   ("markup.mli", ["Markup/index.html"]);
   ("section.mli", ["Section/index.html"]);
@@ -279,18 +278,25 @@ let source_files = [
   ("alias.ml", [
       "Alias/index.html";
       "Alias/X/index.html";
-    ]);
+    ])
 ]
 
-let source_files =
-  let latest_supported = "4.08." in
-  match String.sub (Sys.ocaml_version) 0 (String.length latest_supported) with
-  | s when s = latest_supported -> source_files @
-    [ ("recent.mli", ["Recent/index.html"; "Recent/X/index.html"])
-    ; ("recent_impl.ml", ["Recent_impl/index.html"])]
-  | _ -> source_files
-  | exception _ -> source_files
+let source_files_post408 =
+  [ ("recent.mli", ["Recent/index.html"; "Recent/X/index.html"])
+  ; ("recent_impl.ml", ["Recent_impl/index.html"]) ]
 
+let source_files_pre410 =
+  [ ("bugs_pre_410.ml", ["Bugs_pre_410/index.html"]) ]
+
+let source_files =
+  let cur = Astring.String.cuts ~sep:"." (Sys.ocaml_version) |> List.map (fun i -> try Some (int_of_string i) with _ -> None) in
+  match cur with
+  | Some major :: Some minor :: _ ->
+    List.concat
+      [ (if major=4 && minor<10 then source_files_pre410 else [])
+      ; (if major=4 && minor>8 then source_files_post408 else [])
+      ; source_files_all ]
+  | _ -> source_files_all
 
 let () =
   Env.init ();


### PR DESCRIPTION
This moves us in the direction of using 4.10's data types everywhere - though it doesn't go quite as far as making the module names optional.