### PR TITLE
adjust default `font-weight` for bold text

### DIFF
--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -65,7 +65,7 @@ body {
 /* Basic markup elements */
 
 b, strong {
-  font-weight: 500;
+  font-weight: bold;
 }
 
 i, em {


### PR DESCRIPTION
the original value (500) is too small, it will fallback to 400 and has no any visually different to normal text.

https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Fallback_weights