### PR TITLE
Issue 420 nested `<em>` tags not rendering properly in browsers

### DIFF
--- a/src/html/comment.ml
+++ b/src/html/comment.ml
@@ -183,8 +183,7 @@ let styled_element ~emph_level ~(next : ?emph_level:int -> 'a -> 'b) content = f
   | `Emphasis ->
     let a = if emph_level mod 2 = 0 then [] else [Html.a_class ["odd"]] in
     let emph_level = emph_level + 1 in
-    Html.em ~a
-      (next ~emph_level content)
+    Html.em ~a (next ~emph_level content)
   | #Comment.non_nest_aware_styles as style ->
       (style_to_combinator style)
       (next ~emph_level:0 content)
@@ -219,7 +218,6 @@ and non_link_inline_element_list :
 
 let link_content_to_html =
   non_link_inline_element_list ~emph_level:0
-
 
 
 let rec inline_element ~emph_level ?xref_base_uri : Comment.inline_element -> (phrasing Html.elt) option =

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -5,13 +5,16 @@ module Identifier = Paths.Identifier
 type 'a with_location = 'a Location_.with_location
 
 
-
-type style = [
+type non_nest_aware_styles = [
   | `Bold
   | `Italic
-  | `Emphasis
   | `Superscript
   | `Subscript
+]
+
+type style = [
+  | non_nest_aware_styles
+  | `Emphasis
 ]
 
 type raw_markup_target = [

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -68,8 +68,16 @@ b, strong {
   font-weight: bold;
 }
 
-i, em {
+i {
   font-style: italic;
+}
+
+em, i em.odd{
+  font-style: italic;
+}
+
+em.odd, i em {
+  font-style: normal;
 }
 
 sup {

--- a/test/html/cases/markup.mli
+++ b/test/html/cases/markup.mli
@@ -40,6 +40,10 @@
     {b {i bold italic}}, super{^script}, sub{_script}. The line spacing should
     be enough for superscripts and subscripts not to look odd.
 
+    Note: {i In italics {e emphasis} is rendered as normal text while {e
+    emphasis {e in} emphasis} is rendered in italics.} {i It also work the same
+    in {{:#} links in italics with {e emphasis {e in} emphasis}.}}
+
     [code] is a different kind of markup that doesn't allow nested markup.
 
     It's possible for two markup elements to appear {b next} {i to} each other

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -148,7 +148,10 @@
       <a href="#styling" class="anchor"></a>Styling
      </h2>
      <p>
-      This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em>emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
+      This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
+     </p>
+     <p>
+      Note: <i>In italics <em>emphasis</em> is rendered as normal text while <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in italics.</i> <i>It also work the same in <a href="#">links in italics with <em>emphasis <em class="odd">in</em> emphasis</em>.</a></i>
      </p>
      <p>
       <code>code</code> is a different kind of markup that doesn't allow nested markup.

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -148,7 +148,10 @@
       <a href="#styling" class="anchor"></a>Styling
      </h2>
      <p>
-      This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em>emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
+      This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
+     </p>
+     <p>
+      Note: <i>In italics <em>emphasis</em> is rendered as normal text while <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in italics.</i> <i>It also work the same in <a href="#">links in italics with <em>emphasis <em class="odd">in</em> emphasis</em>.</a></i>
      </p>
      <p>
       <code>code</code> is a different kind of markup that doesn't allow nested markup.


### PR DESCRIPTION
This pr fixes #420 

## Issue
Browsers does not style nested emphasis as expected (ie: emphasis should toggle italics on/off, not always on, depending on the context).

## Changes
This PR add logic to `src/html/comment.ml` to annotate `<em>` at an odd level of nesting with the class `odd`. Nesting level is reset when crossing `<it>`tags. Then a few css rules are added to style adequately each case. 

## Notes 
Because this is an issue only for browser rendering, I chose to fix it at the renderer level.
Another choice may have been to fix it at the parser level, by adding an `int` argument to the ``` `Emphasis``` variant.