### PR TITLE
Remove sections and cleanup the code

### DIFF
--- a/src/document/ML.ml
+++ b/src/document/ML.ml
@@ -88,4 +88,4 @@ module ML = Generator.Make (struct
   end
 end)
 
-include ML.Page
+include ML

--- a/src/document/codefmt.ml
+++ b/src/document/codefmt.ml
@@ -169,8 +169,8 @@ let rec list ?sep ~f = function
 let render f = spf "%t" f
 let code ?attr f =
   [inline ?attr @@ Inline.Source (render f)]
-let documentedSrc ?(attr=[]) f =
-  [DocumentedSrc.Code { attr ; code = render f }]
+let documentedSrc f =
+  [DocumentedSrc.Code (render f)]
 let codeblock ?attr f =
   [block ?attr @@ Block.Source (render f)]
 

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -321,13 +321,13 @@ let heading (`Heading (level, `Label (_, label), content)) =
       | `Subparagraph -> 6
     in
     let label = Some label in
-    [Item.Heading {label; level; title}]
+    Item.Heading {label; level; title}
 
 let item_element : Comment.block_element -> Item.t list = function
   | #Comment.attached_block_element as e ->
     [Item.Text (attached_block_element e)]
   | `Heading _ as h ->
-    heading h
+    [heading h]
 
 let first_to_ir = function
   | {Odoc_model.Location_.value = `Paragraph _ as first_paragraph ; _} ::_

--- a/src/document/doctree.ml
+++ b/src/document/doctree.ml
@@ -70,8 +70,6 @@ module Toc = struct
       -> Skip
     | Nested { content = { status; items; _ }; _ } ->
       if on_nested status then Rec items else Skip
-    | Section (doc, items) ->
-      Rec (doc@items)
     | Heading { label = None ; _ } -> Skip
     | Heading { label = Some label; level; title } ->
       Heading ((label, title), level)

--- a/src/document/doctree.ml
+++ b/src/document/doctree.ml
@@ -66,9 +66,9 @@ module Toc = struct
 
   let classify ~on_nested (i : Item.t) : _ Rewire.action = match i with
     | Text _
-    | Declaration (_, _)
+    | Declaration _
       -> Skip
-    | Nested ({ content = { status; items; _ }; _ }, _) ->
+    | Nested { content = { status; items; _ }; _ } ->
       if on_nested status then Rec items else Skip
     | Section (doc, items) ->
       Rec (doc@items)

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1002,9 +1002,9 @@ struct
         let content, docs = state.render_leaf_item item in
         let anchor = state.item_to_id item in
         let kind = state.item_to_spec item in
-        let docs = Comment.first_to_ir docs in
-        let decl = {Item. content ; kind ; anchor } in
-        let ir = Item.Declaration (decl, docs) in
+        let doc = Comment.first_to_ir docs in
+        let decl = {Item. content ; kind ; anchor ; doc} in
+        let ir = Item.Declaration decl in
         section_items level_shift section_level {state with
             input_items;
             comment_state = { state.comment_state with
@@ -1017,13 +1017,14 @@ struct
         in
         let anchor = state.item_to_id item in
         let kind = state.item_to_spec item in
-        let docs = Comment.first_to_ir docs in
+        let doc = Comment.first_to_ir docs in
         let ir = match rendered_item with 
           | `Decl content ->
-            let decl = {Item. content ; kind ; anchor } in
-            Item.Declaration (decl, docs)
+            let decl = {Item. content ; kind ; anchor ; doc} in
+            Item.Declaration decl
           | `Nested content -> 
-            Item.Nested ({Item. content ; kind ; anchor }, docs)
+            let decl = {Item. content ; kind ; anchor ; doc} in
+            Item.Nested decl
         in
         section_items level_shift section_level { state with
           input_items;
@@ -1848,8 +1849,9 @@ struct
         Url.Anchor.from_identifier (id :> Paths.Identifier.t)
       in
       let kind = Some "modules" in
-      let decl = {Item. anchor ; content ; kind } in
-      Item.Declaration (decl, [])
+      let doc = [] in
+      let decl = {Item. anchor ; content ; kind ; doc } in
+      Item.Declaration decl
     in
     List.map f t
 

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -821,31 +821,6 @@ struct
 end
 open Value
 
-module ModuleSubstitution :
-sig
-  val module_substitution : Lang.ModuleSubstitution.t -> Item.t
-end =
-struct
-  let module_substitution (t : Odoc_model.Lang.ModuleSubstitution.t) =
-    let name = Paths.Identifier.name t.id in
-    let path = Link.from_path ~stop_before:true (t.manifest :> Paths.Path.t) in
-    let content =
-      O.documentedSrc (
-        O.keyword "module" ++
-          O.txt " " ++
-          O.txt name ++
-          O.txt " := " ++
-          path
-      )
-    in
-    let kind = Some "module-substitution" in
-    let anchor = path_to_id t.id in
-    let doc = Comment.to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
-end
-open ModuleSubstitution
-
-
 (* This chunk of code is responsible for sectioning list of items
    according to headings and comments.
 
@@ -1341,6 +1316,23 @@ struct
     in
     let region = O.code def_div in
     region, subtree
+
+and module_substitution (t : Odoc_model.Lang.ModuleSubstitution.t) =
+  let name = Paths.Identifier.name t.id in
+  let path = Link.from_path ~stop_before:true (t.manifest :> Paths.Path.t) in
+  let content =
+    O.documentedSrc (
+      O.keyword "module" ++
+        O.txt " " ++
+        O.txt name ++
+        O.txt " := " ++
+        path
+    )
+  in
+  let kind = Some "module-substitution" in
+  let anchor = path_to_id t.id in
+  let doc = Comment.to_ir t.doc in
+  Item.Declaration {kind ; anchor ; doc ; content}
 
 and module_expansion
   : Odoc_model.Lang.Module.expansion

--- a/src/document/generator.mli
+++ b/src/document/generator.mli
@@ -1,0 +1,3 @@
+open Generator_signatures
+
+module Make (Syntax : SYNTAX) : GENERATOR

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -7,9 +7,8 @@ type rendered_item = DocumentedSrc.t
 
 type text = Format.formatter -> unit
 
-type ('item_kind, 'item) tagged_item = [
-  | `Leaf_item of 'item_kind * 'item
-  | `Nested_article of 'item
+type 'item tagged_item = [
+  | `Item of 'item
   | `Comment of Odoc_model.Comment.docs_or_stop
 ]
 
@@ -116,7 +115,7 @@ sig
       render_nested_article:
         (heading_level_shift -> 'item ->
           rendered_item * Odoc_model.Comment.docs * Block.t) ->
-      (_, 'item) tagged_item list ->
+      'item tagged_item list ->
       Block.t * Block.t
 
   val lay_out_page :

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -7,11 +7,6 @@ type rendered_item = DocumentedSrc.t
 
 type text = Format.formatter -> unit
 
-type 'item tagged_item = [
-  | `Item of 'item
-  | `Comment of Odoc_model.Comment.docs_or_stop
-]
-
 (** HTML generation syntax customization module. See {!To_re_html_tree} and
     {!To_ml_html_tree}. *)
 module type SYNTAX =
@@ -99,34 +94,7 @@ sig
   end
 end
 
-
-
-module type GENERATOR =
-sig
-  module Top_level_markup :
-  sig
-    type heading_level_shift
-
-    val lay_out :
-      heading_level_shift option ->
-      item_to_id:('item -> string option) ->
-      item_to_spec:('item -> string option) ->
-      render_leaf_item:('item -> rendered_item * Odoc_model.Comment.docs) ->
-      render_nested_article:
-        (heading_level_shift -> 'item ->
-          rendered_item * Odoc_model.Comment.docs * Block.t) ->
-      'item tagged_item list ->
-      Block.t * Block.t
-
-  val lay_out_page :
-    Odoc_model.Comment.docs -> Block.t * Block.t
-
-  end
-
-  module Page :
-  sig
-    val compilation_unit :
-      ?theme_uri:string -> Lang.Compilation_unit.t -> Block.t
-    val page : ?theme_uri:string -> Lang.Page.t -> Block.t
-  end
+module type GENERATOR = sig
+  val compilation_unit : Lang.Compilation_unit.t -> Page.t
+  val page : Lang.Page.t -> Page.t
 end

--- a/src/document/reason.ml
+++ b/src/document/reason.ml
@@ -90,4 +90,4 @@ module Reason = Generator.Make (struct
   end
 end)
 
-include Reason.Page
+include Reason

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -105,14 +105,10 @@ and DocumentedSrc : sig
     code : 'a ;
     doc : Block.t ;
   }
-  type only_code = {
-    attr : Class.t ;
-    code : Source.t ;
-  }
 
   type t = one list
   and one =
-    | Code of only_code
+    | Code of Source.t
     | Documented of Inline.t documented
     | Nested of t documented
 

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -1,10 +1,3 @@
-type entity = string
-
-type href = string  
-
-type reference = Url.t
-
-
 type style = [
   | `Bold
   | `Italic
@@ -19,20 +12,6 @@ module rec Class : sig
 
 end = Class
 
-(* and Tabular : sig
- * 
- *   type t = {
- *     header : line option ;
- *     lines : line List.t ;
- *   }
- * 
- *   and line = {
- *     attr : Class.t ;
- *     desc : Block.t list ;
- *   }
- *         
- * end = Tabular *)
-
 and InternalLink : sig
 
   type resolved = Url.t * Inline.t
@@ -45,7 +24,7 @@ end = InternalLink
 
 and Raw_markup : sig
 
-  type target = Odoc_model.Comment.raw_markup_target 
+  type target = Odoc_model.Comment.raw_markup_target
   and t = target * string
 
 end = Raw_markup
@@ -62,13 +41,16 @@ end = Source
 
 and Inline : sig
 
+  type entity = string
+  type href = string
+
   type t = one list
 
   and one = {
     attr : Class.t ;
     desc : desc ;
   }
-  
+
   and desc =
     | Text of string
     | Entity of entity
@@ -99,7 +81,7 @@ and Block : sig
     attr : Class.t ;
     desc : desc ;
   }
-  
+
   and desc =
     | Inline of Inline.t
     | Paragraph of Inline.t
@@ -108,18 +90,11 @@ and Block : sig
     | Source of Source.t
     | Verbatim of string
     | Raw_markup of Raw_markup.t
-    (* | DocumentedSrc of DocumentedSrc.t *)
-    (* | Math_blk of Math.t *)
-    (* | Tabular of Tabular.t *)
-    (* | Table of Wrapper.t * t *)
-    (* | Picture of href * string * string option * int option *)
-    (* | Figure of Wrapper.t * t *)
-    (* | Rule *)
 
   and list_type =
     | Ordered
     | Unordered
-  
+
 end = Block
 
 and DocumentedSrc : sig
@@ -152,7 +127,7 @@ and Nested : sig
     status : status ;
     items : Item.t list ;
   }
-  
+
 end = Nested
 
 
@@ -167,7 +142,7 @@ and Item : sig
 
   type declaration = DocumentedSrc.t item
   type text = Block.t
-  
+
   type t =
     | Text of text
     | Heading of Heading.t

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -173,7 +173,6 @@ and Item : sig
     | Heading of Heading.t
     | Declaration of DocumentedSrc.t item
     | Nested of Nested.t item
-    | Section of Item.t list * t list
 
 end = Item
 

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -162,6 +162,7 @@ and Item : sig
     kind : string option ;
     anchor : Url.Anchor.t option ;
     content : 'a ;
+    doc : Block.t ;
   }
 
   type declaration = DocumentedSrc.t item
@@ -170,8 +171,8 @@ and Item : sig
   type t =
     | Text of text
     | Heading of Heading.t
-    | Declaration of declaration * Block.t
-    | Nested of Nested.t item * Block.t
+    | Declaration of DocumentedSrc.t item
+    | Nested of Nested.t item
     | Section of Item.t list * t list
 
 end = Item

--- a/src/document/utils.ml
+++ b/src/document/utils.ml
@@ -11,3 +11,7 @@ let rec flatmap ?sep ~f = function
     match sep with
     | None -> hd @ tl
     | Some sep -> hd @ sep @ tl
+
+let rec skip_until ~p = function
+  | [] -> []
+  | h :: t -> if p h then t else skip_until ~p t

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -251,7 +251,6 @@ let flow_to_item
 let rec is_only_text l =
   let is_text : Item.t -> _ = function
     | Heading _ | Text _ -> true
-    | Section (doc, items) -> is_only_text doc && is_only_text items
     | Declaration _
       -> false
     | Nested { content = { items; _ }; _ }
@@ -296,13 +295,6 @@ let items ~resolve l =
       |> continue_with rest
     | Heading h :: rest ->
       [heading ~resolve h]
-      |> continue_with rest
-    | Section (header, content) :: rest ->
-      let h = items header in
-      let content =
-        (walk_items ~only_text [] content :> any Html.elt list)
-      in
-      [Html.section (Html.header h :: content )]
       |> continue_with rest
     | Nested
         { kind; anchor; doc ; content = { summary; status; items = i } }

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -401,11 +401,11 @@ let rec subpage ?theme_uri
     ({Page. title; header; items = i ; subpages; url }) =
   let resolve = Link.Current url in
   let toc = Toc.from_items i in
-  let header = items ~resolve header @ toc in
+  let header = items ~resolve header in
   let content = (items ~resolve i :> any Html.elt list) in
   let subpages = List.map (subpage ?theme_uri) subpages in
   let page =
-    Tree.make ?theme_uri ~header ~url title content subpages
+    Tree.make ?theme_uri ~header ~toc ~url title content subpages
   in
   page
 

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -198,9 +198,9 @@ let rec block ~resolve (l: Block.t) : flow Html.elt list =
 
 let documentedSrc ~resolve (t : DocumentedSrc.t) =
   let open DocumentedSrc in
-  let take_code attr0 l =
+  let take_code l =
     Doctree.Take.until l ~classify:(function
-      | Code { attr; code } when attr = attr0 -> Accum code
+      | Code code -> Accum code
       | _ -> Stop_and_keep
     )
   in
@@ -215,10 +215,9 @@ let documentedSrc ~resolve (t : DocumentedSrc.t) =
   in
   let rec to_html t : flow Html.elt list = match t with
     | [] -> []
-    | Code { attr ; _ } :: _ ->
-      let code, _, rest = take_code attr t in
-      let a = class_ attr in
-      source (inline ~resolve) ~a code
+    | Code _ :: _ ->
+      let code, _, rest = take_code t in
+      source (inline ~resolve) code
       @ to_html rest
     | (Documented _ | Nested _) :: _ ->
       let l, _, rest = take_descr t in

--- a/src/html/tree.mli
+++ b/src/html/tree.mli
@@ -42,7 +42,8 @@ type uri =
 val make :
   ?theme_uri:uri ->
   url:Odoc_document.Url.Path.t ->
-  header:(Html_types.flow5_without_header_footer Html.elt) list ->
+  header:Html_types.flow5_without_header_footer Html.elt list ->
+  toc:Html_types.flow5 Html.elt list ->
   string ->
   (Html_types.div_content Html.elt) list ->
   t list ->

--- a/test/html/expect/test_package+custom_theme,ml/Include/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Include/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Include
+  </nav>
+  <header>
+   <h1>
+    Module <code>Include</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Include
-    </nav>
-    <h1>
-     Module <code>Include</code>
-    </h1>
-   </header>
    <div class="spec module-type" id="module-type-Not_inlined">
     <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -13,18 +13,18 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Module
+  </nav>
+  <header>
+   <h1>
+    Module <code>Module</code>
+   </h1>
+   <p>
+    Foo.
+   </p>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Module
-    </nav>
-    <h1>
-     Module <code>Module</code>
-    </h1>
-    <p>
-     Foo.
-    </p>
-   </header>
    <dl>
     <dt class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>

--- a/test/html/expect/test_package+custom_theme,ml/Section/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Section/index.html
@@ -55,78 +55,50 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="empty-section">
-      <a href="#empty-section" class="anchor"></a>Empty section
-     </h2>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="text-only">
-      <a href="#text-only" class="anchor"></a>Text only
-     </h2>
-     <p>
-      Foo bar.
-     </p>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="aside-only">
-      <a href="#aside-only" class="anchor"></a>Aside only
-     </h2>
-    </header>
-    <aside>
-     <p>
-      Foo bar.
-     </p>
-    </aside>
-   </section>
-   <section>
-    <header>
-     <h2 id="value-only">
-      <a href="#value-only" class="anchor"></a>Value only
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-     </dt>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="empty-section">
-      <a href="#empty-section" class="anchor"></a>Empty section
-     </h2>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="within-a-comment">
-      <a href="#within-a-comment" class="anchor"></a>within a comment
-     </h2>
-    </header>
-    <section>
-     <header>
-      <h3 id="and-one-with-a-nested-section">
-       <a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section
-      </h3>
-     </header>
-    </section>
-   </section>
-   <section>
-    <header>
-     <h2 id="this-section-title-has-markup">
-      <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
-     </h2>
-     <p>
-      But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
-     </p>
-    </header>
-   </section>
+   <h2 id="empty-section">
+    <a href="#empty-section" class="anchor"></a>Empty section
+   </h2>
+   <h2 id="text-only">
+    <a href="#text-only" class="anchor"></a>Text only
+   </h2>
+   <aside>
+    <p>
+     Foo bar.
+    </p>
+   </aside>
+   <h2 id="aside-only">
+    <a href="#aside-only" class="anchor"></a>Aside only
+   </h2>
+   <aside>
+    <p>
+     Foo bar.
+    </p>
+   </aside>
+   <h2 id="value-only">
+    <a href="#value-only" class="anchor"></a>Value only
+   </h2>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+    </dt>
+   </dl>
+   <h2 id="empty-section">
+    <a href="#empty-section" class="anchor"></a>Empty section
+   </h2>
+   <h2 id="within-a-comment">
+    <a href="#within-a-comment" class="anchor"></a>within a comment
+   </h2>
+   <h3 id="and-one-with-a-nested-section">
+    <a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section
+   </h3>
+   <h2 id="this-section-title-has-markup">
+    <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
+   </h2>
+   <aside>
+    <p>
+     But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+    </p>
+   </aside>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+custom_theme,ml/Section/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Section/index.html
@@ -13,48 +13,48 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Section
-    </nav>
-    <h1>
-     Module <code>Section</code>
-    </h1>
-    <p>
-     This is the module comment. Eventually, sections won't be allowed in it.
-    </p>
-    <nav class="toc">
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Section
+  </nav>
+  <header>
+   <h1>
+    Module <code>Section</code>
+   </h1>
+   <p>
+    This is the module comment. Eventually, sections won't be allowed in it.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#empty-section">Empty section</a>
+    </li>
+    <li>
+     <a href="#text-only">Text only</a>
+    </li>
+    <li>
+     <a href="#aside-only">Aside only</a>
+    </li>
+    <li>
+     <a href="#value-only">Value only</a>
+    </li>
+    <li>
+     <a href="#empty-section">Empty section</a>
+    </li>
+    <li>
+     <a href="#within-a-comment">within a comment</a>
      <ul>
       <li>
-       <a href="#empty-section">Empty section</a>
-      </li>
-      <li>
-       <a href="#text-only">Text only</a>
-      </li>
-      <li>
-       <a href="#aside-only">Aside only</a>
-      </li>
-      <li>
-       <a href="#value-only">Value only</a>
-      </li>
-      <li>
-       <a href="#empty-section">Empty section</a>
-      </li>
-      <li>
-       <a href="#within-a-comment">within a comment</a>
-       <ul>
-        <li>
-         <a href="#and-one-with-a-nested-section">and one with a nested section</a>
-        </li>
-       </ul>
-      </li>
-      <li>
-       <a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a>
+       <a href="#and-one-with-a-nested-section">and one with a nested section</a>
       </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+    <li>
+     <a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
    </h2>

--- a/test/html/expect/test_package+custom_theme,ml/Val/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Val/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Val
+  </nav>
+  <header>
+   <h1>
+    Module <code>Val</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Val
-    </nav>
-    <h1>
-     Module <code>Val</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span class="keyword">val</span> documented : unit</code>

--- a/test/html/expect/test_package+ml/Alias/X/index.html
+++ b/test/html/expect/test_package+ml/Alias/X/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Alias</a> » X
+  </nav>
+  <header>
+   <h1>
+    Module <code>Alias.X</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Alias</a> » X
-    </nav>
-    <h1>
-     Module <code>Alias.X</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = int</code>

--- a/test/html/expect/test_package+ml/Alias/index.html
+++ b/test/html/expect/test_package+ml/Alias/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Alias
+  </nav>
+  <header>
+   <h1>
+    Module <code>Alias</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Alias
-    </nav>
-    <h1>
-     Module <code>Alias</code>
-    </h1>
-   </header>
    <div class="spec module" id="module-Foo__X">
     <a href="#module-Foo__X" class="anchor"></a><code><span class="keyword">module</span> <a href="Foo__X/index.html">Foo__X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Bugs
+  </nav>
+  <header>
+   <h1>
+    Module <code>Bugs</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Bugs
-    </nav>
-    <h1>
-     Module <code>Bugs</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec type" id="type-opt">
      <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt</span> = <span><span class="type-var">'a</span> option</span></code>

--- a/test/html/expect/test_package+ml/Bugs_pre_410/index.html
+++ b/test/html/expect/test_package+ml/Bugs_pre_410/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Bugs_pre_410
+  </nav>
+  <header>
+   <h1>
+    Module <code>Bugs_pre_410</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Bugs_pre_410
-    </nav>
-    <h1>
-     Module <code>Bugs_pre_410</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec type" id="type-opt'">
      <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt'</span> = <span>int option</span></code>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Class
+  </nav>
+  <header>
+   <h1>
+    Module <code>Class</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Class
-    </nav>
-    <h1>
-     Module <code>Class</code>
-    </h1>
-   </header>
    <div class="spec class-type" id="class-type-empty">
     <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/External/index.html
+++ b/test/html/expect/test_package+ml/External/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » External
+  </nav>
+  <header>
+   <h1>
+    Module <code>External</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » External
-    </nav>
-    <h1>
-     Module <code>External</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec external" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit <span>-&gt;</span> unit</code>

--- a/test/html/expect/test_package+ml/Functor/index.html
+++ b/test/html/expect/test_package+ml/Functor/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Functor
+  </nav>
+  <header>
+   <h1>
+    Module <code>Functor</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Functor
-    </nav>
-    <h1>
-     Module <code>Functor</code>
-    </h1>
-   </header>
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Include/index.html
+++ b/test/html/expect/test_package+ml/Include/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Include
+  </nav>
+  <header>
+   <h1>
+    Module <code>Include</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Include
-    </nav>
-    <h1>
-     Module <code>Include</code>
-    </h1>
-   </header>
    <div class="spec module-type" id="module-type-Not_inlined">
     <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Include2/index.html
+++ b/test/html/expect/test_package+ml/Include2/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Include2
+  </nav>
+  <header>
+   <h1>
+    Module <code>Include2</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Include2
-    </nav>
-    <h1>
-     Module <code>Include2</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>

--- a/test/html/expect/test_package+ml/Include_sections/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/index.html
@@ -13,15 +13,29 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Include_sections
-    </nav>
-    <h1>
-     Module <code>Include_sections</code>
-    </h1>
-    <nav class="toc">
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Include_sections
+  </nav>
+  <header>
+   <h1>
+    Module <code>Include_sections</code>
+   </h1>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#something-1">Something 1</a>
+     <ul>
+      <li>
+       <a href="#something-2">Something 2</a>
+      </li>
+     </ul>
+    </li>
+    <li>
+     <a href="#something-1-bis">Something 1-bis</a>
+    </li>
+    <li>
+     <a href="#second-include">Second include</a>
      <ul>
       <li>
        <a href="#something-1">Something 1</a>
@@ -35,7 +49,7 @@
        <a href="#something-1-bis">Something 1-bis</a>
       </li>
       <li>
-       <a href="#second-include">Second include</a>
+       <a href="#third-include">Third include</a>
        <ul>
         <li>
          <a href="#something-1">Something 1</a>
@@ -48,27 +62,13 @@
         <li>
          <a href="#something-1-bis">Something 1-bis</a>
         </li>
-        <li>
-         <a href="#third-include">Third include</a>
-         <ul>
-          <li>
-           <a href="#something-1">Something 1</a>
-           <ul>
-            <li>
-             <a href="#something-2">Something 2</a>
-            </li>
-           </ul>
-          </li>
-          <li>
-           <a href="#something-1-bis">Something 1-bis</a>
-          </li>
-         </ul>
-        </li>
        </ul>
       </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <dl>
     <dt class="spec module-type" id="module-type-Something">
      <a href="#module-type-Something" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Something/index.html">Something</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>

--- a/test/html/expect/test_package+ml/Include_sections/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/index.html
@@ -92,240 +92,204 @@
         <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
        </dt>
       </dl>
-      <section>
-       <header>
-        <h2 id="something-1">
-         <a href="#something-1" class="anchor"></a>Something 1
-        </h2>
+      <h2 id="something-1">
+       <a href="#something-1" class="anchor"></a>Something 1
+      </h2>
+      <aside>
+       <p>
+        foo
+       </p>
+      </aside>
+      <dl>
+       <dt class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+       </dt>
+      </dl>
+      <h3 id="something-2">
+       <a href="#something-2" class="anchor"></a>Something 2
+      </h3>
+      <dl>
+       <dt class="spec value" id="val-bar">
+        <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
+       </dt>
+       <dd>
         <p>
-         foo
+         foo bar
         </p>
-       </header>
-       <dl>
-        <dt class="spec value" id="val-foo">
-         <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-        </dt>
-       </dl>
-       <section>
-        <header>
-         <h3 id="something-2">
-          <a href="#something-2" class="anchor"></a>Something 2
-         </h3>
-        </header>
-        <dl>
-         <dt class="spec value" id="val-bar">
-          <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-         </dt>
-         <dd>
-          <p>
-           foo bar
-          </p>
-         </dd>
-        </dl>
-       </section>
-      </section>
-      <section>
-       <header>
-        <h2 id="something-1-bis">
-         <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-        </h2>
-        <p>
-         Some text.
-        </p>
-       </header>
-      </section>
+       </dd>
+      </dl>
+      <h2 id="something-1-bis">
+       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+      </h2>
+      <aside>
+       <p>
+        Some text.
+       </p>
+      </aside>
      </div>
     </div>
    </div>
-   <section>
-    <header>
-     <h2 id="second-include">
-      <a href="#second-include" class="anchor"></a>Second include
-     </h2>
-     <p>
-      Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
-     </p>
-    </header>
-    <div>
-     <div class="spec include">
-      <div class="doc">
+   <h2 id="second-include">
+    <a href="#second-include" class="anchor"></a>Second include
+   </h2>
+   <aside>
+    <p>
+     Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
+    </p>
+   </aside>
+   <div>
+    <div class="spec include">
+     <div class="doc">
+      <dl>
+       <dt class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
+       </dt>
+      </dl>
+      <h3 id="something-1">
+       <a href="#something-1" class="anchor"></a>Something 1
+      </h3>
+      <aside>
+       <p>
+        foo
+       </p>
+      </aside>
+      <dl>
+       <dt class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+       </dt>
+      </dl>
+      <h4 id="something-2">
+       <a href="#something-2" class="anchor"></a>Something 2
+      </h4>
+      <dl>
+       <dt class="spec value" id="val-bar">
+        <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
+       </dt>
+       <dd>
+        <p>
+         foo bar
+        </p>
+       </dd>
+      </dl>
+      <h3 id="something-1-bis">
+       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+      </h3>
+      <aside>
+       <p>
+        Some text.
+       </p>
+      </aside>
+     </div>
+    </div>
+   </div>
+   <h3 id="third-include">
+    <a href="#third-include" class="anchor"></a>Third include
+   </h3>
+   <aside>
+    <p>
+     Shifted some more.
+    </p>
+   </aside>
+   <div>
+    <div class="spec include">
+     <div class="doc">
+      <dl>
+       <dt class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
+       </dt>
+      </dl>
+      <h4 id="something-1">
+       <a href="#something-1" class="anchor"></a>Something 1
+      </h4>
+      <aside>
+       <p>
+        foo
+       </p>
+      </aside>
+      <dl>
+       <dt class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+       </dt>
+      </dl>
+      <h5 id="something-2">
+       <a href="#something-2" class="anchor"></a>Something 2
+      </h5>
+      <dl>
+       <dt class="spec value" id="val-bar">
+        <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
+       </dt>
+       <dd>
+        <p>
+         foo bar
+        </p>
+       </dd>
+      </dl>
+      <h4 id="something-1-bis">
+       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+      </h4>
+      <aside>
+       <p>
+        Some text.
+       </p>
+      </aside>
+     </div>
+    </div>
+   </div>
+   <aside>
+    <p>
+     And let's include it again, but without inlining it this time: the ToC shouldn't grow.
+    </p>
+   </aside>
+   <div>
+    <div class="spec include">
+     <div class="doc">
+      <details open="open">
+       <summary>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Something">Something</a></code></span>
+       </summary>
        <dl>
         <dt class="spec value" id="val-something">
          <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
         </dt>
        </dl>
-       <section>
-        <header>
-         <h3 id="something-1">
-          <a href="#something-1" class="anchor"></a>Something 1
-         </h3>
+       <h2 id="something-1">
+        <a href="#something-1" class="anchor"></a>Something 1
+       </h2>
+       <aside>
+        <p>
+         foo
+        </p>
+       </aside>
+       <dl>
+        <dt class="spec value" id="val-foo">
+         <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+        </dt>
+       </dl>
+       <h3 id="something-2">
+        <a href="#something-2" class="anchor"></a>Something 2
+       </h3>
+       <dl>
+        <dt class="spec value" id="val-bar">
+         <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
+        </dt>
+        <dd>
          <p>
-          foo
+          foo bar
          </p>
-        </header>
-        <dl>
-         <dt class="spec value" id="val-foo">
-          <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-         </dt>
-        </dl>
-        <section>
-         <header>
-          <h4 id="something-2">
-           <a href="#something-2" class="anchor"></a>Something 2
-          </h4>
-         </header>
-         <dl>
-          <dt class="spec value" id="val-bar">
-           <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-          </dt>
-          <dd>
-           <p>
-            foo bar
-           </p>
-          </dd>
-         </dl>
-        </section>
-       </section>
-       <section>
-        <header>
-         <h3 id="something-1-bis">
-          <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-         </h3>
-         <p>
-          Some text.
-         </p>
-        </header>
-       </section>
-      </div>
+        </dd>
+       </dl>
+       <h2 id="something-1-bis">
+        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+       </h2>
+       <aside>
+        <p>
+         Some text.
+        </p>
+       </aside>
+      </details>
      </div>
     </div>
-    <section>
-     <header>
-      <h3 id="third-include">
-       <a href="#third-include" class="anchor"></a>Third include
-      </h3>
-      <p>
-       Shifted some more.
-      </p>
-     </header>
-     <div>
-      <div class="spec include">
-       <div class="doc">
-        <dl>
-         <dt class="spec value" id="val-something">
-          <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
-         </dt>
-        </dl>
-        <section>
-         <header>
-          <h4 id="something-1">
-           <a href="#something-1" class="anchor"></a>Something 1
-          </h4>
-          <p>
-           foo
-          </p>
-         </header>
-         <dl>
-          <dt class="spec value" id="val-foo">
-           <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-          </dt>
-         </dl>
-         <section>
-          <header>
-           <h5 id="something-2">
-            <a href="#something-2" class="anchor"></a>Something 2
-           </h5>
-          </header>
-          <dl>
-           <dt class="spec value" id="val-bar">
-            <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-           </dt>
-           <dd>
-            <p>
-             foo bar
-            </p>
-           </dd>
-          </dl>
-         </section>
-        </section>
-        <section>
-         <header>
-          <h4 id="something-1-bis">
-           <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-          </h4>
-          <p>
-           Some text.
-          </p>
-         </header>
-        </section>
-       </div>
-      </div>
-     </div>
-     <aside>
-      <p>
-       And let's include it again, but without inlining it this time: the ToC shouldn't grow.
-      </p>
-     </aside>
-     <div>
-      <div class="spec include">
-       <div class="doc">
-        <details open="open">
-         <summary>
-          <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Something">Something</a></code></span>
-         </summary>
-         <dl>
-          <dt class="spec value" id="val-something">
-           <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
-          </dt>
-         </dl>
-         <section>
-          <header>
-           <h2 id="something-1">
-            <a href="#something-1" class="anchor"></a>Something 1
-           </h2>
-           <p>
-            foo
-           </p>
-          </header>
-          <dl>
-           <dt class="spec value" id="val-foo">
-            <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-           </dt>
-          </dl>
-          <section>
-           <header>
-            <h3 id="something-2">
-             <a href="#something-2" class="anchor"></a>Something 2
-            </h3>
-           </header>
-           <dl>
-            <dt class="spec value" id="val-bar">
-             <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-            </dt>
-            <dd>
-             <p>
-              foo bar
-             </p>
-            </dd>
-           </dl>
-          </section>
-         </section>
-         <section>
-          <header>
-           <h2 id="something-1-bis">
-            <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-           </h2>
-           <p>
-            Some text.
-           </p>
-          </header>
-         </section>
-        </details>
-       </div>
-      </div>
-     </div>
-    </section>
-   </section>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
@@ -45,48 +45,40 @@
      <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
     </dt>
    </dl>
-   <section>
-    <header>
-     <h2 id="something-1">
-      <a href="#something-1" class="anchor"></a>Something 1
-     </h2>
+   <h2 id="something-1">
+    <a href="#something-1" class="anchor"></a>Something 1
+   </h2>
+   <aside>
+    <p>
+     foo
+    </p>
+   </aside>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+    </dt>
+   </dl>
+   <h3 id="something-2">
+    <a href="#something-2" class="anchor"></a>Something 2
+   </h3>
+   <dl>
+    <dt class="spec value" id="val-bar">
+     <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
+    </dt>
+    <dd>
      <p>
-      foo
+      foo bar
      </p>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-     </dt>
-    </dl>
-    <section>
-     <header>
-      <h3 id="something-2">
-       <a href="#something-2" class="anchor"></a>Something 2
-      </h3>
-     </header>
-     <dl>
-      <dt class="spec value" id="val-bar">
-       <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-      </dt>
-      <dd>
-       <p>
-        foo bar
-       </p>
-      </dd>
-     </dl>
-    </section>
-   </section>
-   <section>
-    <header>
-     <h2 id="something-1-bis">
-      <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-     </h2>
-     <p>
-      Some text.
-     </p>
-    </header>
-   </section>
+    </dd>
+   </dl>
+   <h2 id="something-1-bis">
+    <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+   </h2>
+   <aside>
+    <p>
+     Some text.
+    </p>
+   </aside>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
@@ -13,33 +13,33 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Include_sections</a> » Something
-    </nav>
-    <h1>
-     Module type <code>Include_sections.Something</code>
-    </h1>
-    <p>
-     A module type.
-    </p>
-    <nav class="toc">
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Include_sections</a> » Something
+  </nav>
+  <header>
+   <h1>
+    Module type <code>Include_sections.Something</code>
+   </h1>
+   <p>
+    A module type.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#something-1">Something 1</a>
      <ul>
       <li>
-       <a href="#something-1">Something 1</a>
-       <ul>
-        <li>
-         <a href="#something-2">Something 2</a>
-        </li>
-       </ul>
-      </li>
-      <li>
-       <a href="#something-1-bis">Something 1-bis</a>
+       <a href="#something-2">Something 2</a>
       </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+    <li>
+     <a href="#something-1-bis">Something 1-bis</a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <dl>
     <dt class="spec value" id="val-something">
      <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>

--- a/test/html/expect/test_package+ml/Interlude/index.html
+++ b/test/html/expect/test_package+ml/Interlude/index.html
@@ -13,18 +13,18 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Interlude
+  </nav>
+  <header>
+   <h1>
+    Module <code>Interlude</code>
+   </h1>
+   <p>
+    This is the comment associated to the module.
+   </p>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Interlude
-    </nav>
-    <h1>
-     Module <code>Interlude</code>
-    </h1>
-    <p>
-     This is the comment associated to the module.
-    </p>
-   </header>
    <aside>
     <p>
      Some separate stray text at the top of the module.

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -13,38 +13,36 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Markup
-    </nav>
-    <h1>
-     Module <code>Markup</code>
-    </h1>
-    <p>
-     Here, we test the rendering of comment markup.
-    </p>
-    <nav class="toc">
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Markup
+  </nav>
+  <header>
+   <h1>
+    Module <code>Markup</code>
+   </h1>
+   <p>
+    Here, we test the rendering of comment markup.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#sections">Sections</a>
      <ul>
       <li>
-       <a href="#sections">Sections</a>
+       <a href="#subsection-headings">Subsection headings</a>
        <ul>
         <li>
-         <a href="#subsection-headings">Subsection headings</a>
+         <a href="#sub-subsection-headings">Sub-subsection headings</a>
+        </li>
+        <li>
+         <a href="#anchors">Anchors</a>
          <ul>
           <li>
-           <a href="#sub-subsection-headings">Sub-subsection headings</a>
-          </li>
-          <li>
-           <a href="#anchors">Anchors</a>
+           <a href="#paragraph">Paragraph</a>
            <ul>
             <li>
-             <a href="#paragraph">Paragraph</a>
-             <ul>
-              <li>
-               <a href="#subparagraph">Subparagraph</a>
-              </li>
-             </ul>
+             <a href="#subparagraph">Subparagraph</a>
             </li>
            </ul>
           </li>
@@ -52,33 +50,35 @@
         </li>
        </ul>
       </li>
-      <li>
-       <a href="#styling">Styling</a>
-      </li>
-      <li>
-       <a href="#links-and-references">Links and references</a>
-      </li>
-      <li>
-       <a href="#preformatted-text">Preformatted text</a>
-      </li>
-      <li>
-       <a href="#lists">Lists</a>
-      </li>
-      <li>
-       <a href="#unicode">Unicode</a>
-      </li>
-      <li>
-       <a href="#raw-html">Raw HTML</a>
-      </li>
-      <li>
-       <a href="#modules">Modules</a>
-      </li>
-      <li>
-       <a href="#tags">Tags</a>
-      </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+    <li>
+     <a href="#styling">Styling</a>
+    </li>
+    <li>
+     <a href="#links-and-references">Links and references</a>
+    </li>
+    <li>
+     <a href="#preformatted-text">Preformatted text</a>
+    </li>
+    <li>
+     <a href="#lists">Lists</a>
+    </li>
+    <li>
+     <a href="#unicode">Unicode</a>
+    </li>
+    <li>
+     <a href="#raw-html">Raw HTML</a>
+    </li>
+    <li>
+     <a href="#modules">Modules</a>
+    </li>
+    <li>
+     <a href="#tags">Tags</a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <h2 id="sections">
     <a href="#sections" class="anchor"></a>Sections
    </h2>

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -79,380 +79,352 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="sections">
-      <a href="#sections" class="anchor"></a>Sections
-     </h2>
-     <p>
-      Let's get these done first, because sections will be used to break up the rest of this test.
-     </p>
-     <p>
-      Besides the section heading above, there are also
-     </p>
-    </header>
-    <section>
-     <header>
-      <h3 id="subsection-headings">
-       <a href="#subsection-headings" class="anchor"></a>Subsection headings
-      </h3>
-      <p>
-       and
-      </p>
-     </header>
-     <section>
-      <header>
-       <h4 id="sub-subsection-headings">
-        <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings
-       </h4>
-       <p>
-        but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
-       </p>
-      </header>
-     </section>
-     <section>
-      <header>
-       <h4 id="anchors">
-        <a href="#anchors" class="anchor"></a>Anchors
-       </h4>
-       <p>
-        Sections can have attached <a href="index.html#anchors">Anchors</a>, and it is possible to <a href="index.html#anchors">link</a> to them. Links to section headers should not be set in source code style.
-       </p>
-      </header>
-      <section>
-       <header>
-        <h5 id="paragraph">
-         <a href="#paragraph" class="anchor"></a>Paragraph
-        </h5>
-        <p>
-         Individual paragraphs can have a heading.
-        </p>
-       </header>
-       <section>
-        <header>
-         <h6 id="subparagraph">
-          <a href="#subparagraph" class="anchor"></a>Subparagraph
-         </h6>
-         <p>
-          Parts of a longer paragraph that can be considered alone can also have headings.
-         </p>
-        </header>
-       </section>
-      </section>
-     </section>
-    </section>
-   </section>
-   <section>
-    <header>
-     <h2 id="styling">
-      <a href="#styling" class="anchor"></a>Styling
-     </h2>
-     <p>
-      This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
-     </p>
-     <p>
-      Note: <i>In italics <em>emphasis</em> is rendered as normal text while <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in italics.</i> <i>It also work the same in <a href="#">links in italics with <em>emphasis <em class="odd">in</em> emphasis</em>.</a></i>
-     </p>
-     <p>
-      <code>code</code> is a different kind of markup that doesn't allow nested markup.
-     </p>
-     <p>
-      It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.
-     </p>
-     <p>
-      This is also true between <em>non-</em><code>code</code> markup <em>and</em> <code>code</code>.
-     </p>
-     <p>
-      Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.
-     </p>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="links-and-references">
-      <a href="#links-and-references" class="anchor"></a>Links and references
-     </h2>
-     <p>
-      This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
-     </p>
-     <p>
-      This is a reference to <a href="index.html#val-foo"><code>foo</code></a>. References can have replacement text: <a href="index.html#val-foo">the value foo</a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="index.html#val-foo"><b>bold</b></a>, <a href="index.html#val-foo"><i>italic</i></a>, <a href="index.html#val-foo"><em>emphasis</em></a>, <a href="index.html#val-foo">super<sup>script</sup></a>, <a href="index.html#val-foo">sub<sub>script</sub></a>, and <a href="index.html#val-foo"><code>code</code></a>. It's also possible to surround a reference in a style: <b><a href="index.html#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.
-     </p>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="preformatted-text">
-      <a href="#preformatted-text" class="anchor"></a>Preformatted text
-     </h2>
-     <p>
-      This is a code block:
-     </p>
-     <pre><code>let foo = ()
+   <h2 id="sections">
+    <a href="#sections" class="anchor"></a>Sections
+   </h2>
+   <aside>
+    <p>
+     Let's get these done first, because sections will be used to break up the rest of this test.
+    </p>
+    <p>
+     Besides the section heading above, there are also
+    </p>
+   </aside>
+   <h3 id="subsection-headings">
+    <a href="#subsection-headings" class="anchor"></a>Subsection headings
+   </h3>
+   <aside>
+    <p>
+     and
+    </p>
+   </aside>
+   <h4 id="sub-subsection-headings">
+    <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings
+   </h4>
+   <aside>
+    <p>
+     but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
+    </p>
+   </aside>
+   <h4 id="anchors">
+    <a href="#anchors" class="anchor"></a>Anchors
+   </h4>
+   <aside>
+    <p>
+     Sections can have attached <a href="index.html#anchors">Anchors</a>, and it is possible to <a href="index.html#anchors">link</a> to them. Links to section headers should not be set in source code style.
+    </p>
+   </aside>
+   <h5 id="paragraph">
+    <a href="#paragraph" class="anchor"></a>Paragraph
+   </h5>
+   <aside>
+    <p>
+     Individual paragraphs can have a heading.
+    </p>
+   </aside>
+   <h6 id="subparagraph">
+    <a href="#subparagraph" class="anchor"></a>Subparagraph
+   </h6>
+   <aside>
+    <p>
+     Parts of a longer paragraph that can be considered alone can also have headings.
+    </p>
+   </aside>
+   <h2 id="styling">
+    <a href="#styling" class="anchor"></a>Styling
+   </h2>
+   <aside>
+    <p>
+     This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
+    </p>
+    <p>
+     Note: <i>In italics <em>emphasis</em> is rendered as normal text while <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in italics.</i> <i>It also work the same in <a href="#">links in italics with <em>emphasis <em class="odd">in</em> emphasis</em>.</a></i>
+    </p>
+    <p>
+     <code>code</code> is a different kind of markup that doesn't allow nested markup.
+    </p>
+    <p>
+     It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.
+    </p>
+    <p>
+     This is also true between <em>non-</em><code>code</code> markup <em>and</em> <code>code</code>.
+    </p>
+    <p>
+     Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.
+    </p>
+   </aside>
+   <h2 id="links-and-references">
+    <a href="#links-and-references" class="anchor"></a>Links and references
+   </h2>
+   <aside>
+    <p>
+     This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
+    </p>
+    <p>
+     This is a reference to <a href="index.html#val-foo"><code>foo</code></a>. References can have replacement text: <a href="index.html#val-foo">the value foo</a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="index.html#val-foo"><b>bold</b></a>, <a href="index.html#val-foo"><i>italic</i></a>, <a href="index.html#val-foo"><em>emphasis</em></a>, <a href="index.html#val-foo">super<sup>script</sup></a>, <a href="index.html#val-foo">sub<sub>script</sub></a>, and <a href="index.html#val-foo"><code>code</code></a>. It's also possible to surround a reference in a style: <b><a href="index.html#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.
+    </p>
+   </aside>
+   <h2 id="preformatted-text">
+    <a href="#preformatted-text" class="anchor"></a>Preformatted text
+   </h2>
+   <aside>
+    <p>
+     This is a code block:
+    </p>
+    <pre><code>let foo = ()
 (** There are some nested comments in here, but an unpaired comment
     terminator would terminate the whole doc surrounding comment. It's
     best to keep code blocks no wider than 72 characters. *)
 
 let bar =
   ignore foo</code></pre>
-     <p>
-      There are also verbatim blocks:
-     </p>
-     <pre>The main difference is these don't get syntax highlighting.</pre>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="lists">
-      <a href="#lists" class="anchor"></a>Lists
-     </h2>
-     <ul>
-      <li>
-       This is a
-      </li>
-      <li>
-       shorthand bulleted list,
-      </li>
-      <li>
-       and the paragraphs in each list item support <em>styling</em>.
-      </li>
-     </ul>
-     <ol>
-      <li>
-       This is a
-      </li>
-      <li>
-       shorthand numbered list.
-      </li>
-     </ol>
-     <ul>
-      <li>
-       Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
-      </li>
-     </ul>
-     <p>
-      just creates a paragraph outside the list.
-     </p>
-     <ul>
-      <li>
-       Similarly, inserting a blank line between two list items
-      </li>
-     </ul>
-     <ul>
-      <li>
-       creates two separate lists.
-      </li>
-     </ul>
-     <ul>
-      <li>
-       <p>
-        To get around this limitation, one
-       </p>
-       <p>
-        can use explicitly-delimited lists.
-       </p>
-      </li>
-      <li>
-       This one is bulleted,
-      </li>
-     </ul>
-     <ol>
-      <li>
-       but there is also the numbered variant.
-      </li>
-     </ol>
-     <ul>
-      <li>
-       <ul>
-        <li>
-         lists
-        </li>
-        <li>
-         can be nested
-        </li>
-        <li>
-         and can include references
-        </li>
-        <li>
-         <a href="index.html#val-foo"><code>foo</code></a>
-        </li>
-       </ul>
-      </li>
-     </ul>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="unicode">
-      <a href="#unicode" class="anchor"></a>Unicode
-     </h2>
-     <p>
-      The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
-     </p>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="raw-html">
-      <a href="#raw-html" class="anchor"></a>Raw HTML
-     </h2>
-     <p>
-      Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
-     </p>
-     <blockquote>
-      If the raw HTML is the only thing in a paragraph, it is treated as a block
+    <p>
+     There are also verbatim blocks:
+    </p>
+    <pre>The main difference is these don't get syntax highlighting.</pre>
+   </aside>
+   <h2 id="lists">
+    <a href="#lists" class="anchor"></a>Lists
+   </h2>
+   <aside>
+    <ul>
+     <li>
+      This is a
+     </li>
+     <li>
+      shorthand bulleted list,
+     </li>
+     <li>
+      and the paragraphs in each list item support <em>styling</em>.
+     </li>
+    </ul>
+    <ol>
+     <li>
+      This is a
+     </li>
+     <li>
+      shorthand numbered list.
+     </li>
+    </ol>
+    <ul>
+     <li>
+      Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
+     </li>
+    </ul>
+    <p>
+     just creates a paragraph outside the list.
+    </p>
+    <ul>
+     <li>
+      Similarly, inserting a blank line between two list items
+     </li>
+    </ul>
+    <ul>
+     <li>
+      creates two separate lists.
+     </li>
+    </ul>
+    <ul>
+     <li>
+      <p>
+       To get around this limitation, one
+      </p>
+      <p>
+       can use explicitly-delimited lists.
+      </p>
+     </li>
+     <li>
+      This one is bulleted,
+     </li>
+    </ul>
+    <ol>
+     <li>
+      but there is also the numbered variant.
+     </li>
+    </ol>
+    <ul>
+     <li>
+      <ul>
+       <li>
+        lists
+       </li>
+       <li>
+        can be nested
+       </li>
+       <li>
+        and can include references
+       </li>
+       <li>
+        <a href="index.html#val-foo"><code>foo</code></a>
+       </li>
+      </ul>
+     </li>
+    </ul>
+   </aside>
+   <h2 id="unicode">
+    <a href="#unicode" class="anchor"></a>Unicode
+   </h2>
+   <aside>
+    <p>
+     The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
+    </p>
+   </aside>
+   <h2 id="raw-html">
+    <a href="#raw-html" class="anchor"></a>Raw HTML
+   </h2>
+   <aside>
+    <p>
+     Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
+    </p>
+    <blockquote>
+     If the raw HTML is the only thing in a paragraph, it is treated as a block
       element, and won't be wrapped in paragraph tags by the HTML generator.
-     </blockquote>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="modules">
-      <a href="#modules" class="anchor"></a>Modules
-     </h2>
-     <ul class="modules"></ul>
-     <ul class="modules">
-      <li>
-       <code>X</code>
-      </li>
-     </ul>
-     <ul class="modules">
-      <li>
-       <code>X</code>
-      </li>
-      <li>
-       <code>Y</code>
-      </li>
-      <li>
-       <code>Z</code>
-      </li>
-     </ul>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="tags">
-      <a href="#tags" class="anchor"></a>Tags
-     </h2>
-     <p>
-      Each comment can end with zero or more tags. Here are some examples:
-     </p>
-     <dl>
-      <dt>
-       author
-      </dt>
-      <dd>
-       antron
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       deprecated
-      </dt>
-      <dd>
-       <p>
-        a <em>long</em> time ago
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       parameter foo
-      </dt>
-      <dd>
-       <p>
-        unused
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       raises Failure
-      </dt>
-      <dd>
-       <p>
-        always
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       returns
-      </dt>
-      <dd>
-       <p>
-        never
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       see <a href="#">#</a>
-      </dt>
-      <dd>
-       <p>
-        this url
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       see <code>foo.ml</code>
-      </dt>
-      <dd>
-       <p>
-        this file
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       see Foo
-      </dt>
-      <dd>
-       <p>
-        this document
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       since
-      </dt>
-      <dd>
-       0
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       before 1.0
-      </dt>
-      <dd>
-       <p>
-        it was in b<sup>e</sup>t<sub>a</sub>
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       version
-      </dt>
-      <dd>
-       -1
-      </dd>
-     </dl>
-    </header>
+    </blockquote>
+   </aside>
+   <h2 id="modules">
+    <a href="#modules" class="anchor"></a>Modules
+   </h2>
+   <aside>
+    <ul class="modules"></ul>
+    <ul class="modules">
+     <li>
+      <code>X</code>
+     </li>
+    </ul>
+    <ul class="modules">
+     <li>
+      <code>X</code>
+     </li>
+     <li>
+      <code>Y</code>
+     </li>
+     <li>
+      <code>Z</code>
+     </li>
+    </ul>
+   </aside>
+   <h2 id="tags">
+    <a href="#tags" class="anchor"></a>Tags
+   </h2>
+   <aside>
+    <p>
+     Each comment can end with zero or more tags. Here are some examples:
+    </p>
     <dl>
-     <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+     <dt>
+      author
+     </dt>
+     <dd>
+      antron
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      deprecated
      </dt>
      <dd>
       <p>
-       Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.
+       a <em>long</em> time ago
       </p>
      </dd>
     </dl>
-   </section>
+    <dl>
+     <dt>
+      parameter foo
+     </dt>
+     <dd>
+      <p>
+       unused
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      raises Failure
+     </dt>
+     <dd>
+      <p>
+       always
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      returns
+     </dt>
+     <dd>
+      <p>
+       never
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      see <a href="#">#</a>
+     </dt>
+     <dd>
+      <p>
+       this url
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      see <code>foo.ml</code>
+     </dt>
+     <dd>
+      <p>
+       this file
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      see Foo
+     </dt>
+     <dd>
+      <p>
+       this document
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      since
+     </dt>
+     <dd>
+      0
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      before 1.0
+     </dt>
+     <dd>
+      <p>
+       it was in b<sup>e</sup>t<sub>a</sub>
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      version
+     </dt>
+     <dd>
+      -1
+     </dd>
+    </dl>
+   </aside>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+    </dt>
+    <dd>
+     <p>
+      Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -13,18 +13,18 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Module
+  </nav>
+  <header>
+   <h1>
+    Module <code>Module</code>
+   </h1>
+   <p>
+    Foo.
+   </p>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Module
-    </nav>
-    <h1>
-     Module <code>Module</code>
-    </h1>
-    <p>
-     Foo.
-    </p>
-   </header>
    <dl>
     <dt class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>

--- a/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
@@ -13,25 +13,25 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+ml</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 1-Arg1
+  </nav>
+  <header>
+   <h1>
+    Parameter <code>F.1-Arg1</code>
+   </h1>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+    <li>
+     <a href="#values">Values</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+ml</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 1-Arg1
-    </nav>
-    <h1>
-     Parameter <code>F.1-Arg1</code>
-    </h1>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#type">Type</a>
-      </li>
-      <li>
-       <a href="#values">Values</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
@@ -32,40 +32,32 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="type">
-      <a href="#type" class="anchor"></a>Type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
-     </dt>
-     <dd>
-      <p>
-       Some type.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="values">
-      <a href="#values" class="anchor"></a>Values
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-y">
-      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : <a href="index.html#type-t">t</a></code>
-     </dt>
-     <dd>
-      <p>
-       The value of y.
-      </p>
-     </dd>
-    </dl>
-   </section>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
+    </dt>
+    <dd>
+     <p>
+      Some type.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="values">
+    <a href="#values" class="anchor"></a>Values
+   </h2>
+   <dl>
+    <dt class="spec value" id="val-y">
+     <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : <a href="index.html#type-t">t</a></code>
+    </dt>
+    <dd>
+     <p>
+      The value of y.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
@@ -29,23 +29,19 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="type">
-      <a href="#type" class="anchor"></a>Type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
-     </dt>
-     <dd>
-      <p>
-       Some type.
-      </p>
-     </dd>
-    </dl>
-   </section>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
+    </dt>
+    <dd>
+     <p>
+      Some type.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
@@ -13,22 +13,22 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+ml</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 2-Arg2
+  </nav>
+  <header>
+   <h1>
+    Parameter <code>F.2-Arg2</code>
+   </h1>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+ml</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 2-Arg2
-    </nav>
-    <h1>
-     Parameter <code>F.2-Arg2</code>
-    </h1>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#type">Type</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -49,23 +49,19 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="type">
-      <a href="#type" class="anchor"></a>Type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = <a href="argument-1-Arg1/index.html#type-t">Arg1.t</a> * <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a></code>
-     </dt>
-     <dd>
-      <p>
-       Some type.
-      </p>
-     </dd>
-    </dl>
-   </section>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = <a href="argument-1-Arg1/index.html#type-t">Arg1.t</a> * <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a></code>
+    </dt>
+    <dd>
+     <p>
+      Some type.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -13,42 +13,42 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » F
+  </nav>
+  <header>
+   <h1>
+    Module <code>Nested.F</code>
+   </h1>
+   <p>
+    This is a functor F.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
+   <h3 id="heading">
+    <a href="#heading" class="anchor"></a>Parameters
+   </h3>
+   <ul>
+    <li>
+     <code><a href="argument-1-Arg1/index.html">Arg1</a> : <a href="../index.html#module-type-Y">Y</a></code>
+    </li>
+    <li>
+     <code><a href="argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    </li>
+   </ul>
+   <h3 id="heading">
+    <a href="#heading" class="anchor"></a>Signature
+   </h3>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » F
-    </nav>
-    <h1>
-     Module <code>Nested.F</code>
-    </h1>
-    <p>
-     This is a functor F.
-    </p>
-    <p>
-     Some additional comments.
-    </p>
-    <h3 id="heading">
-     <a href="#heading" class="anchor"></a>Parameters
-    </h3>
-    <ul>
-     <li>
-      <code><a href="argument-1-Arg1/index.html">Arg1</a> : <a href="../index.html#module-type-Y">Y</a></code>
-     </li>
-     <li>
-      <code><a href="argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-     </li>
-    </ul>
-    <h3 id="heading">
-     <a href="#heading" class="anchor"></a>Signature
-    </h3>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#type">Type</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -13,31 +13,31 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » X
+  </nav>
+  <header>
+   <h1>
+    Module <code>Nested.X</code>
+   </h1>
+   <p>
+    This is module X.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+    <li>
+     <a href="#values">Values</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » X
-    </nav>
-    <h1>
-     Module <code>Nested.X</code>
-    </h1>
-    <p>
-     This is module X.
-    </p>
-    <p>
-     Some additional comments.
-    </p>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#type">Type</a>
-      </li>
-      <li>
-       <a href="#values">Values</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -38,40 +38,32 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="type">
-      <a href="#type" class="anchor"></a>Type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
-     </dt>
-     <dd>
-      <p>
-       Some type.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="values">
-      <a href="#values" class="anchor"></a>Values
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-x">
-      <a href="#val-x" class="anchor"></a><code><span class="keyword">val</span> x : <a href="index.html#type-t">t</a></code>
-     </dt>
-     <dd>
-      <p>
-       The value of x.
-      </p>
-     </dd>
-    </dl>
-   </section>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
+    </dt>
+    <dd>
+     <p>
+      Some type.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="values">
+    <a href="#values" class="anchor"></a>Values
+   </h2>
+   <dl>
+    <dt class="spec value" id="val-x">
+     <a href="#val-x" class="anchor"></a><code><span class="keyword">val</span> x : <a href="index.html#type-t">t</a></code>
+    </dt>
+    <dd>
+     <p>
+      The value of x.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-inherits/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » inherits
+  </nav>
+  <header>
+   <h1>
+    Class <code>Nested.inherits</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » inherits
-    </nav>
-    <h1>
-     Class <code>Nested.inherits</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec inherit">
      <code><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></code>

--- a/test/html/expect/test_package+ml/Nested/class-z/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-z/index.html
@@ -50,28 +50,24 @@
      <a href="#val-y'" class="anchor"></a><code><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y' : int</code>
     </dt>
    </dl>
-   <section>
-    <header>
-     <h2 id="methods">
-      <a href="#methods" class="anchor"></a>Methods
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec method" id="method-z">
-      <a href="#method-z" class="anchor"></a><code><span class="keyword">method</span> z : int</code>
-     </dt>
-     <dd>
-      <p>
-       Some method.
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt class="spec method" id="method-z'">
-      <a href="#method-z'" class="anchor"></a><code><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z' : int</code>
-     </dt>
-    </dl>
-   </section>
+   <h2 id="methods">
+    <a href="#methods" class="anchor"></a>Methods
+   </h2>
+   <dl>
+    <dt class="spec method" id="method-z">
+     <a href="#method-z" class="anchor"></a><code><span class="keyword">method</span> z : int</code>
+    </dt>
+    <dd>
+     <p>
+      Some method.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec method" id="method-z'">
+     <a href="#method-z'" class="anchor"></a><code><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z' : int</code>
+    </dt>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/class-z/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-z/index.html
@@ -13,28 +13,28 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » z
+  </nav>
+  <header>
+   <h1>
+    Class <code>Nested.z</code>
+   </h1>
+   <p>
+    This is class z.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#methods">Methods</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » z
-    </nav>
-    <h1>
-     Class <code>Nested.z</code>
-    </h1>
-    <p>
-     This is class z.
-    </p>
-    <p>
-     Some additional comments.
-    </p>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#methods">Methods</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <dl>
     <dt class="spec instance-variable" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : int</code>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -41,77 +41,61 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="module">
-      <a href="#module" class="anchor"></a>Module
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec module" id="module-X">
-      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-     </dt>
-     <dd>
-      <p>
-       This is module X.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="module-type">
-      <a href="#module-type" class="anchor"></a>Module type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec module-type" id="module-type-Y">
-      <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Y/index.html">Y</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-     </dt>
-     <dd>
-      <p>
-       This is module type Y.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="functor">
-      <a href="#functor" class="anchor"></a>Functor
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec module" id="module-F">
-      <a href="#module-F" class="anchor"></a><code><span class="keyword">module</span> <a href="F/index.html">F</a> : <span class="keyword">functor</span> (<a href="F/argument-1-Arg1/index.html">Arg1</a> : <a href="index.html#module-type-Y">Y</a>) <span>-&gt;</span> <span class="keyword">functor</span> (<a href="F/argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-     </dt>
-     <dd>
-      <p>
-       This is a functor F.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="class">
-      <a href="#class" class="anchor"></a>Class
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec class" id="class-z">
-      <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
-     </dt>
-     <dd>
-      <p>
-       This is class z.
-      </p>
-     </dd>
-    </dl>
-    <div class="spec class" id="class-inherits">
-     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-inherits/index.html">inherits</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
-    </div>
-   </section>
+   <h2 id="module">
+    <a href="#module" class="anchor"></a>Module
+   </h2>
+   <dl>
+    <dt class="spec module" id="module-X">
+     <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is module X.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="module-type">
+    <a href="#module-type" class="anchor"></a>Module type
+   </h2>
+   <dl>
+    <dt class="spec module-type" id="module-type-Y">
+     <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Y/index.html">Y</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is module type Y.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="functor">
+    <a href="#functor" class="anchor"></a>Functor
+   </h2>
+   <dl>
+    <dt class="spec module" id="module-F">
+     <a href="#module-F" class="anchor"></a><code><span class="keyword">module</span> <a href="F/index.html">F</a> : <span class="keyword">functor</span> (<a href="F/argument-1-Arg1/index.html">Arg1</a> : <a href="index.html#module-type-Y">Y</a>) <span>-&gt;</span> <span class="keyword">functor</span> (<a href="F/argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is a functor F.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="class">
+    <a href="#class" class="anchor"></a>Class
+   </h2>
+   <dl>
+    <dt class="spec class" id="class-z">
+     <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    </dt>
+    <dd>
+     <p>
+      This is class z.
+     </p>
+    </dd>
+   </dl>
+   <div class="spec class" id="class-inherits">
+    <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-inherits/index.html">inherits</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -13,34 +13,34 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Nested
+  </nav>
+  <header>
+   <h1>
+    Module <code>Nested</code>
+   </h1>
+   <p>
+    This comment needs to be here before #235 is fixed.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#module">Module</a>
+    </li>
+    <li>
+     <a href="#module-type">Module type</a>
+    </li>
+    <li>
+     <a href="#functor">Functor</a>
+    </li>
+    <li>
+     <a href="#class">Class</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Nested
-    </nav>
-    <h1>
-     Module <code>Nested</code>
-    </h1>
-    <p>
-     This comment needs to be here before #235 is fixed.
-    </p>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#module">Module</a>
-      </li>
-      <li>
-       <a href="#module-type">Module type</a>
-      </li>
-      <li>
-       <a href="#functor">Functor</a>
-      </li>
-      <li>
-       <a href="#class">Class</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="module">
     <a href="#module" class="anchor"></a>Module
    </h2>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -38,40 +38,32 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="type">
-      <a href="#type" class="anchor"></a>Type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
-     </dt>
-     <dd>
-      <p>
-       Some type.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="values">
-      <a href="#values" class="anchor"></a>Values
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-y">
-      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : <a href="index.html#type-t">t</a></code>
-     </dt>
-     <dd>
-      <p>
-       The value of y.
-      </p>
-     </dd>
-    </dl>
-   </section>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
+    </dt>
+    <dd>
+     <p>
+      Some type.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="values">
+    <a href="#values" class="anchor"></a>Values
+   </h2>
+   <dl>
+    <dt class="spec value" id="val-y">
+     <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : <a href="index.html#type-t">t</a></code>
+    </dt>
+    <dd>
+     <p>
+      The value of y.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -13,31 +13,31 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » Y
+  </nav>
+  <header>
+   <h1>
+    Module type <code>Nested.Y</code>
+   </h1>
+   <p>
+    This is module type Y.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+    <li>
+     <a href="#values">Values</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » Y
-    </nav>
-    <h1>
-     Module type <code>Nested.Y</code>
-    </h1>
-    <p>
-     This is module type Y.
-    </p>
-    <p>
-     Some additional comments.
-    </p>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#type">Type</a>
-      </li>
-      <li>
-       <a href="#values">Values</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Recent/X/index.html
+++ b/test/html/expect/test_package+ml/Recent/X/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Recent</a> » X
+  </nav>
+  <header>
+   <h1>
+    Module <code>Recent.X</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Recent</a> » X
-    </nav>
-    <h1>
-     Module <code>Recent.X</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec module-substitution" id="module-L">
      <a href="#module-L" class="anchor"></a><code><span class="keyword">module</span> L := <a href="../Z/index.html#module-Y">Z.Y</a></code>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Recent
+  </nav>
+  <header>
+   <h1>
+    Module <code>Recent</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Recent
-    </nav>
-    <h1>
-     Module <code>Recent</code>
-    </h1>
-   </header>
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Recent_impl/index.html
+++ b/test/html/expect/test_package+ml/Recent_impl/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Recent_impl
+  </nav>
+  <header>
+   <h1>
+    Module <code>Recent_impl</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Recent_impl
-    </nav>
-    <h1>
-     Module <code>Recent_impl</code>
-    </h1>
-   </header>
    <div class="spec module" id="module-Foo">
     <a href="#module-Foo" class="anchor"></a><code><span class="keyword">module</span> <a href="Foo/index.html">Foo</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Section/index.html
+++ b/test/html/expect/test_package+ml/Section/index.html
@@ -55,78 +55,50 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="empty-section">
-      <a href="#empty-section" class="anchor"></a>Empty section
-     </h2>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="text-only">
-      <a href="#text-only" class="anchor"></a>Text only
-     </h2>
-     <p>
-      Foo bar.
-     </p>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="aside-only">
-      <a href="#aside-only" class="anchor"></a>Aside only
-     </h2>
-    </header>
-    <aside>
-     <p>
-      Foo bar.
-     </p>
-    </aside>
-   </section>
-   <section>
-    <header>
-     <h2 id="value-only">
-      <a href="#value-only" class="anchor"></a>Value only
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-     </dt>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="empty-section">
-      <a href="#empty-section" class="anchor"></a>Empty section
-     </h2>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="within-a-comment">
-      <a href="#within-a-comment" class="anchor"></a>within a comment
-     </h2>
-    </header>
-    <section>
-     <header>
-      <h3 id="and-one-with-a-nested-section">
-       <a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section
-      </h3>
-     </header>
-    </section>
-   </section>
-   <section>
-    <header>
-     <h2 id="this-section-title-has-markup">
-      <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
-     </h2>
-     <p>
-      But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
-     </p>
-    </header>
-   </section>
+   <h2 id="empty-section">
+    <a href="#empty-section" class="anchor"></a>Empty section
+   </h2>
+   <h2 id="text-only">
+    <a href="#text-only" class="anchor"></a>Text only
+   </h2>
+   <aside>
+    <p>
+     Foo bar.
+    </p>
+   </aside>
+   <h2 id="aside-only">
+    <a href="#aside-only" class="anchor"></a>Aside only
+   </h2>
+   <aside>
+    <p>
+     Foo bar.
+    </p>
+   </aside>
+   <h2 id="value-only">
+    <a href="#value-only" class="anchor"></a>Value only
+   </h2>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+    </dt>
+   </dl>
+   <h2 id="empty-section">
+    <a href="#empty-section" class="anchor"></a>Empty section
+   </h2>
+   <h2 id="within-a-comment">
+    <a href="#within-a-comment" class="anchor"></a>within a comment
+   </h2>
+   <h3 id="and-one-with-a-nested-section">
+    <a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section
+   </h3>
+   <h2 id="this-section-title-has-markup">
+    <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
+   </h2>
+   <aside>
+    <p>
+     But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+    </p>
+   </aside>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Section/index.html
+++ b/test/html/expect/test_package+ml/Section/index.html
@@ -13,48 +13,48 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Section
-    </nav>
-    <h1>
-     Module <code>Section</code>
-    </h1>
-    <p>
-     This is the module comment. Eventually, sections won't be allowed in it.
-    </p>
-    <nav class="toc">
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Section
+  </nav>
+  <header>
+   <h1>
+    Module <code>Section</code>
+   </h1>
+   <p>
+    This is the module comment. Eventually, sections won't be allowed in it.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#empty-section">Empty section</a>
+    </li>
+    <li>
+     <a href="#text-only">Text only</a>
+    </li>
+    <li>
+     <a href="#aside-only">Aside only</a>
+    </li>
+    <li>
+     <a href="#value-only">Value only</a>
+    </li>
+    <li>
+     <a href="#empty-section">Empty section</a>
+    </li>
+    <li>
+     <a href="#within-a-comment">within a comment</a>
      <ul>
       <li>
-       <a href="#empty-section">Empty section</a>
-      </li>
-      <li>
-       <a href="#text-only">Text only</a>
-      </li>
-      <li>
-       <a href="#aside-only">Aside only</a>
-      </li>
-      <li>
-       <a href="#value-only">Value only</a>
-      </li>
-      <li>
-       <a href="#empty-section">Empty section</a>
-      </li>
-      <li>
-       <a href="#within-a-comment">within a comment</a>
-       <ul>
-        <li>
-         <a href="#and-one-with-a-nested-section">and one with a nested section</a>
-        </li>
-       </ul>
-      </li>
-      <li>
-       <a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a>
+       <a href="#and-one-with-a-nested-section">and one with a nested section</a>
       </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+    <li>
+     <a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
    </h2>

--- a/test/html/expect/test_package+ml/Stop/index.html
+++ b/test/html/expect/test_package+ml/Stop/index.html
@@ -13,18 +13,18 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Stop
+  </nav>
+  <header>
+   <h1>
+    Module <code>Stop</code>
+   </h1>
+   <p>
+    This test cases exercises stop comments.
+   </p>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Stop
-    </nav>
-    <h1>
-     Module <code>Stop</code>
-    </h1>
-    <p>
-     This test cases exercises stop comments.
-    </p>
-   </header>
    <dl>
     <dt class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : int</code>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Type
+  </nav>
+  <header>
+   <h1>
+    Module <code>Type</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Type
-    </nav>
-    <h1>
-     Module <code>Type</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec type" id="type-abstract">
      <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type</span> abstract</code>

--- a/test/html/expect/test_package+ml/Val/index.html
+++ b/test/html/expect/test_package+ml/Val/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Val
+  </nav>
+  <header>
+   <h1>
+    Module <code>Val</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Val
-    </nav>
-    <h1>
-     Module <code>Val</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span class="keyword">val</span> documented : unit</code>

--- a/test/html/expect/test_package+ml/mld.html
+++ b/test/html/expect/test_package+ml/mld.html
@@ -13,39 +13,39 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="index.html">Up</a> – <a href="index.html">test_package+ml</a> » mld
-    </nav>
-    <h1 id="mld-page">
-     <a href="#mld-page" class="anchor"></a>Mld Page
-    </h1>
-    <p>
-     This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
-    </p>
-    <p>
-     It will have a TOC generated from section headings.
-    </p>
-    <nav class="toc">
+  <nav>
+   <a href="index.html">Up</a> – <a href="index.html">test_package+ml</a> » mld
+  </nav>
+  <header>
+   <h1 id="mld-page">
+    <a href="#mld-page" class="anchor"></a>Mld Page
+   </h1>
+   <p>
+    This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
+   </p>
+   <p>
+    It will have a TOC generated from section headings.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#section">Section</a>
+    </li>
+    <li>
+     <a href="#another-section">Another section</a>
      <ul>
       <li>
-       <a href="#section">Section</a>
+       <a href="#subsection">Subsection</a>
       </li>
       <li>
-       <a href="#another-section">Another section</a>
-       <ul>
-        <li>
-         <a href="#subsection">Subsection</a>
-        </li>
-        <li>
-         <a href="#another-subsection">Another Subsection</a>
-        </li>
-       </ul>
+       <a href="#another-subsection">Another Subsection</a>
       </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <h2 id="section">
     <a href="#section" class="anchor"></a>Section
    </h2>

--- a/test/html/expect/test_package+re/Alias/X/index.html
+++ b/test/html/expect/test_package+re/Alias/X/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Alias</a> » X
+  </nav>
+  <header>
+   <h1>
+    Module <code>Alias.X</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Alias</a> » X
-    </nav>
-    <h1>
-     Module <code>Alias.X</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = int;</code>

--- a/test/html/expect/test_package+re/Alias/index.html
+++ b/test/html/expect/test_package+re/Alias/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Alias
+  </nav>
+  <header>
+   <h1>
+    Module <code>Alias</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Alias
-    </nav>
-    <h1>
-     Module <code>Alias</code>
-    </h1>
-   </header>
    <div class="spec module" id="module-Foo__X">
     <a href="#module-Foo__X" class="anchor"></a><code><span class="keyword">module</span> <a href="Foo__X/index.html">Foo__X</a>: { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Bugs/index.html
+++ b/test/html/expect/test_package+re/Bugs/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Bugs
+  </nav>
+  <header>
+   <h1>
+    Module <code>Bugs</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Bugs
-    </nav>
-    <h1>
-     Module <code>Bugs</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec type" id="type-opt">
      <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> opt('a) = option(<span class="type-var">'a</span>);</code>

--- a/test/html/expect/test_package+re/Bugs_pre_410/index.html
+++ b/test/html/expect/test_package+re/Bugs_pre_410/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Bugs_pre_410
+  </nav>
+  <header>
+   <h1>
+    Module <code>Bugs_pre_410</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Bugs_pre_410
-    </nav>
-    <h1>
-     Module <code>Bugs_pre_410</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec type" id="type-opt'">
      <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> opt'('a) = option(int);</code>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Class
+  </nav>
+  <header>
+   <h1>
+    Module <code>Class</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Class
-    </nav>
-    <h1>
-     Module <code>Class</code>
-    </h1>
-   </header>
    <div class="spec class-type" id="class-type-empty">
     <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a> = { ... }</code>
    </div>

--- a/test/html/expect/test_package+re/External/index.html
+++ b/test/html/expect/test_package+re/External/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » External
+  </nav>
+  <header>
+   <h1>
+    Module <code>External</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » External
-    </nav>
-    <h1>
-     Module <code>External</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec external" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit <span>=&gt;</span> unit;</code>

--- a/test/html/expect/test_package+re/Functor/index.html
+++ b/test/html/expect/test_package+re/Functor/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Functor
+  </nav>
+  <header>
+   <h1>
+    Module <code>Functor</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Functor
-    </nav>
-    <h1>
-     Module <code>Functor</code>
-    </h1>
-   </header>
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Include/index.html
+++ b/test/html/expect/test_package+re/Include/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Include
+  </nav>
+  <header>
+   <h1>
+    Module <code>Include</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Include
-    </nav>
-    <h1>
-     Module <code>Include</code>
-    </h1>
-   </header>
    <div class="spec module-type" id="module-type-Not_inlined">
     <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a> = { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Include2/index.html
+++ b/test/html/expect/test_package+re/Include2/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Include2
+  </nav>
+  <header>
+   <h1>
+    Module <code>Include2</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Include2
-    </nav>
-    <h1>
-     Module <code>Include2</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a>: { ... };</code>

--- a/test/html/expect/test_package+re/Include_sections/index.html
+++ b/test/html/expect/test_package+re/Include_sections/index.html
@@ -13,15 +13,29 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Include_sections
-    </nav>
-    <h1>
-     Module <code>Include_sections</code>
-    </h1>
-    <nav class="toc">
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Include_sections
+  </nav>
+  <header>
+   <h1>
+    Module <code>Include_sections</code>
+   </h1>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#something-1">Something 1</a>
+     <ul>
+      <li>
+       <a href="#something-2">Something 2</a>
+      </li>
+     </ul>
+    </li>
+    <li>
+     <a href="#something-1-bis">Something 1-bis</a>
+    </li>
+    <li>
+     <a href="#second-include">Second include</a>
      <ul>
       <li>
        <a href="#something-1">Something 1</a>
@@ -35,7 +49,7 @@
        <a href="#something-1-bis">Something 1-bis</a>
       </li>
       <li>
-       <a href="#second-include">Second include</a>
+       <a href="#third-include">Third include</a>
        <ul>
         <li>
          <a href="#something-1">Something 1</a>
@@ -48,27 +62,13 @@
         <li>
          <a href="#something-1-bis">Something 1-bis</a>
         </li>
-        <li>
-         <a href="#third-include">Third include</a>
-         <ul>
-          <li>
-           <a href="#something-1">Something 1</a>
-           <ul>
-            <li>
-             <a href="#something-2">Something 2</a>
-            </li>
-           </ul>
-          </li>
-          <li>
-           <a href="#something-1-bis">Something 1-bis</a>
-          </li>
-         </ul>
-        </li>
        </ul>
       </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <dl>
     <dt class="spec module-type" id="module-type-Something">
      <a href="#module-type-Something" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Something/index.html">Something</a> = { ... };</code>

--- a/test/html/expect/test_package+re/Include_sections/index.html
+++ b/test/html/expect/test_package+re/Include_sections/index.html
@@ -92,240 +92,204 @@
         <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
        </dt>
       </dl>
-      <section>
-       <header>
-        <h2 id="something-1">
-         <a href="#something-1" class="anchor"></a>Something 1
-        </h2>
+      <h2 id="something-1">
+       <a href="#something-1" class="anchor"></a>Something 1
+      </h2>
+      <aside>
+       <p>
+        foo
+       </p>
+      </aside>
+      <dl>
+       <dt class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+       </dt>
+      </dl>
+      <h3 id="something-2">
+       <a href="#something-2" class="anchor"></a>Something 2
+      </h3>
+      <dl>
+       <dt class="spec value" id="val-bar">
+        <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
+       </dt>
+       <dd>
         <p>
-         foo
+         foo bar
         </p>
-       </header>
-       <dl>
-        <dt class="spec value" id="val-foo">
-         <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-        </dt>
-       </dl>
-       <section>
-        <header>
-         <h3 id="something-2">
-          <a href="#something-2" class="anchor"></a>Something 2
-         </h3>
-        </header>
-        <dl>
-         <dt class="spec value" id="val-bar">
-          <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-         </dt>
-         <dd>
-          <p>
-           foo bar
-          </p>
-         </dd>
-        </dl>
-       </section>
-      </section>
-      <section>
-       <header>
-        <h2 id="something-1-bis">
-         <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-        </h2>
-        <p>
-         Some text.
-        </p>
-       </header>
-      </section>
+       </dd>
+      </dl>
+      <h2 id="something-1-bis">
+       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+      </h2>
+      <aside>
+       <p>
+        Some text.
+       </p>
+      </aside>
      </div>
     </div>
    </div>
-   <section>
-    <header>
-     <h2 id="second-include">
-      <a href="#second-include" class="anchor"></a>Second include
-     </h2>
-     <p>
-      Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
-     </p>
-    </header>
-    <div>
-     <div class="spec include">
-      <div class="doc">
+   <h2 id="second-include">
+    <a href="#second-include" class="anchor"></a>Second include
+   </h2>
+   <aside>
+    <p>
+     Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
+    </p>
+   </aside>
+   <div>
+    <div class="spec include">
+     <div class="doc">
+      <dl>
+       <dt class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
+       </dt>
+      </dl>
+      <h3 id="something-1">
+       <a href="#something-1" class="anchor"></a>Something 1
+      </h3>
+      <aside>
+       <p>
+        foo
+       </p>
+      </aside>
+      <dl>
+       <dt class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+       </dt>
+      </dl>
+      <h4 id="something-2">
+       <a href="#something-2" class="anchor"></a>Something 2
+      </h4>
+      <dl>
+       <dt class="spec value" id="val-bar">
+        <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
+       </dt>
+       <dd>
+        <p>
+         foo bar
+        </p>
+       </dd>
+      </dl>
+      <h3 id="something-1-bis">
+       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+      </h3>
+      <aside>
+       <p>
+        Some text.
+       </p>
+      </aside>
+     </div>
+    </div>
+   </div>
+   <h3 id="third-include">
+    <a href="#third-include" class="anchor"></a>Third include
+   </h3>
+   <aside>
+    <p>
+     Shifted some more.
+    </p>
+   </aside>
+   <div>
+    <div class="spec include">
+     <div class="doc">
+      <dl>
+       <dt class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
+       </dt>
+      </dl>
+      <h4 id="something-1">
+       <a href="#something-1" class="anchor"></a>Something 1
+      </h4>
+      <aside>
+       <p>
+        foo
+       </p>
+      </aside>
+      <dl>
+       <dt class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+       </dt>
+      </dl>
+      <h5 id="something-2">
+       <a href="#something-2" class="anchor"></a>Something 2
+      </h5>
+      <dl>
+       <dt class="spec value" id="val-bar">
+        <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
+       </dt>
+       <dd>
+        <p>
+         foo bar
+        </p>
+       </dd>
+      </dl>
+      <h4 id="something-1-bis">
+       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+      </h4>
+      <aside>
+       <p>
+        Some text.
+       </p>
+      </aside>
+     </div>
+    </div>
+   </div>
+   <aside>
+    <p>
+     And let's include it again, but without inlining it this time: the ToC shouldn't grow.
+    </p>
+   </aside>
+   <div>
+    <div class="spec include">
+     <div class="doc">
+      <details open="open">
+       <summary>
+        <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Something">Something</a><span class="keyword">;</span></code></span>
+       </summary>
        <dl>
         <dt class="spec value" id="val-something">
          <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
         </dt>
        </dl>
-       <section>
-        <header>
-         <h3 id="something-1">
-          <a href="#something-1" class="anchor"></a>Something 1
-         </h3>
+       <h2 id="something-1">
+        <a href="#something-1" class="anchor"></a>Something 1
+       </h2>
+       <aside>
+        <p>
+         foo
+        </p>
+       </aside>
+       <dl>
+        <dt class="spec value" id="val-foo">
+         <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+        </dt>
+       </dl>
+       <h3 id="something-2">
+        <a href="#something-2" class="anchor"></a>Something 2
+       </h3>
+       <dl>
+        <dt class="spec value" id="val-bar">
+         <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
+        </dt>
+        <dd>
          <p>
-          foo
+          foo bar
          </p>
-        </header>
-        <dl>
-         <dt class="spec value" id="val-foo">
-          <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-         </dt>
-        </dl>
-        <section>
-         <header>
-          <h4 id="something-2">
-           <a href="#something-2" class="anchor"></a>Something 2
-          </h4>
-         </header>
-         <dl>
-          <dt class="spec value" id="val-bar">
-           <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-          </dt>
-          <dd>
-           <p>
-            foo bar
-           </p>
-          </dd>
-         </dl>
-        </section>
-       </section>
-       <section>
-        <header>
-         <h3 id="something-1-bis">
-          <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-         </h3>
-         <p>
-          Some text.
-         </p>
-        </header>
-       </section>
-      </div>
+        </dd>
+       </dl>
+       <h2 id="something-1-bis">
+        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+       </h2>
+       <aside>
+        <p>
+         Some text.
+        </p>
+       </aside>
+      </details>
      </div>
     </div>
-    <section>
-     <header>
-      <h3 id="third-include">
-       <a href="#third-include" class="anchor"></a>Third include
-      </h3>
-      <p>
-       Shifted some more.
-      </p>
-     </header>
-     <div>
-      <div class="spec include">
-       <div class="doc">
-        <dl>
-         <dt class="spec value" id="val-something">
-          <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
-         </dt>
-        </dl>
-        <section>
-         <header>
-          <h4 id="something-1">
-           <a href="#something-1" class="anchor"></a>Something 1
-          </h4>
-          <p>
-           foo
-          </p>
-         </header>
-         <dl>
-          <dt class="spec value" id="val-foo">
-           <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-          </dt>
-         </dl>
-         <section>
-          <header>
-           <h5 id="something-2">
-            <a href="#something-2" class="anchor"></a>Something 2
-           </h5>
-          </header>
-          <dl>
-           <dt class="spec value" id="val-bar">
-            <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-           </dt>
-           <dd>
-            <p>
-             foo bar
-            </p>
-           </dd>
-          </dl>
-         </section>
-        </section>
-        <section>
-         <header>
-          <h4 id="something-1-bis">
-           <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-          </h4>
-          <p>
-           Some text.
-          </p>
-         </header>
-        </section>
-       </div>
-      </div>
-     </div>
-     <aside>
-      <p>
-       And let's include it again, but without inlining it this time: the ToC shouldn't grow.
-      </p>
-     </aside>
-     <div>
-      <div class="spec include">
-       <div class="doc">
-        <details open="open">
-         <summary>
-          <span class="def"><code><span class="keyword">include</span> <a href="index.html#module-type-Something">Something</a><span class="keyword">;</span></code></span>
-         </summary>
-         <dl>
-          <dt class="spec value" id="val-something">
-           <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
-          </dt>
-         </dl>
-         <section>
-          <header>
-           <h2 id="something-1">
-            <a href="#something-1" class="anchor"></a>Something 1
-           </h2>
-           <p>
-            foo
-           </p>
-          </header>
-          <dl>
-           <dt class="spec value" id="val-foo">
-            <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-           </dt>
-          </dl>
-          <section>
-           <header>
-            <h3 id="something-2">
-             <a href="#something-2" class="anchor"></a>Something 2
-            </h3>
-           </header>
-           <dl>
-            <dt class="spec value" id="val-bar">
-             <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-            </dt>
-            <dd>
-             <p>
-              foo bar
-             </p>
-            </dd>
-           </dl>
-          </section>
-         </section>
-         <section>
-          <header>
-           <h2 id="something-1-bis">
-            <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-           </h2>
-           <p>
-            Some text.
-           </p>
-          </header>
-         </section>
-        </details>
-       </div>
-      </div>
-     </div>
-    </section>
-   </section>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
@@ -45,48 +45,40 @@
      <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
     </dt>
    </dl>
-   <section>
-    <header>
-     <h2 id="something-1">
-      <a href="#something-1" class="anchor"></a>Something 1
-     </h2>
+   <h2 id="something-1">
+    <a href="#something-1" class="anchor"></a>Something 1
+   </h2>
+   <aside>
+    <p>
+     foo
+    </p>
+   </aside>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+    </dt>
+   </dl>
+   <h3 id="something-2">
+    <a href="#something-2" class="anchor"></a>Something 2
+   </h3>
+   <dl>
+    <dt class="spec value" id="val-bar">
+     <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
+    </dt>
+    <dd>
      <p>
-      foo
+      foo bar
      </p>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-     </dt>
-    </dl>
-    <section>
-     <header>
-      <h3 id="something-2">
-       <a href="#something-2" class="anchor"></a>Something 2
-      </h3>
-     </header>
-     <dl>
-      <dt class="spec value" id="val-bar">
-       <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-      </dt>
-      <dd>
-       <p>
-        foo bar
-       </p>
-      </dd>
-     </dl>
-    </section>
-   </section>
-   <section>
-    <header>
-     <h2 id="something-1-bis">
-      <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-     </h2>
-     <p>
-      Some text.
-     </p>
-    </header>
-   </section>
+    </dd>
+   </dl>
+   <h2 id="something-1-bis">
+    <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+   </h2>
+   <aside>
+    <p>
+     Some text.
+    </p>
+   </aside>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
@@ -13,33 +13,33 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Include_sections</a> » Something
-    </nav>
-    <h1>
-     Module type <code>Include_sections.Something</code>
-    </h1>
-    <p>
-     A module type.
-    </p>
-    <nav class="toc">
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Include_sections</a> » Something
+  </nav>
+  <header>
+   <h1>
+    Module type <code>Include_sections.Something</code>
+   </h1>
+   <p>
+    A module type.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#something-1">Something 1</a>
      <ul>
       <li>
-       <a href="#something-1">Something 1</a>
-       <ul>
-        <li>
-         <a href="#something-2">Something 2</a>
-        </li>
-       </ul>
-      </li>
-      <li>
-       <a href="#something-1-bis">Something 1-bis</a>
+       <a href="#something-2">Something 2</a>
       </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+    <li>
+     <a href="#something-1-bis">Something 1-bis</a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <dl>
     <dt class="spec value" id="val-something">
      <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>

--- a/test/html/expect/test_package+re/Interlude/index.html
+++ b/test/html/expect/test_package+re/Interlude/index.html
@@ -13,18 +13,18 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Interlude
+  </nav>
+  <header>
+   <h1>
+    Module <code>Interlude</code>
+   </h1>
+   <p>
+    This is the comment associated to the module.
+   </p>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Interlude
-    </nav>
-    <h1>
-     Module <code>Interlude</code>
-    </h1>
-    <p>
-     This is the comment associated to the module.
-    </p>
-   </header>
    <aside>
     <p>
      Some separate stray text at the top of the module.

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -13,38 +13,36 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Markup
-    </nav>
-    <h1>
-     Module <code>Markup</code>
-    </h1>
-    <p>
-     Here, we test the rendering of comment markup.
-    </p>
-    <nav class="toc">
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Markup
+  </nav>
+  <header>
+   <h1>
+    Module <code>Markup</code>
+   </h1>
+   <p>
+    Here, we test the rendering of comment markup.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#sections">Sections</a>
      <ul>
       <li>
-       <a href="#sections">Sections</a>
+       <a href="#subsection-headings">Subsection headings</a>
        <ul>
         <li>
-         <a href="#subsection-headings">Subsection headings</a>
+         <a href="#sub-subsection-headings">Sub-subsection headings</a>
+        </li>
+        <li>
+         <a href="#anchors">Anchors</a>
          <ul>
           <li>
-           <a href="#sub-subsection-headings">Sub-subsection headings</a>
-          </li>
-          <li>
-           <a href="#anchors">Anchors</a>
+           <a href="#paragraph">Paragraph</a>
            <ul>
             <li>
-             <a href="#paragraph">Paragraph</a>
-             <ul>
-              <li>
-               <a href="#subparagraph">Subparagraph</a>
-              </li>
-             </ul>
+             <a href="#subparagraph">Subparagraph</a>
             </li>
            </ul>
           </li>
@@ -52,33 +50,35 @@
         </li>
        </ul>
       </li>
-      <li>
-       <a href="#styling">Styling</a>
-      </li>
-      <li>
-       <a href="#links-and-references">Links and references</a>
-      </li>
-      <li>
-       <a href="#preformatted-text">Preformatted text</a>
-      </li>
-      <li>
-       <a href="#lists">Lists</a>
-      </li>
-      <li>
-       <a href="#unicode">Unicode</a>
-      </li>
-      <li>
-       <a href="#raw-html">Raw HTML</a>
-      </li>
-      <li>
-       <a href="#modules">Modules</a>
-      </li>
-      <li>
-       <a href="#tags">Tags</a>
-      </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+    <li>
+     <a href="#styling">Styling</a>
+    </li>
+    <li>
+     <a href="#links-and-references">Links and references</a>
+    </li>
+    <li>
+     <a href="#preformatted-text">Preformatted text</a>
+    </li>
+    <li>
+     <a href="#lists">Lists</a>
+    </li>
+    <li>
+     <a href="#unicode">Unicode</a>
+    </li>
+    <li>
+     <a href="#raw-html">Raw HTML</a>
+    </li>
+    <li>
+     <a href="#modules">Modules</a>
+    </li>
+    <li>
+     <a href="#tags">Tags</a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <h2 id="sections">
     <a href="#sections" class="anchor"></a>Sections
    </h2>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -79,380 +79,352 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="sections">
-      <a href="#sections" class="anchor"></a>Sections
-     </h2>
-     <p>
-      Let's get these done first, because sections will be used to break up the rest of this test.
-     </p>
-     <p>
-      Besides the section heading above, there are also
-     </p>
-    </header>
-    <section>
-     <header>
-      <h3 id="subsection-headings">
-       <a href="#subsection-headings" class="anchor"></a>Subsection headings
-      </h3>
-      <p>
-       and
-      </p>
-     </header>
-     <section>
-      <header>
-       <h4 id="sub-subsection-headings">
-        <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings
-       </h4>
-       <p>
-        but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
-       </p>
-      </header>
-     </section>
-     <section>
-      <header>
-       <h4 id="anchors">
-        <a href="#anchors" class="anchor"></a>Anchors
-       </h4>
-       <p>
-        Sections can have attached <a href="index.html#anchors">Anchors</a>, and it is possible to <a href="index.html#anchors">link</a> to them. Links to section headers should not be set in source code style.
-       </p>
-      </header>
-      <section>
-       <header>
-        <h5 id="paragraph">
-         <a href="#paragraph" class="anchor"></a>Paragraph
-        </h5>
-        <p>
-         Individual paragraphs can have a heading.
-        </p>
-       </header>
-       <section>
-        <header>
-         <h6 id="subparagraph">
-          <a href="#subparagraph" class="anchor"></a>Subparagraph
-         </h6>
-         <p>
-          Parts of a longer paragraph that can be considered alone can also have headings.
-         </p>
-        </header>
-       </section>
-      </section>
-     </section>
-    </section>
-   </section>
-   <section>
-    <header>
-     <h2 id="styling">
-      <a href="#styling" class="anchor"></a>Styling
-     </h2>
-     <p>
-      This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
-     </p>
-     <p>
-      Note: <i>In italics <em>emphasis</em> is rendered as normal text while <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in italics.</i> <i>It also work the same in <a href="#">links in italics with <em>emphasis <em class="odd">in</em> emphasis</em>.</a></i>
-     </p>
-     <p>
-      <code>code</code> is a different kind of markup that doesn't allow nested markup.
-     </p>
-     <p>
-      It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.
-     </p>
-     <p>
-      This is also true between <em>non-</em><code>code</code> markup <em>and</em> <code>code</code>.
-     </p>
-     <p>
-      Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.
-     </p>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="links-and-references">
-      <a href="#links-and-references" class="anchor"></a>Links and references
-     </h2>
-     <p>
-      This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
-     </p>
-     <p>
-      This is a reference to <a href="index.html#val-foo"><code>foo</code></a>. References can have replacement text: <a href="index.html#val-foo">the value foo</a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="index.html#val-foo"><b>bold</b></a>, <a href="index.html#val-foo"><i>italic</i></a>, <a href="index.html#val-foo"><em>emphasis</em></a>, <a href="index.html#val-foo">super<sup>script</sup></a>, <a href="index.html#val-foo">sub<sub>script</sub></a>, and <a href="index.html#val-foo"><code>code</code></a>. It's also possible to surround a reference in a style: <b><a href="index.html#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.
-     </p>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="preformatted-text">
-      <a href="#preformatted-text" class="anchor"></a>Preformatted text
-     </h2>
-     <p>
-      This is a code block:
-     </p>
-     <pre><code>let foo = ()
+   <h2 id="sections">
+    <a href="#sections" class="anchor"></a>Sections
+   </h2>
+   <aside>
+    <p>
+     Let's get these done first, because sections will be used to break up the rest of this test.
+    </p>
+    <p>
+     Besides the section heading above, there are also
+    </p>
+   </aside>
+   <h3 id="subsection-headings">
+    <a href="#subsection-headings" class="anchor"></a>Subsection headings
+   </h3>
+   <aside>
+    <p>
+     and
+    </p>
+   </aside>
+   <h4 id="sub-subsection-headings">
+    <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings
+   </h4>
+   <aside>
+    <p>
+     but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
+    </p>
+   </aside>
+   <h4 id="anchors">
+    <a href="#anchors" class="anchor"></a>Anchors
+   </h4>
+   <aside>
+    <p>
+     Sections can have attached <a href="index.html#anchors">Anchors</a>, and it is possible to <a href="index.html#anchors">link</a> to them. Links to section headers should not be set in source code style.
+    </p>
+   </aside>
+   <h5 id="paragraph">
+    <a href="#paragraph" class="anchor"></a>Paragraph
+   </h5>
+   <aside>
+    <p>
+     Individual paragraphs can have a heading.
+    </p>
+   </aside>
+   <h6 id="subparagraph">
+    <a href="#subparagraph" class="anchor"></a>Subparagraph
+   </h6>
+   <aside>
+    <p>
+     Parts of a longer paragraph that can be considered alone can also have headings.
+    </p>
+   </aside>
+   <h2 id="styling">
+    <a href="#styling" class="anchor"></a>Styling
+   </h2>
+   <aside>
+    <p>
+     This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
+    </p>
+    <p>
+     Note: <i>In italics <em>emphasis</em> is rendered as normal text while <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in italics.</i> <i>It also work the same in <a href="#">links in italics with <em>emphasis <em class="odd">in</em> emphasis</em>.</a></i>
+    </p>
+    <p>
+     <code>code</code> is a different kind of markup that doesn't allow nested markup.
+    </p>
+    <p>
+     It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.
+    </p>
+    <p>
+     This is also true between <em>non-</em><code>code</code> markup <em>and</em> <code>code</code>.
+    </p>
+    <p>
+     Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.
+    </p>
+   </aside>
+   <h2 id="links-and-references">
+    <a href="#links-and-references" class="anchor"></a>Links and references
+   </h2>
+   <aside>
+    <p>
+     This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
+    </p>
+    <p>
+     This is a reference to <a href="index.html#val-foo"><code>foo</code></a>. References can have replacement text: <a href="index.html#val-foo">the value foo</a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="index.html#val-foo"><b>bold</b></a>, <a href="index.html#val-foo"><i>italic</i></a>, <a href="index.html#val-foo"><em>emphasis</em></a>, <a href="index.html#val-foo">super<sup>script</sup></a>, <a href="index.html#val-foo">sub<sub>script</sub></a>, and <a href="index.html#val-foo"><code>code</code></a>. It's also possible to surround a reference in a style: <b><a href="index.html#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.
+    </p>
+   </aside>
+   <h2 id="preformatted-text">
+    <a href="#preformatted-text" class="anchor"></a>Preformatted text
+   </h2>
+   <aside>
+    <p>
+     This is a code block:
+    </p>
+    <pre><code>let foo = ()
 (** There are some nested comments in here, but an unpaired comment
     terminator would terminate the whole doc surrounding comment. It's
     best to keep code blocks no wider than 72 characters. *)
 
 let bar =
   ignore foo</code></pre>
-     <p>
-      There are also verbatim blocks:
-     </p>
-     <pre>The main difference is these don't get syntax highlighting.</pre>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="lists">
-      <a href="#lists" class="anchor"></a>Lists
-     </h2>
-     <ul>
-      <li>
-       This is a
-      </li>
-      <li>
-       shorthand bulleted list,
-      </li>
-      <li>
-       and the paragraphs in each list item support <em>styling</em>.
-      </li>
-     </ul>
-     <ol>
-      <li>
-       This is a
-      </li>
-      <li>
-       shorthand numbered list.
-      </li>
-     </ol>
-     <ul>
-      <li>
-       Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
-      </li>
-     </ul>
-     <p>
-      just creates a paragraph outside the list.
-     </p>
-     <ul>
-      <li>
-       Similarly, inserting a blank line between two list items
-      </li>
-     </ul>
-     <ul>
-      <li>
-       creates two separate lists.
-      </li>
-     </ul>
-     <ul>
-      <li>
-       <p>
-        To get around this limitation, one
-       </p>
-       <p>
-        can use explicitly-delimited lists.
-       </p>
-      </li>
-      <li>
-       This one is bulleted,
-      </li>
-     </ul>
-     <ol>
-      <li>
-       but there is also the numbered variant.
-      </li>
-     </ol>
-     <ul>
-      <li>
-       <ul>
-        <li>
-         lists
-        </li>
-        <li>
-         can be nested
-        </li>
-        <li>
-         and can include references
-        </li>
-        <li>
-         <a href="index.html#val-foo"><code>foo</code></a>
-        </li>
-       </ul>
-      </li>
-     </ul>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="unicode">
-      <a href="#unicode" class="anchor"></a>Unicode
-     </h2>
-     <p>
-      The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
-     </p>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="raw-html">
-      <a href="#raw-html" class="anchor"></a>Raw HTML
-     </h2>
-     <p>
-      Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
-     </p>
-     <blockquote>
-      If the raw HTML is the only thing in a paragraph, it is treated as a block
+    <p>
+     There are also verbatim blocks:
+    </p>
+    <pre>The main difference is these don't get syntax highlighting.</pre>
+   </aside>
+   <h2 id="lists">
+    <a href="#lists" class="anchor"></a>Lists
+   </h2>
+   <aside>
+    <ul>
+     <li>
+      This is a
+     </li>
+     <li>
+      shorthand bulleted list,
+     </li>
+     <li>
+      and the paragraphs in each list item support <em>styling</em>.
+     </li>
+    </ul>
+    <ol>
+     <li>
+      This is a
+     </li>
+     <li>
+      shorthand numbered list.
+     </li>
+    </ol>
+    <ul>
+     <li>
+      Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
+     </li>
+    </ul>
+    <p>
+     just creates a paragraph outside the list.
+    </p>
+    <ul>
+     <li>
+      Similarly, inserting a blank line between two list items
+     </li>
+    </ul>
+    <ul>
+     <li>
+      creates two separate lists.
+     </li>
+    </ul>
+    <ul>
+     <li>
+      <p>
+       To get around this limitation, one
+      </p>
+      <p>
+       can use explicitly-delimited lists.
+      </p>
+     </li>
+     <li>
+      This one is bulleted,
+     </li>
+    </ul>
+    <ol>
+     <li>
+      but there is also the numbered variant.
+     </li>
+    </ol>
+    <ul>
+     <li>
+      <ul>
+       <li>
+        lists
+       </li>
+       <li>
+        can be nested
+       </li>
+       <li>
+        and can include references
+       </li>
+       <li>
+        <a href="index.html#val-foo"><code>foo</code></a>
+       </li>
+      </ul>
+     </li>
+    </ul>
+   </aside>
+   <h2 id="unicode">
+    <a href="#unicode" class="anchor"></a>Unicode
+   </h2>
+   <aside>
+    <p>
+     The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
+    </p>
+   </aside>
+   <h2 id="raw-html">
+    <a href="#raw-html" class="anchor"></a>Raw HTML
+   </h2>
+   <aside>
+    <p>
+     Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
+    </p>
+    <blockquote>
+     If the raw HTML is the only thing in a paragraph, it is treated as a block
       element, and won't be wrapped in paragraph tags by the HTML generator.
-     </blockquote>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="modules">
-      <a href="#modules" class="anchor"></a>Modules
-     </h2>
-     <ul class="modules"></ul>
-     <ul class="modules">
-      <li>
-       <code>X</code>
-      </li>
-     </ul>
-     <ul class="modules">
-      <li>
-       <code>X</code>
-      </li>
-      <li>
-       <code>Y</code>
-      </li>
-      <li>
-       <code>Z</code>
-      </li>
-     </ul>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="tags">
-      <a href="#tags" class="anchor"></a>Tags
-     </h2>
-     <p>
-      Each comment can end with zero or more tags. Here are some examples:
-     </p>
-     <dl>
-      <dt>
-       author
-      </dt>
-      <dd>
-       antron
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       deprecated
-      </dt>
-      <dd>
-       <p>
-        a <em>long</em> time ago
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       parameter foo
-      </dt>
-      <dd>
-       <p>
-        unused
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       raises Failure
-      </dt>
-      <dd>
-       <p>
-        always
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       returns
-      </dt>
-      <dd>
-       <p>
-        never
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       see <a href="#">#</a>
-      </dt>
-      <dd>
-       <p>
-        this url
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       see <code>foo.ml</code>
-      </dt>
-      <dd>
-       <p>
-        this file
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       see Foo
-      </dt>
-      <dd>
-       <p>
-        this document
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       since
-      </dt>
-      <dd>
-       0
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       before 1.0
-      </dt>
-      <dd>
-       <p>
-        it was in b<sup>e</sup>t<sub>a</sub>
-       </p>
-      </dd>
-     </dl>
-     <dl>
-      <dt>
-       version
-      </dt>
-      <dd>
-       -1
-      </dd>
-     </dl>
-    </header>
+    </blockquote>
+   </aside>
+   <h2 id="modules">
+    <a href="#modules" class="anchor"></a>Modules
+   </h2>
+   <aside>
+    <ul class="modules"></ul>
+    <ul class="modules">
+     <li>
+      <code>X</code>
+     </li>
+    </ul>
+    <ul class="modules">
+     <li>
+      <code>X</code>
+     </li>
+     <li>
+      <code>Y</code>
+     </li>
+     <li>
+      <code>Z</code>
+     </li>
+    </ul>
+   </aside>
+   <h2 id="tags">
+    <a href="#tags" class="anchor"></a>Tags
+   </h2>
+   <aside>
+    <p>
+     Each comment can end with zero or more tags. Here are some examples:
+    </p>
     <dl>
-     <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+     <dt>
+      author
+     </dt>
+     <dd>
+      antron
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      deprecated
      </dt>
      <dd>
       <p>
-       Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.
+       a <em>long</em> time ago
       </p>
      </dd>
     </dl>
-   </section>
+    <dl>
+     <dt>
+      parameter foo
+     </dt>
+     <dd>
+      <p>
+       unused
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      raises Failure
+     </dt>
+     <dd>
+      <p>
+       always
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      returns
+     </dt>
+     <dd>
+      <p>
+       never
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      see <a href="#">#</a>
+     </dt>
+     <dd>
+      <p>
+       this url
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      see <code>foo.ml</code>
+     </dt>
+     <dd>
+      <p>
+       this file
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      see Foo
+     </dt>
+     <dd>
+      <p>
+       this document
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      since
+     </dt>
+     <dd>
+      0
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      before 1.0
+     </dt>
+     <dd>
+      <p>
+       it was in b<sup>e</sup>t<sub>a</sub>
+      </p>
+     </dd>
+    </dl>
+    <dl>
+     <dt>
+      version
+     </dt>
+     <dd>
+      -1
+     </dd>
+    </dl>
+   </aside>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+    </dt>
+    <dd>
+     <p>
+      Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -13,18 +13,18 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Module
+  </nav>
+  <header>
+   <h1>
+    Module <code>Module</code>
+   </h1>
+   <p>
+    Foo.
+   </p>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Module
-    </nav>
-    <h1>
-     Module <code>Module</code>
-    </h1>
-    <p>
-     Foo.
-    </p>
-   </header>
    <dl>
     <dt class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>

--- a/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
@@ -32,40 +32,32 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="type">
-      <a href="#type" class="anchor"></a>Type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
-     </dt>
-     <dd>
-      <p>
-       Some type.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="values">
-      <a href="#values" class="anchor"></a>Values
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-y">
-      <a href="#val-y" class="anchor"></a><code><span class="keyword">let</span> y: <a href="index.html#type-t">t</a>;</code>
-     </dt>
-     <dd>
-      <p>
-       The value of y.
-      </p>
-     </dd>
-    </dl>
-   </section>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
+    </dt>
+    <dd>
+     <p>
+      Some type.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="values">
+    <a href="#values" class="anchor"></a>Values
+   </h2>
+   <dl>
+    <dt class="spec value" id="val-y">
+     <a href="#val-y" class="anchor"></a><code><span class="keyword">let</span> y: <a href="index.html#type-t">t</a>;</code>
+    </dt>
+    <dd>
+     <p>
+      The value of y.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
@@ -13,25 +13,25 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+re</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 1-Arg1
+  </nav>
+  <header>
+   <h1>
+    Parameter <code>F.1-Arg1</code>
+   </h1>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+    <li>
+     <a href="#values">Values</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+re</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 1-Arg1
-    </nav>
-    <h1>
-     Parameter <code>F.1-Arg1</code>
-    </h1>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#type">Type</a>
-      </li>
-      <li>
-       <a href="#values">Values</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
@@ -29,23 +29,19 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="type">
-      <a href="#type" class="anchor"></a>Type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
-     </dt>
-     <dd>
-      <p>
-       Some type.
-      </p>
-     </dd>
-    </dl>
-   </section>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
+    </dt>
+    <dd>
+     <p>
+      Some type.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
@@ -13,22 +13,22 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+re</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 2-Arg2
+  </nav>
+  <header>
+   <h1>
+    Parameter <code>F.2-Arg2</code>
+   </h1>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+re</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 2-Arg2
-    </nav>
-    <h1>
-     Parameter <code>F.2-Arg2</code>
-    </h1>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#type">Type</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -13,42 +13,42 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » F
+  </nav>
+  <header>
+   <h1>
+    Module <code>Nested.F</code>
+   </h1>
+   <p>
+    This is a functor F.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
+   <h3 id="heading">
+    <a href="#heading" class="anchor"></a>Parameters
+   </h3>
+   <ul>
+    <li>
+     <code><a href="argument-1-Arg1/index.html">Arg1</a>: <a href="../index.html#module-type-Y">Y</a></code>
+    </li>
+    <li>
+     <code><a href="argument-2-Arg2/index.html">Arg2</a>: { ... }</code>
+    </li>
+   </ul>
+   <h3 id="heading">
+    <a href="#heading" class="anchor"></a>Signature
+   </h3>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » F
-    </nav>
-    <h1>
-     Module <code>Nested.F</code>
-    </h1>
-    <p>
-     This is a functor F.
-    </p>
-    <p>
-     Some additional comments.
-    </p>
-    <h3 id="heading">
-     <a href="#heading" class="anchor"></a>Parameters
-    </h3>
-    <ul>
-     <li>
-      <code><a href="argument-1-Arg1/index.html">Arg1</a>: <a href="../index.html#module-type-Y">Y</a></code>
-     </li>
-     <li>
-      <code><a href="argument-2-Arg2/index.html">Arg2</a>: { ... }</code>
-     </li>
-    </ul>
-    <h3 id="heading">
-     <a href="#heading" class="anchor"></a>Signature
-    </h3>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#type">Type</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -49,23 +49,19 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="type">
-      <a href="#type" class="anchor"></a>Type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = <span>(<a href="argument-1-Arg1/index.html#type-t">Arg1.t</a>, <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a>)</span>;</code>
-     </dt>
-     <dd>
-      <p>
-       Some type.
-      </p>
-     </dd>
-    </dl>
-   </section>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = <span>(<a href="argument-1-Arg1/index.html#type-t">Arg1.t</a>, <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a>)</span>;</code>
+    </dt>
+    <dd>
+     <p>
+      Some type.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -13,31 +13,31 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » X
+  </nav>
+  <header>
+   <h1>
+    Module <code>Nested.X</code>
+   </h1>
+   <p>
+    This is module X.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+    <li>
+     <a href="#values">Values</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » X
-    </nav>
-    <h1>
-     Module <code>Nested.X</code>
-    </h1>
-    <p>
-     This is module X.
-    </p>
-    <p>
-     Some additional comments.
-    </p>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#type">Type</a>
-      </li>
-      <li>
-       <a href="#values">Values</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -38,40 +38,32 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="type">
-      <a href="#type" class="anchor"></a>Type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
-     </dt>
-     <dd>
-      <p>
-       Some type.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="values">
-      <a href="#values" class="anchor"></a>Values
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-x">
-      <a href="#val-x" class="anchor"></a><code><span class="keyword">let</span> x: <a href="index.html#type-t">t</a>;</code>
-     </dt>
-     <dd>
-      <p>
-       The value of x.
-      </p>
-     </dd>
-    </dl>
-   </section>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
+    </dt>
+    <dd>
+     <p>
+      Some type.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="values">
+    <a href="#values" class="anchor"></a>Values
+   </h2>
+   <dl>
+    <dt class="spec value" id="val-x">
+     <a href="#val-x" class="anchor"></a><code><span class="keyword">let</span> x: <a href="index.html#type-t">t</a>;</code>
+    </dt>
+    <dd>
+     <p>
+      The value of x.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+re/Nested/class-inherits/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » inherits
+  </nav>
+  <header>
+   <h1>
+    Class <code>Nested.inherits</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » inherits
-    </nav>
-    <h1>
-     Class <code>Nested.inherits</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec inherit">
      <code><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></code>

--- a/test/html/expect/test_package+re/Nested/class-z/index.html
+++ b/test/html/expect/test_package+re/Nested/class-z/index.html
@@ -13,28 +13,28 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » z
+  </nav>
+  <header>
+   <h1>
+    Class <code>Nested.z</code>
+   </h1>
+   <p>
+    This is class z.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#methods">Methods</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » z
-    </nav>
-    <h1>
-     Class <code>Nested.z</code>
-    </h1>
-    <p>
-     This is class z.
-    </p>
-    <p>
-     Some additional comments.
-    </p>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#methods">Methods</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <dl>
     <dt class="spec instance-variable" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y: int</code>

--- a/test/html/expect/test_package+re/Nested/class-z/index.html
+++ b/test/html/expect/test_package+re/Nested/class-z/index.html
@@ -50,28 +50,24 @@
      <a href="#val-y'" class="anchor"></a><code><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y': int</code>
     </dt>
    </dl>
-   <section>
-    <header>
-     <h2 id="methods">
-      <a href="#methods" class="anchor"></a>Methods
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec method" id="method-z">
-      <a href="#method-z" class="anchor"></a><code><span class="keyword">method</span> z: int</code>
-     </dt>
-     <dd>
-      <p>
-       Some method.
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt class="spec method" id="method-z'">
-      <a href="#method-z'" class="anchor"></a><code><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z': int</code>
-     </dt>
-    </dl>
-   </section>
+   <h2 id="methods">
+    <a href="#methods" class="anchor"></a>Methods
+   </h2>
+   <dl>
+    <dt class="spec method" id="method-z">
+     <a href="#method-z" class="anchor"></a><code><span class="keyword">method</span> z: int</code>
+    </dt>
+    <dd>
+     <p>
+      Some method.
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt class="spec method" id="method-z'">
+     <a href="#method-z'" class="anchor"></a><code><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z': int</code>
+    </dt>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -41,77 +41,61 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="module">
-      <a href="#module" class="anchor"></a>Module
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec module" id="module-X">
-      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a>: { ... };</code>
-     </dt>
-     <dd>
-      <p>
-       This is module X.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="module-type">
-      <a href="#module-type" class="anchor"></a>Module type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec module-type" id="module-type-Y">
-      <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Y/index.html">Y</a> = { ... };</code>
-     </dt>
-     <dd>
-      <p>
-       This is module type Y.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="functor">
-      <a href="#functor" class="anchor"></a>Functor
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec module" id="module-F">
-      <a href="#module-F" class="anchor"></a><code><span class="keyword">module</span> <a href="F/index.html">F</a>:  (<a href="F/argument-1-Arg1/index.html">Arg1</a>: <a href="index.html#module-type-Y">Y</a>) <span>=&gt;</span>  (<a href="F/argument-2-Arg2/index.html">Arg2</a>: { ... }) <span>=&gt;</span> { ... };</code>
-     </dt>
-     <dd>
-      <p>
-       This is a functor F.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="class">
-      <a href="#class" class="anchor"></a>Class
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec class" id="class-z">
-      <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-z/index.html">z</a>: { ... }</code>
-     </dt>
-     <dd>
-      <p>
-       This is class z.
-      </p>
-     </dd>
-    </dl>
-    <div class="spec class" id="class-inherits">
-     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-inherits/index.html">inherits</a>: { ... }</code>
-    </div>
-   </section>
+   <h2 id="module">
+    <a href="#module" class="anchor"></a>Module
+   </h2>
+   <dl>
+    <dt class="spec module" id="module-X">
+     <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a>: { ... };</code>
+    </dt>
+    <dd>
+     <p>
+      This is module X.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="module-type">
+    <a href="#module-type" class="anchor"></a>Module type
+   </h2>
+   <dl>
+    <dt class="spec module-type" id="module-type-Y">
+     <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Y/index.html">Y</a> = { ... };</code>
+    </dt>
+    <dd>
+     <p>
+      This is module type Y.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="functor">
+    <a href="#functor" class="anchor"></a>Functor
+   </h2>
+   <dl>
+    <dt class="spec module" id="module-F">
+     <a href="#module-F" class="anchor"></a><code><span class="keyword">module</span> <a href="F/index.html">F</a>:  (<a href="F/argument-1-Arg1/index.html">Arg1</a>: <a href="index.html#module-type-Y">Y</a>) <span>=&gt;</span>  (<a href="F/argument-2-Arg2/index.html">Arg2</a>: { ... }) <span>=&gt;</span> { ... };</code>
+    </dt>
+    <dd>
+     <p>
+      This is a functor F.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="class">
+    <a href="#class" class="anchor"></a>Class
+   </h2>
+   <dl>
+    <dt class="spec class" id="class-z">
+     <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-z/index.html">z</a>: { ... }</code>
+    </dt>
+    <dd>
+     <p>
+      This is class z.
+     </p>
+    </dd>
+   </dl>
+   <div class="spec class" id="class-inherits">
+    <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-inherits/index.html">inherits</a>: { ... }</code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -13,34 +13,34 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Nested
+  </nav>
+  <header>
+   <h1>
+    Module <code>Nested</code>
+   </h1>
+   <p>
+    This comment needs to be here before #235 is fixed.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#module">Module</a>
+    </li>
+    <li>
+     <a href="#module-type">Module type</a>
+    </li>
+    <li>
+     <a href="#functor">Functor</a>
+    </li>
+    <li>
+     <a href="#class">Class</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Nested
-    </nav>
-    <h1>
-     Module <code>Nested</code>
-    </h1>
-    <p>
-     This comment needs to be here before #235 is fixed.
-    </p>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#module">Module</a>
-      </li>
-      <li>
-       <a href="#module-type">Module type</a>
-      </li>
-      <li>
-       <a href="#functor">Functor</a>
-      </li>
-      <li>
-       <a href="#class">Class</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="module">
     <a href="#module" class="anchor"></a>Module
    </h2>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -13,31 +13,31 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » Y
+  </nav>
+  <header>
+   <h1>
+    Module type <code>Nested.Y</code>
+   </h1>
+   <p>
+    This is module type Y.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+    <li>
+     <a href="#values">Values</a>
+    </li>
+   </ul>
+  </nav>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » Y
-    </nav>
-    <h1>
-     Module type <code>Nested.Y</code>
-    </h1>
-    <p>
-     This is module type Y.
-    </p>
-    <p>
-     Some additional comments.
-    </p>
-    <nav class="toc">
-     <ul>
-      <li>
-       <a href="#type">Type</a>
-      </li>
-      <li>
-       <a href="#values">Values</a>
-      </li>
-     </ul>
-    </nav>
-   </header>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -38,40 +38,32 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="type">
-      <a href="#type" class="anchor"></a>Type
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec type" id="type-t">
-      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
-     </dt>
-     <dd>
-      <p>
-       Some type.
-      </p>
-     </dd>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="values">
-      <a href="#values" class="anchor"></a>Values
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-y">
-      <a href="#val-y" class="anchor"></a><code><span class="keyword">let</span> y: <a href="index.html#type-t">t</a>;</code>
-     </dt>
-     <dd>
-      <p>
-       The value of y.
-      </p>
-     </dd>
-    </dl>
-   </section>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
+   <dl>
+    <dt class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
+    </dt>
+    <dd>
+     <p>
+      Some type.
+     </p>
+    </dd>
+   </dl>
+   <h2 id="values">
+    <a href="#values" class="anchor"></a>Values
+   </h2>
+   <dl>
+    <dt class="spec value" id="val-y">
+     <a href="#val-y" class="anchor"></a><code><span class="keyword">let</span> y: <a href="index.html#type-t">t</a>;</code>
+    </dt>
+    <dd>
+     <p>
+      The value of y.
+     </p>
+    </dd>
+   </dl>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Recent/X/index.html
+++ b/test/html/expect/test_package+re/Recent/X/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Recent</a> » X
+  </nav>
+  <header>
+   <h1>
+    Module <code>Recent.X</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Recent</a> » X
-    </nav>
-    <h1>
-     Module <code>Recent.X</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec module-substitution" id="module-L">
      <a href="#module-L" class="anchor"></a><code><span class="keyword">module</span> L := <a href="../Z/index.html#module-Y">Z.Y</a></code>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Recent
+  </nav>
+  <header>
+   <h1>
+    Module <code>Recent</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Recent
-    </nav>
-    <h1>
-     Module <code>Recent</code>
-    </h1>
-   </header>
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Recent_impl/index.html
+++ b/test/html/expect/test_package+re/Recent_impl/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Recent_impl
+  </nav>
+  <header>
+   <h1>
+    Module <code>Recent_impl</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Recent_impl
-    </nav>
-    <h1>
-     Module <code>Recent_impl</code>
-    </h1>
-   </header>
    <div class="spec module" id="module-Foo">
     <a href="#module-Foo" class="anchor"></a><code><span class="keyword">module</span> <a href="Foo/index.html">Foo</a>: { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Section/index.html
+++ b/test/html/expect/test_package+re/Section/index.html
@@ -55,78 +55,50 @@
      </ul>
     </nav>
    </header>
-   <section>
-    <header>
-     <h2 id="empty-section">
-      <a href="#empty-section" class="anchor"></a>Empty section
-     </h2>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="text-only">
-      <a href="#text-only" class="anchor"></a>Text only
-     </h2>
-     <p>
-      Foo bar.
-     </p>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="aside-only">
-      <a href="#aside-only" class="anchor"></a>Aside only
-     </h2>
-    </header>
-    <aside>
-     <p>
-      Foo bar.
-     </p>
-    </aside>
-   </section>
-   <section>
-    <header>
-     <h2 id="value-only">
-      <a href="#value-only" class="anchor"></a>Value only
-     </h2>
-    </header>
-    <dl>
-     <dt class="spec value" id="val-foo">
-      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-     </dt>
-    </dl>
-   </section>
-   <section>
-    <header>
-     <h2 id="empty-section">
-      <a href="#empty-section" class="anchor"></a>Empty section
-     </h2>
-    </header>
-   </section>
-   <section>
-    <header>
-     <h2 id="within-a-comment">
-      <a href="#within-a-comment" class="anchor"></a>within a comment
-     </h2>
-    </header>
-    <section>
-     <header>
-      <h3 id="and-one-with-a-nested-section">
-       <a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section
-      </h3>
-     </header>
-    </section>
-   </section>
-   <section>
-    <header>
-     <h2 id="this-section-title-has-markup">
-      <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
-     </h2>
-     <p>
-      But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
-     </p>
-    </header>
-   </section>
+   <h2 id="empty-section">
+    <a href="#empty-section" class="anchor"></a>Empty section
+   </h2>
+   <h2 id="text-only">
+    <a href="#text-only" class="anchor"></a>Text only
+   </h2>
+   <aside>
+    <p>
+     Foo bar.
+    </p>
+   </aside>
+   <h2 id="aside-only">
+    <a href="#aside-only" class="anchor"></a>Aside only
+   </h2>
+   <aside>
+    <p>
+     Foo bar.
+    </p>
+   </aside>
+   <h2 id="value-only">
+    <a href="#value-only" class="anchor"></a>Value only
+   </h2>
+   <dl>
+    <dt class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+    </dt>
+   </dl>
+   <h2 id="empty-section">
+    <a href="#empty-section" class="anchor"></a>Empty section
+   </h2>
+   <h2 id="within-a-comment">
+    <a href="#within-a-comment" class="anchor"></a>within a comment
+   </h2>
+   <h3 id="and-one-with-a-nested-section">
+    <a href="#and-one-with-a-nested-section" class="anchor"></a>and one with a nested section
+   </h3>
+   <h2 id="this-section-title-has-markup">
+    <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
+   </h2>
+   <aside>
+    <p>
+     But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+    </p>
+   </aside>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Section/index.html
+++ b/test/html/expect/test_package+re/Section/index.html
@@ -13,48 +13,48 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Section
-    </nav>
-    <h1>
-     Module <code>Section</code>
-    </h1>
-    <p>
-     This is the module comment. Eventually, sections won't be allowed in it.
-    </p>
-    <nav class="toc">
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Section
+  </nav>
+  <header>
+   <h1>
+    Module <code>Section</code>
+   </h1>
+   <p>
+    This is the module comment. Eventually, sections won't be allowed in it.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#empty-section">Empty section</a>
+    </li>
+    <li>
+     <a href="#text-only">Text only</a>
+    </li>
+    <li>
+     <a href="#aside-only">Aside only</a>
+    </li>
+    <li>
+     <a href="#value-only">Value only</a>
+    </li>
+    <li>
+     <a href="#empty-section">Empty section</a>
+    </li>
+    <li>
+     <a href="#within-a-comment">within a comment</a>
      <ul>
       <li>
-       <a href="#empty-section">Empty section</a>
-      </li>
-      <li>
-       <a href="#text-only">Text only</a>
-      </li>
-      <li>
-       <a href="#aside-only">Aside only</a>
-      </li>
-      <li>
-       <a href="#value-only">Value only</a>
-      </li>
-      <li>
-       <a href="#empty-section">Empty section</a>
-      </li>
-      <li>
-       <a href="#within-a-comment">within a comment</a>
-       <ul>
-        <li>
-         <a href="#and-one-with-a-nested-section">and one with a nested section</a>
-        </li>
-       </ul>
-      </li>
-      <li>
-       <a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a>
+       <a href="#and-one-with-a-nested-section">and one with a nested section</a>
       </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+    <li>
+     <a href="#this-section-title-has-markup"><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup></a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
    </h2>

--- a/test/html/expect/test_package+re/Stop/index.html
+++ b/test/html/expect/test_package+re/Stop/index.html
@@ -13,18 +13,18 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Stop
+  </nav>
+  <header>
+   <h1>
+    Module <code>Stop</code>
+   </h1>
+   <p>
+    This test cases exercises stop comments.
+   </p>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Stop
-    </nav>
-    <h1>
-     Module <code>Stop</code>
-    </h1>
-    <p>
-     This test cases exercises stop comments.
-    </p>
-   </header>
    <dl>
     <dt class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: int;</code>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Type
+  </nav>
+  <header>
+   <h1>
+    Module <code>Type</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Type
-    </nav>
-    <h1>
-     Module <code>Type</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec type" id="type-abstract">
      <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type</span> abstract;</code>

--- a/test/html/expect/test_package+re/Val/index.html
+++ b/test/html/expect/test_package+re/Val/index.html
@@ -13,15 +13,15 @@
   </script>
  </head>
  <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Val
+  </nav>
+  <header>
+   <h1>
+    Module <code>Val</code>
+   </h1>
+  </header>
   <div class="content">
-   <header>
-    <nav>
-     <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Val
-    </nav>
-    <h1>
-     Module <code>Val</code>
-    </h1>
-   </header>
    <dl>
     <dt class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span class="keyword">let</span> documented: unit;</code>

--- a/test/html/expect/test_package+re/mld.html
+++ b/test/html/expect/test_package+re/mld.html
@@ -13,39 +13,39 @@
   </script>
  </head>
  <body>
-  <div class="content">
-   <header>
-    <nav>
-     <a href="index.html">Up</a> – <a href="index.html">test_package+re</a> » mld
-    </nav>
-    <h1 id="mld-page">
-     <a href="#mld-page" class="anchor"></a>Mld Page
-    </h1>
-    <p>
-     This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
-    </p>
-    <p>
-     It will have a TOC generated from section headings.
-    </p>
-    <nav class="toc">
+  <nav>
+   <a href="index.html">Up</a> – <a href="index.html">test_package+re</a> » mld
+  </nav>
+  <header>
+   <h1 id="mld-page">
+    <a href="#mld-page" class="anchor"></a>Mld Page
+   </h1>
+   <p>
+    This is an <code>.mld</code> file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
+   </p>
+   <p>
+    It will have a TOC generated from section headings.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#section">Section</a>
+    </li>
+    <li>
+     <a href="#another-section">Another section</a>
      <ul>
       <li>
-       <a href="#section">Section</a>
+       <a href="#subsection">Subsection</a>
       </li>
       <li>
-       <a href="#another-section">Another section</a>
-       <ul>
-        <li>
-         <a href="#subsection">Subsection</a>
-        </li>
-        <li>
-         <a href="#another-subsection">Another Subsection</a>
-        </li>
-       </ul>
+       <a href="#another-subsection">Another Subsection</a>
       </li>
      </ul>
-    </nav>
-   </header>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <h2 id="section">
     <a href="#section" class="anchor"></a>Section
    </h2>

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -178,7 +178,7 @@ let diff =
   fun output ->
     let actual_file   = Env.path `scratch // output in
     let expected_file = Env.path `expect  // output in
-    let cmd = sprintf "diff -u %s %s" expected_file actual_file in
+    let cmd = sprintf "diff -u -b %s %s" expected_file actual_file in
     match Sys.command cmd with
     | 0 -> ()
 

--- a/test/html/tidy.ml
+++ b/test/html/tidy.ml
@@ -9,6 +9,8 @@ let muted_warnings = [
 
   (* NOTE: see https://github.com/ocaml/odoc/issues/186 *)
   "ANCHOR_NOT_UNIQUE";
+
+  "TRIM_EMPTY_ELEMENT";
 ]
 
 


### PR DESCRIPTION
This patch removes the wrapping in `<section>` tags, as discussed in #327 and other various places.
The structure is the one proposed by @dbuenzli in https://github.com/ocaml/odoc/issues/327#issuecomment-467593801 . It can be changed later on fairly easily as well.

The generator initially contained a pretty complicated piece of code to rediscover sectioning while generating the markup. Removing sections allowed to simplify this piece of code dramatically, which is what is done in the rest of the commits. All in all, This removes around 600 lines of code (making the combination of this patch set + #423 a net negative in number of lines!). There are still many code simplification opportunities around, notably around the handling of links, but the IR is now in an (imho) acceptable shape.

I recommend reading commits by commits, and to ignore whitespace in diffs for the test fixes.

Now, Onto man pages! :rocket: 