### PR TITLE
OCaml 4.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ matrix:
       env: OCAML=4.08.1
     - <<: *opam
       os: linux
-      env: OCAML=4.11.0+trunk OCAML_BETA=enable
+      env: OCAML=4.11.0+trunk REPOSITORIES="--repo=default,beta=git://github.com/ocaml/ocaml-beta-repository.git"
     - <<: *opam
       os: linux
       env: OCAML=4.10.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,9 @@ matrix:
       env: OCAML=4.08.1
     - <<: *opam
       os: linux
+      env: OCAML=4.11.0+trunk
+    - <<: *opam
+      os: linux
       env: OCAML=4.10.0
     - <<: *opam
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ matrix:
       env: OCAML=4.08.1
     - <<: *opam
       os: linux
-      env: OCAML=4.11.0+trunk
+      env: OCAML=4.11.0+trunk OCAML_BETA=enable
     - <<: *opam
       os: linux
       env: OCAML=4.10.0

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -78,7 +78,7 @@ let rec read_pattern env parent doc pat =
         read_pattern env parent doc pat
     | Tpat_lazy pat ->
         read_pattern env parent doc pat
-#if OCAML_MAJOR = 4 && OCAML_MINOR >= 08
+#if OCAML_MAJOR = 4 && OCAML_MINOR >= 08 && OCAML_MINOR < 11
     | Tpat_exception pat ->
         read_pattern env parent doc pat
 #endif

--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -33,8 +33,10 @@ let load_payload : Parsetree.payload -> (string * Location.t) option = function
       Pstr_eval ({pexp_desc =
 #if OCAML_MAJOR = 4 && OCAML_MINOR = 02
         Pexp_constant (Const_string (text, _))
-#else
+#elif OCAML_MAJOR = 4 && OCAML_MINOR < 11
         Pexp_constant (Pconst_string (text, _))
+#else
+        Pexp_constant (Pconst_string (text, _, _))
 #endif
    ; pexp_loc = loc; _}, _); _}] ->
     Some (text, loc)


### PR DESCRIPTION
OCaml 4.11.0~alpha1 is out. This PR fixes the compilation issues with this new version