### PR TITLE
Latex backend

### DIFF
--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -112,24 +112,41 @@ and DocumentedSrc : sig
     | Documented of Inline.t documented
     | Nested of t documented
     | Subpage of Subpage.t
+    | Alternative of Alternative.t
 
 end = DocumentedSrc
+
+and Alternative : sig
+  type expansion = { status:[ `Inline | `Open | `Closed | `Default ]; summary: Source.t; expansion: DocumentedSrc.t; url: Url.Path.t }
+  type t =
+    | Expansion of expansion
+
+end =
+  Alternative
 
 and Subpage : sig
 
   type status = [ `Inline | `Open | `Closed | `Default ]
 
   type t = {
-    summary : Source.t ;
     status : status ;
-    content : content ;
+    content : Page.t ;
   }
 
-  and content =
-    | Items of Item.t list
-    | Page of Page.t
 
 end = Subpage
+
+and Include : sig
+
+  type status = [ `Inline | `Open | `Closed | `Default ]
+
+  type t = {
+    status : status ;
+    content : Item.t list ;
+    summary: Source.t
+  }
+
+end = Include
 
 
 and Item : sig
@@ -148,7 +165,7 @@ and Item : sig
     | Text of text
     | Heading of Heading.t
     | Declaration of DocumentedSrc.t item
-    | Subpage of Subpage.t item
+    | Include of Include.t item
 
 end = Item
 

--- a/src/latex/dune
+++ b/src/latex/dune
@@ -1,0 +1,17 @@
+(* -*- tuareg -*- *)
+
+let preprocess =
+  match Sys.getenv "BISECT_ENABLE" with
+  | "yes" -> "(preprocess (pps bisect_ppx))"
+  | _ -> ""
+  | exception Not_found -> ""
+
+let () =
+  Jbuild_plugin.V1.send @@
+    {|
+(library
+ (name odoc_latex)
+ (public_name odoc.latex)
+    |} ^ preprocess ^ {|
+ (libraries odoc_model odoc_document))
+    |}

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -1,0 +1,591 @@
+open Odoc_document.Types
+
+module Doctree = Odoc_document.Doctree
+
+let rec list_concat_map ?sep ~f = function
+  | [] -> []
+  | [x] -> f x
+  | x :: xs ->
+    let hd = f x in
+    let tl = list_concat_map ?sep ~f xs in
+    match sep with
+    | None -> hd @ tl
+    | Some sep -> hd @ sep :: tl
+
+
+type break_hierarchy =
+  | Aesthetic
+  | Simple
+  | Line
+  | Paragraph
+  | Separation
+
+
+type row_size =
+  | Empty
+  | Small (** text only *)
+  | Large (** No table *)
+  | Huge (** tables **)
+
+type elt =
+  | Txt of string list
+  | Section of section
+  | Verbatim of string
+  | Internal_ref of reference
+  | External_ref of string * t option
+  | Label of string
+  | Raw of string
+  | Tag of string * t
+  | Style of [`Emphasis|`Bold|`Superscript|`Subscript|`Italic] * t
+  | Code_block of t
+  | Inlined_code of t
+  | Code_fragment of t
+  | Break of break_hierarchy
+  | List of list_info
+  | Description of (t * t) list
+  | Subpage of t
+  | Table of table
+
+and section = {level:int; label:string option; content:t }
+and list_info = { typ : Block.list_type; items: t list }
+and table = { row_size: row_size; tbl: t list list}
+
+
+and t = elt list
+and reference = { short:bool; target:string; text: t option }
+let const s ppf = Fmt.pf ppf s
+
+
+let option ppf pp = Fmt.pf ppf "[%t]" pp
+let macro name ?(options=[]) pp ppf content =
+  Fmt.pf ppf {|\%s%a{%a}|} name
+    (Fmt.list option) options
+    pp content
+
+let escape_text ~code_hyphenation  =
+  let b = Buffer.create 17 in
+  fun s ->
+    for i = 0 to String.length s - 1 do
+      match s.[i] with
+      | '{' -> Buffer.add_string b "\\{"
+      | '}' ->  Buffer.add_string b "\\}"
+      | '\\' ->  Buffer.add_string b "\\textbackslash{}"
+      | '%' ->  Buffer.add_string b "\\%"
+      | '~' ->  Buffer.add_string b "\\textasciitilde{}"
+      | '^' -> Buffer.add_string b "\\textasciicircum{}"
+      | '_' ->
+        if code_hyphenation then Buffer.add_string b {|\_\allowbreak{}|}
+        else Buffer.add_string b {|\_|}
+      | '.' when code_hyphenation ->  Buffer.add_string b {|.\allowbreak{}|}
+      | ';' when code_hyphenation ->  Buffer.add_string b {|;\allowbreak{}|}
+      | ',' when code_hyphenation ->  Buffer.add_string b {|,\allowbreak{}|}
+
+      | '&' ->  Buffer.add_string b "\\&"
+      | '#' ->  Buffer.add_string b "\\#"
+      | '$' ->  Buffer.add_string b "\\$"
+
+
+      | c ->  Buffer.add_char b c
+    done;
+    let s = Buffer.contents b in
+    Buffer.reset b;
+    s
+
+let escape_ref ppf s =
+  for i = 0 to String.length s - 1 do
+    match s.[i] with
+    | '~' -> Fmt.pf ppf "+t+"
+    | '_' -> Fmt.pf  ppf "+u+"
+    | '+' -> Fmt.pf ppf "+++"
+    | c -> Fmt.pf ppf "%c" c
+  done
+
+module Link = struct
+
+  let rec flatten_path ppf (x: Odoc_document.Url.Path.t) = match x.parent with
+    | Some p -> Fmt.pf ppf "%a-%s-%s" flatten_path p x.kind x.name
+    | None -> Fmt.pf ppf "%s-%s" x.kind x.name
+
+ let page p =
+   Format.asprintf "%a" flatten_path p
+
+
+ let label (x:Odoc_document.Url.t) =
+   match x.anchor with
+   | "" -> page x.page
+   | anchor ->
+       Format.asprintf "%a-%s"
+       flatten_path x.page
+       anchor
+
+  let rec is_class_or_module_path (url : Odoc_document.Url.Path.t) = match url.kind with
+    | "module" | "package" | "class" ->
+      begin match url.parent with
+      | None -> true
+      | Some url -> is_class_or_module_path url
+      end
+    | _ -> false
+
+  let should_inline status url = match status with
+    | `Inline | `Open -> true
+    | `Closed -> false
+    | `Default -> not @@ is_class_or_module_path url
+
+
+end
+
+
+
+let bind pp x ppf = pp ppf x
+let mlabel ppf = macro "label" escape_ref ppf
+let verbatim = macro "verbatim" Fmt.string
+let mbegin ?options = macro "begin" ?options Fmt.string
+let mend = macro "end" Fmt.string
+let mhyperref pp r ppf =
+  match r.target, r.text with
+  | "", None -> ()
+  | "", Some content ->  pp ppf content
+  | s, None ->
+    macro "ref" escape_ref ppf s
+  | s, Some content ->
+      let pp =
+        if r.short then pp else
+          fun ppf x -> Fmt.pf ppf "%a[p%a]" pp x (macro "pageref*" escape_ref) s in
+      macro "hyperref" ~options:[bind escape_ref s] pp ppf content
+
+let label = function
+  | None -> []
+  | Some  x (* {Odoc_document.Url.Anchor.anchor ; page;  _ }*) -> [Label (Link.label  x)]
+
+
+
+let mstyle = function
+  | `Emphasis | `Italic -> macro "emph"
+  | `Bold -> macro "textbf"
+  | `Subscript -> macro "textsubscript"
+  | `Superscript -> macro "textsuperscript"
+
+
+
+let break ppf level =
+  let pre: _ format6 = match level with
+    | Aesthetic -> "%%"
+    | Line -> {|\\|}
+    | Separation -> {|\medbreak|}
+    | _ -> "" in
+  let post: _ format6 = match level with
+    | Line | Separation | Aesthetic | Simple -> ""
+    | Paragraph -> "@," in
+  Fmt.pf ppf (pre ^^ "@," ^^ post)
+
+let env name pp ?(with_break=false) ?(opts=[]) ?(args=[]) ppf content =
+  mbegin ppf name;
+  List.iter (Fmt.pf ppf "[%t]") opts;
+  List.iter (Fmt.pf ppf "{%t}") args;
+  pp ppf content;
+  mend ppf name;
+  break ppf (if with_break then Simple else Aesthetic)
+
+let inline_code = macro "inlinecode"
+let code_block pp ppf x =
+  let name = "ocamlcodeblock" in
+  mbegin ppf name;
+  Fmt.cut ppf ();
+  pp ppf x;
+  Fmt.cut ppf ();
+  mend ppf name
+
+let code_fragment = macro "codefragment"
+let sub pp ppf x = env "adjustwidth" ~args:[const "2em"; const "0pt"] pp ppf x
+
+
+let level_macro = function
+  | 0 ->  macro "section"
+  | 1 -> macro "subsection"
+  | 2 -> macro "subsubsection"
+  | 3 | _ -> macro "paragraph"
+
+let none _ppf () = ()
+
+let list kind pp ppf x =
+  let list =
+    match kind with
+    | Block.Ordered -> env "enumerate"
+    | Unordered -> env "itemize" in
+  let elt ppf = macro "item" pp ppf in
+  list
+    (Fmt.list ~sep:(fun ppf () -> break ppf Aesthetic) elt)
+    ppf
+    x
+
+let description pp ppf x =
+  let elt ppf (d,elt) = macro "item" ~options:[bind pp d] pp ppf elt in
+  let all ppf x =
+    Fmt.pf ppf
+      {|\kern-\topsep
+\makeatletter\advance\%@topsepadd-\topsep\makeatother%% topsep is hardcoded
+|};
+    Fmt.list ~sep:(fun ppf () -> break ppf Aesthetic) elt ppf x in
+  env "description" all ppf x
+
+
+let escape_entity  = function
+  | "#45" -> "-"
+  | "gt" -> ">"
+  | "#8288" -> ""
+  | s -> s
+
+
+let filter_map f x =
+  List.rev @@ List.fold_left (fun acc x ->
+    match f x with
+    | Some x -> x :: acc
+    | None -> acc)
+    [] x
+
+
+let elt_size (x:elt) = match x with
+  | Txt _ | Internal_ref _ | External_ref _ | Label _ | Style _ | Inlined_code _ | Code_fragment _ | Tag _ | Break _ -> Small
+  | List _ | Section _ | Verbatim _ | Raw _ | Code_block _ | Subpage _ | Description _-> Large
+  | Table _  -> Huge
+
+let table = function
+  | [] -> []
+  | a :: _ as m ->
+    let start = List.map (fun _ -> Empty) a in
+    let content_size l = List.fold_left (fun s x -> max s (elt_size x)) Empty l in
+    let row mask l = List.map2 (fun x y -> max x @@ content_size y) mask l in
+    let mask = List.fold_left row start m in
+    let filter_empty = function Empty, _ -> None | (Small | Large | Huge), x -> Some x in
+    let filter_row row = filter_map filter_empty @@ List.combine mask row in
+    let row_size = List.fold_left max Empty mask in
+    [Table { row_size; tbl= List.map filter_row m }]
+
+let txt ~verbatim ~in_source ws =
+  if verbatim then [Txt ws] else
+    let escaped = List.map (escape_text ~code_hyphenation:in_source) ws in
+    match List.filter ( (<>) "" ) escaped with
+    | [] -> []
+    | l -> [ Txt l ]
+
+
+let rec pp_elt ppf = function
+  | Txt words ->
+    Fmt.list Fmt.string ~sep:none ppf words
+  | Section {level; label; content } ->
+    let with_label ppf (label,content) =
+      pp ppf content;
+      match label with
+      | None -> ()
+      | Some label -> mlabel ppf label in
+    level_macro level with_label ppf (label,content)
+  | Break lvl -> break ppf lvl
+  | Raw s -> Fmt.string ppf s
+  | Tag (x,t) -> env ~with_break:true x pp ppf t
+  | Verbatim s -> verbatim ppf s
+  | Internal_ref r -> hyperref ppf r
+  | External_ref (l,x) -> href ppf (l,x)
+  | Style (s,x) -> mstyle s pp ppf x
+  | Code_block [] -> ()
+  | Code_block x -> code_block pp ppf x
+  | Inlined_code x -> inline_code pp ppf x
+  | Code_fragment x -> code_fragment pp ppf x
+  | List {typ; items} -> list typ pp ppf items
+  | Description items -> description pp ppf items
+  | Table { row_size=Large|Huge as size; tbl } -> large_table size ppf tbl
+  | Table { row_size=Small|Empty; tbl } -> small_table ppf tbl
+  | Label x -> mlabel ppf x
+  | Subpage x ->  sub pp ppf x
+
+and pp ppf = function
+  | [] -> ()
+  | Break _ :: (Table _ :: _ as q) -> pp ppf q
+  | Table _ as t :: Break _ :: q ->
+    pp ppf ( t :: q )
+  | Break a :: (Break b :: q) ->
+    pp ppf ( Break (max a b) :: q)
+  | a :: q ->
+    pp_elt ppf a; pp ppf q
+
+and hyperref ppf r = mhyperref pp r ppf
+
+and href ppf (l,txt) =
+  let url ppf s = macro "url" Fmt.string ppf (escape_text ~code_hyphenation:false s) in
+  let footnote = macro "footnote" url in
+  match txt with
+  | Some txt ->
+    Fmt.pf ppf {|\href{%s}{%a}%a|} l pp txt footnote l
+  | None ->  url ppf l
+
+and large_table size ppf tbl =
+    let rec row ppf = function
+      | [] -> break ppf Line
+      | [a] -> pp ppf a
+      | a :: (_ :: _ as q) ->
+        Fmt.pf ppf "%a%a%a"
+          pp a
+          break Aesthetic
+          (sub row) q  in
+    let matrix ppf m =
+
+      List.iter (row ppf) m in
+    match size with
+    | Huge -> break ppf Line; matrix ppf tbl
+    | Large | _ -> sub matrix ppf tbl
+
+and small_table ppf tbl =
+    let columns = List.length (List.hd tbl) in
+    let row ppf x =
+      let ampersand ppf () = Fmt.pf ppf "& " in
+      Fmt.list ~sep:ampersand pp ppf x;
+      break ppf Line in
+    let matrix ppf m = List.iter (row ppf) m in
+    let rec repeat n s ppf = if n = 0 then () else
+        Fmt.pf ppf "%c%t" s (repeat (n - 1) s) in
+    let table ppf tbl = env "longtable"
+      ~opts:[const "l"]
+      ~args:[ repeat columns 'l' ]
+      matrix ppf tbl in
+    Fmt.pf ppf {|{\setlength{\LTpre}{0pt}\setlength{\LTpost}{0pt}%a}|}
+    table tbl
+
+let raw_markup (t:Raw_markup.t) =
+  match t with
+  | `Latex, c -> [Raw c]
+  | _ -> []
+
+let source k (t : Source.t) =
+  let rec token (x : Source.token) = match x with
+    | Elt i -> k i
+    | Tag (None, l) -> tokens l
+    | Tag (Some s, l) -> [Tag(s, tokens l)]
+  and tokens t = list_concat_map t ~f:token in
+  tokens t
+
+
+let rec internalref ~verbatim ~in_source (t : InternalLink.t) =
+  match t with
+  | Resolved (uri, content) ->
+    let target = Link.label uri in
+    let text = Some (inline ~verbatim ~in_source content) in
+    let short = in_source in
+    Internal_ref { short; text; target }
+  | Unresolved content ->
+    let target = "xref-unresolved" in
+    let text = Some (inline ~verbatim ~in_source content) in
+    let short = in_source in
+    Internal_ref { short; target; text }
+
+and inline ~in_source ~verbatim (l : Inline.t) =
+  let one (t : Inline.one) =
+    match t.desc with
+    | Text _s -> assert false
+    | Linebreak -> [Break Line]
+    | Styled (style, c) ->
+      [Style(style, inline ~verbatim ~in_source c)]
+    | Link (ext, c) ->
+      let content = inline ~verbatim:false ~in_source:false  c in
+      [External_ref(ext, Some content)]
+    | InternalLink c ->
+      [internalref ~in_source ~verbatim c]
+    | Source c ->
+      [Inlined_code (source (inline ~verbatim:false ~in_source:true) c)]
+    | Raw_markup r -> raw_markup r
+    | Entity s -> txt ~in_source ~verbatim:true [escape_entity s] in
+
+  let take_text (l: Inline.t) =
+    Doctree.Take.until l ~classify:(function
+      | { Inline.desc = Text code; _ } -> Accum [code]
+      | { desc = Entity e; _ } -> Accum [escape_entity e]
+      | _ -> Stop_and_keep
+    )
+  in
+(* if in_source then block_code_txt s else if_not_empty (fun x -> Txt x) s *)
+  let rec prettify = function
+    | { Inline.desc = Inline.Text _; _ } :: _ as l ->
+      let words, _, rest = take_text l in
+      txt ~in_source ~verbatim words
+      @ prettify rest
+    | o :: q -> one o @ prettify q
+    | [] -> [] in
+  prettify l
+
+let heading (h : Heading.t) =
+  let content = inline ~in_source:false ~verbatim:false h.title in
+  [Section { label=h.label; level=h.level; content }; Break Aesthetic]
+
+let non_empty_block_code  c =
+  let s = source (inline ~verbatim:true ~in_source:true) c in
+  match s with
+  | [] -> []
+  | _ :: _ as l -> [Break Separation; Code_block l; Break Separation]
+
+
+let non_empty_code_fragment c =
+  let s = source (inline ~verbatim:false ~in_source:true) c in
+  match s with
+  | [] -> []
+  | _ :: _ as l -> [Code_fragment l]
+
+let rec block ~in_source (l: Block.t)  =
+  let one (t : Block.one) =
+    match t.desc with
+    | Inline i ->
+      inline ~verbatim:false ~in_source:false i
+    | Paragraph i ->
+      inline ~in_source:false ~verbatim:false i @ if in_source then [] else [Break Paragraph]
+    | List (typ, l) ->
+      [List { typ; items = List.map (block ~in_source:false) l }]
+    | Description l ->
+      [Description (List.map (fun (i,b) ->
+          inline ~in_source ~verbatim:false i,
+          block ~in_source b
+      ) l)]
+    | Raw_markup r ->
+       raw_markup r
+    | Verbatim s -> [Verbatim s]
+    | Source c -> non_empty_block_code c
+  in
+  list_concat_map l ~f:one
+
+
+let rec is_only_text l =
+  let is_text : Item.t -> _ = function
+    | Heading _ | Text _ -> true
+    | Declaration _
+      -> false
+    |  Include { content = items; _ }
+      -> is_only_text items.content
+  in
+  List.for_all is_text l
+
+
+let rec documentedSrc (t : DocumentedSrc.t) =
+  let open DocumentedSrc in
+  let rec to_latex t = match t with
+    | [] -> []
+    | Code _ :: _ ->
+      let take_code l =
+        Doctree.Take.until l ~classify:(function
+          | Code code -> Accum code
+          | _ -> Stop_and_keep
+        )
+      in
+      let code, _, rest = take_code t in
+      non_empty_code_fragment code
+      @ to_latex rest
+    | Alternative (Expansion e) :: rest ->
+      begin if Link.should_inline e.status e.url then
+        to_latex e.expansion
+      else
+        non_empty_code_fragment e.summary
+    end
+        @ to_latex rest
+    | Subpage subp :: rest ->
+      Subpage (items subp.content.items)
+      :: to_latex rest
+    | (Documented _ | Nested _) :: _ ->
+      let take_descr l =
+        Doctree.Take.until l ~classify:(function
+          | Documented { attrs; anchor; code; doc }  ->
+            Accum [{DocumentedSrc. attrs ; anchor ; code = `D code; doc }]
+          | Nested { attrs; anchor; code; doc } ->
+            Accum [{DocumentedSrc. attrs ; anchor ; code = `N code; doc }]
+          | _ -> Stop_and_keep
+        )
+      in
+      let l, _, rest = take_descr t in
+      let one dsrc =
+        let content = match dsrc.code with
+          | `D code -> inline ~verbatim:false ~in_source:true code
+          | `N n -> to_latex n
+        in
+        let doc = [block ~in_source:true dsrc.doc] in
+        (content @ label dsrc.anchor ) :: doc
+      in
+      table (List.map one l) @ to_latex rest
+  in
+  to_latex t
+
+
+and items l =
+  let[@tailrec] rec walk_items
+      ~only_text acc (t : Item.t list) =
+    let continue_with rest elts =
+      walk_items ~only_text (List.rev_append elts acc) rest
+    in
+    match t with
+    | [] -> List.rev acc
+    | Text _ :: _ as t ->
+      let text, _, rest = Doctree.Take.until t ~classify:(function
+        | Item.Text text -> Accum text
+        | _ -> Stop_and_keep)
+      in
+      let content = block ~in_source:false text in
+      let elts = content in
+      elts
+      |> continue_with rest
+    | Heading h :: rest ->
+      heading h
+      |> continue_with rest
+    | Include
+        { kind=_; anchor; doc ; content = { summary; status=_; content } }
+      :: rest ->
+      let included = items content  in
+      let docs = block ~in_source:true  doc in
+      let summary = source (inline ~verbatim:false ~in_source:true) summary in
+      let content = included in
+      (label anchor @ docs @ summary @ content)
+      |> continue_with rest
+
+    | Declaration {Item. kind=_; anchor ; content ; doc} :: rest ->
+      let content =  label anchor @ documentedSrc content in
+      let elts = match doc with
+        | [] -> content @ [Break Line]
+        | docs -> content @ Break Line :: block ~in_source:true docs @ [Break Separation]
+      in
+      continue_with rest elts
+
+  and items l = walk_items ~only_text:(is_only_text l) [] l in
+  items l
+
+
+module Doc = struct
+
+let make url filename content children =
+  let label = Label (Link.page url) in
+  let content = match content with
+    | [] -> [label]
+    | Section _ as s  :: q -> s :: label :: q
+    | q -> label :: q in
+  let content ppf = Fmt.pf ppf "@[<v>%a@]@." pp content in
+  {Odoc_document.Renderer. filename; content; children }
+end
+
+module Page = struct
+
+
+
+  let on_sub = function
+    | `Page _ -> Some 1
+    | `Include _ -> None
+
+
+  let rec subpage (p:Subpage.t) = if Link.should_inline p.status p.content.url then [] else [ page p.content ]
+
+  and subpages i =
+    List.flatten @@ List.map subpage @@ Doctree.Subpages.compute i
+
+  and page ({Page. title; header; items = i; url } as p) =
+    let i = Doctree.Shift.compute ~on_sub i in
+    let subpages = subpages p in
+    let header = items header in
+    let content = items i in
+    let page =
+      Doc.make url title (header@content) subpages
+    in
+    page
+
+end
+
+let render page = Page.page page

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -45,6 +45,7 @@ type elt =
   | Description of (t * t) list
   | Subpage of t
   | Table of table
+  | Ligaturable of string
 
 and section = {level:int; label:string option; content:t }
 and list_info = { typ : Block.list_type; items: t list }
@@ -243,9 +244,8 @@ let filter_map f x =
     | None -> acc)
     [] x
 
-
 let elt_size (x:elt) = match x with
-  | Txt _ | Internal_ref _ | External_ref _ | Label _ | Style _ | Inlined_code _ | Code_fragment _ | Tag _ | Break _ -> Small
+  | Txt _ | Internal_ref _ | External_ref _ | Label _ | Style _ | Inlined_code _ | Code_fragment _ | Tag _ | Break _ | Ligaturable _ -> Small
   | List _ | Section _ | Verbatim _ | Raw _ | Code_block _ | Subpage _ | Description _-> Large
   | Table _  -> Huge
 
@@ -268,6 +268,11 @@ let txt ~verbatim ~in_source ws =
     | [] -> []
     | l -> [ Txt l ]
 
+let entity ~in_source ~verbatim x =
+  if in_source && not verbatim then
+    Ligaturable (escape_entity x)
+  else
+    Txt [escape_entity x]
 
 let rec pp_elt ppf = function
   | Txt words ->
@@ -296,6 +301,7 @@ let rec pp_elt ppf = function
   | Table { row_size=Small|Empty; tbl } -> small_table ppf tbl
   | Label x -> mlabel ppf x
   | Subpage x ->  sub pp ppf x
+  | Ligaturable s -> Fmt.string ppf s
 
 and pp ppf = function
   | [] -> ()
@@ -304,6 +310,8 @@ and pp ppf = function
     pp ppf ( t :: q )
   | Break a :: (Break b :: q) ->
     pp ppf ( Break (max a b) :: q)
+  | Ligaturable "-" :: Ligaturable ">" :: q ->
+     Fmt.string ppf {|$\rightarrow$|}; pp ppf q
   | a :: q ->
     pp_elt ppf a; pp ppf q
 
@@ -391,7 +399,7 @@ and inline ~in_source ~verbatim (l : Inline.t) =
     | Source c ->
       [Inlined_code (source (inline ~verbatim:false ~in_source:true) c)]
     | Raw_markup r -> raw_markup r
-    | Entity s -> txt ~in_source ~verbatim:true [escape_entity s] in
+    | Entity s -> [entity ~in_source ~verbatim s] in
 
   let take_text (l: Inline.t) =
     Doctree.Take.until l ~classify:(function

--- a/src/latex/generator.mli
+++ b/src/latex/generator.mli
@@ -1,0 +1,1 @@
+val render : Odoc_document.Types.Page.t -> Odoc_document.Renderer.page

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -15,6 +15,8 @@ type style = [
 
 type raw_markup_target = [
   | `Html
+  | `Latex
+  | `Manpage
 ]
 
 type leaf_inline_element = [

--- a/src/odoc/dune
+++ b/src/odoc/dune
@@ -7,6 +7,7 @@
   odoc_compat
   odoc_html
   odoc_manpage
+  odoc_latex
   odoc_loader
   odoc_model
   odoc_xref2

--- a/src/odoc/latex.ml
+++ b/src/odoc/latex.ml
@@ -1,0 +1,93 @@
+
+open StdLabels
+open Or_error
+open Odoc_document
+
+let document_of_page ~syntax v =
+  match syntax with
+  | Renderer.Reason -> Odoc_document.Reason.page v
+  | Renderer.OCaml -> Odoc_document.ML.page v
+
+let document_of_compilation_unit ~syntax v =
+  match syntax with
+  | Renderer.Reason -> Odoc_document.Reason.compilation_unit v
+  | Renderer.OCaml -> Odoc_document.ML.compilation_unit v
+
+let mk_page ~syntax v =
+  Odoc_latex.Generator.render @@
+  document_of_page ~syntax v
+
+let mk_compilation_unit ~syntax v =
+  Odoc_latex.Generator.render @@
+  document_of_compilation_unit ~syntax v
+
+
+let with_tex_file ~pkg_dir ~page_name f =
+  let oc =
+    let f = Fs.File.create ~directory:pkg_dir ~name:(page_name ^ ".tex") in
+    open_out (Fs.File.to_string f)
+  in
+  let fmt = Format.formatter_of_out_channel oc in
+  Format.fprintf fmt "%t@?" f;
+  close_out oc
+
+let mk_pkg_dir root_dir pkg_name =
+  let pkg_dir = Fs.Directory.reach_from ~dir:root_dir pkg_name in
+  Fs.Directory.mkdir_p pkg_dir;
+  pkg_dir
+
+
+let link_children pkgdir parents self children ppf =
+  let page_input ppf name =
+    let child_fullname = String.concat ~sep:"." (List.rev (name :: self :: parents)) ^ ".tex" in
+    let loc = Fs.File.( to_string @@ create ~directory:pkgdir ~name:child_fullname) in
+    Format.fprintf ppf  {|@[<v>\input{%s}@,@]|} loc in
+  List.iter ~f:(page_input ppf) children
+
+
+(* We need to take care of linking children ourselves *)
+let traverse ~f t =
+  let rec aux parents (node:Renderer.page) =
+    let children_names = List.map ~f:(fun (x:Renderer.page) -> x.filename) node.children in
+    f ~parents ~children_names node.filename node.content;
+    List.iter ~f:(aux (node.filename :: parents)) node.children
+  in
+  aux [] t
+
+
+let from_odoc ~env ?(syntax=Renderer.OCaml) ?(with_children=true) ~output:root_dir input =
+  Root.read input >>= fun root ->
+  let input_s = Fs.File.to_string input in
+  match root.file with
+  | Page page_name ->
+    Page.load input >>= fun page ->
+    let odoctree =
+      let resolve_env = Env.build env (`Page page) in
+      Odoc_xref2.Link.resolve_page resolve_env page
+      |> Odoc_xref2.Lookup_failures.to_warning ~filename:input_s
+      |> Odoc_model.Error.shed_warnings
+    in
+    let pkg_name = root.package in
+    let pkg_dir = mk_pkg_dir root_dir pkg_name in
+    let pages = mk_page ~syntax odoctree in
+    Renderer.traverse pages ~f:(fun ~parents _pkg_name content ->
+      assert (parents = []); with_tex_file ~pkg_dir ~page_name content
+    );
+    Ok ()
+  | Compilation_unit {hidden = _; _} ->
+    Compilation_unit.load input >>= fun unit ->
+    let odoctree =
+      let env = Env.build env (`Unit unit) in
+      Odoc_xref2.Link.link env unit
+      |> Odoc_xref2.Lookup_failures.to_warning ~filename:input_s
+      |> Odoc_model.Error.shed_warnings in
+    let pkg_dir = mk_pkg_dir  root_dir root.package in
+    let pages = mk_compilation_unit ~syntax odoctree in
+    traverse pages ~f:(fun ~parents ~children_names name content ->
+      let page_name = String.concat ~sep:"." (List.rev @@ name :: parents) in
+      with_tex_file ~pkg_dir ~page_name (fun ppf ->
+        content ppf;
+        if with_children then link_children pkg_dir parents name children_names ppf
+      )
+    );
+    Ok ()

--- a/test/html/expect/test_package+custom_theme,ml/Include/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Include/index.html
@@ -32,11 +32,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
+       </div>
       </details>
      </div>
     </div>
@@ -47,11 +45,9 @@
    <div>
     <div class="spec include">
      <div class="doc">
-      <dl>
-       <dt class="spec type" id="type-u">
-        <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code>
-       </dt>
-      </dl>
+      <div class="spec type" id="type-u">
+       <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code>
+      </div>
      </div>
     </div>
    </div>
@@ -65,11 +61,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-v">
-         <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-v">
+        <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v</code>
+       </div>
       </details>
      </div>
     </div>
@@ -84,11 +78,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-w">
-         <a href="#type-w" class="anchor"></a><code><span class="keyword">type</span> w</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-w">
+        <a href="#type-w" class="anchor"></a><code><span class="keyword">type</span> w</code>
+       </div>
       </details>
      </div>
     </div>

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -25,16 +25,16 @@
    </p>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
@@ -53,11 +53,9 @@
    <div class="spec module-type" id="module-type-S5">
     <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <span>'a <a href="module-type-S/index.html#type-v">v</a></span> := <span><span class="type-var">'a</span> list</span></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-result">
-     <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) result</span></code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-result">
+    <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) result</span></code>
+   </div>
    <div class="spec module-type" id="module-type-S6">
     <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <span>('a, 'b) <a href="module-type-S/index.html#type-w">w</a></span> := <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="index.html#type-result">result</a></span></code>
    </div>

--- a/test/html/expect/test_package+custom_theme,ml/Section/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Section/index.html
@@ -77,11 +77,9 @@
    <h2 id="value-only">
     <a href="#value-only" class="anchor"></a>Value only
    </h2>
-   <dl>
-    <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-foo">
+    <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+   </div>
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
    </h2>

--- a/test/html/expect/test_package+custom_theme,ml/Val/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Val/index.html
@@ -22,29 +22,29 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec value" id="val-documented">
+   <div>
+    <div class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span class="keyword">val</span> documented : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Foo.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-undocumented">
-     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val</span> undocumented : unit</code>
-    </dt>
-    <dt class="spec value" id="val-documented_above">
+    </div>
+   </div>
+   <div class="spec value" id="val-undocumented">
+    <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val</span> undocumented : unit</code>
+   </div>
+   <div>
+    <div class="spec value" id="val-documented_above">
      <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">val</span> documented_above : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Bar.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Alias/X/index.html
+++ b/test/html/expect/test_package+ml/Alias/X/index.html
@@ -22,16 +22,16 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = int</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Module Foo__X documentation. This should appear in the documentation for the alias to this module 'X'
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -22,21 +22,19 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec type" id="type-opt">
-     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt</span> = <span><span class="type-var">'a</span> option</span></code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div class="spec type" id="type-opt">
+    <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt</span> = <span><span class="type-var">'a</span> option</span></code>
+   </div>
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : <span>?⁠bar:<span class="type-var">'a</span></span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Triggers an assertion failure when <a href="https://github.com/ocaml/odoc/issues/101">https://github.com/ocaml/odoc/issues/101</a> is not fixed.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Bugs_pre_410/index.html
+++ b/test/html/expect/test_package+ml/Bugs_pre_410/index.html
@@ -22,21 +22,19 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec type" id="type-opt'">
-     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt'</span> = <span>int option</span></code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-foo'">
+   <div class="spec type" id="type-opt'">
+    <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt'</span> = <span>int option</span></code>
+   </div>
+   <div>
+    <div class="spec value" id="val-foo'">
      <a href="#val-foo'" class="anchor"></a><code><span class="keyword">val</span> foo' : <span>?⁠bar:<span class="type-var">'a</span></span> <span>-&gt;</span> unit <span>-&gt;</span> unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Similar to <code>Bugs</code>, but the printed type of <code>~bar</code> should be <code>int</code>, not <code>'a</code>. This probably requires fixing in the compiler. See <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">https://github.com/ocaml/odoc/pull/230#issuecomment-433226807</a>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -23,13 +23,13 @@
   </header>
   <div class="content">
    <div class="spec class-type" id="class-type-empty">
-    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class-type" id="class-type-mutually">
-    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-mutually/index.html">mutually</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-mutually/index.html">mutually</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class-type" id="class-type-recursive">
-    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-type-recursive/index.html">recursive</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-type-recursive/index.html">recursive</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-mutually'">
     <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-mutually'/index.html">mutually'</a> : <a href="class-type-mutually/index.html">mutually</a></code>
@@ -38,13 +38,13 @@
     <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-recursive'/index.html">recursive'</a> : <a href="class-type-recursive/index.html">recursive</a></code>
    </div>
    <div class="spec class-type" id="class-type-empty_virtual">
-    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  <a href="class-type-empty_virtual/index.html">empty_virtual</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  <a href="class-type-empty_virtual/index.html">empty_virtual</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-empty_virtual'">
     <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-empty_virtual'/index.html">empty_virtual'</a> : <a href="class-type-empty/index.html">empty</a></code>
    </div>
    <div class="spec class-type" id="class-type-polymorphic">
-    <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> 'a <a href="class-type-polymorphic/index.html">polymorphic</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> 'a <a href="class-type-polymorphic/index.html">polymorphic</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-polymorphic'">
     <a href="#class-polymorphic'" class="anchor"></a><code><span class="keyword">class</span> 'a <a href="class-polymorphic'/index.html">polymorphic'</a> : <span><span class="type-var">'a</span> <a href="class-type-polymorphic/index.html">polymorphic</a></span></code>

--- a/test/html/expect/test_package+ml/External/index.html
+++ b/test/html/expect/test_package+ml/External/index.html
@@ -22,16 +22,16 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec external" id="val-foo">
+   <div>
+    <div class="spec external" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit <span>-&gt;</span> unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Foo <em>bar</em>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Include/index.html
+++ b/test/html/expect/test_package+ml/Include/index.html
@@ -32,11 +32,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
+       </div>
       </details>
      </div>
     </div>
@@ -47,11 +45,9 @@
    <div>
     <div class="spec include">
      <div class="doc">
-      <dl>
-       <dt class="spec type" id="type-u">
-        <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code>
-       </dt>
-      </dl>
+      <div class="spec type" id="type-u">
+       <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code>
+      </div>
      </div>
     </div>
    </div>
@@ -65,11 +61,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-v">
-         <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-v">
+        <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v</code>
+       </div>
       </details>
      </div>
     </div>
@@ -84,11 +78,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-w">
-         <a href="#type-w" class="anchor"></a><code><span class="keyword">type</span> w</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-w">
+        <a href="#type-w" class="anchor"></a><code><span class="keyword">type</span> w</code>
+       </div>
       </details>
      </div>
     </div>

--- a/test/html/expect/test_package+ml/Include2/index.html
+++ b/test/html/expect/test_package+ml/Include2/index.html
@@ -22,16 +22,16 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec module" id="module-X">
+   <div>
+    <div class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Comment about X that should not appear when including X below.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div>
     <div class="spec include">
      <div class="doc">
@@ -39,11 +39,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="X/index.html">X</a></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = int</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = int</code>
+       </div>
       </details>
      </div>
     </div>

--- a/test/html/expect/test_package+ml/Include_sections/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/index.html
@@ -69,16 +69,16 @@
    </ul>
   </nav>
   <div class="content">
-   <dl>
-    <dt class="spec module-type" id="module-type-Something">
+   <div>
+    <div class="spec module-type" id="module-type-Something">
      <a href="#module-type-Something" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Something/index.html">Something</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A module type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <aside>
     <p>
      Let's include <a href="module-type-Something/index.html"><code>Something</code></a> once
@@ -87,11 +87,9 @@
    <div>
     <div class="spec include">
      <div class="doc">
-      <dl>
-       <dt class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-something">
+       <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
+      </div>
       <h2 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h2>
@@ -100,24 +98,22 @@
         foo
        </p>
       </aside>
-      <dl>
-       <dt class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-foo">
+       <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+      </div>
       <h3 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h3>
-      <dl>
-       <dt class="spec value" id="val-bar">
+      <div>
+       <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-       </dt>
-       <dd>
+       </div>
+       <div>
         <p>
          foo bar
         </p>
-       </dd>
-      </dl>
+       </div>
+      </div>
       <h2 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h2>
@@ -140,11 +136,9 @@
    <div>
     <div class="spec include">
      <div class="doc">
-      <dl>
-       <dt class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-something">
+       <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
+      </div>
       <h3 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h3>
@@ -153,24 +147,22 @@
         foo
        </p>
       </aside>
-      <dl>
-       <dt class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-foo">
+       <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+      </div>
       <h4 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h4>
-      <dl>
-       <dt class="spec value" id="val-bar">
+      <div>
+       <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-       </dt>
-       <dd>
+       </div>
+       <div>
         <p>
          foo bar
         </p>
-       </dd>
-      </dl>
+       </div>
+      </div>
       <h3 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h3>
@@ -193,11 +185,9 @@
    <div>
     <div class="spec include">
      <div class="doc">
-      <dl>
-       <dt class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-something">
+       <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
+      </div>
       <h4 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h4>
@@ -206,24 +196,22 @@
         foo
        </p>
       </aside>
-      <dl>
-       <dt class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-foo">
+       <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+      </div>
       <h5 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h5>
-      <dl>
-       <dt class="spec value" id="val-bar">
+      <div>
+       <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-       </dt>
-       <dd>
+       </div>
+       <div>
         <p>
          foo bar
         </p>
-       </dd>
-      </dl>
+       </div>
+      </div>
       <h4 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h4>
@@ -247,11 +235,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Something/index.html">Something</a></code></span>
        </summary>
-       <dl>
-        <dt class="spec value" id="val-something">
-         <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
-        </dt>
-       </dl>
+       <div class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
+       </div>
        <h2 id="something-1">
         <a href="#something-1" class="anchor"></a>Something 1
        </h2>
@@ -260,24 +246,22 @@
          foo
         </p>
        </aside>
-       <dl>
-        <dt class="spec value" id="val-foo">
-         <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-        </dt>
-       </dl>
+       <div class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+       </div>
        <h3 id="something-2">
         <a href="#something-2" class="anchor"></a>Something 2
        </h3>
-       <dl>
-        <dt class="spec value" id="val-bar">
+       <div>
+        <div class="spec value" id="val-bar">
          <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-        </dt>
-        <dd>
+        </div>
+        <div>
          <p>
           foo bar
          </p>
-        </dd>
-       </dl>
+        </div>
+       </div>
        <h2 id="something-1-bis">
         <a href="#something-1-bis" class="anchor"></a>Something 1-bis
        </h2>

--- a/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
@@ -40,11 +40,9 @@
    </ul>
   </nav>
   <div class="content">
-   <dl>
-    <dt class="spec value" id="val-something">
-     <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-something">
+    <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
+   </div>
    <h2 id="something-1">
     <a href="#something-1" class="anchor"></a>Something 1
    </h2>
@@ -53,24 +51,22 @@
      foo
     </p>
    </aside>
-   <dl>
-    <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-foo">
+    <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+   </div>
    <h3 id="something-2">
     <a href="#something-2" class="anchor"></a>Something 2
    </h3>
-   <dl>
-    <dt class="spec value" id="val-bar">
+   <div>
+    <div class="spec value" id="val-bar">
      <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       foo bar
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="something-1-bis">
     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
    </h2>

--- a/test/html/expect/test_package+ml/Interlude/index.html
+++ b/test/html/expect/test_package+ml/Interlude/index.html
@@ -30,16 +30,16 @@
      Some separate stray text at the top of the module.
     </p>
    </aside>
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Foo.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <aside>
     <p>
      Some stray text that is not associated with any signature item.
@@ -51,27 +51,25 @@
      A separate block of stray text, adjacent to the preceding one.
     </p>
    </aside>
-   <dl>
-    <dt class="spec value" id="val-bar">
+   <div>
+    <div class="spec value" id="val-bar">
      <a href="#val-bar" class="anchor"></a><code><span class="keyword">val</span> bar : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Bar.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-multiple">
-     <a href="#val-multiple" class="anchor"></a><code><span class="keyword">val</span> multiple : unit</code>
-    </dt>
-    <dt class="spec value" id="val-signature">
-     <a href="#val-signature" class="anchor"></a><code><span class="keyword">val</span> signature : unit</code>
-    </dt>
-    <dt class="spec value" id="val-items">
-     <a href="#val-items" class="anchor"></a><code><span class="keyword">val</span> items : unit</code>
-    </dt>
-   </dl>
+    </div>
+   </div>
+   <div class="spec value" id="val-multiple">
+    <a href="#val-multiple" class="anchor"></a><code><span class="keyword">val</span> multiple : unit</code>
+   </div>
+   <div class="spec value" id="val-signature">
+    <a href="#val-signature" class="anchor"></a><code><span class="keyword">val</span> signature : unit</code>
+   </div>
+   <div class="spec value" id="val-items">
+    <a href="#val-items" class="anchor"></a><code><span class="keyword">val</span> items : unit</code>
+   </div>
    <aside>
     <p>
      Stray text at the bottom of the module.

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -415,16 +415,16 @@ let bar =
      </dd>
     </dl>
    </aside>
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -25,16 +25,16 @@
    </p>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
@@ -53,11 +53,9 @@
    <div class="spec module-type" id="module-type-S5">
     <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <span>'a <a href="module-type-S/index.html#type-v">v</a></span> := <span><span class="type-var">'a</span> list</span></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-result">
-     <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) result</span></code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-result">
+    <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) result</span></code>
+   </div>
    <div class="spec module-type" id="module-type-S6">
     <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <span>('a, 'b) <a href="module-type-S/index.html#type-w">w</a></span> := <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="index.html#type-result">result</a></span></code>
    </div>

--- a/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
@@ -35,29 +35,29 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <dl>
-    <dt class="spec value" id="val-y">
+   <div>
+    <div class="spec value" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : <a href="index.html#type-t">t</a></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       The value of y.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
@@ -32,16 +32,16 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -28,8 +28,8 @@
      Some additional comments.
     </p>
    </aside>
-   <h3 id="heading">
-    <a href="#heading" class="anchor"></a>Parameters
+   <h3 id="parameters">
+    <a href="#parameters" class="anchor"></a>Parameters
    </h3>
    <div class="spec parameter" id="argument-1-Arg1">
     <a href="#argument-1-Arg1" class="anchor"></a><code><span class="keyword">module</span> <a href="argument-1-Arg1/index.html">Arg1</a> : <a href="../module-type-Y/index.html">Y</a></code>
@@ -37,8 +37,8 @@
    <div class="spec parameter" id="argument-2-Arg2">
     <a href="#argument-2-Arg2" class="anchor"></a><code><span class="keyword">module</span> <a href="argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <h3 id="heading">
-    <a href="#heading" class="anchor"></a>Signature
+   <h3 id="signature">
+    <a href="#signature" class="anchor"></a>Signature
    </h3>
   </header>
   <nav class="toc">
@@ -52,16 +52,16 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = <a href="argument-1-Arg1/index.html#type-t">Arg1.t</a> * <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -41,29 +41,29 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <dl>
-    <dt class="spec value" id="val-x">
+   <div>
+    <div class="spec value" id="val-x">
      <a href="#val-x" class="anchor"></a><code><span class="keyword">val</span> x : <a href="index.html#type-t">t</a></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       The value of x.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-inherits/index.html
@@ -22,11 +22,9 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec inherit">
-     <code><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></code>
-    </dt>
-   </dl>
+   <div class="spec inherit">
+    <code><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/class-z/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-z/index.html
@@ -35,39 +35,35 @@
    </ul>
   </nav>
   <div class="content">
-   <dl>
-    <dt class="spec instance-variable" id="val-y">
+   <div>
+    <div class="spec instance-variable" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : int</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some value.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec instance-variable" id="val-y'">
-     <a href="#val-y'" class="anchor"></a><code><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y' : int</code>
-    </dt>
-   </dl>
+    </div>
+   </div>
+   <div class="spec instance-variable" id="val-y'">
+    <a href="#val-y'" class="anchor"></a><code><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y' : int</code>
+   </div>
    <h2 id="methods">
     <a href="#methods" class="anchor"></a>Methods
    </h2>
-   <dl>
-    <dt class="spec method" id="method-z">
+   <div>
+    <div class="spec method" id="method-z">
      <a href="#method-z" class="anchor"></a><code><span class="keyword">method</span> z : int</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some method.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec method" id="method-z'">
-     <a href="#method-z'" class="anchor"></a><code><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z' : int</code>
-    </dt>
-   </dl>
+    </div>
+   </div>
+   <div class="spec method" id="method-z'">
+    <a href="#method-z'" class="anchor"></a><code><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z' : int</code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -44,55 +44,55 @@
    <h2 id="module">
     <a href="#module" class="anchor"></a>Module
    </h2>
-   <dl>
-    <dt class="spec module" id="module-X">
+   <div>
+    <div class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is module X.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="module-type">
     <a href="#module-type" class="anchor"></a>Module type
    </h2>
-   <dl>
-    <dt class="spec module-type" id="module-type-Y">
+   <div>
+    <div class="spec module-type" id="module-type-Y">
      <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Y/index.html">Y</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is module type Y.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="functor">
     <a href="#functor" class="anchor"></a>Functor
    </h2>
-   <dl>
-    <dt class="spec module" id="module-F">
+   <div>
+    <div class="spec module" id="module-F">
      <a href="#module-F" class="anchor"></a><code><span class="keyword">module</span> <a href="F/index.html">F</a> : <span class="keyword">functor</span> (<a href="F/argument-1-Arg1/index.html">Arg1</a> : <a href="module-type-Y/index.html">Y</a>) <span>-&gt;</span> <span class="keyword">functor</span> (<a href="F/argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is a functor F.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="class">
     <a href="#class" class="anchor"></a>Class
    </h2>
-   <dl>
-    <dt class="spec class" id="class-z">
+   <div>
+    <div class="spec class" id="class-z">
      <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-z/index.html">z</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is class z.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec class" id="class-inherits">
     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-inherits/index.html">inherits</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -41,29 +41,29 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <dl>
-    <dt class="spec value" id="val-y">
+   <div>
+    <div class="spec value" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : <a href="index.html#type-t">t</a></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       The value of y.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -214,105 +214,105 @@
    <h4 id="basic-module-stuff">
     <a href="#basic-module-stuff" class="anchor"></a>Basic module stuff
    </h4>
-   <dl>
-    <dt class="spec module" id="module-Empty">
+   <div>
+    <div class="spec module" id="module-Empty">
      <a href="#module-Empty" class="anchor"></a><code><span class="keyword">module</span> <a href="Empty/index.html">Empty</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain, empty module
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-Empty">
+    </div>
+   </div>
+   <div>
+    <div class="spec module-type" id="module-type-Empty">
      <a href="#module-type-Empty" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Empty/index.html">Empty</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       An ambiguous, misnamed module type
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-MissingComment">
+    </div>
+   </div>
+   <div>
+    <div class="spec module-type" id="module-type-MissingComment">
      <a href="#module-type-MissingComment" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-MissingComment/index.html">MissingComment</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       An ambiguous, misnamed module type
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h6 id="s9000">
     <a href="#s9000" class="anchor"></a>Level 9000
    </h6>
-   <dl>
-    <dt class="spec module" id="module-EmptyAlias">
+   <div>
+    <div class="spec module" id="module-EmptyAlias">
      <a href="#module-EmptyAlias" class="anchor"></a><code><span class="keyword">module</span> EmptyAlias = <a href="Empty/index.html">Empty</a></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain module alias of <code>Empty</code>
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h4 id="emptySig">
     <a href="#emptySig" class="anchor"></a>EmptySig
    </h4>
-   <dl>
-    <dt class="spec module-type" id="module-type-EmptySig">
+   <div>
+    <div class="spec module-type" id="module-type-EmptySig">
      <a href="#module-type-EmptySig" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-EmptySig/index.html">EmptySig</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain, empty module signature
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-EmptySigAlias">
+    </div>
+   </div>
+   <div>
+    <div class="spec module-type" id="module-type-EmptySigAlias">
      <a href="#module-type-EmptySigAlias" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-EmptySigAlias/index.html">EmptySigAlias</a> = <a href="module-type-EmptySig/index.html">EmptySig</a></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain, empty module signature alias of
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module" id="module-ModuleWithSignature">
+    </div>
+   </div>
+   <div>
+    <div class="spec module" id="module-ModuleWithSignature">
      <a href="#module-ModuleWithSignature" class="anchor"></a><code><span class="keyword">module</span> <a href="ModuleWithSignature/index.html">ModuleWithSignature</a> : <a href="module-type-EmptySig/index.html">EmptySig</a></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain module of a signature of <a href="index.html#exception-EmptySig"><code>EmptySig</code></a> (reference)
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module" id="module-ModuleWithSignatureAlias">
+    </div>
+   </div>
+   <div>
+    <div class="spec module" id="module-ModuleWithSignatureAlias">
      <a href="#module-ModuleWithSignatureAlias" class="anchor"></a><code><span class="keyword">module</span> <a href="ModuleWithSignatureAlias/index.html">ModuleWithSignatureAlias</a> : <a href="module-type-EmptySigAlias/index.html">EmptySigAlias</a></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain module with an alias signature
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module" id="module-One">
     <a href="#module-One" class="anchor"></a><code><span class="keyword">module</span> <a href="One/index.html">One</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec module-type" id="module-type-SigForMod">
+   <div>
+    <div class="spec module-type" id="module-type-SigForMod">
      <a href="#module-type-SigForMod" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-SigForMod/index.html">SigForMod</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       There's a signature in a module in this signature.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module-type" id="module-type-SuperSig">
     <a href="#module-type-SuperSig" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-SuperSig/index.html">SuperSig</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
@@ -321,16 +321,16 @@
      For a good time, see <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a> or <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigB:subSig</code></a> or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="index.html#s9000">Level 9000</a> is also interesting. <a href="index.html#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="index.html#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
     </p>
    </aside>
-   <dl>
-    <dt class="spec module" id="module-Buffer">
+   <div>
+    <div class="spec module" id="module-Buffer">
      <a href="#module-Buffer" class="anchor"></a><code><span class="keyword">module</span> <a href="Buffer/index.html">Buffer</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       <code>Buffer</code>.t
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <aside>
     <p>
      Some text before exception title.
@@ -344,74 +344,74 @@
      After exception title.
     </p>
    </aside>
-   <dl>
-    <dt class="spec exception" id="exception-Kaboom">
+   <div>
+    <div class="spec exception" id="exception-Kaboom">
      <a href="#exception-Kaboom" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Kaboom</span> <span class="keyword">of</span> unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Unary exception constructor
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-Kablam">
+    </div>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-Kablam">
      <a href="#exception-Kablam" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Kablam</span> <span class="keyword">of</span> unit * unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Binary exception constructor
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-Kapow">
+    </div>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-Kapow">
      <a href="#exception-Kapow" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Kapow</span> <span class="keyword">of</span> unit * unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Unary exception constructor over binary tuple
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-EmptySig">
+    </div>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-EmptySig">
      <a href="#exception-EmptySig" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">EmptySig</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       <a href="index.html#exception-EmptySig"><code>EmptySig</code></a> is general but <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is a module and <a href="index.html#exception-EmptySig"><code>EmptySig</code></a> is this exception.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-EmptySigAlias">
+    </div>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-EmptySigAlias">
      <a href="#exception-EmptySigAlias" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">EmptySigAlias</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       <a href="index.html#exception-EmptySigAlias"><code>EmptySigAlias</code></a> is this exception.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h4 id="basic-type-and-value-stuff-with-advanced-doc-comments">
     <a href="#basic-type-and-value-stuff-with-advanced-doc-comments" class="anchor"></a>Basic type and value stuff with advanced doc comments
    </h4>
-   <dl>
-    <dt class="spec type" id="type-a_function">
+   <div>
+    <div class="spec type" id="type-a_function">
      <a href="#type-a_function" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) a_function</span> = <span class="type-var">'a</span> <span>-&gt;</span> <span class="type-var">'b</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       <a href="index.html#val-a_function"><code>a_function</code></a> is general but <a href="index.html#type-a_function"><code>a_function</code></a> is this type and <a href="index.html#val-a_function"><code>a_function</code></a> is the value below.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-a_function">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-a_function">
      <a href="#val-a_function" class="anchor"></a><code><span class="keyword">val</span> a_function : <span>x:int</span> <span>-&gt;</span> int</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is <code>a_function</code> with param and return type.
      </p>
@@ -435,19 +435,19 @@
        </p>
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-fun_fun_fun">
-     <a href="#val-fun_fun_fun" class="anchor"></a><code><span class="keyword">val</span> fun_fun_fun : <span><span>(<span><span>(int,&nbsp;int)</span> <a href="index.html#type-a_function">a_function</a></span>,&nbsp;<span><span>(unit,&nbsp;unit)</span> <a href="index.html#type-a_function">a_function</a></span>)</span> <a href="index.html#type-a_function">a_function</a></span></code>
-    </dt>
-    <dt class="spec value" id="val-fun_maybe">
-     <a href="#val-fun_maybe" class="anchor"></a><code><span class="keyword">val</span> fun_maybe : <span>?⁠yes:unit</span> <span>-&gt;</span> unit <span>-&gt;</span> int</code>
-    </dt>
-    <dt class="spec value" id="val-not_found">
+    </div>
+   </div>
+   <div class="spec value" id="val-fun_fun_fun">
+    <a href="#val-fun_fun_fun" class="anchor"></a><code><span class="keyword">val</span> fun_fun_fun : <span><span>(<span><span>(int,&nbsp;int)</span> <a href="index.html#type-a_function">a_function</a></span>,&nbsp;<span><span>(unit,&nbsp;unit)</span> <a href="index.html#type-a_function">a_function</a></span>)</span> <a href="index.html#type-a_function">a_function</a></span></code>
+   </div>
+   <div class="spec value" id="val-fun_maybe">
+    <a href="#val-fun_maybe" class="anchor"></a><code><span class="keyword">val</span> fun_maybe : <span>?⁠yes:unit</span> <span>-&gt;</span> unit <span>-&gt;</span> int</code>
+   </div>
+   <div>
+    <div class="spec value" id="val-not_found">
      <a href="#val-not_found" class="anchor"></a><code><span class="keyword">val</span> not_found : unit <span>-&gt;</span> unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <dl>
       <dt>
        raises Not_found
@@ -458,13 +458,13 @@
        </p>
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-ocaml_org">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-ocaml_org">
      <a href="#val-ocaml_org" class="anchor"></a><code><span class="keyword">val</span> ocaml_org : string</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <dl>
       <dt>
        see <a href="http://ocaml.org/">http://ocaml.org/</a>
@@ -475,13 +475,13 @@
        </p>
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-some_file">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-some_file">
      <a href="#val-some_file" class="anchor"></a><code><span class="keyword">val</span> some_file : string</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <dl>
       <dt>
        see <code>some_file</code>
@@ -492,13 +492,13 @@
        </p>
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-some_doc">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-some_doc">
      <a href="#val-some_doc" class="anchor"></a><code><span class="keyword">val</span> some_doc : string</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <dl>
       <dt>
        see some_doc
@@ -509,13 +509,13 @@
        </p>
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-since_mesozoic">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-since_mesozoic">
      <a href="#val-since_mesozoic" class="anchor"></a><code><span class="keyword">val</span> since_mesozoic : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This value was introduced in the Mesozoic era.
      </p>
@@ -527,13 +527,13 @@
        mesozoic
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-changing">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-changing">
      <a href="#val-changing" class="anchor"></a><code><span class="keyword">val</span> changing : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This value has had changes in 1.0.0, 1.1.0, and 1.2.0.
      </p>
@@ -565,88 +565,86 @@
        1.2.0
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-with_foo">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-with_foo">
      <a href="#val-with_foo" class="anchor"></a><code><span class="keyword">val</span> with_foo : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This value has a custom tag <code>foo</code>. @foo the body of the custom <code>foo</code> tag
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h4 id="some-operators">
     <a href="#some-operators" class="anchor"></a>Some Operators
    </h4>
-   <dl>
-    <dt class="spec value" id="val-(~-)">
-     <a href="#val-(~-)" class="anchor"></a><code><span class="keyword">val</span> (~-) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(!)">
-     <a href="#val-(!)" class="anchor"></a><code><span class="keyword">val</span> (!) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(@)">
-     <a href="#val-(@)" class="anchor"></a><code><span class="keyword">val</span> (@) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-($)">
-     <a href="#val-($)" class="anchor"></a><code><span class="keyword">val</span> ($) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(%)">
-     <a href="#val-(%)" class="anchor"></a><code><span class="keyword">val</span> (%) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(&amp;)">
-     <a href="#val-(&amp;)" class="anchor"></a><code><span class="keyword">val</span> (&amp;) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(*)">
-     <a href="#val-(*)" class="anchor"></a><code><span class="keyword">val</span> (*) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(-)">
-     <a href="#val-(-)" class="anchor"></a><code><span class="keyword">val</span> (-) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(+)">
-     <a href="#val-(+)" class="anchor"></a><code><span class="keyword">val</span> (+) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(-?)">
-     <a href="#val-(-?)" class="anchor"></a><code><span class="keyword">val</span> (-?) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(/)">
-     <a href="#val-(/)" class="anchor"></a><code><span class="keyword">val</span> (/) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(:=)">
-     <a href="#val-(:=)" class="anchor"></a><code><span class="keyword">val</span> (:=) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(=)">
-     <a href="#val-(=)" class="anchor"></a><code><span class="keyword">val</span> (=) : unit</code>
-    </dt>
-    <dt class="spec value" id="val-(land)">
-     <a href="#val-(land)" class="anchor"></a><code><span class="keyword">val</span> (land) : unit</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-(~-)">
+    <a href="#val-(~-)" class="anchor"></a><code><span class="keyword">val</span> (~-) : unit</code>
+   </div>
+   <div class="spec value" id="val-(!)">
+    <a href="#val-(!)" class="anchor"></a><code><span class="keyword">val</span> (!) : unit</code>
+   </div>
+   <div class="spec value" id="val-(@)">
+    <a href="#val-(@)" class="anchor"></a><code><span class="keyword">val</span> (@) : unit</code>
+   </div>
+   <div class="spec value" id="val-($)">
+    <a href="#val-($)" class="anchor"></a><code><span class="keyword">val</span> ($) : unit</code>
+   </div>
+   <div class="spec value" id="val-(%)">
+    <a href="#val-(%)" class="anchor"></a><code><span class="keyword">val</span> (%) : unit</code>
+   </div>
+   <div class="spec value" id="val-(&amp;)">
+    <a href="#val-(&amp;)" class="anchor"></a><code><span class="keyword">val</span> (&amp;) : unit</code>
+   </div>
+   <div class="spec value" id="val-(*)">
+    <a href="#val-(*)" class="anchor"></a><code><span class="keyword">val</span> (*) : unit</code>
+   </div>
+   <div class="spec value" id="val-(-)">
+    <a href="#val-(-)" class="anchor"></a><code><span class="keyword">val</span> (-) : unit</code>
+   </div>
+   <div class="spec value" id="val-(+)">
+    <a href="#val-(+)" class="anchor"></a><code><span class="keyword">val</span> (+) : unit</code>
+   </div>
+   <div class="spec value" id="val-(-?)">
+    <a href="#val-(-?)" class="anchor"></a><code><span class="keyword">val</span> (-?) : unit</code>
+   </div>
+   <div class="spec value" id="val-(/)">
+    <a href="#val-(/)" class="anchor"></a><code><span class="keyword">val</span> (/) : unit</code>
+   </div>
+   <div class="spec value" id="val-(:=)">
+    <a href="#val-(:=)" class="anchor"></a><code><span class="keyword">val</span> (:=) : unit</code>
+   </div>
+   <div class="spec value" id="val-(=)">
+    <a href="#val-(=)" class="anchor"></a><code><span class="keyword">val</span> (=) : unit</code>
+   </div>
+   <div class="spec value" id="val-(land)">
+    <a href="#val-(land)" class="anchor"></a><code><span class="keyword">val</span> (land) : unit</code>
+   </div>
    <h4 id="advanced-module-stuff">
     <a href="#advanced-module-stuff" class="anchor"></a>Advanced Module Stuff
    </h4>
-   <dl>
-    <dt class="spec module" id="module-CollectionModule">
+   <div>
+    <div class="spec module" id="module-CollectionModule">
      <a href="#module-CollectionModule" class="anchor"></a><code><span class="keyword">module</span> <a href="CollectionModule/index.html">CollectionModule</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>CollectionModule</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-COLLECTION">
+    </div>
+   </div>
+   <div>
+    <div class="spec module-type" id="module-type-COLLECTION">
      <a href="#module-type-COLLECTION" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-COLLECTION/index.html">COLLECTION</a> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="CollectionModule/index.html">CollectionModule</a></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       module type of
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module" id="module-Recollection">
     <a href="#module-Recollection" class="anchor"></a><code><span class="keyword">module</span> <a href="Recollection/index.html">Recollection</a> : <span class="keyword">functor</span> (<a href="Recollection/argument-1-C/index.html">C</a> : <a href="module-type-COLLECTION/index.html">COLLECTION</a>) <span>-&gt;</span> <a href="module-type-COLLECTION/index.html">COLLECTION</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-collection">collection</a> = <span><a href="Recollection/argument-1-C/index.html#type-element">C.element</a> list</span> <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-element">element</a> = <a href="Recollection/argument-1-C/index.html#type-collection">C.collection</a></code>
    </div>
@@ -665,36 +663,36 @@
    <div class="spec module-type" id="module-type-B">
     <a href="#module-type-B" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-B/index.html">B</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec module-type" id="module-type-C">
+   <div>
+    <div class="spec module-type" id="module-type-C">
      <a href="#module-type-C" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-C/index.html">C</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This module type includes two signatures.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module" id="module-FunctorTypeOf">
+    </div>
+   </div>
+   <div>
+    <div class="spec module" id="module-FunctorTypeOf">
      <a href="#module-FunctorTypeOf" class="anchor"></a><code><span class="keyword">module</span> <a href="FunctorTypeOf/index.html">FunctorTypeOf</a> : <span class="keyword">functor</span> (<a href="FunctorTypeOf/argument-1-Collection/index.html">Collection</a> : <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="CollectionModule/index.html">CollectionModule</a>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>FunctorTypeOf</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-IncludeModuleType">
+    </div>
+   </div>
+   <div>
+    <div class="spec module-type" id="module-type-IncludeModuleType">
      <a href="#module-type-IncludeModuleType" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-IncludeModuleType/index.html">IncludeModuleType</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>IncludeModuleType</code>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module-type" id="module-type-ToInclude">
     <a href="#module-type-ToInclude" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-ToInclude/index.html">ToInclude</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
@@ -718,8 +716,8 @@
    <h4 id="advanced-type-stuff">
     <a href="#advanced-type-stuff" class="anchor"></a>Advanced Type Stuff
    </h4>
-   <dl>
-    <dt class="spec type" id="type-record">
+   <div>
+    <div class="spec type" id="type-record">
      <a href="#type-record" class="anchor"></a><code><span class="keyword">type</span> record = {</code>
      <table>
       <tbody>
@@ -746,69 +744,69 @@
       </tbody>
      </table>
      <code>}</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>record</code>.
      </p>
      <p>
       This comment is also for <code>record</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-mutable_record">
-     <a href="#type-mutable_record" class="anchor"></a><code><span class="keyword">type</span> mutable_record = {</code>
-     <table>
-      <tbody>
-       <tr id="type-mutable_record.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.a" class="anchor"></a><code><span class="keyword">mutable</span> a : int;</code>
-        </td>
-        <td class="doc">
-         <p>
-          <code>a</code> is first and mutable
-         </p>
-        </td>
-       </tr>
-       <tr id="type-mutable_record.b" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.b" class="anchor"></a><code>b : unit;</code>
-        </td>
-        <td class="doc">
-         <p>
-          <code>b</code> is second and immutable
-         </p>
-        </td>
-       </tr>
-       <tr id="type-mutable_record.c" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.c" class="anchor"></a><code><span class="keyword">mutable</span> c : int;</code>
-        </td>
-        <td class="doc">
-         <p>
-          <code>c</code> is third and mutable
-         </p>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>}</code>
-    </dt>
-    <dt class="spec type" id="type-universe_record">
-     <a href="#type-universe_record" class="anchor"></a><code><span class="keyword">type</span> universe_record = {</code>
-     <table>
-      <tbody>
-       <tr id="type-universe_record.nihilate" class="anchored">
-        <td class="def record field">
-         <a href="#type-universe_record.nihilate" class="anchor"></a><code>nihilate : a. <span class="type-var">'a</span> <span>-&gt;</span> unit;</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>}</code>
-    </dt>
-    <dt class="spec type" id="type-variant">
+    </div>
+   </div>
+   <div class="spec type" id="type-mutable_record">
+    <a href="#type-mutable_record" class="anchor"></a><code><span class="keyword">type</span> mutable_record = {</code>
+    <table>
+     <tbody>
+      <tr id="type-mutable_record.a" class="anchored">
+       <td class="def record field">
+        <a href="#type-mutable_record.a" class="anchor"></a><code><span class="keyword">mutable</span> a : int;</code>
+       </td>
+       <td class="doc">
+        <p>
+         <code>a</code> is first and mutable
+        </p>
+       </td>
+      </tr>
+      <tr id="type-mutable_record.b" class="anchored">
+       <td class="def record field">
+        <a href="#type-mutable_record.b" class="anchor"></a><code>b : unit;</code>
+       </td>
+       <td class="doc">
+        <p>
+         <code>b</code> is second and immutable
+        </p>
+       </td>
+      </tr>
+      <tr id="type-mutable_record.c" class="anchored">
+       <td class="def record field">
+        <a href="#type-mutable_record.c" class="anchor"></a><code><span class="keyword">mutable</span> c : int;</code>
+       </td>
+       <td class="doc">
+        <p>
+         <code>c</code> is third and mutable
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>}</code>
+   </div>
+   <div class="spec type" id="type-universe_record">
+    <a href="#type-universe_record" class="anchor"></a><code><span class="keyword">type</span> universe_record = {</code>
+    <table>
+     <tbody>
+      <tr id="type-universe_record.nihilate" class="anchored">
+       <td class="def record field">
+        <a href="#type-universe_record.nihilate" class="anchor"></a><code>nihilate : a. <span class="type-var">'a</span> <span>-&gt;</span> unit;</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>}</code>
+   </div>
+   <div>
+    <div class="spec type" id="type-variant">
      <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant = </code>
      <table>
       <tbody>
@@ -854,18 +852,18 @@
        </tr>
       </tbody>
      </table>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>variant</code>.
      </p>
      <p>
       This comment is also for <code>variant</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-poly_variant">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-poly_variant">
      <a href="#type-poly_variant" class="anchor"></a><code><span class="keyword">type</span> poly_variant = [ </code>
      <table>
       <tbody>
@@ -882,18 +880,18 @@
       </tbody>
      </table>
      <code> ]</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>poly_variant</code>.
      </p>
      <p>
       Wow! It was a polymorphic variant!
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-full_gadt">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-full_gadt">
      <a href="#type-full_gadt" class="anchor"></a><code><span class="keyword">type</span> <span>(_, _) full_gadt</span> = </code>
      <table>
       <tbody>
@@ -919,18 +917,18 @@
        </tr>
       </tbody>
      </table>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>full_gadt</code>.
      </p>
      <p>
       Wow! It was a GADT!
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-partial_gadt">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-partial_gadt">
      <a href="#type-partial_gadt" class="anchor"></a><code><span class="keyword">type</span> <span>'a partial_gadt</span> = </code>
      <table>
       <tbody>
@@ -951,38 +949,38 @@
        </tr>
       </tbody>
      </table>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>partial_gadt</code>.
      </p>
      <p>
       Wow! It was a mixed GADT!
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-alias">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-alias">
      <a href="#type-alias" class="anchor"></a><code><span class="keyword">type</span> alias = <a href="index.html#type-variant">variant</a></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>alias</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-tuple">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-tuple">
      <a href="#type-tuple" class="anchor"></a><code><span class="keyword">type</span> tuple = <span>(<a href="index.html#type-alias">alias</a> * <a href="index.html#type-alias">alias</a>)</span> * <a href="index.html#type-alias">alias</a> * <span>(<a href="index.html#type-alias">alias</a> * <a href="index.html#type-alias">alias</a>)</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>tuple</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-variant_alias">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-variant_alias">
      <a href="#type-variant_alias" class="anchor"></a><code><span class="keyword">type</span> variant_alias = <a href="index.html#type-variant">variant</a> = </code>
      <table>
       <tbody>
@@ -1008,15 +1006,15 @@
        </tr>
       </tbody>
      </table>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>variant_alias</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-record_alias">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-record_alias">
      <a href="#type-record_alias" class="anchor"></a><code><span class="keyword">type</span> record_alias = <a href="index.html#type-record">record</a> = {</code>
      <table>
       <tbody>
@@ -1033,15 +1031,15 @@
       </tbody>
      </table>
      <code>}</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>record_alias</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-poly_variant_union">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-poly_variant_union">
      <a href="#type-poly_variant_union" class="anchor"></a><code><span class="keyword">type</span> poly_variant_union = [ </code>
      <table>
       <tbody>
@@ -1058,95 +1056,95 @@
       </tbody>
      </table>
      <code> ]</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>poly_variant_union</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-poly_poly_variant">
-     <a href="#type-poly_poly_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a poly_poly_variant</span> = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-poly_poly_variant.TagA" class="anchored">
-        <td class="def constructor">
-         <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code>| </code><code>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ]</code>
-    </dt>
-    <dt class="spec type" id="type-bin_poly_poly_variant">
-     <a href="#type-bin_poly_poly_variant" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) bin_poly_poly_variant</span> = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
-        <td class="def constructor">
-         <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code>| </code><code>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></code>
-        </td>
-       </tr>
-       <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
-        <td class="def constructor">
-         <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code>| </code><code>`ConstrB <span class="keyword">of</span> <span class="type-var">'b</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ]</code>
-    </dt>
-    <dt class="spec type" id="type-open_poly_variant">
-     <a href="#type-open_poly_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a open_poly_variant</span> = <span>[&gt; `TagA ]</span> <span class="keyword">as</span> 'a</code>
-    </dt>
-    <dt class="spec type" id="type-open_poly_variant2">
-     <a href="#type-open_poly_variant2" class="anchor"></a><code><span class="keyword">type</span> <span>'a open_poly_variant2</span> = <span>[&gt; <span>`ConstrB of int</span> ]</span> <span class="keyword">as</span> 'a</code>
-    </dt>
-    <dt class="spec type" id="type-open_poly_variant_alias">
-     <a href="#type-open_poly_variant_alias" class="anchor"></a><code><span class="keyword">type</span> <span>'a open_poly_variant_alias</span> = <span><span><span class="type-var">'a</span> <a href="index.html#type-open_poly_variant">open_poly_variant</a></span> <a href="index.html#type-open_poly_variant2">open_poly_variant2</a></span></code>
-    </dt>
-    <dt class="spec type" id="type-poly_fun">
-     <a href="#type-poly_fun" class="anchor"></a><code><span class="keyword">type</span> <span>'a poly_fun</span> = <span>[&gt; <span>`ConstrB of int</span> ]</span> <span class="keyword">as</span> 'a <span>-&gt;</span> <span class="type-var">'a</span></code>
-    </dt>
-    <dt class="spec type" id="type-poly_fun_constraint">
-     <a href="#type-poly_fun_constraint" class="anchor"></a><code><span class="keyword">type</span> <span>'a poly_fun_constraint</span> = <span class="type-var">'a</span> <span>-&gt;</span> <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `TagA ]</span></code>
-    </dt>
-    <dt class="spec type" id="type-closed_poly_variant">
-     <a href="#type-closed_poly_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a closed_poly_variant</span> = <span>[&lt; `One <span>| `Two</span> ]</span> <span class="keyword">as</span> 'a</code>
-    </dt>
-    <dt class="spec type" id="type-clopen_poly_variant">
-     <a href="#type-clopen_poly_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a clopen_poly_variant</span> = <span>[&lt; `One <span><span>| `Two</span> of int</span> <span>| `Three</span> Two Three ]</span> <span class="keyword">as</span> 'a</code>
-    </dt>
-    <dt class="spec type" id="type-nested_poly_variant">
-     <a href="#type-nested_poly_variant" class="anchor"></a><code><span class="keyword">type</span> nested_poly_variant = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-nested_poly_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.A" class="anchor"></a><code>| </code><code>`A</code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.B" class="anchor"></a><code>| </code><code>`B <span class="keyword">of</span> <span>[ `B1 <span>| `B2</span> ]</span></code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.C" class="anchor"></a><code>| </code><code>`C</code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.D" class="anchor"></a><code>| </code><code>`D <span class="keyword">of</span> <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ]</code>
-    </dt>
-    <dt class="spec type" id="type-full_gadt_alias">
+    </div>
+   </div>
+   <div class="spec type" id="type-poly_poly_variant">
+    <a href="#type-poly_poly_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a poly_poly_variant</span> = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-poly_poly_variant.TagA" class="anchored">
+       <td class="def constructor">
+        <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code>| </code><code>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ]</code>
+   </div>
+   <div class="spec type" id="type-bin_poly_poly_variant">
+    <a href="#type-bin_poly_poly_variant" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) bin_poly_poly_variant</span> = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
+       <td class="def constructor">
+        <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code>| </code><code>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></code>
+       </td>
+      </tr>
+      <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
+       <td class="def constructor">
+        <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code>| </code><code>`ConstrB <span class="keyword">of</span> <span class="type-var">'b</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ]</code>
+   </div>
+   <div class="spec type" id="type-open_poly_variant">
+    <a href="#type-open_poly_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a open_poly_variant</span> = <span>[&gt; `TagA ]</span> <span class="keyword">as</span> 'a</code>
+   </div>
+   <div class="spec type" id="type-open_poly_variant2">
+    <a href="#type-open_poly_variant2" class="anchor"></a><code><span class="keyword">type</span> <span>'a open_poly_variant2</span> = <span>[&gt; <span>`ConstrB of int</span> ]</span> <span class="keyword">as</span> 'a</code>
+   </div>
+   <div class="spec type" id="type-open_poly_variant_alias">
+    <a href="#type-open_poly_variant_alias" class="anchor"></a><code><span class="keyword">type</span> <span>'a open_poly_variant_alias</span> = <span><span><span class="type-var">'a</span> <a href="index.html#type-open_poly_variant">open_poly_variant</a></span> <a href="index.html#type-open_poly_variant2">open_poly_variant2</a></span></code>
+   </div>
+   <div class="spec type" id="type-poly_fun">
+    <a href="#type-poly_fun" class="anchor"></a><code><span class="keyword">type</span> <span>'a poly_fun</span> = <span>[&gt; <span>`ConstrB of int</span> ]</span> <span class="keyword">as</span> 'a <span>-&gt;</span> <span class="type-var">'a</span></code>
+   </div>
+   <div class="spec type" id="type-poly_fun_constraint">
+    <a href="#type-poly_fun_constraint" class="anchor"></a><code><span class="keyword">type</span> <span>'a poly_fun_constraint</span> = <span class="type-var">'a</span> <span>-&gt;</span> <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `TagA ]</span></code>
+   </div>
+   <div class="spec type" id="type-closed_poly_variant">
+    <a href="#type-closed_poly_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a closed_poly_variant</span> = <span>[&lt; `One <span>| `Two</span> ]</span> <span class="keyword">as</span> 'a</code>
+   </div>
+   <div class="spec type" id="type-clopen_poly_variant">
+    <a href="#type-clopen_poly_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a clopen_poly_variant</span> = <span>[&lt; `One <span><span>| `Two</span> of int</span> <span>| `Three</span> Two Three ]</span> <span class="keyword">as</span> 'a</code>
+   </div>
+   <div class="spec type" id="type-nested_poly_variant">
+    <a href="#type-nested_poly_variant" class="anchor"></a><code><span class="keyword">type</span> nested_poly_variant = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-nested_poly_variant.A" class="anchored">
+       <td class="def constructor">
+        <a href="#type-nested_poly_variant.A" class="anchor"></a><code>| </code><code>`A</code>
+       </td>
+      </tr>
+      <tr id="type-nested_poly_variant.B" class="anchored">
+       <td class="def constructor">
+        <a href="#type-nested_poly_variant.B" class="anchor"></a><code>| </code><code>`B <span class="keyword">of</span> <span>[ `B1 <span>| `B2</span> ]</span></code>
+       </td>
+      </tr>
+      <tr id="type-nested_poly_variant.C" class="anchored">
+       <td class="def constructor">
+        <a href="#type-nested_poly_variant.C" class="anchor"></a><code>| </code><code>`C</code>
+       </td>
+      </tr>
+      <tr id="type-nested_poly_variant.D" class="anchored">
+       <td class="def constructor">
+        <a href="#type-nested_poly_variant.D" class="anchor"></a><code>| </code><code>`D <span class="keyword">of</span> <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ]</code>
+   </div>
+   <div>
+    <div class="spec type" id="type-full_gadt_alias">
      <a href="#type-full_gadt_alias" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) full_gadt_alias</span> = <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="index.html#type-full_gadt">full_gadt</a></span> = </code>
      <table>
       <tbody>
@@ -1172,15 +1170,15 @@
        </tr>
       </tbody>
      </table>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>full_gadt_alias</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-partial_gadt_alias">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-partial_gadt_alias">
      <a href="#type-partial_gadt_alias" class="anchor"></a><code><span class="keyword">type</span> <span>'a partial_gadt_alias</span> = <span><span class="type-var">'a</span> <a href="index.html#type-partial_gadt">partial_gadt</a></span> = </code>
      <table>
       <tbody>
@@ -1201,25 +1199,25 @@
        </tr>
       </tbody>
      </table>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>partial_gadt_alias</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-Exn_arrow">
+    </div>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-Exn_arrow">
      <a href="#exception-Exn_arrow" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Exn_arrow</span> : unit <span>-&gt;</span> exn</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <a href="index.html#exception-Exn_arrow"><code>Exn_arrow</code></a>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-mutual_constr_a">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-mutual_constr_a">
      <a href="#type-mutual_constr_a" class="anchor"></a><code><span class="keyword">type</span> mutual_constr_a = </code>
      <table>
       <tbody>
@@ -1240,15 +1238,15 @@
        </tr>
       </tbody>
      </table>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <a href="index.html#type-mutual_constr_a"><code>mutual_constr_a</code></a> then <a href="index.html#type-mutual_constr_b"><code>mutual_constr_b</code></a>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-mutual_constr_b">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-mutual_constr_b">
      <a href="#type-mutual_constr_b" class="anchor"></a><code><span class="keyword">and</span> mutual_constr_b = </code>
      <table>
       <tbody>
@@ -1269,107 +1267,101 @@
        </tr>
       </tbody>
      </table>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <a href="index.html#type-mutual_constr_b"><code>mutual_constr_b</code></a> then <a href="index.html#type-mutual_constr_a"><code>mutual_constr_a</code></a>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-rec_obj">
-     <a href="#type-rec_obj" class="anchor"></a><code><span class="keyword">type</span> rec_obj = &lt; f : int; g : unit <span>-&gt;</span> unit; h : <a href="index.html#type-rec_obj">rec_obj</a>; &gt;</code>
-    </dt>
-    <dt class="spec type" id="type-open_obj">
-     <a href="#type-open_obj" class="anchor"></a><code><span class="keyword">type</span> <span>'a open_obj</span> = &lt; f : int; g : unit <span>-&gt;</span> unit; .. &gt; <span class="keyword">as</span> 'a</code>
-    </dt>
-    <dt class="spec type" id="type-oof">
-     <a href="#type-oof" class="anchor"></a><code><span class="keyword">type</span> <span>'a oof</span> = &lt; a : unit; .. &gt; <span class="keyword">as</span> 'a <span>-&gt;</span> <span class="type-var">'a</span></code>
-    </dt>
-    <dt class="spec type" id="type-any_obj">
-     <a href="#type-any_obj" class="anchor"></a><code><span class="keyword">type</span> <span>'a any_obj</span> = &lt; .. &gt; <span class="keyword">as</span> 'a</code>
-    </dt>
-    <dt class="spec type" id="type-empty_obj">
-     <a href="#type-empty_obj" class="anchor"></a><code><span class="keyword">type</span> empty_obj = &lt; &gt;</code>
-    </dt>
-    <dt class="spec type" id="type-one_meth">
-     <a href="#type-one_meth" class="anchor"></a><code><span class="keyword">type</span> one_meth = &lt; meth : unit; &gt;</code>
-    </dt>
-    <dt class="spec type" id="type-ext">
+    </div>
+   </div>
+   <div class="spec type" id="type-rec_obj">
+    <a href="#type-rec_obj" class="anchor"></a><code><span class="keyword">type</span> rec_obj = &lt; f : int; g : unit <span>-&gt;</span> unit; h : <a href="index.html#type-rec_obj">rec_obj</a>; &gt;</code>
+   </div>
+   <div class="spec type" id="type-open_obj">
+    <a href="#type-open_obj" class="anchor"></a><code><span class="keyword">type</span> <span>'a open_obj</span> = &lt; f : int; g : unit <span>-&gt;</span> unit; .. &gt; <span class="keyword">as</span> 'a</code>
+   </div>
+   <div class="spec type" id="type-oof">
+    <a href="#type-oof" class="anchor"></a><code><span class="keyword">type</span> <span>'a oof</span> = &lt; a : unit; .. &gt; <span class="keyword">as</span> 'a <span>-&gt;</span> <span class="type-var">'a</span></code>
+   </div>
+   <div class="spec type" id="type-any_obj">
+    <a href="#type-any_obj" class="anchor"></a><code><span class="keyword">type</span> <span>'a any_obj</span> = &lt; .. &gt; <span class="keyword">as</span> 'a</code>
+   </div>
+   <div class="spec type" id="type-empty_obj">
+    <a href="#type-empty_obj" class="anchor"></a><code><span class="keyword">type</span> empty_obj = &lt; &gt;</code>
+   </div>
+   <div class="spec type" id="type-one_meth">
+    <a href="#type-one_meth" class="anchor"></a><code><span class="keyword">type</span> one_meth = &lt; meth : unit; &gt;</code>
+   </div>
+   <div>
+    <div class="spec type" id="type-ext">
      <a href="#type-ext" class="anchor"></a><code><span class="keyword">type</span> ext = ..</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A mystery wrapped in an ellipsis
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtA</span></code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtB</span></code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtC</span> <span class="keyword">of</span> unit| <span class="extension">ExtD</span> <span class="keyword">of</span> <a href="index.html#type-ext">ext</a></code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtE</span></code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtF</span></code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-poly_ext">
+    </div>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtA</span></code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtB</span></code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtC</span> <span class="keyword">of</span> unit| <span class="extension">ExtD</span> <span class="keyword">of</span> <a href="index.html#type-ext">ext</a></code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtE</span></code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtF</span></code>
+   </div>
+   <div>
+    <div class="spec type" id="type-poly_ext">
      <a href="#type-poly_ext" class="anchor"></a><code><span class="keyword">type</span> <span>'a poly_ext</span> = ..</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       'a poly_ext
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Foo</span> <span class="keyword">of</span> <span class="type-var">'b</span>| <span class="extension">Bar</span> <span class="keyword">of</span> <span class="type-var">'b</span> * <span class="type-var">'b</span></code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Quux</span> <span class="keyword">of</span> <span class="type-var">'c</span></code>
-    </dt>
-   </dl>
+    </div>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Foo</span> <span class="keyword">of</span> <span class="type-var">'b</span>| <span class="extension">Bar</span> <span class="keyword">of</span> <span class="type-var">'b</span> * <span class="type-var">'b</span></code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Quux</span> <span class="keyword">of</span> <span class="type-var">'c</span></code>
+   </div>
    <div class="spec module" id="module-ExtMod">
     <a href="#module-ExtMod" class="anchor"></a><code><span class="keyword">module</span> <a href="ExtMod/index.html">ExtMod</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop0</span></code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop</span> <span class="keyword">of</span> unit</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec external" id="val-launch_missiles">
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop0</span></code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop</span> <span class="keyword">of</span> unit</code>
+   </div>
+   <div>
+    <div class="spec external" id="val-launch_missiles">
      <a href="#val-launch_missiles" class="anchor"></a><code><span class="keyword">val</span> launch_missiles : unit <span>-&gt;</span> unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Rotate keys on my mark...
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-my_mod">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-my_mod">
      <a href="#type-my_mod" class="anchor"></a><code><span class="keyword">type</span> my_mod = <span>(<span class="keyword">module</span> <a href="module-type-COLLECTION/index.html">COLLECTION</a>)</span></code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A brown paper package tied up with string
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec class" id="class-empty_class">
     <a href="#class-empty_class" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-empty_class/index.html">empty_class</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
@@ -1382,25 +1374,21 @@
    <div class="spec class" id="class-param_class">
     <a href="#class-param_class" class="anchor"></a><code><span class="keyword">class</span> 'a <a href="class-param_class/index.html">param_class</a> : <span class="type-var">'a</span> <span>-&gt;</span> <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-my_unit_object">
-     <a href="#type-my_unit_object" class="anchor"></a><code><span class="keyword">type</span> my_unit_object = <span>unit <a href="class-param_class/index.html">param_class</a></span></code>
-    </dt>
-    <dt class="spec type" id="type-my_unit_class">
-     <a href="#type-my_unit_class" class="anchor"></a><code><span class="keyword">type</span> <span>'a my_unit_class</span> = <span>unit <a href="class-param_class/index.html">param_class</a></span> <span class="keyword">as</span> 'a</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-my_unit_object">
+    <a href="#type-my_unit_object" class="anchor"></a><code><span class="keyword">type</span> my_unit_object = <span>unit <a href="class-param_class/index.html">param_class</a></span></code>
+   </div>
+   <div class="spec type" id="type-my_unit_class">
+    <a href="#type-my_unit_class" class="anchor"></a><code><span class="keyword">type</span> <span>'a my_unit_class</span> = <span>unit <a href="class-param_class/index.html">param_class</a></span> <span class="keyword">as</span> 'a</code>
+   </div>
    <div class="spec module" id="module-Dep1">
     <a href="#module-Dep1" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep1/index.html">Dep1</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-Dep2">
     <a href="#module-Dep2" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep2/index.html">Dep2</a> : <span class="keyword">functor</span> (<a href="Dep2/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-dep1">
-     <a href="#type-dep1" class="anchor"></a><code><span class="keyword">type</span> dep1 = <a href="Dep1/module-type-S/index.html#type-c">Dep2(Dep1).B.c</a></code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-dep1">
+    <a href="#type-dep1" class="anchor"></a><code><span class="keyword">type</span> dep1 = <a href="Dep1/module-type-S/index.html#type-c">Dep2(Dep1).B.c</a></code>
+   </div>
    <div class="spec module" id="module-Dep3">
     <a href="#module-Dep3" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep3/index.html">Dep3</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
@@ -1410,25 +1398,21 @@
    <div class="spec module" id="module-Dep5">
     <a href="#module-Dep5" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep5/index.html">Dep5</a> : <span class="keyword">functor</span> (<a href="Dep5/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-dep2">
-     <a href="#type-dep2" class="anchor"></a><code><span class="keyword">type</span> dep2 = <a href="Dep4/module-type-T/index.html#type-b">Dep5(Dep4).Z.X.b</a></code>
-    </dt>
-    <dt class="spec type" id="type-dep3">
-     <a href="#type-dep3" class="anchor"></a><code><span class="keyword">type</span> dep3 = <a href="Dep3/index.html#type-a">Dep5(Dep4).Z.Y.a</a></code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-dep2">
+    <a href="#type-dep2" class="anchor"></a><code><span class="keyword">type</span> dep2 = <a href="Dep4/module-type-T/index.html#type-b">Dep5(Dep4).Z.X.b</a></code>
+   </div>
+   <div class="spec type" id="type-dep3">
+    <a href="#type-dep3" class="anchor"></a><code><span class="keyword">type</span> dep3 = <a href="Dep3/index.html#type-a">Dep5(Dep4).Z.Y.a</a></code>
+   </div>
    <div class="spec module" id="module-Dep6">
     <a href="#module-Dep6" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep6/index.html">Dep6</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-Dep7">
     <a href="#module-Dep7" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep7/index.html">Dep7</a> : <span class="keyword">functor</span> (<a href="Dep7/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-dep4">
-     <a href="#type-dep4" class="anchor"></a><code><span class="keyword">type</span> dep4 = <a href="Dep6/module-type-S/index.html#type-d">Dep7(Dep6).M.Y.d</a></code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-dep4">
+    <a href="#type-dep4" class="anchor"></a><code><span class="keyword">type</span> dep4 = <a href="Dep6/module-type-S/index.html#type-d">Dep7(Dep6).M.Y.d</a></code>
+   </div>
    <div class="spec module" id="module-Dep8">
     <a href="#module-Dep8" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep8/index.html">Dep8</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
@@ -1447,11 +1431,9 @@
    <div class="spec module" id="module-Dep13">
     <a href="#module-Dep13" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep13/index.html">Dep13</a> : <a href="Dep11/module-type-S/index.html">Dep12(Dep11).T</a></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-dep5">
-     <a href="#type-dep5" class="anchor"></a><code><span class="keyword">type</span> dep5 = <a href="Dep13/index.html#type-c">Dep13.c</a></code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-dep5">
+    <a href="#type-dep5" class="anchor"></a><code><span class="keyword">type</span> dep5 = <a href="Dep13/index.html#type-c">Dep13.c</a></code>
+   </div>
    <div class="spec module-type" id="module-type-With1">
     <a href="#module-type-With1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-With1/index.html">With1</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
@@ -1461,19 +1443,15 @@
    <div class="spec module" id="module-With3">
     <a href="#module-With3" class="anchor"></a><code><span class="keyword">module</span> <a href="With3/index.html">With3</a> : <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> = <a href="With2/index.html">With2</a></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-with1">
-     <a href="#type-with1" class="anchor"></a><code><span class="keyword">type</span> with1 = <a href="With3/N/index.html#type-t">With3.N.t</a></code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-with1">
+    <a href="#type-with1" class="anchor"></a><code><span class="keyword">type</span> with1 = <a href="With3/N/index.html#type-t">With3.N.t</a></code>
+   </div>
    <div class="spec module" id="module-With4">
     <a href="#module-With4" class="anchor"></a><code><span class="keyword">module</span> <a href="With4/index.html">With4</a> : <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> := <a href="With2/index.html">With2</a></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-with2">
-     <a href="#type-with2" class="anchor"></a><code><span class="keyword">type</span> with2 = <a href="With4/N/index.html#type-t">With4.N.t</a></code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-with2">
+    <a href="#type-with2" class="anchor"></a><code><span class="keyword">type</span> with2 = <a href="With4/N/index.html#type-t">With4.N.t</a></code>
+   </div>
    <div class="spec module" id="module-With5">
     <a href="#module-With5" class="anchor"></a><code><span class="keyword">module</span> <a href="With5/index.html">With5</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
@@ -1519,11 +1497,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-NestedInclude2/index.html">NestedInclude2</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-NestedInclude2/index.html#type-nested_include">nested_include</a> = int</code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-nested_include">
-         <a href="#type-nested_include" class="anchor"></a><code><span class="keyword">type</span> nested_include = int</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-nested_include">
+        <a href="#type-nested_include" class="anchor"></a><code><span class="keyword">type</span> nested_include = int</code>
+       </div>
       </details>
      </div>
     </div>
@@ -1541,11 +1517,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="DoubleInclude3/DoubleInclude2/index.html">DoubleInclude3.DoubleInclude2</a></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-double_include">
-         <a href="#type-double_include" class="anchor"></a><code><span class="keyword">type</span> double_include</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-double_include">
+        <a href="#type-double_include" class="anchor"></a><code><span class="keyword">type</span> double_include</code>
+       </div>
       </details>
      </div>
     </div>
@@ -1574,11 +1548,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-include_include">
-         <a href="#type-include_include" class="anchor"></a><code><span class="keyword">type</span> include_include</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-include_include">
+        <a href="#type-include_include" class="anchor"></a><code><span class="keyword">type</span> include_include</code>
+       </div>
       </details>
      </div>
     </div>
@@ -1630,16 +1602,16 @@
    <div class="spec module" id="module-CanonicalTest">
     <a href="#module-CanonicalTest" class="anchor"></a><code><span class="keyword">module</span> <a href="CanonicalTest/index.html">CanonicalTest</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec value" id="val-test">
+   <div>
+    <div class="spec value" id="val-test">
      <a href="#val-test" class="anchor"></a><code><span class="keyword">val</span> test : <span><span class="type-var">'a</span> <a href="CanonicalTest/Base/List/index.html#type-t">CanonicalTest.Base.List.t</a></span> <span>-&gt;</span> unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some ref to <a href="CanonicalTest/Base__Tests/C/index.html#type-t"><code>CanonicalTest.Base__Tests.C.t</code></a> and <a href="CanonicalTest/Base/List/index.html#val-id"><code>CanonicalTest.Base__Tests.L.id</code></a>. But also to <a href="CanonicalTest/Base__/List/index.html"><code>CanonicalTest.Base__.List</code></a> and <a href="CanonicalTest/Base__/List/index.html#type-t"><code>CanonicalTest.Base__.List.t</code></a>
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="aliases">
     <a href="#aliases" class="anchor"></a>Aliases again
    </h2>
@@ -1737,16 +1709,12 @@
    <div class="spec module-type" id="module-type-TypeExt">
     <a href="#module-type-TypeExt" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-TypeExt/index.html">TypeExt</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-new_t">
-     <a href="#type-new_t" class="anchor"></a><code><span class="keyword">type</span> new_t = ..</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-new_t">new_t</a> += | <span class="extension">C</span></code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-new_t">
+    <a href="#type-new_t" class="anchor"></a><code><span class="keyword">type</span> new_t = ..</code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-new_t">new_t</a> += | <span class="extension">C</span></code>
+   </div>
    <div class="spec module-type" id="module-type-TypeExtPruned">
     <a href="#module-type-TypeExtPruned" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-TypeExtPruned/index.html">TypeExtPruned</a> = <a href="module-type-TypeExt/index.html">TypeExt</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-TypeExt/index.html#type-t">t</a> := <a href="index.html#type-new_t">new_t</a></code>
    </div>

--- a/test/html/expect/test_package+ml/Recent/X/index.html
+++ b/test/html/expect/test_package+ml/Recent/X/index.html
@@ -22,26 +22,18 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec module-substitution" id="module-L">
-     <a href="#module-L" class="anchor"></a><code><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-t">
-     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = <span>int <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a></span></code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec type-subst" id="type-u">
-     <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u := int</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-v">
-     <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v = <span><a href="index.html#type-u">u</a> <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a></span></code>
-    </dt>
-   </dl>
+   <div class="spec module-substitution" id="module-L">
+    <a href="#module-L" class="anchor"></a><code><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></code>
+   </div>
+   <div class="spec type" id="type-t">
+    <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = <span>int <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a></span></code>
+   </div>
+   <div class="spec type-subst" id="type-u">
+    <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u := int</code>
+   </div>
+   <div class="spec type" id="type-v">
+    <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v = <span><a href="index.html#type-u">u</a> <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a></span></code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -28,173 +28,169 @@
    <div class="spec module-type" id="module-type-S1">
     <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> = <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="module-type-S/index.html">S</a>) <span>-&gt;</span> <a href="module-type-S/index.html">S</a></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-variant">
-     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant = </code>
-     <table>
-      <tbody>
-       <tr id="type-variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.B" class="anchor"></a><code>| <span class="constructor">B</span> <span class="keyword">of</span> int</code>
-        </td>
-       </tr>
-       <tr id="type-variant.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.C" class="anchor"></a><code>| <span class="constructor">C</span></code>
-        </td>
-        <td class="doc">
-         <p>
-          foo
-         </p>
-        </td>
-       </tr>
-       <tr id="type-variant.D" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.D" class="anchor"></a><code>| <span class="constructor">D</span></code>
-        </td>
-        <td class="doc">
-         <p>
-          <em>bar</em>
-         </p>
-        </td>
-       </tr>
-       <tr id="type-variant.E" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.E" class="anchor"></a><code>| <span class="constructor">E</span> <span class="keyword">of</span> {</code>
-         <table>
-          <tbody>
-           <tr id="type-variant.a" class="anchored">
-            <td class="def record field">
-             <a href="#type-variant.a" class="anchor"></a><code>a : int;</code>
-            </td>
-           </tr>
-          </tbody>
-         </table>
-         <code>}</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dt>
-    <dt class="spec type" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> <span>_ gadt</span> = </code>
-     <table>
-      <tbody>
-       <tr id="type-gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <span>int <a href="index.html#type-gadt">gadt</a></span></code>
-        </td>
-       </tr>
-       <tr id="type-gadt.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code>| <span class="constructor">B</span> : int <span>-&gt;</span> <span>string <a href="index.html#type-gadt">gadt</a></span></code>
-        </td>
-        <td class="doc">
-         <p>
-          foo
-         </p>
-        </td>
-       </tr>
-       <tr id="type-gadt.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code>| <span class="constructor">C</span> : {</code>
-         <table>
-          <tbody>
-           <tr id="type-gadt.a" class="anchored">
-            <td class="def record field">
-             <a href="#type-gadt.a" class="anchor"></a><code>a : int;</code>
-            </td>
-           </tr>
-          </tbody>
-         </table>
-         <code>} <span>-&gt;</span> <span>unit <a href="index.html#type-gadt">gadt</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dt>
-    <dt class="spec type" id="type-polymorphic_variant">
-     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B <span class="keyword">of</span> int</code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C</code>
-        </td>
-        <td class="doc">
-         <p>
-          foo
-         </p>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
-        </td>
-        <td class="doc">
-         <p>
-          bar
-         </p>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ]</code>
-    </dt>
-    <dt class="spec type" id="type-empty_variant">
-     <a href="#type-empty_variant" class="anchor"></a><code><span class="keyword">type</span> empty_variant = |</code>
-    </dt>
-    <dt class="spec type" id="type-nonrec_">
-     <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_ = int</code>
-    </dt>
-    <dt class="spec type" id="type-empty_conj">
-     <a href="#type-empty_conj" class="anchor"></a><code><span class="keyword">type</span> empty_conj = </code>
-     <table>
-      <tbody>
-       <tr id="type-empty_conj.X" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-empty_conj.X" class="anchor"></a><code>| <span class="constructor">X</span> : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span> <span>-&gt;</span> <a href="index.html#type-empty_conj">empty_conj</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dt>
-    <dt class="spec type" id="type-conj">
-     <a href="#type-conj" class="anchor"></a><code><span class="keyword">type</span> conj = </code>
-     <table>
-      <tbody>
-       <tr id="type-conj.X" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-conj.X" class="anchor"></a><code>| <span class="constructor">X</span> : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span> <span>-&gt;</span> <a href="index.html#type-conj">conj</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-empty_conj">
-     <a href="#val-empty_conj" class="anchor"></a><code><span class="keyword">val</span> empty_conj : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span></code>
-    </dt>
-    <dt class="spec value" id="val-conj">
-     <a href="#val-conj" class="anchor"></a><code><span class="keyword">val</span> conj : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span></code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-variant">
+    <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant = </code>
+    <table>
+     <tbody>
+      <tr id="type-variant.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
+       </td>
+      </tr>
+      <tr id="type-variant.B" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.B" class="anchor"></a><code>| <span class="constructor">B</span> <span class="keyword">of</span> int</code>
+       </td>
+      </tr>
+      <tr id="type-variant.C" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.C" class="anchor"></a><code>| <span class="constructor">C</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         foo
+        </p>
+       </td>
+      </tr>
+      <tr id="type-variant.D" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.D" class="anchor"></a><code>| <span class="constructor">D</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         <em>bar</em>
+        </p>
+       </td>
+      </tr>
+      <tr id="type-variant.E" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.E" class="anchor"></a><code>| <span class="constructor">E</span> <span class="keyword">of</span> {</code>
+        <table>
+         <tbody>
+          <tr id="type-variant.a" class="anchored">
+           <td class="def record field">
+            <a href="#type-variant.a" class="anchor"></a><code>a : int;</code>
+           </td>
+          </tr>
+         </tbody>
+        </table>
+        <code>}</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec type" id="type-gadt">
+    <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> <span>_ gadt</span> = </code>
+    <table>
+     <tbody>
+      <tr id="type-gadt.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <span>int <a href="index.html#type-gadt">gadt</a></span></code>
+       </td>
+      </tr>
+      <tr id="type-gadt.B" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.B" class="anchor"></a><code>| <span class="constructor">B</span> : int <span>-&gt;</span> <span>string <a href="index.html#type-gadt">gadt</a></span></code>
+       </td>
+       <td class="doc">
+        <p>
+         foo
+        </p>
+       </td>
+      </tr>
+      <tr id="type-gadt.C" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.C" class="anchor"></a><code>| <span class="constructor">C</span> : {</code>
+        <table>
+         <tbody>
+          <tr id="type-gadt.a" class="anchored">
+           <td class="def record field">
+            <a href="#type-gadt.a" class="anchor"></a><code>a : int;</code>
+           </td>
+          </tr>
+         </tbody>
+        </table>
+        <code>} <span>-&gt;</span> <span>unit <a href="index.html#type-gadt">gadt</a></span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec type" id="type-polymorphic_variant">
+    <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-polymorphic_variant.A" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.B" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B <span class="keyword">of</span> int</code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.C" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C</code>
+       </td>
+       <td class="doc">
+        <p>
+         foo
+        </p>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.D" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
+       </td>
+       <td class="doc">
+        <p>
+         bar
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ]</code>
+   </div>
+   <div class="spec type" id="type-empty_variant">
+    <a href="#type-empty_variant" class="anchor"></a><code><span class="keyword">type</span> empty_variant = |</code>
+   </div>
+   <div class="spec type" id="type-nonrec_">
+    <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_ = int</code>
+   </div>
+   <div class="spec type" id="type-empty_conj">
+    <a href="#type-empty_conj" class="anchor"></a><code><span class="keyword">type</span> empty_conj = </code>
+    <table>
+     <tbody>
+      <tr id="type-empty_conj.X" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-empty_conj.X" class="anchor"></a><code>| <span class="constructor">X</span> : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span> <span>-&gt;</span> <a href="index.html#type-empty_conj">empty_conj</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec type" id="type-conj">
+    <a href="#type-conj" class="anchor"></a><code><span class="keyword">type</span> conj = </code>
+    <table>
+     <tbody>
+      <tr id="type-conj.X" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-conj.X" class="anchor"></a><code>| <span class="constructor">X</span> : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span> <span>-&gt;</span> <a href="index.html#type-conj">conj</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec value" id="val-empty_conj">
+    <a href="#val-empty_conj" class="anchor"></a><code><span class="keyword">val</span> empty_conj : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span></code>
+   </div>
+   <div class="spec value" id="val-conj">
+    <a href="#val-conj" class="anchor"></a><code><span class="keyword">val</span> conj : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span></code>
+   </div>
    <div class="spec module" id="module-Z">
     <a href="#module-Z" class="anchor"></a><code><span class="keyword">module</span> <a href="Z/index.html">Z</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Recent_impl/index.html
+++ b/test/html/expect/test_package+ml/Recent_impl/index.html
@@ -28,11 +28,9 @@
    <div class="spec module" id="module-B">
     <a href="#module-B" class="anchor"></a><code><span class="keyword">module</span> <a href="B/index.html">B</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-u">
-     <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-u">
+    <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u</code>
+   </div>
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Section/index.html
+++ b/test/html/expect/test_package+ml/Section/index.html
@@ -77,11 +77,9 @@
    <h2 id="value-only">
     <a href="#value-only" class="anchor"></a>Value only
    </h2>
-   <dl>
-    <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-foo">
+    <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>
+   </div>
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
    </h2>

--- a/test/html/expect/test_package+ml/Stop/index.html
+++ b/test/html/expect/test_package+ml/Stop/index.html
@@ -25,16 +25,16 @@
    </p>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : int</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is normal commented text.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <aside>
     <p>
      The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
@@ -49,11 +49,9 @@
    <div class="spec module" id="module-N">
     <a href="#module-N" class="anchor"></a><code><span class="keyword">module</span> <a href="N/index.html">N</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec value" id="val-lol">
-     <a href="#val-lol" class="anchor"></a><code><span class="keyword">val</span> lol : int</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-lol">
+    <a href="#val-lol" class="anchor"></a><code><span class="keyword">val</span> lol : int</code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -22,393 +22,383 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec type" id="type-abstract">
+   <div>
+    <div class="spec type" id="type-abstract">
      <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type</span> abstract</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some <em>documentation</em>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-alias">
-     <a href="#type-alias" class="anchor"></a><code><span class="keyword">type</span> alias = int</code>
-    </dt>
-    <dt class="spec type" id="type-private_">
-     <a href="#type-private_" class="anchor"></a><code><span class="keyword">type</span> private_ = <span class="keyword">private</span> int</code>
-    </dt>
-    <dt class="spec type" id="type-constructor">
-     <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type</span> <span>'a constructor</span> = <span class="type-var">'a</span></code>
-    </dt>
-    <dt class="spec type" id="type-arrow">
-     <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type</span> arrow = int <span>-&gt;</span> int</code>
-    </dt>
-    <dt class="spec type" id="type-higher_order">
-     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order = <span>(int <span>-&gt;</span> int)</span> <span>-&gt;</span> int</code>
-    </dt>
-    <dt class="spec type" id="type-labeled">
-     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled = <span>l:int</span> <span>-&gt;</span> int</code>
-    </dt>
-    <dt class="spec type" id="type-optional">
-     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional = <span>?⁠l:int</span> <span>-&gt;</span> int</code>
-    </dt>
-    <dt class="spec type" id="type-labeled_higher_order">
-     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order = <span>(<span>l:int</span> <span>-&gt;</span> int)</span> <span>-&gt;</span> <span>(<span>?⁠l:int</span> <span>-&gt;</span> int)</span> <span>-&gt;</span> int</code>
-    </dt>
-    <dt class="spec type" id="type-pair">
-     <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair = int * int</code>
-    </dt>
-    <dt class="spec type" id="type-parens_dropped">
-     <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type</span> parens_dropped = int * int</code>
-    </dt>
-    <dt class="spec type" id="type-triple">
-     <a href="#type-triple" class="anchor"></a><code><span class="keyword">type</span> triple = int * int * int</code>
-    </dt>
-    <dt class="spec type" id="type-nested_pair">
-     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair = <span>(int * int)</span> * int</code>
-    </dt>
-    <dt class="spec type" id="type-instance">
-     <a href="#type-instance" class="anchor"></a><code><span class="keyword">type</span> instance = <span>int <a href="index.html#type-constructor">constructor</a></span></code>
-    </dt>
-    <dt class="spec type" id="type-variant_e">
-     <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type</span> variant_e = {</code>
-     <table>
-      <tbody>
-       <tr id="type-variant_e.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-variant_e.a" class="anchor"></a><code>a : int;</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>}</code>
-    </dt>
-    <dt class="spec type" id="type-variant">
-     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant = </code>
-     <table>
-      <tbody>
-       <tr id="type-variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.B" class="anchor"></a><code>| <span class="constructor">B</span> <span class="keyword">of</span> int</code>
-        </td>
-       </tr>
-       <tr id="type-variant.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.C" class="anchor"></a><code>| <span class="constructor">C</span></code>
-        </td>
-        <td class="doc">
-         <p>
-          foo
-         </p>
-        </td>
-       </tr>
-       <tr id="type-variant.D" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.D" class="anchor"></a><code>| <span class="constructor">D</span></code>
-        </td>
-        <td class="doc">
-         <p>
-          <em>bar</em>
-         </p>
-        </td>
-       </tr>
-       <tr id="type-variant.E" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.E" class="anchor"></a><code>| <span class="constructor">E</span> <span class="keyword">of</span> <a href="index.html#type-variant_e">variant_e</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dt>
-    <dt class="spec type" id="type-variant_c">
-     <a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type</span> variant_c = {</code>
-     <table>
-      <tbody>
-       <tr id="type-variant_c.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-variant_c.a" class="anchor"></a><code>a : int;</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>}</code>
-    </dt>
-    <dt class="spec type" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> <span>_ gadt</span> = </code>
-     <table>
-      <tbody>
-       <tr id="type-gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <span>int <a href="index.html#type-gadt">gadt</a></span></code>
-        </td>
-       </tr>
-       <tr id="type-gadt.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code>| <span class="constructor">B</span> : int <span>-&gt;</span> <span>string <a href="index.html#type-gadt">gadt</a></span></code>
-        </td>
-       </tr>
-       <tr id="type-gadt.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code>| <span class="constructor">C</span> : <a href="index.html#type-variant_c">variant_c</a> <span>-&gt;</span> <span>unit <a href="index.html#type-gadt">gadt</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dt>
-    <dt class="spec type" id="type-degenerate_gadt">
-     <a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type</span> degenerate_gadt = </code>
-     <table>
-      <tbody>
-       <tr id="type-degenerate_gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-degenerate_gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dt>
-    <dt class="spec type" id="type-private_variant">
-     <a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type</span> private_variant = <span class="keyword">private</span> </code>
-     <table>
-      <tbody>
-       <tr id="type-private_variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-private_variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dt>
-    <dt class="spec type" id="type-record">
-     <a href="#type-record" class="anchor"></a><code><span class="keyword">type</span> record = {</code>
-     <table>
-      <tbody>
-       <tr id="type-record.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.a" class="anchor"></a><code>a : int;</code>
-        </td>
-       </tr>
-       <tr id="type-record.b" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable</span> b : int;</code>
-        </td>
-       </tr>
-       <tr id="type-record.c" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.c" class="anchor"></a><code>c : int;</code>
-        </td>
-        <td class="doc">
-         <p>
-          foo
-         </p>
-        </td>
-       </tr>
-       <tr id="type-record.d" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.d" class="anchor"></a><code>d : int;</code>
-        </td>
-        <td class="doc">
-         <p>
-          <em>bar</em>
-         </p>
-        </td>
-       </tr>
-       <tr id="type-record.e" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.e" class="anchor"></a><code>e : a. <span class="type-var">'a</span>;</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>}</code>
-    </dt>
-    <dt class="spec type" id="type-polymorphic_variant">
-     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B <span class="keyword">of</span> int</code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C <span class="keyword">of</span> int * unit</code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ]</code>
-    </dt>
-    <dt class="spec type" id="type-polymorphic_variant_extension">
-     <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant_extension = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
-        <td class="def type">
-         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant_extension.E" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code>| </code><code>`E</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ]</code>
-    </dt>
-    <dt class="spec type" id="type-nested_polymorphic_variant">
-     <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> nested_polymorphic_variant = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-nested_polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A <span class="keyword">of</span> <span>[ `B <span>| `C</span> ]</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ]</code>
-    </dt>
-    <dt class="spec type" id="type-private_extenion#row">
-     <a href="#type-private_extenion#row" class="anchor"></a><code><span class="keyword">type</span> private_extenion#row</code>
-    </dt>
-    <dt class="spec type" id="type-private_extenion">
-     <a href="#type-private_extenion" class="anchor"></a><code><span class="keyword">and</span> private_extenion = <span class="keyword">private</span> [&gt; </code>
-     <table>
-      <tbody>
-       <tr id="type-private_extenion.polymorphic_variant" class="anchored">
-        <td class="def type">
-         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ]</code>
-    </dt>
-    <dt class="spec type" id="type-object_">
-     <a href="#type-object_" class="anchor"></a><code><span class="keyword">type</span> object_ = &lt; a : int; b : int; c : int; &gt;</code>
-    </dt>
-   </dl>
+    </div>
+   </div>
+   <div class="spec type" id="type-alias">
+    <a href="#type-alias" class="anchor"></a><code><span class="keyword">type</span> alias = int</code>
+   </div>
+   <div class="spec type" id="type-private_">
+    <a href="#type-private_" class="anchor"></a><code><span class="keyword">type</span> private_ = <span class="keyword">private</span> int</code>
+   </div>
+   <div class="spec type" id="type-constructor">
+    <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type</span> <span>'a constructor</span> = <span class="type-var">'a</span></code>
+   </div>
+   <div class="spec type" id="type-arrow">
+    <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type</span> arrow = int <span>-&gt;</span> int</code>
+   </div>
+   <div class="spec type" id="type-higher_order">
+    <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order = <span>(int <span>-&gt;</span> int)</span> <span>-&gt;</span> int</code>
+   </div>
+   <div class="spec type" id="type-labeled">
+    <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled = <span>l:int</span> <span>-&gt;</span> int</code>
+   </div>
+   <div class="spec type" id="type-optional">
+    <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional = <span>?⁠l:int</span> <span>-&gt;</span> int</code>
+   </div>
+   <div class="spec type" id="type-labeled_higher_order">
+    <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order = <span>(<span>l:int</span> <span>-&gt;</span> int)</span> <span>-&gt;</span> <span>(<span>?⁠l:int</span> <span>-&gt;</span> int)</span> <span>-&gt;</span> int</code>
+   </div>
+   <div class="spec type" id="type-pair">
+    <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair = int * int</code>
+   </div>
+   <div class="spec type" id="type-parens_dropped">
+    <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type</span> parens_dropped = int * int</code>
+   </div>
+   <div class="spec type" id="type-triple">
+    <a href="#type-triple" class="anchor"></a><code><span class="keyword">type</span> triple = int * int * int</code>
+   </div>
+   <div class="spec type" id="type-nested_pair">
+    <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair = <span>(int * int)</span> * int</code>
+   </div>
+   <div class="spec type" id="type-instance">
+    <a href="#type-instance" class="anchor"></a><code><span class="keyword">type</span> instance = <span>int <a href="index.html#type-constructor">constructor</a></span></code>
+   </div>
+   <div class="spec type" id="type-variant_e">
+    <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type</span> variant_e = {</code>
+    <table>
+     <tbody>
+      <tr id="type-variant_e.a" class="anchored">
+       <td class="def record field">
+        <a href="#type-variant_e.a" class="anchor"></a><code>a : int;</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>}</code>
+   </div>
+   <div class="spec type" id="type-variant">
+    <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant = </code>
+    <table>
+     <tbody>
+      <tr id="type-variant.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
+       </td>
+      </tr>
+      <tr id="type-variant.B" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.B" class="anchor"></a><code>| <span class="constructor">B</span> <span class="keyword">of</span> int</code>
+       </td>
+      </tr>
+      <tr id="type-variant.C" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.C" class="anchor"></a><code>| <span class="constructor">C</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         foo
+        </p>
+       </td>
+      </tr>
+      <tr id="type-variant.D" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.D" class="anchor"></a><code>| <span class="constructor">D</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         <em>bar</em>
+        </p>
+       </td>
+      </tr>
+      <tr id="type-variant.E" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.E" class="anchor"></a><code>| <span class="constructor">E</span> <span class="keyword">of</span> <a href="index.html#type-variant_e">variant_e</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec type" id="type-variant_c">
+    <a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type</span> variant_c = {</code>
+    <table>
+     <tbody>
+      <tr id="type-variant_c.a" class="anchored">
+       <td class="def record field">
+        <a href="#type-variant_c.a" class="anchor"></a><code>a : int;</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>}</code>
+   </div>
+   <div class="spec type" id="type-gadt">
+    <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> <span>_ gadt</span> = </code>
+    <table>
+     <tbody>
+      <tr id="type-gadt.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <span>int <a href="index.html#type-gadt">gadt</a></span></code>
+       </td>
+      </tr>
+      <tr id="type-gadt.B" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.B" class="anchor"></a><code>| <span class="constructor">B</span> : int <span>-&gt;</span> <span>string <a href="index.html#type-gadt">gadt</a></span></code>
+       </td>
+      </tr>
+      <tr id="type-gadt.C" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.C" class="anchor"></a><code>| <span class="constructor">C</span> : <a href="index.html#type-variant_c">variant_c</a> <span>-&gt;</span> <span>unit <a href="index.html#type-gadt">gadt</a></span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec type" id="type-degenerate_gadt">
+    <a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type</span> degenerate_gadt = </code>
+    <table>
+     <tbody>
+      <tr id="type-degenerate_gadt.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-degenerate_gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec type" id="type-private_variant">
+    <a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type</span> private_variant = <span class="keyword">private</span> </code>
+    <table>
+     <tbody>
+      <tr id="type-private_variant.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-private_variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec type" id="type-record">
+    <a href="#type-record" class="anchor"></a><code><span class="keyword">type</span> record = {</code>
+    <table>
+     <tbody>
+      <tr id="type-record.a" class="anchored">
+       <td class="def record field">
+        <a href="#type-record.a" class="anchor"></a><code>a : int;</code>
+       </td>
+      </tr>
+      <tr id="type-record.b" class="anchored">
+       <td class="def record field">
+        <a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable</span> b : int;</code>
+       </td>
+      </tr>
+      <tr id="type-record.c" class="anchored">
+       <td class="def record field">
+        <a href="#type-record.c" class="anchor"></a><code>c : int;</code>
+       </td>
+       <td class="doc">
+        <p>
+         foo
+        </p>
+       </td>
+      </tr>
+      <tr id="type-record.d" class="anchored">
+       <td class="def record field">
+        <a href="#type-record.d" class="anchor"></a><code>d : int;</code>
+       </td>
+       <td class="doc">
+        <p>
+         <em>bar</em>
+        </p>
+       </td>
+      </tr>
+      <tr id="type-record.e" class="anchored">
+       <td class="def record field">
+        <a href="#type-record.e" class="anchor"></a><code>e : a. <span class="type-var">'a</span>;</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>}</code>
+   </div>
+   <div class="spec type" id="type-polymorphic_variant">
+    <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-polymorphic_variant.A" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.B" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B <span class="keyword">of</span> int</code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.C" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C <span class="keyword">of</span> int * unit</code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.D" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ]</code>
+   </div>
+   <div class="spec type" id="type-polymorphic_variant_extension">
+    <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant_extension = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
+       <td class="def type">
+        <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant_extension.E" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code>| </code><code>`E</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ]</code>
+   </div>
+   <div class="spec type" id="type-nested_polymorphic_variant">
+    <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> nested_polymorphic_variant = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-nested_polymorphic_variant.A" class="anchored">
+       <td class="def constructor">
+        <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A <span class="keyword">of</span> <span>[ `B <span>| `C</span> ]</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ]</code>
+   </div>
+   <div class="spec type" id="type-private_extenion#row">
+    <a href="#type-private_extenion#row" class="anchor"></a><code><span class="keyword">type</span> private_extenion#row</code>
+   </div>
+   <div class="spec type" id="type-private_extenion">
+    <a href="#type-private_extenion" class="anchor"></a><code><span class="keyword">and</span> private_extenion = <span class="keyword">private</span> [&gt; </code>
+    <table>
+     <tbody>
+      <tr id="type-private_extenion.polymorphic_variant" class="anchored">
+       <td class="def type">
+        <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ]</code>
+   </div>
+   <div class="spec type" id="type-object_">
+    <a href="#type-object_" class="anchor"></a><code><span class="keyword">type</span> object_ = &lt; a : int; b : int; c : int; &gt;</code>
+   </div>
    <div class="spec module-type" id="module-type-X">
     <a href="#module-type-X" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-X/index.html">X</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-module_">
-     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type</span> module_ = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</span></code>
-    </dt>
-    <dt class="spec type" id="type-module_substitution">
-     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span></code>
-    </dt>
-    <dt class="spec type" id="type-covariant">
-     <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type</span> <span>+'a covariant</span></code>
-    </dt>
-    <dt class="spec type" id="type-contravariant">
-     <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type</span> <span>-'a contravariant</span></code>
-    </dt>
-    <dt class="spec type" id="type-bivariant">
-     <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type</span> <span>_ bivariant</span> = int</code>
-    </dt>
-    <dt class="spec type" id="type-binary">
-     <a href="#type-binary" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) binary</span></code>
-    </dt>
-    <dt class="spec type" id="type-using_binary">
-     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary = <span><span>(int,&nbsp;int)</span> <a href="index.html#type-binary">binary</a></span></code>
-    </dt>
-    <dt class="spec type" id="type-name">
-     <a href="#type-name" class="anchor"></a><code><span class="keyword">type</span> <span>'custom name</span></code>
-    </dt>
-    <dt class="spec type" id="type-constrained">
-     <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type</span> <span>'a constrained</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</code>
-    </dt>
-    <dt class="spec type" id="type-exact_variant">
-     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a exact_variant</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[ `A <span><span>| `B</span> of int</span> ]</span></code>
-    </dt>
-    <dt class="spec type" id="type-lower_variant">
-     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a lower_variant</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `A <span><span>| `B</span> of int</span> ]</span></code>
-    </dt>
-    <dt class="spec type" id="type-any_variant">
-     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a any_variant</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt;  ]</span></code>
-    </dt>
-    <dt class="spec type" id="type-upper_variant">
-     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a upper_variant</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; `A <span><span>| `B</span> of int</span> ]</span></code>
-    </dt>
-    <dt class="spec type" id="type-named_variant">
-     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a named_variant</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</span></code>
-    </dt>
-    <dt class="spec type" id="type-exact_object">
-     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type</span> <span>'a exact_object</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; &gt;</code>
-    </dt>
-    <dt class="spec type" id="type-lower_object">
-     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type</span> <span>'a lower_object</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; .. &gt;</code>
-    </dt>
-    <dt class="spec type" id="type-poly_object">
-     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> <span>'a poly_object</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : a. <span class="type-var">'a</span>; &gt;</code>
-    </dt>
-    <dt class="spec type" id="type-double_constrained">
-     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) double_constrained</span> = <span class="type-var">'a</span> * <span class="type-var">'b</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</code>
-    </dt>
-    <dt class="spec type" id="type-as_">
-     <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_ = int <span class="keyword">as</span> 'a * <span class="type-var">'a</span></code>
-    </dt>
-    <dt class="spec type" id="type-extensible">
-     <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type</span> extensible = ..</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-extensible">extensible</a> += | <span class="extension">Extension</span>| <span class="extension">Another_extension</span></code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-mutually">
-     <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type</span> mutually = </code>
-     <table>
-      <tbody>
-       <tr id="type-mutually.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutually.A" class="anchor"></a><code>| <span class="constructor">A</span> <span class="keyword">of</span> <a href="index.html#type-recursive">recursive</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dt>
-    <dt class="spec type" id="type-recursive">
-     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">and</span> recursive = </code>
-     <table>
-      <tbody>
-       <tr id="type-recursive.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-recursive.B" class="anchor"></a><code>| <span class="constructor">B</span> <span class="keyword">of</span> <a href="index.html#type-mutually">mutually</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-Foo">
-     <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Foo</span> <span class="keyword">of</span> int * int</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-module_">
+    <a href="#type-module_" class="anchor"></a><code><span class="keyword">type</span> module_ = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</span></code>
+   </div>
+   <div class="spec type" id="type-module_substitution">
+    <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span></code>
+   </div>
+   <div class="spec type" id="type-covariant">
+    <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type</span> <span>+'a covariant</span></code>
+   </div>
+   <div class="spec type" id="type-contravariant">
+    <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type</span> <span>-'a contravariant</span></code>
+   </div>
+   <div class="spec type" id="type-bivariant">
+    <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type</span> <span>_ bivariant</span> = int</code>
+   </div>
+   <div class="spec type" id="type-binary">
+    <a href="#type-binary" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) binary</span></code>
+   </div>
+   <div class="spec type" id="type-using_binary">
+    <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary = <span><span>(int,&nbsp;int)</span> <a href="index.html#type-binary">binary</a></span></code>
+   </div>
+   <div class="spec type" id="type-name">
+    <a href="#type-name" class="anchor"></a><code><span class="keyword">type</span> <span>'custom name</span></code>
+   </div>
+   <div class="spec type" id="type-constrained">
+    <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type</span> <span>'a constrained</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</code>
+   </div>
+   <div class="spec type" id="type-exact_variant">
+    <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a exact_variant</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[ `A <span><span>| `B</span> of int</span> ]</span></code>
+   </div>
+   <div class="spec type" id="type-lower_variant">
+    <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a lower_variant</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `A <span><span>| `B</span> of int</span> ]</span></code>
+   </div>
+   <div class="spec type" id="type-any_variant">
+    <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a any_variant</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt;  ]</span></code>
+   </div>
+   <div class="spec type" id="type-upper_variant">
+    <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a upper_variant</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; `A <span><span>| `B</span> of int</span> ]</span></code>
+   </div>
+   <div class="spec type" id="type-named_variant">
+    <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> <span>'a named_variant</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</span></code>
+   </div>
+   <div class="spec type" id="type-exact_object">
+    <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type</span> <span>'a exact_object</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; &gt;</code>
+   </div>
+   <div class="spec type" id="type-lower_object">
+    <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type</span> <span>'a lower_object</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : int; b : int; .. &gt;</code>
+   </div>
+   <div class="spec type" id="type-poly_object">
+    <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> <span>'a poly_object</span> = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = &lt; a : a. <span class="type-var">'a</span>; &gt;</code>
+   </div>
+   <div class="spec type" id="type-double_constrained">
+    <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> <span>('a, 'b) double_constrained</span> = <span class="type-var">'a</span> * <span class="type-var">'b</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</code>
+   </div>
+   <div class="spec type" id="type-as_">
+    <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_ = int <span class="keyword">as</span> 'a * <span class="type-var">'a</span></code>
+   </div>
+   <div class="spec type" id="type-extensible">
+    <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type</span> extensible = ..</code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-extensible">extensible</a> += | <span class="extension">Extension</span>| <span class="extension">Another_extension</span></code>
+   </div>
+   <div class="spec type" id="type-mutually">
+    <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type</span> mutually = </code>
+    <table>
+     <tbody>
+      <tr id="type-mutually.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-mutually.A" class="anchor"></a><code>| <span class="constructor">A</span> <span class="keyword">of</span> <a href="index.html#type-recursive">recursive</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec type" id="type-recursive">
+    <a href="#type-recursive" class="anchor"></a><code><span class="keyword">and</span> recursive = </code>
+    <table>
+     <tbody>
+      <tr id="type-recursive.B" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-recursive.B" class="anchor"></a><code>| <span class="constructor">B</span> <span class="keyword">of</span> <a href="index.html#type-mutually">mutually</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec exception" id="exception-Foo">
+    <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Foo</span> <span class="keyword">of</span> int * int</code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Val/index.html
+++ b/test/html/expect/test_package+ml/Val/index.html
@@ -22,29 +22,29 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec value" id="val-documented">
+   <div>
+    <div class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span class="keyword">val</span> documented : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Foo.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-undocumented">
-     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val</span> undocumented : unit</code>
-    </dt>
-    <dt class="spec value" id="val-documented_above">
+    </div>
+   </div>
+   <div class="spec value" id="val-undocumented">
+    <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">val</span> undocumented : unit</code>
+   </div>
+   <div>
+    <div class="spec value" id="val-documented_above">
      <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">val</span> documented_above : unit</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Bar.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Alias/X/index.html
+++ b/test/html/expect/test_package+re/Alias/X/index.html
@@ -22,16 +22,16 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = int;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Module Foo__X documentation. This should appear in the documentation for the alias to this module 'X'
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Bugs/index.html
+++ b/test/html/expect/test_package+re/Bugs/index.html
@@ -22,21 +22,19 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec type" id="type-opt">
-     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> opt('a) = option(<span class="type-var">'a</span>);</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div class="spec type" id="type-opt">
+    <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> opt('a) = option(<span class="type-var">'a</span>);</code>
+   </div>
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: <span>?⁠bar:<span class="type-var">'a</span></span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Triggers an assertion failure when <a href="https://github.com/ocaml/odoc/issues/101">https://github.com/ocaml/odoc/issues/101</a> is not fixed.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Bugs_pre_410/index.html
+++ b/test/html/expect/test_package+re/Bugs_pre_410/index.html
@@ -22,21 +22,19 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec type" id="type-opt'">
-     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> opt'('a) = option(int);</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-foo'">
+   <div class="spec type" id="type-opt'">
+    <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> opt'('a) = option(int);</code>
+   </div>
+   <div>
+    <div class="spec value" id="val-foo'">
      <a href="#val-foo'" class="anchor"></a><code><span class="keyword">let</span> foo': <span>?⁠bar:<span class="type-var">'a</span></span> <span>=&gt;</span> unit <span>=&gt;</span> unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Similar to <code>Bugs</code>, but the printed type of <code>~bar</code> should be <code>int</code>, not <code>'a</code>. This probably requires fixing in the compiler. See <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">https://github.com/ocaml/odoc/pull/230#issuecomment-433226807</a>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -23,13 +23,13 @@
   </header>
   <div class="content">
    <div class="spec class-type" id="class-type-empty">
-    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a> = { ... }</code>
+    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a>{ ... }</code>
    </div>
    <div class="spec class-type" id="class-type-mutually">
-    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-mutually/index.html">mutually</a> = { ... }</code>
+    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-mutually/index.html">mutually</a>{ ... }</code>
    </div>
    <div class="spec class-type" id="class-type-recursive">
-    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-type-recursive/index.html">recursive</a> = { ... }</code>
+    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-type-recursive/index.html">recursive</a>{ ... }</code>
    </div>
    <div class="spec class" id="class-mutually'">
     <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-mutually'/index.html">mutually'</a>: <a href="class-type-mutually/index.html">mutually</a></code>
@@ -38,13 +38,13 @@
     <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-recursive'/index.html">recursive'</a>: <a href="class-type-recursive/index.html">recursive</a></code>
    </div>
    <div class="spec class-type" id="class-type-empty_virtual">
-    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  <a href="class-type-empty_virtual/index.html">empty_virtual</a> = { ... }</code>
+    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  <a href="class-type-empty_virtual/index.html">empty_virtual</a>{ ... }</code>
    </div>
    <div class="spec class" id="class-empty_virtual'">
     <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-empty_virtual'/index.html">empty_virtual'</a>: <a href="class-type-empty/index.html">empty</a></code>
    </div>
    <div class="spec class-type" id="class-type-polymorphic">
-    <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> ('a) <a href="class-type-polymorphic/index.html">polymorphic</a> = { ... }</code>
+    <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> ('a) <a href="class-type-polymorphic/index.html">polymorphic</a>{ ... }</code>
    </div>
    <div class="spec class" id="class-polymorphic'">
     <a href="#class-polymorphic'" class="anchor"></a><code><span class="keyword">class</span> ('a) <a href="class-polymorphic'/index.html">polymorphic'</a>: <a href="class-type-polymorphic/index.html">polymorphic</a>(<span class="type-var">'a</span>)</code>

--- a/test/html/expect/test_package+re/External/index.html
+++ b/test/html/expect/test_package+re/External/index.html
@@ -22,16 +22,16 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec external" id="val-foo">
+   <div>
+    <div class="spec external" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit <span>=&gt;</span> unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Foo <em>bar</em>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Include/index.html
+++ b/test/html/expect/test_package+re/Include/index.html
@@ -32,11 +32,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a><span class="keyword">;</span></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
+       </div>
       </details>
      </div>
     </div>
@@ -47,11 +45,9 @@
    <div>
     <div class="spec include">
      <div class="doc">
-      <dl>
-       <dt class="spec type" id="type-u">
-        <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u;</code>
-       </dt>
-      </dl>
+      <div class="spec type" id="type-u">
+       <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u;</code>
+      </div>
      </div>
     </div>
    </div>
@@ -65,11 +61,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a><span class="keyword">;</span></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-v">
-         <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v;</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-v">
+        <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v;</code>
+       </div>
       </details>
      </div>
     </div>
@@ -84,11 +78,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a><span class="keyword">;</span></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-w">
-         <a href="#type-w" class="anchor"></a><code><span class="keyword">type</span> w;</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-w">
+        <a href="#type-w" class="anchor"></a><code><span class="keyword">type</span> w;</code>
+       </div>
       </details>
      </div>
     </div>

--- a/test/html/expect/test_package+re/Include2/index.html
+++ b/test/html/expect/test_package+re/Include2/index.html
@@ -22,16 +22,16 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec module" id="module-X">
+   <div>
+    <div class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a>: { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Comment about X that should not appear when including X below.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div>
     <div class="spec include">
      <div class="doc">
@@ -39,11 +39,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="X/index.html">X</a><span class="keyword">;</span></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = int;</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = int;</code>
+       </div>
       </details>
      </div>
     </div>

--- a/test/html/expect/test_package+re/Include_sections/index.html
+++ b/test/html/expect/test_package+re/Include_sections/index.html
@@ -69,16 +69,16 @@
    </ul>
   </nav>
   <div class="content">
-   <dl>
-    <dt class="spec module-type" id="module-type-Something">
+   <div>
+    <div class="spec module-type" id="module-type-Something">
      <a href="#module-type-Something" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Something/index.html">Something</a> = { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A module type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <aside>
     <p>
      Let's include <a href="module-type-Something/index.html"><code>Something</code></a> once
@@ -87,11 +87,9 @@
    <div>
     <div class="spec include">
      <div class="doc">
-      <dl>
-       <dt class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-something">
+       <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
+      </div>
       <h2 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h2>
@@ -100,24 +98,22 @@
         foo
        </p>
       </aside>
-      <dl>
-       <dt class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-foo">
+       <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+      </div>
       <h3 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h3>
-      <dl>
-       <dt class="spec value" id="val-bar">
+      <div>
+       <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-       </dt>
-       <dd>
+       </div>
+       <div>
         <p>
          foo bar
         </p>
-       </dd>
-      </dl>
+       </div>
+      </div>
       <h2 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h2>
@@ -140,11 +136,9 @@
    <div>
     <div class="spec include">
      <div class="doc">
-      <dl>
-       <dt class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-something">
+       <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
+      </div>
       <h3 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h3>
@@ -153,24 +147,22 @@
         foo
        </p>
       </aside>
-      <dl>
-       <dt class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-foo">
+       <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+      </div>
       <h4 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h4>
-      <dl>
-       <dt class="spec value" id="val-bar">
+      <div>
+       <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-       </dt>
-       <dd>
+       </div>
+       <div>
         <p>
          foo bar
         </p>
-       </dd>
-      </dl>
+       </div>
+      </div>
       <h3 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h3>
@@ -193,11 +185,9 @@
    <div>
     <div class="spec include">
      <div class="doc">
-      <dl>
-       <dt class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-something">
+       <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
+      </div>
       <h4 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h4>
@@ -206,24 +196,22 @@
         foo
        </p>
       </aside>
-      <dl>
-       <dt class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-       </dt>
-      </dl>
+      <div class="spec value" id="val-foo">
+       <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+      </div>
       <h5 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h5>
-      <dl>
-       <dt class="spec value" id="val-bar">
+      <div>
+       <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-       </dt>
-       <dd>
+       </div>
+       <div>
         <p>
          foo bar
         </p>
-       </dd>
-      </dl>
+       </div>
+      </div>
       <h4 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h4>
@@ -247,11 +235,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-Something/index.html">Something</a><span class="keyword">;</span></code></span>
        </summary>
-       <dl>
-        <dt class="spec value" id="val-something">
-         <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
-        </dt>
-       </dl>
+       <div class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
+       </div>
        <h2 id="something-1">
         <a href="#something-1" class="anchor"></a>Something 1
        </h2>
@@ -260,24 +246,22 @@
          foo
         </p>
        </aside>
-       <dl>
-        <dt class="spec value" id="val-foo">
-         <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-        </dt>
-       </dl>
+       <div class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+       </div>
        <h3 id="something-2">
         <a href="#something-2" class="anchor"></a>Something 2
        </h3>
-       <dl>
-        <dt class="spec value" id="val-bar">
+       <div>
+        <div class="spec value" id="val-bar">
          <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-        </dt>
-        <dd>
+        </div>
+        <div>
          <p>
           foo bar
          </p>
-        </dd>
-       </dl>
+        </div>
+       </div>
        <h2 id="something-1-bis">
         <a href="#something-1-bis" class="anchor"></a>Something 1-bis
        </h2>

--- a/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
@@ -40,11 +40,9 @@
    </ul>
   </nav>
   <div class="content">
-   <dl>
-    <dt class="spec value" id="val-something">
-     <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-something">
+    <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
+   </div>
    <h2 id="something-1">
     <a href="#something-1" class="anchor"></a>Something 1
    </h2>
@@ -53,24 +51,22 @@
      foo
     </p>
    </aside>
-   <dl>
-    <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-foo">
+    <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+   </div>
    <h3 id="something-2">
     <a href="#something-2" class="anchor"></a>Something 2
    </h3>
-   <dl>
-    <dt class="spec value" id="val-bar">
+   <div>
+    <div class="spec value" id="val-bar">
      <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       foo bar
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="something-1-bis">
     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
    </h2>

--- a/test/html/expect/test_package+re/Interlude/index.html
+++ b/test/html/expect/test_package+re/Interlude/index.html
@@ -30,16 +30,16 @@
      Some separate stray text at the top of the module.
     </p>
    </aside>
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Foo.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <aside>
     <p>
      Some stray text that is not associated with any signature item.
@@ -51,27 +51,25 @@
      A separate block of stray text, adjacent to the preceding one.
     </p>
    </aside>
-   <dl>
-    <dt class="spec value" id="val-bar">
+   <div>
+    <div class="spec value" id="val-bar">
      <a href="#val-bar" class="anchor"></a><code><span class="keyword">let</span> bar: unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Bar.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-multiple">
-     <a href="#val-multiple" class="anchor"></a><code><span class="keyword">let</span> multiple: unit;</code>
-    </dt>
-    <dt class="spec value" id="val-signature">
-     <a href="#val-signature" class="anchor"></a><code><span class="keyword">let</span> signature: unit;</code>
-    </dt>
-    <dt class="spec value" id="val-items">
-     <a href="#val-items" class="anchor"></a><code><span class="keyword">let</span> items: unit;</code>
-    </dt>
-   </dl>
+    </div>
+   </div>
+   <div class="spec value" id="val-multiple">
+    <a href="#val-multiple" class="anchor"></a><code><span class="keyword">let</span> multiple: unit;</code>
+   </div>
+   <div class="spec value" id="val-signature">
+    <a href="#val-signature" class="anchor"></a><code><span class="keyword">let</span> signature: unit;</code>
+   </div>
+   <div class="spec value" id="val-items">
+    <a href="#val-items" class="anchor"></a><code><span class="keyword">let</span> items: unit;</code>
+   </div>
    <aside>
     <p>
      Stray text at the bottom of the module.

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -415,16 +415,16 @@ let bar =
      </dd>
     </dl>
    </aside>
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -25,16 +25,16 @@
    </p>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>
@@ -53,11 +53,9 @@
    <div class="spec module-type" id="module-type-S5">
     <a href="#module-type-S5" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S5/index.html">S5</a> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>);</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-result">
-     <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> result('a, 'b);</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-result">
+    <a href="#type-result" class="anchor"></a><code><span class="keyword">type</span> result('a, 'b);</code>
+   </div>
    <div class="spec module-type" id="module-type-S6">
     <a href="#module-type-S6" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S6/index.html">S6</a> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S/index.html#type-w">w</a>('a, 'b) := <a href="index.html#type-result">result</a><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span>;</code>
    </div>

--- a/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
@@ -35,29 +35,29 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <dl>
-    <dt class="spec value" id="val-y">
+   <div>
+    <div class="spec value" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span class="keyword">let</span> y: <a href="index.html#type-t">t</a>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       The value of y.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
@@ -32,16 +32,16 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -28,8 +28,8 @@
      Some additional comments.
     </p>
    </aside>
-   <h3 id="heading">
-    <a href="#heading" class="anchor"></a>Parameters
+   <h3 id="parameters">
+    <a href="#parameters" class="anchor"></a>Parameters
    </h3>
    <div class="spec parameter" id="argument-1-Arg1">
     <a href="#argument-1-Arg1" class="anchor"></a><code><span class="keyword">module</span> <a href="argument-1-Arg1/index.html">Arg1</a>: <a href="../module-type-Y/index.html">Y</a></code>
@@ -37,8 +37,8 @@
    <div class="spec parameter" id="argument-2-Arg2">
     <a href="#argument-2-Arg2" class="anchor"></a><code><span class="keyword">module</span> <a href="argument-2-Arg2/index.html">Arg2</a>: { ... }</code>
    </div>
-   <h3 id="heading">
-    <a href="#heading" class="anchor"></a>Signature
+   <h3 id="signature">
+    <a href="#signature" class="anchor"></a>Signature
    </h3>
   </header>
   <nav class="toc">
@@ -52,16 +52,16 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = <span>(<a href="argument-1-Arg1/index.html#type-t">Arg1.t</a>, <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a>)</span>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -41,29 +41,29 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <dl>
-    <dt class="spec value" id="val-x">
+   <div>
+    <div class="spec value" id="val-x">
      <a href="#val-x" class="anchor"></a><code><span class="keyword">let</span> x: <a href="index.html#type-t">t</a>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       The value of x.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+re/Nested/class-inherits/index.html
@@ -22,11 +22,9 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec inherit">
-     <code><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></code>
-    </dt>
-   </dl>
+   <div class="spec inherit">
+    <code><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/class-z/index.html
+++ b/test/html/expect/test_package+re/Nested/class-z/index.html
@@ -35,39 +35,35 @@
    </ul>
   </nav>
   <div class="content">
-   <dl>
-    <dt class="spec instance-variable" id="val-y">
+   <div>
+    <div class="spec instance-variable" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y: int</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some value.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec instance-variable" id="val-y'">
-     <a href="#val-y'" class="anchor"></a><code><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y': int</code>
-    </dt>
-   </dl>
+    </div>
+   </div>
+   <div class="spec instance-variable" id="val-y'">
+    <a href="#val-y'" class="anchor"></a><code><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y': int</code>
+   </div>
    <h2 id="methods">
     <a href="#methods" class="anchor"></a>Methods
    </h2>
-   <dl>
-    <dt class="spec method" id="method-z">
+   <div>
+    <div class="spec method" id="method-z">
      <a href="#method-z" class="anchor"></a><code><span class="keyword">method</span> z: int</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some method.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec method" id="method-z'">
-     <a href="#method-z'" class="anchor"></a><code><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z': int</code>
-    </dt>
-   </dl>
+    </div>
+   </div>
+   <div class="spec method" id="method-z'">
+    <a href="#method-z'" class="anchor"></a><code><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z': int</code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -44,55 +44,55 @@
    <h2 id="module">
     <a href="#module" class="anchor"></a>Module
    </h2>
-   <dl>
-    <dt class="spec module" id="module-X">
+   <div>
+    <div class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a>: { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is module X.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="module-type">
     <a href="#module-type" class="anchor"></a>Module type
    </h2>
-   <dl>
-    <dt class="spec module-type" id="module-type-Y">
+   <div>
+    <div class="spec module-type" id="module-type-Y">
      <a href="#module-type-Y" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Y/index.html">Y</a> = { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is module type Y.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="functor">
     <a href="#functor" class="anchor"></a>Functor
    </h2>
-   <dl>
-    <dt class="spec module" id="module-F">
+   <div>
+    <div class="spec module" id="module-F">
      <a href="#module-F" class="anchor"></a><code><span class="keyword">module</span> <a href="F/index.html">F</a>:  (<a href="F/argument-1-Arg1/index.html">Arg1</a>: <a href="module-type-Y/index.html">Y</a>) <span>=&gt;</span>  (<a href="F/argument-2-Arg2/index.html">Arg2</a>: { ... }) <span>=&gt;</span> { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is a functor F.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="class">
     <a href="#class" class="anchor"></a>Class
    </h2>
-   <dl>
-    <dt class="spec class" id="class-z">
+   <div>
+    <div class="spec class" id="class-z">
      <a href="#class-z" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-z/index.html">z</a>: { ... }</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is class z.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec class" id="class-inherits">
     <a href="#class-inherits" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-inherits/index.html">inherits</a>: { ... }</code>
    </div>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -41,29 +41,29 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <dl>
-    <dt class="spec type" id="type-t">
+   <div>
+    <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some type.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <dl>
-    <dt class="spec value" id="val-y">
+   <div>
+    <div class="spec value" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span class="keyword">let</span> y: <a href="index.html#type-t">t</a>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       The value of y.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -214,105 +214,105 @@
    <h4 id="basic-module-stuff">
     <a href="#basic-module-stuff" class="anchor"></a>Basic module stuff
    </h4>
-   <dl>
-    <dt class="spec module" id="module-Empty">
+   <div>
+    <div class="spec module" id="module-Empty">
      <a href="#module-Empty" class="anchor"></a><code><span class="keyword">module</span> <a href="Empty/index.html">Empty</a>: { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain, empty module
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-Empty">
+    </div>
+   </div>
+   <div>
+    <div class="spec module-type" id="module-type-Empty">
      <a href="#module-type-Empty" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Empty/index.html">Empty</a> = { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       An ambiguous, misnamed module type
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-MissingComment">
+    </div>
+   </div>
+   <div>
+    <div class="spec module-type" id="module-type-MissingComment">
      <a href="#module-type-MissingComment" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-MissingComment/index.html">MissingComment</a> = { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       An ambiguous, misnamed module type
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h6 id="s9000">
     <a href="#s9000" class="anchor"></a>Level 9000
    </h6>
-   <dl>
-    <dt class="spec module" id="module-EmptyAlias">
+   <div>
+    <div class="spec module" id="module-EmptyAlias">
      <a href="#module-EmptyAlias" class="anchor"></a><code><span class="keyword">module</span> EmptyAlias = <a href="Empty/index.html">Empty</a>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain module alias of <code>Empty</code>
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h4 id="emptySig">
     <a href="#emptySig" class="anchor"></a>EmptySig
    </h4>
-   <dl>
-    <dt class="spec module-type" id="module-type-EmptySig">
+   <div>
+    <div class="spec module-type" id="module-type-EmptySig">
      <a href="#module-type-EmptySig" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-EmptySig/index.html">EmptySig</a> = { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain, empty module signature
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-EmptySigAlias">
+    </div>
+   </div>
+   <div>
+    <div class="spec module-type" id="module-type-EmptySigAlias">
      <a href="#module-type-EmptySigAlias" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-EmptySigAlias/index.html">EmptySigAlias</a> = <a href="module-type-EmptySig/index.html">EmptySig</a>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain, empty module signature alias of
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module" id="module-ModuleWithSignature">
+    </div>
+   </div>
+   <div>
+    <div class="spec module" id="module-ModuleWithSignature">
      <a href="#module-ModuleWithSignature" class="anchor"></a><code><span class="keyword">module</span> <a href="ModuleWithSignature/index.html">ModuleWithSignature</a>: <a href="module-type-EmptySig/index.html">EmptySig</a>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain module of a signature of <a href="index.html#exception-EmptySig"><code>EmptySig</code></a> (reference)
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module" id="module-ModuleWithSignatureAlias">
+    </div>
+   </div>
+   <div>
+    <div class="spec module" id="module-ModuleWithSignatureAlias">
      <a href="#module-ModuleWithSignatureAlias" class="anchor"></a><code><span class="keyword">module</span> <a href="ModuleWithSignatureAlias/index.html">ModuleWithSignatureAlias</a>: <a href="module-type-EmptySigAlias/index.html">EmptySigAlias</a>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A plain module with an alias signature
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module" id="module-One">
     <a href="#module-One" class="anchor"></a><code><span class="keyword">module</span> <a href="One/index.html">One</a>: { ... };</code>
    </div>
-   <dl>
-    <dt class="spec module-type" id="module-type-SigForMod">
+   <div>
+    <div class="spec module-type" id="module-type-SigForMod">
      <a href="#module-type-SigForMod" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-SigForMod/index.html">SigForMod</a> = { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       There's a signature in a module in this signature.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module-type" id="module-type-SuperSig">
     <a href="#module-type-SuperSig" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-SuperSig/index.html">SuperSig</a> = { ... };</code>
    </div>
@@ -321,16 +321,16 @@
      For a good time, see <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a> or <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigB:subSig</code></a> or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="index.html#s9000">Level 9000</a> is also interesting. <a href="index.html#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="index.html#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
     </p>
    </aside>
-   <dl>
-    <dt class="spec module" id="module-Buffer">
+   <div>
+    <div class="spec module" id="module-Buffer">
      <a href="#module-Buffer" class="anchor"></a><code><span class="keyword">module</span> <a href="Buffer/index.html">Buffer</a>: { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       <code>Buffer</code>.t
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <aside>
     <p>
      Some text before exception title.
@@ -344,74 +344,74 @@
      After exception title.
     </p>
    </aside>
-   <dl>
-    <dt class="spec exception" id="exception-Kaboom">
+   <div>
+    <div class="spec exception" id="exception-Kaboom">
      <a href="#exception-Kaboom" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Kaboom</span>(unit);</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Unary exception constructor
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-Kablam">
+    </div>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-Kablam">
      <a href="#exception-Kablam" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Kablam</span>(unit, unit);</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Binary exception constructor
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-Kapow">
+    </div>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-Kapow">
      <a href="#exception-Kapow" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Kapow</span>(<span>(unit, unit)</span>);</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Unary exception constructor over binary tuple
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-EmptySig">
+    </div>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-EmptySig">
      <a href="#exception-EmptySig" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">EmptySig</span>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       <a href="index.html#exception-EmptySig"><code>EmptySig</code></a> is general but <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is a module and <a href="index.html#exception-EmptySig"><code>EmptySig</code></a> is this exception.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-EmptySigAlias">
+    </div>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-EmptySigAlias">
      <a href="#exception-EmptySigAlias" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">EmptySigAlias</span>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       <a href="index.html#exception-EmptySigAlias"><code>EmptySigAlias</code></a> is this exception.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h4 id="basic-type-and-value-stuff-with-advanced-doc-comments">
     <a href="#basic-type-and-value-stuff-with-advanced-doc-comments" class="anchor"></a>Basic type and value stuff with advanced doc comments
    </h4>
-   <dl>
-    <dt class="spec type" id="type-a_function">
+   <div>
+    <div class="spec type" id="type-a_function">
      <a href="#type-a_function" class="anchor"></a><code><span class="keyword">type</span> a_function('a, 'b) = <span class="type-var">'a</span> <span>=&gt;</span> <span class="type-var">'b</span>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       <a href="index.html#val-a_function"><code>a_function</code></a> is general but <a href="index.html#type-a_function"><code>a_function</code></a> is this type and <a href="index.html#val-a_function"><code>a_function</code></a> is the value below.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-a_function">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-a_function">
      <a href="#val-a_function" class="anchor"></a><code><span class="keyword">let</span> a_function: <span>x:int</span> <span>=&gt;</span> int;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is <code>a_function</code> with param and return type.
      </p>
@@ -435,19 +435,19 @@
        </p>
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-fun_fun_fun">
-     <a href="#val-fun_fun_fun" class="anchor"></a><code><span class="keyword">let</span> fun_fun_fun: <a href="index.html#type-a_function">a_function</a><span>(<a href="index.html#type-a_function">a_function</a><span>(int,&nbsp;int)</span>,&nbsp;<a href="index.html#type-a_function">a_function</a><span>(unit,&nbsp;unit)</span>)</span>;</code>
-    </dt>
-    <dt class="spec value" id="val-fun_maybe">
-     <a href="#val-fun_maybe" class="anchor"></a><code><span class="keyword">let</span> fun_maybe: <span>?⁠yes:unit</span> <span>=&gt;</span> unit <span>=&gt;</span> int;</code>
-    </dt>
-    <dt class="spec value" id="val-not_found">
+    </div>
+   </div>
+   <div class="spec value" id="val-fun_fun_fun">
+    <a href="#val-fun_fun_fun" class="anchor"></a><code><span class="keyword">let</span> fun_fun_fun: <a href="index.html#type-a_function">a_function</a><span>(<a href="index.html#type-a_function">a_function</a><span>(int,&nbsp;int)</span>,&nbsp;<a href="index.html#type-a_function">a_function</a><span>(unit,&nbsp;unit)</span>)</span>;</code>
+   </div>
+   <div class="spec value" id="val-fun_maybe">
+    <a href="#val-fun_maybe" class="anchor"></a><code><span class="keyword">let</span> fun_maybe: <span>?⁠yes:unit</span> <span>=&gt;</span> unit <span>=&gt;</span> int;</code>
+   </div>
+   <div>
+    <div class="spec value" id="val-not_found">
      <a href="#val-not_found" class="anchor"></a><code><span class="keyword">let</span> not_found: unit <span>=&gt;</span> unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <dl>
       <dt>
        raises Not_found
@@ -458,13 +458,13 @@
        </p>
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-ocaml_org">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-ocaml_org">
      <a href="#val-ocaml_org" class="anchor"></a><code><span class="keyword">let</span> ocaml_org: string;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <dl>
       <dt>
        see <a href="http://ocaml.org/">http://ocaml.org/</a>
@@ -475,13 +475,13 @@
        </p>
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-some_file">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-some_file">
      <a href="#val-some_file" class="anchor"></a><code><span class="keyword">let</span> some_file: string;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <dl>
       <dt>
        see <code>some_file</code>
@@ -492,13 +492,13 @@
        </p>
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-some_doc">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-some_doc">
      <a href="#val-some_doc" class="anchor"></a><code><span class="keyword">let</span> some_doc: string;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <dl>
       <dt>
        see some_doc
@@ -509,13 +509,13 @@
        </p>
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-since_mesozoic">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-since_mesozoic">
      <a href="#val-since_mesozoic" class="anchor"></a><code><span class="keyword">let</span> since_mesozoic: unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This value was introduced in the Mesozoic era.
      </p>
@@ -527,13 +527,13 @@
        mesozoic
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-changing">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-changing">
      <a href="#val-changing" class="anchor"></a><code><span class="keyword">let</span> changing: unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This value has had changes in 1.0.0, 1.1.0, and 1.2.0.
      </p>
@@ -565,88 +565,86 @@
        1.2.0
       </dd>
      </dl>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-with_foo">
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-with_foo">
      <a href="#val-with_foo" class="anchor"></a><code><span class="keyword">let</span> with_foo: unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This value has a custom tag <code>foo</code>. @foo the body of the custom <code>foo</code> tag
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h4 id="some-operators">
     <a href="#some-operators" class="anchor"></a>Some Operators
    </h4>
-   <dl>
-    <dt class="spec value" id="val-(~-)">
-     <a href="#val-(~-)" class="anchor"></a><code><span class="keyword">let</span> (~-): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(!)">
-     <a href="#val-(!)" class="anchor"></a><code><span class="keyword">let</span> (!): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(@)">
-     <a href="#val-(@)" class="anchor"></a><code><span class="keyword">let</span> (@): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-($)">
-     <a href="#val-($)" class="anchor"></a><code><span class="keyword">let</span> ($): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(%)">
-     <a href="#val-(%)" class="anchor"></a><code><span class="keyword">let</span> (%): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(&amp;)">
-     <a href="#val-(&amp;)" class="anchor"></a><code><span class="keyword">let</span> (&amp;): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(*)">
-     <a href="#val-(*)" class="anchor"></a><code><span class="keyword">let</span> (*): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(-)">
-     <a href="#val-(-)" class="anchor"></a><code><span class="keyword">let</span> (-): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(+)">
-     <a href="#val-(+)" class="anchor"></a><code><span class="keyword">let</span> (+): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(-?)">
-     <a href="#val-(-?)" class="anchor"></a><code><span class="keyword">let</span> (-?): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(/)">
-     <a href="#val-(/)" class="anchor"></a><code><span class="keyword">let</span> (/): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(:=)">
-     <a href="#val-(:=)" class="anchor"></a><code><span class="keyword">let</span> (:=): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(=)">
-     <a href="#val-(=)" class="anchor"></a><code><span class="keyword">let</span> (=): unit;</code>
-    </dt>
-    <dt class="spec value" id="val-(land)">
-     <a href="#val-(land)" class="anchor"></a><code><span class="keyword">let</span> (land): unit;</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-(~-)">
+    <a href="#val-(~-)" class="anchor"></a><code><span class="keyword">let</span> (~-): unit;</code>
+   </div>
+   <div class="spec value" id="val-(!)">
+    <a href="#val-(!)" class="anchor"></a><code><span class="keyword">let</span> (!): unit;</code>
+   </div>
+   <div class="spec value" id="val-(@)">
+    <a href="#val-(@)" class="anchor"></a><code><span class="keyword">let</span> (@): unit;</code>
+   </div>
+   <div class="spec value" id="val-($)">
+    <a href="#val-($)" class="anchor"></a><code><span class="keyword">let</span> ($): unit;</code>
+   </div>
+   <div class="spec value" id="val-(%)">
+    <a href="#val-(%)" class="anchor"></a><code><span class="keyword">let</span> (%): unit;</code>
+   </div>
+   <div class="spec value" id="val-(&amp;)">
+    <a href="#val-(&amp;)" class="anchor"></a><code><span class="keyword">let</span> (&amp;): unit;</code>
+   </div>
+   <div class="spec value" id="val-(*)">
+    <a href="#val-(*)" class="anchor"></a><code><span class="keyword">let</span> (*): unit;</code>
+   </div>
+   <div class="spec value" id="val-(-)">
+    <a href="#val-(-)" class="anchor"></a><code><span class="keyword">let</span> (-): unit;</code>
+   </div>
+   <div class="spec value" id="val-(+)">
+    <a href="#val-(+)" class="anchor"></a><code><span class="keyword">let</span> (+): unit;</code>
+   </div>
+   <div class="spec value" id="val-(-?)">
+    <a href="#val-(-?)" class="anchor"></a><code><span class="keyword">let</span> (-?): unit;</code>
+   </div>
+   <div class="spec value" id="val-(/)">
+    <a href="#val-(/)" class="anchor"></a><code><span class="keyword">let</span> (/): unit;</code>
+   </div>
+   <div class="spec value" id="val-(:=)">
+    <a href="#val-(:=)" class="anchor"></a><code><span class="keyword">let</span> (:=): unit;</code>
+   </div>
+   <div class="spec value" id="val-(=)">
+    <a href="#val-(=)" class="anchor"></a><code><span class="keyword">let</span> (=): unit;</code>
+   </div>
+   <div class="spec value" id="val-(land)">
+    <a href="#val-(land)" class="anchor"></a><code><span class="keyword">let</span> (land): unit;</code>
+   </div>
    <h4 id="advanced-module-stuff">
     <a href="#advanced-module-stuff" class="anchor"></a>Advanced Module Stuff
    </h4>
-   <dl>
-    <dt class="spec module" id="module-CollectionModule">
+   <div>
+    <div class="spec module" id="module-CollectionModule">
      <a href="#module-CollectionModule" class="anchor"></a><code><span class="keyword">module</span> <a href="CollectionModule/index.html">CollectionModule</a>: { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>CollectionModule</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-COLLECTION">
+    </div>
+   </div>
+   <div>
+    <div class="spec module-type" id="module-type-COLLECTION">
      <a href="#module-type-COLLECTION" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-COLLECTION/index.html">COLLECTION</a> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="CollectionModule/index.html">CollectionModule</a>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       module type of
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module" id="module-Recollection">
     <a href="#module-Recollection" class="anchor"></a><code><span class="keyword">module</span> <a href="Recollection/index.html">Recollection</a>:  (<a href="Recollection/argument-1-C/index.html">C</a>: <a href="module-type-COLLECTION/index.html">COLLECTION</a>) <span>=&gt;</span> <a href="module-type-COLLECTION/index.html">COLLECTION</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-collection">collection</a> = list(<a href="Recollection/argument-1-C/index.html#type-element">C.element</a>) <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-element">element</a> = <a href="Recollection/argument-1-C/index.html#type-collection">C.collection</a>;</code>
    </div>
@@ -665,36 +663,36 @@
    <div class="spec module-type" id="module-type-B">
     <a href="#module-type-B" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-B/index.html">B</a> = { ... };</code>
    </div>
-   <dl>
-    <dt class="spec module-type" id="module-type-C">
+   <div>
+    <div class="spec module-type" id="module-type-C">
      <a href="#module-type-C" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-C/index.html">C</a> = { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This module type includes two signatures.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module" id="module-FunctorTypeOf">
+    </div>
+   </div>
+   <div>
+    <div class="spec module" id="module-FunctorTypeOf">
      <a href="#module-FunctorTypeOf" class="anchor"></a><code><span class="keyword">module</span> <a href="FunctorTypeOf/index.html">FunctorTypeOf</a>:  (<a href="FunctorTypeOf/argument-1-Collection/index.html">Collection</a>: <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="CollectionModule/index.html">CollectionModule</a>) <span>=&gt;</span> { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>FunctorTypeOf</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec module-type" id="module-type-IncludeModuleType">
+    </div>
+   </div>
+   <div>
+    <div class="spec module-type" id="module-type-IncludeModuleType">
      <a href="#module-type-IncludeModuleType" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-IncludeModuleType/index.html">IncludeModuleType</a> = { ... };</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>IncludeModuleType</code>.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec module-type" id="module-type-ToInclude">
     <a href="#module-type-ToInclude" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-ToInclude/index.html">ToInclude</a> = { ... };</code>
    </div>
@@ -718,8 +716,8 @@
    <h4 id="advanced-type-stuff">
     <a href="#advanced-type-stuff" class="anchor"></a>Advanced Type Stuff
    </h4>
-   <dl>
-    <dt class="spec type" id="type-record">
+   <div>
+    <div class="spec type" id="type-record">
      <a href="#type-record" class="anchor"></a><code><span class="keyword">type</span> record = {</code>
      <table>
       <tbody>
@@ -746,69 +744,69 @@
       </tbody>
      </table>
      <code>};</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>record</code>.
      </p>
      <p>
       This comment is also for <code>record</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-mutable_record">
-     <a href="#type-mutable_record" class="anchor"></a><code><span class="keyword">type</span> mutable_record = {</code>
-     <table>
-      <tbody>
-       <tr id="type-mutable_record.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.a" class="anchor"></a><code><span class="keyword">mutable</span> a: int,</code>
-        </td>
-        <td class="doc">
-         <p>
-          <code>a</code> is first and mutable
-         </p>
-        </td>
-       </tr>
-       <tr id="type-mutable_record.b" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.b" class="anchor"></a><code>b: unit,</code>
-        </td>
-        <td class="doc">
-         <p>
-          <code>b</code> is second and immutable
-         </p>
-        </td>
-       </tr>
-       <tr id="type-mutable_record.c" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.c" class="anchor"></a><code><span class="keyword">mutable</span> c: int,</code>
-        </td>
-        <td class="doc">
-         <p>
-          <code>c</code> is third and mutable
-         </p>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>};</code>
-    </dt>
-    <dt class="spec type" id="type-universe_record">
-     <a href="#type-universe_record" class="anchor"></a><code><span class="keyword">type</span> universe_record = {</code>
-     <table>
-      <tbody>
-       <tr id="type-universe_record.nihilate" class="anchored">
-        <td class="def record field">
-         <a href="#type-universe_record.nihilate" class="anchor"></a><code>nihilate: a. <span class="type-var">'a</span> <span>=&gt;</span> unit,</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>};</code>
-    </dt>
-    <dt class="spec type" id="type-variant">
+    </div>
+   </div>
+   <div class="spec type" id="type-mutable_record">
+    <a href="#type-mutable_record" class="anchor"></a><code><span class="keyword">type</span> mutable_record = {</code>
+    <table>
+     <tbody>
+      <tr id="type-mutable_record.a" class="anchored">
+       <td class="def record field">
+        <a href="#type-mutable_record.a" class="anchor"></a><code><span class="keyword">mutable</span> a: int,</code>
+       </td>
+       <td class="doc">
+        <p>
+         <code>a</code> is first and mutable
+        </p>
+       </td>
+      </tr>
+      <tr id="type-mutable_record.b" class="anchored">
+       <td class="def record field">
+        <a href="#type-mutable_record.b" class="anchor"></a><code>b: unit,</code>
+       </td>
+       <td class="doc">
+        <p>
+         <code>b</code> is second and immutable
+        </p>
+       </td>
+      </tr>
+      <tr id="type-mutable_record.c" class="anchored">
+       <td class="def record field">
+        <a href="#type-mutable_record.c" class="anchor"></a><code><span class="keyword">mutable</span> c: int,</code>
+       </td>
+       <td class="doc">
+        <p>
+         <code>c</code> is third and mutable
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>};</code>
+   </div>
+   <div class="spec type" id="type-universe_record">
+    <a href="#type-universe_record" class="anchor"></a><code><span class="keyword">type</span> universe_record = {</code>
+    <table>
+     <tbody>
+      <tr id="type-universe_record.nihilate" class="anchored">
+       <td class="def record field">
+        <a href="#type-universe_record.nihilate" class="anchor"></a><code>nihilate: a. <span class="type-var">'a</span> <span>=&gt;</span> unit,</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>};</code>
+   </div>
+   <div>
+    <div class="spec type" id="type-variant">
      <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant = </code>
      <table>
       <tbody>
@@ -855,18 +853,18 @@
       </tbody>
      </table>
      <code>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>variant</code>.
      </p>
      <p>
       This comment is also for <code>variant</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-poly_variant">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-poly_variant">
      <a href="#type-poly_variant" class="anchor"></a><code><span class="keyword">type</span> poly_variant = [ </code>
      <table>
       <tbody>
@@ -883,18 +881,18 @@
       </tbody>
      </table>
      <code> ];</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>poly_variant</code>.
      </p>
      <p>
       Wow! It was a polymorphic variant!
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-full_gadt">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-full_gadt">
      <a href="#type-full_gadt" class="anchor"></a><code><span class="keyword">type</span> full_gadt(_, _) = </code>
      <table>
       <tbody>
@@ -921,18 +919,18 @@
       </tbody>
      </table>
      <code>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>full_gadt</code>.
      </p>
      <p>
       Wow! It was a GADT!
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-partial_gadt">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-partial_gadt">
      <a href="#type-partial_gadt" class="anchor"></a><code><span class="keyword">type</span> partial_gadt('a) = </code>
      <table>
       <tbody>
@@ -954,38 +952,38 @@
       </tbody>
      </table>
      <code>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>partial_gadt</code>.
      </p>
      <p>
       Wow! It was a mixed GADT!
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-alias">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-alias">
      <a href="#type-alias" class="anchor"></a><code><span class="keyword">type</span> alias = <a href="index.html#type-variant">variant</a>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>alias</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-tuple">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-tuple">
      <a href="#type-tuple" class="anchor"></a><code><span class="keyword">type</span> tuple = <span>(<span>(<a href="index.html#type-alias">alias</a>, <a href="index.html#type-alias">alias</a>)</span>, <a href="index.html#type-alias">alias</a>, <span>(<a href="index.html#type-alias">alias</a>, <a href="index.html#type-alias">alias</a>)</span>)</span>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>tuple</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-variant_alias">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-variant_alias">
      <a href="#type-variant_alias" class="anchor"></a><code><span class="keyword">type</span> variant_alias = <a href="index.html#type-variant">variant</a> = </code>
      <table>
       <tbody>
@@ -1012,15 +1010,15 @@
       </tbody>
      </table>
      <code>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>variant_alias</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-record_alias">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-record_alias">
      <a href="#type-record_alias" class="anchor"></a><code><span class="keyword">type</span> record_alias = <a href="index.html#type-record">record</a> = {</code>
      <table>
       <tbody>
@@ -1037,15 +1035,15 @@
       </tbody>
      </table>
      <code>};</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>record_alias</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-poly_variant_union">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-poly_variant_union">
      <a href="#type-poly_variant_union" class="anchor"></a><code><span class="keyword">type</span> poly_variant_union = [ </code>
      <table>
       <tbody>
@@ -1062,95 +1060,95 @@
       </tbody>
      </table>
      <code> ];</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>poly_variant_union</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-poly_poly_variant">
-     <a href="#type-poly_poly_variant" class="anchor"></a><code><span class="keyword">type</span> poly_poly_variant('a) = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-poly_poly_variant.TagA" class="anchored">
-        <td class="def constructor">
-         <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code>| </code><code>`TagA(<span class="type-var">'a</span>)</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ];</code>
-    </dt>
-    <dt class="spec type" id="type-bin_poly_poly_variant">
-     <a href="#type-bin_poly_poly_variant" class="anchor"></a><code><span class="keyword">type</span> bin_poly_poly_variant('a, 'b) = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
-        <td class="def constructor">
-         <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code>| </code><code>`TagA(<span class="type-var">'a</span>)</code>
-        </td>
-       </tr>
-       <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
-        <td class="def constructor">
-         <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code>| </code><code>`ConstrB(<span class="type-var">'b</span>)</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ];</code>
-    </dt>
-    <dt class="spec type" id="type-open_poly_variant">
-     <a href="#type-open_poly_variant" class="anchor"></a><code><span class="keyword">type</span> open_poly_variant('a) = <span>[&gt; `TagA ]</span> <span class="keyword">as</span> 'a;</code>
-    </dt>
-    <dt class="spec type" id="type-open_poly_variant2">
-     <a href="#type-open_poly_variant2" class="anchor"></a><code><span class="keyword">type</span> open_poly_variant2('a) = <span>[&gt; <span>`ConstrB<span>(int)</span></span> ]</span> <span class="keyword">as</span> 'a;</code>
-    </dt>
-    <dt class="spec type" id="type-open_poly_variant_alias">
-     <a href="#type-open_poly_variant_alias" class="anchor"></a><code><span class="keyword">type</span> open_poly_variant_alias('a) = <a href="index.html#type-open_poly_variant2">open_poly_variant2</a>(<a href="index.html#type-open_poly_variant">open_poly_variant</a>(<span class="type-var">'a</span>));</code>
-    </dt>
-    <dt class="spec type" id="type-poly_fun">
-     <a href="#type-poly_fun" class="anchor"></a><code><span class="keyword">type</span> poly_fun('a) = <span>[&gt; <span>`ConstrB<span>(int)</span></span> ]</span> <span class="keyword">as</span> 'a <span>=&gt;</span> <span class="type-var">'a</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-poly_fun_constraint">
-     <a href="#type-poly_fun_constraint" class="anchor"></a><code><span class="keyword">type</span> poly_fun_constraint('a) = <span class="type-var">'a</span> <span>=&gt;</span> <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `TagA ]</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-closed_poly_variant">
-     <a href="#type-closed_poly_variant" class="anchor"></a><code><span class="keyword">type</span> closed_poly_variant('a) = <span>[&lt; `One <span>| `Two</span> ]</span> <span class="keyword">as</span> 'a;</code>
-    </dt>
-    <dt class="spec type" id="type-clopen_poly_variant">
-     <a href="#type-clopen_poly_variant" class="anchor"></a><code><span class="keyword">type</span> clopen_poly_variant('a) = <span>[&lt; `One <span><span>| `Two</span><span>(int)</span></span> <span>| `Three</span> Two Three ]</span> <span class="keyword">as</span> 'a;</code>
-    </dt>
-    <dt class="spec type" id="type-nested_poly_variant">
-     <a href="#type-nested_poly_variant" class="anchor"></a><code><span class="keyword">type</span> nested_poly_variant = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-nested_poly_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.A" class="anchor"></a><code>| </code><code>`A</code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.B" class="anchor"></a><code>| </code><code>`B(<span>[ `B1 <span>| `B2</span> ]</span>)</code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.C" class="anchor"></a><code>| </code><code>`C</code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.D" class="anchor"></a><code>| </code><code>`D(<span>[ <span>`D1<span>(<span>[ `D1a ]</span>)</span></span> ]</span>)</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ];</code>
-    </dt>
-    <dt class="spec type" id="type-full_gadt_alias">
+    </div>
+   </div>
+   <div class="spec type" id="type-poly_poly_variant">
+    <a href="#type-poly_poly_variant" class="anchor"></a><code><span class="keyword">type</span> poly_poly_variant('a) = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-poly_poly_variant.TagA" class="anchored">
+       <td class="def constructor">
+        <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code>| </code><code>`TagA(<span class="type-var">'a</span>)</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ];</code>
+   </div>
+   <div class="spec type" id="type-bin_poly_poly_variant">
+    <a href="#type-bin_poly_poly_variant" class="anchor"></a><code><span class="keyword">type</span> bin_poly_poly_variant('a, 'b) = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
+       <td class="def constructor">
+        <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code>| </code><code>`TagA(<span class="type-var">'a</span>)</code>
+       </td>
+      </tr>
+      <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
+       <td class="def constructor">
+        <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code>| </code><code>`ConstrB(<span class="type-var">'b</span>)</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ];</code>
+   </div>
+   <div class="spec type" id="type-open_poly_variant">
+    <a href="#type-open_poly_variant" class="anchor"></a><code><span class="keyword">type</span> open_poly_variant('a) = <span>[&gt; `TagA ]</span> <span class="keyword">as</span> 'a;</code>
+   </div>
+   <div class="spec type" id="type-open_poly_variant2">
+    <a href="#type-open_poly_variant2" class="anchor"></a><code><span class="keyword">type</span> open_poly_variant2('a) = <span>[&gt; <span>`ConstrB<span>(int)</span></span> ]</span> <span class="keyword">as</span> 'a;</code>
+   </div>
+   <div class="spec type" id="type-open_poly_variant_alias">
+    <a href="#type-open_poly_variant_alias" class="anchor"></a><code><span class="keyword">type</span> open_poly_variant_alias('a) = <a href="index.html#type-open_poly_variant2">open_poly_variant2</a>(<a href="index.html#type-open_poly_variant">open_poly_variant</a>(<span class="type-var">'a</span>));</code>
+   </div>
+   <div class="spec type" id="type-poly_fun">
+    <a href="#type-poly_fun" class="anchor"></a><code><span class="keyword">type</span> poly_fun('a) = <span>[&gt; <span>`ConstrB<span>(int)</span></span> ]</span> <span class="keyword">as</span> 'a <span>=&gt;</span> <span class="type-var">'a</span>;</code>
+   </div>
+   <div class="spec type" id="type-poly_fun_constraint">
+    <a href="#type-poly_fun_constraint" class="anchor"></a><code><span class="keyword">type</span> poly_fun_constraint('a) = <span class="type-var">'a</span> <span>=&gt;</span> <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `TagA ]</span>;</code>
+   </div>
+   <div class="spec type" id="type-closed_poly_variant">
+    <a href="#type-closed_poly_variant" class="anchor"></a><code><span class="keyword">type</span> closed_poly_variant('a) = <span>[&lt; `One <span>| `Two</span> ]</span> <span class="keyword">as</span> 'a;</code>
+   </div>
+   <div class="spec type" id="type-clopen_poly_variant">
+    <a href="#type-clopen_poly_variant" class="anchor"></a><code><span class="keyword">type</span> clopen_poly_variant('a) = <span>[&lt; `One <span><span>| `Two</span><span>(int)</span></span> <span>| `Three</span> Two Three ]</span> <span class="keyword">as</span> 'a;</code>
+   </div>
+   <div class="spec type" id="type-nested_poly_variant">
+    <a href="#type-nested_poly_variant" class="anchor"></a><code><span class="keyword">type</span> nested_poly_variant = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-nested_poly_variant.A" class="anchored">
+       <td class="def constructor">
+        <a href="#type-nested_poly_variant.A" class="anchor"></a><code>| </code><code>`A</code>
+       </td>
+      </tr>
+      <tr id="type-nested_poly_variant.B" class="anchored">
+       <td class="def constructor">
+        <a href="#type-nested_poly_variant.B" class="anchor"></a><code>| </code><code>`B(<span>[ `B1 <span>| `B2</span> ]</span>)</code>
+       </td>
+      </tr>
+      <tr id="type-nested_poly_variant.C" class="anchored">
+       <td class="def constructor">
+        <a href="#type-nested_poly_variant.C" class="anchor"></a><code>| </code><code>`C</code>
+       </td>
+      </tr>
+      <tr id="type-nested_poly_variant.D" class="anchored">
+       <td class="def constructor">
+        <a href="#type-nested_poly_variant.D" class="anchor"></a><code>| </code><code>`D(<span>[ <span>`D1<span>(<span>[ `D1a ]</span>)</span></span> ]</span>)</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ];</code>
+   </div>
+   <div>
+    <div class="spec type" id="type-full_gadt_alias">
      <a href="#type-full_gadt_alias" class="anchor"></a><code><span class="keyword">type</span> full_gadt_alias('a, 'b) = <a href="index.html#type-full_gadt">full_gadt</a><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> = </code>
      <table>
       <tbody>
@@ -1177,15 +1175,15 @@
       </tbody>
      </table>
      <code>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>full_gadt_alias</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-partial_gadt_alias">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-partial_gadt_alias">
      <a href="#type-partial_gadt_alias" class="anchor"></a><code><span class="keyword">type</span> partial_gadt_alias('a) = <a href="index.html#type-partial_gadt">partial_gadt</a>(<span class="type-var">'a</span>) = </code>
      <table>
       <tbody>
@@ -1207,25 +1205,25 @@
       </tbody>
      </table>
      <code>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <code>partial_gadt_alias</code>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-Exn_arrow">
+    </div>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-Exn_arrow">
      <a href="#exception-Exn_arrow" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Exn_arrow</span>(unit) : exn;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <a href="index.html#exception-Exn_arrow"><code>Exn_arrow</code></a>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-mutual_constr_a">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-mutual_constr_a">
      <a href="#type-mutual_constr_a" class="anchor"></a><code><span class="keyword">type</span> mutual_constr_a = </code>
      <table>
       <tbody>
@@ -1247,15 +1245,15 @@
       </tbody>
      </table>
      <code>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <a href="index.html#type-mutual_constr_a"><code>mutual_constr_a</code></a> then <a href="index.html#type-mutual_constr_b"><code>mutual_constr_b</code></a>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-mutual_constr_b">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-mutual_constr_b">
      <a href="#type-mutual_constr_b" class="anchor"></a><code><span class="keyword">and</span> mutual_constr_b = </code>
      <table>
       <tbody>
@@ -1277,107 +1275,101 @@
       </tbody>
      </table>
      <code>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This comment is for <a href="index.html#type-mutual_constr_b"><code>mutual_constr_b</code></a> then <a href="index.html#type-mutual_constr_a"><code>mutual_constr_a</code></a>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-rec_obj">
-     <a href="#type-rec_obj" class="anchor"></a><code><span class="keyword">type</span> rec_obj = {. f: int, g: unit <span>=&gt;</span> unit, h: <a href="index.html#type-rec_obj">rec_obj</a>, };</code>
-    </dt>
-    <dt class="spec type" id="type-open_obj">
-     <a href="#type-open_obj" class="anchor"></a><code><span class="keyword">type</span> open_obj('a) = {.. f: int, g: unit <span>=&gt;</span> unit, } <span class="keyword">as</span> 'a;</code>
-    </dt>
-    <dt class="spec type" id="type-oof">
-     <a href="#type-oof" class="anchor"></a><code><span class="keyword">type</span> oof('a) = {.. a: unit, } <span class="keyword">as</span> 'a <span>=&gt;</span> <span class="type-var">'a</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-any_obj">
-     <a href="#type-any_obj" class="anchor"></a><code><span class="keyword">type</span> any_obj('a) = {.. } <span class="keyword">as</span> 'a;</code>
-    </dt>
-    <dt class="spec type" id="type-empty_obj">
-     <a href="#type-empty_obj" class="anchor"></a><code><span class="keyword">type</span> empty_obj = {. };</code>
-    </dt>
-    <dt class="spec type" id="type-one_meth">
-     <a href="#type-one_meth" class="anchor"></a><code><span class="keyword">type</span> one_meth = {. meth: unit, };</code>
-    </dt>
-    <dt class="spec type" id="type-ext">
+    </div>
+   </div>
+   <div class="spec type" id="type-rec_obj">
+    <a href="#type-rec_obj" class="anchor"></a><code><span class="keyword">type</span> rec_obj = {. f: int, g: unit <span>=&gt;</span> unit, h: <a href="index.html#type-rec_obj">rec_obj</a>, };</code>
+   </div>
+   <div class="spec type" id="type-open_obj">
+    <a href="#type-open_obj" class="anchor"></a><code><span class="keyword">type</span> open_obj('a) = {.. f: int, g: unit <span>=&gt;</span> unit, } <span class="keyword">as</span> 'a;</code>
+   </div>
+   <div class="spec type" id="type-oof">
+    <a href="#type-oof" class="anchor"></a><code><span class="keyword">type</span> oof('a) = {.. a: unit, } <span class="keyword">as</span> 'a <span>=&gt;</span> <span class="type-var">'a</span>;</code>
+   </div>
+   <div class="spec type" id="type-any_obj">
+    <a href="#type-any_obj" class="anchor"></a><code><span class="keyword">type</span> any_obj('a) = {.. } <span class="keyword">as</span> 'a;</code>
+   </div>
+   <div class="spec type" id="type-empty_obj">
+    <a href="#type-empty_obj" class="anchor"></a><code><span class="keyword">type</span> empty_obj = {. };</code>
+   </div>
+   <div class="spec type" id="type-one_meth">
+    <a href="#type-one_meth" class="anchor"></a><code><span class="keyword">type</span> one_meth = {. meth: unit, };</code>
+   </div>
+   <div>
+    <div class="spec type" id="type-ext">
      <a href="#type-ext" class="anchor"></a><code><span class="keyword">type</span> ext = ..;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A mystery wrapped in an ellipsis
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtA</span>;</code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtB</span>;</code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtC</span>(unit)| <span class="extension">ExtD</span>(<a href="index.html#type-ext">ext</a>);</code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtE</span>;</code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtF</span>;</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-poly_ext">
+    </div>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtA</span>;</code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtB</span>;</code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtC</span>(unit)| <span class="extension">ExtD</span>(<a href="index.html#type-ext">ext</a>);</code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtE</span>;</code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtF</span>;</code>
+   </div>
+   <div>
+    <div class="spec type" id="type-poly_ext">
      <a href="#type-poly_ext" class="anchor"></a><code><span class="keyword">type</span> poly_ext('a) = ..;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       'a poly_ext
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Foo</span>(<span class="type-var">'b</span>)| <span class="extension">Bar</span>(<span class="type-var">'b</span>, <span class="type-var">'b</span>);</code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Quux</span>(<span class="type-var">'c</span>);</code>
-    </dt>
-   </dl>
+    </div>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Foo</span>(<span class="type-var">'b</span>)| <span class="extension">Bar</span>(<span class="type-var">'b</span>, <span class="type-var">'b</span>);</code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Quux</span>(<span class="type-var">'c</span>);</code>
+   </div>
    <div class="spec module" id="module-ExtMod">
     <a href="#module-ExtMod" class="anchor"></a><code><span class="keyword">module</span> <a href="ExtMod/index.html">ExtMod</a>: { ... };</code>
    </div>
-   <dl>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop0</span>;</code>
-    </dt>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop</span>(unit);</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec external" id="val-launch_missiles">
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop0</span>;</code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop</span>(unit);</code>
+   </div>
+   <div>
+    <div class="spec external" id="val-launch_missiles">
      <a href="#val-launch_missiles" class="anchor"></a><code><span class="keyword">let</span> launch_missiles: unit <span>=&gt;</span> unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Rotate keys on my mark...
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-my_mod">
+    </div>
+   </div>
+   <div>
+    <div class="spec type" id="type-my_mod">
      <a href="#type-my_mod" class="anchor"></a><code><span class="keyword">type</span> my_mod = <span>(<span class="keyword">module</span> <a href="module-type-COLLECTION/index.html">COLLECTION</a>)</span>;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       A brown paper package tied up with string
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <div class="spec class" id="class-empty_class">
     <a href="#class-empty_class" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-empty_class/index.html">empty_class</a>: { ... }</code>
    </div>
@@ -1390,25 +1382,21 @@
    <div class="spec class" id="class-param_class">
     <a href="#class-param_class" class="anchor"></a><code><span class="keyword">class</span> ('a) <a href="class-param_class/index.html">param_class</a>: <span class="type-var">'a</span> <span>=&gt;</span> { ... }</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-my_unit_object">
-     <a href="#type-my_unit_object" class="anchor"></a><code><span class="keyword">type</span> my_unit_object = <a href="class-param_class/index.html">param_class</a>(unit);</code>
-    </dt>
-    <dt class="spec type" id="type-my_unit_class">
-     <a href="#type-my_unit_class" class="anchor"></a><code><span class="keyword">type</span> my_unit_class('a) = <a href="class-param_class/index.html">param_class</a>(unit) <span class="keyword">as</span> 'a;</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-my_unit_object">
+    <a href="#type-my_unit_object" class="anchor"></a><code><span class="keyword">type</span> my_unit_object = <a href="class-param_class/index.html">param_class</a>(unit);</code>
+   </div>
+   <div class="spec type" id="type-my_unit_class">
+    <a href="#type-my_unit_class" class="anchor"></a><code><span class="keyword">type</span> my_unit_class('a) = <a href="class-param_class/index.html">param_class</a>(unit) <span class="keyword">as</span> 'a;</code>
+   </div>
    <div class="spec module" id="module-Dep1">
     <a href="#module-Dep1" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep1/index.html">Dep1</a>: { ... };</code>
    </div>
    <div class="spec module" id="module-Dep2">
     <a href="#module-Dep2" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep2/index.html">Dep2</a>:  (<a href="Dep2/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span> { ... };</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-dep1">
-     <a href="#type-dep1" class="anchor"></a><code><span class="keyword">type</span> dep1 = <a href="Dep1/module-type-S/index.html#type-c">Dep2(Dep1).B.c</a>;</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-dep1">
+    <a href="#type-dep1" class="anchor"></a><code><span class="keyword">type</span> dep1 = <a href="Dep1/module-type-S/index.html#type-c">Dep2(Dep1).B.c</a>;</code>
+   </div>
    <div class="spec module" id="module-Dep3">
     <a href="#module-Dep3" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep3/index.html">Dep3</a>: { ... };</code>
    </div>
@@ -1418,25 +1406,21 @@
    <div class="spec module" id="module-Dep5">
     <a href="#module-Dep5" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep5/index.html">Dep5</a>:  (<a href="Dep5/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span> { ... };</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-dep2">
-     <a href="#type-dep2" class="anchor"></a><code><span class="keyword">type</span> dep2 = <a href="Dep4/module-type-T/index.html#type-b">Dep5(Dep4).Z.X.b</a>;</code>
-    </dt>
-    <dt class="spec type" id="type-dep3">
-     <a href="#type-dep3" class="anchor"></a><code><span class="keyword">type</span> dep3 = <a href="Dep3/index.html#type-a">Dep5(Dep4).Z.Y.a</a>;</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-dep2">
+    <a href="#type-dep2" class="anchor"></a><code><span class="keyword">type</span> dep2 = <a href="Dep4/module-type-T/index.html#type-b">Dep5(Dep4).Z.X.b</a>;</code>
+   </div>
+   <div class="spec type" id="type-dep3">
+    <a href="#type-dep3" class="anchor"></a><code><span class="keyword">type</span> dep3 = <a href="Dep3/index.html#type-a">Dep5(Dep4).Z.Y.a</a>;</code>
+   </div>
    <div class="spec module" id="module-Dep6">
     <a href="#module-Dep6" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep6/index.html">Dep6</a>: { ... };</code>
    </div>
    <div class="spec module" id="module-Dep7">
     <a href="#module-Dep7" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep7/index.html">Dep7</a>:  (<a href="Dep7/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span> { ... };</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-dep4">
-     <a href="#type-dep4" class="anchor"></a><code><span class="keyword">type</span> dep4 = <a href="Dep6/module-type-S/index.html#type-d">Dep7(Dep6).M.Y.d</a>;</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-dep4">
+    <a href="#type-dep4" class="anchor"></a><code><span class="keyword">type</span> dep4 = <a href="Dep6/module-type-S/index.html#type-d">Dep7(Dep6).M.Y.d</a>;</code>
+   </div>
    <div class="spec module" id="module-Dep8">
     <a href="#module-Dep8" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep8/index.html">Dep8</a>: { ... };</code>
    </div>
@@ -1455,11 +1439,9 @@
    <div class="spec module" id="module-Dep13">
     <a href="#module-Dep13" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep13/index.html">Dep13</a>: <a href="Dep11/module-type-S/index.html">Dep12(Dep11).T</a>;</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-dep5">
-     <a href="#type-dep5" class="anchor"></a><code><span class="keyword">type</span> dep5 = <a href="Dep13/index.html#type-c">Dep13.c</a>;</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-dep5">
+    <a href="#type-dep5" class="anchor"></a><code><span class="keyword">type</span> dep5 = <a href="Dep13/index.html#type-c">Dep13.c</a>;</code>
+   </div>
    <div class="spec module-type" id="module-type-With1">
     <a href="#module-type-With1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-With1/index.html">With1</a> = { ... };</code>
    </div>
@@ -1469,19 +1451,15 @@
    <div class="spec module" id="module-With3">
     <a href="#module-With3" class="anchor"></a><code><span class="keyword">module</span> <a href="With3/index.html">With3</a>: <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> = <a href="With2/index.html">With2</a>;</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-with1">
-     <a href="#type-with1" class="anchor"></a><code><span class="keyword">type</span> with1 = <a href="With3/N/index.html#type-t">With3.N.t</a>;</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-with1">
+    <a href="#type-with1" class="anchor"></a><code><span class="keyword">type</span> with1 = <a href="With3/N/index.html#type-t">With3.N.t</a>;</code>
+   </div>
    <div class="spec module" id="module-With4">
     <a href="#module-With4" class="anchor"></a><code><span class="keyword">module</span> <a href="With4/index.html">With4</a>: <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> := <a href="With2/index.html">With2</a>;</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-with2">
-     <a href="#type-with2" class="anchor"></a><code><span class="keyword">type</span> with2 = <a href="With4/N/index.html#type-t">With4.N.t</a>;</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-with2">
+    <a href="#type-with2" class="anchor"></a><code><span class="keyword">type</span> with2 = <a href="With4/N/index.html#type-t">With4.N.t</a>;</code>
+   </div>
    <div class="spec module" id="module-With5">
     <a href="#module-With5" class="anchor"></a><code><span class="keyword">module</span> <a href="With5/index.html">With5</a>: { ... };</code>
    </div>
@@ -1527,11 +1505,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-NestedInclude2/index.html">NestedInclude2</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-NestedInclude2/index.html#type-nested_include">nested_include</a> = int<span class="keyword">;</span></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-nested_include">
-         <a href="#type-nested_include" class="anchor"></a><code><span class="keyword">type</span> nested_include = int;</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-nested_include">
+        <a href="#type-nested_include" class="anchor"></a><code><span class="keyword">type</span> nested_include = int;</code>
+       </div>
       </details>
      </div>
     </div>
@@ -1549,11 +1525,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="DoubleInclude3/DoubleInclude2/index.html">DoubleInclude3.DoubleInclude2</a><span class="keyword">;</span></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-double_include">
-         <a href="#type-double_include" class="anchor"></a><code><span class="keyword">type</span> double_include;</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-double_include">
+        <a href="#type-double_include" class="anchor"></a><code><span class="keyword">type</span> double_include;</code>
+       </div>
       </details>
      </div>
     </div>
@@ -1582,11 +1556,9 @@
        <summary>
         <span class="def"><code><span class="keyword">include</span> <a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a><span class="keyword">;</span></code></span>
        </summary>
-       <dl>
-        <dt class="spec type" id="type-include_include">
-         <a href="#type-include_include" class="anchor"></a><code><span class="keyword">type</span> include_include;</code>
-        </dt>
-       </dl>
+       <div class="spec type" id="type-include_include">
+        <a href="#type-include_include" class="anchor"></a><code><span class="keyword">type</span> include_include;</code>
+       </div>
       </details>
      </div>
     </div>
@@ -1638,16 +1610,16 @@
    <div class="spec module" id="module-CanonicalTest">
     <a href="#module-CanonicalTest" class="anchor"></a><code><span class="keyword">module</span> <a href="CanonicalTest/index.html">CanonicalTest</a>: { ... };</code>
    </div>
-   <dl>
-    <dt class="spec value" id="val-test">
+   <div>
+    <div class="spec value" id="val-test">
      <a href="#val-test" class="anchor"></a><code><span class="keyword">let</span> test: <a href="CanonicalTest/Base/List/index.html#type-t">CanonicalTest.Base.List.t</a>(<span class="type-var">'a</span>) <span>=&gt;</span> unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some ref to <a href="CanonicalTest/Base__Tests/C/index.html#type-t"><code>CanonicalTest.Base__Tests.C.t</code></a> and <a href="CanonicalTest/Base/List/index.html#val-id"><code>CanonicalTest.Base__Tests.L.id</code></a>. But also to <a href="CanonicalTest/Base__/List/index.html"><code>CanonicalTest.Base__.List</code></a> and <a href="CanonicalTest/Base__/List/index.html#type-t"><code>CanonicalTest.Base__.List.t</code></a>
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <h2 id="aliases">
     <a href="#aliases" class="anchor"></a>Aliases again
    </h2>
@@ -1745,16 +1717,12 @@
    <div class="spec module-type" id="module-type-TypeExt">
     <a href="#module-type-TypeExt" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-TypeExt/index.html">TypeExt</a> = { ... };</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-new_t">
-     <a href="#type-new_t" class="anchor"></a><code><span class="keyword">type</span> new_t = ..;</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-new_t">new_t</a> += | <span class="extension">C</span>;</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-new_t">
+    <a href="#type-new_t" class="anchor"></a><code><span class="keyword">type</span> new_t = ..;</code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-new_t">new_t</a> += | <span class="extension">C</span>;</code>
+   </div>
    <div class="spec module-type" id="module-type-TypeExtPruned">
     <a href="#module-type-TypeExtPruned" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-TypeExtPruned/index.html">TypeExtPruned</a> = <a href="module-type-TypeExt/index.html">TypeExt</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-TypeExt/index.html#type-t">t</a> := <a href="index.html#type-new_t">new_t</a>;</code>
    </div>

--- a/test/html/expect/test_package+re/Recent/X/index.html
+++ b/test/html/expect/test_package+re/Recent/X/index.html
@@ -22,26 +22,18 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec module-substitution" id="module-L">
-     <a href="#module-L" class="anchor"></a><code><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-t">
-     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a>(int);</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec type-subst" id="type-u">
-     <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u := int;</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-v">
-     <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v = <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a>(<a href="index.html#type-u">u</a>);</code>
-    </dt>
-   </dl>
+   <div class="spec module-substitution" id="module-L">
+    <a href="#module-L" class="anchor"></a><code><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></code>
+   </div>
+   <div class="spec type" id="type-t">
+    <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a>(int);</code>
+   </div>
+   <div class="spec type-subst" id="type-u">
+    <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u := int;</code>
+   </div>
+   <div class="spec type" id="type-v">
+    <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v = <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a>(<a href="index.html#type-u">u</a>);</code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -28,177 +28,173 @@
    <div class="spec module-type" id="module-type-S1">
     <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> =  (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span> <a href="module-type-S/index.html">S</a>;</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-variant">
-     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant = </code>
-     <table>
-      <tbody>
-       <tr id="type-variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.B" class="anchor"></a><code>| <span class="constructor">B</span>(int)</code>
-        </td>
-       </tr>
-       <tr id="type-variant.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.C" class="anchor"></a><code>| <span class="constructor">C</span></code>
-        </td>
-        <td class="doc">
-         <p>
-          foo
-         </p>
-        </td>
-       </tr>
-       <tr id="type-variant.D" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.D" class="anchor"></a><code>| <span class="constructor">D</span></code>
-        </td>
-        <td class="doc">
-         <p>
-          <em>bar</em>
-         </p>
-        </td>
-       </tr>
-       <tr id="type-variant.E" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.E" class="anchor"></a><code>| <span class="constructor">E</span> <span class="keyword">of</span> {</code>
-         <table>
-          <tbody>
-           <tr id="type-variant.a" class="anchored">
-            <td class="def record field">
-             <a href="#type-variant.a" class="anchor"></a><code>a: int,</code>
-            </td>
-           </tr>
-          </tbody>
-         </table>
-         <code>}</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>;</code>
-    </dt>
-    <dt class="spec type" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> gadt(_) = </code>
-     <table>
-      <tbody>
-       <tr id="type-gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <a href="index.html#type-gadt">gadt</a>(int)</code>
-        </td>
-       </tr>
-       <tr id="type-gadt.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code>| <span class="constructor">B</span>(int) : <a href="index.html#type-gadt">gadt</a>(string)</code>
-        </td>
-        <td class="doc">
-         <p>
-          foo
-         </p>
-        </td>
-       </tr>
-       <tr id="type-gadt.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code>| <span class="constructor">C</span>: {</code>
-         <table>
-          <tbody>
-           <tr id="type-gadt.a" class="anchored">
-            <td class="def record field">
-             <a href="#type-gadt.a" class="anchor"></a><code>a: int,</code>
-            </td>
-           </tr>
-          </tbody>
-         </table>
-         <code>} : <a href="index.html#type-gadt">gadt</a>(unit)</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>;</code>
-    </dt>
-    <dt class="spec type" id="type-polymorphic_variant">
-     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B(int)</code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C</code>
-        </td>
-        <td class="doc">
-         <p>
-          foo
-         </p>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
-        </td>
-        <td class="doc">
-         <p>
-          bar
-         </p>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ];</code>
-    </dt>
-    <dt class="spec type" id="type-empty_variant">
-     <a href="#type-empty_variant" class="anchor"></a><code><span class="keyword">type</span> empty_variant = |;</code>
-    </dt>
-    <dt class="spec type" id="type-nonrec_">
-     <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_ = int;</code>
-    </dt>
-    <dt class="spec type" id="type-empty_conj">
-     <a href="#type-empty_conj" class="anchor"></a><code><span class="keyword">type</span> empty_conj = </code>
-     <table>
-      <tbody>
-       <tr id="type-empty_conj.X" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-empty_conj.X" class="anchor"></a><code>| <span class="constructor">X</span>(<span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>) : <a href="index.html#type-empty_conj">empty_conj</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>;</code>
-    </dt>
-    <dt class="spec type" id="type-conj">
-     <a href="#type-conj" class="anchor"></a><code><span class="keyword">type</span> conj = </code>
-     <table>
-      <tbody>
-       <tr id="type-conj.X" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-conj.X" class="anchor"></a><code>| <span class="constructor">X</span>(<span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>) : <a href="index.html#type-conj">conj</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>;</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-empty_conj">
-     <a href="#val-empty_conj" class="anchor"></a><code><span class="keyword">let</span> empty_conj: <span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>;</code>
-    </dt>
-    <dt class="spec value" id="val-conj">
-     <a href="#val-conj" class="anchor"></a><code><span class="keyword">let</span> conj: <span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>;</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-variant">
+    <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant = </code>
+    <table>
+     <tbody>
+      <tr id="type-variant.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
+       </td>
+      </tr>
+      <tr id="type-variant.B" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.B" class="anchor"></a><code>| <span class="constructor">B</span>(int)</code>
+       </td>
+      </tr>
+      <tr id="type-variant.C" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.C" class="anchor"></a><code>| <span class="constructor">C</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         foo
+        </p>
+       </td>
+      </tr>
+      <tr id="type-variant.D" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.D" class="anchor"></a><code>| <span class="constructor">D</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         <em>bar</em>
+        </p>
+       </td>
+      </tr>
+      <tr id="type-variant.E" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.E" class="anchor"></a><code>| <span class="constructor">E</span> <span class="keyword">of</span> {</code>
+        <table>
+         <tbody>
+          <tr id="type-variant.a" class="anchored">
+           <td class="def record field">
+            <a href="#type-variant.a" class="anchor"></a><code>a: int,</code>
+           </td>
+          </tr>
+         </tbody>
+        </table>
+        <code>}</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec type" id="type-gadt">
+    <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> gadt(_) = </code>
+    <table>
+     <tbody>
+      <tr id="type-gadt.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <a href="index.html#type-gadt">gadt</a>(int)</code>
+       </td>
+      </tr>
+      <tr id="type-gadt.B" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.B" class="anchor"></a><code>| <span class="constructor">B</span>(int) : <a href="index.html#type-gadt">gadt</a>(string)</code>
+       </td>
+       <td class="doc">
+        <p>
+         foo
+        </p>
+       </td>
+      </tr>
+      <tr id="type-gadt.C" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.C" class="anchor"></a><code>| <span class="constructor">C</span>: {</code>
+        <table>
+         <tbody>
+          <tr id="type-gadt.a" class="anchored">
+           <td class="def record field">
+            <a href="#type-gadt.a" class="anchor"></a><code>a: int,</code>
+           </td>
+          </tr>
+         </tbody>
+        </table>
+        <code>} : <a href="index.html#type-gadt">gadt</a>(unit)</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec type" id="type-polymorphic_variant">
+    <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-polymorphic_variant.A" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.B" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B(int)</code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.C" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C</code>
+       </td>
+       <td class="doc">
+        <p>
+         foo
+        </p>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.D" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
+       </td>
+       <td class="doc">
+        <p>
+         bar
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ];</code>
+   </div>
+   <div class="spec type" id="type-empty_variant">
+    <a href="#type-empty_variant" class="anchor"></a><code><span class="keyword">type</span> empty_variant = |;</code>
+   </div>
+   <div class="spec type" id="type-nonrec_">
+    <a href="#type-nonrec_" class="anchor"></a><code><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_ = int;</code>
+   </div>
+   <div class="spec type" id="type-empty_conj">
+    <a href="#type-empty_conj" class="anchor"></a><code><span class="keyword">type</span> empty_conj = </code>
+    <table>
+     <tbody>
+      <tr id="type-empty_conj.X" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-empty_conj.X" class="anchor"></a><code>| <span class="constructor">X</span>(<span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>) : <a href="index.html#type-empty_conj">empty_conj</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec type" id="type-conj">
+    <a href="#type-conj" class="anchor"></a><code><span class="keyword">type</span> conj = </code>
+    <table>
+     <tbody>
+      <tr id="type-conj.X" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-conj.X" class="anchor"></a><code>| <span class="constructor">X</span>(<span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>) : <a href="index.html#type-conj">conj</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec value" id="val-empty_conj">
+    <a href="#val-empty_conj" class="anchor"></a><code><span class="keyword">let</span> empty_conj: <span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>;</code>
+   </div>
+   <div class="spec value" id="val-conj">
+    <a href="#val-conj" class="anchor"></a><code><span class="keyword">let</span> conj: <span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>;</code>
+   </div>
    <div class="spec module" id="module-Z">
     <a href="#module-Z" class="anchor"></a><code><span class="keyword">module</span> <a href="Z/index.html">Z</a>: { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Recent_impl/index.html
+++ b/test/html/expect/test_package+re/Recent_impl/index.html
@@ -28,11 +28,9 @@
    <div class="spec module" id="module-B">
     <a href="#module-B" class="anchor"></a><code><span class="keyword">module</span> <a href="B/index.html">B</a>: { ... };</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-u">
-     <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u;</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-u">
+    <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u;</code>
+   </div>
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Section/index.html
+++ b/test/html/expect/test_package+re/Section/index.html
@@ -77,11 +77,9 @@
    <h2 id="value-only">
     <a href="#value-only" class="anchor"></a>Value only
    </h2>
-   <dl>
-    <dt class="spec value" id="val-foo">
-     <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-foo">
+    <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>
+   </div>
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
    </h2>

--- a/test/html/expect/test_package+re/Stop/index.html
+++ b/test/html/expect/test_package+re/Stop/index.html
@@ -25,16 +25,16 @@
    </p>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec value" id="val-foo">
+   <div>
+    <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: int;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       This is normal commented text.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
    <aside>
     <p>
      The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
@@ -49,11 +49,9 @@
    <div class="spec module" id="module-N">
     <a href="#module-N" class="anchor"></a><code><span class="keyword">module</span> <a href="N/index.html">N</a>: { ... };</code>
    </div>
-   <dl>
-    <dt class="spec value" id="val-lol">
-     <a href="#val-lol" class="anchor"></a><code><span class="keyword">let</span> lol: int;</code>
-    </dt>
-   </dl>
+   <div class="spec value" id="val-lol">
+    <a href="#val-lol" class="anchor"></a><code><span class="keyword">let</span> lol: int;</code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -22,399 +22,389 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec type" id="type-abstract">
+   <div>
+    <div class="spec type" id="type-abstract">
      <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type</span> abstract;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Some <em>documentation</em>.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-alias">
-     <a href="#type-alias" class="anchor"></a><code><span class="keyword">type</span> alias = int;</code>
-    </dt>
-    <dt class="spec type" id="type-private_">
-     <a href="#type-private_" class="anchor"></a><code><span class="keyword">type</span> private_ = <span class="keyword">pri</span> int;</code>
-    </dt>
-    <dt class="spec type" id="type-constructor">
-     <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type</span> constructor('a) = <span class="type-var">'a</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-arrow">
-     <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type</span> arrow = int <span>=&gt;</span> int;</code>
-    </dt>
-    <dt class="spec type" id="type-higher_order">
-     <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order = <span>(int <span>=&gt;</span> int)</span> <span>=&gt;</span> int;</code>
-    </dt>
-    <dt class="spec type" id="type-labeled">
-     <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled = <span>l:int</span> <span>=&gt;</span> int;</code>
-    </dt>
-    <dt class="spec type" id="type-optional">
-     <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional = <span>?⁠l:int</span> <span>=&gt;</span> int;</code>
-    </dt>
-    <dt class="spec type" id="type-labeled_higher_order">
-     <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order = <span>(<span>l:int</span> <span>=&gt;</span> int)</span> <span>=&gt;</span> <span>(<span>?⁠l:int</span> <span>=&gt;</span> int)</span> <span>=&gt;</span> int;</code>
-    </dt>
-    <dt class="spec type" id="type-pair">
-     <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair = <span>(int, int)</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-parens_dropped">
-     <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type</span> parens_dropped = <span>(int, int)</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-triple">
-     <a href="#type-triple" class="anchor"></a><code><span class="keyword">type</span> triple = <span>(int, int, int)</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-nested_pair">
-     <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair = <span>(<span>(int, int)</span>, int)</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-instance">
-     <a href="#type-instance" class="anchor"></a><code><span class="keyword">type</span> instance = <a href="index.html#type-constructor">constructor</a>(int);</code>
-    </dt>
-    <dt class="spec type" id="type-variant_e">
-     <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type</span> variant_e = {</code>
-     <table>
-      <tbody>
-       <tr id="type-variant_e.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-variant_e.a" class="anchor"></a><code>a: int,</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>};</code>
-    </dt>
-    <dt class="spec type" id="type-variant">
-     <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant = </code>
-     <table>
-      <tbody>
-       <tr id="type-variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.B" class="anchor"></a><code>| <span class="constructor">B</span>(int)</code>
-        </td>
-       </tr>
-       <tr id="type-variant.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.C" class="anchor"></a><code>| <span class="constructor">C</span></code>
-        </td>
-        <td class="doc">
-         <p>
-          foo
-         </p>
-        </td>
-       </tr>
-       <tr id="type-variant.D" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.D" class="anchor"></a><code>| <span class="constructor">D</span></code>
-        </td>
-        <td class="doc">
-         <p>
-          <em>bar</em>
-         </p>
-        </td>
-       </tr>
-       <tr id="type-variant.E" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.E" class="anchor"></a><code>| <span class="constructor">E</span>(<a href="index.html#type-variant_e">variant_e</a>)</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>;</code>
-    </dt>
-    <dt class="spec type" id="type-variant_c">
-     <a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type</span> variant_c = {</code>
-     <table>
-      <tbody>
-       <tr id="type-variant_c.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-variant_c.a" class="anchor"></a><code>a: int,</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>};</code>
-    </dt>
-    <dt class="spec type" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> gadt(_) = </code>
-     <table>
-      <tbody>
-       <tr id="type-gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <a href="index.html#type-gadt">gadt</a>(int)</code>
-        </td>
-       </tr>
-       <tr id="type-gadt.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code>| <span class="constructor">B</span>(int) : <a href="index.html#type-gadt">gadt</a>(string)</code>
-        </td>
-       </tr>
-       <tr id="type-gadt.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code>| <span class="constructor">C</span>(<a href="index.html#type-variant_c">variant_c</a>) : <a href="index.html#type-gadt">gadt</a>(unit)</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>;</code>
-    </dt>
-    <dt class="spec type" id="type-degenerate_gadt">
-     <a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type</span> degenerate_gadt = </code>
-     <table>
-      <tbody>
-       <tr id="type-degenerate_gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-degenerate_gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>;</code>
-    </dt>
-    <dt class="spec type" id="type-private_variant">
-     <a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type</span> private_variant = <span class="keyword">pri</span> </code>
-     <table>
-      <tbody>
-       <tr id="type-private_variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-private_variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>;</code>
-    </dt>
-    <dt class="spec type" id="type-record">
-     <a href="#type-record" class="anchor"></a><code><span class="keyword">type</span> record = {</code>
-     <table>
-      <tbody>
-       <tr id="type-record.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.a" class="anchor"></a><code>a: int,</code>
-        </td>
-       </tr>
-       <tr id="type-record.b" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable</span> b: int,</code>
-        </td>
-       </tr>
-       <tr id="type-record.c" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.c" class="anchor"></a><code>c: int,</code>
-        </td>
-        <td class="doc">
-         <p>
-          foo
-         </p>
-        </td>
-       </tr>
-       <tr id="type-record.d" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.d" class="anchor"></a><code>d: int,</code>
-        </td>
-        <td class="doc">
-         <p>
-          <em>bar</em>
-         </p>
-        </td>
-       </tr>
-       <tr id="type-record.e" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.e" class="anchor"></a><code>e: a. <span class="type-var">'a</span>,</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>};</code>
-    </dt>
-    <dt class="spec type" id="type-polymorphic_variant">
-     <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B(int)</code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C(<span>(int, unit)</span>)</code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ];</code>
-    </dt>
-    <dt class="spec type" id="type-polymorphic_variant_extension">
-     <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant_extension = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
-        <td class="def type">
-         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant_extension.E" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code>| </code><code>`E</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ];</code>
-    </dt>
-    <dt class="spec type" id="type-nested_polymorphic_variant">
-     <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> nested_polymorphic_variant = [ </code>
-     <table>
-      <tbody>
-       <tr id="type-nested_polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A(<span>[ `B <span>| `C</span> ]</span>)</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ];</code>
-    </dt>
-    <dt class="spec type" id="type-private_extenion#row">
-     <a href="#type-private_extenion#row" class="anchor"></a><code><span class="keyword">type</span> private_extenion#row;</code>
-    </dt>
-    <dt class="spec type" id="type-private_extenion">
-     <a href="#type-private_extenion" class="anchor"></a><code><span class="keyword">and</span> private_extenion = <span class="keyword">pri</span> [&gt; </code>
-     <table>
-      <tbody>
-       <tr id="type-private_extenion.polymorphic_variant" class="anchored">
-        <td class="def type">
-         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code> ];</code>
-    </dt>
-    <dt class="spec type" id="type-object_">
-     <a href="#type-object_" class="anchor"></a><code><span class="keyword">type</span> object_ = {. a: int, b: int, c: int, };</code>
-    </dt>
-   </dl>
+    </div>
+   </div>
+   <div class="spec type" id="type-alias">
+    <a href="#type-alias" class="anchor"></a><code><span class="keyword">type</span> alias = int;</code>
+   </div>
+   <div class="spec type" id="type-private_">
+    <a href="#type-private_" class="anchor"></a><code><span class="keyword">type</span> private_ = <span class="keyword">pri</span> int;</code>
+   </div>
+   <div class="spec type" id="type-constructor">
+    <a href="#type-constructor" class="anchor"></a><code><span class="keyword">type</span> constructor('a) = <span class="type-var">'a</span>;</code>
+   </div>
+   <div class="spec type" id="type-arrow">
+    <a href="#type-arrow" class="anchor"></a><code><span class="keyword">type</span> arrow = int <span>=&gt;</span> int;</code>
+   </div>
+   <div class="spec type" id="type-higher_order">
+    <a href="#type-higher_order" class="anchor"></a><code><span class="keyword">type</span> higher_order = <span>(int <span>=&gt;</span> int)</span> <span>=&gt;</span> int;</code>
+   </div>
+   <div class="spec type" id="type-labeled">
+    <a href="#type-labeled" class="anchor"></a><code><span class="keyword">type</span> labeled = <span>l:int</span> <span>=&gt;</span> int;</code>
+   </div>
+   <div class="spec type" id="type-optional">
+    <a href="#type-optional" class="anchor"></a><code><span class="keyword">type</span> optional = <span>?⁠l:int</span> <span>=&gt;</span> int;</code>
+   </div>
+   <div class="spec type" id="type-labeled_higher_order">
+    <a href="#type-labeled_higher_order" class="anchor"></a><code><span class="keyword">type</span> labeled_higher_order = <span>(<span>l:int</span> <span>=&gt;</span> int)</span> <span>=&gt;</span> <span>(<span>?⁠l:int</span> <span>=&gt;</span> int)</span> <span>=&gt;</span> int;</code>
+   </div>
+   <div class="spec type" id="type-pair">
+    <a href="#type-pair" class="anchor"></a><code><span class="keyword">type</span> pair = <span>(int, int)</span>;</code>
+   </div>
+   <div class="spec type" id="type-parens_dropped">
+    <a href="#type-parens_dropped" class="anchor"></a><code><span class="keyword">type</span> parens_dropped = <span>(int, int)</span>;</code>
+   </div>
+   <div class="spec type" id="type-triple">
+    <a href="#type-triple" class="anchor"></a><code><span class="keyword">type</span> triple = <span>(int, int, int)</span>;</code>
+   </div>
+   <div class="spec type" id="type-nested_pair">
+    <a href="#type-nested_pair" class="anchor"></a><code><span class="keyword">type</span> nested_pair = <span>(<span>(int, int)</span>, int)</span>;</code>
+   </div>
+   <div class="spec type" id="type-instance">
+    <a href="#type-instance" class="anchor"></a><code><span class="keyword">type</span> instance = <a href="index.html#type-constructor">constructor</a>(int);</code>
+   </div>
+   <div class="spec type" id="type-variant_e">
+    <a href="#type-variant_e" class="anchor"></a><code><span class="keyword">type</span> variant_e = {</code>
+    <table>
+     <tbody>
+      <tr id="type-variant_e.a" class="anchored">
+       <td class="def record field">
+        <a href="#type-variant_e.a" class="anchor"></a><code>a: int,</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>};</code>
+   </div>
+   <div class="spec type" id="type-variant">
+    <a href="#type-variant" class="anchor"></a><code><span class="keyword">type</span> variant = </code>
+    <table>
+     <tbody>
+      <tr id="type-variant.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
+       </td>
+      </tr>
+      <tr id="type-variant.B" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.B" class="anchor"></a><code>| <span class="constructor">B</span>(int)</code>
+       </td>
+      </tr>
+      <tr id="type-variant.C" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.C" class="anchor"></a><code>| <span class="constructor">C</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         foo
+        </p>
+       </td>
+      </tr>
+      <tr id="type-variant.D" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.D" class="anchor"></a><code>| <span class="constructor">D</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         <em>bar</em>
+        </p>
+       </td>
+      </tr>
+      <tr id="type-variant.E" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-variant.E" class="anchor"></a><code>| <span class="constructor">E</span>(<a href="index.html#type-variant_e">variant_e</a>)</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec type" id="type-variant_c">
+    <a href="#type-variant_c" class="anchor"></a><code><span class="keyword">type</span> variant_c = {</code>
+    <table>
+     <tbody>
+      <tr id="type-variant_c.a" class="anchored">
+       <td class="def record field">
+        <a href="#type-variant_c.a" class="anchor"></a><code>a: int,</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>};</code>
+   </div>
+   <div class="spec type" id="type-gadt">
+    <a href="#type-gadt" class="anchor"></a><code><span class="keyword">type</span> gadt(_) = </code>
+    <table>
+     <tbody>
+      <tr id="type-gadt.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <a href="index.html#type-gadt">gadt</a>(int)</code>
+       </td>
+      </tr>
+      <tr id="type-gadt.B" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.B" class="anchor"></a><code>| <span class="constructor">B</span>(int) : <a href="index.html#type-gadt">gadt</a>(string)</code>
+       </td>
+      </tr>
+      <tr id="type-gadt.C" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-gadt.C" class="anchor"></a><code>| <span class="constructor">C</span>(<a href="index.html#type-variant_c">variant_c</a>) : <a href="index.html#type-gadt">gadt</a>(unit)</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec type" id="type-degenerate_gadt">
+    <a href="#type-degenerate_gadt" class="anchor"></a><code><span class="keyword">type</span> degenerate_gadt = </code>
+    <table>
+     <tbody>
+      <tr id="type-degenerate_gadt.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-degenerate_gadt.A" class="anchor"></a><code>| <span class="constructor">A</span> : <a href="index.html#type-degenerate_gadt">degenerate_gadt</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec type" id="type-private_variant">
+    <a href="#type-private_variant" class="anchor"></a><code><span class="keyword">type</span> private_variant = <span class="keyword">pri</span> </code>
+    <table>
+     <tbody>
+      <tr id="type-private_variant.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-private_variant.A" class="anchor"></a><code>| <span class="constructor">A</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec type" id="type-record">
+    <a href="#type-record" class="anchor"></a><code><span class="keyword">type</span> record = {</code>
+    <table>
+     <tbody>
+      <tr id="type-record.a" class="anchored">
+       <td class="def record field">
+        <a href="#type-record.a" class="anchor"></a><code>a: int,</code>
+       </td>
+      </tr>
+      <tr id="type-record.b" class="anchored">
+       <td class="def record field">
+        <a href="#type-record.b" class="anchor"></a><code><span class="keyword">mutable</span> b: int,</code>
+       </td>
+      </tr>
+      <tr id="type-record.c" class="anchored">
+       <td class="def record field">
+        <a href="#type-record.c" class="anchor"></a><code>c: int,</code>
+       </td>
+       <td class="doc">
+        <p>
+         foo
+        </p>
+       </td>
+      </tr>
+      <tr id="type-record.d" class="anchored">
+       <td class="def record field">
+        <a href="#type-record.d" class="anchor"></a><code>d: int,</code>
+       </td>
+       <td class="doc">
+        <p>
+         <em>bar</em>
+        </p>
+       </td>
+      </tr>
+      <tr id="type-record.e" class="anchored">
+       <td class="def record field">
+        <a href="#type-record.e" class="anchor"></a><code>e: a. <span class="type-var">'a</span>,</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>};</code>
+   </div>
+   <div class="spec type" id="type-polymorphic_variant">
+    <a href="#type-polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-polymorphic_variant.A" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A</code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.B" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.B" class="anchor"></a><code>| </code><code>`B(int)</code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.C" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.C" class="anchor"></a><code>| </code><code>`C(<span>(int, unit)</span>)</code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant.D" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant.D" class="anchor"></a><code>| </code><code>`D</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ];</code>
+   </div>
+   <div class="spec type" id="type-polymorphic_variant_extension">
+    <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span class="keyword">type</span> polymorphic_variant_extension = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
+       <td class="def type">
+        <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+       </td>
+      </tr>
+      <tr id="type-polymorphic_variant_extension.E" class="anchored">
+       <td class="def constructor">
+        <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code>| </code><code>`E</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ];</code>
+   </div>
+   <div class="spec type" id="type-nested_polymorphic_variant">
+    <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span class="keyword">type</span> nested_polymorphic_variant = [ </code>
+    <table>
+     <tbody>
+      <tr id="type-nested_polymorphic_variant.A" class="anchored">
+       <td class="def constructor">
+        <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code>| </code><code>`A(<span>[ `B <span>| `C</span> ]</span>)</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ];</code>
+   </div>
+   <div class="spec type" id="type-private_extenion#row">
+    <a href="#type-private_extenion#row" class="anchor"></a><code><span class="keyword">type</span> private_extenion#row;</code>
+   </div>
+   <div class="spec type" id="type-private_extenion">
+    <a href="#type-private_extenion" class="anchor"></a><code><span class="keyword">and</span> private_extenion = <span class="keyword">pri</span> [&gt; </code>
+    <table>
+     <tbody>
+      <tr id="type-private_extenion.polymorphic_variant" class="anchored">
+       <td class="def type">
+        <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code>| </code><code><a href="index.html#type-polymorphic_variant">polymorphic_variant</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code> ];</code>
+   </div>
+   <div class="spec type" id="type-object_">
+    <a href="#type-object_" class="anchor"></a><code><span class="keyword">type</span> object_ = {. a: int, b: int, c: int, };</code>
+   </div>
    <div class="spec module-type" id="module-type-X">
     <a href="#module-type-X" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-X/index.html">X</a> = { ... };</code>
    </div>
-   <dl>
-    <dt class="spec type" id="type-module_">
-     <a href="#type-module_" class="anchor"></a><code><span class="keyword">type</span> module_ = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-module_substitution">
-     <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-covariant">
-     <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type</span> covariant(+'a);</code>
-    </dt>
-    <dt class="spec type" id="type-contravariant">
-     <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type</span> contravariant(-'a);</code>
-    </dt>
-    <dt class="spec type" id="type-bivariant">
-     <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type</span> bivariant(_) = int;</code>
-    </dt>
-    <dt class="spec type" id="type-binary">
-     <a href="#type-binary" class="anchor"></a><code><span class="keyword">type</span> binary('a, 'b);</code>
-    </dt>
-    <dt class="spec type" id="type-using_binary">
-     <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary = <a href="index.html#type-binary">binary</a><span>(int,&nbsp;int)</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-name">
-     <a href="#type-name" class="anchor"></a><code><span class="keyword">type</span> name('custom);</code>
-    </dt>
-    <dt class="spec type" id="type-constrained">
-     <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type</span> constrained('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int;</code>
-    </dt>
-    <dt class="spec type" id="type-exact_variant">
-     <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> exact_variant('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[ `A <span><span>| `B</span><span>(int)</span></span> ]</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-lower_variant">
-     <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> lower_variant('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `A <span><span>| `B</span><span>(int)</span></span> ]</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-any_variant">
-     <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> any_variant('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt;  ]</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-upper_variant">
-     <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> upper_variant('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; `A <span><span>| `B</span><span>(int)</span></span> ]</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-named_variant">
-     <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> named_variant('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-exact_object">
-     <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type</span> exact_object('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {. a: int, b: int, };</code>
-    </dt>
-    <dt class="spec type" id="type-lower_object">
-     <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type</span> lower_object('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {.. a: int, b: int, };</code>
-    </dt>
-    <dt class="spec type" id="type-poly_object">
-     <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> poly_object('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {. a: a. <span class="type-var">'a</span>, };</code>
-    </dt>
-    <dt class="spec type" id="type-double_constrained">
-     <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> double_constrained('a, 'b) = <span>(<span class="type-var">'a</span>, <span class="type-var">'b</span>)</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit;</code>
-    </dt>
-    <dt class="spec type" id="type-as_">
-     <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_ = <span>(int <span class="keyword">as</span> 'a, <span class="type-var">'a</span>)</span>;</code>
-    </dt>
-    <dt class="spec type" id="type-extensible">
-     <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type</span> extensible = ..;</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-extensible">extensible</a> += | <span class="extension">Extension</span>| <span class="extension">Another_extension</span>;</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec type" id="type-mutually">
-     <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type</span> mutually = </code>
-     <table>
-      <tbody>
-       <tr id="type-mutually.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutually.A" class="anchor"></a><code>| <span class="constructor">A</span>(<a href="index.html#type-recursive">recursive</a>)</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>;</code>
-    </dt>
-    <dt class="spec type" id="type-recursive">
-     <a href="#type-recursive" class="anchor"></a><code><span class="keyword">and</span> recursive = </code>
-     <table>
-      <tbody>
-       <tr id="type-recursive.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-recursive.B" class="anchor"></a><code>| <span class="constructor">B</span>(<a href="index.html#type-mutually">mutually</a>)</code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
-     <code>;</code>
-    </dt>
-   </dl>
-   <dl>
-    <dt class="spec exception" id="exception-Foo">
-     <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Foo</span>(int, int);</code>
-    </dt>
-   </dl>
+   <div class="spec type" id="type-module_">
+    <a href="#type-module_" class="anchor"></a><code><span class="keyword">type</span> module_ = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</span>;</code>
+   </div>
+   <div class="spec type" id="type-module_substitution">
+    <a href="#type-module_substitution" class="anchor"></a><code><span class="keyword">type</span> module_substitution = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span>;</code>
+   </div>
+   <div class="spec type" id="type-covariant">
+    <a href="#type-covariant" class="anchor"></a><code><span class="keyword">type</span> covariant(+'a);</code>
+   </div>
+   <div class="spec type" id="type-contravariant">
+    <a href="#type-contravariant" class="anchor"></a><code><span class="keyword">type</span> contravariant(-'a);</code>
+   </div>
+   <div class="spec type" id="type-bivariant">
+    <a href="#type-bivariant" class="anchor"></a><code><span class="keyword">type</span> bivariant(_) = int;</code>
+   </div>
+   <div class="spec type" id="type-binary">
+    <a href="#type-binary" class="anchor"></a><code><span class="keyword">type</span> binary('a, 'b);</code>
+   </div>
+   <div class="spec type" id="type-using_binary">
+    <a href="#type-using_binary" class="anchor"></a><code><span class="keyword">type</span> using_binary = <a href="index.html#type-binary">binary</a><span>(int,&nbsp;int)</span>;</code>
+   </div>
+   <div class="spec type" id="type-name">
+    <a href="#type-name" class="anchor"></a><code><span class="keyword">type</span> name('custom);</code>
+   </div>
+   <div class="spec type" id="type-constrained">
+    <a href="#type-constrained" class="anchor"></a><code><span class="keyword">type</span> constrained('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int;</code>
+   </div>
+   <div class="spec type" id="type-exact_variant">
+    <a href="#type-exact_variant" class="anchor"></a><code><span class="keyword">type</span> exact_variant('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[ `A <span><span>| `B</span><span>(int)</span></span> ]</span>;</code>
+   </div>
+   <div class="spec type" id="type-lower_variant">
+    <a href="#type-lower_variant" class="anchor"></a><code><span class="keyword">type</span> lower_variant('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `A <span><span>| `B</span><span>(int)</span></span> ]</span>;</code>
+   </div>
+   <div class="spec type" id="type-any_variant">
+    <a href="#type-any_variant" class="anchor"></a><code><span class="keyword">type</span> any_variant('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt;  ]</span>;</code>
+   </div>
+   <div class="spec type" id="type-upper_variant">
+    <a href="#type-upper_variant" class="anchor"></a><code><span class="keyword">type</span> upper_variant('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; `A <span><span>| `B</span><span>(int)</span></span> ]</span>;</code>
+   </div>
+   <div class="spec type" id="type-named_variant">
+    <a href="#type-named_variant" class="anchor"></a><code><span class="keyword">type</span> named_variant('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; <a href="index.html#type-polymorphic_variant">polymorphic_variant</a> ]</span>;</code>
+   </div>
+   <div class="spec type" id="type-exact_object">
+    <a href="#type-exact_object" class="anchor"></a><code><span class="keyword">type</span> exact_object('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {. a: int, b: int, };</code>
+   </div>
+   <div class="spec type" id="type-lower_object">
+    <a href="#type-lower_object" class="anchor"></a><code><span class="keyword">type</span> lower_object('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {.. a: int, b: int, };</code>
+   </div>
+   <div class="spec type" id="type-poly_object">
+    <a href="#type-poly_object" class="anchor"></a><code><span class="keyword">type</span> poly_object('a) = <span class="type-var">'a</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = {. a: a. <span class="type-var">'a</span>, };</code>
+   </div>
+   <div class="spec type" id="type-double_constrained">
+    <a href="#type-double_constrained" class="anchor"></a><code><span class="keyword">type</span> double_constrained('a, 'b) = <span>(<span class="type-var">'a</span>, <span class="type-var">'b</span>)</span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit;</code>
+   </div>
+   <div class="spec type" id="type-as_">
+    <a href="#type-as_" class="anchor"></a><code><span class="keyword">type</span> as_ = <span>(int <span class="keyword">as</span> 'a, <span class="type-var">'a</span>)</span>;</code>
+   </div>
+   <div class="spec type" id="type-extensible">
+    <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type</span> extensible = ..;</code>
+   </div>
+   <div class="spec extension">
+    <code><span class="keyword">type</span> <a href="index.html#type-extensible">extensible</a> += | <span class="extension">Extension</span>| <span class="extension">Another_extension</span>;</code>
+   </div>
+   <div class="spec type" id="type-mutually">
+    <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type</span> mutually = </code>
+    <table>
+     <tbody>
+      <tr id="type-mutually.A" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-mutually.A" class="anchor"></a><code>| <span class="constructor">A</span>(<a href="index.html#type-recursive">recursive</a>)</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec type" id="type-recursive">
+    <a href="#type-recursive" class="anchor"></a><code><span class="keyword">and</span> recursive = </code>
+    <table>
+     <tbody>
+      <tr id="type-recursive.B" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-recursive.B" class="anchor"></a><code>| <span class="constructor">B</span>(<a href="index.html#type-mutually">mutually</a>)</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec exception" id="exception-Foo">
+    <a href="#exception-Foo" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">Foo</span>(int, int);</code>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Val/index.html
+++ b/test/html/expect/test_package+re/Val/index.html
@@ -22,29 +22,29 @@
    </h1>
   </header>
   <div class="content">
-   <dl>
-    <dt class="spec value" id="val-documented">
+   <div>
+    <div class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span class="keyword">let</span> documented: unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Foo.
      </p>
-    </dd>
-   </dl>
-   <dl>
-    <dt class="spec value" id="val-undocumented">
-     <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">let</span> undocumented: unit;</code>
-    </dt>
-    <dt class="spec value" id="val-documented_above">
+    </div>
+   </div>
+   <div class="spec value" id="val-undocumented">
+    <a href="#val-undocumented" class="anchor"></a><code><span class="keyword">let</span> undocumented: unit;</code>
+   </div>
+   <div>
+    <div class="spec value" id="val-documented_above">
      <a href="#val-documented_above" class="anchor"></a><code><span class="keyword">let</span> documented_above: unit;</code>
-    </dt>
-    <dd>
+    </div>
+    <div>
      <p>
       Bar.
      </p>
-    </dd>
-   </dl>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/print/print.ml
+++ b/test/print/print.ml
@@ -258,6 +258,9 @@ struct
     | `Word w -> List [Atom "word"; Atom w]
     | `Code_span c -> List [Atom "code_span"; Atom c]
     | `Raw_markup (`Html, s) -> List [Atom "raw_markup"; Atom "html"; Atom s]
+    | `Raw_markup (`Manpage, s) -> List [Atom "raw_markup"; Atom "manpage"; Atom s]
+    | `Raw_markup (`Latex, s) -> List [Atom "raw_markup"; Atom "latex"; Atom s]
+
 
   let rec non_link_inline_element : Comment.non_link_inline_element -> sexp =
     function


### PR DESCRIPTION
This PRs adds an initial latex backend that can compile the [OCaml standard library](https://www.polychoron.fr/ocaml-nonmanual/odoc_latex_manual.pdf) quite nicely.

During the implementation, @Drup and me modified the documentation IR to allow backends to take more easily the decision to inline submodules and other subpages, since for a latex backend we try to generate readable paper texts, where following link is not so immediate.

The backend probably some need more testing with other libraries and more tuning with people feedback.
A remaining point is the question of the user interface, currently, I am using a hand-written [makefile]( https://github.com/Octachron/odoc/blob/latex/stdlib_latex_test/Makefile) combined with a handwritten [latex header file](https://github.com/Octachron/odoc/blob/latex/stdlib_latex_test/glue.tex). I was wondering if we should provide a template latex header but this is not done yet.