### PR TITLE
xref2: Fix stack overflow on classes

### DIFF
--- a/test/compile/cases/impl_only.ml
+++ b/test/compile/cases/impl_only.ml
@@ -1,0 +1,6 @@
+(* Loader bugs *)
+
+class foo =
+  object (o)
+    method bar = o
+  end

--- a/test/compile/dune
+++ b/test/compile/dune
@@ -41,3 +41,18 @@
 (alias
  (name runtest)
  (action (diff expect/parser_errors_fatal.txt parser_errors_fatal.output)))
+
+(rule
+ (deps cases/impl_only.ml)
+ (targets impl_only.output)
+ (action
+  (progn
+   (run %{ocamlc} -bin-annot -o impl_only.cmt -c cases/impl_only.ml)
+   (with-stderr-to
+    impl_only.output
+    (run odoc compile --package foo impl_only.cmt)))))
+
+(alias
+ (name runtest)
+ (action
+  (diff expect/impl_only.txt impl_only.output)))


### PR DESCRIPTION
Fixes the small reproduction case in https://github.com/ocaml/odoc/issues/388

This fixes the crash but the output for classes is not great and should be
reworked.

The output for:

```ocaml
class foo =
  object(o)
    method test () = o
  end
```

is:

```ocaml
method test : < test : unit -> 'a; .. > -> unit -> 'a
```