### PR TITLE
xref2: Ambiguous reference warning

### DIFF
--- a/src/document/url.mli
+++ b/src/document/url.mli
@@ -40,7 +40,7 @@ module Anchor : sig
   type t = {
     page : Path.t ;
     anchor : string;
-    (** Anchor in {!page} where the element is attached *)
+    (** Anchor in {!field-page} where the element is attached *)
 
     kind : string;
     (** What kind of element the path points to.

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -671,10 +671,10 @@ and type_expression : Env.t -> Id.Parent.t -> _ -> _ =
       let cp = Component.Of_Lang.(type_path empty path) in
       let ts = List.map (type_expression env parent) ts' in
       match Tools.resolve_type env cp with
-      | Ok (cp, (`T _ | `C _ | `CT _)) ->
+      | Ok (cp, (`FType _ | `FClass _ | `FClassType _)) ->
           let p = Cpath.resolved_type_path_of_cpath cp in
           Constr (`Resolved p, ts)
-      | Ok (_cp, `T_removed (_, x)) -> Lang_of.(type_expr empty parent x)
+      | Ok (_cp, `FType_removed (_, x)) -> Lang_of.(type_expr empty parent x)
       | Error _ -> Constr (Cpath.type_path_of_cpath cp, ts) )
   | Polymorphic_variant v ->
       Polymorphic_variant (type_expression_polyvar env parent v)

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -671,10 +671,10 @@ and type_expression : Env.t -> Id.Parent.t -> _ -> _ =
       let cp = Component.Of_Lang.(type_path empty path) in
       let ts = List.map (type_expression env parent) ts' in
       match Tools.resolve_type env cp with
-      | Ok (cp, Found _t) ->
+      | Ok (cp, (`T _ | `C _ | `CT _)) ->
           let p = Cpath.resolved_type_path_of_cpath cp in
           Constr (`Resolved p, ts)
-      | Ok (_cp, Replaced x) -> Lang_of.(type_expr empty parent x)
+      | Ok (_cp, `T_removed (_, x)) -> Lang_of.(type_expr empty parent x)
       | Error _ -> Constr (Cpath.type_path_of_cpath cp, ts) )
   | Polymorphic_variant v ->
       Polymorphic_variant (type_expression_polyvar env parent v)

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -140,8 +140,12 @@ type value_or_external =
 type 'a scope constraint 'a = [< Component.Element.any ]
 (** Target of a lookup *)
 
-val lookup_by_name : 'a scope -> string -> t -> 'a option
-(** Lookup an element in Env depending on the given [scope]. *)
+type 'a maybe_ambiguous =
+  ('a, [ `Ambiguous of ('a * 'a list) | `Not_found ]) Result.result
+
+val lookup_by_name : 'a scope -> string -> t -> 'a maybe_ambiguous
+(** Lookup an element in Env depending on the given [scope].
+    Return [Error (`Ambiguous _)] when two or more elements match the given scope and name. *)
 
 val lookup_by_id :
   'a scope -> [< Odoc_model.Paths_types.Identifier.any ] -> t -> 'a option

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -1,104 +1,145 @@
+open Odoc_model.Names
+
 open Component
 
-type class_type = [ `C of Class.t | `CT of ClassType.t ]
+type module_ = [ `M of ModuleName.t * Module.t ]
 
-type type_ = [ `T of TypeDecl.t | class_type ]
+type module_type = [ `MT of ModuleTypeName.t * ModuleType.t ]
 
-type value = [ `V of Value.t | `E of External.t ]
+type datatype = [ `T of TypeName.t * TypeDecl.t ]
 
-type ('a, 'b) found = Found of 'a | Replaced of 'b
+type class_ = [ `C of ClassName.t * Class.t | `CT of ClassTypeName.t * ClassType.t ]
 
-let careful_module_in_sig (s : Signature.t) name =
-  let rec inner_removed = function
-    | Signature.RModule (id, p) :: _ when Ident.Name.typed_module id = name ->
-        Some (Replaced p)
-    | _ :: rest -> inner_removed rest
-    | [] -> None
-  in
-  let rec inner = function
-    | Signature.Module (id, _, m) :: _ when Ident.Name.typed_module id = name ->
-        Some (Found (Ident.Name.module' id, Delayed.get m))
-    | Signature.Include i :: rest -> (
-        match inner i.Include.expansion_.items with
-        | Some _ as found -> found
-        | None -> inner rest )
-    | _ :: rest -> inner rest
-    | [] -> inner_removed s.removed
-  in
-  inner s.items
+type value = [ `E of External.t | `V of Value.t ]
 
-let careful_type_in_sig (s : Signature.t) name =
-  let rec inner_removed = function
-    | Signature.RType (id, p) :: _ when Ident.Name.type_ id = name ->
-        Some (Replaced (Ident.Name.type' id, p))
-    | _ :: rest -> inner_removed rest
-    | [] -> None
-  in
-  let rec inner = function
-    | Signature.Type (id, _, m) :: _ when Ident.Name.type_ id = name ->
-        Some (Found (`T (Ident.Name.type' id, Component.Delayed.get m)))
-    | Signature.Class (id, _, c) :: _ when Ident.Name.class_ id = name ->
-        Some (Found (`C (Ident.Name.class' id, c)))
-    | Signature.ClassType (id, _, c) :: _ when Ident.Name.class_type id = name
-      ->
-        Some (Found (`CT (Ident.Name.class_type' id, c)))
-    | Signature.Include i :: rest -> (
-        match inner i.Include.expansion_.items with
-        | Some _ as found -> found
-        | None -> inner rest )
-    | _ :: rest -> inner rest
-    | [] -> inner_removed s.removed
-  in
-  inner s.items
+type label = [ `L of Ident.label ]
 
-let careful_class_type_in_sig (s : Signature.t) name =
-  let rec inner_removed = function
-    | Signature.RType (id, p) :: _ when Ident.Name.type_ id = name ->
-        Some (Replaced (Ident.Name.type' id, p))
-    | _ :: rest -> inner_removed rest
-    | [] -> None
-  in
-  let rec inner = function
-    | Signature.Class (id, _, c) :: _ when Ident.Name.class_ id = name ->
-        Some (Found (`C (Ident.Name.class' id, c)))
-    | Signature.ClassType (id, _, c) :: _ when Ident.Name.class_type id = name
-      ->
-        Some (Found (`CT (Ident.Name.class_type' id, c)))
-    | Signature.Include i :: rest -> (
-        match inner i.Include.expansion_.items with
-        | Some _ as found -> found
-        | None -> inner rest )
-    | _ :: rest -> inner rest
-    | [] -> inner_removed s.removed
-  in
-  inner s.items
+type exception_ = [ `Exn of Exception.t ]
 
-let typename_of_typeid (`LType (n, _) | `LCoreType n) = n
+type extension = [ `Ext of Extension.t * Extension.Constructor.t ]
 
-let datatype_in_sig (s : Signature.t) name =
-  let rec inner = function
-    | Signature.Type (id, _, m) :: _ when Ident.Name.typed_type id = name ->
-        Some (Component.Delayed.get m)
+type substitution = [ `Msub of ModuleSubstitution.t | `Tsub of TypeDecl.t ]
+
+type signature = [ module_ | module_type ]
+
+type type_ = [ datatype | class_ ]
+
+type label_parent = [ signature | type_ ]
+
+type constructor = [ `Cs of TypeDecl.Constructor.t ]
+
+type field = [ `Fd of TypeDecl.Field.t ]
+
+type any_in_type = [ constructor | field ]
+
+type any_in_type_in_sig =
+  [ `In_type of Odoc_model.Names.TypeName.t * TypeDecl.t * any_in_type ]
+
+type any_in_sig =
+  [ label_parent
+  | value
+  | label
+  | exception_
+  | extension
+  | substitution
+  | any_in_type_in_sig ]
+
+type instance_variable = [ `Mv of InstanceVariable.t ]
+
+type method_ = [ `Mm of Method.t ]
+
+type any_in_class_sig = [ instance_variable | method_ ]
+
+module N = Ident.Name
+
+let rec filter_map f = function
+  | hd :: tl -> ( match f hd with Some _ as x -> x | None -> filter_map f tl )
+  | [] -> None
+
+let find_in_sig sg f =
+  let rec inner f = function
     | Signature.Include i :: tl -> (
-        match inner i.Include.expansion_.items with
-        | Some _ as found -> found
-        | None -> inner tl )
-    | _ :: tl -> inner tl
+        match inner f i.Include.expansion_.items with
+        | Some _ as x -> x
+        | None -> inner f tl )
+    | hd :: tl -> ( match f hd with Some _ as x -> x | None -> inner f tl )
     | [] -> None
   in
-  inner s.items
+  inner f sg.Signature.items
+
+let module_in_sig sg name =
+  find_in_sig sg (function
+    | Signature.Module (id, _, m) when N.typed_module id = name ->
+        Some (`M (N.typed_module id, Delayed.get m))
+    | _ -> None)
+
+let type_in_sig sg name =
+  find_in_sig sg (function
+    | Signature.Type (id, _, m) when N.type_ id = name ->
+        Some (`T (N.type' id, Delayed.get m))
+    | Class (id, _, c) when N.class_ id = name -> Some (`C (N.class' id, c))
+    | ClassType (id, _, c) when N.class_type id = name -> Some (`CT (N.class_type' id, c))
+    | _ -> None)
+
+let class_in_sig sg name =
+  find_in_sig sg (function
+    | Signature.Class (id, _, c) when N.class_ id = name -> Some (`C (N.class' id, c))
+    | Signature.ClassType (id, _, c) when N.class_type id = name -> Some (`CT (N.class_type' id, c))
+    | _ -> None)
+
+type removed_type = [ `T_removed of TypeName.t * TypeExpr.t ]
+
+type careful_module = [ module_ | `M_removed of Cpath.Resolved.module_ ]
+
+type careful_type = [ type_ | removed_type ]
+
+type careful_class = [ class_ | removed_type ]
+
+let careful_module_in_sig sg name =
+  let removed_module = function
+    | Signature.RModule (id, p) when N.typed_module id = name ->
+        Some (`M_removed p)
+    | _ -> None
+  in
+  match module_in_sig sg name with
+  | Some _ as x -> x
+  | None -> filter_map removed_module sg.Signature.removed
+
+let removed_type_in_sig sg name =
+  let removed_type = function
+    | Signature.RType (id, p) when N.type_ id = name ->
+      Some (`T_removed (N.type' id, p))
+    | _ -> None
+  in
+  filter_map removed_type sg.Signature.removed
+
+let careful_type_in_sig sg name =
+  match type_in_sig sg name with
+  | Some _ as x -> x
+  | None -> removed_type_in_sig sg name
+
+let careful_class_in_sig sg name =
+  match class_in_sig sg name with
+  | Some _ as x -> x
+  | None -> removed_type_in_sig sg name
+
+let datatype_in_sig sg name =
+  find_in_sig sg (function
+    | Signature.Type (id, _, t) when N.type_ id = name ->
+        Some (`T (N.type' id, Component.Delayed.get t))
+    | _ -> None)
 
 let any_in_type (typ : TypeDecl.t) name =
   let rec find_cons = function
     | ({ TypeDecl.Constructor.name = name'; _ } as cons) :: _ when name' = name
       ->
-        Some (`Constructor cons)
+        Some (`Cs cons)
     | _ :: tl -> find_cons tl
     | [] -> None
   in
   let rec find_field = function
     | ({ TypeDecl.Field.name = name'; _ } as field) :: _ when name' = name ->
-        Some (`Field field)
+        Some (`Fd field)
     | _ :: tl -> find_field tl
     | [] -> None
   in
@@ -111,7 +152,7 @@ let any_in_typext (typext : Extension.t) name =
   let rec inner = function
     | ({ Extension.Constructor.name = name'; _ } as cons) :: _ when name' = name
       ->
-        Some (`ExtConstructor (typext, cons))
+        Some (`Ext (typext, cons))
     | _ :: tl -> inner tl
     | [] -> None
   in
@@ -123,43 +164,27 @@ let any_in_comment d name =
     | elt :: rest -> (
         match elt.Odoc_model.Location_.value with
         | `Heading (_, label, _) when Ident.Name.label label = name ->
-            Some (`Label label)
+            Some (`L label)
         | _ -> inner rest )
     | [] -> None
   in
   inner d
 
 let any_in_sig (s : Signature.t) name =
-  let module N = Ident.Name in
-  let rec inner_removed = function
-    | Signature.RModule (id, m) :: _ when N.module_ id = name ->
-        Some (`Removed (`Module (id, m)))
-    | RType (id, t) :: _ when N.type_ id = name ->
-        Some (`Removed (`Type (id, t)))
-    | _ :: tl -> inner_removed tl
-    | [] -> None
-  in
   let rec inner = function
-    | Signature.Module (id, rec_, m) :: _ when N.module_ id = name ->
-        Some (`Module (id, rec_, m))
+    | Signature.Module (id, _, m) :: _ when N.module_ id = name ->
+        Some (`M (N.typed_module id, Delayed.get m))
     | ModuleSubstitution (id, ms) :: _ when N.module_ id = name ->
-        Some (`ModuleSubstitution (id, ms))
+        Some (`Msub ms)
     | ModuleType (id, mt) :: _ when N.module_type id = name ->
-        Some (`ModuleType (id, mt))
-    | Type (id, rec_, t) :: _ when N.type_ id = name ->
-        Some (`Type (id, rec_, t))
-    | TypeSubstitution (id, ts) :: _ when N.type_ id = name ->
-        Some (`TypeSubstitution (id, ts))
-    | Exception (id, exc) :: _ when N.exception_ id = name ->
-        Some (`Exception (id, exc))
-    | Value (id, v) :: _ when N.value id = name ->
-        Some (`Value (id, Delayed.get v))
-    | External (id, vex) :: _ when N.value id = name ->
-        Some (`External (id, vex))
-    | Class (id, rec_, c) :: _ when N.class_ id = name ->
-        Some (`Class (id, rec_, c))
-    | ClassType (id, rec_, ct) :: _ when N.class_type id = name ->
-        Some (`ClassType (id, rec_, ct))
+        Some (`MT (N.typed_module_type id, Delayed.get mt))
+    | Type (id, _, t) :: _ when N.type_ id = name -> Some (`T (N.type' id, Delayed.get t))
+    | TypeSubstitution (id, ts) :: _ when N.type_ id = name -> Some (`Tsub ts)
+    | Exception (id, exc) :: _ when N.exception_ id = name -> Some (`Exn exc)
+    | Value (id, v) :: _ when N.value id = name -> Some (`V (Delayed.get v))
+    | External (id, vex) :: _ when N.value id = name -> Some (`E vex)
+    | Class (id, _, c) :: _ when N.class_ id = name -> Some (`C (N.class' id, c))
+    | ClassType (id, _, ct) :: _ when N.class_type id = name -> Some (`CT (N.class_type' id, ct))
     | Include inc :: tl -> (
         match inner inc.Include.expansion_.items with
         | Some _ as found -> found
@@ -167,10 +192,7 @@ let any_in_sig (s : Signature.t) name =
     | Type (id, _, t) :: tl -> (
         let typ = Delayed.get t in
         match any_in_type typ name with
-        | Some (`Constructor cons) ->
-            Some (`Constructor (typename_of_typeid id, typ, cons))
-        | Some (`Field field) ->
-            Some (`Field (typename_of_typeid id, typ, field))
+        | Some r -> Some (`In_type (N.type' id, typ, r))
         | None -> inner tl )
     | TypExt typext :: tl -> (
         match any_in_typext typext name with
@@ -181,152 +203,69 @@ let any_in_sig (s : Signature.t) name =
         | Some _ as found -> found
         | None -> inner tl )
     | _ :: tl -> inner tl
-    | [] -> inner_removed s.removed
-  in
-  inner s.items
-
-(** Search a module or module type *)
-let signature_in_sig (s : Signature.t) name =
-  let module N = Ident.Name in
-  let rec inner = function
-    | Signature.Module (id, rec_, m) :: _ when N.module_ id = name ->
-        Some (`Module (id, rec_, m))
-    | ModuleType (id, mt) :: _ when N.module_type id = name ->
-        Some (`ModuleType (id, mt))
-    | Include inc :: tl -> (
-        match inner inc.Include.expansion_.items with
-        | Some _ as found -> found
-        | None -> inner tl )
-    | _ :: tl -> inner tl
     | [] -> None
   in
   inner s.items
 
-let module_in_sig s name =
-  match careful_module_in_sig s name with
-  | Some (Found (_, m)) -> Some m
-  | Some (Replaced _) | None -> None
-
-let module_type_in_sig (s : Signature.t) name =
-  let rec inner = function
-    | Signature.ModuleType (id, m) :: _
-      when Ident.Name.typed_module_type id = name ->
-        Some (Delayed.get m)
-    | Signature.Include i :: rest -> (
-        match inner i.Include.expansion_.items with
-        | Some _ as found -> found
-        | None -> inner rest )
-    | _ :: rest -> inner rest
-    | [] -> None
-  in
-  inner s.items
-
-let opt_module_type_in_sig s name =
-  try Some (module_type_in_sig s name) with _ -> None
-
-let opt_value_in_sig s name : value option =
-  let rec inner = function
-    | Signature.Value (id, m) :: _ when Ident.Name.value id = name ->
-        Some (`V (Delayed.get m))
-    | Signature.External (id, e) :: _ when Ident.Name.value id = name ->
-        Some (`E e)
-    | Signature.Include i :: rest -> (
-        match inner i.Include.expansion_.items with
-        | Some m -> Some m
-        | None -> inner rest )
-    | _ :: rest -> inner rest
-    | [] -> None
-  in
-
-  inner s.Signature.items
-
-let type_in_sig s name =
-  match careful_type_in_sig s name with
-  | Some (Found t) -> Some t
-  | Some (Replaced _) | None -> None
-
-let class_type_in_sig (s : Signature.t) name =
-  let rec inner = function
-    | Signature.Class (id, _, c) :: _ when Ident.Name.class_ id = name ->
-        Some (`C c)
-    | Signature.ClassType (id, _, c) :: _ when Ident.Name.class_type id = name
-      ->
-        Some (`CT c)
-    | Signature.Include i :: rest -> (
-        match inner i.Include.expansion_.items with
-        | Some _ as found -> found
-        | None -> inner rest )
-    | _ :: rest -> inner rest
-    | [] -> None
-  in
-  inner s.items
-
-let opt_label_in_sig s name =
-  let rec inner = function
-    | Signature.Comment (`Docs d) :: rest -> (
-        let rec inner' xs =
-          match xs with
-          | elt :: rest -> (
-              match elt.Odoc_model.Location_.value with
-              | `Heading (_, label, _) when Ident.Name.label label = name ->
-                  Some label
-              | _ -> inner' rest )
-          | _ -> None
-        in
-        match inner' d with None -> inner rest | x -> x )
-    | Signature.Include i :: rest -> (
-        match inner i.Include.expansion_.items with
-        | Some _ as x -> x
-        | None -> inner rest )
-    | _ :: rest -> inner rest
-    | [] -> None
-  in
-  inner s.Signature.items
-
-let find_in_sig sg f =
-  let rec inner = function
-    | Signature.Include i :: tl -> (
-        match inner i.Include.expansion_.items with
-        | Some _ as x -> x
-        | None -> inner tl )
-    | hd :: tl -> ( match f hd with Some _ as x -> x | None -> inner tl )
-    | [] -> None
-  in
-  inner sg.Signature.items
-
-let exception_in_sig s name =
-  find_in_sig s (function
-    | Signature.Exception (id, e) when Ident.Name.exception_ id = name -> Some e
-    | _ -> None)
-
-let extension_in_sig s name =
-  let rec inner = function
-    | ec :: _ when ec.Extension.Constructor.name = name -> Some ec
-    | _ :: tl -> inner tl
-    | [] -> None
-  in
-  find_in_sig s (function
-    | Signature.TypExt t -> inner t.Extension.constructors
-    | _ -> None)
-
-let label_parent_in_sig s name =
-  let module N = Ident.Name in
-  find_in_sig s (function
+let signature_in_sig sg name =
+  find_in_sig sg (function
     | Signature.Module (id, _, m) when N.module_ id = name ->
-        Some (`M (Component.Delayed.get m))
+        Some (`M (N.typed_module id, Delayed.get m))
     | ModuleType (id, mt) when N.module_type id = name ->
-        Some (`MT (Component.Delayed.get mt))
-    | Type (id, _, t) when N.type_ id = name ->
-        Some (`T (Component.Delayed.get t))
-    | Class (id, _, c) when N.class_ id = name -> Some (`C c)
-    | ClassType (id, _, c) when N.class_type id = name -> Some (`CT c)
+        Some (`MT (N.typed_module_type id, Delayed.get mt))
     | _ -> None)
 
-let any_in_type_in_sig s name =
-  find_in_sig s (function
+let module_type_in_sig sg name =
+  find_in_sig sg (function
+    | Signature.ModuleType (id, m) when N.typed_module_type id = name ->
+        Some (`MT (N.typed_module_type id, Delayed.get m))
+    | _ -> None)
+
+let value_in_sig sg name =
+  find_in_sig sg (function
+    | Signature.Value (id, m) when N.value id = name ->
+        Some (`V (Delayed.get m))
+    | External (id, e) when N.value id = name -> Some (`E e)
+    | _ -> None)
+
+let label_in_sig sg name =
+  find_in_sig sg (function
+    | Signature.Comment (`Docs d) -> any_in_comment d name
+    | _ -> None)
+
+let exception_in_sig sg name =
+  find_in_sig sg (function
+    | Signature.Exception (id, e) when N.exception_ id = name -> Some (`Exn e)
+    | _ -> None)
+
+let extension_in_sig sg name =
+  let rec inner t = function
+    | ec :: _ when ec.Extension.Constructor.name = name -> Some (`Ext (t, ec))
+    | _ :: tl -> inner t tl
+    | [] -> None
+  in
+  find_in_sig sg (function
+    | Signature.TypExt t -> inner t t.Extension.constructors
+    | _ -> None)
+
+let label_parent_in_sig sg name =
+  let module N = Ident.Name in
+  find_in_sig sg (function
+    | Signature.Module (id, _, m) when N.module_ id = name ->
+        Some (`M (N.typed_module id, Component.Delayed.get m))
+    | ModuleType (id, mt) when N.module_type id = name ->
+        Some (`MT (N.typed_module_type id, Component.Delayed.get mt))
+    | Type (id, _, t) when N.type_ id = name ->
+        Some (`T (N.type' id, Component.Delayed.get t))
+    | Class (id, _, c) when N.class_ id = name -> Some (`C (N.class' id, c))
+    | ClassType (id, _, c) when N.class_type id = name -> Some (`CT (N.class_type' id, c))
+    | _ -> None)
+
+let any_in_type_in_sig sg name =
+  find_in_sig sg (function
     | Signature.Type (id, _, t) -> (
         match any_in_type (Component.Delayed.get t) name with
-        | Some x -> Some (typename_of_typeid id, x)
+        | Some x -> Some (N.type' id, x)
         | None -> None )
     | _ -> None)
 
@@ -345,19 +284,20 @@ let find_in_class_signature cs f =
 let any_in_class_signature cs name =
   find_in_class_signature cs (function
     | ClassSignature.Method (id, m) when Ident.Name.method_ id = name ->
-        Some (`Method m)
+        Some (`Mm m)
     | InstanceVariable (id, iv) when Ident.Name.instance_variable id = name ->
-        Some (`InstanceVariable iv)
+        Some (`Mv iv)
     | _ -> None)
 
 let method_in_class_signature cs name =
   find_in_class_signature cs (function
-    | ClassSignature.Method (id, m) when Ident.Name.method_ id = name -> Some m
+    | ClassSignature.Method (id, m) when Ident.Name.method_ id = name ->
+        Some (`Mm m)
     | _ -> None)
 
 let instance_variable_in_class_signature cs name =
   find_in_class_signature cs (function
     | ClassSignature.InstanceVariable (id, iv)
       when Ident.Name.instance_variable id = name ->
-        Some (`InstanceVariable iv)
+        Some (`Mv iv)
     | _ -> None)

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -76,23 +76,22 @@ val instance_variable_in_class_signature :
 
 (** Maybe ambiguous *)
 
-val class_in_sig : Signature.t -> string -> class_ option
+val class_in_sig : Signature.t -> string -> class_ list
 
-val signature_in_sig : Signature.t -> string -> signature option
+val signature_in_sig : Signature.t -> string -> signature list
 
-val value_in_sig : Signature.t -> string -> value option
+val value_in_sig : Signature.t -> string -> value list
 
-val label_in_sig : Signature.t -> string -> label option
+val label_in_sig : Signature.t -> string -> label list
 
-val label_parent_in_sig : Signature.t -> string -> label_parent option
+val label_parent_in_sig : Signature.t -> string -> label_parent list
 
-val any_in_sig : Signature.t -> string -> any_in_sig option
+val any_in_sig : Signature.t -> string -> any_in_sig list
 
-val any_in_type_in_sig :
-  Signature.t -> string -> (Odoc_model.Names.TypeName.t * any_in_type) option
+val any_in_type_in_sig : Signature.t -> string -> any_in_type_in_sig list
 
 val any_in_class_signature :
-  ClassSignature.t -> string -> any_in_class_sig option
+  ClassSignature.t -> string -> any_in_class_sig list
 
 (** Lookup removed items *)
 

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -1,25 +1,27 @@
 (* Find *)
 open Odoc_model.Names
-
 open Component
 
-type module_ = [ `M of ModuleName.t * Module.t ]
+type module_ = [ `FModule of ModuleName.t * Module.t ]
 
-type module_type = [ `MT of ModuleTypeName.t * ModuleType.t ]
+type module_type = [ `FModuleType of ModuleTypeName.t * ModuleType.t ]
 
-type datatype = [ `T of TypeName.t * TypeDecl.t ]
+type datatype = [ `FType of TypeName.t * TypeDecl.t ]
 
-type class_ = [ `C of ClassName.t * Class.t | `CT of ClassTypeName.t * ClassType.t ]
+type class_ =
+  [ `FClass of ClassName.t * Class.t
+  | `FClassType of ClassTypeName.t * ClassType.t ]
 
-type value = [ `E of External.t | `V of Value.t ]
+type value = [ `FExternal of External.t | `FValue of Value.t ]
 
-type label = [ `L of Ident.label ]
+type label = [ `FLabel of Ident.label ]
 
-type exception_ = [ `Exn of Exception.t ]
+type exception_ = [ `FExn of Exception.t ]
 
-type extension = [ `Ext of Extension.t * Extension.Constructor.t ]
+type extension = [ `FExt of Extension.t * Extension.Constructor.t ]
 
-type substitution = [ `Msub of ModuleSubstitution.t | `Tsub of TypeDecl.t ]
+type substitution =
+  [ `FModule_subst of ModuleSubstitution.t | `FType_subst of TypeDecl.t ]
 
 type signature = [ module_ | module_type ]
 
@@ -27,9 +29,9 @@ type type_ = [ datatype | class_ ]
 
 type label_parent = [ signature | type_ ]
 
-type constructor = [ `Cs of TypeDecl.Constructor.t ]
+type constructor = [ `FConstructor of TypeDecl.Constructor.t ]
 
-type field = [ `Fd of TypeDecl.Field.t ]
+type field = [ `FField of TypeDecl.Field.t ]
 
 type any_in_type = [ constructor | field ]
 
@@ -45,9 +47,9 @@ type any_in_sig =
   | substitution
   | any_in_type_in_sig ]
 
-type instance_variable = [ `Mv of InstanceVariable.t ]
+type instance_variable = [ `FInstance_variable of InstanceVariable.t ]
 
-type method_ = [ `Mm of Method.t ]
+type method_ = [ `FMethod of Method.t ]
 
 type any_in_class_sig = [ instance_variable | method_ ]
 
@@ -90,14 +92,13 @@ val any_in_sig : Signature.t -> string -> any_in_sig list
 
 val any_in_type_in_sig : Signature.t -> string -> any_in_type_in_sig list
 
-val any_in_class_signature :
-  ClassSignature.t -> string -> any_in_class_sig list
+val any_in_class_signature : ClassSignature.t -> string -> any_in_class_sig list
 
 (** Lookup removed items *)
 
-type removed_type = [ `T_removed of TypeName.t * TypeExpr.t ]
+type removed_type = [ `FType_removed of TypeName.t * TypeExpr.t ]
 
-type careful_module = [ module_ | `M_removed of Cpath.Resolved.module_ ]
+type careful_module = [ module_ | `FModule_removed of Cpath.Resolved.module_ ]
 
 type careful_type = [ type_ | removed_type ]
 

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -1,178 +1,111 @@
 (* Find *)
 open Odoc_model.Names
 
-type class_type = [ `C of Component.Class.t | `CT of Component.ClassType.t ]
+open Component
 
-type type_ =
-  [ `C of Component.Class.t
-  | `CT of Component.ClassType.t
-  | `T of Component.TypeDecl.t ]
+type module_ = [ `M of ModuleName.t * Module.t ]
 
-type value = [ `E of Component.External.t | `V of Component.Value.t ]
+type module_type = [ `MT of ModuleTypeName.t * ModuleType.t ]
 
-type ('a, 'b) found = Found of 'a | Replaced of 'b
+type datatype = [ `T of TypeName.t * TypeDecl.t ]
 
-val careful_module_in_sig :
-  Component.Signature.t ->
-  ModuleName.t ->
-  (ModuleName.t * Component.Module.t, Cpath.Resolved.module_) found option
+type class_ = [ `C of ClassName.t * Class.t | `CT of ClassTypeName.t * ClassType.t ]
 
-val careful_type_in_sig :
-  Component.Signature.t ->
-  string ->
-  ( [> `C of ClassName.t * Component.Class.t
-    | `CT of ClassTypeName.t * Component.ClassType.t
-    | `T of TypeName.t * Component.TypeDecl.t ],
-    TypeName.t * Component.TypeExpr.t )
-  found
-  option
+type value = [ `E of External.t | `V of Value.t ]
 
-val careful_class_type_in_sig :
-  Component.Signature.t ->
-  string ->
-  ( [> `C of ClassName.t * Component.Class.t
-    | `CT of ClassTypeName.t * Component.ClassType.t ],
-    TypeName.t * Component.TypeExpr.t )
-  found
-  option
+type label = [ `L of Ident.label ]
 
-val typename_of_typeid : [< `LCoreType of 'a | `LType of 'a * 'b ] -> 'a
+type exception_ = [ `Exn of Exception.t ]
 
-val datatype_in_sig :
-  Component.Signature.t -> TypeName.t -> Component.TypeDecl.t option
+type extension = [ `Ext of Extension.t * Extension.Constructor.t ]
 
-val any_in_type :
-  Component.TypeDecl.t ->
-  string ->
-  [> `Constructor of Component.TypeDecl.Constructor.t
-  | `Field of Component.TypeDecl.Field.t ]
-  option
+type substitution = [ `Msub of ModuleSubstitution.t | `Tsub of TypeDecl.t ]
 
-val any_in_typext :
-  Component.Extension.t ->
-  string ->
-  [> `ExtConstructor of
-     Component.Extension.t * Component.Extension.Constructor.t ]
-  option
+type signature = [ module_ | module_type ]
 
-val any_in_comment :
-  [> `Heading of 'a * Ident.label * 'b ] Odoc_model.Location_.with_location list ->
-  string ->
-  [> `Label of Ident.label ] option
+type type_ = [ datatype | class_ ]
 
-val any_in_sig :
-  Component.Signature.t ->
-  string ->
-  [> `Class of Ident.class_ * Component.Signature.recursive * Component.Class.t
-  | `ClassType of
-    Ident.class_type * Component.Signature.recursive * Component.ClassType.t
-  | `Constructor of
-    TypeName.t * Component.TypeDecl.t * Component.TypeDecl.Constructor.t
-  | `Exception of Ident.exception_ * Component.Exception.t
-  | `ExtConstructor of Component.Extension.t * Component.Extension.Constructor.t
-  | `External of Ident.value * Component.External.t
-  | `Field of TypeName.t * Component.TypeDecl.t * Component.TypeDecl.Field.t
-  | `Label of Ident.label
-  | `Module of
-    Ident.module_
-    * Component.Signature.recursive
-    * Component.Module.t Component.Delayed.t
-  | `ModuleSubstitution of Ident.module_ * Component.ModuleSubstitution.t
-  | `ModuleType of
-    Ident.module_type * Component.ModuleType.t Component.Delayed.t
-  | `Removed of
-    [> `Module of Ident.module_ * Cpath.Resolved.module_
-    | `Type of Ident.type_ * Component.TypeExpr.t ]
-  | `Type of
-    Ident.type_
-    * Component.Signature.recursive
-    * Component.TypeDecl.t Component.Delayed.t
-  | `TypeSubstitution of Ident.type_ * Component.TypeDecl.t
-  | `Value of Ident.value * Component.Value.t ]
-  option
+type label_parent = [ signature | type_ ]
 
-val signature_in_sig :
-  Component.Signature.t ->
-  string ->
-  [> `Module of
-     Ident.module_
-     * Component.Signature.recursive
-     * Component.Module.t Component.Delayed.t
-  | `ModuleType of
-    Ident.module_type * Component.ModuleType.t Component.Delayed.t ]
-  option
+type constructor = [ `Cs of TypeDecl.Constructor.t ]
 
-val module_in_sig :
-  Component.Signature.t -> ModuleName.t -> Component.Module.t option
+type field = [ `Fd of TypeDecl.Field.t ]
 
-val module_type_in_sig :
-  Component.Signature.t -> ModuleTypeName.t -> Component.ModuleType.t option
+type any_in_type = [ constructor | field ]
 
-val opt_module_type_in_sig :
-  Component.Signature.t ->
-  ModuleTypeName.t ->
-  Component.ModuleType.t option option
+type any_in_type_in_sig =
+  [ `In_type of Odoc_model.Names.TypeName.t * TypeDecl.t * any_in_type ]
 
-val opt_value_in_sig : Component.Signature.t -> string -> value option
+type any_in_sig =
+  [ label_parent
+  | value
+  | label
+  | exception_
+  | extension
+  | substitution
+  | any_in_type_in_sig ]
 
-val type_in_sig :
-  Component.Signature.t ->
-  string ->
-  [> `C of ClassName.t * Component.Class.t
-  | `CT of ClassTypeName.t * Component.ClassType.t
-  | `T of TypeName.t * Component.TypeDecl.t ]
-  option
+type instance_variable = [ `Mv of InstanceVariable.t ]
 
-val class_type_in_sig :
-  Component.Signature.t ->
-  string ->
-  [> `C of Component.Class.t | `CT of Component.ClassType.t ] option
+type method_ = [ `Mm of Method.t ]
 
-val opt_label_in_sig : Component.Signature.t -> string -> Ident.label option
+type any_in_class_sig = [ instance_variable | method_ ]
 
-val find_in_sig :
-  Component.Signature.t -> (Component.Signature.item -> 'a option) -> 'a option
+(** Lookup by name, unambiguous *)
 
-val exception_in_sig :
-  Component.Signature.t -> string -> Component.Exception.t option
+val module_in_sig : Signature.t -> ModuleName.t -> module_ option
 
-val extension_in_sig :
-  Component.Signature.t -> string -> Component.Extension.Constructor.t option
+val type_in_sig : Signature.t -> string -> type_ option
 
-val label_parent_in_sig :
-  Component.Signature.t ->
-  string ->
-  [> `C of Component.Class.t
-  | `CT of Component.ClassType.t
-  | `M of Component.Module.t
-  | `MT of Component.ModuleType.t
-  | `T of Component.TypeDecl.t ]
-  option
+val datatype_in_sig : Signature.t -> string -> datatype option
 
-val any_in_type_in_sig :
-  Component.Signature.t ->
-  string ->
-  ( TypeName.t
-  * [> `Constructor of Component.TypeDecl.Constructor.t
-    | `Field of Component.TypeDecl.Field.t ] )
-  option
+val module_type_in_sig : Signature.t -> ModuleTypeName.t -> module_type option
 
-val find_in_class_signature :
-  Component.ClassSignature.t ->
-  (Component.ClassSignature.item -> 'a option) ->
-  'a option
+val exception_in_sig : Signature.t -> string -> exception_ option
 
-val any_in_class_signature :
-  Component.ClassSignature.t ->
-  string ->
-  [> `InstanceVariable of Component.InstanceVariable.t
-  | `Method of Component.Method.t ]
-  option
+val extension_in_sig : Signature.t -> string -> extension option
 
-val method_in_class_signature :
-  Component.ClassSignature.t -> string -> Component.Method.t option
+val any_in_type : TypeDecl.t -> string -> any_in_type option
+
+val any_in_typext : Extension.t -> string -> extension option
+
+val method_in_class_signature : ClassSignature.t -> string -> method_ option
 
 val instance_variable_in_class_signature :
-  Component.ClassSignature.t ->
-  string ->
-  [> `InstanceVariable of Component.InstanceVariable.t ] option
+  ClassSignature.t -> string -> instance_variable option
+
+(** Maybe ambiguous *)
+
+val class_in_sig : Signature.t -> string -> class_ option
+
+val signature_in_sig : Signature.t -> string -> signature option
+
+val value_in_sig : Signature.t -> string -> value option
+
+val label_in_sig : Signature.t -> string -> label option
+
+val label_parent_in_sig : Signature.t -> string -> label_parent option
+
+val any_in_sig : Signature.t -> string -> any_in_sig option
+
+val any_in_type_in_sig :
+  Signature.t -> string -> (Odoc_model.Names.TypeName.t * any_in_type) option
+
+val any_in_class_signature :
+  ClassSignature.t -> string -> any_in_class_sig option
+
+(** Lookup removed items *)
+
+type removed_type = [ `T_removed of TypeName.t * TypeExpr.t ]
+
+type careful_module = [ module_ | `M_removed of Cpath.Resolved.module_ ]
+
+type careful_type = [ type_ | removed_type ]
+
+type careful_class = [ class_ | removed_type ]
+
+val careful_module_in_sig : Signature.t -> ModuleName.t -> careful_module option
+
+val careful_type_in_sig : Signature.t -> string -> careful_type option
+
+val careful_class_in_sig : Signature.t -> string -> careful_class option

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -197,7 +197,11 @@ and with_location :
     Env.t ->
     a Location_.with_location ->
     a Location_.with_location =
- fun fn env x -> { x with Location_.value = fn env x.Location_.value }
+ fun fn env x ->
+  let value =
+    Lookup_failures.with_location x.location (fun () -> fn env x.value)
+  in
+  { x with value }
 
 and comment_docs env d = List.map (with_location comment_block_element env) d
 

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -638,7 +638,7 @@ and type_decl : Env.t -> Id.Signature.t -> TypeDecl.t -> TypeDecl.t =
         in
         Format.eprintf "found hidden path: %a\n%!" Component.Fmt.resolved_type_path p';
         match Tools.lookup_type env p' with
-        | Ok (`T (_, t')) ->
+        | Ok (`FType (_, t')) ->
             {
               default with
               equation =
@@ -650,7 +650,7 @@ and type_decl : Env.t -> Id.Signature.t -> TypeDecl.t -> TypeDecl.t =
                       params
                   with _ -> default.equation );
             }
-        | Ok (`C _ | `CT _ | `T_removed _) | Error _ -> default )
+        | Ok (`FClass _ | `FClassType _ | `FType_removed _) | Error _ -> default )
     | None -> default
   in
   (* Format.fprintf Format.err_formatter "type_decl result: %a\n%!"
@@ -755,7 +755,7 @@ and type_expression : Env.t -> Id.Signature.t -> _ -> _ =
       else
         let cp = Component.Of_Lang.(type_path empty path') in
         match Tools.resolve_type env cp with
-        | Ok (cp', `T (_, t)) ->
+        | Ok (cp', `FType (_, t)) ->
             let cp' = Tools.reresolve_type env cp' in
             let p = Cpath.resolved_type_path_of_cpath cp' in
             if List.mem p visited then raise Loop
@@ -787,10 +787,10 @@ and type_expression : Env.t -> Id.Signature.t -> _ -> _ =
                       Constr (`Resolved p, ts) )
               | _ -> Constr (`Resolved p, ts)
             else Constr (`Resolved p, ts)
-        | Ok (cp', (`C _ | `CT _)) ->
+        | Ok (cp', (`FClass _ | `FClassType _)) ->
             let p = Cpath.resolved_type_path_of_cpath cp' in
             Constr (`Resolved p, ts)
-        | Ok (_cp, `T_removed (_, x)) ->
+        | Ok (_cp, `FType_removed (_, x)) ->
             Lang_of.(type_expr empty (parent :> Id.Parent.t) x)
         | Error _ -> Constr (Cpath.type_path_of_cpath cp, ts) )
   | Polymorphic_variant v ->

--- a/src/xref2/lookup_failures.mli
+++ b/src/xref2/lookup_failures.mli
@@ -1,6 +1,10 @@
 (** Report non-fatal errors *)
 
-type kind = [ `Root | `Internal ]
+type kind = [ `Root | `Internal | `Warning ]
+(** [`Root] failures won't be turned into fatal warnings.
+    [`Internal] is for lookup failures other than root modules and [`Warning]
+    for messages to the users. They may be turned into fatal warnings depending
+    on [~warn_error]. *)
 
 type 'a with_failures
 (** A value that may be partially unresolved due to failures. *)
@@ -14,6 +18,10 @@ val report_important :
   ?kind:kind -> exn -> ('fmt, Format.formatter, unit, unit) format4 -> 'fmt
 (** Like [report] above but may raise the exception [exn] if strict mode is
     enabled *)
+
+val with_location : Odoc_model.Location_.span -> (unit -> 'a) -> 'a
+(** Failures reported indirectly by this function will have a location
+    attached. *)
 
 val handle_failures :
   warn_error:bool ->

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -70,6 +70,14 @@ end
 
 module Memos2 = Hashtbl.Make (Hashable2)
 
+let env_lookup_by_name scope name env =
+  match Env.lookup_by_name scope name env with
+  | Ok x -> Some x
+  | Error (`Ambiguous (hd, _)) ->
+      Lookup_failures.report ~kind:`Warning "Reference to '%s' is ambiguous" name;
+      Some hd
+  | Error `Not_found -> None
+
 let module_lookup_to_signature_lookup :
     Env.t -> module_lookup_result -> signature_lookup_result option =
  fun env (ref, cp, m) ->
@@ -134,7 +142,7 @@ module M = struct
     Some (of_component env m base base)
 
   let in_env env name : t option =
-    match Env.(lookup_by_name s_module) name env with
+    match env_lookup_by_name Env.s_module name env with
     | Some e -> of_element env e
     | None -> (
         match Env.lookup_root_module name env with
@@ -162,7 +170,7 @@ module MT = struct
     Some (`Identifier id, `Identifier id, mt)
 
   let in_env env name : t option =
-    Env.(lookup_by_name s_module_type) name env >>= of_element env
+    env_lookup_by_name Env.s_module_type name env >>= of_element env
 end
 
 module CL = struct
@@ -173,7 +181,7 @@ module CL = struct
   let of_element _env (`Class (id, t)) : t = (`Identifier id, t)
 
   let in_env env name =
-    Env.(lookup_by_name s_class) name env >>= fun e -> Some (of_element env e)
+    env_lookup_by_name Env.s_class name env >>= fun e -> Some (of_element env e)
 
   let of_component _env c ~parent_ref name : t option =
     Some (`Class (parent_ref, ClassName.of_string name), c)
@@ -186,8 +194,8 @@ module CT = struct
     ((`Identifier id :> Resolved.ClassType.t), t)
 
   let in_env env name =
-    Env.(lookup_by_name s_class_type) name env >>= fun e ->
-    Some (of_element env e)
+    env_lookup_by_name Env.s_class_type name env
+    >>= fun e -> Some (of_element env e)
 
   let of_component _env ct ~parent_ref name : t option =
     Some (`ClassType (parent_ref, ClassTypeName.of_string name), ct)
@@ -204,7 +212,7 @@ module DT = struct
   let of_element _env (`Type (id, t)) : t = (`Identifier id, t)
 
   let in_env env name : t option =
-    Env.(lookup_by_name s_datatype) name env >>= function
+    env_lookup_by_name Env.s_datatype name env >>= function
     | `Type _ as e -> Some (of_element env e)
     | _ -> None
 
@@ -220,7 +228,7 @@ module T = struct
   type t = type_lookup_result
 
   let in_env env name : t option =
-    Env.(lookup_by_name s_datatype) name env >>= function
+    env_lookup_by_name Env.s_datatype name env >>= function
     | `Type (id, t) -> Some (`T (`Identifier id, t))
     | `Class _ as e -> Some (`C (CL.of_element env e))
     | `ClassType _ as e -> Some (`CT (CT.of_element env e))
@@ -241,7 +249,7 @@ module V = struct
   type t = value_lookup_result
 
   let in_env env name : t option =
-    Env.(lookup_by_name s_value) name env >>= function
+    env_lookup_by_name Env.s_value name env >>= function
     | `Value (id, _x) -> return (`Identifier id)
     | `External (id, _x) -> return (`Identifier id)
 
@@ -264,7 +272,7 @@ module L = struct
   type t = Resolved.Label.t
 
   let in_env env name : t option =
-    Env.(lookup_by_name s_label) name env >>= fun (`Label id) ->
+    env_lookup_by_name Env.s_label name env >>= fun (`Label id) ->
     Some (`Identifier id)
 
   let in_page _env (`Page (_, p)) name : t option =
@@ -291,7 +299,7 @@ module EC = struct
   type t = Resolved.Constructor.t
 
   let in_env env name : t option =
-    Env.(lookup_by_name s_extension) name env >>= fun (`Extension (id, _)) ->
+    env_lookup_by_name Env.s_extension name env >>= fun (`Extension (id, _)) ->
     Some (`Identifier id :> t)
 
   let of_component _env ~parent_ref name : t option =
@@ -310,7 +318,7 @@ module EX = struct
   type t = Resolved.Exception.t
 
   let in_env env name : t option =
-    Env.(lookup_by_name s_exception) name env >>= fun (`Exception (id, _)) ->
+    env_lookup_by_name Env.s_exception name env >>= fun (`Exception (id, _)) ->
     Some (`Identifier id)
 
   let of_component _env ~parent_ref name : t option =
@@ -328,7 +336,7 @@ module CS = struct
   (** Constructor *)
 
   let in_env env name : t option =
-    Env.(lookup_by_name s_constructor) name env
+    env_lookup_by_name Env.s_constructor name env
     >>= fun (`Constructor (id, _)) -> Some (`Identifier id :> t)
 
   let in_datatype _env ((parent', t) : datatype_lookup_result) name : t option =
@@ -346,7 +354,7 @@ module F = struct
   type t = Resolved.Field.t
 
   let in_env env name : t option =
-    Env.(lookup_by_name s_field) name env >>= fun (`Field (id, _)) ->
+    env_lookup_by_name Env.s_field name env >>= fun (`Field (id, _)) ->
     Some (`Identifier id :> t)
 
   let in_parent _env (parent : label_parent_lookup_result) name : t option =
@@ -408,7 +416,7 @@ module LP = struct
   type t = label_parent_lookup_result
 
   let in_env env name : t option =
-    Env.(lookup_by_name s_label_parent) name env >>= function
+    env_lookup_by_name Env.s_label_parent name env >>= function
     | `Module _ as e ->
         M.of_element env e >>= module_lookup_to_signature_lookup env
         >>= fun r -> Some (`S r)
@@ -516,7 +524,7 @@ and resolve_signature_reference :
           MT.in_signature env p name
           >>= module_type_lookup_to_signature_lookup env
       | `Root (name, `TUnknown) -> (
-          Env.(lookup_by_name s_signature) name env >>= function
+          env_lookup_by_name Env.s_signature name env >>= function
           | `Module (_, _) as e ->
               M.of_element env e >>= module_lookup_to_signature_lookup env
           | `ModuleType (_, _) as e ->
@@ -643,6 +651,7 @@ let resolve_reference_dot env parent name =
   | (`C _ | `CT _) as p -> resolve_reference_dot_class env p name
   | `Page _ as page -> resolve_reference_dot_page env page name
 
+(** Warnings may be generated with [Error.implicit_warning] *)
 let resolve_reference : Env.t -> t -> Resolved.t option =
   let resolved = resolved3 in
   fun env r ->
@@ -651,7 +660,7 @@ let resolve_reference : Env.t -> t -> Resolved.t option =
         let identifier id =
           return (`Identifier (id :> Odoc_model.Paths.Identifier.t))
         in
-        Env.(lookup_by_name s_any) name env >>= function
+        env_lookup_by_name Env.s_any name env >>= function
         | `Module (_, _) as e -> M.of_element env e >>= resolved
         | `ModuleType (_, _) as e -> MT.of_element env e >>= resolved
         | `Value (id, _) -> identifier id

--- a/src/xref2/test.md
+++ b/src/xref2/test.md
@@ -527,19 +527,7 @@ we then return along with the fully resolved identifier.
             (`Identifier (Common.root_module "A")),
           "B"),
        "t"));;
-- : Cpath.Resolved.type_ * Odoc_xref2.Find.careful_type =
-(`Type
-   (`Module
-      (`Module
-         (`Module (`Identifier (`Module (`Root (Common.root, Root), A))), B)),
-    t),
- `T
-   (t,
-    {Odoc_xref2.Component.TypeDecl.doc = [];
-     equation =
-      {Odoc_xref2.Component.TypeDecl.Equation.params = []; private_ = false;
-       manifest = None; constraints = []};
-     representation = None}))
+...
 ```
 
 ### Module aliases

--- a/src/xref2/test.md
+++ b/src/xref2/test.md
@@ -527,19 +527,19 @@ we then return along with the fully resolved identifier.
             (`Identifier (Common.root_module "A")),
           "B"),
        "t"));;
-- : Cpath.Resolved.type_ * (Find.type_, Component.TypeExpr.t) Find.found =
+- : Cpath.Resolved.type_ * Odoc_xref2.Find.careful_type =
 (`Type
    (`Module
       (`Module
          (`Module (`Identifier (`Module (`Root (Common.root, Root), A))), B)),
     t),
- Odoc_xref2.Find.Found
-  (`T
-     {Odoc_xref2.Component.TypeDecl.doc = [];
-      equation =
-       {Odoc_xref2.Component.TypeDecl.Equation.params = []; private_ = false;
-        manifest = None; constraints = []};
-      representation = None}))
+ `T
+   (t,
+    {Odoc_xref2.Component.TypeDecl.doc = [];
+     equation =
+      {Odoc_xref2.Component.TypeDecl.Equation.params = []; private_ = false;
+       manifest = None; constraints = []};
+     representation = None}))
 ```
 
 ### Module aliases

--- a/src/xref2/tools.mli
+++ b/src/xref2/tools.mli
@@ -61,9 +61,7 @@ val lookup_module_type :
 val lookup_type :
   Env.t ->
   Cpath.Resolved.type_ ->
-  ( Find.careful_type,
-    simple_type_lookup_error )
-  Result.result
+  (Find.careful_type, simple_type_lookup_error) Result.result
 (** [lookup_type env p] takes a resolved type path and an environment and returns
     a representation of the type. The type can be an ordinary type, a class type
     or a class. If the type has been destructively substituted, the path to the
@@ -72,9 +70,7 @@ val lookup_type :
 val lookup_class_type :
   Env.t ->
   Cpath.Resolved.class_type ->
-  ( Find.careful_class,
-    simple_type_lookup_error )
-  Result.result
+  (Find.careful_class, simple_type_lookup_error) Result.result
 (** [lookup_class_type env p] takes a resolved class type path and an environment and returns
     a representation of the class type. The type can be a class type
     or a class. *)
@@ -105,7 +101,9 @@ val resolve_module_type :
 val resolve_type :
   Env.t ->
   Cpath.type_ ->
-  ( Cpath.Resolved.type_ * Find.careful_type, simple_type_lookup_error ) Result.result
+  ( Cpath.Resolved.type_ * Find.careful_type,
+    simple_type_lookup_error )
+  Result.result
 (** [resolve_type env p] takes an unresolved
     type path and an environment and returns a tuple of the resolved type
     path alongside a representation of the type itself. As with {!val:lookup_type}

--- a/src/xref2/tools.mli
+++ b/src/xref2/tools.mli
@@ -61,7 +61,7 @@ val lookup_module_type :
 val lookup_type :
   Env.t ->
   Cpath.Resolved.type_ ->
-  ( (Find.type_, Component.TypeExpr.t) Find.found,
+  ( Find.careful_type,
     simple_type_lookup_error )
   Result.result
 (** [lookup_type env p] takes a resolved type path and an environment and returns
@@ -72,7 +72,7 @@ val lookup_type :
 val lookup_class_type :
   Env.t ->
   Cpath.Resolved.class_type ->
-  ( (Find.class_type, Component.TypeExpr.t) Find.found,
+  ( Find.careful_class,
     simple_type_lookup_error )
   Result.result
 (** [lookup_class_type env p] takes a resolved class type path and an environment and returns
@@ -105,9 +105,7 @@ val resolve_module_type :
 val resolve_type :
   Env.t ->
   Cpath.type_ ->
-  ( Cpath.Resolved.type_ * (Find.type_, Component.TypeExpr.t) Find.found,
-    simple_type_lookup_error )
-  Result.result
+  ( Cpath.Resolved.type_ * Find.careful_type, simple_type_lookup_error ) Result.result
 (** [resolve_type env p] takes an unresolved
     type path and an environment and returns a tuple of the resolved type
     path alongside a representation of the type itself. As with {!val:lookup_type}
@@ -118,8 +116,7 @@ val resolve_type :
 val resolve_class_type :
   Env.t ->
   Cpath.class_type ->
-  ( Cpath.Resolved.class_type
-    * (Find.class_type, Component.TypeExpr.t) Find.found,
+  ( Cpath.Resolved.class_type * Find.careful_class,
     simple_type_lookup_error )
   Result.result
 (** [resolve_class_type env p] takes an unresolved

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -494,11 +494,11 @@ Ambiguous:
 # resolve_ref "t"
 Exception: Failure "Warnings have been generated.".
 File "tests":
-Reference to 't' is ambiguous
+Reference to 't' is ambiguous. Please specify its kind: val-t, type-t.
 # resolve_ref "X"
 Exception: Failure "Warnings have been generated.".
 File "tests":
-Reference to 'X' is ambiguous
+Reference to 'X' is ambiguous. Please specify its kind: module-X, constructor-X.
 ```
 
 Unambiguous:

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -2,7 +2,35 @@ Testing resolution of references
 
 ## Env
 
-Test data:
+Helpers:
+
+```ocaml
+let parse_ref ref_str =
+  let open Odoc_model in
+  let parse acc = Odoc_parser__Reference.parse acc (Location_.span []) ref_str in
+  match Error.handle_errors_and_warnings ~warn_error:true (Error.accumulate_warnings parse) with
+  | Ok ref -> ref
+  | Error (`Msg e) -> failwith e
+
+(* Shorten type for nicer output *)
+type ref = Odoc_model.Paths_types.Resolved_reference.any
+
+let resolve_ref' env ref_str : ref =
+  let open Odoc_model in
+  let unresolved = parse_ref ref_str in
+  let resolve () = Ref_tools.resolve_reference env unresolved in
+  match
+    Lookup_failures.catch_failures resolve
+    |> Lookup_failures.handle_failures ~warn_error:true ~filename:"tests"
+  with
+  | Error (`Msg e) -> failwith e
+  | Ok None -> failwith "resolve_reference"
+  | Ok (Some r) -> r
+```
+
+## Resolving
+
+Env:
 
 ```ocaml
 let test_mli = {|

--- a/test/xref2/subst/test.md
+++ b/test/xref2/subst/test.md
@@ -26,7 +26,7 @@ let module_substitution ~idents ~targets m test_data =
 
   let m =
     match Find.module_in_sig c (Odoc_model.Names.ModuleName.of_string "S") with
-    | Some m -> m
+    | Some (`M (name, m)) -> m
     | None -> failwith "Error finding module!"
   in
 

--- a/test/xref2/subst/test.md
+++ b/test/xref2/subst/test.md
@@ -26,7 +26,7 @@ let module_substitution ~idents ~targets m test_data =
 
   let m =
     match Find.module_in_sig c (Odoc_model.Names.ModuleName.of_string "S") with
-    | Some (`M (name, m)) -> m
+    | Some (`FModule (name, m)) -> m
     | None -> failwith "Error finding module!"
   in
 


### PR DESCRIPTION
Adds a warning when a reference is ambiguous:

```
Reference to 't' is ambiguous. Please specify its kind: val-t, type-t.
```

Adds the notion of "implicit warning" which may not be well defined/named and complicated error handling a bit in xref2.
The interface of `Find` needed to be changed. 