### PR TITLE
Small set of patches for functors

### DIFF
--- a/src/document/ML.ml
+++ b/src/document/ML.ml
@@ -73,6 +73,7 @@ module ML = Generator.Make (struct
     let close_tag_semicolon = false
     let include_semicolon = false
     let functor_keyword = true
+    let functor_contraction = true
   end
 
   module Class =

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1324,7 +1324,7 @@ struct
         let prelude =
           Item.Heading {
             label = Some "parameters" ;
-            level = 2 ;
+            level = 1 ;
             title = [inline @@ Text "Parameters"];
           }
           :: params

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -79,6 +79,7 @@ sig
     val close_tag_semicolon : bool
     val include_semicolon : bool
     val functor_keyword : bool
+    val functor_contraction : bool
   end
 
   module Class :

--- a/src/document/reason.ml
+++ b/src/document/reason.ml
@@ -75,6 +75,7 @@ module Reason = Generator.Make (struct
     let close_tag_semicolon = true
     let include_semicolon = true
     let functor_keyword = false
+    let functor_contraction = false
   end
 
   module Class =

--- a/test/cases/functor.mli
+++ b/test/cases/functor.mli
@@ -16,5 +16,4 @@ end
 
 module F4 (Arg : S) : S
 
-module F5 : functor () -> S
-
+module F5 () : S

--- a/test/html/expect/test_package+ml/Functor/index.html
+++ b/test/html/expect/test_package+ml/Functor/index.html
@@ -29,19 +29,19 @@
     <a href="#module-type-S1" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S1/index.html">S1</a> = <span class="keyword">functor</span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="module-type-S/index.html">S</a>) <span>-&gt;</span> <a href="module-type-S/index.html">S</a></code>
    </div>
    <div class="spec module" id="module-F1">
-    <a href="#module-F1" class="anchor"></a><code><span class="keyword">module</span> <a href="F1/index.html">F1</a> : <span class="keyword">functor</span> (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) <span>-&gt;</span> <a href="module-type-S/index.html">S</a></code>
+    <a href="#module-F1" class="anchor"></a><code><span class="keyword">module</span> <a href="F1/index.html">F1</a> (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <a href="module-type-S/index.html">S</a></code>
    </div>
    <div class="spec module" id="module-F2">
-    <a href="#module-F2" class="anchor"></a><code><span class="keyword">module</span> <a href="F2/index.html">F2</a> : <span class="keyword">functor</span> (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) <span>-&gt;</span> <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = <a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></code>
+    <a href="#module-F2" class="anchor"></a><code><span class="keyword">module</span> <a href="F2/index.html">F2</a> (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = <a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></code>
    </div>
    <div class="spec module" id="module-F3">
-    <a href="#module-F3" class="anchor"></a><code><span class="keyword">module</span> <a href="F3/index.html">F3</a> : <span class="keyword">functor</span> (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-F3" class="anchor"></a><code><span class="keyword">module</span> <a href="F3/index.html">F3</a> (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-F4">
-    <a href="#module-F4" class="anchor"></a><code><span class="keyword">module</span> <a href="F4/index.html">F4</a> : <span class="keyword">functor</span> (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) <span>-&gt;</span> <a href="module-type-S/index.html">S</a></code>
+    <a href="#module-F4" class="anchor"></a><code><span class="keyword">module</span> <a href="F4/index.html">F4</a> (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <a href="module-type-S/index.html">S</a></code>
    </div>
    <div class="spec module" id="module-F5">
-    <a href="#module-F5" class="anchor"></a><code><span class="keyword">module</span> <a href="F5/index.html">F5</a> : <span class="keyword">functor</span> () <span>-&gt;</span> <a href="module-type-S/index.html">S</a></code>
+    <a href="#module-F5" class="anchor"></a><code><span class="keyword">module</span> <a href="F5/index.html">F5</a> () : <a href="module-type-S/index.html">S</a></code>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -20,14 +20,27 @@
    <h1>
     Module <code>Nested.F</code>
    </h1>
-   <aside>
-    <p>
-     This is a functor F.
-    </p>
-    <p>
-     Some additional comments.
-    </p>
-   </aside>
+   <p>
+    This is a functor F.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#parameters">Parameters</a>
+    </li>
+    <li>
+     <a href="#signature">Signature</a>
+    </li>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <h3 id="parameters">
     <a href="#parameters" class="anchor"></a>Parameters
    </h3>
@@ -37,18 +50,9 @@
    <div class="spec parameter" id="argument-2-Arg2">
     <a href="#argument-2-Arg2" class="anchor"></a><code><span class="keyword">module</span> <a href="argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
-   <h3 id="signature">
+   <h2 id="signature">
     <a href="#signature" class="anchor"></a>Signature
-   </h3>
-  </header>
-  <nav class="toc">
-   <ul>
-    <li>
-     <a href="#type">Type</a>
-    </li>
-   </ul>
-  </nav>
-  <div class="content">
+   </h2>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -41,9 +41,9 @@
    </ul>
   </nav>
   <div class="content">
-   <h3 id="parameters">
+   <h2 id="parameters">
     <a href="#parameters" class="anchor"></a>Parameters
-   </h3>
+   </h2>
    <div class="spec parameter" id="argument-1-Arg1">
     <a href="#argument-1-Arg1" class="anchor"></a><code><span class="keyword">module</span> <a href="argument-1-Arg1/index.html">Arg1</a> : <a href="../module-type-Y/index.html">Y</a></code>
    </div>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -72,7 +72,7 @@
    </h2>
    <div>
     <div class="spec module" id="module-F">
-     <a href="#module-F" class="anchor"></a><code><span class="keyword">module</span> <a href="F/index.html">F</a> : <span class="keyword">functor</span> (<a href="F/argument-1-Arg1/index.html">Arg1</a> : <a href="module-type-Y/index.html">Y</a>) <span>-&gt;</span> <span class="keyword">functor</span> (<a href="F/argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+     <a href="#module-F" class="anchor"></a><code><span class="keyword">module</span> <a href="F/index.html">F</a> (<a href="F/argument-1-Arg1/index.html">Arg1</a> : <a href="module-type-Y/index.html">Y</a>) (<a href="F/argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
     </div>
     <div>
      <p>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -646,7 +646,7 @@
     </div>
    </div>
    <div class="spec module" id="module-Recollection">
-    <a href="#module-Recollection" class="anchor"></a><code><span class="keyword">module</span> <a href="Recollection/index.html">Recollection</a> : <span class="keyword">functor</span> (<a href="Recollection/argument-1-C/index.html">C</a> : <a href="module-type-COLLECTION/index.html">COLLECTION</a>) <span>-&gt;</span> <a href="module-type-COLLECTION/index.html">COLLECTION</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-collection">collection</a> = <span><a href="Recollection/argument-1-C/index.html#type-element">C.element</a> list</span> <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-element">element</a> = <a href="Recollection/argument-1-C/index.html#type-collection">C.collection</a></code>
+    <a href="#module-Recollection" class="anchor"></a><code><span class="keyword">module</span> <a href="Recollection/index.html">Recollection</a> (<a href="Recollection/argument-1-C/index.html">C</a> : <a href="module-type-COLLECTION/index.html">COLLECTION</a>) : <a href="module-type-COLLECTION/index.html">COLLECTION</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-collection">collection</a> = <span><a href="Recollection/argument-1-C/index.html#type-element">C.element</a> list</span> <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-element">element</a> = <a href="Recollection/argument-1-C/index.html#type-collection">C.collection</a></code>
    </div>
    <div class="spec module-type" id="module-type-MMM">
     <a href="#module-type-MMM" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-MMM/index.html">MMM</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
@@ -675,7 +675,7 @@
    </div>
    <div>
     <div class="spec module" id="module-FunctorTypeOf">
-     <a href="#module-FunctorTypeOf" class="anchor"></a><code><span class="keyword">module</span> <a href="FunctorTypeOf/index.html">FunctorTypeOf</a> : <span class="keyword">functor</span> (<a href="FunctorTypeOf/argument-1-Collection/index.html">Collection</a> : <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="CollectionModule/index.html">CollectionModule</a>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+     <a href="#module-FunctorTypeOf" class="anchor"></a><code><span class="keyword">module</span> <a href="FunctorTypeOf/index.html">FunctorTypeOf</a> (<a href="FunctorTypeOf/argument-1-Collection/index.html">Collection</a> : <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="CollectionModule/index.html">CollectionModule</a>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
     </div>
     <div>
      <p>
@@ -1495,7 +1495,7 @@
     <a href="#module-Dep1" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep1/index.html">Dep1</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-Dep2">
-    <a href="#module-Dep2" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep2/index.html">Dep2</a> : <span class="keyword">functor</span> (<a href="Dep2/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-Dep2" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep2/index.html">Dep2</a> (<a href="Dep2/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec type" id="type-dep1">
     <a href="#type-dep1" class="anchor"></a><code><span class="keyword">type</span> dep1 = <a href="Dep1/module-type-S/class-c/index.html">Dep2(Dep1).B.c</a></code>
@@ -1507,7 +1507,7 @@
     <a href="#module-Dep4" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep4/index.html">Dep4</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-Dep5">
-    <a href="#module-Dep5" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep5/index.html">Dep5</a> : <span class="keyword">functor</span> (<a href="Dep5/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-Dep5" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep5/index.html">Dep5</a> (<a href="Dep5/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec type" id="type-dep2">
     <a href="#type-dep2" class="anchor"></a><code><span class="keyword">type</span> dep2 = <a href="Dep4/module-type-T/index.html#type-b">Dep5(Dep4).Z.X.b</a></code>
@@ -1519,7 +1519,7 @@
     <a href="#module-Dep6" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep6/index.html">Dep6</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-Dep7">
-    <a href="#module-Dep7" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep7/index.html">Dep7</a> : <span class="keyword">functor</span> (<a href="Dep7/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-Dep7" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep7/index.html">Dep7</a> (<a href="Dep7/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec type" id="type-dep4">
     <a href="#type-dep4" class="anchor"></a><code><span class="keyword">type</span> dep4 = <a href="Dep6/module-type-S/index.html#type-d">Dep7(Dep6).M.Y.d</a></code>
@@ -1528,7 +1528,7 @@
     <a href="#module-Dep8" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep8/index.html">Dep8</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-Dep9">
-    <a href="#module-Dep9" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep9/index.html">Dep9</a> : <span class="keyword">functor</span> (<a href="Dep9/argument-1-X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-Dep9" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep9/index.html">Dep9</a> (<a href="Dep9/argument-1-X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-Dep10">
     <a href="#module-type-Dep10" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Dep10/index.html">Dep10</a> = <a href="Dep8/module-type-T/index.html">Dep9(Dep8).T</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="Dep8/module-type-T/index.html#type-t">t</a> = int</code>
@@ -1537,7 +1537,7 @@
     <a href="#module-Dep11" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep11/index.html">Dep11</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-Dep12">
-    <a href="#module-Dep12" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep12/index.html">Dep12</a> : <span class="keyword">functor</span> (<a href="Dep12/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-Dep12" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep12/index.html">Dep12</a> (<a href="Dep12/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-Dep13">
     <a href="#module-Dep13" class="anchor"></a><code><span class="keyword">module</span> <a href="Dep13/index.html">Dep13</a> : <a href="Dep11/module-type-S/index.html">Dep12(Dep11).T</a></code>
@@ -1570,7 +1570,7 @@
     <a href="#module-With6" class="anchor"></a><code><span class="keyword">module</span> <a href="With6/index.html">With6</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module" id="module-With7">
-    <a href="#module-With7" class="anchor"></a><code><span class="keyword">module</span> <a href="With7/index.html">With7</a> : <span class="keyword">functor</span> (<a href="With7/argument-1-X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) <span>-&gt;</span> <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+    <a href="#module-With7" class="anchor"></a><code><span class="keyword">module</span> <a href="With7/index.html">With7</a> (<a href="With7/argument-1-X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec module-type" id="module-type-With8">
     <a href="#module-type-With8" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-With8/index.html">With8</a> = <a href="With6/module-type-T/index.html">With7(With6).T</a> <span class="keyword">with</span> <span class="keyword">module</span> <a href="With6/module-type-T/M/index.html">M</a> = <a href="With5/index.html">With5</a> <span class="keyword">and</span> <span class="keyword">type</span> <a href="With5/N/index.html#type-t">M.N.t</a> = <a href="With5/N/index.html#type-t">With5.N.t</a></code>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -41,9 +41,9 @@
    </ul>
   </nav>
   <div class="content">
-   <h3 id="parameters">
+   <h2 id="parameters">
     <a href="#parameters" class="anchor"></a>Parameters
-   </h3>
+   </h2>
    <div class="spec parameter" id="argument-1-Arg1">
     <a href="#argument-1-Arg1" class="anchor"></a><code><span class="keyword">module</span> <a href="argument-1-Arg1/index.html">Arg1</a>: <a href="../module-type-Y/index.html">Y</a></code>
    </div>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -20,14 +20,27 @@
    <h1>
     Module <code>Nested.F</code>
    </h1>
-   <aside>
-    <p>
-     This is a functor F.
-    </p>
-    <p>
-     Some additional comments.
-    </p>
-   </aside>
+   <p>
+    This is a functor F.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#parameters">Parameters</a>
+    </li>
+    <li>
+     <a href="#signature">Signature</a>
+    </li>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
    <h3 id="parameters">
     <a href="#parameters" class="anchor"></a>Parameters
    </h3>
@@ -37,18 +50,9 @@
    <div class="spec parameter" id="argument-2-Arg2">
     <a href="#argument-2-Arg2" class="anchor"></a><code><span class="keyword">module</span> <a href="argument-2-Arg2/index.html">Arg2</a>: { ... }</code>
    </div>
-   <h3 id="signature">
+   <h2 id="signature">
     <a href="#signature" class="anchor"></a>Signature
-   </h3>
-  </header>
-  <nav class="toc">
-   <ul>
-    <li>
-     <a href="#type">Type</a>
-    </li>
-   </ul>
-  </nav>
-  <div class="content">
+   </h2>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/man/expect/test_package+ml/Functor.3o
+++ b/test/man/expect/test_package+ml/Functor.3o
@@ -23,7 +23,7 @@ test_package+ml\.Functor
 .ti +2
 .sp 
 .ti +2
-\fB1\.1\.1 Parameters\fR
+\fB1\.1 Parameters\fR
 .sp 
 .ti +2
 \f[CB]module\fR _ : \f[CB]sig\fR

--- a/test/man/expect/test_package+ml/Functor.3o
+++ b/test/man/expect/test_package+ml/Functor.3o
@@ -21,6 +21,23 @@ test_package+ml\.Functor
 \f[CB]module\fR \f[CB]type\fR S1 = \f[CB]sig\fR
 .br 
 .ti +2
+.sp 
+.ti +2
+\fB1\.1\.1 Parameters\fR
+.sp 
+.ti +2
+\f[CB]module\fR _ : \f[CB]sig\fR
+.br 
+.ti +4
+\f[CB]type\fR t
+.br 
+.ti +2
+\f[CB]end\fR
+.sp 
+.ti +2
+\fB1\.2 Signature\fR
+.sp 
+.ti +2
 \f[CB]type\fR t
 .br 
 \f[CB]end\fR

--- a/test/man/expect/test_package+ml/Functor.3o
+++ b/test/man/expect/test_package+ml/Functor.3o
@@ -25,12 +25,12 @@ test_package+ml\.Functor
 .br 
 \f[CB]end\fR
 .sp 
-\f[CB]module\fR F1 : \f[CB]functor\fR (Arg : S) \-> S
+\f[CB]module\fR F1 (Arg : S) : S
 .sp 
-\f[CB]module\fR F2 : \f[CB]functor\fR (Arg : S) \-> S \f[CB]with\fR \f[CB]type\fR t = Arg\.t
+\f[CB]module\fR F2 (Arg : S) : S \f[CB]with\fR \f[CB]type\fR t = Arg\.t
 .sp 
-\f[CB]module\fR F3 : \f[CB]functor\fR (Arg : S) \-> \f[CB]sig\fR \.\.\. \f[CB]end\fR
+\f[CB]module\fR F3 (Arg : S) : \f[CB]sig\fR \.\.\. \f[CB]end\fR
 .sp 
-\f[CB]module\fR F4 : \f[CB]functor\fR (Arg : S) \-> S
+\f[CB]module\fR F4 (Arg : S) : S
 .sp 
-\f[CB]module\fR F5 : \f[CB]functor\fR () \-> S
+\f[CB]module\fR F5 () : S

--- a/test/man/expect/test_package+ml/Functor.F1.3o
+++ b/test/man/expect/test_package+ml/Functor.F1.3o
@@ -8,6 +8,10 @@ test_package+ml\.Functor\.F1
 \fBModule Functor\.F1\fR
 .in 
 .sp 
+.SH Documentation
+.sp 
+.nf 
+.sp 
 .in 4
 \fB1\.1 Parameters\fR
 .in 
@@ -19,11 +23,8 @@ test_package+ml\.Functor\.F1
 .br 
 \f[CB]end\fR
 .sp 
-.in 4
-\fB1\.2 Signature\fR
+.in 3
+\fB2 Signature\fR
 .in 
 .sp 
-.SH Documentation
-.sp 
-.nf 
 \f[CB]type\fR t

--- a/test/man/expect/test_package+ml/Functor.F1.3o
+++ b/test/man/expect/test_package+ml/Functor.F1.3o
@@ -12,8 +12,8 @@ test_package+ml\.Functor\.F1
 .sp 
 .nf 
 .sp 
-.in 4
-\fB1\.1 Parameters\fR
+.in 3
+\fB1 Parameters\fR
 .in 
 .sp 
 \f[CB]module\fR Arg : \f[CB]sig\fR

--- a/test/man/expect/test_package+ml/Functor.F2.3o
+++ b/test/man/expect/test_package+ml/Functor.F2.3o
@@ -12,8 +12,8 @@ test_package+ml\.Functor\.F2
 .sp 
 .nf 
 .sp 
-.in 4
-\fB1\.1 Parameters\fR
+.in 3
+\fB1 Parameters\fR
 .in 
 .sp 
 \f[CB]module\fR Arg : \f[CB]sig\fR

--- a/test/man/expect/test_package+ml/Functor.F2.3o
+++ b/test/man/expect/test_package+ml/Functor.F2.3o
@@ -8,6 +8,10 @@ test_package+ml\.Functor\.F2
 \fBModule Functor\.F2\fR
 .in 
 .sp 
+.SH Documentation
+.sp 
+.nf 
+.sp 
 .in 4
 \fB1\.1 Parameters\fR
 .in 
@@ -19,11 +23,8 @@ test_package+ml\.Functor\.F2
 .br 
 \f[CB]end\fR
 .sp 
-.in 4
-\fB1\.2 Signature\fR
+.in 3
+\fB2 Signature\fR
 .in 
 .sp 
-.SH Documentation
-.sp 
-.nf 
 \f[CB]type\fR t = Arg\.t

--- a/test/man/expect/test_package+ml/Functor.F3.3o
+++ b/test/man/expect/test_package+ml/Functor.F3.3o
@@ -8,6 +8,10 @@ test_package+ml\.Functor\.F3
 \fBModule Functor\.F3\fR
 .in 
 .sp 
+.SH Documentation
+.sp 
+.nf 
+.sp 
 .in 4
 \fB1\.1 Parameters\fR
 .in 
@@ -19,11 +23,8 @@ test_package+ml\.Functor\.F3
 .br 
 \f[CB]end\fR
 .sp 
-.in 4
-\fB1\.2 Signature\fR
+.in 3
+\fB2 Signature\fR
 .in 
 .sp 
-.SH Documentation
-.sp 
-.nf 
 \f[CB]type\fR t = Arg\.t

--- a/test/man/expect/test_package+ml/Functor.F3.3o
+++ b/test/man/expect/test_package+ml/Functor.F3.3o
@@ -12,8 +12,8 @@ test_package+ml\.Functor\.F3
 .sp 
 .nf 
 .sp 
-.in 4
-\fB1\.1 Parameters\fR
+.in 3
+\fB1 Parameters\fR
 .in 
 .sp 
 \f[CB]module\fR Arg : \f[CB]sig\fR

--- a/test/man/expect/test_package+ml/Functor.F4.3o
+++ b/test/man/expect/test_package+ml/Functor.F4.3o
@@ -8,6 +8,10 @@ test_package+ml\.Functor\.F4
 \fBModule Functor\.F4\fR
 .in 
 .sp 
+.SH Documentation
+.sp 
+.nf 
+.sp 
 .in 4
 \fB1\.1 Parameters\fR
 .in 
@@ -19,11 +23,8 @@ test_package+ml\.Functor\.F4
 .br 
 \f[CB]end\fR
 .sp 
-.in 4
-\fB1\.2 Signature\fR
+.in 3
+\fB2 Signature\fR
 .in 
 .sp 
-.SH Documentation
-.sp 
-.nf 
 \f[CB]type\fR t

--- a/test/man/expect/test_package+ml/Functor.F4.3o
+++ b/test/man/expect/test_package+ml/Functor.F4.3o
@@ -12,8 +12,8 @@ test_package+ml\.Functor\.F4
 .sp 
 .nf 
 .sp 
-.in 4
-\fB1\.1 Parameters\fR
+.in 3
+\fB1 Parameters\fR
 .in 
 .sp 
 \f[CB]module\fR Arg : \f[CB]sig\fR

--- a/test/man/expect/test_package+ml/Nested.3o
+++ b/test/man/expect/test_package+ml/Nested.3o
@@ -19,7 +19,7 @@ This comment needs to be here before #235 is fixed\.
 \fB1 Module\fR
 .in 
 .sp 
-\f[CB]module\fR X : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+\f[CB]module\fR X :  \f[CB]sig\fR \.\.\. \f[CB]end\fR
 .fi 
 .br 
 .ti +2
@@ -68,7 +68,7 @@ This is module type Y\.
 \fB3 Functor\fR
 .in 
 .sp 
-\f[CB]module\fR F : \f[CB]functor\fR (Arg1 : Y) \-> \f[CB]functor\fR (Arg2 : \f[CB]sig\fR \.\.\. \f[CB]end\fR) \-> \f[CB]sig\fR \.\.\. \f[CB]end\fR
+\f[CB]module\fR F (Arg1 : Y) (Arg2 : \f[CB]sig\fR \.\.\. \f[CB]end\fR) :  \f[CB]sig\fR \.\.\. \f[CB]end\fR
 .fi 
 .br 
 .ti +2

--- a/test/man/expect/test_package+ml/Nested.F.3o
+++ b/test/man/expect/test_package+ml/Nested.F.3o
@@ -15,6 +15,9 @@ This is a functor F\.
 .fi 
 Some additional comments\.
 .nf 
+.SH Documentation
+.sp 
+.nf 
 .sp 
 .in 4
 \fB1\.1 Parameters\fR
@@ -67,16 +70,12 @@ Some type\.
 .br 
 \f[CB]end\fR
 .sp 
-.in 4
-\fB1\.2 Signature\fR
+.in 3
+\fB2 Signature\fR
 .in 
 .sp 
-.SH Documentation
-.sp 
-.nf 
-.sp 
 .in 3
-\fB1 Type\fR
+\fB3 Type\fR
 .in 
 .sp 
 \f[CB]type\fR t = Arg1\.t * Arg2\.t

--- a/test/man/expect/test_package+ml/Nested.F.3o
+++ b/test/man/expect/test_package+ml/Nested.F.3o
@@ -19,8 +19,8 @@ Some additional comments\.
 .sp 
 .nf 
 .sp 
-.in 4
-\fB1\.1 Parameters\fR
+.in 3
+\fB1 Parameters\fR
 .in 
 .sp 
 \f[CB]module\fR Arg1 : \f[CB]sig\fR
@@ -28,7 +28,7 @@ Some additional comments\.
 .ti +2
 .sp 
 .ti +2
-\fBType\fR
+\fB1\.1\.1 Type\fR
 .sp 
 .ti +2
 \f[CB]type\fR t
@@ -39,7 +39,7 @@ Some type\.
 .nf 
 .sp 
 .ti +2
-\fBValues\fR
+\fB1\.1\.2 Values\fR
 .sp 
 .ti +2
 \f[CB]val\fR y : t
@@ -57,7 +57,7 @@ The value of y\.
 .ti +2
 .sp 
 .ti +2
-\fBType\fR
+\fB1\.1\.3 Type\fR
 .sp 
 .ti +2
 \f[CB]type\fR t

--- a/test/man/expect/test_package+ml/Recent.3o
+++ b/test/man/expect/test_package+ml/Recent.3o
@@ -18,7 +18,7 @@ test_package+ml\.Recent
 .ti +2
 .sp 
 .ti +2
-\fB1\.1\.1 Parameters\fR
+\fB1\.1 Parameters\fR
 .sp 
 .ti +2
 \f[CB]module\fR _ : \f[CB]sig\fR \f[CB]end\fR

--- a/test/man/expect/test_package+ml/Recent.3o
+++ b/test/man/expect/test_package+ml/Recent.3o
@@ -13,7 +13,23 @@ test_package+ml\.Recent
 .nf 
 \f[CB]module\fR \f[CB]type\fR S = \f[CB]sig\fR \f[CB]end\fR
 .sp 
-\f[CB]module\fR \f[CB]type\fR S1 = \f[CB]sig\fR \f[CB]end\fR
+\f[CB]module\fR \f[CB]type\fR S1 = \f[CB]sig\fR
+.br 
+.ti +2
+.sp 
+.ti +2
+\fB1\.1\.1 Parameters\fR
+.sp 
+.ti +2
+\f[CB]module\fR _ : \f[CB]sig\fR \f[CB]end\fR
+.sp 
+.ti +2
+\fB1\.2 Signature\fR
+.sp 
+.ti +2
+
+.br 
+\f[CB]end\fR
 .sp 
 \f[CB]type\fR variant = 
 .br 

--- a/test/man/expect/test_package+ml/Recent_impl.3o
+++ b/test/man/expect/test_package+ml/Recent_impl.3o
@@ -23,6 +23,17 @@ test_package+ml\.Recent_impl
 \f[CB]module\fR F : \f[CB]sig\fR
 .br 
 .ti +4
+.sp 
+.ti +4
+\fB1\.1\.1 Parameters\fR
+.sp 
+.ti +4
+\f[CB]module\fR _ : \f[CB]sig\fR \f[CB]end\fR
+.sp 
+.ti +4
+\fB1\.2 Signature\fR
+.sp 
+.ti +4
 \f[CB]type\fR t
 .br 
 .ti +2

--- a/test/man/expect/test_package+ml/Recent_impl.3o
+++ b/test/man/expect/test_package+ml/Recent_impl.3o
@@ -25,7 +25,7 @@ test_package+ml\.Recent_impl
 .ti +4
 .sp 
 .ti +4
-\fB1\.1\.1 Parameters\fR
+\fB1\.1 Parameters\fR
 .sp 
 .ti +4
 \f[CB]module\fR _ : \f[CB]sig\fR \f[CB]end\fR


### PR DESCRIPTION
The output of functor in odoc is not terribly satisfying. A while ago, I moved the description of parameters to the header of the page, but that didn't make anything better, on the contrary. With the last few changes, we can improve things a little bit more.

This patch sets provides 2 improvements:
- Parameters are back inside the body of the page, inside a (single) header of level 1 (just below the main title). The `Signature` header is gone. As a result, parameters and their documentation are now in the sidebar outline.
- The output of functor declaration uses the short form when available. This applies to all backends and should preserve expansion/alternatives/etc.
![Functors](https://user-images.githubusercontent.com/801124/87697351-45e4da00-c792-11ea-89ef-3cd4cd6d2d33.png)
