### PR TITLE
Don't ignore labels attached to signature items

### DIFF
--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -43,7 +43,32 @@ module Identifier = struct
 
   let name : [< t] -> string = fun n -> name_aux (n :> t)
 
-  
+  let rec label_parent_aux =
+    let open Paths_types.Identifier in
+    fun (n : any) ->
+      match n with
+      | `Result i -> label_parent_aux (i :> any)
+      | `CoreType _ | `CoreException _ -> assert false
+      | `Root _ as p -> (p :> label_parent)
+      | `Page _ as p -> (p :> label_parent)
+      | `Module (p, _)
+      | `ModuleType (p, _)
+      | `Parameter (p, _)
+      | `Class (p, _)
+      | `ClassType (p, _)
+      | `Type (p, _)
+      | `Extension (p, _)
+      | `Exception (p, _)
+      | `Value (p, _) ->
+          (p : signature :> label_parent)
+      | `Label (p, _) -> p
+      | `Method (p, _) | `InstanceVariable (p, _) ->
+          (p : class_signature :> label_parent)
+      | `Constructor (p, _) -> (p : datatype :> label_parent)
+      | `Field (p, _) -> (p : parent :> label_parent)
+
+  let label_parent n = label_parent_aux (n :> t)
+
   let rec hash (id : t) =
     let open Paths_types.Identifier in
     match id with

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -211,6 +211,8 @@ module Identifier : sig
 
   val equal : t -> t -> bool
 
+  val label_parent : [< t] -> LabelParent.t
+
   module Sets : sig
     module Signature : Set.S with type elt = Signature.t
     module ClassSignature : Set.S with type elt = ClassSignature.t

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -218,6 +218,7 @@ let add_type identifier t env =
         (`Type (identifier, t))
         elts;
   }
+  |> add_cdocs identifier t.doc
 
 let add_module_type identifier t env =
   {
@@ -231,6 +232,7 @@ let add_module_type identifier t env =
         (`ModuleType (identifier, t))
         env.elts;
   }
+  |> add_cdocs identifier t.doc
 
 let add_value identifier t env =
   {
@@ -244,6 +246,7 @@ let add_value identifier t env =
         (`Value (identifier, t))
         env.elts;
   }
+  |> add_cdocs identifier t.doc
 
 let add_external identifier t env =
   {
@@ -257,6 +260,7 @@ let add_external identifier t env =
         (`External (identifier, t))
         env.elts;
   }
+  |> add_cdocs identifier t.doc
 
 let add_class identifier t env =
   {
@@ -270,6 +274,7 @@ let add_class identifier t env =
         (`Class (identifier, t))
         env.elts;
   }
+  |> add_cdocs identifier t.doc
 
 let add_class_type identifier t env =
   {
@@ -283,6 +288,7 @@ let add_class_type identifier t env =
         (`ClassType (identifier, t))
         env.elts;
   }
+  |> add_cdocs identifier t.doc
 
 let add_method _identifier _t env =
   (* TODO *)
@@ -300,6 +306,7 @@ let add_exception identifier e env =
         (`Exception (identifier, e))
         env.elts;
   }
+  |> add_cdocs identifier e.doc
 
 let add_extension_constructor identifier ec env =
   {
@@ -313,6 +320,7 @@ let add_extension_constructor identifier ec env =
         (`Extension (identifier, ec))
         env.elts;
   }
+  |> add_cdocs identifier ec.doc
 
 let module_of_unit : Odoc_model.Lang.Compilation_unit.t -> Component.Module.t =
  fun unit ->

--- a/test/cases/labels.mli
+++ b/test/cases/labels.mli
@@ -1,0 +1,52 @@
+(** {1:L1 Attached to unit} *)
+
+(** {1:L2 Attached to nothing} *)
+
+(** {1:L3 Attached to module} *)
+module A : sig end
+
+(** {1:L4 Attached to type} *)
+type t
+
+(** {1:L5 Attached to value} *)
+val f : t
+
+(** {1:L5bis Attached to external} *)
+external e : unit -> t = "t"
+
+(** {1:L6 Attached to module type} *)
+module type S = sig end
+
+(** {1:L6 Attached to class} *)
+class c : object end
+
+(** {1:L7 Attached to class type} *)
+class type cs = object end
+
+(** {1:L8 Attached to exception} *)
+exception E
+
+type x = ..
+
+(** {1:L9 Attached to extension} *)
+type x += X
+
+(** {1:L10 Attached to module subst} *)
+module S := A
+
+(** {1:L11 Attached to type subst} *)
+type s := t
+
+(** Testing that labels can be referenced
+    - {!L1}
+    - {!L2}
+    - {!L3}
+    - {!L4}
+    - {!L5}
+    - {!L6}
+    - {!L7}
+    - {!L8}
+    - {!L9}
+    - {!L10}
+    - {!L11}
+  *)

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -126,13 +126,13 @@
     </p>
     <ul>
      <li>
-      <code>L1</code>
+      <a href="index.html#L1">Attached to unit</a>
      </li>
      <li>
       <a href="index.html#L2">Attached to nothing</a>
      </li>
      <li>
-      <code>L3</code>
+      <a href="index.html#L3">Attached to module</a>
      </li>
      <li>
       <code>L4</code>
@@ -153,7 +153,7 @@
       <code>L9</code>
      </li>
      <li>
-      <code>L10</code>
+      <a href="index.html#L10">Attached to module subst</a>
      </li>
      <li>
       <code>L11</code>

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Labels (test_package+ml.Labels)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Labels
+  </nav>
+  <header>
+   <h1>
+    Module <code>Labels</code>
+   </h1>
+   <h2 id="L1">
+    <a href="#L1" class="anchor"></a>Attached to unit
+   </h2>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#L2">Attached to nothing</a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
+   <h2 id="L2">
+    <a href="#L2" class="anchor"></a>Attached to nothing
+   </h2>
+   <div class="spec module" id="module-A">
+    <a href="#module-A" class="anchor"></a><code><span class="keyword">module</span> <a href="A/index.html">A</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </div>
+   <div>
+    <div class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t</code>
+    </div>
+    <div>
+     <p>
+      Attached to type
+     </p>
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-f">
+     <a href="#val-f" class="anchor"></a><code><span class="keyword">val</span> f : <a href="index.html#type-t">t</a></code>
+    </div>
+    <div>
+     <p>
+      Attached to value
+     </p>
+    </div>
+   </div>
+   <div>
+    <div class="spec external" id="val-e">
+     <a href="#val-e" class="anchor"></a><code><span class="keyword">val</span> e : unit <span>-&gt;</span> <a href="index.html#type-t">t</a></code>
+    </div>
+    <div>
+     <p>
+      Attached to external
+     </p>
+    </div>
+   </div>
+   <div class="spec module-type" id="module-type-S">
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
+   </div>
+   <div class="spec class" id="class-c">
+    <a href="#class-c" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-c/index.html">c</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
+   </div>
+   <div class="spec class-type" id="class-type-cs">
+    <a href="#class-type-cs" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-cs/index.html">cs</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-E">
+     <a href="#exception-E" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">E</span></code>
+    </div>
+    <div>
+     <p>
+      Attached to exception
+     </p>
+    </div>
+   </div>
+   <div class="spec type" id="type-x">
+    <a href="#type-x" class="anchor"></a><code><span class="keyword">type</span> x = ..</code>
+   </div>
+   <div>
+    <div class="spec extension">
+     <code><span class="keyword">type</span> <a href="index.html#type-x">x</a> += | <span class="extension">X</span></code>
+    </div>
+    <div>
+     <p>
+      Attached to extension
+     </p>
+    </div>
+   </div>
+   <div>
+    <div class="spec module-substitution" id="module-S">
+     <a href="#module-S" class="anchor"></a><code><span class="keyword">module</span> S := <a href="A/index.html">A</a></code>
+    </div>
+    <div>
+     <p>
+      Attached to module subst
+     </p>
+    </div>
+   </div>
+   <div>
+    <div class="spec type-subst" id="type-s">
+     <a href="#type-s" class="anchor"></a><code><span class="keyword">type</span> s := <a href="index.html#type-t">t</a></code>
+    </div>
+    <div>
+     <p>
+      Attached to type subst
+     </p>
+    </div>
+   </div>
+   <aside>
+    <p>
+     Testing that labels can be referenced
+    </p>
+    <ul>
+     <li>
+      <code>L1</code>
+     </li>
+     <li>
+      <a href="index.html#L2">Attached to nothing</a>
+     </li>
+     <li>
+      <code>L3</code>
+     </li>
+     <li>
+      <code>L4</code>
+     </li>
+     <li>
+      <code>L5</code>
+     </li>
+     <li>
+      <code>L6</code>
+     </li>
+     <li>
+      <code>L7</code>
+     </li>
+     <li>
+      <code>L8</code>
+     </li>
+     <li>
+      <code>L9</code>
+     </li>
+     <li>
+      <code>L10</code>
+     </li>
+     <li>
+      <code>L11</code>
+     </li>
+    </ul>
+   </aside>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -135,19 +135,19 @@
       <a href="index.html#L3">Attached to module</a>
      </li>
      <li>
-      <code>L4</code>
+      <a href="index.html#L4">Attached to type</a>
      </li>
      <li>
-      <code>L5</code>
+      <a href="index.html#L5">Attached to value</a>
      </li>
      <li>
-      <code>L6</code>
+      <a href="index.html#L6">Attached to class</a>
      </li>
      <li>
-      <code>L7</code>
+      <a href="index.html#L7">Attached to class type</a>
      </li>
      <li>
-      <code>L8</code>
+      <a href="index.html#L8">Attached to exception</a>
      </li>
      <li>
       <code>L9</code>
@@ -156,7 +156,7 @@
       <a href="index.html#L10">Attached to module subst</a>
      </li>
      <li>
-      <code>L11</code>
+      <a href="index.html#L11">Attached to type subst</a>
      </li>
     </ul>
    </aside>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Labels (test_package+re.Labels)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body>
+  <nav>
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Labels
+  </nav>
+  <header>
+   <h1>
+    Module <code>Labels</code>
+   </h1>
+   <h2 id="L1">
+    <a href="#L1" class="anchor"></a>Attached to unit
+   </h2>
+  </header>
+  <nav class="toc">
+   <ul>
+    <li>
+     <a href="#L2">Attached to nothing</a>
+    </li>
+   </ul>
+  </nav>
+  <div class="content">
+   <h2 id="L2">
+    <a href="#L2" class="anchor"></a>Attached to nothing
+   </h2>
+   <div class="spec module" id="module-A">
+    <a href="#module-A" class="anchor"></a><code><span class="keyword">module</span> <a href="A/index.html">A</a>: { ... };</code>
+   </div>
+   <div>
+    <div class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t;</code>
+    </div>
+    <div>
+     <p>
+      Attached to type
+     </p>
+    </div>
+   </div>
+   <div>
+    <div class="spec value" id="val-f">
+     <a href="#val-f" class="anchor"></a><code><span class="keyword">let</span> f: <a href="index.html#type-t">t</a>;</code>
+    </div>
+    <div>
+     <p>
+      Attached to value
+     </p>
+    </div>
+   </div>
+   <div>
+    <div class="spec external" id="val-e">
+     <a href="#val-e" class="anchor"></a><code><span class="keyword">let</span> e: unit <span>=&gt;</span> <a href="index.html#type-t">t</a>;</code>
+    </div>
+    <div>
+     <p>
+      Attached to external
+     </p>
+    </div>
+   </div>
+   <div class="spec module-type" id="module-type-S">
+    <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
+   </div>
+   <div class="spec class" id="class-c">
+    <a href="#class-c" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-c/index.html">c</a>: { ... }</code>
+   </div>
+   <div class="spec class-type" id="class-type-cs">
+    <a href="#class-type-cs" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-cs/index.html">cs</a>{ ... }</code>
+   </div>
+   <div>
+    <div class="spec exception" id="exception-E">
+     <a href="#exception-E" class="anchor"></a><code><span class="keyword">exception</span> <span class="exception">E</span>;</code>
+    </div>
+    <div>
+     <p>
+      Attached to exception
+     </p>
+    </div>
+   </div>
+   <div class="spec type" id="type-x">
+    <a href="#type-x" class="anchor"></a><code><span class="keyword">type</span> x = ..;</code>
+   </div>
+   <div>
+    <div class="spec extension">
+     <code><span class="keyword">type</span> <a href="index.html#type-x">x</a> += | <span class="extension">X</span>;</code>
+    </div>
+    <div>
+     <p>
+      Attached to extension
+     </p>
+    </div>
+   </div>
+   <div>
+    <div class="spec module-substitution" id="module-S">
+     <a href="#module-S" class="anchor"></a><code><span class="keyword">module</span> S := <a href="A/index.html">A</a></code>
+    </div>
+    <div>
+     <p>
+      Attached to module subst
+     </p>
+    </div>
+   </div>
+   <div>
+    <div class="spec type-subst" id="type-s">
+     <a href="#type-s" class="anchor"></a><code><span class="keyword">type</span> s := <a href="index.html#type-t">t</a>;</code>
+    </div>
+    <div>
+     <p>
+      Attached to type subst
+     </p>
+    </div>
+   </div>
+   <aside>
+    <p>
+     Testing that labels can be referenced
+    </p>
+    <ul>
+     <li>
+      <code>L1</code>
+     </li>
+     <li>
+      <a href="index.html#L2">Attached to nothing</a>
+     </li>
+     <li>
+      <code>L3</code>
+     </li>
+     <li>
+      <code>L4</code>
+     </li>
+     <li>
+      <code>L5</code>
+     </li>
+     <li>
+      <code>L6</code>
+     </li>
+     <li>
+      <code>L7</code>
+     </li>
+     <li>
+      <code>L8</code>
+     </li>
+     <li>
+      <code>L9</code>
+     </li>
+     <li>
+      <code>L10</code>
+     </li>
+     <li>
+      <code>L11</code>
+     </li>
+    </ul>
+   </aside>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -126,13 +126,13 @@
     </p>
     <ul>
      <li>
-      <code>L1</code>
+      <a href="index.html#L1">Attached to unit</a>
      </li>
      <li>
       <a href="index.html#L2">Attached to nothing</a>
      </li>
      <li>
-      <code>L3</code>
+      <a href="index.html#L3">Attached to module</a>
      </li>
      <li>
       <code>L4</code>
@@ -153,7 +153,7 @@
       <code>L9</code>
      </li>
      <li>
-      <code>L10</code>
+      <a href="index.html#L10">Attached to module subst</a>
      </li>
      <li>
       <code>L11</code>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -135,19 +135,19 @@
       <a href="index.html#L3">Attached to module</a>
      </li>
      <li>
-      <code>L4</code>
+      <a href="index.html#L4">Attached to type</a>
      </li>
      <li>
-      <code>L5</code>
+      <a href="index.html#L5">Attached to value</a>
      </li>
      <li>
-      <code>L6</code>
+      <a href="index.html#L6">Attached to class</a>
      </li>
      <li>
-      <code>L7</code>
+      <a href="index.html#L7">Attached to class type</a>
      </li>
      <li>
-      <code>L8</code>
+      <a href="index.html#L8">Attached to exception</a>
      </li>
      <li>
       <code>L9</code>
@@ -156,7 +156,7 @@
       <a href="index.html#L10">Attached to module subst</a>
      </li>
      <li>
-      <code>L11</code>
+      <a href="index.html#L11">Attached to type subst</a>
      </li>
     </ul>
    </aside>

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -283,12 +283,14 @@ let source_files_all = [
   ("alias.ml", [
       "Alias/index.html";
       "Alias/X/index.html";
-    ])
+    ]);
 ]
 
 let source_files_post408 =
   [ ("recent.mli", ["Recent/index.html"; "Recent/X/index.html"])
-  ; ("recent_impl.ml", ["Recent_impl/index.html"]) ]
+  ; ("recent_impl.ml", ["Recent_impl/index.html"])
+  ; ("labels.mli", ["Labels/index.html"])
+  ]
 
 let source_files_pre410 =
   [ ("bugs_pre_410.ml", ["Bugs_pre_410/index.html"]) ]


### PR DESCRIPTION
Fix https://github.com/ocaml/odoc/issues/448

This is especially useful for the top comments, which is attached to the compilation unit.
