### PR TITLE
xref2: Remove Tools.ResolvedMonad

### DIFF
--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -19,7 +19,7 @@ let type_path : Env.t -> Paths.Path.Type.t -> Paths.Path.Type.t =
     let cp = Component.Of_Lang.(type_path empty p) in
     match Tools.resolve_type_path env cp with
     | Ok p' -> `Resolved (Cpath.resolved_type_path_of_cpath p')
-    | Error _ -> Cpath.type_path_of_cpath cp
+    | Error _ -> p
 
 and module_type_path :
     Env.t -> Paths.Path.ModuleType.t -> Paths.Path.ModuleType.t =
@@ -30,7 +30,7 @@ and module_type_path :
     let cp = Component.Of_Lang.(module_type_path empty p) in
     match Tools.resolve_module_type_path env cp with
     | Ok p' -> `Resolved (Cpath.resolved_module_type_path_of_cpath p')
-    | Error _ -> Cpath.module_type_path_of_cpath cp
+    | Error _ -> p
 
 and module_path : Env.t -> Paths.Path.Module.t -> Paths.Path.Module.t =
  fun env p ->
@@ -40,7 +40,7 @@ and module_path : Env.t -> Paths.Path.Module.t -> Paths.Path.Module.t =
     let cp = Component.Of_Lang.(module_path empty p) in
     match Tools.resolve_module_path env cp with
     | Ok p' -> `Resolved (Cpath.resolved_module_path_of_cpath p')
-    | Error _ -> Cpath.module_path_of_cpath cp
+    | Error _ -> p
 
 and class_type_path : Env.t -> Paths.Path.ClassType.t -> Paths.Path.ClassType.t
     =
@@ -306,7 +306,7 @@ and module_decl : Env.t -> Id.Signature.t -> Module.decl -> Module.decl =
       match Tools.resolve_module_path env cp with
       | Ok p' ->
           Alias (`Resolved (Cpath.resolved_module_path_of_cpath p'))
-      | Error _ -> Alias (Cpath.module_path_of_cpath cp) )
+      | Error _ -> Alias p )
 
 and module_type : Env.t -> ModuleType.t -> ModuleType.t =
  fun env m ->

--- a/src/xref2/errors.mli
+++ b/src/xref2/errors.mli
@@ -22,7 +22,8 @@ type simple_module_lookup_error =
   | (*** Internal error: the module was not found in the parent signature *)
     `Lookup_failure of
     Identifier.Path.Module.t
-    (** Could not find the module in the environment *) ]
+    (** Could not find the module in the environment *)
+  | `Parent of parent_lookup_error ]
 
 and simple_module_type_expr_of_module_error =
   [ `ApplyNotFunctor
@@ -31,25 +32,28 @@ and simple_module_type_expr_of_module_error =
   | `UnresolvedForwardPath
     (** The module signature depends upon a forward path *)
   | `UnresolvedPath of
-    [ `Module of Cpath.module_ | `ModuleType of Cpath.module_type ] ]
+    [ `Module of Cpath.module_ | `ModuleType of Cpath.module_type ]
+  | `Parent of parent_lookup_error ]
 
 and simple_module_type_lookup_error =
-  [ `LocalMT of Env.t * Cpath.Resolved.module_type
+  [ `LocalMT of Env.t * Ident.module_type
     (** Internal error: Found local path during lookup *)
   | `Find_failure
     (** Internal error: the module was not found in the parent signature *)
   | `Lookup_failureMT of Identifier.ModuleType.t
-    (** Could not find the module in the environment *) ]
+    (** Could not find the module in the environment *)
+  | `Parent of parent_lookup_error ]
 
 and simple_type_lookup_error =
-  [ `LocalType of Env.t * Cpath.Resolved.type_
+  [ `LocalType of Env.t * Ident.path_type
     (** Internal error: Found local path during lookup *)
   | `Class_replaced
     (** Class was replaced with a destructive substitution and we're not sure what to do now *)
   | `Find_failure
     (** Internal error: the type was not found in the parent signature *)
   | `Lookup_failureT of Identifier.Path.Type.t
-    (** Could not find the module in the environment *) ]
+    (** Could not find the module in the environment *)
+  | `Parent of parent_lookup_error ]
 
 and parent_lookup_error =
   [ `Parent_sig of signature_of_module_error
@@ -60,11 +64,11 @@ and parent_lookup_error =
     (** Error found while evaluating parent module expression *)
   | `Parent_module of simple_module_lookup_error
     (** Error found while looking up parent module *)
-  | `Fragment_root (* Encountered unexpected fragment root *) ]
+  | `Fragment_root (* Encountered unexpected fragment root *)
+  | `Parent of parent_lookup_error ]
 
 type any =
-  [ parent_lookup_error
-  | simple_type_lookup_error
+  [ simple_type_lookup_error
   | simple_module_type_lookup_error
   | simple_module_type_expr_of_module_error
   | simple_module_lookup_error

--- a/src/xref2/expand_tools.ml
+++ b/src/xref2/expand_tools.ml
@@ -47,7 +47,7 @@ and aux_expansion_of_module_alias env ~strengthen path =
   match
     Tools.resolve_module env ~mark_substituted:false ~add_canonical:false path
   with
-  | Resolved (p, m) -> (
+  | Ok (p, m) -> (
       (* Don't strengthen if the alias is definitely hidden. We can't always resolve canonical
          paths at this stage so use the weak canonical test that assumes all canonical paths
          will resolve correctly *)
@@ -83,7 +83,7 @@ and aux_expansion_of_module_alias env ~strengthen path =
              Component.Fmt.signature sg'; *)
           Ok (Signature { sg' with items = Comment (`Docs docs) :: sg'.items })
       | Ok (Functor _ as x), _ -> Ok x )
-  | Unresolved p -> Error (`UnresolvedPath (`Module p))
+  | Error _ -> Error (`UnresolvedPath (`Module path))
 
 (* We need to reresolve fragments in expansions as the root of the fragment
    may well change - so we turn resolved fragments back into unresolved ones
@@ -129,8 +129,8 @@ and aux_expansion_of_module_type_expr env expr :
   match expr with
   | Path p -> (
       match Tools.resolve_module_type ~mark_substituted:false env p with
-      | Resolved (_, mt) -> aux_expansion_of_module_type env mt
-      | Unresolved p -> Error (`UnresolvedPath (`ModuleType p)) )
+      | Ok (_, mt) -> aux_expansion_of_module_type env mt
+      | Error _ -> Error (`UnresolvedPath (`ModuleType p)) )
   | Signature s -> Ok (Signature s)
   | With (s, subs) -> (
       match aux_expansion_of_module_type_expr env s with

--- a/src/xref2/scratch.md
+++ b/src/xref2/scratch.md
@@ -69,7 +69,6 @@ end
 
 ```ocaml env=e1
 # let sg = Common.model_of_string test_data;;
-typeof struct_include
 val sg :
   Odoc_model.Paths_types.Identifier.root_module * Odoc_model.Comment.docs *
   Odoc_model.Lang.Signature.t =

--- a/src/xref2/test.md
+++ b/src/xref2/test.md
@@ -246,15 +246,11 @@ the environment. This gets us back the path and a `Component.Module.t` represent
 which are:
 
 ```ocaml env=e1
-# let get_resolved = function
-    | Tools.ResolvedMonad.Resolved x -> x
-    | Unresolved _ -> failwith "Unresolved path" ;;
-val get_resolved : ('a, 'b) Tools.ResolvedMonad.t -> 'a = <fun>
 # let get_ok = function
     | Ok x -> x
     | Error _ -> failwith "Found error";;
 val get_ok : ('a, 'b) result -> 'a = <fun>
-# let (path, module_) = get_resolved @@ Tools.resolve_module ~mark_substituted:true ~add_canonical:true env (`Resolved (`Identifier (Common.root_module "M")));;
+# let (path, module_) = get_ok @@ Tools.resolve_module ~mark_substituted:true ~add_canonical:true env (`Resolved (`Identifier (Common.root_module "M")));;
 val path : Cpath.Resolved.module_ =
   `Identifier (`Module (`Root (Common.root, Root), M))
 val module_ : Component.Module.t Component.Delayed.t =
@@ -317,7 +313,7 @@ It proceeds much as the previous example until we get the result
 of looking up the module `N`:
 
 ```ocaml env=e1
-# let (path, module_) = get_resolved @@ Tools.resolve_module ~mark_substituted:true ~add_canonical:true env (`Resolved (`Identifier (Common.root_module "N")));;
+# let (path, module_) = get_ok @@ Tools.resolve_module ~mark_substituted:true ~add_canonical:true env (`Resolved (`Identifier (Common.root_module "N")));;
 val path : Cpath.Resolved.module_ =
   `Identifier (`Module (`Root (Common.root, Root), N))
 val module_ : Component.Module.t Component.Delayed.t =
@@ -488,10 +484,10 @@ we then return along with the fully resolved identifier.
           "B"),
        "t"));;
 - : (Cpath.Resolved.type_ * (Find.type_, Component.TypeExpr.t) Find.found,
-     Cpath.type_)
-    Tools.ResolvedMonad.t
+     Odoc_xref2.Errors.simple_type_lookup_error)
+    result
 =
-Odoc_xref2.Tools.ResolvedMonad.Resolved
+Result.Ok
  (`Type
     (`Module
        (`Module
@@ -943,7 +939,7 @@ let cp = Component.Of_Lang.(module_path empty test_path);;
 Now let's lookup that module:
 
 ```ocaml env=e1
-# let (p,m) = get_resolved @@ Tools.resolve_module ~mark_substituted:true ~add_canonical:true env cp;;
+# let (p,m) = get_ok @@ Tools.resolve_module ~mark_substituted:true ~add_canonical:true env cp;;
 val p : Cpath.Resolved.module_ =
   `Apply
     (`Apply

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -703,17 +703,8 @@ and resolve_module :
             let m = Component.Delayed.get m in
             match handle_apply ~mark_substituted env func_path' arg_path' m with
             | Ok (p, m) -> Ok (p, Component.Delayed.put_val m)
-            (* | Error _ -> *)
-            (*     Error (`Best_effort ( *)
-            (*       `Apply (`Resolved func_path', `Resolved arg_path'))) *)
             | Error e -> Error (`Parent (`Parent_expr e)) )
-        | _ -> Error `Unresolved_apply
-        (* | Error _, Ok (arg_path', _) -> *)
-        (*     Error (`Best_effort (`Apply (m1, `Resolved arg_path'))) *)
-        (* | Ok (func_path', _), Error _ -> *)
-        (*     Error (`Best_effort (`Apply (`Resolved func_path', m2))) *)
-        (* | Error _, Error _ -> *)
-        (*     Error (`Best_effort (`Apply (m1, m2)))) *) )
+        | _ -> Error `Unresolved_apply )
     | `Identifier (i, hidden) ->
         of_option ~error:`Find_failure (Env.(lookup_by_id s_module) i env)
         >>= fun (`Module (_, m)) ->

--- a/src/xref2/tools.mli
+++ b/src/xref2/tools.mli
@@ -7,10 +7,6 @@
 
 open Errors
 
-module ResolvedMonad : sig
-  type ('a, 'b) t = Resolved of 'a | Unresolved of 'b
-end
-
 (** {2 Lookup and resolve functions} *)
 
 (** The following lookup and resolve functions take {{!module:Cpath.Resolved}resolved paths}
@@ -45,7 +41,7 @@ val lookup_module :
   Env.t ->
   Cpath.Resolved.module_ ->
   ( Component.Module.t Component.Delayed.t,
-    [ simple_module_lookup_error | parent_lookup_error ] )
+    simple_module_lookup_error )
   Result.result
 (** [lookup_module ~mark_substituted env p] takes a resolved module cpath [p] and
     an environment and returns a representation of the module. 
@@ -55,9 +51,7 @@ val lookup_module_type :
   mark_substituted:bool ->
   Env.t ->
   Cpath.Resolved.module_type ->
-  ( Component.ModuleType.t,
-    [ simple_module_type_lookup_error | parent_lookup_error ] )
-  Result.result
+  (Component.ModuleType.t, simple_module_type_lookup_error) Result.result
 (** [lookup_module_type ~mark_substituted env p] takes a resolved module type
     cpath and an environment and returns a representation of the module type.
 *)
@@ -66,7 +60,7 @@ val lookup_type :
   Env.t ->
   Cpath.Resolved.type_ ->
   ( (Find.type_, Component.TypeExpr.t) Find.found,
-    [ simple_type_lookup_error | parent_lookup_error ] )
+    simple_type_lookup_error )
   Result.result
 (** [lookup_type env p] takes a resolved type path and an environment and returns
     a representation of the type. The type can be an ordinary type, a class type
@@ -77,7 +71,7 @@ val lookup_class_type :
   Env.t ->
   Cpath.Resolved.class_type ->
   ( (Find.class_type, Component.TypeExpr.t) Find.found,
-    [ simple_type_lookup_error | parent_lookup_error ] )
+    simple_type_lookup_error )
   Result.result
 (** [lookup_class_type env p] takes a resolved class type path and an environment and returns
     a representation of the class type. The type can be a class type
@@ -89,8 +83,8 @@ val resolve_module :
   Env.t ->
   Cpath.module_ ->
   ( Cpath.Resolved.module_ * Component.Module.t Component.Delayed.t,
-    Cpath.module_ )
-  ResolvedMonad.t
+    simple_module_lookup_error )
+  Result.result
 (** [resolve_module ~mark_substituted ~add_canonical env p] takes an unresolved
     module path and an environment and returns a tuple of the resolved module
     path alongside a representation of the module itself. *)
@@ -100,8 +94,8 @@ val resolve_module_type :
   Env.t ->
   Cpath.module_type ->
   ( Cpath.Resolved.module_type * Component.ModuleType.t,
-    Cpath.module_type )
-  ResolvedMonad.t
+    simple_module_type_lookup_error )
+  Result.result
 (** [resolve_module_type ~mark_substituted env p] takes an unresolved module
     type path and an environment and returns a tuple of the resolved module type
     path alongside a representation of the module type itself. *)
@@ -110,8 +104,8 @@ val resolve_type :
   Env.t ->
   Cpath.type_ ->
   ( Cpath.Resolved.type_ * (Find.type_, Component.TypeExpr.t) Find.found,
-    Cpath.type_ )
-  ResolvedMonad.t
+    simple_type_lookup_error )
+  Result.result
 (** [resolve_type env p] takes an unresolved
     type path and an environment and returns a tuple of the resolved type
     path alongside a representation of the type itself. As with {!val:lookup_type}
@@ -124,8 +118,8 @@ val resolve_class_type :
   Cpath.class_type ->
   ( Cpath.Resolved.class_type
     * (Find.class_type, Component.TypeExpr.t) Find.found,
-    Cpath.class_type )
-  ResolvedMonad.t
+    simple_type_lookup_error )
+  Result.result
 (** [resolve_class_type env p] takes an unresolved
       class type path and an environment and returns a tuple of the resolved class type
       path alongside a representation of the class type itself. As with {!val:lookup_type}
@@ -142,20 +136,22 @@ val resolve_class_type :
 val resolve_module_path :
   Env.t ->
   Cpath.module_ ->
-  (Cpath.Resolved.module_, Cpath.module_) ResolvedMonad.t
+  (Cpath.Resolved.module_, simple_module_lookup_error) Result.result
 
 val resolve_module_type_path :
   Env.t ->
   Cpath.module_type ->
-  (Cpath.Resolved.module_type, Cpath.module_type) ResolvedMonad.t
+  (Cpath.Resolved.module_type, simple_module_type_lookup_error) Result.result
 
 val resolve_type_path :
-  Env.t -> Cpath.type_ -> (Cpath.Resolved.type_, Cpath.type_) ResolvedMonad.t
+  Env.t ->
+  Cpath.type_ ->
+  (Cpath.Resolved.type_, simple_type_lookup_error) Result.result
 
 val resolve_class_type_path :
   Env.t ->
   Cpath.class_type ->
-  (Cpath.Resolved.class_type, Cpath.class_type) ResolvedMonad.t
+  (Cpath.Resolved.class_type, simple_type_lookup_error) Result.result
 
 (** {2 Re-resolve functions} *)
 


### PR DESCRIPTION
As @jonludlam noticed, the Unresolved case is not much used and always correspond to the input value.
Use `result` instead, which will be convenient to show better errors.