### PR TITLE
xref2: Remove some Name.of_string

### DIFF
--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -81,7 +81,7 @@ let filter_in_sig sg f =
 
 let module_in_sig sg name =
   find_in_sig sg (function
-    | Signature.Module (id, _, m) when N.typed_module id = name ->
+    | Signature.Module (id, _, m) when N.module_ id = name ->
         Some (`FModule (N.typed_module id, Delayed.get m))
     | _ -> None)
 
@@ -113,7 +113,7 @@ type careful_class = [ class_ | removed_type ]
 
 let careful_module_in_sig sg name =
   let removed_module = function
-    | Signature.RModule (id, p) when N.typed_module id = name ->
+    | Signature.RModule (id, p) when N.module_ id = name ->
         Some (`FModule_removed p)
     | _ -> None
   in
@@ -231,7 +231,7 @@ let signature_in_sig sg name =
 
 let module_type_in_sig sg name =
   find_in_sig sg (function
-    | Signature.ModuleType (id, m) when N.typed_module_type id = name ->
+    | Signature.ModuleType (id, m) when N.module_type id = name ->
         Some (`FModuleType (N.typed_module_type id, Delayed.get m))
     | _ -> None)
 

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -11,11 +11,11 @@ type class_ =
   [ `FClass of ClassName.t * Class.t
   | `FClassType of ClassTypeName.t * ClassType.t ]
 
-type value = [ `FExternal of External.t | `FValue of Value.t ]
+type value = [ `FExternal of ValueName.t * External.t | `FValue of ValueName.t * Value.t ]
 
 type label = [ `FLabel of Ident.label ]
 
-type exception_ = [ `FExn of Exception.t ]
+type exception_ = [ `FExn of ExceptionName.t * Exception.t ]
 
 type extension = [ `FExt of Extension.t * Extension.Constructor.t ]
 
@@ -46,9 +46,9 @@ type any_in_sig =
   | substitution
   | any_in_type_in_sig ]
 
-type instance_variable = [ `FInstance_variable of InstanceVariable.t ]
+type instance_variable = [ `FInstance_variable of InstanceVariableName.t * InstanceVariable.t ]
 
-type method_ = [ `FMethod of Method.t ]
+type method_ = [ `FMethod of MethodName.t * Method.t ]
 
 type any_in_class_sig = [ instance_variable | method_ ]
 
@@ -205,9 +205,9 @@ let any_in_sig sg name =
     | Type (id, _, t) when N.type_ id = name ->
         Some (`FType (N.type' id, Delayed.get t))
     | TypeSubstitution (id, ts) when N.type_ id = name -> Some (`FType_subst ts)
-    | Exception (id, exc) when N.exception_ id = name -> Some (`FExn exc)
-    | Value (id, v) when N.value id = name -> Some (`FValue (Delayed.get v))
-    | External (id, vex) when N.value id = name -> Some (`FExternal vex)
+    | Exception (id, exc) when N.exception_ id = name -> Some (`FExn (N.typed_exception id, exc))
+    | Value (id, v) when N.value id = name -> Some (`FValue (N.typed_value id, Delayed.get v))
+    | External (id, vex) when N.value id = name -> Some (`FExternal (N.typed_value id, vex))
     | Class (id, _, c) when N.class_ id = name ->
         Some (`FClass (N.class' id, c))
     | ClassType (id, _, ct) when N.class_type id = name ->
@@ -238,8 +238,8 @@ let module_type_in_sig sg name =
 let value_in_sig sg name =
   filter_in_sig sg (function
     | Signature.Value (id, m) when N.value id = name ->
-        Some (`FValue (Delayed.get m))
-    | External (id, e) when N.value id = name -> Some (`FExternal e)
+        Some (`FValue (N.typed_value id, Delayed.get m))
+    | External (id, e) when N.value id = name -> Some (`FExternal (N.typed_value id, e))
     | _ -> None)
 
 let label_in_sig sg name =
@@ -249,7 +249,7 @@ let label_in_sig sg name =
 
 let exception_in_sig sg name =
   find_in_sig sg (function
-    | Signature.Exception (id, e) when N.exception_ id = name -> Some (`FExn e)
+    | Signature.Exception (id, e) when N.exception_ id = name -> Some (`FExn (N.typed_exception id, e))
     | _ -> None)
 
 let extension_in_sig sg name =
@@ -303,20 +303,20 @@ let find_in_class_signature cs f =
 let any_in_class_signature cs name =
   filter_in_class_signature cs (function
     | ClassSignature.Method (id, m) when N.method_ id = name ->
-        Some (`FMethod m)
+        Some (`FMethod (N.typed_method id, m))
     | InstanceVariable (id, iv) when N.instance_variable id = name ->
-        Some (`FInstance_variable iv)
+        Some (`FInstance_variable (N.typed_instance_variable id, iv))
     | _ -> None)
 
 let method_in_class_signature cs name =
   find_in_class_signature cs (function
     | ClassSignature.Method (id, m) when N.method_ id = name ->
-        Some (`FMethod m)
+        Some (`FMethod (N.typed_method id, m))
     | _ -> None)
 
 let instance_variable_in_class_signature cs name =
   find_in_class_signature cs (function
     | ClassSignature.InstanceVariable (id, iv)
       when N.instance_variable id = name ->
-        Some (`FInstance_variable iv)
+        Some (`FInstance_variable (N.typed_instance_variable id, iv))
     | _ -> None)

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -54,13 +54,13 @@ type any_in_class_sig = [ instance_variable | method_ ]
 
 (** Lookup by name, unambiguous *)
 
-val module_in_sig : Signature.t -> ModuleName.t -> module_ option
+val module_in_sig : Signature.t -> string -> module_ option
 
 val type_in_sig : Signature.t -> string -> type_ option
 
 val datatype_in_sig : Signature.t -> string -> datatype option
 
-val module_type_in_sig : Signature.t -> ModuleTypeName.t -> module_type option
+val module_type_in_sig : Signature.t -> string -> module_type option
 
 val exception_in_sig : Signature.t -> string -> exception_ option
 
@@ -103,7 +103,7 @@ type careful_type = [ type_ | removed_type ]
 
 type careful_class = [ class_ | removed_type ]
 
-val careful_module_in_sig : Signature.t -> ModuleName.t -> careful_module option
+val careful_module_in_sig : Signature.t -> string -> careful_module option
 
 val careful_type_in_sig : Signature.t -> string -> careful_type option
 

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -12,11 +12,11 @@ type class_ =
   [ `FClass of ClassName.t * Class.t
   | `FClassType of ClassTypeName.t * ClassType.t ]
 
-type value = [ `FExternal of External.t | `FValue of Value.t ]
+type value = [ `FExternal of ValueName.t * External.t | `FValue of ValueName.t * Value.t ]
 
 type label = [ `FLabel of Ident.label ]
 
-type exception_ = [ `FExn of Exception.t ]
+type exception_ = [ `FExn of ExceptionName.t * Exception.t ]
 
 type extension = [ `FExt of Extension.t * Extension.Constructor.t ]
 
@@ -35,8 +35,7 @@ type field = [ `FField of TypeDecl.Field.t ]
 
 type any_in_type = [ constructor | field ]
 
-type any_in_type_in_sig =
-  [ `In_type of Odoc_model.Names.TypeName.t * TypeDecl.t * any_in_type ]
+type any_in_type_in_sig = [ `In_type of TypeName.t * TypeDecl.t * any_in_type ]
 
 type any_in_sig =
   [ label_parent
@@ -47,9 +46,9 @@ type any_in_sig =
   | substitution
   | any_in_type_in_sig ]
 
-type instance_variable = [ `FInstance_variable of InstanceVariable.t ]
+type instance_variable = [ `FInstance_variable of InstanceVariableName.t * InstanceVariable.t ]
 
-type method_ = [ `FMethod of Method.t ]
+type method_ = [ `FMethod of MethodName.t * Method.t ]
 
 type any_in_class_sig = [ instance_variable | method_ ]
 

--- a/src/xref2/tools.mli
+++ b/src/xref2/tools.mli
@@ -174,7 +174,7 @@ val reresolve_parent : Env.t -> Cpath.Resolved.parent -> Cpath.Resolved.parent
 
 val handle_module_type_lookup :
   Env.t ->
-  Odoc_model.Names.ModuleTypeName.t ->
+  string ->
   Cpath.Resolved.parent ->
   Component.Signature.t ->
   Component.Substitution.t ->

--- a/test/xref2/subst/test.md
+++ b/test/xref2/subst/test.md
@@ -25,7 +25,7 @@ let module_substitution ~idents ~targets m test_data =
   in
 
   let m =
-    match Find.module_in_sig c (Odoc_model.Names.ModuleName.of_string "S") with
+    match Find.module_in_sig c "S" with
     | Some (`FModule (name, m)) -> m
     | None -> failwith "Error finding module!"
   in


### PR DESCRIPTION
This is on top of https://github.com/ocaml/odoc/pull/445

I think names shouldn't be created outside of `Lang`.
Some are still remaining and could be removed with some work. (eg. constructors, fields and extension constructors don't have names in `Lang`)