### PR TITLE
Eliminate opaque warning with xref2 test

### DIFF
--- a/test/xref2/lib/dune
+++ b/test/xref2/lib/dune
@@ -10,6 +10,7 @@
 (library
  (name odoc_xref_test)
  (public_name odoc.xref_test)
+ (modes byte)
  (libraries tyxml compiler-libs.toplevel compiler-libs.common odoc_xref2
    odoc_odoc odoc_model)
  (modules common))


### PR DESCRIPTION
Toploop is called, so this library can only be used in bytecode.