### PR TITLE
Check comments attached to constructors and fields

### DIFF
--- a/test/cases/labels.mli
+++ b/test/cases/labels.mli
@@ -37,6 +37,10 @@ module S := A
 (** {1:L11 Attached to type subst} *)
 type s := t
 
+type u = A' (** {1:L12 Attached to constructor} *)
+
+type v = { f : t (** {1:L13 Attached to field} *) }
+
 (** Testing that labels can be referenced
     - {!L1}
     - {!L2}
@@ -49,4 +53,6 @@ type s := t
     - {!L9}
     - {!L10}
     - {!L11}
+    - {!L12}
+    - {!L13}
   *)

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -203,10 +203,10 @@
       <a href="index.html#L11">Attached to type subst</a>
      </li>
      <li>
-      <code>L12</code>
+      <a href="index.html#L12">Attached to constructor</a>
      </li>
      <li>
-      <code>L13</code>
+      <a href="index.html#L13">Attached to field</a>
      </li>
     </ul>
    </aside>

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -129,6 +129,41 @@
      </p>
     </div>
    </div>
+   <div class="spec type" id="type-u">
+    <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u = </code>
+    <table>
+     <tbody>
+      <tr id="type-u.A'" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-u.A'" class="anchor"></a><code>| <span class="constructor">A'</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         Attached to constructor
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+   </div>
+   <div class="spec type" id="type-v">
+    <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v = {</code>
+    <table>
+     <tbody>
+      <tr id="type-v.f" class="anchored">
+       <td class="def record field">
+        <a href="#type-v.f" class="anchor"></a><code>f : <a href="index.html#type-t">t</a>;</code>
+       </td>
+       <td class="doc">
+        <p>
+         Attached to field
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>}</code>
+   </div>
    <aside>
     <p>
      Testing that labels can be referenced
@@ -166,6 +201,12 @@
      </li>
      <li>
       <a href="index.html#L11">Attached to type subst</a>
+     </li>
+     <li>
+      <code>L12</code>
+     </li>
+     <li>
+      <code>L13</code>
      </li>
     </ul>
    </aside>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -130,6 +130,42 @@
      </p>
     </div>
    </div>
+   <div class="spec type" id="type-u">
+    <a href="#type-u" class="anchor"></a><code><span class="keyword">type</span> u = </code>
+    <table>
+     <tbody>
+      <tr id="type-u.A'" class="anchored">
+       <td class="def variant constructor">
+        <a href="#type-u.A'" class="anchor"></a><code>| <span class="constructor">A'</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         Attached to constructor
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
+   </div>
+   <div class="spec type" id="type-v">
+    <a href="#type-v" class="anchor"></a><code><span class="keyword">type</span> v = {</code>
+    <table>
+     <tbody>
+      <tr id="type-v.f" class="anchored">
+       <td class="def record field">
+        <a href="#type-v.f" class="anchor"></a><code>f: <a href="index.html#type-t">t</a>,</code>
+       </td>
+       <td class="doc">
+        <p>
+         Attached to field
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>};</code>
+   </div>
    <aside>
     <p>
      Testing that labels can be referenced
@@ -167,6 +203,12 @@
      </li>
      <li>
       <a href="index.html#L11">Attached to type subst</a>
+     </li>
+     <li>
+      <code>L12</code>
+     </li>
+     <li>
+      <code>L13</code>
      </li>
     </ul>
    </aside>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -205,10 +205,10 @@
       <a href="index.html#L11">Attached to type subst</a>
      </li>
      <li>
-      <code>L12</code>
+      <a href="index.html#L12">Attached to constructor</a>
      </li>
      <li>
-      <code>L13</code>
+      <a href="index.html#L13">Attached to field</a>
      </li>
     </ul>
    </aside>


### PR DESCRIPTION
Fix https://github.com/ocaml/odoc/issues/465

In the example in the issue, `{!LA}` now resolves but `{!t.LA}` don't.