### PR TITLE
document: support documentation and linking of type extensions

### DIFF
--- a/test/cases/type.mli
+++ b/test/cases/type.mli
@@ -125,7 +125,9 @@ type as_ = (int as 'a) * 'a
 
 type extensible = ..
 
-type extensible += Extension | Another_extension
+type extensible +=
+   | Extension (** Documentation for {!Extension}. *)
+   | Another_extension (** Documentation for {!Another_extension}. *)
 
 type mutually = A of recursive
 and recursive = B of mutually

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -92,7 +92,16 @@
    </div>
    <div>
     <div class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-x">x</a> += | <span class="extension">X</span></code>
+     <code><span class="keyword">type</span> <a href="index.html#type-x">x</a> += </code>
+     <table>
+      <tbody>
+       <tr id="extension-X" class="anchored">
+        <td class="def extension">
+         <a href="#extension-X" class="anchor"></a><code>| <span class="extension">X</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
     </div>
     <div>
      <p>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -1303,19 +1303,69 @@
     </div>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtA</span></code>
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ExtA" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtA" class="anchor"></a><code>| <span class="extension">ExtA</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtB</span></code>
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ExtB" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtB" class="anchor"></a><code>| <span class="extension">ExtB</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtC</span> <span class="keyword">of</span> unit| <span class="extension">ExtD</span> <span class="keyword">of</span> <a href="index.html#type-ext">ext</a></code>
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ExtC" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtC" class="anchor"></a><code>| <span class="extension">ExtC</span> <span class="keyword">of</span> unit</code>
+       </td>
+      </tr>
+      <tr id="extension-ExtD" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtD" class="anchor"></a><code>| <span class="extension">ExtD</span> <span class="keyword">of</span> <a href="index.html#type-ext">ext</a></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtE</span></code>
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ExtE" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtE" class="anchor"></a><code>| <span class="extension">ExtE</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtF</span></code>
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ExtF" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtF" class="anchor"></a><code>| <span class="extension">ExtF</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div>
     <div class="spec type" id="type-poly_ext">
@@ -1328,19 +1378,80 @@
     </div>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Foo</span> <span class="keyword">of</span> <span class="type-var">'b</span>| <span class="extension">Bar</span> <span class="keyword">of</span> <span class="type-var">'b</span> * <span class="type-var">'b</span></code>
+    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-Foo" class="anchored">
+       <td class="def extension">
+        <a href="#extension-Foo" class="anchor"></a><code>| <span class="extension">Foo</span> <span class="keyword">of</span> <span class="type-var">'b</span></code>
+       </td>
+      </tr>
+      <tr id="extension-Bar" class="anchored">
+       <td class="def extension">
+        <a href="#extension-Bar" class="anchor"></a><code>| <span class="extension">Bar</span> <span class="keyword">of</span> <span class="type-var">'b</span> * <span class="type-var">'b</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         'b poly_ext
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Quux</span> <span class="keyword">of</span> <span class="type-var">'c</span></code>
+    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-Quux" class="anchored">
+       <td class="def extension">
+        <a href="#extension-Quux" class="anchor"></a><code>| <span class="extension">Quux</span> <span class="keyword">of</span> <span class="type-var">'c</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         'c poly_ext
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div class="spec module" id="module-ExtMod">
     <a href="#module-ExtMod" class="anchor"></a><code><span class="keyword">module</span> <a href="ExtMod/index.html">ExtMod</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop0</span></code>
+    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ZzzTop0" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ZzzTop0" class="anchor"></a><code>| <span class="extension">ZzzTop0</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         It's got the rock
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop</span> <span class="keyword">of</span> unit</code>
+    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ZzzTop" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ZzzTop" class="anchor"></a><code>| <span class="extension">ZzzTop</span> <span class="keyword">of</span> unit</code>
+       </td>
+       <td class="doc">
+        <p>
+         and it packs a unit.
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div>
     <div class="spec external" id="val-launch_missiles">
@@ -1713,7 +1824,16 @@
     <a href="#type-new_t" class="anchor"></a><code><span class="keyword">type</span> new_t = ..</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-new_t">new_t</a> += | <span class="extension">C</span></code>
+    <code><span class="keyword">type</span> <a href="index.html#type-new_t">new_t</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-C" class="anchored">
+       <td class="def extension">
+        <a href="#extension-C" class="anchor"></a><code>| <span class="extension">C</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div class="spec module-type" id="module-type-TypeExtPruned">
     <a href="#module-type-TypeExtPruned" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-TypeExtPruned/index.html">TypeExtPruned</a> = <a href="module-type-TypeExt/index.html">TypeExt</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-TypeExt/index.html#type-t">t</a> := <a href="index.html#type-new_t">new_t</a></code>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -370,7 +370,31 @@
     <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type</span> extensible = ..</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-extensible">extensible</a> += | <span class="extension">Extension</span>| <span class="extension">Another_extension</span></code>
+    <code><span class="keyword">type</span> <a href="index.html#type-extensible">extensible</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-Extension" class="anchored">
+       <td class="def extension">
+        <a href="#extension-Extension" class="anchor"></a><code>| <span class="extension">Extension</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         Documentation for <a href="index.html#extension-Extension"><code>Extension</code></a>.
+        </p>
+       </td>
+      </tr>
+      <tr id="extension-Another_extension" class="anchored">
+       <td class="def extension">
+        <a href="#extension-Another_extension" class="anchor"></a><code>| <span class="extension">Another_extension</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         Documentation for <a href="index.html#extension-Another_extension"><code>Another_extension</code></a>.
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
    </div>
    <div class="spec type" id="type-mutually">
     <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type</span> mutually = </code>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -92,7 +92,17 @@
    </div>
    <div>
     <div class="spec extension">
-     <code><span class="keyword">type</span> <a href="index.html#type-x">x</a> += | <span class="extension">X</span>;</code>
+     <code><span class="keyword">type</span> <a href="index.html#type-x">x</a> += </code>
+     <table>
+      <tbody>
+       <tr id="extension-X" class="anchored">
+        <td class="def extension">
+         <a href="#extension-X" class="anchor"></a><code>| <span class="extension">X</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code>;</code>
     </div>
     <div>
      <p>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -1311,19 +1311,74 @@
     </div>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtA</span>;</code>
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ExtA" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtA" class="anchor"></a><code>| <span class="extension">ExtA</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtB</span>;</code>
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ExtB" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtB" class="anchor"></a><code>| <span class="extension">ExtB</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtC</span>(unit)| <span class="extension">ExtD</span>(<a href="index.html#type-ext">ext</a>);</code>
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ExtC" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtC" class="anchor"></a><code>| <span class="extension">ExtC</span>(unit)</code>
+       </td>
+      </tr>
+      <tr id="extension-ExtD" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtD" class="anchor"></a><code>| <span class="extension">ExtD</span>(<a href="index.html#type-ext">ext</a>)</code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtE</span>;</code>
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ExtE" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtE" class="anchor"></a><code>| <span class="extension">ExtE</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += | <span class="extension">ExtF</span>;</code>
+    <code><span class="keyword">type</span> <a href="index.html#type-ext">ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ExtF" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ExtF" class="anchor"></a><code>| <span class="extension">ExtF</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div>
     <div class="spec type" id="type-poly_ext">
@@ -1336,19 +1391,84 @@
     </div>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Foo</span>(<span class="type-var">'b</span>)| <span class="extension">Bar</span>(<span class="type-var">'b</span>, <span class="type-var">'b</span>);</code>
+    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-Foo" class="anchored">
+       <td class="def extension">
+        <a href="#extension-Foo" class="anchor"></a><code>| <span class="extension">Foo</span>(<span class="type-var">'b</span>)</code>
+       </td>
+      </tr>
+      <tr id="extension-Bar" class="anchored">
+       <td class="def extension">
+        <a href="#extension-Bar" class="anchor"></a><code>| <span class="extension">Bar</span>(<span class="type-var">'b</span>, <span class="type-var">'b</span>)</code>
+       </td>
+       <td class="doc">
+        <p>
+         'b poly_ext
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += | <span class="extension">Quux</span>(<span class="type-var">'c</span>);</code>
+    <code><span class="keyword">type</span> <a href="index.html#type-poly_ext">poly_ext</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-Quux" class="anchored">
+       <td class="def extension">
+        <a href="#extension-Quux" class="anchor"></a><code>| <span class="extension">Quux</span>(<span class="type-var">'c</span>)</code>
+       </td>
+       <td class="doc">
+        <p>
+         'c poly_ext
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div class="spec module" id="module-ExtMod">
     <a href="#module-ExtMod" class="anchor"></a><code><span class="keyword">module</span> <a href="ExtMod/index.html">ExtMod</a>: { ... };</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop0</span>;</code>
+    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ZzzTop0" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ZzzTop0" class="anchor"></a><code>| <span class="extension">ZzzTop0</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         It's got the rock
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += | <span class="extension">ZzzTop</span>(unit);</code>
+    <code><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-ZzzTop" class="anchored">
+       <td class="def extension">
+        <a href="#extension-ZzzTop" class="anchor"></a><code>| <span class="extension">ZzzTop</span>(unit)</code>
+       </td>
+       <td class="doc">
+        <p>
+         and it packs a unit.
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div>
     <div class="spec external" id="val-launch_missiles">
@@ -1721,7 +1841,17 @@
     <a href="#type-new_t" class="anchor"></a><code><span class="keyword">type</span> new_t = ..;</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-new_t">new_t</a> += | <span class="extension">C</span>;</code>
+    <code><span class="keyword">type</span> <a href="index.html#type-new_t">new_t</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-C" class="anchored">
+       <td class="def extension">
+        <a href="#extension-C" class="anchor"></a><code>| <span class="extension">C</span></code>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div class="spec module-type" id="module-type-TypeExtPruned">
     <a href="#module-type-TypeExtPruned" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-TypeExtPruned/index.html">TypeExtPruned</a> = <a href="module-type-TypeExt/index.html">TypeExt</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-TypeExt/index.html#type-t">t</a> := <a href="index.html#type-new_t">new_t</a>;</code>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -374,7 +374,32 @@
     <a href="#type-extensible" class="anchor"></a><code><span class="keyword">type</span> extensible = ..;</code>
    </div>
    <div class="spec extension">
-    <code><span class="keyword">type</span> <a href="index.html#type-extensible">extensible</a> += | <span class="extension">Extension</span>| <span class="extension">Another_extension</span>;</code>
+    <code><span class="keyword">type</span> <a href="index.html#type-extensible">extensible</a> += </code>
+    <table>
+     <tbody>
+      <tr id="extension-Extension" class="anchored">
+       <td class="def extension">
+        <a href="#extension-Extension" class="anchor"></a><code>| <span class="extension">Extension</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         Documentation for <a href="index.html#extension-Extension"><code>Extension</code></a>.
+        </p>
+       </td>
+      </tr>
+      <tr id="extension-Another_extension" class="anchored">
+       <td class="def extension">
+        <a href="#extension-Another_extension" class="anchor"></a><code>| <span class="extension">Another_extension</span></code>
+       </td>
+       <td class="doc">
+        <p>
+         Documentation for <a href="index.html#extension-Another_extension"><code>Another_extension</code></a>.
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <code>;</code>
    </div>
    <div class="spec type" id="type-mutually">
     <a href="#type-mutually" class="anchor"></a><code><span class="keyword">type</span> mutually = </code>

--- a/test/man/expect/test_package+ml/Type.3o
+++ b/test/man/expect/test_package+ml/Type.3o
@@ -225,7 +225,20 @@ e : a\. \f[CB]'a\fR;
 .sp 
 \f[CB]type\fR extensible = \.\.
 .sp 
-\f[CB]type\fR extensible += | \f[CB]Extension\fR| \f[CB]Another_extension\fR
+\f[CB]type\fR extensible += 
+.br 
+.ti +2
+| \f[CB]Extension\fR
+.br 
+.ti +4
+(* Documentation for \f[CI]Extension\fR\. *)
+.br 
+.ti +2
+| \f[CB]Another_extension\fR
+.br 
+.ti +4
+(* Documentation for \f[CI]Another_extension\fR\. *)
+.br 
 .sp 
 \f[CB]type\fR mutually = 
 .br 


### PR DESCRIPTION
This adds support for documenting type extensions, as in:

```ocaml
type extensible +=
   | Extension (** Documentation for {!Extension}. *)
   | Another_extension (** Documentation for {!Another_extension}. *)
```

which gets rid of [a `TODO` in the document generator](https://github.com/ocaml/odoc/blob/master/src/document/generator.ml#L563). The approach taken is symmetric with that of variant cases.