### PR TITLE
Disallow unresolved arguments to Apply

### DIFF
--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -32,7 +32,7 @@ let render_path : Odoc_model.Paths.Path.t -> string =
     | `Module (p, s) -> render_resolved (p :> t) ^ "." ^ (ModuleName.to_string s)
     | `Canonical (_, `Resolved p) -> render_resolved (p :> t)
     | `Canonical (p, _) -> render_resolved (p :> t)
-    | `Apply (rp, p) -> render_resolved (rp :> t) ^ "(" ^ render_path (p :> Odoc_model.Paths.Path.t) ^ ")"
+    | `Apply (rp, p) -> render_resolved (rp :> t) ^ "(" ^ render_resolved (p :> Odoc_model.Paths.Path.Resolved.t) ^ ")"
     | `ModuleType (p, s) -> render_resolved (p :> t) ^ "." ^ (ModuleTypeName.to_string s)
     | `Type (p, s) -> render_resolved (p :> t) ^ "." ^ (TypeName.to_string s)
     | `Class (p, s) -> render_resolved (p :> t) ^ "." ^ (ClassName.to_string s)

--- a/src/html/url.ml
+++ b/src/html/url.ml
@@ -219,7 +219,7 @@ let render_path : Odoc_model.Paths.Path.t -> string =
     | `Module (p, s) -> render_resolved (p :> t) ^ "." ^ (ModuleName.to_string s)
     | `Canonical (_, `Resolved p) -> render_resolved (p :> t)
     | `Canonical (p, _) -> render_resolved (p :> t)
-    | `Apply (rp, p) -> render_resolved (rp :> t) ^ "(" ^ render_path (p :> Odoc_model.Paths.Path.t) ^ ")"
+    | `Apply (rp, p) -> render_resolved (rp :> t) ^ "(" ^ render_resolved (p :> Odoc_model.Paths.Path.Resolved.t) ^ ")"
     | `ModuleType (p, s) -> render_resolved (p :> t) ^ "." ^ (ModuleTypeName.to_string s)
     | `SubstT (_, p) -> render_resolved (p :> t)
     | `Type (p, s) -> render_resolved (p :> t) ^ "." ^ (TypeName.to_string s)

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -495,6 +495,7 @@ module Path = struct
     let rec inner = function
     | `Identifier (`ModuleType (_, m)) when Names.ModuleTypeName.is_internal m -> true
     | `Identifier (`Type (_, t)) when Names.TypeName.is_internal t -> true
+    | `Identifier (`Module (_, m)) when Names.ModuleName.is_internal m -> true
     | `Identifier _ -> false
     | `Canonical (_, `Resolved _) -> false
     | `Canonical (x, _) -> inner (x : module_ :> any)

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -219,7 +219,7 @@ sig
     | `Module of module_ * ModuleName.t
     (* TODO: The canonical path should be a reference not a path *)
     | `Canonical of module_ * Path.module_
-    | `Apply of module_ * Path.module_
+    | `Apply of module_ * module_
     | `Alias of module_ * module_
     | `OpaqueModule of module_
     ]
@@ -237,7 +237,7 @@ sig
     | `Hidden of module_
     | `Module of module_ * ModuleName.t
     | `Canonical of module_ * Path.module_
-    | `Apply of module_ * Path.module_
+    | `Apply of module_ * module_
     | `Alias of module_ * module_
     | `OpaqueModule of module_
     ]

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -736,7 +736,7 @@ module Fmt = struct
     match p with
     | `Local ident -> Format.fprintf ppf "local(%a)" Ident.fmt ident
     | `Apply (p1, p2) ->
-        Format.fprintf ppf "%a(%a)" resolved_module_path p1 module_path p2
+        Format.fprintf ppf "%a(%a)" resolved_module_path p1 resolved_module_path p2
     | `Identifier p ->
         Format.fprintf ppf "identifier(%a)" model_identifier
           (p :> Odoc_model.Paths.Identifier.t)
@@ -951,8 +951,8 @@ module Fmt = struct
     | `Apply (funct, arg) ->
         Format.fprintf ppf "%a(%a)" model_resolved_path
           (funct :> t)
-          model_path
-          (arg :> Odoc_model.Paths.Path.t)
+          model_resolved_path
+          (arg :> t)
     | `Canonical (p1, p2) ->
         Format.fprintf ppf "canonical(%a,%a)" model_resolved_path
           (p1 :> t)
@@ -1496,7 +1496,7 @@ module Of_Lang = struct
     match p with
     | `Identifier i -> identifier find_any_module ident_map i
     | `Module (p, name) -> `Module (`Module (recurse p), name)
-    | `Apply (p1, p2) -> `Apply (recurse p1, module_path ident_map p2)
+    | `Apply (p1, p2) -> `Apply (recurse p1, recurse p2)
     | `Alias (p1, p2) -> `Alias (recurse p1, recurse p2)
     | `Subst (p1, p2) ->
         `Subst (resolved_module_type_path ident_map p1, recurse p2)

--- a/src/xref2/cpath.ml
+++ b/src/xref2/cpath.ml
@@ -14,7 +14,7 @@ module rec Resolved : sig
     | `Hidden of module_
     | `Module of parent * ModuleName.t
     | `Canonical of module_ * Cpath.module_
-    | `Apply of module_ * Cpath.module_
+    | `Apply of module_ * module_
     | `Alias of module_ * module_
     | `OpaqueModule of module_ ]
 
@@ -102,7 +102,7 @@ let rec resolved_module_hash : Resolved.module_ -> int = function
   | `Module (m, n) -> Hashtbl.hash (6, resolved_parent_hash m, n)
   | `Canonical (m, m2) ->
       Hashtbl.hash (7, resolved_module_hash m, module_hash m2)
-  | `Apply (m1, m2) -> Hashtbl.hash (8, resolved_module_hash m1, module_hash m2)
+  | `Apply (m1, m2) -> Hashtbl.hash (8, resolved_module_hash m1, resolved_module_hash m2)
   | `Alias (m1, m2) ->
       Hashtbl.hash (9, resolved_module_hash m1, resolved_module_hash m2)
   | `OpaqueModule m -> Hashtbl.hash (10, resolved_module_hash m)
@@ -162,7 +162,7 @@ let rec resolved_module_path_of_cpath :
   | `Canonical (a, b) ->
       `Canonical (resolved_module_path_of_cpath a, module_path_of_cpath b)
   | `Apply (a, b) ->
-      `Apply (resolved_module_path_of_cpath a, module_path_of_cpath b)
+      `Apply (resolved_module_path_of_cpath a, resolved_module_path_of_cpath b)
   | `Alias (a, b) ->
       `Alias (resolved_module_path_of_cpath a, resolved_module_path_of_cpath b)
   | `Module (p, m) -> `Module (resolved_module_path_of_cpath_parent p, m)
@@ -474,9 +474,8 @@ let rec unresolve_resolved_module_path : Resolved.module_ -> module_ = function
   | `Module (p, m) ->
       `Dot (unresolve_resolved_parent_path p, ModuleName.to_string m)
   | `Canonical (m, _) -> unresolve_resolved_module_path m
-  | `Apply (m, `Resolved a) ->
+  | `Apply (m, a) ->
       `Apply (unresolve_resolved_module_path m, unresolve_resolved_module_path a)
-  | `Apply (m, p) -> `Apply (unresolve_resolved_module_path m, p)
   | `Alias (_, m) -> unresolve_resolved_module_path m
   | `OpaqueModule m -> unresolve_resolved_module_path m
 

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -136,7 +136,7 @@ module Path = struct
     | `Hidden h -> `Hidden (resolved_module map h)
     | `Module (p, n) -> `Module (resolved_parent map p, n)
     | `Canonical (r, m) -> `Canonical (resolved_module map r, module_ map m)
-    | `Apply (m1, m2) -> `Apply (resolved_module map m1, module_ map m2)
+    | `Apply (m1, m2) -> `Apply (resolved_module map m1, resolved_module map m2)
     | `Alias (m1, m2) -> `Alias (resolved_module map m1, resolved_module map m2)
     | `OpaqueModule m -> `OpaqueModule (resolved_module map m)
 

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -32,7 +32,7 @@ let rec should_reresolve : Paths.Path.Resolved.t -> bool =
   | `Canonical (x, y) ->
       should_reresolve (x :> t) || should_resolve (y :> Paths.Path.t)
   | `Apply (x, y) ->
-      should_reresolve (x :> t) || should_resolve (y :> Paths.Path.t)
+      should_reresolve (x :> t) || should_reresolve (y :> Paths.Path.Resolved.t)
   | `SubstT (x, y) -> should_reresolve (x :> t) || should_reresolve (y :> t)
   | `Alias (x, y) -> should_reresolve (x :> t) || should_reresolve (y :> t)
   | `Type (p, _)

--- a/src/xref2/paths.md
+++ b/src/xref2/paths.md
@@ -261,8 +261,7 @@ path as this `` `Subst `` constructor:
          `Module
            (`Apply
               (`Identifier (`Module (`Root (Common.root, Root), F)),
-               `Resolved
-                 (`Identifier (`Module (`Root (Common.root, Root), M)))),
+               `Identifier (`Module (`Root (Common.root, Root), M))),
             N)),
       t))
 ```

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -114,7 +114,7 @@ let rec resolved_module_path :
       | Some `Substituted -> `Substituted p
       | None -> p )
   | `Identifier _ -> p
-  | `Apply (p1, p2) -> `Apply (resolved_module_path s p1, module_path s p2)
+  | `Apply (p1, p2) -> `Apply (resolved_module_path s p1, resolved_module_path s p2)
   | `Substituted p -> `Substituted (resolved_module_path s p)
   | `Module (p, n) -> `Module (resolved_parent_path s p, n)
   | `Alias (p1, p2) ->

--- a/src/xref2/test.md
+++ b/src/xref2/test.md
@@ -773,10 +773,9 @@ Some
                   (`Module
                      (`Identifier (`Module (`Root (Common.root, Root), M)),
                       F),
-                   `Resolved
-                     (`Module
-                        (`Identifier (`Module (`Root (Common.root, Root), M)),
-                         T))),
+                   `Module
+                     (`Identifier (`Module (`Root (Common.root, Root), M)),
+                      T)),
                 N)),
           t)),
    []))
@@ -864,10 +863,8 @@ Some
             (`Apply
                (`Module
                   (`Identifier (`Module (`Root (Common.root, Root), M)), O),
-                `Resolved
-                  (`Module
-                     (`Identifier (`Module (`Root (Common.root, Root), M)),
-                      T))),
+                `Module
+                  (`Identifier (`Module (`Root (Common.root, Root), M)), T)),
              N),
           t)),
    []))
@@ -945,15 +942,11 @@ val p : Cpath.Resolved.module_ =
     (`Apply
        (`Apply
           (`Identifier (`Module (`Root (Common.root, Root), App)),
-           `Resolved
-             (`Substituted
-                (`Identifier (`Module (`Root (Common.root, Root), Bar))))),
-        `Resolved
-          (`Substituted
-             (`Identifier (`Module (`Root (Common.root, Root), Foo))))),
-     `Resolved
-       (`Substituted
-          (`Identifier (`Module (`Root (Common.root, Root), FooBarInt)))))
+           `Substituted
+             (`Identifier (`Module (`Root (Common.root, Root), Bar)))),
+        `Substituted (`Identifier (`Module (`Root (Common.root, Root), Foo)))),
+     `Substituted
+       (`Identifier (`Module (`Root (Common.root, Root), FooBarInt))))
 val m : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
@@ -1001,15 +994,11 @@ Some
                      (`Apply
                         (`Identifier
                            (`Module (`Root (Common.root, Root), App)),
-                         `Resolved
-                           (`Identifier
-                              (`Module (`Root (Common.root, Root), Bar)))),
-                      `Resolved
-                        (`Identifier
-                           (`Module (`Root (Common.root, Root), Foo)))),
-                   `Resolved
-                     (`Identifier
-                        (`Module (`Root (Common.root, Root), FooBarInt)))),
+                         `Identifier
+                           (`Module (`Root (Common.root, Root), Bar))),
+                      `Identifier (`Module (`Root (Common.root, Root), Foo))),
+                   `Identifier
+                     (`Module (`Root (Common.root, Root), FooBarInt))),
                 Foo)),
           bar)),
    []))
@@ -1047,8 +1036,7 @@ Some
             (`Apply
                (`Module
                   (`Identifier (`Module (`Root (Common.root, Root), M)), O),
-                `Resolved
-                  (`Identifier (`Module (`Root (Common.root, Root), M)))),
+                `Identifier (`Module (`Root (Common.root, Root), M))),
              N),
           t)),
    []))
@@ -1099,16 +1087,14 @@ Some
                      (`Apply
                         (`Identifier
                            (`Module (`Root (Common.root, Root), Dep2)),
-                         `Resolved
-                           (`Identifier
-                              (`Module (`Root (Common.root, Root), Dep1)))),
+                         `Identifier
+                           (`Module (`Root (Common.root, Root), Dep1))),
                       A),
                    Y)),
              `Module
                (`Apply
                   (`Identifier (`Module (`Root (Common.root, Root), Dep2)),
-                   `Resolved
-                     (`Identifier (`Module (`Root (Common.root, Root), Dep1)))),
+                   `Identifier (`Module (`Root (Common.root, Root), Dep1))),
                 B)),
           c)),
    []))
@@ -1158,9 +1144,7 @@ Some
                (`Module
                   (`Apply
                      (`Identifier (`Module (`Root (Common.root, Root), Dep5)),
-                      `Resolved
-                        (`Identifier
-                           (`Module (`Root (Common.root, Root), Dep4)))),
+                      `Identifier (`Module (`Root (Common.root, Root), Dep4))),
                    Z),
                 X)),
           b)),
@@ -1177,9 +1161,7 @@ Some
                (`Module
                   (`Apply
                      (`Identifier (`Module (`Root (Common.root, Root), Dep5)),
-                      `Resolved
-                        (`Identifier
-                           (`Module (`Root (Common.root, Root), Dep4)))),
+                      `Identifier (`Module (`Root (Common.root, Root), Dep4))),
                    Z),
                 Y)),
           a)),
@@ -1237,9 +1219,8 @@ Some
                         (`Apply
                            (`Identifier
                               (`Module (`Root (Common.root, Root), Dep7)),
-                            `Resolved
-                              (`Identifier
-                                 (`Module (`Root (Common.root, Root), Dep6)))),
+                            `Identifier
+                              (`Module (`Root (Common.root, Root), Dep6))),
                          M)),
                    R)),
              `Module
@@ -1251,9 +1232,8 @@ Some
                      (`Apply
                         (`Identifier
                            (`Module (`Root (Common.root, Root), Dep7)),
-                         `Resolved
-                           (`Identifier
-                              (`Module (`Root (Common.root, Root), Dep6)))),
+                         `Identifier
+                           (`Module (`Root (Common.root, Root), Dep6))),
                       M)),
                 Y)),
           d)),
@@ -1512,9 +1492,7 @@ let module_M_expansion =
                 (`Type
                    (`Apply
                       (`Identifier (`Module (`Root (Common.root, Root), Foo)),
-                       `Resolved
-                         (`Identifier
-                            (`Module (`Root (Common.root, Root), Bar)))),
+                       `Identifier (`Module (`Root (Common.root, Root), Bar))),
                     t)),
              [])];
          res = None}])})]

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -369,7 +369,7 @@ let rec handle_apply ~mark_substituted env func_path arg_path m =
     if mark_substituted then `Substituted arg_path else arg_path
   in
 
-  let path = `Apply (func_path, `Resolved substitution) in
+  let path = `Apply (func_path, substitution) in
   Ok
     ( path,
       Subst.module_
@@ -495,7 +495,7 @@ and lookup_module :
         of_option ~error:(`Lookup_failure i) (Env.(lookup_by_id s_module) i env)
         >>= fun (`Module (_, m)) -> Ok m
     | `Substituted x -> lookup_module ~mark_substituted env x
-    | `Apply (functor_path, `Resolved argument_path) -> (
+    | `Apply (functor_path, argument_path) -> (
         match lookup_module ~mark_substituted env functor_path with
         | Ok functor_module ->
             let functor_module = Component.Delayed.get functor_module in
@@ -520,7 +520,6 @@ and lookup_module :
     | `SubstAlias (_, p) -> lookup_module ~mark_substituted env p
     | `Hidden p -> lookup_module ~mark_substituted env p
     | `Canonical (p, _) -> lookup_module ~mark_substituted env p
-    | `Apply (_, _) -> Error `Unresolved_apply
     | `OpaqueModule m -> lookup_module ~mark_substituted env m
   in
   LookupModuleMemo.memoize lookup env' (m, path')
@@ -917,10 +916,10 @@ and reresolve_module : Env.t -> Cpath.Resolved.module_ -> Cpath.Resolved.module_
   match path with
   | `Local _ | `Identifier _ -> path
   | `Substituted x -> `Substituted (reresolve_module env x)
-  | `Apply (functor_path, `Resolved argument_path) ->
+  | `Apply (functor_path, argument_path) ->
       `Apply
         ( reresolve_module env functor_path,
-          `Resolved (reresolve_module env argument_path) )
+          (reresolve_module env argument_path) )
   | `Module (parent, name) -> `Module (reresolve_parent env parent, name)
   | `Alias (p1, p2) -> `Alias (reresolve_module env p1, reresolve_module env p2)
   | `Subst (p1, p2) ->
@@ -948,12 +947,6 @@ and reresolve_module : Env.t -> Cpath.Resolved.module_ -> Cpath.Resolved.module_
               `Resolved (simplify_resolved_module_path env p2') )
       | Error _ -> `Canonical (reresolve_module env p, p2)
       | exception _ -> `Canonical (reresolve_module env p, p2) )
-  | `Apply (p, p2) -> (
-      match
-        resolve_module ~mark_substituted:true ~add_canonical:false env p2
-      with
-      | Ok (p2', _) -> `Apply (reresolve_module env p, `Resolved p2')
-      | Error _ -> `Apply (reresolve_module env p, p2) )
   | `OpaqueModule m -> `OpaqueModule (reresolve_module env m)
 
 and reresolve_module_type :
@@ -1329,11 +1322,9 @@ and find_external_module_path :
       | Some x, None -> Some x
       | None, Some x -> Some x
       | None, None -> None )
-  | `Apply (x, `Resolved y) ->
-      find_external_module_path x >>= fun x ->
-      find_external_module_path y >>= fun y -> Some (`Apply (x, `Resolved y))
   | `Apply (x, y) ->
-      find_external_module_path x >>= fun x -> Some (`Apply (x, y))
+      find_external_module_path x >>= fun x ->
+      find_external_module_path y >>= fun y -> Some (`Apply (x, y))
   | `Identifier x -> Some (`Identifier x)
   | `OpaqueModule m ->
       find_external_module_path m >>= fun x -> Some (`OpaqueModule x)

--- a/test/print/print.ml
+++ b/test/print/print.ml
@@ -109,7 +109,7 @@ struct
     |`Canonical (m, p) ->
       List [Atom "canonical"; resolved (m :> Resolved.t); path (p :> Path.t)]
     |`Apply (m, p) ->
-      List [Atom "apply"; resolved (m :> Resolved.t); path (p :> Path.t)]
+      List [Atom "apply"; resolved (m :> Resolved.t); resolved (p :> Resolved.t)]
     |`ModuleType (m, s) ->
       List [Atom "module_type"; Atom (ModuleTypeName.to_string s); resolved (m :> Resolved.t)]
     |`Type (m, s) ->

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -506,7 +506,7 @@ module LangUtils = struct
         and resolved_path : Format.formatter -> Odoc_model.Paths.Path.Resolved.t -> unit = fun ppf p ->
             let cast p = (p :> Odoc_model.Paths.Path.Resolved.t) in 
             match p with
-            | `Apply (p1, p2) -> Format.fprintf ppf "%a(%a)" resolved_path (cast p1) path (p2 :> Odoc_model.Paths.Path.t)
+            | `Apply (p1, p2) -> Format.fprintf ppf "%a(%a)" resolved_path (cast p1) resolved_path (cast p2)
             | `Identifier p -> Format.fprintf ppf "global(%a)" identifier p
             | `Alias (path, realpath) -> Format.fprintf ppf "(%a -> %a)" resolved_path (cast path) resolved_path (cast realpath)
             | `Subst (modty, m) -> Format.fprintf ppf "(%a subst-> %a)" resolved_path (cast modty) resolved_path (cast m)

--- a/test/xref2/resolve/test.md
+++ b/test/xref2/resolve/test.md
@@ -789,7 +789,7 @@ AFTER
 module type (root Root).Type = sig
   module type (root Root).Type.T
   end
-module (root Root).App : ((param (root Root).App T) : resolved[global((root Root).Type)]) -> ((param (root Root).App.result F) : ((param (param (root Root).App.result F) _) : resolved[global((root Root).Type)]) -> resolved[global((root Root).Type)]) -> ((param (root Root).App.result.result M) : resolved[opaquemoduletype(global((param (root Root).App.result F))(resolved[global((param (root Root).App T))]).T)]) -> resolved[opaquemoduletype(global((param (root Root).App.result F))(resolved[global((param (root Root).App T))]).T)]
+module (root Root).App : ((param (root Root).App T) : resolved[global((root Root).Type)]) -> ((param (root Root).App.result F) : ((param (param (root Root).App.result F) _) : resolved[global((root Root).Type)]) -> resolved[global((root Root).Type)]) -> ((param (root Root).App.result.result M) : resolved[opaquemoduletype(global((param (root Root).App.result F))(global((param (root Root).App T))).T)]) -> resolved[opaquemoduletype(global((param (root Root).App.result F))(global((param (root Root).App T))).T)]
 module (root Root).Bar : sig
   module type (root Root).Bar.T = sig
     type (root Root).Bar.T.bar
@@ -805,7 +805,7 @@ module (root Root).FooBarInt : sig
     type (root Root).FooBarInt.Foo.bar = resolved[global(int)]
     end
   end
-type (root Root).t = resolved[(global((root Root).Bar).T subst-> global((root Root).App)(resolved[global((root Root).Bar)])(resolved[global((root Root).Foo)])(resolved[global((root Root).FooBarInt)]).Foo).bar]
+type (root Root).t = resolved[(global((root Root).Bar).T subst-> global((root Root).App)(global((root Root).Bar))(global((root Root).Foo))(global((root Root).FooBarInt)).Foo).bar]
 
 - : unit = ()
 ```


### PR DESCRIPTION
As discussed in the previous dev meeting. This fixes the expansion of a few modules, though it's not entirely clear why. We may well want to relax this condition in the future as many functor bodies can be expanded even if the argument is unresolved, as it's usually the case that the result is independent of the argument.

Signed-off-by: Jon Ludlam <jon@recoil.org>