### PR TITLE
latex backend: minor rendering tweaks

### DIFF
--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -348,10 +348,11 @@ and small_table ppf tbl =
       break ppf Line in
     let matrix ppf m = List.iter (row ppf) m in
     let rec repeat n s ppf = if n = 0 then () else
-        Fmt.pf ppf "%c%t" s (repeat (n - 1) s) in
+        Fmt.pf ppf "%t%t" s (repeat (n - 1) s) in
+    let cell ppf = Fmt.pf ppf "p{%.3f\\textwidth}" (1.0 /. float_of_int columns) in
     let table ppf tbl = env "longtable"
       ~opts:[const "l"]
-      ~args:[ repeat columns 'l' ]
+      ~args:[ repeat columns cell ]
       matrix ppf tbl in
     Fmt.pf ppf {|{\setlength{\LTpre}{0pt}\setlength{\LTpost}{0pt}%a}|}
     table tbl

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -169,13 +169,13 @@ let inline_code = macro "inlinecode"
 let mhyperref pp r ppf =
   match r.target, r.text with
   | "", None -> ()
-  | "", Some content ->  pp ppf content
+  | "", Some content ->  inline_code pp ppf content
   | s, None ->
     macro "ref" escape_ref ppf s
   | s, Some content ->
       let pp =
-        if r.short then pp else
-          fun ppf x -> Fmt.pf ppf "%a[p%a]" pp x (macro "pageref*" escape_ref) s in
+        if r.short then inline_code pp else
+          fun ppf x -> Fmt.pf ppf "%a[p%a]" (inline_code pp) x (macro "pageref*" escape_ref) s in
       macro "hyperref" ~options:[bind escape_ref s] pp ppf content
 
 let label = function


### PR DESCRIPTION
This PR implements three small tweaks on the latex backend:

1. the description of signature items is now indented.
> val foo: int
>     The documentation is indented
>     Compared to the item itself      

2. Small tables uses now paragraph columns: overfull cells are rendered with a line break rather than overflow

3. Internal references use a monospace fonts. 