### PR TITLE
Fix `module type of` expansions

### DIFF
--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1434,8 +1434,8 @@ struct
     | With (_, umt) -> extract_path_from_umt ~default umt
     | Path (`Resolved r) ->
       (Paths.Path.Resolved.ModuleType.identifier r :> Paths.Identifier.Signature.t)
-    | TypeOf (ModPath (`Resolved r)) 
-    | TypeOf (StructInclude (`Resolved r)) ->
+    | TypeOf { t_desc = ModPath (`Resolved r); _ } 
+    | TypeOf { t_desc = StructInclude (`Resolved r); _ } ->
       (Paths.Path.Resolved.Module.identifier r :> Paths.Identifier.Signature.t)
     | _ -> default
 
@@ -1508,8 +1508,8 @@ struct
     = function
     | Path p -> Paths.Path.(is_hidden (p :> t))
     | With (_, expr) -> umty_hidden expr
-    | TypeOf (ModPath m)
-    | TypeOf (StructInclude m) ->
+    | TypeOf { t_desc = ModPath m; _}
+    | TypeOf { t_desc = StructInclude m; _} ->
       Paths.Path.(is_hidden (m :> t))
     | Signature _ -> false
   
@@ -1561,7 +1561,7 @@ struct
       match m with
       | Path p -> Link.from_path (p :> Paths.Path.t)
       | With (subs, expr) -> mty_with base subs expr
-      | TypeOf t_desc -> mty_typeof t_desc
+      | TypeOf { t_desc; _ } -> mty_typeof t_desc
       | Signature _ ->
         Syntax.Mod.open_tag ++ O.txt " ... " ++ Syntax.Mod.close_tag
 

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -60,17 +60,23 @@ and ModuleType : sig
     | ModPath of Path.Module.t
     | StructInclude of Path.Module.t
 
+  type simple_expansion =
+    | Signature of Signature.t
+    | Functor of FunctorParameter.t * simple_expansion
+  
+  type typeof_t = {
+    t_desc : type_of_desc;
+    t_expansion : simple_expansion option
+  }
+  
   module U : sig
     type expr =
         | Path of Path.ModuleType.t
         | Signature of Signature.t
         | With of substitution list * expr
-        | TypeOf of type_of_desc
+        | TypeOf of typeof_t (* Nb. this may have an expansion! *)
   end
   
-  type simple_expansion =
-    | Signature of Signature.t
-    | Functor of FunctorParameter.t * simple_expansion
 
   type path_t = {
     p_expansion : simple_expansion option;
@@ -83,10 +89,6 @@ and ModuleType : sig
     w_expr : U.expr
   }
 
-  type typeof_t = {
-    t_desc : type_of_desc;
-    t_expansion : simple_expansion option
-  }
 
   type expr =
     | Path of path_t
@@ -456,5 +458,5 @@ let umty_of_mty : ModuleType.expr -> ModuleType.U.expr =
   | Signature sg -> Signature sg
   | Path { p_path; _} -> Path p_path
   | Functor _ -> assert false
-  | TypeOf { t_desc; _} -> TypeOf t_desc
+  | TypeOf t -> TypeOf t
   | With {w_substitutions; w_expr; _ } -> With (w_substitutions, w_expr)

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -119,7 +119,7 @@ and moduletype_u_expr =
     | Signature x -> C ("Signature", x, signature_t)
     | With (t, e) ->
       C ("With", (t, e), Pair (List moduletype_substitution, moduletype_u_expr))
-    | TypeOf x -> C ("TypeOf", x, moduletype_type_of_desc))
+    | TypeOf x -> C ("TypeOf", x, moduletype_typeof_t))
 
 and moduletype_t =
   let open Lang.ModuleType in

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -62,8 +62,14 @@ and content env id =
   let open Compilation_unit in
   function
   | Module m ->
-    let sg = Type_of.signature env m in
-    Tools.reset_caches ();
+    let rec loop sg =
+      Type_of.again := false;
+      let sg' = Type_of.signature env sg in
+      Tools.reset_caches ();
+      if !Type_of.again
+      then loop sg'
+      else sg' in
+    let sg = loop m in
     Module (signature env (id :> Id.Signature.t) sg)
   | Pack _ -> failwith "Unhandled content"
 

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -429,8 +429,8 @@ let rec find_parent : Component.ModuleType.U.expr -> Cfrag.root option =
    | Path (`Resolved p) -> Some (`ModuleType p)
    | Path _ -> None
    | With (_, e) -> find_parent e
-   | TypeOf ModPath (`Resolved p)
-   | TypeOf StructInclude (`Resolved p) -> Some (`Module p)
+   | TypeOf {t_desc = ModPath (`Resolved p); _}
+   | TypeOf { t_desc = StructInclude (`Resolved p); _ } -> Some (`Module p)
    | TypeOf _ -> None
 in
   match find_parent cexpr with
@@ -483,12 +483,12 @@ and u_module_type_expr :
         match subs' with
         | None -> With (subs, expr)
         | Some s -> With (s, expr))
-    | TypeOf t_desc ->
+    | TypeOf { t_desc; t_expansion } ->
       let t_desc = match t_desc with
         | ModPath p -> ModPath (module_path env p)
         | StructInclude p -> StructInclude (module_path env p)
       in
-      TypeOf t_desc
+      TypeOf { t_desc; t_expansion }
   in
   inner expr
 

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -61,7 +61,10 @@ let rec unit (resolver : Env.resolver) t =
 and content env id =
   let open Compilation_unit in
   function
-  | Module m -> Module (signature env (id :> Id.Signature.t) m)
+  | Module m ->
+    let sg = Type_of.signature env m in
+    Tools.reset_caches ();
+    Module (signature env (id :> Id.Signature.t) sg)
   | Pack _ -> failwith "Unhandled content"
 
 and value_ env parent t =

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -419,6 +419,7 @@ and Substitution : sig
     class_type : subst_class_type PathClassTypeMap.t;
     type_replacement : TypeExpr.t PathTypeMap.t;
     path_invalidating_modules : Ident.path_module list;
+    module_type_of_invalidating_modules : Ident.path_module list;
   }
 end =
   Substitution

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -418,7 +418,7 @@ and Substitution : sig
     type_ : subst_type PathTypeMap.t;
     class_type : subst_class_type PathClassTypeMap.t;
     type_replacement : TypeExpr.t PathTypeMap.t;
-    invalidated_modules : Ident.path_module list;
+    path_invalidating_modules : Ident.path_module list;
   }
 end =
   Substitution

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -393,6 +393,7 @@ and Substitution : sig
     class_type : subst_class_type PathClassTypeMap.t;
     type_replacement : TypeExpr.t PathTypeMap.t;
     path_invalidating_modules : Ident.path_module list;
+    module_type_of_invalidating_modules : Ident.path_module list;
   }
 end
 

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -392,7 +392,7 @@ and Substitution : sig
     type_ : subst_type PathTypeMap.t;
     class_type : subst_class_type PathClassTypeMap.t;
     type_replacement : TypeExpr.t PathTypeMap.t;
-    invalidated_modules : Ident.path_module list;
+    path_invalidating_modules : Ident.path_module list;
   }
 end
 

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -171,18 +171,23 @@ and ModuleType : sig
     | ModPath of Cpath.module_
     | StructInclude of Cpath.module_
 
+  type simple_expansion =
+    | Signature of Signature.t
+    | Functor of FunctorParameter.t * simple_expansion
+  
+  type typeof_t = {
+    t_desc : type_of_desc;
+    t_expansion : simple_expansion option
+  }
+  
   module U : sig
     type expr =
     | Path of Cpath.module_type
     | Signature of Signature.t
     | With of substitution list * expr
-    | TypeOf of type_of_desc
+    | TypeOf of typeof_t
   end
 
-  type simple_expansion =
-    | Signature of Signature.t
-    | Functor of FunctorParameter.t * simple_expansion
-  
   type path_t = {
     p_expansion : simple_expansion option;
     p_path : Cpath.module_type
@@ -194,10 +199,6 @@ and ModuleType : sig
     w_expr : U.expr;
   }
 
-  type typeof_t = {
-    t_desc : type_of_desc;
-    t_expansion : simple_expansion option
-  }
 
   type expr =
     | Path of path_t

--- a/src/xref2/expand_tools.ml
+++ b/src/xref2/expand_tools.ml
@@ -124,9 +124,7 @@ and aux_expansion_of_u_module_type_expr env expr :
     let subs = unresolve_subs subs in
     Tools.handle_signature_with_subs ~mark_substituted:false env sg subs)
   | TypeOf { t_expansion = Some (Signature sg); _} -> Ok sg
-  | TypeOf { t_desc; _ } ->
-    aux_expansion_of_module_type_type_of_desc env t_desc
-    >>= assert_not_functor
+  | TypeOf _ -> raise Tools.UnexpandedTypeOf
 
 and aux_expansion_of_module_type_expr env expr :
     (expansion, signature_of_module_error) Result.result =
@@ -144,8 +142,8 @@ and aux_expansion_of_module_type_expr env expr :
       >>= fun sg -> Ok (Signature sg)
   | Functor (arg, expr) -> Ok (Functor (arg, expr))
   | TypeOf {t_expansion = Some (Signature sg); _} -> Ok (Signature sg)
-  | TypeOf {t_desc; _} -> aux_expansion_of_module_type_type_of_desc env t_desc
-
+  | TypeOf _ -> raise Tools.UnexpandedTypeOf
+  
 and aux_expansion_of_module_type env mt =
   let open Component.ModuleType in
   match mt.expr with

--- a/src/xref2/expand_tools.ml
+++ b/src/xref2/expand_tools.ml
@@ -179,6 +179,11 @@ and handle_expansion env id expansion =
             (`Resolved (`Identifier identifier))
             (`Identifier identifier) Subst.identity
         in
+        let subst =
+          Subst.mto_invalidate_module
+            (arg.id :> Ident.path_module)
+            subst
+        in
         (env', Subst.module_type_expr subst expr)
   in
   let rec expand id env expansion : (Env.t * Component.ModuleType.simple_expansion, _) Result.result =

--- a/src/xref2/expand_tools.ml
+++ b/src/xref2/expand_tools.ml
@@ -123,6 +123,7 @@ and aux_expansion_of_u_module_type_expr env expr :
     >>= fun sg ->
     let subs = unresolve_subs subs in
     Tools.handle_signature_with_subs ~mark_substituted:false env sg subs)
+  | TypeOf { t_expansion = Some (Signature sg); _} -> Ok sg
   | TypeOf { t_desc; _ } ->
     aux_expansion_of_module_type_type_of_desc env t_desc
     >>= assert_not_functor
@@ -142,6 +143,7 @@ and aux_expansion_of_module_type_expr env expr :
       Tools.handle_signature_with_subs ~mark_substituted:false env sg subs)
       >>= fun sg -> Ok (Signature sg)
   | Functor (arg, expr) -> Ok (Functor (arg, expr))
+  | TypeOf {t_expansion = Some (Signature sg); _} -> Ok (Signature sg)
   | TypeOf {t_desc; _} -> aux_expansion_of_module_type_type_of_desc env t_desc
 
 and aux_expansion_of_module_type env mt =
@@ -200,6 +202,11 @@ let expansion_of_module_type_expr env id expr =
   aux_expansion_of_module_type_expr env expr >>= handle_expansion env id
   >>= fun (env, e) -> Ok (env, module_type_expr_needs_recompile expr, e)
 
+let expansion_of_u_module_type_expr env id expr =
+  aux_expansion_of_u_module_type_expr env expr
+  >>= fun sg -> handle_expansion env id (Signature sg)
+  >>= fun (env, e) -> Ok (env, false, e)
+  
 let expansion_of_module_alias env id path =
   let open Paths.Identifier in
   aux_expansion_of_module_alias ~strengthen:false env path

--- a/src/xref2/expand_tools.ml
+++ b/src/xref2/expand_tools.ml
@@ -123,7 +123,7 @@ and aux_expansion_of_u_module_type_expr env expr :
     >>= fun sg ->
     let subs = unresolve_subs subs in
     Tools.handle_signature_with_subs ~mark_substituted:false env sg subs)
-  | TypeOf t_desc ->
+  | TypeOf { t_desc; _ } ->
     aux_expansion_of_module_type_type_of_desc env t_desc
     >>= assert_not_functor
 

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -671,8 +671,8 @@ and u_module_type_expr map identifier =
           map s)
   | With (subs, expr) ->
       With (List.map (mty_substitution map identifier) subs, u_module_type_expr map identifier expr)
-  | TypeOf (ModPath p) -> TypeOf (ModPath (Path.module_ map p))
-  | TypeOf (StructInclude p)-> TypeOf (StructInclude (Path.module_ map p))
+  | TypeOf { t_desc = ModPath p; t_expansion } -> TypeOf { t_desc = ModPath (Path.module_ map p); t_expansion = Opt.map (simple_expansion map identifier) t_expansion }
+  | TypeOf { t_desc = StructInclude p; t_expansion }-> TypeOf { t_desc = StructInclude (Path.module_ map p); t_expansion = Opt.map (simple_expansion map identifier) t_expansion }
 
 and module_type_expr map identifier =
   function

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -590,6 +590,7 @@ and module_type_expr :
           unresolved )
   | Functor (arg, res) ->
       let arg' = functor_argument env arg in
+      let env = Env.add_functor_parameter arg env in
       let res' = module_type_expr env (`Result id) res in
       Functor (arg', res')
   | TypeOf {t_desc=StructInclude p; t_expansion} -> TypeOf {t_desc=StructInclude (module_path env p); t_expansion=do_expn t_expansion}

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -565,8 +565,8 @@ and u_module_type_expr :
       | Error e ->
           Errors.report ~what:(`Module_type_U cexpr) ~tools_error:e `Resolve;
           unresolved )
-  | TypeOf (StructInclude p)-> TypeOf (StructInclude (module_path env p))
-  | TypeOf (ModPath p) -> TypeOf (ModPath (module_path env p))
+  | TypeOf { t_desc = StructInclude p; t_expansion }-> TypeOf { t_desc = StructInclude (module_path env p); t_expansion }
+  | TypeOf { t_desc = ModPath p; t_expansion } -> TypeOf { t_desc = ModPath (module_path env p); t_expansion }
 
 and module_type_expr :
     Env.t -> Id.Signature.t -> ModuleType.expr -> ModuleType.expr =

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -783,7 +783,7 @@ and type_expression : Env.t -> Id.Signature.t -> _ -> _ =
                       Constr (`Resolved p, ts) )
               | _ ->
                 Constr (`Resolved p, ts)
-            else ( Format.eprintf "not hidden...?"; Constr (`Resolved p, ts))
+            else (Constr (`Resolved p, ts))
         | Ok (cp', Found _) ->
             let p = Cpath.resolved_type_path_of_cpath cp' in
             Constr (`Resolved p, ts)

--- a/src/xref2/strengthen.ml
+++ b/src/xref2/strengthen.ml
@@ -69,7 +69,7 @@ let rec signature :
       ([],[]) sg.items
   in
   (* Format.eprintf "Invalidating modules: %a\n%!" (Format.pp_print_list Ident.fmt) strengthened_modules; *)
-  let substs = List.fold_left (fun s mid -> Subst.invalidate_module (mid :> Ident.path_module) s) Subst.identity strengthened_modules in
+  let substs = List.fold_left (fun s mid -> Subst.path_invalidate_module (mid :> Ident.path_module) s) Subst.identity strengthened_modules in
   Subst.signature substs { items = List.rev items; removed = sg.removed }
 
 and module_ :

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -429,7 +429,7 @@ and u_module_type_expr s t =
   | Path p -> Path (module_type_path s p)
   | Signature sg -> Signature (signature s sg)
   | With (subs, e) -> With (List.map (module_type_substitution s) subs, u_module_type_expr s e)
-  | TypeOf desc -> TypeOf (module_type_type_of_desc s desc)
+  | TypeOf { t_desc; t_expansion } -> TypeOf { t_desc = module_type_type_of_desc s t_desc; t_expansion = option_ simple_expansion s t_expansion }
 
 and module_type_expr s t =
   let open Component.ModuleType in

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -14,11 +14,12 @@ let identity =
     type_ = PathTypeMap.empty;
     class_type = PathClassTypeMap.empty;
     type_replacement = PathTypeMap.empty;
-    invalidated_modules = [];
+    path_invalidating_modules = [];
+
   }
 
 let invalidate_module id t =
-  { t with invalidated_modules = id :: t.invalidated_modules }
+  { t with path_invalidating_modules = id :: t.path_invalidating_modules }
 
 let add_module id p rp t =
   { t with module_ = PathModuleMap.add id (`Prefixed (p, rp)) t.module_ }
@@ -79,7 +80,7 @@ let add_module_substitution : Ident.path_module -> t -> t =
  fun id t ->
   {
     t with
-    invalidated_modules = id :: t.invalidated_modules;
+    path_invalidating_modules = id :: t.path_invalidating_modules;
     module_ = PathModuleMap.add id `Substituted t.module_;
   }
 
@@ -107,7 +108,7 @@ let rec resolved_module_path :
  fun s p ->
   match p with
   | `Local id -> (
-      if List.mem id s.invalidated_modules then raise Invalidated;
+      if List.mem id s.path_invalidating_modules then raise Invalidated;
       match
         try Some (PathModuleMap.find (id :> Ident.path_module) s.module_)
         with _ -> None

--- a/src/xref2/subst.mli
+++ b/src/xref2/subst.mli
@@ -4,7 +4,9 @@ type t = Component.Substitution.t
 
 val identity : t
 
-val invalidate_module : Ident.path_module -> t -> t
+val path_invalidate_module : Ident.path_module -> t -> t
+
+val mto_invalidate_module : Ident.path_module -> t -> t
 
 val add_module :
   Ident.path_module -> Cpath.module_ -> Cpath.Resolved.module_ -> t -> t

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -1008,6 +1008,7 @@ and signature_of_u_module_type_expr :
   | With (subs, s) ->
       signature_of_u_module_type_expr ~mark_substituted env s >>= fun sg ->
       handle_signature_with_subs ~mark_substituted env sg subs
+  | TypeOf { t_expansion = Some (Signature sg); _ } -> Ok sg
   | TypeOf { t_desc = StructInclude p; _ } -> signature_of_module_path env ~strengthen:true p
   | TypeOf { t_desc = ModPath p; _ } -> signature_of_module_path env ~strengthen:false p
     

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -1111,13 +1111,6 @@ and fragmap :
         Ok (ModuleType (Signature sg))
     (* | ModuleType (With (mty', subs')) ->
         Ok (ModuleType (With (mty', subs' @ [ subst ]))) *)
-    | ModuleType (Signature sg as mty') -> begin
-      match fragmap ~mark_substituted env subst sg with
-      | Ok sg' ->
-        Ok (ModuleType (Signature sg'))
-      | Error _ ->
-        Ok (ModuleType (With {w_substitutions=[ subst ]; w_expansion=None; w_expr=umty_of_mty mty'}))
-      end
     | ModuleType mty' -> Ok (ModuleType (With {w_substitutions=[ subst ]; w_expansion=None; w_expr = umty_of_mty mty'}))
   in
   let map_include_decl decl subst =

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -4,6 +4,7 @@ open Odoc_model.Names
 open Utils
 open ResultMonad
 
+exception UnexpandedTypeOf
 type ('a, 'b) either = Left of 'a | Right of 'b
 
 type module_modifiers =
@@ -1009,9 +1010,8 @@ and signature_of_u_module_type_expr :
       signature_of_u_module_type_expr ~mark_substituted env s >>= fun sg ->
       handle_signature_with_subs ~mark_substituted env sg subs
   | TypeOf { t_expansion = Some (Signature sg); _ } -> Ok sg
-  | TypeOf { t_desc = StructInclude p; _ } -> signature_of_module_path env ~strengthen:true p
-  | TypeOf { t_desc = ModPath p; _ } -> signature_of_module_path env ~strengthen:false p
-    
+  | TypeOf _ -> raise UnexpandedTypeOf
+
 and signature_of_simple_expansion : Component.ModuleType.simple_expansion -> Component.Signature.t =
     function
     | Signature sg -> sg
@@ -1043,9 +1043,7 @@ and signature_of_module_type_expr :
       signature_of_module_type_expr ~mark_substituted env expr
   | Component.ModuleType.TypeOf { t_expansion = Some e; _ } ->
     Ok (signature_of_simple_expansion e)
-  | Component.ModuleType.TypeOf { t_desc = StructInclude p; _} -> signature_of_module_path env ~strengthen:true p
-  | Component.ModuleType.TypeOf { t_desc = ModPath p; _} -> signature_of_module_path env ~strengthen:false p
-    
+  | Component.ModuleType.TypeOf _ -> raise UnexpandedTypeOf
 
 and signature_of_module_type :
     Env.t ->

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -1008,8 +1008,8 @@ and signature_of_u_module_type_expr :
   | With (subs, s) ->
       signature_of_u_module_type_expr ~mark_substituted env s >>= fun sg ->
       handle_signature_with_subs ~mark_substituted env sg subs
-  | TypeOf (StructInclude p) -> signature_of_module_path env ~strengthen:true p
-  | TypeOf (ModPath p) -> signature_of_module_path env ~strengthen:false p
+  | TypeOf { t_desc = StructInclude p; _ } -> signature_of_module_path env ~strengthen:true p
+  | TypeOf { t_desc = ModPath p; _ } -> signature_of_module_path env ~strengthen:false p
     
 and signature_of_simple_expansion : Component.ModuleType.simple_expansion -> Component.Signature.t =
     function
@@ -1087,7 +1087,7 @@ and umty_of_mty : Component.ModuleType.expr -> Component.ModuleType.U.expr =
     function
     | Signature sg -> Signature sg
     | Path { p_path; _ } -> Path p_path
-    | TypeOf { t_desc; _ } -> TypeOf t_desc
+    | TypeOf t -> TypeOf t
     | With {w_substitutions; w_expr; _} -> With (w_substitutions, w_expr)
     | Functor _ -> assert false
 

--- a/src/xref2/tools.mli
+++ b/src/xref2/tools.mli
@@ -7,6 +7,8 @@
 
 open Errors.Tools_error
 
+exception UnexpandedTypeOf
+
 (** {2 Lookup and resolve functions} *)
 
 (** The following lookup and resolve functions take {{!module:Cpath.Resolved}resolved paths}

--- a/src/xref2/type_of.ml
+++ b/src/xref2/type_of.ml
@@ -1,0 +1,79 @@
+(* Type_of.ml *)
+
+(* Deals with expanding `module type of` expressions *)
+
+open Odoc_model
+open Lang
+module Id = Odoc_model.Paths.Identifier
+
+
+let rec signature : Env.t -> Signature.t -> Signature.t =
+  fun env sg ->
+    let env = Env.open_signature sg env in
+    signature_items env sg
+
+and signature_items : Env.t -> Signature.t -> Signature.t =
+    fun env s ->
+     let open Signature in
+     List.map
+       (fun item ->
+         match item with
+         | Module (r, m) -> Module (r, module_ env m)
+         | ModuleType mt -> ModuleType (module_type env mt)
+         | Include i -> Include (include_ env i)
+         | item -> item)
+       s
+
+and module_ env m =
+  match m.type_ with
+  | Alias _ -> m
+  | ModuleType expr -> { m with type_ = ModuleType (module_type_expr env (m.id :> Id.Signature.t) expr) }
+
+and module_type env m =
+  match m.expr with
+  | None -> m
+  | Some expr -> { m with expr = Some (module_type_expr env (m.id :> Id.Signature.t) expr) }
+
+and module_type_expr env (id : Id.Signature.t) expr =
+  match expr with
+  | Path _ -> expr
+  | Functor (Unit, expr) -> Functor (Unit, module_type_expr env id expr)
+  | Functor (Named p, expr) ->
+    let env = Env.add_functor_parameter (Named p) env in
+    Functor (Named (functor_parameter env p), module_type_expr env id expr)
+  | Signature sg -> Signature (signature env sg)
+  | With w -> With {w with w_expr = u_module_type_expr env id w.w_expr }
+  | TypeOf t ->
+    let cexpr = Component.Of_Lang.(module_type_expr empty expr) in
+    match Expand_tools.expansion_of_module_type_expr env id cexpr with
+    | Ok (_, _, cexpansion) ->
+      let t_expansion = Some (Lang_of.(simple_expansion empty id cexpansion)) in
+      TypeOf { t with t_expansion }
+    | Error e ->
+      Format.eprintf "Couldn't expand module_type_of expression: %a\n%!" Tools.Fmt.error (e :> Errors.any);
+      failwith "Couldn't expand module_type_of expression"
+
+and u_module_type_expr env id expr =
+  match expr with
+  | Path _ -> expr
+  | Signature sg -> Signature (signature env sg)
+  | With (subs, w) -> With ( subs, u_module_type_expr env id w)
+  | TypeOf t ->
+    let cexpr = Component.Of_Lang.(u_module_type_expr empty expr) in
+    match Expand_tools.expansion_of_u_module_type_expr env id cexpr with
+    | Ok (_, _, cexpansion) ->
+      let t_expansion = Some (Lang_of.(simple_expansion empty id cexpansion)) in
+      TypeOf { t with t_expansion }
+    | Error _ ->
+      failwith "Couldn't expand u_module_type_of expression"
+
+and functor_parameter env p =
+  { p with expr = module_type_expr env (p.id :> Id.Signature.t) p.expr}
+
+and include_ env i =
+  let decl =
+    match i.decl with
+    | Alias _ -> i.decl
+    | ModuleType t -> ModuleType (u_module_type_expr env i.parent t)
+  in
+  { i with expansion = { i.expansion with content = signature env i.expansion.content }; decl }


### PR DESCRIPTION
OCaml expands `module type of` expressions early, and subsequent operations -- such as substitution, functor application and so on -- operate on the expansion rather than the `module type of` expression. Before this PR, odoc did not do this, which led to differences in expansions. For example, on the following code:

```ocaml
module type S = sig
  module X : sig type t end
  module type Y = module type of X
end
module X1 : sig type t type u end
module type T = S with module X := X1
```

OCaml produces

```ocaml
module type T = sig module type Y = sig type t end end
```

whereas odoc was producing

```ocaml
module type T = sig module type Y = sig type t type u end
```

This PR fixes this problem by expanding all `module type of` expressions present in the current cmt/cmti before doing anything else, in a kind of 'zeroth' pass. All subsequent operations use this expansion. The zeroth pass occasionally needs to be done more than once if a `module type of` expression includes another `module type of`, e.g.:

```ocaml
module type X = sig type t end
module X0 : sig
  type t = int
  type t2 = int
end

module type Y = functor ( X : X ) -> sig
  module type Y = module type of struct include X end
end

module Z : Y
module Z2 : Z(X0).Y
module type Z3 = sig include module type of Z2 end
```

in this case, we notice that the expansion of `module type Z3` hits an unexpanded `module type of` expression during the first pass, and so we do another pass, by which time `module type Y` has had its expansion calculated.

Additionally, this PR also attempts to remove `module type of` expressions when they are no longer correct - e.g. in the above first example the expansion of `T` will not include a `module type of` expression, since no expression of this form can accurately describe what the result is. Instead it is replaced with a `Signature`. 