### PR TITLE
Typo in command name

### DIFF
--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -493,7 +493,7 @@ module Depends = struct
 
     let info =
       Term.info "html-deps"
-        ~doc:"DEPRECATED: alias for render-deps"
+        ~doc:"DEPRECATED: alias for link-deps"
   end
 end
 


### PR DESCRIPTION
This PR fixes a minor typo in the description of html-deps.