### PR TITLE
Add missing test-dependency on Yojson

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -37,6 +37,7 @@ depends: [
   "markup" {with-test & >= "0.8.0"}
   "ocamlfind" {with-test}
   "sexplib" {with-test & >= "113.33.00"}
+  "yojson" {with-test}
 
   "bisect_ppx" {with-test & >= "1.3.0"}
 ]


### PR DESCRIPTION
Yojson is used to print Lang values to a format that can be post-processed.