### PR TITLE
Simplify/clarify the handling of raw markup and add support in manpages.

### DIFF
--- a/src/html/dune
+++ b/src/html/dune
@@ -13,5 +13,5 @@ let () =
  (name odoc_html)
  (public_name odoc.html)
     |} ^ preprocess ^ {|
- (libraries odoc_model odoc_document tyxml))
+ (libraries odoc_model odoc_document odoc_compat tyxml))
     |}

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -39,10 +39,14 @@ let class_ (l : Class.t) =
 
 and raw_markup (t : Raw_markup.t) =
   let target, content = t in
-  if `Html = target then
-    [Html.Unsafe.data content] (* This is wrong *)
-  else
-    []
+  match Odoc_compat.String.lowercase_ascii target with
+  | "html" ->
+    (* This is OK because we output *textual* HTML. 
+       In theory, we should try to parse the HTML with lambdasoup and rebuild
+       the HTML tree from there.
+    *)
+    [Html.Unsafe.data content]
+  | _ -> []
 
 and source k ?a (t : Source.t) =
   let rec token (x : Source.token) = match x with

--- a/src/latex/dune
+++ b/src/latex/dune
@@ -13,5 +13,5 @@ let () =
  (name odoc_latex)
  (public_name odoc.latex)
     |} ^ preprocess ^ {|
- (libraries odoc_model odoc_document))
+ (libraries odoc_model odoc_document odoc_compat))
     |}

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -357,9 +357,10 @@ and small_table ppf tbl =
     Fmt.pf ppf {|{\setlength{\LTpre}{0pt}\setlength{\LTpost}{0pt}%a}|}
     table tbl
 
-let raw_markup (t:Raw_markup.t) =
-  match t with
-  | `Latex, c -> [Raw c]
+let raw_markup (t : Raw_markup.t) =
+  let target, content = t in
+  match Odoc_compat.String.lowercase_ascii target with
+  | "latex" | "tex" -> [Raw content]
   | _ -> []
 
 let source k (t : Source.t) =

--- a/src/manpage/dune
+++ b/src/manpage/dune
@@ -13,5 +13,5 @@ let () =
  (name odoc_manpage)
  (public_name odoc.manpage)
     |} ^ preprocess ^ {|
- (libraries odoc_model odoc_document))
+ (libraries odoc_model odoc_document odoc_compat))
     |}

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -259,6 +259,12 @@ let entity e = match e with
   | "#8288" -> noop
   | s -> str "&%s;" s (* Should hopefully make people notice and report *)
 
+let raw_markup (t : Raw_markup.t) =
+  let target, content = t in
+  match Odoc_compat.String.lowercase_ascii target with
+  | "manpage" | "troff" | "roff" -> String content
+  | _ -> noop
+
 let rec source_code (s : Source.t) =
   match s with
   | [] -> noop
@@ -304,8 +310,9 @@ and inline (l : Inline.t) = match l with
     | Source content ->
       source_code content
       ++ inline rest
-    | Raw_markup _ ->
-      inline rest
+    | Raw_markup t ->
+      raw_markup t
+      ++ inline rest
 
 let rec block (l : Block.t) = match l with
   | [] -> noop
@@ -343,8 +350,8 @@ let rec block (l : Block.t) = match l with
     | Verbatim content ->
       env "EX" "EE" "" (str "%s" content)
       ++ continue rest
-    | Raw_markup _ ->
-      noop
+    | Raw_markup t ->
+      raw_markup t
       ++ continue rest
 
 let next_heading, reset_heading =

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -13,11 +13,7 @@ type style = [
   | `Subscript
 ]
 
-type raw_markup_target = [
-  | `Html
-  | `Latex
-  | `Manpage
-]
+type raw_markup_target = string
 
 type leaf_inline_element = [
   | `Space

--- a/src/model_desc/comment_desc.ml
+++ b/src/model_desc/comment_desc.ml
@@ -50,11 +50,7 @@ and general_tag =
 and general_docs = general_block_element with_location list
 
 let rec inline_element : general_inline_element t =
-  let raw_markup_target =
-    Variant
-      (function
-      | `Html -> C0 "`Html" | `Latex -> C0 "`Latex" | `Manpage -> C0 "`Manpage")
-  and style =
+  let style =
     Variant
       (function
       | `Bold -> C0 "`Bold"
@@ -69,7 +65,7 @@ let rec inline_element : general_inline_element t =
     | `Word x -> C ("`Word", x, string)
     | `Code_span x -> C ("`Code_span", x, string)
     | `Raw_markup (x1, x2) ->
-        C ("`Raw_markup", (x1, x2), Pair (raw_markup_target, string))
+        C ("`Raw_markup", (x1, x2), Pair (string, string))
     | `Styled (x1, x2) -> C ("`Styled", (x1, x2), Pair (style, link_content))
     | `Reference (x1, x2) ->
         C ("`Reference", (x1, x2), Pair (reference, link_content))

--- a/test/compile/cases/parser_errors.mli
+++ b/test/compile/cases/parser_errors.mli
@@ -49,9 +49,6 @@ val o : int
 (** ] unpaired *)
 val p : int
 
-(** {%invalid: raw markup target %} *)
-val q : int
-
 (** This comment has bad
     } markup on the second line. *)
 val r : int

--- a/test/compile/expect/parser_errors.txt
+++ b/test/compile/expect/parser_errors.txt
@@ -35,12 +35,9 @@ Suggestion: try '\}'.
 File "cases/parser_errors.mli", line 49, characters 4-5:
 Unpaired ']' (end of code).
 Suggestion: try '\]'.
-File "cases/parser_errors.mli", line 52, characters 4-35:
-'{%invalid:': bad raw markup target.
-Suggestion: try '{%html:...%}'.
-File "cases/parser_errors.mli", line 56, characters 4-5:
+File "cases/parser_errors.mli", line 53, characters 4-5:
 Unpaired '}' (end of markup).
 Suggestion: try '\}'.
-File "cases/parser_errors.mli", line 59, characters 4-18:
+File "cases/parser_errors.mli", line 56, characters 4-18:
 '{x bad markup}': bad markup.
 Suggestion: did you mean '{!x bad markup}' or '[x bad markup]'?

--- a/test/parser/expect/raw-markup/incorrect-case-target.txt
+++ b/test/parser/expect/raw-markup/incorrect-case-target.txt
@@ -1,6 +1,0 @@
-((output
-  (((f.ml (1 0) (1 12)) (paragraph (((f.ml (1 0) (1 12)) (code_span foo)))))))
- (warnings
-  ( "File \"f.ml\", line 1, characters 0-12:\
-   \n'{%HTML:': bad raw markup target.\
-   \nSuggestion: try '{%html:...%}'.")))

--- a/test/parser/expect/raw-markup/invalid-target.txt
+++ b/test/parser/expect/raw-markup/invalid-target.txt
@@ -1,6 +1,0 @@
-((output
-  (((f.ml (1 0) (1 11)) (paragraph (((f.ml (1 0) (1 11)) (code_span foo)))))))
- (warnings
-  ( "File \"f.ml\", line 1, characters 0-11:\
-   \n'{%xml:': bad raw markup target.\
-   \nSuggestion: try '{%html:...%}'.")))

--- a/test/parser/test.ml
+++ b/test/parser/test.ml
@@ -255,8 +255,6 @@ let tests : test_suite list = [
     t "no-target" "{%foo%}";
     t "empty-target" "{%:foo%}";
     t "whitespace-target" "{% :foo%}";
-    t "invalid-target" "{%xml:foo%}";
-    t "incorrect-case-target" "{%HTML:foo%}";
     t "multiline-target" "{%\n:foo%}";
     t "percent-in-target" "{%%:%}";
     t "percent-in-payload" "{%html:%%}";

--- a/test/print/print.ml
+++ b/test/print/print.ml
@@ -259,9 +259,7 @@ struct
     | `Space -> Atom "space"
     | `Word w -> List [Atom "word"; Atom w]
     | `Code_span c -> List [Atom "code_span"; Atom c]
-    | `Raw_markup (`Html, s) -> List [Atom "raw_markup"; Atom "html"; Atom s]
-    | `Raw_markup (`Manpage, s) -> List [Atom "raw_markup"; Atom "manpage"; Atom s]
-    | `Raw_markup (`Latex, s) -> List [Atom "raw_markup"; Atom "latex"; Atom s]
+    | `Raw_markup (target, s) -> List [Atom "raw_markup"; Atom target; Atom s]
 
 
   let rec non_link_inline_element : Comment.non_link_inline_element -> sexp =


### PR DESCRIPTION
With this change, the frontend of odoc doesn't know anything about raw markups anymore. Raw markup is just a pair of a tag designating the language, and some .... raw markup. Each backend will look at the tag and decide for itself what to do with it.

Later on, we can have more sophisticated handling (like HTML backend handling latex raw markup through mathjax, for instance).

So far, the following tags are handled:
- Html backend handles `html` tag
- Latex backend handles `latex` and `tex` tags
- manpage backend handles `manpage`,`roff` and `troff` tags.