### PR TITLE
Improve handling of warnings

### DIFF
--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -66,7 +66,7 @@ let attached parent attrs =
                 ~containing_definition:parent
                 ~location:start_pos
                 ~text:str
-              |> Odoc_model.Error.shed_warnings
+              |> Odoc_model.Error.raise_warnings
             in
             loop false 0 (acc @ parsed) rest
           end
@@ -90,7 +90,7 @@ let read_string parent loc str : Odoc_model.Comment.docs_or_stop =
       ~containing_definition:parent
       ~location:start_pos
       ~text:str
-    |> Odoc_model.Error.shed_warnings
+    |> Odoc_model.Error.raise_warnings
   in
   `Docs doc
 

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -1,83 +1,80 @@
 open Odoc_compat
-open Result
 
 module Error = Odoc_model.Error
 
 
 
 let read_string parent_definition location text =
-  Error.catch (fun () ->
+  Error.catch_errors_and_warnings (fun () ->
     Doc_attr.page parent_definition location text)
 
 
 
-let corrupted : string -> Error.t =
-  Error.filename_only "corrupted"
+let corrupted file =
+  Error.raise_exception (Error.filename_only "corrupted" file)
 
-let not_a_typedtree : string -> Error.t =
-  Error.filename_only "not a Typedtree"
+let not_a_typedtree file =
+  Error.raise_exception (Error.filename_only "not a Typedtree" file)
 
-let not_an_implementation : string -> Error.t =
-  Error.filename_only "not an implementation"
+let not_an_implementation file =
+  Error.raise_exception (Error.filename_only "not an implementation" file)
 
-let not_an_interface : string -> Error.t =
-  Error.filename_only "not an interface"
+let not_an_interface file =
+  Error.raise_exception (Error.filename_only "not an interface" file)
 
-let wrong_version : string -> Error.t =
-  Error.filename_only "wrong OCaml version"
+let wrong_version file =
+  Error.raise_exception (Error.filename_only "wrong OCaml version" file)
 
 
 
-let read_cmti ~make_root ~filename =
+let read_cmti ~make_root ~filename () =
   match Cmt_format.read_cmt filename with
   | exception Cmi_format.Error (Not_an_interface _) ->
-    Error (not_an_interface filename)
+    not_an_interface filename
   | exception Cmt_format.Error (Not_a_typedtree _) ->
-    Error (not_a_typedtree filename)
+    not_a_typedtree filename
   | cmt_info ->
     match cmt_info.cmt_annots with
     | Interface intf ->
       begin match cmt_info.cmt_interface_digest with
-      | None -> Error (corrupted filename)
+      | None -> corrupted filename
       | Some digest ->
-        Error.catch begin fun () ->
-          let name = cmt_info.cmt_modname in
-          let root = make_root ~module_name:name ~digest in
-          let (id, doc, items) = Cmti.read_interface root name intf in
-          let imports =
-            List.filter (fun (name', _) -> name <> name') cmt_info.cmt_imports
-          in
-          let imports =
-            List.map (fun (s, d) ->
-              Odoc_model.Lang.Compilation_unit.Import.Unresolved (s, d))
-            imports
-          in
-          let interface = true in
-          let hidden = Odoc_model.Root.contains_double_underscore name in
-          let source =
-            match cmt_info.cmt_sourcefile, cmt_info.cmt_source_digest with
-            | Some file, Some digest ->
-              let build_dir = cmt_info.cmt_builddir in
-              Some {Odoc_model.Lang.Compilation_unit.Source.file; digest; build_dir}
-            | _, _ -> None
-          in
-          let content = Odoc_model.Lang.Compilation_unit.Module items in
-          {Odoc_model.Lang.Compilation_unit.id; doc; digest; imports; source;
-           interface; hidden; content; expansion = None}
-        end
+        let name = cmt_info.cmt_modname in
+        let root = make_root ~module_name:name ~digest in
+        let (id, doc, items) = Cmti.read_interface root name intf in
+        let imports =
+          List.filter (fun (name', _) -> name <> name') cmt_info.cmt_imports
+        in
+        let imports =
+          List.map (fun (s, d) ->
+            Odoc_model.Lang.Compilation_unit.Import.Unresolved (s, d))
+          imports
+        in
+        let interface = true in
+        let hidden = Odoc_model.Root.contains_double_underscore name in
+        let source =
+          match cmt_info.cmt_sourcefile, cmt_info.cmt_source_digest with
+          | Some file, Some digest ->
+            let build_dir = cmt_info.cmt_builddir in
+            Some {Odoc_model.Lang.Compilation_unit.Source.file; digest; build_dir}
+          | _, _ -> None
+        in
+        let content = Odoc_model.Lang.Compilation_unit.Module items in
+        {Odoc_model.Lang.Compilation_unit.id; doc; digest; imports; source;
+         interface; hidden; content; expansion = None}
       end
-    | _ -> Error (not_an_interface filename)
+    | _ -> not_an_interface filename
 
-let read_cmt ~make_root ~filename =
+let read_cmt ~make_root ~filename () =
   match Cmt_format.read_cmt filename with
   | exception Cmi_format.Error (Not_an_interface _) ->
-    Error (not_an_implementation filename)
+    not_an_implementation filename
   | exception Cmi_format.Error (Wrong_version_interface _) ->
-    Error (wrong_version filename)
+    wrong_version filename
   | exception Cmi_format.Error (Corrupted_interface _) ->
-    Error (corrupted filename)
+    corrupted filename
   | exception Cmt_format.Error (Not_a_typedtree _) ->
-    Error (not_a_typedtree filename)
+    not_a_typedtree filename
   | cmt_info ->
     match cmt_info.cmt_annots with
     | Packed(_, files) ->
@@ -117,68 +114,73 @@ let read_cmt ~make_root ~filename =
       let doc = Doc_attr.empty in
       let source = None in
       let content = Odoc_model.Lang.Compilation_unit.Pack items in
-      Ok {Odoc_model.Lang.Compilation_unit.id; doc; digest; imports;
+      {Odoc_model.Lang.Compilation_unit.id; doc; digest; imports;
           source; interface; hidden; content; expansion = None}
 
     | Implementation impl ->
-      Error.catch begin fun () ->
-        let name = cmt_info.cmt_modname in
-        let interface, digest =
-          match cmt_info.cmt_interface_digest with
-          | Some digest -> true, digest
-          | None ->
-            match List.assoc name cmt_info.cmt_imports with
-            | Some digest -> false, digest
-            | None -> assert false
-            | exception Not_found -> assert false
-        in
-        let hidden = Odoc_model.Root.contains_double_underscore name in
-        let root = make_root ~module_name:name ~digest in
-        let (id, doc, items) = Cmt.read_implementation root name impl in
-        let imports =
-          List.filter (fun (name', _) -> name <> name') cmt_info.cmt_imports in
-        let imports =
-          List.map (fun (s, d) ->
-            Odoc_model.Lang.Compilation_unit.Import.Unresolved(s, d)) imports
-        in
-        let source =
-          match cmt_info.cmt_sourcefile, cmt_info.cmt_source_digest with
-          | Some file, Some digest ->
-            let build_dir = cmt_info.cmt_builddir in
-            Some {Odoc_model.Lang.Compilation_unit.Source.file; digest; build_dir}
-          | _, _ -> None
-        in
-        let content = Odoc_model.Lang.Compilation_unit.Module items in
-        {Odoc_model.Lang.Compilation_unit.id; doc; digest; imports;
-         source; interface; hidden; content; expansion = None}
-      end
+      let name = cmt_info.cmt_modname in
+      let interface, digest =
+        match cmt_info.cmt_interface_digest with
+        | Some digest -> true, digest
+        | None ->
+          match List.assoc name cmt_info.cmt_imports with
+          | Some digest -> false, digest
+          | None -> assert false
+          | exception Not_found -> assert false
+      in
+      let hidden = Odoc_model.Root.contains_double_underscore name in
+      let root = make_root ~module_name:name ~digest in
+      let (id, doc, items) = Cmt.read_implementation root name impl in
+      let imports =
+        List.filter (fun (name', _) -> name <> name') cmt_info.cmt_imports in
+      let imports =
+        List.map (fun (s, d) ->
+          Odoc_model.Lang.Compilation_unit.Import.Unresolved(s, d)) imports
+      in
+      let source =
+        match cmt_info.cmt_sourcefile, cmt_info.cmt_source_digest with
+        | Some file, Some digest ->
+          let build_dir = cmt_info.cmt_builddir in
+          Some {Odoc_model.Lang.Compilation_unit.Source.file; digest; build_dir}
+        | _, _ -> None
+      in
+      let content = Odoc_model.Lang.Compilation_unit.Module items in
+      {Odoc_model.Lang.Compilation_unit.id; doc; digest; imports;
+       source; interface; hidden; content; expansion = None}
 
-    | _ -> Error (not_an_implementation filename)
+    | _ -> not_an_implementation filename
 
-let read_cmi ~make_root ~filename =
+let read_cmi ~make_root ~filename () =
   match Cmi_format.read_cmi filename with
   | exception Cmi_format.Error (Not_an_interface _) ->
-    Error (not_an_interface filename)
+    not_an_interface filename
   | exception Cmi_format.Error (Wrong_version_interface _) ->
-    Error (wrong_version filename)
+    wrong_version filename
   | exception Cmi_format.Error (Corrupted_interface _) ->
-    Error (corrupted filename)
+    corrupted filename
   | cmi_info ->
     match cmi_info.cmi_crcs with
     | (name, Some digest) :: imports when name = cmi_info.cmi_name ->
-      Error.catch begin fun () ->
-        let root = make_root ~module_name:name ~digest:digest in
-        let (id, doc, items) = Cmi.read_interface root name (Odoc_model.Compat.signature cmi_info.cmi_sign) in
-        let imports =
-          List.map (fun (s, d) ->
-            Odoc_model.Lang.Compilation_unit.Import.Unresolved(s, d)) imports
-        in
-        let interface = true in
-        let hidden = Odoc_model.Root.contains_double_underscore name in
-        let source = None in
-        let content = Odoc_model.Lang.Compilation_unit.Module items in
-        {Odoc_model.Lang.Compilation_unit.id; doc; digest; imports;
-         source; interface; hidden; content; expansion = None}
-      end
+      let root = make_root ~module_name:name ~digest:digest in
+      let (id, doc, items) = Cmi.read_interface root name (Odoc_model.Compat.signature cmi_info.cmi_sign) in
+      let imports =
+        List.map (fun (s, d) ->
+          Odoc_model.Lang.Compilation_unit.Import.Unresolved(s, d)) imports
+      in
+      let interface = true in
+      let hidden = Odoc_model.Root.contains_double_underscore name in
+      let source = None in
+      let content = Odoc_model.Lang.Compilation_unit.Module items in
+      {Odoc_model.Lang.Compilation_unit.id; doc; digest; imports;
+       source; interface; hidden; content; expansion = None}
 
-    | _ -> Error (corrupted filename)
+    | _ -> corrupted filename
+
+let read_cmti ~make_root ~filename =
+  Odoc_model.Error.catch_errors_and_warnings (read_cmti ~make_root ~filename)
+
+let read_cmt ~make_root ~filename =
+  Odoc_model.Error.catch_errors_and_warnings (read_cmt ~make_root ~filename)
+
+let read_cmi ~make_root ~filename =
+  Odoc_model.Error.catch_errors_and_warnings (read_cmi ~make_root ~filename)

--- a/src/loader/odoc_loader.mli
+++ b/src/loader/odoc_loader.mli
@@ -1,22 +1,23 @@
 open Result
+open Odoc_model
 
 val read_string :
-  Odoc_model.Paths.Identifier.LabelParent.t ->
+  Paths.Identifier.LabelParent.t ->
   Location.t ->
   string ->
-    (Odoc_model.Comment.docs_or_stop, Odoc_model.Error.t) result
+  (Comment.docs_or_stop, Error.t) result Error.with_warnings
 
 val read_cmti :
-  make_root:(module_name:string -> digest:Digest.t -> Odoc_model.Root.t) ->
+  make_root:(module_name:string -> digest:Digest.t -> Root.t) ->
   filename:string ->
-    (Odoc_model.Lang.Compilation_unit.t, Odoc_model.Error.t) result
+  (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_cmt :
-  make_root:(module_name:string -> digest:Digest.t -> Odoc_model.Root.t) ->
+  make_root:(module_name:string -> digest:Digest.t -> Root.t) ->
   filename:string ->
-    (Odoc_model.Lang.Compilation_unit.t, Odoc_model.Error.t) result
+  (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_cmi :
-  make_root:(module_name:string -> digest:Digest.t -> Odoc_model.Root.t) ->
+  make_root:(module_name:string -> digest:Digest.t -> Root.t) ->
   filename:string ->
-    (Odoc_model.Lang.Compilation_unit.t, Odoc_model.Error.t) result
+  (Lang.Compilation_unit.t, Error.t) result Error.with_warnings

--- a/src/model/error.ml
+++ b/src/model/error.ml
@@ -107,3 +107,11 @@ let shed_warnings with_warnings =
   with_warnings.value
 
 let set_warn_error b = warn_error := b
+
+let handle_warnings ~warn_error with_warnings =
+  match with_warnings.warnings with
+  | [] -> Ok with_warnings.value
+  | _ :: _ as warnings ->
+      warnings |> List.iter (fun w -> prerr_endline (to_string w));
+      if warn_error then Error (`Msg "Warnings have been generated.")
+      else Ok with_warnings.value

--- a/src/model/error.ml
+++ b/src/model/error.ml
@@ -15,7 +15,6 @@ type filename_only_payload = {
 type t = [
   | `With_full_location of full_location_payload
   | `With_filename_only of filename_only_payload
-  | `Without_location of string
 ]
 
 let kasprintf k fmt =
@@ -36,10 +35,6 @@ let filename_only ?suggestion format =
   let k message file = `With_filename_only {file; message} in
   kmake k ?suggestion format
 
-(** Only used internally *)
-let without_location message =
-  `Without_location message
-
 let to_string = function
   | `With_full_location {location; message} ->
     let location_string =
@@ -59,10 +54,6 @@ let to_string = function
 
   | `With_filename_only {file; message} ->
     Printf.sprintf "File \"%s\":\n%s" file message
-
-  | `Without_location message ->
-    message
-
 
 
 exception Conveyed_by_exception of t
@@ -120,19 +111,6 @@ let catch_warnings f =
 
 let catch_errors_and_warnings f =
   catch_warnings (fun () -> catch f)
-
-let warn_error = ref false
-
-(* TODO This is a temporary measure until odoc is ported to handle warnings
-   throughout. *)
-let shed_warnings with_warnings =
-  with_warnings.warnings
-  |> List.iter (fun warning -> warning |> to_string |> prerr_endline);
-  if !warn_error && with_warnings.warnings <> [] then
-    raise_exception (without_location "Warnings have been generated.");
-  with_warnings.value
-
-let set_warn_error b = warn_error := b
 
 let print_warnings = List.iter (fun w -> prerr_endline (to_string w))
 

--- a/src/model/error.mli
+++ b/src/model/error.mli
@@ -20,7 +20,6 @@ type warning_accumulator
 
 val accumulate_warnings : (warning_accumulator -> 'a) -> 'a with_warnings
 val warning : warning_accumulator -> t -> unit
-val shed_warnings : 'a with_warnings -> 'a
 
 val raise_warnings : 'a with_warnings -> 'a
 (** Accumulate warnings into a global variable. See [catch_warnings]. *)
@@ -31,10 +30,6 @@ val catch_warnings : (unit -> 'a) -> 'a with_warnings
 val catch_errors_and_warnings :
   (unit -> 'a) -> ('a, t) Result.result with_warnings
 (** Combination of [catch] and [catch_warnings]. *)
-
-(** When set to [true],
-   [shed_warnings] will raise [Failure] if it had to print warnings. *)
-val set_warn_error : bool -> unit
 
 val handle_warnings :
   warn_error:bool -> 'a with_warnings -> ('a, [> `Msg of string ]) Result.result

--- a/src/model/error.mli
+++ b/src/model/error.mli
@@ -22,10 +22,28 @@ val accumulate_warnings : (warning_accumulator -> 'a) -> 'a with_warnings
 val warning : warning_accumulator -> t -> unit
 val shed_warnings : 'a with_warnings -> 'a
 
+val raise_warnings : 'a with_warnings -> 'a
+(** Accumulate warnings into a global variable. See [catch_warnings]. *)
+
+val catch_warnings : (unit -> 'a) -> 'a with_warnings
+(** Catch warnings accumulated by [raise_warning]. Safe to nest. *)
+
+val catch_errors_and_warnings :
+  (unit -> 'a) -> ('a, t) Result.result with_warnings
+(** Combination of [catch] and [catch_warnings]. *)
+
 (** When set to [true],
    [shed_warnings] will raise [Failure] if it had to print warnings. *)
 val set_warn_error : bool -> unit
 
 val handle_warnings :
   warn_error:bool -> 'a with_warnings -> ('a, [> `Msg of string ]) Result.result
-(** Print warnings to stderr. If [warn_error] is [true] and there was warnings, returns an [Error]. *)
+(** Print warnings to stderr. If [warn_error] is [true] and there was warnings,
+    returns an [Error]. *)
+
+val handle_errors_and_warnings :
+  warn_error:bool ->
+  ('a, t) Result.result with_warnings ->
+  ('a, [> `Msg of string ]) Result.result
+(** Like [handle_warnings] but works on the output of
+    [catch_errors_and_warnings]. Error case is converted into a [`Msg]. *)

--- a/src/model/error.mli
+++ b/src/model/error.mli
@@ -25,3 +25,7 @@ val shed_warnings : 'a with_warnings -> 'a
 (** When set to [true],
    [shed_warnings] will raise [Failure] if it had to print warnings. *)
 val set_warn_error : bool -> unit
+
+val handle_warnings :
+  warn_error:bool -> 'a with_warnings -> ('a, [> `Msg of string ]) Result.result
+(** Print warnings to stderr. If [warn_error] is [true] and there was warnings, returns an [Error]. *)

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -194,21 +194,20 @@ end = struct
   | None -> Fs.File.(set_ext ".odocl" input)
 
   let link directories input_file output_file warn_error =
-    ignore(warn_error);
     let input = Fs.File.of_string input_file in
     let output = get_output_file ~output_file ~input in
     let env = Env.create ~important_digests:false ~directories ~open_modules:[] in
-    Odoc_link.from_odoc ~env input output
+    Odoc_link.from_odoc ~env ~warn_error input output
 
 
-    let dst =
-      let doc = "Output file path. Non-existing intermediate directories are
-                   created. If absent outputs a .odocl file in the same
-                   directory as the input file."
-      in
-      Arg.(value & opt (some string) None & info ~docs ~docv:"PATH" ~doc ["o"])
+  let dst =
+    let doc = "Output file path. Non-existing intermediate directories are
+                 created. If absent outputs a .odocl file in the same
+                 directory as the input file."
+    in
+    Arg.(value & opt (some string) None & info ~docs ~docv:"PATH" ~doc ["o"])
 
-    let cmd =
+  let cmd =
     let input =
       let doc = "Input file" in
       Arg.(required & pos 0 (some file) None & info ~doc ~docv:"file.odoc" [])
@@ -237,14 +236,14 @@ end = struct
 
   module Process = struct
     let process extra _hidden directories output_dir
-        syntax input_file =
+        syntax input_file warn_error =
       let env =
         Env.create ~important_digests:false ~directories ~open_modules:[]
       in
       let file = Fs.File.of_string input_file in
       Rendering.render_odoc
         ~renderer:R.renderer
-        ~env ~syntax ~output:output_dir extra file
+        ~env ~warn_error ~syntax ~output:output_dir extra file
 
     let cmd =
       let syntax =
@@ -256,7 +255,7 @@ end = struct
       in
       Term.(const handle_error $ (const process $ R.extra_args $ hidden $
           odoc_file_directories $ dst ~create:true () $ syntax $
-          input))
+          input $ warn_error))
 
     let info =
       let doc = Format.sprintf "Render %s files from an odoc one" R.renderer.name in

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -18,7 +18,6 @@ open Or_error
 
 
 let resolve_and_substitute ~env ~output ~warn_error input_file read_file =
-  Odoc_model.Error.set_warn_error warn_error;
   let filename = Fs.File.to_string input_file in
 
   read_file ~filename |> Odoc_model.Error.handle_errors_and_warnings ~warn_error >>= fun unit ->
@@ -69,7 +68,6 @@ let cmi ~env ~package ~hidden ~output ~warn_error input =
 
 (* TODO: move most of this to doc-ock. *)
 let mld ~env:_ ~package ~output ~warn_error input =
-  Odoc_model.Error.set_warn_error warn_error;
   let root_name =
     let page_dash_root =
       Filename.chop_extension (Fs.File.(to_string @@ basename output))

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -32,11 +32,11 @@ let resolve_and_substitute ~env ~output ~warn_error input_file read_file =
             " Using %S while you should use the .cmti file" filename)
     );
     let env = Env.build env (`Unit unit) in
-    let compiled =
-      Odoc_xref2.Compile.compile env unit
-      |> Odoc_xref2.Lookup_failures.to_warning ~filename
-      |> Odoc_model.Error.shed_warnings
-    in
+
+    Odoc_xref2.Compile.compile env unit
+    |> Odoc_xref2.Lookup_failures.to_warning ~filename
+    |> Odoc_model.Error.handle_warnings ~warn_error
+    >>= fun compiled ->
 
     (* [expand unit] fetches [unit] from [env] to get the expansion of local, previously
        defined, elements. We'd rather it got back the resolved bit so we rebuild an

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -1,7 +1,6 @@
 open Or_error
 
 let from_mld ~xref_base_uri ~env ~output ~warn_error input =
-  Odoc_model.Error.set_warn_error warn_error;
   (* Internal names, they don't have effect on the output. *)
   let page_name = "__fragment_page__" in
   let package = "__fragment_package__" in

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -43,7 +43,8 @@ let from_mld ~xref_base_uri ~env ~output ~warn_error input =
   match Fs.File.read input with
   | Error _ as e -> e
   | Ok str ->
-    match Odoc_loader.read_string name location str with
-    | Error e -> Error (`Msg (Odoc_model.Error.to_string e))
-    | Ok (`Docs content) -> to_html content
-    | Ok `Stop -> to_html [] (* TODO: Error? *)
+    Odoc_loader.read_string name location str
+    |> Odoc_model.Error.handle_errors_and_warnings ~warn_error
+    >>= function
+    | `Docs content -> to_html content
+    | `Stop -> to_html [] (* TODO: Error? *)

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -27,11 +27,10 @@ let from_mld ~xref_base_uri ~env ~output ~warn_error input =
     (* This is a mess. *)
     let page = Odoc_model.Lang.Page.{ name; content; digest } in
     let env = Env.build env (`Page page) in
-    let resolved =
-      Odoc_xref2.Link.resolve_page env page
-      |> Odoc_xref2.Lookup_failures.to_warning ~filename:input_s
-      |> Odoc_model.Error.shed_warnings
-    in
+    Odoc_xref2.Link.resolve_page env page
+    |> Odoc_xref2.Lookup_failures.to_warning ~filename:input_s
+    |> Odoc_model.Error.handle_warnings ~warn_error
+    >>= fun resolved ->
 
     let page = Odoc_document.Comment.to_ir resolved.content in
     let html = Odoc_html.Generator.doc ~xref_base_uri page in

--- a/src/odoc/rendering.ml
+++ b/src/odoc/rendering.ml
@@ -12,18 +12,17 @@ let document_of_odocl ~syntax input =
     Compilation_unit.load input >>= fun odoctree ->
     Ok (Renderer.document_of_compilation_unit ~syntax odoctree)
 
-let document_of_input ~env ~syntax input =
+let document_of_input ~env ~warn_error ~syntax input =
   Root.read input >>= fun root ->
   let input_s = Fs.File.to_string input in
   match root.file with
   | Page _ ->
     Page.load input >>= fun page ->
-    let odoctree =
-      let resolve_env = Env.build env (`Page page) in
-      Odoc_xref2.Link.resolve_page resolve_env page
-      |> Odoc_xref2.Lookup_failures.to_warning ~filename:input_s
-      |> Odoc_model.Error.shed_warnings
-    in
+    let resolve_env = Env.build env (`Page page) in
+    Odoc_xref2.Link.resolve_page resolve_env page
+    |> Odoc_xref2.Lookup_failures.to_warning ~filename:input_s
+    |> Odoc_model.Error.handle_warnings ~warn_error
+    >>= fun odoctree ->
     Ok (Renderer.document_of_page ~syntax odoctree)
   | Compilation_unit {hidden; _} ->
     (* If hidden, we should not generate HTML. See
@@ -34,18 +33,17 @@ let document_of_input ~env ~syntax input =
       then {unit with content = Odoc_model.Lang.Compilation_unit.Module []; expansion=None }
       else unit
     in
-    let odoctree =
-      let env = Env.build env (`Unit unit) in
-      (* let startlink = Unix.gettimeofday () in *)
-      (* Format.fprintf Format.err_formatter "**** Link...\n%!"; *)
-      let linked = Odoc_xref2.Link.link env unit in
-      (* let finishlink = Unix.gettimeofday () in *)
-      (* Format.fprintf Format.err_formatter "**** Finished: Link=%f\n%!" (finishlink -. startlink); *)
-      (* Printf.fprintf stderr "num_times: %d\n%!" !Odoc_xref2.Tools.num_times; *)
-      linked
-      |> Odoc_xref2.Lookup_failures.to_warning ~filename:input_s
-      |> Odoc_model.Error.shed_warnings
-    in
+    let env = Env.build env (`Unit unit) in
+    (* let startlink = Unix.gettimeofday () in *)
+    (* Format.fprintf Format.err_formatter "**** Link...\n%!"; *)
+    let linked = Odoc_xref2.Link.link env unit in
+    (* let finishlink = Unix.gettimeofday () in *)
+    (* Format.fprintf Format.err_formatter "**** Finished: Link=%f\n%!" (finishlink -. startlink); *)
+    (* Printf.fprintf stderr "num_times: %d\n%!" !Odoc_xref2.Tools.num_times; *)
+    linked
+    |> Odoc_xref2.Lookup_failures.to_warning ~filename:input_s
+    |> Odoc_model.Error.handle_warnings ~warn_error
+    >>= fun odoctree ->
 
     Odoc_xref2.Tools.reset_caches ();
     Hashtbl.clear Compilation_unit.units_cache;
@@ -91,8 +89,8 @@ let urls_of_input input =
         let targets = Targets.unit (* ~package *) unit in
         Ok targets
 
-let render_odoc ~env ~syntax ~renderer ~output extra file =
-  document_of_input ~env ~syntax file
+let render_odoc ~env ~warn_error ~syntax ~renderer ~output extra file =
+  document_of_input ~env ~warn_error ~syntax file
   >>= render_document renderer ~output ~extra
 
 let generate_odoc ~syntax ~renderer ~output extra file =

--- a/src/xref2/dune
+++ b/src/xref2/dune
@@ -2,7 +2,7 @@
  (name odoc_xref2)
  (public_name odoc.xref2)
 ; (preprocess (pps landmarks.ppx --auto))
- (libraries compiler-libs.common odoc_model odoc_loader 
+ (libraries compiler-libs.common odoc_model
 ; landmarks 
  unix)
  (modules_without_implementation errors)

--- a/test/compile/expect/parser_errors_fatal.txt
+++ b/test/compile/expect/parser_errors_fatal.txt
@@ -1,4 +1,45 @@
 File "cases/parser_errors_fatal.mli", line 1, characters 4-26:
 '{x This is bad markup}': bad markup.
 Suggestion: did you mean '{!x This is bad markup}' or '[x This is bad markup]'?
+File "cases/parser_errors_fatal.mli", line 4, characters 4-24:
+'9': bad heading level (0-5 allowed).
+File "cases/parser_errors_fatal.mli", line 10, characters 8-11:
+'{li ...}' should be followed by space, a tab, or a new line.
+File "cases/parser_errors_fatal.mli", line 13, characters 4-7:
+'{li ...}' (list item) is not allowed in top-level text.
+Suggestion: move '{li ...}' into '{ul ...}' (bulleted list), or use '-' (bulleted list item).
+File "cases/parser_errors_fatal.mli", line 13, characters 19-20:
+Unpaired '}' (end of markup).
+Suggestion: try '\}'.
+File "cases/parser_errors_fatal.mli", line 16, characters 4-6:
+'{v' should be followed by whitespace.
+File "cases/parser_errors_fatal.mli", line 19, characters 37-39:
+'v}' should be preceded by whitespace.
+File "cases/parser_errors_fatal.mli", line 22, characters 4-5:
+Stray '@'.
+File "cases/parser_errors_fatal.mli", line 28, characters 4-11:
+'@before' expects version number on the same line.
+File "cases/parser_errors_fatal.mli", line 31, characters 4-10:
+'@param' expects parameter name on the same line.
+File "cases/parser_errors_fatal.mli", line 34, characters 4-10:
+'@raise' expects exception constructor on the same line.
+File "cases/parser_errors_fatal.mli", line 37, characters 4-8:
+'@see' should be followed by <url>, 'file', or "document title".
+File "cases/parser_errors_fatal.mli", line 40, characters 4-15:
+Unknown tag '@UnknownTag'.
+File "cases/parser_errors_fatal.mli", line 43, characters 4-5:
+Unpaired '}' (end of markup).
+Suggestion: try '\}'.
+File "cases/parser_errors_fatal.mli", line 46, characters 4-5:
+Unpaired ']' (end of code).
+Suggestion: try '\]'.
+File "cases/parser_errors_fatal.mli", line 49, characters 4-35:
+'{%invalid:': bad raw markup target.
+Suggestion: try '{%html:...%}'.
+File "cases/parser_errors_fatal.mli", line 53, characters 4-5:
+Unpaired '}' (end of markup).
+Suggestion: try '\}'.
+File "cases/parser_errors_fatal.mli", line 56, characters 4-18:
+'{x bad markup}': bad markup.
+Suggestion: did you mean '{!x bad markup}' or '[x bad markup]'?
 ERROR: Warnings have been generated.

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -60,11 +60,10 @@ Helpers:
 ```ocaml
 let parse_ref ref_str =
   let open Odoc_model in
-  Error.set_warn_error true;
   let parse acc = Odoc_parser__Reference.parse acc (Location_.span []) ref_str in
-  match Error.shed_warnings (Error.accumulate_warnings parse) with
+  match Error.handle_errors_and_warnings ~warn_error:true (Error.accumulate_warnings parse) with
   | Ok ref -> ref
-  | Error e -> failwith (Error.to_string e)
+  | Error (`Msg msg) -> failwith msg
 
 type ref = Odoc_model.Paths_types.Resolved_reference.any
 


### PR DESCRIPTION
Fix an uncaught exception with `--warn-error` and improve the code:

- Cleaner way of handling `--warn-error`
- Remove exceptions from the loader API. Handling of errors and warnings is cleaner and fits better with code for the first point.
- Remove `shed_warnings`. This means that all warnings are accumulated before an error is raised.