### PR TITLE
Add GitHub actions for building and testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          # - windows-latest Windows doesn't work yet
         ocaml-version:
           # Don't include every versions. OCaml-CI already covers that
           - 4.11.1
@@ -64,7 +64,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          # - windows-latest Not working yet.
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: "Build"
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build: # Check build on various OSes
+
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        ocaml-version:
+          # Don't include every versions. OCaml-CI already covers that
+          - 4.11.1
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Clone the project
+      - uses: actions/checkout@v2
+
+      # Setup
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.opam
+          key: ${{ matrix.os }}-${{ matrix.ocaml-version }}-${{ hashFiles('*.opam') }}-opam
+      - name: Setup OCaml ${{ matrix.ocaml-version }}
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+
+      # Build and test script
+      - run: opam pin add -n .
+      - run: opam depext -y -t odoc
+      - run: opam install --deps-only -t odoc
+      - run: opam exec -- dune build
+      - run: opam exec -- dune runtest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,16 +39,23 @@ jobs:
       # actions/checkout doesn't support that
       # Also, this is supposed to be temporary
       - run: git submodule update --init
-      - run: opam pin add -n ./mdx
-      - run: opam depext -y -t mdx
-      - run: opam install --deps-only mdx
 
-      # Build and test script
-      - run: opam pin add -n .
-      - run: opam depext -y -t odoc
-      - run: opam install --deps-only -t odoc
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          # Mdx dependencies
+          opam pin add -n ./mdx
+          opam depext -y -t mdx
+          opam install --deps-only mdx
+          # -
+          opam pin add -n .
+          opam depext -y -t odoc
+          opam install --deps-only -t odoc
+
+      - name: dune build
+        run: opam exec -- dune build
+      - name: dune runtest
+        run: opam exec -- dune runtest
 
   esy: # Check build using esy
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,14 @@ jobs:
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
 
+      # Pull the Mdx submodule
+      # actions/checkout doesn't support that
+      # Also, this is supposed to be temporary
+      - run: git submodule update --init
+      - run: opam pin add -n ./mdx
+      - run: opam depext -y -t mdx
+      - run: opam install --deps-only mdx
+
       # Build and test script
       - run: opam pin add -n .
       - run: opam depext -y -t odoc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,23 @@ jobs:
       - run: opam install --deps-only -t odoc
       - run: opam exec -- dune build
       - run: opam exec -- dune runtest
+
+  esy: # Check build using esy
+
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - uses: actions/checkout@v2
+      - run: npm --global install esy
+      - run: esy install --verbose
+      - run: esy odoc --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         ocaml-version:
           # Don't include every versions. OCaml-CI already covers that
           - 4.11.1
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This adds CI jobs for what OCaml-CI can't do:
- Build and test on Windows and MacOS
- Build with esy

There is still a small hack to install the dependencies of Mdx but it is easy to remove once we fix the root cause.

This should be enough to replace all of our travis script.