### PR TITLE
html backend: fix linking to mld pages

### DIFF
--- a/src/html/link.ml
+++ b/src/html/link.ml
@@ -73,6 +73,7 @@ let href ~resolve { Url.Anchor. page; anchor; kind } =
       @ target_from_common_ancestor
     in
     let page = String.concat "/" relative_target in
+    let page = if kind="page" then page ^ ".html" else page in
     begin match anchor with
     | "" -> page
     | anchor -> page ^ "#" ^ anchor


### PR DESCRIPTION
Currently the link generated for `{!page:mld}` in the html backend refers to `mld` rather than `mld.html`.
This PR fixes this issue.