### PR TITLE
 Allow type references to resolve to classes 

### DIFF
--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -588,6 +588,41 @@ Exception: Failure "resolve_reference".
    t)
 ```
 
+Classes as type references:
+
+```ocaml
+let resolve_ref = resolve_ref_of_mli {|
+  module M : sig
+    class cl : object method m : int end
+    class type clt = object method m : int end
+  end
+
+  class cl : object method m : int end
+  class type clt = object method m : int end
+|}
+```
+
+```ocaml
+# resolve_ref "type:M.cl" (* Type reference resolves to class *)
+Exception: Failure "resolve_reference".
+# resolve_ref "type:M.clt"
+Exception: Failure "resolve_reference".
+# resolve_ref "type:cl" (* Root TType reference resolves to class *)
+- : ref = `Identifier (`Class (`Root (Common.root, Root), cl))
+# resolve_ref "type:clt"
+- : ref = `Identifier (`ClassType (`Root (Common.root, Root), clt))
+# resolve_ref "M.type-cl.m" (* Type label parent resolves to class *)
+Exception: Failure "resolve_reference".
+# resolve_ref "M.type-clt.m"
+Exception: Failure "resolve_reference".
+# resolve_ref "type-cl.m" (* Root TType label parent resolves to class *)
+Exception: Failure "resolve_reference".
+# resolve_ref "type-clt.m"
+Exception: Failure "resolve_reference".
+# resolve_ref "method:cl.m"
+- : ref = `Method (`Identifier (`Class (`Root (Common.root, Root), cl)), m)
+```
+
 ## Failures
 
 Test some error paths.

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -629,6 +629,28 @@ let resolve_ref = resolve_ref_of_mli {|
 - : ref = `Method (`Identifier (`Class (`Root (Common.root, Root), cl)), m)
 ```
 
+It is not possible to reference to methods through type references:
+
+```ocaml
+# let resolve_ref = resolve_ref_of_mli {|
+    class c : object method m : int end
+    type t = < m : int >
+  |}
+val resolve_ref : string -> ref = <fun>
+# resolve_ref "type-c.m"
+- : ref = `Method (`Identifier (`Class (`Root (Common.root, Root), c)), m)
+# resolve_ref "type-c.method-m"
+Exception:
+Failure
+ "File \"_none_\", line 1, characters 0-6:\nExpected 'class-', 'class-type-', or an unqualified reference.".
+# resolve_ref "type-t.m"
+Exception: Failure "resolve_reference".
+# resolve_ref "type-t.method-m"
+Exception:
+Failure
+ "File \"_none_\", line 1, characters 0-6:\nExpected 'class-', 'class-type-', or an unqualified reference.".
+```
+
 ## Failures
 
 Test some error paths.

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -604,21 +604,27 @@ let resolve_ref = resolve_ref_of_mli {|
 
 ```ocaml
 # resolve_ref "type:M.cl" (* Type reference resolves to class *)
-Exception: Failure "resolve_reference".
+- : ref = `Class (`Identifier (`Module (`Root (Common.root, Root), M)), cl)
 # resolve_ref "type:M.clt"
-Exception: Failure "resolve_reference".
+- : ref =
+`ClassType (`Identifier (`Module (`Root (Common.root, Root), M)), clt)
 # resolve_ref "type:cl" (* Root TType reference resolves to class *)
 - : ref = `Identifier (`Class (`Root (Common.root, Root), cl))
 # resolve_ref "type:clt"
 - : ref = `Identifier (`ClassType (`Root (Common.root, Root), clt))
 # resolve_ref "M.type-cl.m" (* Type label parent resolves to class *)
-Exception: Failure "resolve_reference".
+- : ref =
+`Method
+  (`Class (`Identifier (`Module (`Root (Common.root, Root), M)), cl), m)
 # resolve_ref "M.type-clt.m"
-Exception: Failure "resolve_reference".
+- : ref =
+`Method
+  (`ClassType (`Identifier (`Module (`Root (Common.root, Root), M)), clt), m)
 # resolve_ref "type-cl.m" (* Root TType label parent resolves to class *)
-Exception: Failure "resolve_reference".
+- : ref = `Method (`Identifier (`Class (`Root (Common.root, Root), cl)), m)
 # resolve_ref "type-clt.m"
-Exception: Failure "resolve_reference".
+- : ref =
+`Method (`Identifier (`ClassType (`Root (Common.root, Root), clt)), m)
 # resolve_ref "method:cl.m"
 - : ref = `Method (`Identifier (`Class (`Root (Common.root, Root), cl)), m)
 ```


### PR DESCRIPTION
Fixes https://github.com/ocaml/odoc/issues/523

References with explicit `type:` or `type-` would not resolve classes or class types (except in one case).

This brings a new inconsistency: `type-cl.method-m` is not a valid reference due to the type of method references. Should we relax this or is it expected ? (classes are types but types are not classes)