### PR TITLE
Better handling of errors in 'type_of.ml'

### DIFF
--- a/src/xref2/expand_tools.ml
+++ b/src/xref2/expand_tools.ml
@@ -83,7 +83,8 @@ and aux_expansion_of_module_alias env ~strengthen path =
              Component.Fmt.signature sg'; *)
           Ok (Signature { sg' with items = Comment (`Docs docs) :: sg'.items })
       | Ok (Functor _ as x), _ -> Ok x )
-  | Error _ -> Error (`UnresolvedPath (`Module path))
+  | Error e ->
+    Error (`UnresolvedPath (`Module (path, e)))
 
 (* We need to reresolve fragments in expansions as the root of the fragment
    may well change - so we turn resolved fragments back into unresolved ones
@@ -114,7 +115,7 @@ and aux_expansion_of_u_module_type_expr env expr :
   match expr with
   | Component.ModuleType.U.Path p ->
     Tools.resolve_module_type ~mark_substituted:false env p
-    |> map_error (fun _ -> (`UnresolvedPath (`ModuleType p) : signature_of_module_error))
+    |> map_error (fun e -> (`UnresolvedPath (`ModuleType (p, e)) : signature_of_module_error))
     >>= fun (_, mt) -> aux_expansion_of_module_type env mt
     >>= assert_not_functor
   | Signature sg -> Ok (sg)
@@ -131,7 +132,7 @@ and aux_expansion_of_module_type_expr env expr :
   match expr with
   | Path {p_path; _} ->
       Tools.resolve_module_type ~mark_substituted:false env p_path
-      |> map_error (fun _ -> (`UnresolvedPath (`ModuleType p_path) : signature_of_module_error))
+      |> map_error (fun e -> (`UnresolvedPath (`ModuleType (p_path, e)) : signature_of_module_error))
       >>= fun (_, mt) -> aux_expansion_of_module_type env mt
   | Signature s -> Ok (Signature s)
   | With {w_substitutions; w_expr; _} -> (

--- a/src/xref2/type_of.ml
+++ b/src/xref2/type_of.ml
@@ -61,8 +61,9 @@ and module_type_expr env (id : Id.Signature.t) expr =
   | TypeOf t ->
     match module_type_expr_typeof env id t with
     | Ok e -> TypeOf {t with t_expansion = Some (Lang_of.(simple_expansion empty id e)) }
-    | Error (`UnexpandedTypeOf _) -> again := true; expr
-    | Error _ -> expr
+    | Error e when Errors.is_unexpanded_module_type_of (e :> Errors.Tools_error.any) -> again := true; expr
+    | Error _e ->
+      expr
 
 and u_module_type_expr env id expr =
   match expr with
@@ -72,8 +73,9 @@ and u_module_type_expr env id expr =
   | TypeOf t ->
     match module_type_expr_typeof env id t with
     | Ok e -> TypeOf {t with t_expansion = Some (Lang_of.(simple_expansion empty id e)) }
-    | Error (`UnexpandedTypeOf _) -> again := true; expr
-    | Error _ -> expr
+    | Error e when Errors.is_unexpanded_module_type_of (e :> Errors.Tools_error.any) -> again := true; expr
+    | Error _e ->
+      expr
 
 and functor_parameter env p =
   { p with expr = module_type_expr env (p.id :> Id.Signature.t) p.expr}


### PR DESCRIPTION
The code for 'module type of' expansion runs before any other resolution
happens, and it needs to run until a fixed point. Since the change to
use 'Result.t' over simply raising exceptions when we notice we'll need
to recurse, a bug was introduced when the specific error case we're
looking for was swallowed in another layer. This PR attempts to make
sure we don't ever throw away an error raised during signature expansion
and adds some code to check in the combined error whether the root cause
was in fact the case we're looking for; `` `UnexpandedTypeOf `` in this
case.

Signed-off-by: Jon Ludlam <jon@recoil.org>