### PR TITLE
Fix some leaking hidden paths

### DIFF
--- a/src/document/doctree.ml
+++ b/src/document/doctree.ml
@@ -54,8 +54,7 @@ module Rewire = struct
 
 end
 
-module Toc = struct
-
+module Toc : sig
   type t = one list
 
   and one = {
@@ -63,6 +62,18 @@ module Toc = struct
     text : Inline.t;
     children : t
   }
+
+  val compute : on_sub:(Include.status -> bool) -> Item.t list -> t
+end
+  = struct
+
+    type t = one list
+
+    and one = {
+      anchor : string;
+      text : Inline.t;
+      children : t
+    }
 
   let classify ~on_sub (i : Item.t) : _ Rewire.action = match i with
     | Text _
@@ -86,7 +97,9 @@ module Toc = struct
 end
 
 
-module Subpages = struct
+module Subpages : sig
+  val compute : Page.t -> Subpage.t list
+end = struct
 
   let rec walk_documentedsrc (l : DocumentedSrc.t) =
     Utils.flatmap l ~f:(function

--- a/src/model_desc/comment_desc.mli
+++ b/src/model_desc/comment_desc.mli
@@ -1,0 +1,2 @@
+val docs : Odoc_model.Comment.docs Type_desc.t
+val docs_or_stop : Odoc_model.Comment.docs_or_stop Type_desc.t

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -52,13 +52,13 @@ and moduletype_substitution =
   let open Lang.ModuleType in
   Variant
     (function
-    | ModuleEq (x1, x2) -> C ("ModuleEq", (x1, x2), Pair (fragment, module_decl))
+    | ModuleEq (x1, x2) -> C ("ModuleEq", ((x1 :> Paths.Fragment.t), x2), Pair (fragment, module_decl))
     | TypeEq (x1, x2) ->
-        C ("TypeEq", (x1, x2), Pair (fragment, typedecl_equation))
+        C ("TypeEq", ((x1 :> Paths.Fragment.t), x2), Pair (fragment, typedecl_equation))
     | ModuleSubst (x1, x2) ->
-        C ("ModuleSubst", (x1, (x2 :> Paths.Path.t)), Pair (fragment, path))
+        C ("ModuleSubst", ((x1 :> Paths.Fragment.t), (x2 :> Paths.Path.t)), Pair (fragment, path))
     | TypeSubst (x1, x2) ->
-        C ("TypeSubst", (x1, x2), Pair (fragment, typedecl_equation)))
+        C ("TypeSubst", ((x1 :> Paths.Fragment.t), x2), Pair (fragment, typedecl_equation)))
 
 and moduletype_type_of_desc =
   let open Lang.ModuleType in
@@ -175,7 +175,7 @@ and signature_item =
     | Include x -> C ("Include", x, include_t)
     | Comment x -> C ("Comment", x, docs_or_stop))
 
-and signature_t = List signature_item
+and signature_t : Lang.Signature.t Type_desc.t = List signature_item
 
 (** {3 Open} *)
 and open_t =
@@ -528,7 +528,7 @@ and typeexpr_package =
       F ("path", (fun t -> (t.path :> Paths.Path.t)), path);
       F
         ( "substitutions",
-          (fun t -> t.substitutions),
+          (fun t -> (t.substitutions :> (Paths.Fragment.t * Lang.TypeExpr.t) list)),
           List typeexpr_package_substitution );
     ]
 
@@ -570,7 +570,7 @@ and compilation_unit_import =
     | Unresolved (x1, x2) ->
         C ("Unresolved", (x1, x2), Pair (string, Option Digest.t))
     | Resolved (x1, x2) ->
-        C ("Resolved", (x1, x2), Pair (Root.t, Names.modulename)))
+        C ("Resolved", (x1, x2), Pair (root, modulename)))
 
 and compilation_unit_source =
   let open Lang.Compilation_unit.Source in

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -258,15 +258,18 @@ module General_paths = struct
       | `Root -> C0 "`Root")
 end
 
-(* Indirection seems to be required to make the type open. *)
-let identifier = Indirect ((fun n -> (n :> Paths.Identifier.t)), General_paths.identifier)
+let root = Root.t
+let modulename = Names.modulename
 
-let resolved_path =
+(* Indirection seems to be required to make the type open. *)
+let identifier : [< Paths.Identifier.t] Type_desc.t = Indirect ((fun n -> (n :> Paths.Identifier.t)), General_paths.identifier)
+
+let resolved_path : [< Paths.Path.Resolved.t] Type_desc.t =
   Indirect
     ( (fun n -> (n :> General_paths.rp)),
       General_paths.resolved_path )
 
-let path =
+let path : [< Paths.Path.t] Type_desc.t =
   Indirect
     ((fun n -> (n :> General_paths.p)), General_paths.path)
 

--- a/src/model_desc/paths_desc.mli
+++ b/src/model_desc/paths_desc.mli
@@ -1,0 +1,17 @@
+open Odoc_model.Paths
+
+val root : Odoc_model.Root.t Type_desc.t
+
+val modulename : Odoc_model.Names.ModuleName.t Type_desc.t
+
+val identifier : [< Identifier.t] Type_desc.t
+
+val resolved_path : [< Path.Resolved.t] Type_desc.t 
+
+val path : [< Path.t] Type_desc.t
+
+val resolved_fragment : [< Fragment.Resolved.t ] Type_desc.t
+  
+val fragment : [< Fragment.t ] Type_desc.t
+  
+val reference : [< Reference.t ] Type_desc.t

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -293,7 +293,7 @@ end = struct
   module Targets = struct
     let list_targets output_dir _ extra odoc_file =
       let odoc_file = Fs.File.of_string odoc_file in
-      Rendering.targets ~renderer:R.renderer ~output:output_dir ~extra odoc_file
+      Rendering.targets_odoc ~renderer:R.renderer ~output:output_dir ~extra odoc_file
     
     let back_compat =
       let doc =

--- a/src/odoc/rendering.mli
+++ b/src/odoc/rendering.mli
@@ -1,0 +1,15 @@
+open Odoc_document
+open Or_error
+
+val render_odoc: env:Env.builder ->
+    warn_error:bool ->
+    syntax:Renderer.syntax ->
+    renderer:'a Renderer.t ->
+    output:Fs.directory -> 'a -> Fpath.t -> (unit, [> msg ]) result
+
+val generate_odoc : syntax:Renderer.syntax ->
+    renderer:'a Renderer.t ->
+    output:Fs.directory -> 'a -> Fpath.t -> (unit, [> msg ]) result
+
+val targets_odoc : renderer:'a Renderer.t ->
+    output:Fs.directory -> extra:'a -> Fpath.t -> (unit, [> msg ]) result

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -62,15 +62,7 @@ and content env id =
   let open Compilation_unit in
   function
   | Module m ->
-    let rec loop sg =
-      Type_of.again := false;
-      let sg' = Type_of.signature env sg in
-      Tools.reset_caches ();
-      if !Type_of.again
-      then begin
-        if sg' = sg then sg else loop sg'
-      end else sg' in
-    let sg = loop m in
+    let sg = Type_of.signature env m in
     Module (signature env (id :> Id.Signature.t) sg)
   | Pack _ -> failwith "Unhandled content"
 
@@ -459,7 +451,7 @@ in
           in
           let _, _, subs =
             List.fold_left
-              (module_type_expr_sub id ~fragment_root)
+              (module_type_expr_sub (id :> Id.Signature.t) ~fragment_root)
               (Ok sg, env, []) subs
           in
           let subs = List.rev subs in

--- a/src/xref2/errors.ml
+++ b/src/xref2/errors.ml
@@ -155,7 +155,28 @@ let rec kind_of_error = function
   | `Parent (`Parent _ as e) -> kind_of_error (e :> Tools_error.any)
   | _ -> None
 
-let report ~what ?tools_error action =
+open Paths
+type what = [
+  | `Functor_parameter of Identifier.FunctorParameter.t
+  | `Value of Identifier.Value.t
+  | `Class of Identifier.Class.t
+  | `Class_type of Identifier.ClassType.t
+  | `Module of Identifier.Module.t
+  | `Module_type of Identifier.Signature.t
+  | `Module_path of Cpath.module_
+  | `Module_type_path of Cpath.module_type
+  | `Module_type_U of Component.ModuleType.U.expr
+  | `Include of Component.Include.decl
+  | `Package of Cpath.module_type
+  | `Type of Cfrag.type_
+  | `Type_path of Cpath.type_
+  | `With_module of Cfrag.module_
+  | `With_type of Cfrag.type_
+  | `Module_type_expr of Component.ModuleType.expr
+  | `Module_type_u_expr of Component.ModuleType.U.expr
+]
+
+let report ~(what:what) ?tools_error action =
   let kind =
     match tools_error with
     | Some e -> kind_of_error (e :> Tools_error.any)

--- a/src/xref2/type_of.ml
+++ b/src/xref2/type_of.ml
@@ -85,3 +85,14 @@ and include_ env i =
     | ModuleType t -> ModuleType (u_module_type_expr env i.parent t)
   in
   { i with expansion = { i.expansion with content = signature env i.expansion.content }; decl }
+
+let signature env =
+  let rec loop sg =
+    again := false;
+    let sg' = signature env sg in
+    Tools.reset_caches ();
+    if !again
+    then begin
+      if sg' = sg then sg else loop sg'
+    end else sg' in
+  loop

--- a/src/xref2/type_of.mli
+++ b/src/xref2/type_of.mli
@@ -1,0 +1,9 @@
+(** The purpose of this module is to expand module type
+    expressions of the form [module type of]. This is necessary
+    so odoc can keep track of these expressions but mainting the
+    semantics of the underlying OCaml. *)
+open Odoc_model.Lang
+
+(** Expand all of the [module type of] expressions within the
+    given signature *)
+val signature : Env.t -> Signature.t -> Signature.t

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -397,8 +397,32 @@ module LangUtils = struct
             | Module.ModuleType ModuleType.Signature s -> s
             | _ -> raise Not_found
 
-    module Fmt = struct
+    module Fmt : sig
+        open Odoc_model
+        type 'a fmt = Format.formatter -> 'a -> unit
+
+        open Paths
+        val identifier : [< Identifier.t] fmt
+
+        open Lang
+
+        val signature : Signature.t fmt
+        val module_decl : Module.decl fmt
+        val module_ : Module.t fmt
+        val module_type : ModuleType.t fmt
+        val u_module_type_expr : ModuleType.U.expr fmt
+        val functor_parameter : FunctorParameter.t fmt
+        val type_equation : TypeDecl.Equation.t fmt
+        val substitution : ModuleType.substitution fmt
+        val type_expr : TypeExpr.t fmt
+        val resolved_path : Path.Resolved.t fmt
+        val path : Path.t fmt
+        val model_fragment : Fragment.t fmt
+        val model_resolved_fragment : Fragment.Resolved.t fmt
+    end = struct
         open Odoc_model.Lang
+
+        type 'a fmt = Format.formatter -> 'a -> unit
 
         let identifier ppf i =
             Format.fprintf ppf "%a"


### PR DESCRIPTION
This commit prevents the accidental inclusion of paths that refer to
hidden modules. Usually the cause of this is there is no mli file for
the module and that the inferred types go directly to the type in the
hidden module without going via the module that declares the canonical
paths, so it's as if you've directly referred to a module with a `__` in
its name. The best fix for this is to write an mli file, and the second
best fix is to use some type annotations. This is occasionally tricky
where polymorphic variants are in play.

Signed-off-by: Jon Ludlam <jon@recoil.org>