### PR TITLE
Avoid parenthesising the function `lnot`

### DIFF
--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -37,7 +37,7 @@ let opt_iter f = function
 
 let parenthesise name =
   match name with
-  | "asr" | "land" | "lnot" | "lor" | "lsl" | "lsr"
+  | "asr" | "land" | "lor" | "lsl" | "lsr"
   | "lxor" | "mod" -> "(" ^ name ^ ")"
   | _ ->
     if (String.length name > 0) then

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -27,7 +27,7 @@ module Env = Odoc_model.Ident_env
 
 let parenthesise name =
   match name with
-  | "asr" | "land" | "lnot" | "lor" | "lsl" | "lsr"
+  | "asr" | "land" | "lor" | "lsl" | "lsr"
   | "lxor" | "mod" -> "(" ^ name ^ ")"
   | _ ->
     if (String.length name > 0) then

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -35,7 +35,7 @@ let opt_map f = function
 
 let parenthesise name =
   match name with
-  | "asr" | "land" | "lnot" | "lor" | "lsl" | "lsr"
+  | "asr" | "land" | "lor" | "lsl" | "lsr"
   | "lxor" | "mod" -> "(" ^ name ^ ")"
   | _ ->
     if (String.length name > 0) then


### PR DESCRIPTION
Previously this was displayed as a prefix operator, but the bitwise negation operator `lnot` is [implemented as a function](https://github.com/ocaml/ocaml/blob/4.12/stdlib/stdlib.mli#L413) and the OCaml parser [does not provide a special-case](https://github.com/ocaml/ocaml/blob/4.12/parsing/lexer.mll#L92-L98) for it.