### PR TITLE
Fix substitution of type params

### DIFF
--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -669,7 +669,9 @@ and type_expression : Env.t -> Id.Parent.t -> _ -> _ =
       | Ok (cp, (`FType _ | `FClass _ | `FClassType _)) ->
           let p = Cpath.resolved_type_path_of_cpath cp in
           Constr (`Resolved p, ts)
-      | Ok (_cp, `FType_removed (_, x)) -> Lang_of.(type_expr empty parent x)
+      | Ok (_cp, `FType_removed (_, x, _eq)) ->
+          (* Substitute type variables ? *)
+          Lang_of.(type_expr empty parent x)
       | Error _ -> Constr (Cpath.type_path_of_cpath cp, ts) )
   | Polymorphic_variant v ->
       Polymorphic_variant (type_expression_polyvar env parent v)

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -286,7 +286,7 @@ and Signature : sig
        and the path they've been substituted with *)
   type removed_item =
     | RModule of Ident.module_ * Cpath.Resolved.module_
-    | RType of Ident.type_ * TypeExpr.t
+    | RType of Ident.type_ * TypeExpr.t * TypeDecl.Equation.t
 
   type t = { items : item list; removed : removed_item list }
 end
@@ -391,7 +391,7 @@ and Substitution : sig
     module_type : subst_module_type ModuleTypeMap.t;
     type_ : subst_type PathTypeMap.t;
     class_type : subst_class_type PathClassTypeMap.t;
-    type_replacement : TypeExpr.t PathTypeMap.t;
+    type_replacement : (TypeExpr.t * TypeDecl.Equation.t) PathTypeMap.t;
     path_invalidating_modules : Ident.path_module list;
     module_type_of_invalidating_modules : Ident.path_module list;
   }
@@ -503,8 +503,6 @@ module Fmt : sig
   val type_decl : Format.formatter -> TypeDecl.t -> unit
 
   val type_equation : Format.formatter -> TypeDecl.Equation.t -> unit
-
-  val type_equation2 : Format.formatter -> TypeDecl.Equation.t -> unit
 
   val exception_ : Format.formatter -> Exception.t -> unit
 

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -103,7 +103,7 @@ let class_in_sig sg name =
         Some (`FClassType (N.class_type' id, c))
     | _ -> None)
 
-type removed_type = [ `FType_removed of TypeName.t * TypeExpr.t ]
+type removed_type = [ `FType_removed of TypeName.t * TypeExpr.t * TypeDecl.Equation.t ]
 
 type careful_module = [ module_ | `FModule_removed of Cpath.Resolved.module_ ]
 
@@ -123,8 +123,8 @@ let careful_module_in_sig sg name =
 
 let removed_type_in_sig sg name =
   let removed_type = function
-    | Signature.RType (id, p) when N.type_ id = name ->
-        Some (`FType_removed (N.type' id, p))
+    | Signature.RType (id, p, eq) when N.type_ id = name ->
+        Some (`FType_removed (N.type' id, p, eq))
     | _ -> None
   in
   find_map removed_type sg.Signature.removed

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -95,7 +95,7 @@ val any_in_class_signature : ClassSignature.t -> string -> any_in_class_sig list
 
 (** Lookup removed items *)
 
-type removed_type = [ `FType_removed of TypeName.t * TypeExpr.t ]
+type removed_type = [ `FType_removed of TypeName.t * TypeExpr.t * TypeDecl.Equation.t ]
 
 type careful_module = [ module_ | `FModule_removed of Cpath.Resolved.module_ ]
 

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -790,7 +790,8 @@ and type_expression : Env.t -> Id.Signature.t -> _ -> _ =
         | Ok (cp', (`FClass _ | `FClassType _)) ->
             let p = Cpath.resolved_type_path_of_cpath cp' in
             Constr (`Resolved p, ts)
-        | Ok (_cp, `FType_removed (_, x)) ->
+        | Ok (_cp, `FType_removed (_, x, _eq)) ->
+            (* Type variables ? *)
             Lang_of.(type_expr empty (parent :> Id.Parent.t) x)
         | Error _ -> Constr (Cpath.type_path_of_cpath cp, ts) )
   | Polymorphic_variant v ->

--- a/src/xref2/subst.mli
+++ b/src/xref2/subst.mli
@@ -1,4 +1,5 @@
 (* Subst *)
+open Component
 
 type t = Component.Substitution.t
 
@@ -22,7 +23,7 @@ val add_class :
 val add_class_type :
   Ident.class_type -> Cpath.class_type -> Cpath.Resolved.class_type -> t -> t
 
-val add_type_replacement : Ident.path_type -> Component.TypeExpr.t -> t -> t
+val add_type_replacement : Ident.path_type -> TypeExpr.t -> TypeDecl.Equation.t -> t -> t
 
 val add_module_substitution : Ident.path_module -> t -> t
 

--- a/test/xref2/strengthen/test.md
+++ b/test/xref2/strengthen/test.md
@@ -29,7 +29,7 @@ type u/1 = local(t/0,false)
  (removed=[])
 AFTER
 ======
-type t/2 = resolved(identifier((root Root))).t
+type t/2 = r((root Root)).t
 type u/3 = local(t/2,false)
  (removed=[])
 - : unit = ()

--- a/test/xref2/subst/dune
+++ b/test/xref2/subst/dune
@@ -8,5 +8,6 @@
 
 (rule
  (alias runtest)
+ (enabled_if (>= %{ocaml_version} 4.06))
  (action
   (diff test.md test.output)))

--- a/test/xref2/subst/test.md
+++ b/test/xref2/subst/test.md
@@ -83,3 +83,108 @@ type vv/8 = resolved(local(SubTargets/1)).v
 
 - : unit = ()
 ```
+
+Now test by compiling signatures and printing the result:
+
+```ocaml
+(* Nicer output *)
+#install_printer Component.Fmt.signature;;
+
+let compile mli =
+  let open Component in
+  let id, docs, sg = Common.model_of_string mli in
+  Odoc_xref2.Compile.signature Env.empty (id :> Odoc_model.Paths.Identifier.Signature.t) sg
+  |> Of_Lang.signature Of_Lang.empty
+```
+
+```ocaml
+# compile {|
+  module type Monad = sig
+    type 'a t
+
+    val map : 'a t -> ('a -> 'b) -> 'b t
+
+    val join : 'a t t -> 'a t
+  end
+
+  (** Simplest case *)
+  module SomeMonad : sig
+    type 'a t
+
+    include Monad with type 'a t := 'a t
+  end
+
+  (** Substitute with a more complex type *)
+  module ComplexTypeExpr : sig
+    type ('a, 'b) t
+
+    include Monad with type 'a t := (int, 'a) t * ('a, int) t
+  end
+
+  (** No abstraction *)
+  module Erase : sig
+    include Monad with type 'a t := 'a
+  end
+  |}
+- : Component.Signature.t =
+module type Monad/30 = sig
+  type t/31
+  val map/32 : [a] resolved(t/31) -> a -> b -> [b] resolved(t/31)
+  val join/33 : [[a] resolved(t/31)] resolved(t/31) -> [a] resolved(t/31)
+   (removed=[])end
+module SomeMonad/29 : sig
+  type t/34
+  include : resolved(Monad/30) with [resolved(root(Monad/30).t) = [a] resolved(t/34)] (sig =
+    val map/35 : [a] resolved(t/34) -> a -> b -> [a] resolved(t/34)
+    val join/36 : [a] resolved(t/34) -> [a] resolved(t/34)
+     (removed=[]))
+   (removed=[])end
+module ComplexTypeExpr/27 : sig
+  type t/37
+  include : resolved(Monad/30) with [resolved(root(Monad/30).t) = ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))] (sig =
+    val map/38 : ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37)) -> a -> b -> ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))
+    val join/39 : ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37)) -> ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))
+     (removed=[]))
+   (removed=[])end
+module Erase/28 : sig
+  include : resolved(Monad/30) with [resolved(root(Monad/30).t) = a] (sig =
+    val map/40 : a -> a -> b -> a
+    val join/41 : a -> a
+     (removed=[]))
+   (removed=[])end
+ (removed=[])
+```
+
+More tests with two type variables:
+
+```ocaml
+# compile {|
+  module type Monad_2 = sig
+    type ('a, 'err) t
+    val map : ('a, 'err) t -> f:('a -> 'b) -> ('b, 'err) t
+    val join : (('a, 'e) t, 'e) t -> ('a, 'e) t
+    val both : ('a, 'e) t -> ('b, 'e) t -> ('a * 'b, 'e) t
+  end
+
+  module SwappedVars : sig
+    type ('x, 'y) t
+    include Monad_2 with type ('a, 'b) t := ('b, 'a) t
+  end
+  |}
+- : Component.Signature.t =
+module type Monad_2/54 = sig
+  type t/55
+  val map/56 : [a * err] resolved(t/55) -> a -> b -> [b * err] resolved(t/55)
+  val join/57 : [[a * e] resolved(t/55) * e] resolved(t/55) -> [a * e] resolved(t/55)
+  val both/58 : [a * e] resolved(t/55) -> [b * e] resolved(t/55) -> [(a * b) * e] resolved(t/55)
+   (removed=[])end
+module SwappedVars/53 : sig
+  type t/59
+  include : resolved(Monad_2/54) with [resolved(root(Monad_2/54).t) = [b * a] resolved(t/59)] (sig =
+    val map/60 : [b * a] resolved(t/59) -> a -> b -> [b * a] resolved(t/59)
+    val join/61 : [b * a] resolved(t/59) -> [b * a] resolved(t/59)
+    val both/62 : [b * a] resolved(t/59) -> [b * a] resolved(t/59) -> [b * a] resolved(t/59)
+     (removed=[]))
+   (removed=[])end
+ (removed=[])
+```

--- a/test/xref2/subst/test.md
+++ b/test/xref2/subst/test.md
@@ -202,5 +202,16 @@ Edge cases:
     include S with type 'a t := ([ `A of 'a * 'b ] as 'b) t
   end
   |}
-Exception: Not_found.
+- : Component.Signature.t =
+module type S/69 = sig
+  type t/70
+  val map/71 : ([a] r(t/70)) -> ((a) -> b) -> [b] r(t/70)
+   (removed=[])end
+module M/68 : sig
+  type t/72
+  include : r(S/69) with [r(root(S/69).t) = [(alias (poly_var [ `A of (a * b) ]) b)] r(t/72)] (sig =
+    val map/73 : ([(alias (poly_var [ `A of (a * b) ]) b)] r(t/72)) -> ((a) -> b) -> [(alias (poly_var [ `A of (b * b) ]) b)] r(t/72)
+     (removed=[]))
+   (removed=[])end
+ (removed=[])
 ```

--- a/test/xref2/subst/test.md
+++ b/test/xref2/subst/test.md
@@ -187,3 +187,20 @@ module SwappedVars/53 : sig
    (removed=[])end
  (removed=[])
 ```
+
+Edge cases:
+
+```ocaml
+# compile {|
+  module type S = sig
+    type 'a t
+    val map : 'a t -> ('a -> 'b) -> 'b t
+  end
+
+  module M : sig
+    type 'a t
+    include S with type 'a t := ([ `A of 'a * 'b ] as 'b) t
+  end
+  |}
+Exception: Not_found.
+```

--- a/test/xref2/subst/test.md
+++ b/test/xref2/subst/test.md
@@ -76,9 +76,9 @@ type vv/5 = local(SubstituteMe/2,false).v
 AFTER
 ======
 S: sig
-type tt/6 = resolved(local(SubTargets/1)).t
-type uu/7 = resolved(local(SubTargets/1)).u
-type vv/8 = resolved(local(SubTargets/1)).v
+type tt/6 = r(SubTargets/1).t
+type uu/7 = r(SubTargets/1).u
+type vv/8 = r(SubTargets/1).v
  (removed=[])end
 
 - : unit = ()
@@ -129,28 +129,27 @@ let compile mli =
 - : Component.Signature.t =
 module type Monad/30 = sig
   type t/31
-  val map/32 : [a] resolved(t/31) -> a -> b -> [b] resolved(t/31)
-  val join/33 : [[a] resolved(t/31)] resolved(t/31) -> [a] resolved(t/31)
+  val map/32 : ([a] r(t/31)) -> ((a) -> b) -> [b] r(t/31)
+  val join/33 : ([[a] r(t/31)] r(t/31)) -> [a] r(t/31)
    (removed=[])end
 module SomeMonad/29 : sig
   type t/34
-  include : resolved(Monad/30) with [resolved(root(Monad/30).t) = [a] resolved(t/34)] (sig =
-    val map/35 : [a] resolved(t/34) -> a -> b -> [b] resolved(t/34)
-    val join/36 : [[a] resolved(t/34)] resolved(t/34) -> [a] resolved(t/34)
+  include : r(Monad/30) with [r(root(Monad/30).t) = [a] r(t/34)] (sig =
+    val map/35 : ([a] r(t/34)) -> ((a) -> b) -> [b] r(t/34)
+    val join/36 : ([[a] r(t/34)] r(t/34)) -> [a] r(t/34)
      (removed=[]))
    (removed=[])end
 module ComplexTypeExpr/27 : sig
   type t/37
-  include : resolved(Monad/30) with [resolved(root(Monad/30).t) = ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))] (sig =
-    val map/38 : ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37)) -> a -> b -> ([resolved(identifier(int)) * b] resolved(t/37) * [b * resolved(identifier(int))] resolved(t/37))
-    val join/39 : ([resolved(identifier(int)) * ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))] resolved(t/37) * [([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37)) * resolved(identifier(int))] resolved(t/37)) -> ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))
+  include : r(Monad/30) with [r(root(Monad/30).t) = ([r(int) * a] r(t/37) * [a * r(int)] r(t/37))] (sig =
+    val map/38 : (([r(int) * a] r(t/37) * [a * r(int)] r(t/37))) -> ((a) -> b) -> ([r(int) * b] r(t/37) * [b * r(int)] r(t/37))
+    val join/39 : (([r(int) * ([r(int) * a] r(t/37) * [a * r(int)] r(t/37))] r(t/37) * [([r(int) * a] r(t/37) * [a * r(int)] r(t/37)) * r(int)] r(t/37))) -> ([r(int) * a] r(t/37) * [a * r(int)] r(t/37))
      (removed=[]))
    (removed=[])end
 module Erase/28 : sig
-  include : resolved(Monad/30) with [resolved(root(Monad/30).t) = a] (sig =
-    val map/40 : a -> a -> b -> b
-    val join/41 : a -> a
-     (removed=[]))
+  include : r(Monad/30) with [r(root(Monad/30).t) = a] (sig = val map/40 : (a) -> ((a) -> b) -> b
+                                                              val join/41 : (a) -> a
+                                                               (removed=[]))
    (removed=[])end
  (removed=[])
 ```
@@ -174,16 +173,16 @@ More tests with two type variables:
 - : Component.Signature.t =
 module type Monad_2/54 = sig
   type t/55
-  val map/56 : [a * err] resolved(t/55) -> a -> b -> [b * err] resolved(t/55)
-  val join/57 : [[a * e] resolved(t/55) * e] resolved(t/55) -> [a * e] resolved(t/55)
-  val both/58 : [a * e] resolved(t/55) -> [b * e] resolved(t/55) -> [(a * b) * e] resolved(t/55)
+  val map/56 : ([a * err] r(t/55)) -> f:((a) -> b) -> [b * err] r(t/55)
+  val join/57 : ([[a * e] r(t/55) * e] r(t/55)) -> [a * e] r(t/55)
+  val both/58 : ([a * e] r(t/55)) -> ([b * e] r(t/55)) -> [(a * b) * e] r(t/55)
    (removed=[])end
 module SwappedVars/53 : sig
   type t/59
-  include : resolved(Monad_2/54) with [resolved(root(Monad_2/54).t) = [b * a] resolved(t/59)] (sig =
-    val map/60 : [err * a] resolved(t/59) -> a -> b -> [err * b] resolved(t/59)
-    val join/61 : [e * [e * a] resolved(t/59)] resolved(t/59) -> [e * a] resolved(t/59)
-    val both/62 : [e * a] resolved(t/59) -> [e * b] resolved(t/59) -> [e * (a * b)] resolved(t/59)
+  include : r(Monad_2/54) with [r(root(Monad_2/54).t) = [b * a] r(t/59)] (sig =
+    val map/60 : ([err * a] r(t/59)) -> f:((a) -> b) -> [err * b] r(t/59)
+    val join/61 : ([e * [e * a] r(t/59)] r(t/59)) -> [e * a] r(t/59)
+    val both/62 : ([e * a] r(t/59)) -> ([e * b] r(t/59)) -> [e * (a * b)] r(t/59)
      (removed=[]))
    (removed=[])end
  (removed=[])

--- a/test/xref2/subst/test.md
+++ b/test/xref2/subst/test.md
@@ -135,20 +135,20 @@ module type Monad/30 = sig
 module SomeMonad/29 : sig
   type t/34
   include : resolved(Monad/30) with [resolved(root(Monad/30).t) = [a] resolved(t/34)] (sig =
-    val map/35 : [a] resolved(t/34) -> a -> b -> [a] resolved(t/34)
-    val join/36 : [a] resolved(t/34) -> [a] resolved(t/34)
+    val map/35 : [a] resolved(t/34) -> a -> b -> [b] resolved(t/34)
+    val join/36 : [[a] resolved(t/34)] resolved(t/34) -> [a] resolved(t/34)
      (removed=[]))
    (removed=[])end
 module ComplexTypeExpr/27 : sig
   type t/37
   include : resolved(Monad/30) with [resolved(root(Monad/30).t) = ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))] (sig =
-    val map/38 : ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37)) -> a -> b -> ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))
-    val join/39 : ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37)) -> ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))
+    val map/38 : ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37)) -> a -> b -> ([resolved(identifier(int)) * b] resolved(t/37) * [b * resolved(identifier(int))] resolved(t/37))
+    val join/39 : ([resolved(identifier(int)) * ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))] resolved(t/37) * [([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37)) * resolved(identifier(int))] resolved(t/37)) -> ([resolved(identifier(int)) * a] resolved(t/37) * [a * resolved(identifier(int))] resolved(t/37))
      (removed=[]))
    (removed=[])end
 module Erase/28 : sig
   include : resolved(Monad/30) with [resolved(root(Monad/30).t) = a] (sig =
-    val map/40 : a -> a -> b -> a
+    val map/40 : a -> a -> b -> b
     val join/41 : a -> a
      (removed=[]))
    (removed=[])end
@@ -181,9 +181,9 @@ module type Monad_2/54 = sig
 module SwappedVars/53 : sig
   type t/59
   include : resolved(Monad_2/54) with [resolved(root(Monad_2/54).t) = [b * a] resolved(t/59)] (sig =
-    val map/60 : [b * a] resolved(t/59) -> a -> b -> [b * a] resolved(t/59)
-    val join/61 : [b * a] resolved(t/59) -> [b * a] resolved(t/59)
-    val both/62 : [b * a] resolved(t/59) -> [b * a] resolved(t/59) -> [b * a] resolved(t/59)
+    val map/60 : [err * a] resolved(t/59) -> a -> b -> [err * b] resolved(t/59)
+    val join/61 : [e * [e * a] resolved(t/59)] resolved(t/59) -> [e * a] resolved(t/59)
+    val both/62 : [e * a] resolved(t/59) -> [e * b] resolved(t/59) -> [e * (a * b)] resolved(t/59)
      (removed=[]))
    (removed=[])end
  (removed=[])


### PR DESCRIPTION
Fix https://github.com/ocaml/odoc/issues/538 and https://github.com/ocaml/odoc/issues/462

This substitutes recursively type variables when encountering a "replaced" type. 