### PR TITLE
Enable CI for OCaml 4.02.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
         ocaml-version:
           # Don't include every versions. OCaml-CI already covers that
           - 4.11.1
+          - 4.02.3 # OCaml-CI stops at 4.04
+          - 4.03.0 # OCaml-CI stops at 4.04
         include:
           - os: ubuntu-latest # Enable coverage only on a single build
             send-coverage: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ jobs:
         ocaml-version:
           # Don't include every versions. OCaml-CI already covers that
           - 4.11.1
-          - 4.02.3 # OCaml-CI stops at 4.04
-          - 4.03.0 # OCaml-CI stops at 4.04
         include:
           - os: ubuntu-latest # Enable coverage only on a single build
             send-coverage: true

--- a/odoc.opam
+++ b/odoc.opam
@@ -43,7 +43,7 @@ depends: [
   "markup" {with-test & >= "1.0.0"}
   "ocamlfind" {with-test}
   "yojson" {with-test}
-  ("ocaml" {< "4.04.1"} | "sexplib0" {with-test})
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
   "conf-jq" {with-test}
 
   "bisect_ppx" {with-test & >= "2.5.0"}

--- a/odoc.opam
+++ b/odoc.opam
@@ -43,7 +43,7 @@ depends: [
   "markup" {with-test & >= "1.0.0"}
   "ocamlfind" {with-test}
   "yojson" {with-test}
-  "sexplib0" {with-test}
+  ("ocaml" {< "4.04.1"} | "sexplib0" {with-test})
   "conf-jq" {with-test}
 
   "bisect_ppx" {with-test & >= "2.5.0"}

--- a/src/xref2/errors.ml
+++ b/src/xref2/errors.ml
@@ -5,72 +5,84 @@ module Tools_error = struct
   (** Errors raised by Tools *)
 
   type handle_subs_error =
-    [ `UnresolvedPath of [ `Module of Cpath.module_ ]
-      (** Failed to resolve a module path when applying a fragment item *) ]
+    [ `UnresolvedPath of
+      [ `Module of Cpath.module_ ]
+      (* Failed to resolve a module path when applying a fragment item *) ]
 
   type signature_of_module_error =
-    [ `OpaqueModule  (** The module does not have an expansion *)
+    [ `OpaqueModule (* The module does not have an expansion *)
     | `UnresolvedForwardPath
-      (** The module signature depends upon a forward path *)
+      (* The module signature depends upon a forward path *)
     | `UnresolvedPath of
       [ `Module of Cpath.module_ * simple_module_lookup_error
       | `ModuleType of Cpath.module_type * simple_module_type_lookup_error ]
-      (** The path to the module or module type could not be resolved *)
-    | `UnexpandedTypeOf of Component.ModuleType.type_of_desc
-      (** The `module type of` expression could not be expanded *) ]
+      (* The path to the module or module type could not be resolved *)
+    | `UnexpandedTypeOf of
+      Component.ModuleType.type_of_desc
+      (* The `module type of` expression could not be expanded *) ]
 
   and simple_module_lookup_error =
-    [ `Local of Env.t * Ident.path_module
-      (** Internal error: Found local path during lookup *)
-    | `Unresolved_apply  (** [`Apply] argument is not [`Resolved] *)
+    [ `Local of
+      Env.t * Ident.path_module
+      (* Internal error: Found local path during lookup *)
+    | `Unresolved_apply (* [`Apply] argument is not [`Resolved] *)
     | `Find_failure
-    | (*** Internal error: the module was not found in the parent signature *)
+    | (* Internal error: the module was not found in the parent signature *)
       `Lookup_failure of
       Identifier.Path.Module.t
-      (** Could not find the module in the environment *)
-    | `Lookup_failure_root of string  (** Could not find the root module *)
+      (* Could not find the module in the environment *)
+    | `Lookup_failure_root of string (* Could not find the root module *)
     | `Parent of parent_lookup_error ]
 
   and simple_module_type_expr_of_module_error =
     [ `ApplyNotFunctor
-      (** Internal error: attempt made to apply a module that's not a functor *)
-    | `OpaqueModule  (** The module does not have an expansion *)
+      (* Internal error: attempt made to apply a module that's not a functor *)
+    | `OpaqueModule (* The module does not have an expansion *)
     | `UnresolvedForwardPath
-      (** The module signature depends upon a forward path *)
+      (* The module signature depends upon a forward path *)
     | `UnresolvedPath of
       [ `Module of Cpath.module_ * simple_module_lookup_error
       | `ModuleType of Cpath.module_type * simple_module_type_lookup_error ]
     | `Parent of parent_lookup_error ]
 
   and simple_module_type_lookup_error =
-    [ `LocalMT of Env.t * Ident.module_type
-      (** Internal error: Found local path during lookup *)
+    [ `LocalMT of
+      Env.t * Ident.module_type
+      (* Internal error: Found local path during lookup *)
     | `Find_failure
-      (** Internal error: the module was not found in the parent signature *)
-    | `Lookup_failureMT of Identifier.ModuleType.t
-      (** Could not find the module in the environment *)
+      (* Internal error: the module was not found in the parent signature *)
+    | `Lookup_failureMT of
+      Identifier.ModuleType.t
+      (* Could not find the module in the environment *)
     | `Parent of parent_lookup_error ]
 
   and simple_type_lookup_error =
-    [ `LocalType of Env.t * Ident.path_type
-      (** Internal error: Found local path during lookup *)
+    [ `LocalType of
+      Env.t * Ident.path_type
+      (* Internal error: Found local path during lookup *)
     | `Class_replaced
-      (** Class was replaced with a destructive substitution and we're not sure what to do now *)
+      (* Class was replaced with a destructive substitution and we're not sure
+          what to do now *)
     | `Find_failure
-      (** Internal error: the type was not found in the parent signature *)
-    | `Lookup_failureT of Identifier.Path.Type.t
-      (** Could not find the module in the environment *)
+      (* Internal error: the type was not found in the parent signature *)
+    | `Lookup_failureT of
+      Identifier.Path.Type.t
+      (* Could not find the module in the environment *)
     | `Parent of parent_lookup_error ]
 
   and parent_lookup_error =
-    [ `Parent_sig of signature_of_module_error
-      (** Error found while calculating the parent signature *)
-    | `Parent_module_type of simple_module_type_lookup_error
-      (** Error found while looking up parent module type *)
-    | `Parent_expr of simple_module_type_expr_of_module_error
-      (** Error found while evaluating parent module expression *)
-    | `Parent_module of simple_module_lookup_error
-      (** Error found while looking up parent module *)
+    [ `Parent_sig of
+      signature_of_module_error
+      (* Error found while calculating the parent signature *)
+    | `Parent_module_type of
+      simple_module_type_lookup_error
+      (* Error found while looking up parent module type *)
+    | `Parent_expr of
+      simple_module_type_expr_of_module_error
+      (* Error found while evaluating parent module expression *)
+    | `Parent_module of
+      simple_module_lookup_error
+      (* Error found while looking up parent module *)
     | `Fragment_root (* Encountered unexpected fragment root *)
     | `Parent of parent_lookup_error ]
 
@@ -88,11 +100,13 @@ module Tools_error = struct
     | `OpaqueModule -> Format.fprintf fmt "OpaqueModule"
     | `UnresolvedForwardPath -> Format.fprintf fmt "Unresolved forward path"
     | `UnresolvedPath (`Module (p, e)) ->
-        Format.fprintf fmt "Unresolved module path %a (%a)" Component.Fmt.module_path
-          p pp (e :> any)
+        Format.fprintf fmt "Unresolved module path %a (%a)"
+          Component.Fmt.module_path p pp
+          (e :> any)
     | `UnresolvedPath (`ModuleType (p, e)) ->
         Format.fprintf fmt "Unresolved module type path %a (%a)"
-          Component.Fmt.module_type_path p pp (e :> any)
+          Component.Fmt.module_type_path p pp
+          (e :> any)
     | `LocalMT (_, id) -> Format.fprintf fmt "Local id found: %a" Ident.fmt id
     | `Local (_, id) -> Format.fprintf fmt "Local id found: %a" Ident.fmt id
     | `LocalType (_, id) -> Format.fprintf fmt "Local id found: %a" Ident.fmt id

--- a/test/parser/dune
+++ b/test/parser/dune
@@ -1,8 +1,10 @@
 (executable
  (name test)
+ (enabled_if (>= %{ocaml_version} 4.04.1))
  (libraries alcotest markup odoc_model odoc_parser print))
 
 (rule
  (alias runtest)
+ (enabled_if (>= %{ocaml_version} 4.04.1))
  (action (run %{exe:test.exe}))
  (deps test.exe (source_tree expect)))

--- a/test/print/dune
+++ b/test/print/dune
@@ -1,3 +1,4 @@
 (library
  (name print)
+ (enabled_if (>= %{ocaml_version} 4.04.1)) ; Due to sexplib0 dependency
  (libraries odoc_model sexplib0))


### PR DESCRIPTION
OCaml-CI doesn't test below 4.04.1.
Parser tests are disabled below 4.04.1 because `sexplib0` is not available.