### PR TITLE
Generator: Fix missing '=' after 'class type'

### DIFF
--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1124,11 +1124,8 @@ struct
         O.documentedSrc @@ path url [inline @@ Text name],
         Some page
     in
-    let expr =
-      attach_expansion
-        (" = ","object","end")
-        expansion (class_type_expr t.expr)
-    in
+    let summary = O.txt " = " ++ class_type_expr t.expr in
+    let expr = attach_expansion (" = ","object","end") expansion summary in
     let content =
       let open Lang.Signature in
       let keyword' =

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -24,13 +24,13 @@
   </header>
   <div class="content">
    <div class="spec class-type" id="class-type-empty">
-    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class-type" id="class-type-mutually">
-    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-mutually/index.html">mutually</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-mutually/index.html">mutually</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class-type" id="class-type-recursive">
-    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-type-recursive/index.html">recursive</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-type-recursive/index.html">recursive</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-mutually'">
     <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-mutually'/index.html">mutually'</a> : <a href="class-type-mutually/index.html">mutually</a></code>
@@ -39,13 +39,13 @@
     <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-recursive'/index.html">recursive'</a> : <a href="class-type-recursive/index.html">recursive</a></code>
    </div>
    <div class="spec class-type" id="class-type-empty_virtual">
-    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  <a href="class-type-empty_virtual/index.html">empty_virtual</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  <a href="class-type-empty_virtual/index.html">empty_virtual</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-empty_virtual'">
     <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-empty_virtual'/index.html">empty_virtual'</a> : <a href="class-type-empty/index.html">empty</a></code>
    </div>
    <div class="spec class-type" id="class-type-polymorphic">
-    <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> 'a <a href="class-type-polymorphic/index.html">polymorphic</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> 'a <a href="class-type-polymorphic/index.html">polymorphic</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class" id="class-polymorphic'">
     <a href="#class-polymorphic'" class="anchor"></a><code><span class="keyword">class</span> 'a <a href="class-polymorphic'/index.html">polymorphic'</a> : <span><span class="type-var">'a</span> <a href="class-type-polymorphic/index.html">polymorphic</a></span></code>

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -76,7 +76,7 @@
     <a href="#class-c" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-c/index.html">c</a> : <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div class="spec class-type" id="class-type-cs">
-    <a href="#class-type-cs" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-cs/index.html">cs</a><span class="keyword">object</span> ... <span class="keyword">end</span></code>
+    <a href="#class-type-cs" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-cs/index.html">cs</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>
    <div>
     <div class="spec exception" id="exception-E">

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -24,13 +24,13 @@
   </header>
   <div class="content">
    <div class="spec class-type" id="class-type-empty">
-    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a>{ ... }</code>
+    <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a> = { ... }</code>
    </div>
    <div class="spec class-type" id="class-type-mutually">
-    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-mutually/index.html">mutually</a>{ ... }</code>
+    <a href="#class-type-mutually" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-mutually/index.html">mutually</a> = { ... }</code>
    </div>
    <div class="spec class-type" id="class-type-recursive">
-    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-type-recursive/index.html">recursive</a>{ ... }</code>
+    <a href="#class-type-recursive" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-type-recursive/index.html">recursive</a> = { ... }</code>
    </div>
    <div class="spec class" id="class-mutually'">
     <a href="#class-mutually'" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-mutually'/index.html">mutually'</a>: <a href="class-type-mutually/index.html">mutually</a></code>
@@ -39,13 +39,13 @@
     <a href="#class-recursive'" class="anchor"></a><code><span class="keyword">and</span>  <a href="class-recursive'/index.html">recursive'</a>: <a href="class-type-recursive/index.html">recursive</a></code>
    </div>
    <div class="spec class-type" id="class-type-empty_virtual">
-    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  <a href="class-type-empty_virtual/index.html">empty_virtual</a>{ ... }</code>
+    <a href="#class-type-empty_virtual" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  <a href="class-type-empty_virtual/index.html">empty_virtual</a> = { ... }</code>
    </div>
    <div class="spec class" id="class-empty_virtual'">
     <a href="#class-empty_virtual'" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">virtual</span>  <a href="class-empty_virtual'/index.html">empty_virtual'</a>: <a href="class-type-empty/index.html">empty</a></code>
    </div>
    <div class="spec class-type" id="class-type-polymorphic">
-    <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> ('a) <a href="class-type-polymorphic/index.html">polymorphic</a>{ ... }</code>
+    <a href="#class-type-polymorphic" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span> ('a) <a href="class-type-polymorphic/index.html">polymorphic</a> = { ... }</code>
    </div>
    <div class="spec class" id="class-polymorphic'">
     <a href="#class-polymorphic'" class="anchor"></a><code><span class="keyword">class</span> ('a) <a href="class-polymorphic'/index.html">polymorphic'</a>: <a href="class-type-polymorphic/index.html">polymorphic</a>(<span class="type-var">'a</span>)</code>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -76,7 +76,7 @@
     <a href="#class-c" class="anchor"></a><code><span class="keyword">class</span>  <a href="class-c/index.html">c</a>: { ... }</code>
    </div>
    <div class="spec class-type" id="class-type-cs">
-    <a href="#class-type-cs" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-cs/index.html">cs</a>{ ... }</code>
+    <a href="#class-type-cs" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-cs/index.html">cs</a> = { ... }</code>
    </div>
    <div>
     <div class="spec exception" id="exception-E">


### PR DESCRIPTION
The rendering looked like that before:
`class type ctobject ... end`

After:
`class type ct = object ... end`