### PR TITLE
improve readabilty for linkables in dark mode

### DIFF
--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -10,7 +10,7 @@
 
 :root,
 .light:root {
-  --link-color: #2c5cbd;
+  --link-color: #2C94BD;
   --anchor-hover: #555;
   --anchor-color: #d5d5d5;
   --xref-shadow: #cc6666;
@@ -277,7 +277,7 @@ a.anchor {
 }
 
 .xref-unresolved {
-  color: #2C5CBD;
+  color: #2C94BD;
 }
 .xref-unresolved:hover {
   box-shadow: 0 1px 0 0 #CC6666;


### PR DESCRIPTION
This PR addresses issue #425

**_Before:_**

<img width="763" alt="Screenshot 2020-12-30 at 00 40 56" src="https://user-images.githubusercontent.com/34124177/103315834-cf821e80-4a37-11eb-8f1b-ed5db70aa69e.png">


**_After:_**

![image](https://user-images.githubusercontent.com/34124177/103315725-7e722a80-4a37-11eb-88e4-b7c3683460c4.png)
