### PR TITLE
Auto-format the whole project using OCamlformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Auto-format the whole project using OCamlformat
+75efc08df487fa1a89fb86e446aadc8f6273b5bb

--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,0 +1,4 @@
+src/compat/*
+src/loader/*
+src/model/*.cppo.ml
+test/xref2/lib/*

--- a/dune
+++ b/dune
@@ -1,10 +1,12 @@
 ; Note: We disable warning 18 here to support compiler versions < 4.03
 ; See https://caml.inria.fr/mantis/view.php?id=7135 for details
+
 (env
  (dev
-  (flags (:standard -g -w -18-53)))
+  (flags
+   (:standard -g -w -18-53)))
  (release
-  (flags (:standard -g -w -18-53))))
+  (flags
+   (:standard -g -w -18-53))))
 
 (vendored_dirs mdx)
-

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,4 @@
 (lang dune 2.7)
 (name odoc)
-(formatting disabled)
 (using mdx 0.1)
 (cram enable)

--- a/src/compat/dune
+++ b/src/compat/dune
@@ -1,5 +1,7 @@
 (library
  (name odoc_compat)
  (public_name odoc.compat)
- (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
+ (preprocess
+  (action
+   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
  (libraries compiler-libs.common))

--- a/src/document/ML.ml
+++ b/src/document/ML.ml
@@ -1,90 +1,96 @@
 open Types
-
 module O = Codefmt
 open O.Infix
 
 module ML = Generator.Make (struct
-  module Obj =
-  struct
+  module Obj = struct
     let close_tag_closed = ">"
+
     let close_tag_extendable = ".. >"
+
     let field_separator = "; "
+
     let open_tag_closed = "< "
+
     let open_tag_extendable = "< "
   end
 
-  module Type =
-  struct
+  module Type = struct
     let annotation_separator = " : "
 
-    let handle_params name args =
-      O.span (args ++ O.txt " " ++ name)
+    let handle_params name args = O.span (args ++ O.txt " " ++ name)
 
     let handle_constructor_params = handle_params
+
     let handle_substitution_params = handle_params
+
     let handle_format_params p = p
+
     let type_def_semicolon = false
+
     let private_keyword = "private"
+
     let parenthesize_constructor = false
 
-    module Variant =
-    struct
+    module Variant = struct
       let parenthesize_params = false
     end
 
-    module Tuple =
-    struct
+    module Tuple = struct
       let element_separator = " * "
+
       let always_parenthesize = false
     end
 
-    module Record =
-    struct
+    module Record = struct
       let field_separator = ";"
     end
 
     let var_prefix = "'"
-    let any = "_"
-    let arrow =
-      O.span (O.entity "#45" ++ O.entity "gt")
 
-    module Exception =
-    struct
+    let any = "_"
+
+    let arrow = O.span (O.entity "#45" ++ O.entity "gt")
+
+    module Exception = struct
       let semicolon = false
     end
 
-    module GADT =
-    struct
+    module GADT = struct
       let arrow = arrow
     end
 
-    module External =
-    struct
+    module External = struct
       let semicolon = false
+
       let handle_primitives prims =
         List.map (fun p -> inline @@ Text ("\"" ^ p ^ "\" ")) prims
     end
   end
 
-  module Mod =
-  struct
+  module Mod = struct
     let open_tag = O.keyword "sig"
+
     let close_tag = O.keyword "end"
+
     let close_tag_semicolon = false
+
     let include_semicolon = false
+
     let functor_keyword = true
+
     let functor_contraction = true
   end
 
-  module Class =
-  struct
+  module Class = struct
     let open_tag = O.keyword "object"
+
     let close_tag = O.keyword "end"
   end
 
-  module Value =
-  struct
+  module Value = struct
     let variable_keyword = "val"
+
     let semicolon = false
   end
 end)

--- a/src/document/ML.mli
+++ b/src/document/ML.mli
@@ -15,5 +15,6 @@
  *)
 
 val compilation_unit : Odoc_model.Lang.Compilation_unit.t -> Types.Page.t
+
 val page : Odoc_model.Lang.Page.t -> Types.Page.t
 (** Convert compilation unit or page models into a document *)

--- a/src/document/codefmt.ml
+++ b/src/document/codefmt.ml
@@ -1,17 +1,13 @@
 open Types
 
 type out = Source.t
+
 module State = struct
+  type t = { context : (out * Source.tag) Stack.t; mutable current : out }
 
-  type t = {
-    context : (out * Source.tag) Stack.t ;
-    mutable current : out ;
-  }
+  let create () = { context = Stack.create (); current = [] }
 
-  let create () = { context = Stack.create () ; current = [] }
-
-  let push state elt =
-    state.current <- elt :: state.current
+  let push state elt = state.current <- elt :: state.current
 
   let enter state tag =
     let previous_elt = state.current in
@@ -26,14 +22,14 @@ module State = struct
     ()
 
   let rec flush state =
-    if Stack.is_empty state.context then
-      List.rev state.current
-    else
-      (leave state; flush state)
-
+    if Stack.is_empty state.context then List.rev state.current
+    else (
+      leave state;
+      flush state )
 end
 
 (** Modern implementation using semantic tags, Only for 4.08+ *)
+
 (*
 module Tag = struct
 
@@ -74,33 +70,39 @@ end
 (** Ugly terrible implementation of Format Semantic tags for OCaml < 4.08.
     Please get rid of it as soon as possible. *)
 module Tag = struct
-
   let setup_tags formatter state0 =
     let tag_functions =
       let get_tag s =
         let prefix_tag = "tag:" in
         let l = String.length prefix_tag in
         if String.length s > l && String.sub s 0 l = prefix_tag then
-          let elt : Inline.t =
-            Marshal.from_string s l
-          in
+          let elt : Inline.t = Marshal.from_string s l in
           `Elt elt
-        else
-          `String s
+        else `String s
       in
       let mark_open_tag s =
         match get_tag s with
-        | `Elt elt -> State.push state0 (Elt elt); ""
-        | `String "" -> State.enter state0 None; ""
-        | `String tag -> State.enter state0 (Some tag); ""
+        | `Elt elt ->
+            State.push state0 (Elt elt);
+            ""
+        | `String "" ->
+            State.enter state0 None;
+            ""
+        | `String tag ->
+            State.enter state0 (Some tag);
+            ""
       and mark_close_tag s =
         match get_tag s with
         | `Elt _ -> ""
-        | `String _ -> State.leave state0; ""
-      in {Format.
-        print_open_tag = (fun _ -> ());
+        | `String _ ->
+            State.leave state0;
+            ""
+      in
+      {
+        Format.print_open_tag = (fun _ -> ());
         print_close_tag = (fun _ -> ());
-        mark_open_tag; mark_close_tag;
+        mark_open_tag;
+        mark_close_tag;
       }
     in
     Format.pp_set_tags formatter true;
@@ -109,20 +111,21 @@ module Tag = struct
 
   let elt ppf (elt : Inline.t) =
     Format.fprintf ppf "@{<tag:%s>@}" (Marshal.to_string elt [])
-
-end[@@alert "-deprecated--deprecated"]
+end
+[@@alert "-deprecated--deprecated"]
 
 let make () =
   let open Inline in
   let state0 = State.create () in
   let push elt = State.push state0 (Elt elt) in
-  let push_text s = push [inline @@ Text s] in
+  let push_text s = push [ inline @@ Text s ] in
 
   let formatter =
     let out_string s i j = push_text (String.sub s i j) in
     let out_flush () = () in
     Format.make_formatter out_string out_flush
   in
+
   (* out_functions is only available in OCaml>=4.06 *)
   (* let out_functions = {Format.
    *   out_string = (fun );
@@ -133,10 +136,11 @@ let make () =
    * }
    * in
    * let formatter = Format.formatter_of_out_functions out_functions in *)
-
   Tag.setup_tags formatter state0;
-  (fun () -> Format.pp_print_flush formatter (); State.flush state0),
-  formatter
+  ( (fun () ->
+      Format.pp_print_flush formatter ();
+      State.flush state0),
+    formatter )
 
 let spf fmt =
   let flush, ppf = make () in
@@ -147,37 +151,41 @@ let pf = Format.fprintf
 (** Transitory hackish API *)
 
 let elt = Tag.elt
-let entity e ppf = elt ppf [inline @@ Inline.Entity e]
-let (++) f g ppf = f ppf; g ppf
-let span f ppf =
-  pf ppf "@{<>%t@}" f
+
+let entity e ppf = elt ppf [ inline @@ Inline.Entity e ]
+
+let ( ++ ) f g ppf =
+  f ppf;
+  g ppf
+
+let span f ppf = pf ppf "@{<>%t@}" f
+
 let txt s ppf = Format.pp_print_string ppf s
+
 let noop (_ : Format.formatter) = ()
 
-let (!) (pp : _ Fmt.t) x ppf = pp ppf x
+let ( ! ) (pp : _ Fmt.t) x ppf = pp ppf x
 
 let rec list ?sep ~f = function
   | [] -> noop
-  | [x] -> f x
-  | x :: xs ->
-    let hd = f x in
-    let tl = list ?sep ~f xs in
-    match sep with
-    | None -> hd ++ tl
-    | Some sep -> hd ++ sep ++ tl
+  | [ x ] -> f x
+  | x :: xs -> (
+      let hd = f x in
+      let tl = list ?sep ~f xs in
+      match sep with None -> hd ++ tl | Some sep -> hd ++ sep ++ tl )
 
 let render f = spf "%t" f
-let code ?attr f =
-  [inline ?attr @@ Inline.Source (render f)]
-let documentedSrc f =
-  [DocumentedSrc.Code (render f)]
-let codeblock ?attr f =
-  [block ?attr @@ Block.Source (render f)]
 
-let keyword keyword ppf =
-  pf ppf "@{<keyword>%s@}" keyword
+let code ?attr f = [ inline ?attr @@ Inline.Source (render f) ]
+
+let documentedSrc f = [ DocumentedSrc.Code (render f) ]
+
+let codeblock ?attr f = [ block ?attr @@ Block.Source (render f) ]
+
+let keyword keyword ppf = pf ppf "@{<keyword>%s@}" keyword
 
 module Infix = struct
-  let (!) = (!)
-  let (++) = (++)
+  let ( ! ) = ( ! )
+
+  let ( ++ ) = ( ++ )
 end

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -14,335 +14,322 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-
 open Types
 module Comment = Odoc_model.Comment
 open Odoc_model.Names
 
 let source_of_code s =
-  if s = "" then [] else [Source.Elt [inline @@ Inline.Text s]]
+  if s = "" then [] else [ Source.Elt [ inline @@ Inline.Text s ] ]
 
 module Reference = struct
   open Odoc_model.Paths
 
   let rec render_resolved : Reference.Resolved.t -> string =
-    fun r ->
-      let open Reference.Resolved in
-      match r with
-      | `Identifier id -> Identifier.name id
-      | `SubstAlias(_, r) -> render_resolved (r :> t)
-      | `Module (r, s) -> render_resolved (r :> t) ^ "." ^ (ModuleName.to_string s)
-      | `Canonical (_, `Resolved r) -> render_resolved (r :> t)
-      | `Canonical (p, _) -> render_resolved (p :> t)
-      | `Hidden p -> render_resolved (p :> t)
-      | `ModuleType (r, s) -> render_resolved (r :> t) ^ "." ^ (ModuleTypeName.to_string s)
-      | `Type (r, s) -> render_resolved (r :> t) ^ "." ^ (TypeName.to_string s)
-      | `Constructor (r, s) -> render_resolved (r :> t) ^ "." ^ (ConstructorName.to_string s)
-      | `Field (r, s) -> render_resolved (r :> t) ^ "." ^ (FieldName.to_string s)
-      | `Extension (r, s) -> render_resolved (r :> t) ^ "." ^ (ExtensionName.to_string s)
-      | `Exception (r, s) -> render_resolved (r :> t) ^ "." ^ (ExceptionName.to_string s)
-      | `Value (r, s) -> render_resolved (r :> t) ^ "." ^ (ValueName.to_string s)
-      | `Class (r, s) -> render_resolved (r :> t) ^ "." ^ (ClassName.to_string s)
-      | `ClassType (r, s) -> render_resolved (r :> t) ^ "." ^ (ClassTypeName.to_string s)
-      | `Method (r, s) ->
+   fun r ->
+    let open Reference.Resolved in
+    match r with
+    | `Identifier id -> Identifier.name id
+    | `SubstAlias (_, r) -> render_resolved (r :> t)
+    | `Module (r, s) -> render_resolved (r :> t) ^ "." ^ ModuleName.to_string s
+    | `Canonical (_, `Resolved r) -> render_resolved (r :> t)
+    | `Canonical (p, _) -> render_resolved (p :> t)
+    | `Hidden p -> render_resolved (p :> t)
+    | `ModuleType (r, s) ->
+        render_resolved (r :> t) ^ "." ^ ModuleTypeName.to_string s
+    | `Type (r, s) -> render_resolved (r :> t) ^ "." ^ TypeName.to_string s
+    | `Constructor (r, s) ->
+        render_resolved (r :> t) ^ "." ^ ConstructorName.to_string s
+    | `Field (r, s) -> render_resolved (r :> t) ^ "." ^ FieldName.to_string s
+    | `Extension (r, s) ->
+        render_resolved (r :> t) ^ "." ^ ExtensionName.to_string s
+    | `Exception (r, s) ->
+        render_resolved (r :> t) ^ "." ^ ExceptionName.to_string s
+    | `Value (r, s) -> render_resolved (r :> t) ^ "." ^ ValueName.to_string s
+    | `Class (r, s) -> render_resolved (r :> t) ^ "." ^ ClassName.to_string s
+    | `ClassType (r, s) ->
+        render_resolved (r :> t) ^ "." ^ ClassTypeName.to_string s
+    | `Method (r, s) ->
         (* CR trefis: do we really want to print anything more than [s] here?  *)
-        render_resolved (r :> t) ^ "." ^ (MethodName.to_string s)
-      | `InstanceVariable (r, s) ->
+        render_resolved (r :> t) ^ "." ^ MethodName.to_string s
+    | `InstanceVariable (r, s) ->
         (* CR trefis: the following makes no sense to me... *)
-        render_resolved (r :> t) ^ "." ^ (InstanceVariableName.to_string s)
-      | `Label (r, s) -> render_resolved (r :> t) ^ ":" ^ (LabelName.to_string s)
-
-
+        render_resolved (r :> t) ^ "." ^ InstanceVariableName.to_string s
+    | `Label (r, s) -> render_resolved (r :> t) ^ ":" ^ LabelName.to_string s
 
   let rec ref_to_string : Reference.t -> string =
     let open Reference in
     function
     | `Root (s, _) -> s
     | `Dot (parent, s) -> ref_to_string (parent :> t) ^ "." ^ s
-    | `Module (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ModuleName.to_string s)
-    | `ModuleType (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ModuleTypeName.to_string s)
-    | `Type (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (TypeName.to_string s)
-    | `Constructor (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ConstructorName.to_string s)
-    | `Field (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (FieldName.to_string s)
-    | `Extension (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ExtensionName.to_string s)
-    | `Exception (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ExceptionName.to_string s)
-    | `Value (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ValueName.to_string s)
-    | `Class (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ClassName.to_string s)
-    | `ClassType (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (ClassTypeName.to_string s)
-    | `Method (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (MethodName.to_string s)
-    | `InstanceVariable (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (InstanceVariableName.to_string s)
-    | `Label (parent, s) -> ref_to_string (parent :> t) ^ "." ^ (LabelName.to_string s)
+    | `Module (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ ModuleName.to_string s
+    | `ModuleType (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ ModuleTypeName.to_string s
+    | `Type (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ TypeName.to_string s
+    | `Constructor (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ ConstructorName.to_string s
+    | `Field (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ FieldName.to_string s
+    | `Extension (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ ExtensionName.to_string s
+    | `Exception (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ ExceptionName.to_string s
+    | `Value (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ ValueName.to_string s
+    | `Class (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ ClassName.to_string s
+    | `ClassType (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ ClassTypeName.to_string s
+    | `Method (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ MethodName.to_string s
+    | `InstanceVariable (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ InstanceVariableName.to_string s
+    | `Label (parent, s) ->
+        ref_to_string (parent :> t) ^ "." ^ LabelName.to_string s
     | `Resolved r -> render_resolved r
-
 
   (* This is the entry point. stop_before is false on entry, true on recursive
      call. *)
-  let rec to_ir
-    : ?text:Inline.t ->
-      stop_before:bool ->
-      Reference.t ->
-      Inline.t =
-    fun ?text ~stop_before ref ->
+  let rec to_ir : ?text:Inline.t -> stop_before:bool -> Reference.t -> Inline.t
+      =
+   fun ?text ~stop_before ref ->
     let open Reference in
     match ref with
-    | `Root (s, _) ->
-      begin match text with
-        | None ->
-          let s = source_of_code s in
-          [inline @@ Inline.Source s]
-        | Some s ->
-          [inline @@ Inline.InternalLink (InternalLink.Unresolved s)]
-      end
-    | `Dot (parent, s) ->
-      unresolved ?text (parent :> t) s
-    | `Module (parent, s) ->
-      unresolved ?text (parent :> t) (ModuleName.to_string s)
-    | `ModuleType (parent, s) ->
-      unresolved ?text (parent :> t) (ModuleTypeName.to_string s)
-    | `Type (parent, s) ->
-      unresolved ?text (parent :> t) (TypeName.to_string s)
-    | `Constructor (parent, s) ->
-      unresolved ?text (parent :> t) (ConstructorName.to_string s)
-    | `Field (parent, s) ->
-      unresolved ?text (parent :> t) (FieldName.to_string s)
-    | `Extension (parent, s) ->
-      unresolved ?text (parent :> t) (ExtensionName.to_string s)
-    | `Exception (parent, s) ->
-      unresolved ?text (parent :> t) (ExceptionName.to_string s)
-    | `Value (parent, s) ->
-      unresolved ?text (parent :> t) (ValueName.to_string s)
-    | `Class (parent, s) ->
-      unresolved ?text (parent :> t) (ClassName.to_string s)
-    | `ClassType (parent, s) ->
-      unresolved ?text (parent :> t) (ClassTypeName.to_string s)
-    | `Method (parent, s) ->
-      unresolved ?text (parent :> t) (MethodName.to_string s)
-    | `InstanceVariable (parent, s) ->
-      unresolved ?text (parent :> t) (InstanceVariableName.to_string s)
-    | `Label (parent, s) ->
-      unresolved ?text (parent :> t) (LabelName.to_string s)
-    | `Resolved r ->
-      (* IDENTIFIER MUST BE RENAMED TO DEFINITION. *)
-      let id = Reference.Resolved.identifier r in
-      let txt =
+    | `Root (s, _) -> (
         match text with
-        | None -> [inline @@ Inline.Source (source_of_code (render_resolved r))]
-        | Some s -> s
-      in
-      begin match Url.from_identifier ~stop_before id with
-      | Ok url ->
-        [inline @@ Inline.InternalLink (InternalLink.Resolved (url, txt))]
-      | Error (Not_linkable _) -> txt
-      | Error exn ->
-        (* FIXME: better error message *)
-        Printf.eprintf "Id.href failed: %S\n%!" (Url.Error.to_string exn);
-        txt
-      end
+        | None ->
+            let s = source_of_code s in
+            [ inline @@ Inline.Source s ]
+        | Some s ->
+            [ inline @@ Inline.InternalLink (InternalLink.Unresolved s) ] )
+    | `Dot (parent, s) -> unresolved ?text (parent :> t) s
+    | `Module (parent, s) ->
+        unresolved ?text (parent :> t) (ModuleName.to_string s)
+    | `ModuleType (parent, s) ->
+        unresolved ?text (parent :> t) (ModuleTypeName.to_string s)
+    | `Type (parent, s) -> unresolved ?text (parent :> t) (TypeName.to_string s)
+    | `Constructor (parent, s) ->
+        unresolved ?text (parent :> t) (ConstructorName.to_string s)
+    | `Field (parent, s) ->
+        unresolved ?text (parent :> t) (FieldName.to_string s)
+    | `Extension (parent, s) ->
+        unresolved ?text (parent :> t) (ExtensionName.to_string s)
+    | `Exception (parent, s) ->
+        unresolved ?text (parent :> t) (ExceptionName.to_string s)
+    | `Value (parent, s) ->
+        unresolved ?text (parent :> t) (ValueName.to_string s)
+    | `Class (parent, s) ->
+        unresolved ?text (parent :> t) (ClassName.to_string s)
+    | `ClassType (parent, s) ->
+        unresolved ?text (parent :> t) (ClassTypeName.to_string s)
+    | `Method (parent, s) ->
+        unresolved ?text (parent :> t) (MethodName.to_string s)
+    | `InstanceVariable (parent, s) ->
+        unresolved ?text (parent :> t) (InstanceVariableName.to_string s)
+    | `Label (parent, s) ->
+        unresolved ?text (parent :> t) (LabelName.to_string s)
+    | `Resolved r -> (
+        (* IDENTIFIER MUST BE RENAMED TO DEFINITION. *)
+        let id = Reference.Resolved.identifier r in
+        let txt =
+          match text with
+          | None ->
+              [ inline @@ Inline.Source (source_of_code (render_resolved r)) ]
+          | Some s -> s
+        in
+        match Url.from_identifier ~stop_before id with
+        | Ok url ->
+            [ inline @@ Inline.InternalLink (InternalLink.Resolved (url, txt)) ]
+        | Error (Not_linkable _) -> txt
+        | Error exn ->
+            (* FIXME: better error message *)
+            Printf.eprintf "Id.href failed: %S\n%!" (Url.Error.to_string exn);
+            txt )
 
-  and unresolved
-    : ?text:Inline.t ->
-      Reference.t ->
-      string -> Inline.t =
-    fun ?text parent field ->
+  and unresolved : ?text:Inline.t -> Reference.t -> string -> Inline.t =
+   fun ?text parent field ->
     match text with
-    | Some s ->
-      [inline @@ InternalLink (InternalLink.Unresolved s)]
+    | Some s -> [ inline @@ InternalLink (InternalLink.Unresolved s) ]
     | None ->
-      let tail = [inline @@ Text ("." ^ field) ] in
-      let content = to_ir ~stop_before:true parent in
-      content @ tail
+        let tail = [ inline @@ Text ("." ^ field) ] in
+        let content = to_ir ~stop_before:true parent in
+        content @ tail
 end
 
-
-let leaf_inline_element
-    : Comment.leaf_inline_element -> Inline.one =
-  function
+let leaf_inline_element : Comment.leaf_inline_element -> Inline.one = function
   | `Space -> inline @@ Text " "
   | `Word s -> inline @@ Text s
   | `Code_span s -> inline @@ Source (source_of_code s)
   | `Raw_markup (target, s) -> inline @@ Raw_markup (target, s)
 
-let rec non_link_inline_element
-    : Comment.non_link_inline_element -> Inline.one =
-  function
+let rec non_link_inline_element : Comment.non_link_inline_element -> Inline.one
+    = function
   | #Comment.leaf_inline_element as e -> leaf_inline_element e
   | `Styled (style, content) ->
-    inline @@ Styled (style, non_link_inline_element_list content)
+      inline @@ Styled (style, non_link_inline_element_list content)
 
-and non_link_inline_element_list : _ -> Inline.t = fun elements ->
+and non_link_inline_element_list : _ -> Inline.t =
+ fun elements ->
   List.map
     (fun elt -> non_link_inline_element elt.Odoc_model.Location_.value)
     elements
 
-let link_content =
-  non_link_inline_element_list
+let link_content = non_link_inline_element_list
 
-
-
-let rec inline_element : Comment.inline_element -> Inline.t =
-  function
-  | #Comment.leaf_inline_element as e -> [leaf_inline_element e]
+let rec inline_element : Comment.inline_element -> Inline.t = function
+  | #Comment.leaf_inline_element as e -> [ leaf_inline_element e ]
   | `Styled (style, content) ->
-    [inline @@ Styled (style, inline_element_list content)]
+      [ inline @@ Styled (style, inline_element_list content) ]
   | `Reference (path, content) ->
-    (* TODO Rework that ugly function. *)
-    (* TODO References should be set in code style, if they are to code
-            elements. *)
-    let content =
-      match content with
-      | [] -> None
-      | _ -> Some (non_link_inline_element_list content) (* XXX Span *)
-    in
-    Reference.to_ir ?text:content ~stop_before:false path
+      (* TODO Rework that ugly function. *)
+      (* TODO References should be set in code style, if they are to code
+              elements. *)
+      let content =
+        match content with
+        | [] -> None
+        | _ -> Some (non_link_inline_element_list content)
+        (* XXX Span *)
+      in
+      Reference.to_ir ?text:content ~stop_before:false path
   | `Link (target, content) ->
-    let content =
-      match content with
-      | [] -> [inline @@ Text target]
-      | _ -> non_link_inline_element_list content
-    in
-    [inline @@ Link (target, content)]
+      let content =
+        match content with
+        | [] -> [ inline @@ Text target ]
+        | _ -> non_link_inline_element_list content
+      in
+      [ inline @@ Link (target, content) ]
 
 and inline_element_list elements =
-  List.concat @@ List.map
-    (fun elt -> inline_element elt.Odoc_model.Location_.value)
-    elements
+  List.concat
+  @@ List.map
+       (fun elt -> inline_element elt.Odoc_model.Location_.value)
+       elements
 
-
-let rec nestable_block_element
-  : Comment.nestable_block_element -> Block.one =
-  fun content ->
+let rec nestable_block_element : Comment.nestable_block_element -> Block.one =
+ fun content ->
   match content with
-  | `Paragraph [{value = `Raw_markup (target, s); _}] ->
-    block @@ Block.Raw_markup (target, s)
-  | `Paragraph content ->
-    block @@ Block.Paragraph (inline_element_list content)
-  | `Code_block code ->
-    block @@ Source (source_of_code code)
-  | `Verbatim s ->
-    block @@ Verbatim s
+  | `Paragraph [ { value = `Raw_markup (target, s); _ } ] ->
+      block @@ Block.Raw_markup (target, s)
+  | `Paragraph content -> block @@ Block.Paragraph (inline_element_list content)
+  | `Code_block code -> block @@ Source (source_of_code code)
+  | `Verbatim s -> block @@ Verbatim s
   | `Modules ms ->
-    let items =
-      List.map
-        (fun r ->
-            [block @@ Inline (Reference.to_ir ~stop_before:false r)])
-        (ms :> Odoc_model.Paths.Reference.t list)
-    in
-    block ~attr:["modules"] @@ Block.List (Unordered, items)
+      let items =
+        List.map
+          (fun r -> [ block @@ Inline (Reference.to_ir ~stop_before:false r) ])
+          (ms :> Odoc_model.Paths.Reference.t list)
+      in
+      block ~attr:[ "modules" ] @@ Block.List (Unordered, items)
   | `List (kind, items) ->
-    let kind = match kind with
-      | `Unordered -> Block.Unordered
-      | `Ordered -> Block.Ordered
-    in
-    let f = function
-      | [{Odoc_model.Location_.value = `Paragraph content; _}] ->
-        [block @@ Block.Inline (inline_element_list content)]
-      | item ->
-        nestable_block_element_list item
-    in
-    let items = List.map f items in
-    block @@ Block.List (kind, items)
+      let kind =
+        match kind with
+        | `Unordered -> Block.Unordered
+        | `Ordered -> Block.Ordered
+      in
+      let f = function
+        | [ { Odoc_model.Location_.value = `Paragraph content; _ } ] ->
+            [ block @@ Block.Inline (inline_element_list content) ]
+        | item -> nestable_block_element_list item
+      in
+      let items = List.map f items in
+      block @@ Block.List (kind, items)
 
 and nestable_block_element_list elements =
   elements
   |> List.map Odoc_model.Location_.value
   |> List.map nestable_block_element
 
-let tag : Comment.tag -> Block.t = fun t ->
-  let description a b = [block @@ Description [ a, b ]] in
+let tag : Comment.tag -> Block.t =
+ fun t ->
+  let description a b = [ block @@ Description [ (a, b) ] ] in
   match t with
   | `Author s ->
-    description
-      [inline @@ Text "author"]
-      [{ attr = [] ; desc = Block.Inline [inline @@ Text s] }]
+      description
+        [ inline @@ Text "author" ]
+        [ { attr = []; desc = Block.Inline [ inline @@ Text s ] } ]
   | `Deprecated content ->
-    description
-      [inline @@ Text "deprecated"]
-      (nestable_block_element_list content)
+      description
+        [ inline @@ Text "deprecated" ]
+        (nestable_block_element_list content)
   | `Param (name, content) ->
-    description
-      [inline @@ Text "parameter "; inline @@ Text name]
-      (nestable_block_element_list content)
+      description
+        [ inline @@ Text "parameter "; inline @@ Text name ]
+        (nestable_block_element_list content)
   | `Raise (name, content) ->
-    description
-      [inline @@ Text "raises "; inline @@ Text name]
-      (nestable_block_element_list content)
+      description
+        [ inline @@ Text "raises "; inline @@ Text name ]
+        (nestable_block_element_list content)
   | `Return content ->
-    description
-      [inline @@ Text "returns"]
-      (nestable_block_element_list content)
+      description
+        [ inline @@ Text "returns" ]
+        (nestable_block_element_list content)
   | `See (kind, target, content) ->
-    let target =
-      match kind with
-      | `Url -> Inline.Link (target, [inline @@ Text target])
-      | `File -> Inline.Source (source_of_code target)
-      | `Document -> Inline.Text target
-    in
-    description
-      [inline @@ Text "see "; inline @@ target]
-      (nestable_block_element_list content)
+      let target =
+        match kind with
+        | `Url -> Inline.Link (target, [ inline @@ Text target ])
+        | `File -> Inline.Source (source_of_code target)
+        | `Document -> Inline.Text target
+      in
+      description
+        [ inline @@ Text "see "; inline @@ target ]
+        (nestable_block_element_list content)
   | `Since s ->
-    description
-      [inline @@ Text "since"]
-      [{ attr = []; desc = Block.Inline [inline @@ Text s]}]
+      description [ inline @@ Text "since" ]
+        [ { attr = []; desc = Block.Inline [ inline @@ Text s ] } ]
   | `Before (version, content) ->
-    description
-      [inline @@ Text "before "; inline @@ Text version]
-      (nestable_block_element_list content)
+      description
+        [ inline @@ Text "before "; inline @@ Text version ]
+        (nestable_block_element_list content)
   | `Version s ->
-    description
-      [inline @@ Text "version"]
-      [{ attr = []; desc = Block.Inline [inline @@ Text s]}]
-  | `Canonical _ | `Inline | `Open | `Closed ->
-    []
+      description
+        [ inline @@ Text "version" ]
+        [ { attr = []; desc = Block.Inline [ inline @@ Text s ] } ]
+  | `Canonical _ | `Inline | `Open | `Closed -> []
 
-let attached_block_element : Comment.attached_block_element -> Block.t = function
-  | #Comment.nestable_block_element as e ->
-    [nestable_block_element e]
-  | `Tag t ->
-    tag t
+let attached_block_element : Comment.attached_block_element -> Block.t =
+  function
+  | #Comment.nestable_block_element as e -> [ nestable_block_element e ]
+  | `Tag t -> tag t
 
 let block_element : Comment.block_element -> Block.t = function
-  | #Comment.attached_block_element as e ->
-    attached_block_element e
+  | #Comment.attached_block_element as e -> attached_block_element e
   | `Heading (_, `Label (_, _), content) ->
-    (* We are not supposed to receive Heading in this context.
-       TODO: Remove heading in attached documentation in the model *)
-    [block @@ Paragraph (non_link_inline_element_list content)]
+      (* We are not supposed to receive Heading in this context.
+         TODO: Remove heading in attached documentation in the model *)
+      [ block @@ Paragraph (non_link_inline_element_list content) ]
 
 let heading (`Heading (level, `Label (_, label), content)) =
-    let label = Odoc_model.Names.LabelName.to_string label in
-    let title = non_link_inline_element_list content in
-    let level =
-      match level with
-      | `Title -> 0
-      | `Section -> 1
-      | `Subsection -> 2
-      | `Subsubsection -> 3
-      | `Paragraph -> 4
-      | `Subparagraph -> 5
-    in
-    let label = Some label in
-    Item.Heading {label; level; title}
+  let label = Odoc_model.Names.LabelName.to_string label in
+  let title = non_link_inline_element_list content in
+  let level =
+    match level with
+    | `Title -> 0
+    | `Section -> 1
+    | `Subsection -> 2
+    | `Subsubsection -> 3
+    | `Paragraph -> 4
+    | `Subparagraph -> 5
+  in
+  let label = Some label in
+  Item.Heading { label; level; title }
 
 let item_element : Comment.block_element -> Item.t list = function
   | #Comment.attached_block_element as e ->
-    [Item.Text (attached_block_element e)]
-  | `Heading _ as h ->
-    [heading h]
+      [ Item.Text (attached_block_element e) ]
+  | `Heading _ as h -> [ heading h ]
 
 let first_to_ir = function
-  | {Odoc_model.Location_.value = `Paragraph _ as first_paragraph ; _} ::_
-    ->
-    block_element first_paragraph
+  | { Odoc_model.Location_.value = `Paragraph _ as first_paragraph; _ } :: _ ->
+      block_element first_paragraph
   | _ -> []
 
 let standalone docs =
-  Utils.flatmap ~f:item_element @@
-  List.map (fun x -> x.Odoc_model.Location_.value) docs
+  Utils.flatmap ~f:item_element
+  @@ List.map (fun x -> x.Odoc_model.Location_.value) docs
 
 let to_ir (docs : Comment.docs) =
-  Utils.flatmap ~f:block_element @@
-  List.map (fun x -> x.Odoc_model.Location_.value) docs
+  Utils.flatmap ~f:block_element
+  @@ List.map (fun x -> x.Odoc_model.Location_.value) docs
 
-let has_doc docs =
-  docs <> []
+let has_doc docs = docs <> []

--- a/src/document/doctree.ml
+++ b/src/document/doctree.ml
@@ -1,7 +1,6 @@
 open Types
 
 module Take = struct
-
   type ('a, 'b, 'c) action =
     | Rec of 'a list
     | Skip
@@ -11,198 +10,165 @@ module Take = struct
 
   let until ~classify items =
     let rec loop acc = function
-      | [] -> List.rev acc, None, []
-      | b :: rest ->
-        match classify b with
-        | Skip -> loop acc rest
-        | Rec x -> loop acc (x @ rest)
-        | Accum v -> loop (List.rev_append v acc) rest
-        | Stop_and_keep ->
-          List.rev acc, None, (b :: rest)
-        | Stop_and_accum (v, e) ->
-          List.rev_append acc v, e, rest
+      | [] -> (List.rev acc, None, [])
+      | b :: rest -> (
+          match classify b with
+          | Skip -> loop acc rest
+          | Rec x -> loop acc (x @ rest)
+          | Accum v -> loop (List.rev_append v acc) rest
+          | Stop_and_keep -> (List.rev acc, None, b :: rest)
+          | Stop_and_accum (v, e) -> (List.rev_append acc v, e, rest) )
     in
     loop [] items
-
 end
 
 module Rewire = struct
-
-  type ('a, 'h) action =
-    | Rec of 'a
-    | Skip
-    | Heading of 'h * int
+  type ('a, 'h) action = Rec of 'a | Skip | Heading of 'h * int
 
   let walk ~classify ~node items =
     let rec loop current_level acc l =
       match l with
-      | [] -> List.rev acc, []
-      | b :: rest ->
-        match classify b with
-        | Skip -> loop current_level acc rest
-        | Rec l -> loop current_level acc (l @ rest)
-        | Heading (h, level) ->
-          if level > current_level then
-            let children, rest = loop level [] rest in
-            loop current_level (node h children :: acc) rest
-          else
-            List.rev acc, l
+      | [] -> (List.rev acc, [])
+      | b :: rest -> (
+          match classify b with
+          | Skip -> loop current_level acc rest
+          | Rec l -> loop current_level acc (l @ rest)
+          | Heading (h, level) ->
+              if level > current_level then
+                let children, rest = loop level [] rest in
+                loop current_level (node h children :: acc) rest
+              else (List.rev acc, l) )
     in
     let trees, rest = loop (-1) [] items in
     assert (rest = []);
     trees
-
 end
 
 module Toc : sig
   type t = one list
 
-  and one = {
-    url : Url.t;
-    text : Inline.t;
-    children : t
-  }
+  and one = { url : Url.t; text : Inline.t; children : t }
 
-  val compute : Url.Path.t -> on_sub:(Include.status -> bool) -> Item.t list -> t
-end
-  = struct
+  val compute :
+    Url.Path.t -> on_sub:(Include.status -> bool) -> Item.t list -> t
+end = struct
+  type t = one list
 
-    type t = one list
+  and one = { url : Url.t; text : Inline.t; children : t }
 
-    and one = {
-      url : Url.t;
-      text : Inline.t;
-      children : t
-    }
-
-  let classify ~on_sub (i : Item.t) : _ Rewire.action = match i with
-    | Text _
-    | Declaration _
-      -> Skip
+  let classify ~on_sub (i : Item.t) : _ Rewire.action =
+    match i with
+    | Text _ | Declaration _ -> Skip
     | Include { content = { status; content; _ }; _ } ->
-      if on_sub status then
-        Rec content
-      else Skip
-    | Heading { label = None ; _ } -> Skip
+        if on_sub status then Rec content else Skip
+    | Heading { label = None; _ } -> Skip
     | Heading { label = Some label; level; title } ->
-      Heading ((label, title), level)
+        Heading ((label, title), level)
 
-  let node mkurl (anchor, text) children = { url = mkurl anchor; text; children}
+  let node mkurl (anchor, text) children =
+    { url = mkurl anchor; text; children }
 
   let compute page ~on_sub t =
-    let mkurl anchor = { Url.Anchor.page; anchor; kind="page" } in
-    Rewire.walk
-      ~classify:(classify ~on_sub) ~node:(node mkurl)
-      t
-
+    let mkurl anchor = { Url.Anchor.page; anchor; kind = "page" } in
+    Rewire.walk ~classify:(classify ~on_sub) ~node:(node mkurl) t
 end
-
 
 module Subpages : sig
   val compute : Page.t -> Subpage.t list
 end = struct
-
   let rec walk_documentedsrc (l : DocumentedSrc.t) =
     Utils.flatmap l ~f:(function
       | DocumentedSrc.Code _ -> []
       | Documented _ -> []
-      | Nested { code ; _ } -> walk_documentedsrc code
-      | Subpage p -> [p]
-      | Alternative Expansion r -> walk_documentedsrc r.expansion
-    )
-
+      | Nested { code; _ } -> walk_documentedsrc code
+      | Subpage p -> [ p ]
+      | Alternative (Expansion r) -> walk_documentedsrc r.expansion)
 
   let rec walk_items (l : Item.t list) =
     Utils.flatmap l ~f:(function
       | Item.Text _ -> []
       | Heading _ -> []
-      | Declaration { content ; _ } -> walk_documentedsrc content
-      | Include i -> walk_items i.content.content
-    )
+      | Declaration { content; _ } -> walk_documentedsrc content
+      | Include i -> walk_items i.content.content)
 
   let compute (p : Page.t) = walk_items (p.header @ p.items)
-
 end
 
 module Shift = struct
+  type state = { englobing_level : int; current_level : int }
 
-  type state = {
-    englobing_level : int ;
-    current_level : int ;
-  }
-
-  let start = {
-    englobing_level = 0 ;
-    current_level = 0 ;
-  }
+  let start = { englobing_level = 0; current_level = 0 }
 
   let shift st x =
     let level = st.englobing_level + x in
-    { st with current_level = level },
-    level
+    ({ st with current_level = level }, level)
 
-  let enter { current_level ; _ } i =
-    { englobing_level = current_level + i ; current_level }
+  let enter { current_level; _ } i =
+    { englobing_level = current_level + i; current_level }
 
   let rec walk_documentedsrc ~on_sub shift_state (l : DocumentedSrc.t) =
     match l with
     | [] -> []
-    | (Code _ | Documented _ as h) :: rest ->
-      h
-      :: walk_documentedsrc ~on_sub shift_state rest
+    | ((Code _ | Documented _) as h) :: rest ->
+        h :: walk_documentedsrc ~on_sub shift_state rest
     | Nested ds :: rest ->
-      let ds = {ds with code = walk_documentedsrc ~on_sub shift_state ds.code} in
-      Nested ds
-      :: walk_documentedsrc ~on_sub shift_state rest
+        let ds =
+          { ds with code = walk_documentedsrc ~on_sub shift_state ds.code }
+        in
+        Nested ds :: walk_documentedsrc ~on_sub shift_state rest
     | Subpage subp :: rest ->
-      let subp = subpage ~on_sub shift_state subp in
-      Subpage subp :: walk_documentedsrc ~on_sub shift_state rest
-   | Alternative Expansion r :: rest ->
-      let expansion =  walk_documentedsrc ~on_sub shift_state r.expansion in
-      Alternative (Expansion { r with expansion }) :: walk_documentedsrc ~on_sub shift_state rest
+        let subp = subpage ~on_sub shift_state subp in
+        Subpage subp :: walk_documentedsrc ~on_sub shift_state rest
+    | Alternative (Expansion r) :: rest ->
+        let expansion = walk_documentedsrc ~on_sub shift_state r.expansion in
+        Alternative (Expansion { r with expansion })
+        :: walk_documentedsrc ~on_sub shift_state rest
 
   and subpage ~on_sub shift_state (subp : Subpage.t) =
     match on_sub (`Page subp) with
     | None -> subp
     | Some i ->
-      let shift_state = enter shift_state i in
-      let page = subp.content in
-      let content =
-        {page with
-          header = walk_item ~on_sub shift_state page.header ;
-          items = walk_item ~on_sub shift_state page.items ;
-        }
-      in
-      {subp with content}
+        let shift_state = enter shift_state i in
+        let page = subp.content in
+        let content =
+          {
+            page with
+            header = walk_item ~on_sub shift_state page.header;
+            items = walk_item ~on_sub shift_state page.items;
+          }
+        in
+        { subp with content }
 
   and include_ ~on_sub shift_state (subp : Include.t) =
     match on_sub (`Include subp) with
     | None -> subp
     | Some i ->
-      let shift_state = enter shift_state i in
-      let content = walk_item ~on_sub shift_state subp.content in
-      {subp with content}
+        let shift_state = enter shift_state i in
+        let content = walk_item ~on_sub shift_state subp.content in
+        { subp with content }
 
-  and walk_item ~on_sub shift_state (l : Item.t list) = match l with
+  and walk_item ~on_sub shift_state (l : Item.t list) =
+    match l with
     | [] -> []
-    | Heading { label; level; title } :: rest->
-      let shift_state, level = shift shift_state level in
-      Item.Heading { label; level; title }
-      :: walk_item ~on_sub shift_state rest
+    | Heading { label; level; title } :: rest ->
+        let shift_state, level = shift shift_state level in
+        Item.Heading { label; level; title }
+        :: walk_item ~on_sub shift_state rest
     | Include subp :: rest ->
-      let content = include_ ~on_sub shift_state subp.content in
-      let subp = {subp with content} in
-      Item.Include subp :: walk_item ~on_sub shift_state rest
+        let content = include_ ~on_sub shift_state subp.content in
+        let subp = { subp with content } in
+        Item.Include subp :: walk_item ~on_sub shift_state rest
     | Declaration decl :: rest ->
-      let decl =
-        { decl with content = walk_documentedsrc ~on_sub shift_state decl.content }
-      in
-      Declaration decl :: walk_item ~on_sub shift_state rest
-    | Text txt :: rest ->
-      Text txt :: walk_item ~on_sub shift_state rest
+        let decl =
+          {
+            decl with
+            content = walk_documentedsrc ~on_sub shift_state decl.content;
+          }
+        in
+        Declaration decl :: walk_item ~on_sub shift_state rest
+    | Text txt :: rest -> Text txt :: walk_item ~on_sub shift_state rest
 
   let compute ~on_sub i =
     let shift_state = start in
     walk_item ~on_sub shift_state i
-
 end

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -14,12 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-
 open Odoc_model.Names
 module Location = Odoc_model.Location_
 module Paths = Odoc_model.Paths
 open Types
-
 module O = Codefmt
 open O.Infix
 
@@ -27,1196 +25,1073 @@ open O.Infix
 let format_title kind name =
   let mk title =
     let level = 0 and label = None in
-    [Item.Heading { level ; label ; title}]
+    [ Item.Heading { level; label; title } ]
   in
-  let prefix s = mk (inline (Text (s ^" ")) :: O.code (O.txt name)) in
+  let prefix s = mk (inline (Text (s ^ " ")) :: O.code (O.txt name)) in
   match kind with
   | `Mod -> prefix "Module"
   | `Arg -> prefix "Parameter"
   | `Mty -> prefix "Module type"
   | `Cty -> prefix "Class type"
   | `Class -> prefix "Class"
-  | `Page -> mk [inline @@ Text name]
+  | `Page -> mk [ inline @@ Text name ]
 
-let make_name_from_path {Url.Path. name ; parent ; _ } =
+let make_name_from_path { Url.Path.name; parent; _ } =
   match parent with
   | None -> name
-  | Some p ->
-    Printf.sprintf "%s.%s" p.name name
+  | Some p -> Printf.sprintf "%s.%s" p.name name
 
-let label t ppf = match t with
+let label t ppf =
+  match t with
   | Odoc_model.Lang.TypeExpr.Label s -> O.pf ppf "%s" s
   | Optional s -> O.pf ppf "?%t%s" (O.entity "#8288") s
 
-let tag tag t ppf =
-  O.pf ppf "@{<%s>%t@}" tag t
+let tag tag t ppf = O.pf ppf "@{<%s>%t@}" tag t
 
-let type_var tv =
-  tag "type-var" (O.txt tv)
+let type_var tv = tag "type-var" (O.txt tv)
 
-let enclose ~l ~r x =
-  O.span (fun ppf -> O.pf ppf "%s%t%s" l x r)
+let enclose ~l ~r x = O.span (fun ppf -> O.pf ppf "%s%t%s" l x r)
 
 let path p txt =
-  !O.elt [inline @@ InternalLink (InternalLink.Resolved (Url.from_path p, txt))]
+  !O.elt
+    [ inline @@ InternalLink (InternalLink.Resolved (Url.from_path p, txt)) ]
+
 let resolved p txt =
-  !O.elt [inline @@ InternalLink (InternalLink.Resolved (p, txt))]
+  !O.elt [ inline @@ InternalLink (InternalLink.Resolved (p, txt)) ]
+
 let unresolved txt =
-  !O.elt [inline @@ InternalLink (InternalLink.Unresolved txt)]
+  !O.elt [ inline @@ InternalLink (InternalLink.Unresolved txt) ]
 
 let path_to_id path =
   match Url.Anchor.from_identifier (path :> Paths.Identifier.t) with
   | Error _ -> None
   | Ok url -> Some url
 
-let attach_expansion ?(status=`Default) (eq, o, e) page text =
+let attach_expansion ?(status = `Default) (eq, o, e) page text =
   match page with
-  | None -> O.documentedSrc (text)
+  | None -> O.documentedSrc text
   | Some (page : Page.t) ->
-    let url = page.url in
-    let summary = O.render text in
-    let expansion =
-      O.documentedSrc (O.txt eq ++ O.keyword o)
-      @ DocumentedSrc.[Subpage { status ; content = page }]
-      @ O.documentedSrc (O.keyword e)
-    in
-    DocumentedSrc.[Alternative (Expansion { summary; url ; status; expansion })]
+      let url = page.url in
+      let summary = O.render text in
+      let expansion =
+        O.documentedSrc (O.txt eq ++ O.keyword o)
+        @ DocumentedSrc.[ Subpage { status; content = page } ]
+        @ O.documentedSrc (O.keyword e)
+      in
+      DocumentedSrc.
+        [ Alternative (Expansion { summary; url; status; expansion }) ]
 
 include Generator_signatures
 
 module Make (Syntax : SYNTAX) = struct
+  module Link : sig
+    val from_path : Paths.Path.t -> text
 
-module Link :
-sig
-  val from_path : Paths.Path.t -> text
-  val from_fragment :
-    base:Paths.Identifier.Signature.t -> Paths.Fragment.t -> text
-  val render_fragment : Paths.Fragment.t -> string
-end =
-struct
-  open Paths
+    val from_fragment :
+      base:Paths.Identifier.Signature.t -> Paths.Fragment.t -> text
 
-  let rec from_path : Path.t -> text =
-    fun path ->
+    val render_fragment : Paths.Fragment.t -> string
+  end = struct
+    open Paths
+
+    let rec from_path : Path.t -> text =
+     fun path ->
       match path with
       | `Identifier (id, _) ->
-        unresolved [inline @@ Text (Identifier.name id)]
-      | `Root root -> unresolved [inline @@ Text root]
-      | `Forward root -> unresolved [inline @@ Text root] (* FIXME *)
+          unresolved [ inline @@ Text (Identifier.name id) ]
+      | `Root root -> unresolved [ inline @@ Text root ]
+      | `Forward root -> unresolved [ inline @@ Text root ] (* FIXME *)
       | `Dot (prefix, suffix) ->
-        let link = from_path (prefix :> Path.t) in
-        link ++ O.txt ("." ^ suffix)
+          let link = from_path (prefix :> Path.t) in
+          link ++ O.txt ("." ^ suffix)
       | `Apply (p1, p2) ->
-        let link1 = from_path (p1 :> Path.t) in
-        let link2 = from_path (p2 :> Path.t) in
-        link1 ++ O.txt "(" ++ link2 ++ O.txt ")"
+          let link1 = from_path (p1 :> Path.t) in
+          let link2 = from_path (p2 :> Path.t) in
+          link1 ++ O.txt "(" ++ link2 ++ O.txt ")"
       | `Resolved _ when Paths.Path.is_hidden path ->
-        let txt = Url.render_path path in
-        Format.eprintf "Warning, resolved hidden path: %s\n%!" txt;
-        unresolved [inline @@ Text txt]
-      | `Resolved rp ->
-        (* If the path is pointing to an opaque module or module type
-           there won't be a page generated - so we stop before; at
-           the parent page, and link instead to the anchor representing
-           the declaration of the opaque module(_type) *)
-        let stop_before = 
-          match rp with
-          | `OpaqueModule _
-          | `OpaqueModuleType _ -> true
-          | _ -> false
-        in
-        let id = Paths.Path.Resolved.identifier rp in
-        let txt = Url.render_path path in
-        begin match Url.from_identifier ~stop_before id with
-        | Ok href ->
-          resolved href [inline @@ Text txt]
-        | Error Url.Error.Not_linkable _ -> O.txt txt
-        | Error exn ->
-          Printf.eprintf "Id.href failed: %S\n%!" (Url.Error.to_string exn);
-          O.txt txt
-        end
+          let txt = Url.render_path path in
+          Format.eprintf "Warning, resolved hidden path: %s\n%!" txt;
+          unresolved [ inline @@ Text txt ]
+      | `Resolved rp -> (
+          (* If the path is pointing to an opaque module or module type
+             there won't be a page generated - so we stop before; at
+             the parent page, and link instead to the anchor representing
+             the declaration of the opaque module(_type) *)
+          let stop_before =
+            match rp with
+            | `OpaqueModule _ | `OpaqueModuleType _ -> true
+            | _ -> false
+          in
+          let id = Paths.Path.Resolved.identifier rp in
+          let txt = Url.render_path path in
+          match Url.from_identifier ~stop_before id with
+          | Ok href -> resolved href [ inline @@ Text txt ]
+          | Error (Url.Error.Not_linkable _) -> O.txt txt
+          | Error exn ->
+              Printf.eprintf "Id.href failed: %S\n%!" (Url.Error.to_string exn);
+              O.txt txt )
 
-  let dot prefix suffix =
-    match prefix with
-    | "" -> suffix
-    | _  -> prefix ^ "." ^ suffix
+    let dot prefix suffix =
+      match prefix with "" -> suffix | _ -> prefix ^ "." ^ suffix
 
-  let rec render_fragment : Fragment.t -> string =
-    fun fragment ->
-    match fragment with
-    | `Resolved rr -> render_resolved_fragment rr
-    | `Dot (prefix, suffix) ->
-      dot (render_fragment (prefix :> Fragment.t)) suffix
-    | `Root -> ""
-
-  and render_resolved_fragment : Fragment.Resolved.t -> string =
-    let open Fragment.Resolved in
-    fun fragment ->
+    let rec render_fragment : Fragment.t -> string =
+     fun fragment ->
       match fragment with
-      | `Root _ -> ""
-      | `Subst (_, rr) -> render_resolved_fragment (rr :> t)
-      | `SubstAlias (_, rr) -> render_resolved_fragment (rr :> t)
-      | `Module (rr, s) ->
-        dot (render_resolved_fragment (rr :> t)) (ModuleName.to_string s)
-      | `Type (rr, s) ->
-        dot (render_resolved_fragment (rr :> t)) (TypeName.to_string s)
-      | `Class (rr, s) ->
-        dot (render_resolved_fragment ( rr :> t)) (ClassName.to_string s)
-      | `ClassType (rr, s) ->
-        dot (render_resolved_fragment (rr :> t)) (ClassTypeName.to_string s)
-      | `OpaqueModule r ->
-        render_resolved_fragment (r :> t)
+      | `Resolved rr -> render_resolved_fragment rr
+      | `Dot (prefix, suffix) ->
+          dot (render_fragment (prefix :> Fragment.t)) suffix
+      | `Root -> ""
 
-  let rec fragment_to_ir : stop_before:bool ->
-    base:Identifier.Signature.t -> Fragment.t -> text =
-    fun ~stop_before ~base fragment ->
-    let open Fragment in
-    match fragment with
-    | `Root 
-    | `Resolved (`Root _) ->
-      let id = (base :> Identifier.t) in
-      begin match Url.from_identifier ~stop_before:true id with
-      | Ok href ->
-        resolved href [inline @@ Text (Identifier.name id)]
-      | Error (Not_linkable _) ->
-        unresolved [inline @@ Text (Identifier.name id)]
-      | Error exn ->
-        Printf.eprintf "[FRAG] Id.href failed: %S\n%!"
-          (Url.Error.to_string exn);
-        unresolved [inline @@ Text (Identifier.name id)]
-      end
-    | `Resolved rr ->
-      let id = Resolved.identifier (rr :> Resolved.t) in
-      let txt = render_resolved_fragment rr in
-      begin match Url.from_identifier ~stop_before id with
-      | Ok href ->
-        resolved href [inline @@ Text txt]
-      | Error (Not_linkable _) ->
-        unresolved [inline @@ Text txt]
-      | Error exn ->
-        Printf.eprintf "[FRAG] Id.href failed: %S\n%!"
-          (Url.Error.to_string exn);
-        unresolved [inline @@ Text txt]
-      end
-    | `Dot (prefix, suffix) ->
-      let link = fragment_to_ir ~stop_before:true ~base (prefix :> Fragment.t) in
-      link ++ O.txt ("." ^ suffix)
+    and render_resolved_fragment : Fragment.Resolved.t -> string =
+      let open Fragment.Resolved in
+      fun fragment ->
+        match fragment with
+        | `Root _ -> ""
+        | `Subst (_, rr) -> render_resolved_fragment (rr :> t)
+        | `SubstAlias (_, rr) -> render_resolved_fragment (rr :> t)
+        | `Module (rr, s) ->
+            dot (render_resolved_fragment (rr :> t)) (ModuleName.to_string s)
+        | `Type (rr, s) ->
+            dot (render_resolved_fragment (rr :> t)) (TypeName.to_string s)
+        | `Class (rr, s) ->
+            dot (render_resolved_fragment (rr :> t)) (ClassName.to_string s)
+        | `ClassType (rr, s) ->
+            dot (render_resolved_fragment (rr :> t)) (ClassTypeName.to_string s)
+        | `OpaqueModule r -> render_resolved_fragment (r :> t)
 
-  let from_fragment = fragment_to_ir ~stop_before:false
+    let rec fragment_to_ir :
+        stop_before:bool -> base:Identifier.Signature.t -> Fragment.t -> text =
+     fun ~stop_before ~base fragment ->
+      let open Fragment in
+      match fragment with
+      | `Root | `Resolved (`Root _) -> (
+          let id = (base :> Identifier.t) in
+          match Url.from_identifier ~stop_before:true id with
+          | Ok href -> resolved href [ inline @@ Text (Identifier.name id) ]
+          | Error (Not_linkable _) ->
+              unresolved [ inline @@ Text (Identifier.name id) ]
+          | Error exn ->
+              Printf.eprintf "[FRAG] Id.href failed: %S\n%!"
+                (Url.Error.to_string exn);
+              unresolved [ inline @@ Text (Identifier.name id) ] )
+      | `Resolved rr -> (
+          let id = Resolved.identifier (rr :> Resolved.t) in
+          let txt = render_resolved_fragment rr in
+          match Url.from_identifier ~stop_before id with
+          | Ok href -> resolved href [ inline @@ Text txt ]
+          | Error (Not_linkable _) -> unresolved [ inline @@ Text txt ]
+          | Error exn ->
+              Printf.eprintf "[FRAG] Id.href failed: %S\n%!"
+                (Url.Error.to_string exn);
+              unresolved [ inline @@ Text txt ] )
+      | `Dot (prefix, suffix) ->
+          let link =
+            fragment_to_ir ~stop_before:true ~base (prefix :> Fragment.t)
+          in
+          link ++ O.txt ("." ^ suffix)
 
-end
+    let from_fragment = fragment_to_ir ~stop_before:false
+  end
 
+  module Type_expression : sig
+    val type_expr : ?needs_parentheses:bool -> Lang.TypeExpr.t -> text
 
-module Type_expression :
-sig
-  val type_expr : ?needs_parentheses:bool -> Lang.TypeExpr.t -> text
-
-  val format_type_path :
-    delim:[ `parens | `brackets ] -> Lang.TypeExpr.t list -> text -> text
-end =
-struct
-  let rec te_variant (t : Odoc_model.Lang.TypeExpr.Polymorphic_variant.t) =
-    let style_arguments ~constant arguments =
-      (* Multiple arguments in a polymorphic variant constructor correspond
-         to a conjunction of types, not a product: [`Lbl int&float].
-         If constant is [true], the conjunction starts with an empty type,
-         for instance [`Lbl &int].
-      *)
-      let wrapped_type_expr =
-        (* type conjunction in Reason is printed as `Lbl (t1)&(t2)` *)
-        if Syntax.Type.Variant.parenthesize_params then
-          fun x ->
+    val format_type_path :
+      delim:[ `parens | `brackets ] -> Lang.TypeExpr.t list -> text -> text
+  end = struct
+    let rec te_variant (t : Odoc_model.Lang.TypeExpr.Polymorphic_variant.t) =
+      let style_arguments ~constant arguments =
+        (* Multiple arguments in a polymorphic variant constructor correspond
+           to a conjunction of types, not a product: [`Lbl int&float].
+           If constant is [true], the conjunction starts with an empty type,
+           for instance [`Lbl &int].
+        *)
+        let wrapped_type_expr =
+          (* type conjunction in Reason is printed as `Lbl (t1)&(t2)` *)
+          if Syntax.Type.Variant.parenthesize_params then fun x ->
             O.span (O.txt "(" ++ type_expr x ++ O.txt ")")
-        else
-          fun x -> type_expr x
-      in
-      let arguments =
-        O.list
-          arguments
-          ~sep:(O.txt " & ")
-          ~f:wrapped_type_expr
-      in
-      if constant
-      then O.txt "& " ++ arguments
-      else arguments
-    in
-    let rec style_elements ~add_pipe = function
-      | [] -> O.noop
-      | first :: rest ->
-        let first =
-          match first with
-          | Odoc_model.Lang.TypeExpr.Polymorphic_variant.Type te ->
-            let res = type_expr te in
-            if add_pipe
-            then O.txt " " ++ O.span (O.txt "| " ++ res)
-            else res
-          | Constructor {constant; name; arguments; _} ->
-            let constr =
-              let name = "`" ^ name in
-              if add_pipe
-              then O.span (O.txt ("| " ^ name))
-              else O.txt name
-            in
-            let res =
-              match arguments with
-              | [] -> constr
-              | _ ->
-                let arguments = style_arguments ~constant arguments in
-                O.span (
-                  if Syntax.Type.Variant.parenthesize_params
-                  then constr ++ arguments
-                  else constr ++ O.txt  " of " ++ arguments
-                )
-            in
-            if add_pipe
-            then O.txt " " ++ res
-            else res
+          else fun x -> type_expr x
         in
-        first ++ style_elements ~add_pipe:true rest
-    in
-    let elements = style_elements ~add_pipe:false t.elements in
-    O.span (
-       match t.kind with
-       | Fixed -> O.txt "[ " ++ elements ++ O.txt " ]"
-       | Open -> O.txt "[> " ++ elements ++ O.txt " ]"
-       | Closed [] -> O.txt "[< " ++ elements ++ O.txt " ]"
-       | Closed lst ->
-         let constrs = String.concat " " lst in
-         O.txt "[< " ++ elements ++ (O.txt (" " ^ constrs ^ " ]"))
-     )
+        let arguments =
+          O.list arguments ~sep:(O.txt " & ") ~f:wrapped_type_expr
+        in
+        if constant then O.txt "& " ++ arguments else arguments
+      in
+      let rec style_elements ~add_pipe = function
+        | [] -> O.noop
+        | first :: rest ->
+            let first =
+              match first with
+              | Odoc_model.Lang.TypeExpr.Polymorphic_variant.Type te ->
+                  let res = type_expr te in
+                  if add_pipe then O.txt " " ++ O.span (O.txt "| " ++ res)
+                  else res
+              | Constructor { constant; name; arguments; _ } ->
+                  let constr =
+                    let name = "`" ^ name in
+                    if add_pipe then O.span (O.txt ("| " ^ name))
+                    else O.txt name
+                  in
+                  let res =
+                    match arguments with
+                    | [] -> constr
+                    | _ ->
+                        let arguments = style_arguments ~constant arguments in
+                        O.span
+                          ( if Syntax.Type.Variant.parenthesize_params then
+                            constr ++ arguments
+                          else constr ++ O.txt " of " ++ arguments )
+                  in
+                  if add_pipe then O.txt " " ++ res else res
+            in
+            first ++ style_elements ~add_pipe:true rest
+      in
+      let elements = style_elements ~add_pipe:false t.elements in
+      O.span
+        ( match t.kind with
+        | Fixed -> O.txt "[ " ++ elements ++ O.txt " ]"
+        | Open -> O.txt "[> " ++ elements ++ O.txt " ]"
+        | Closed [] -> O.txt "[< " ++ elements ++ O.txt " ]"
+        | Closed lst ->
+            let constrs = String.concat " " lst in
+            O.txt "[< " ++ elements ++ O.txt (" " ^ constrs ^ " ]") )
 
-  and te_object (t : Odoc_model.Lang.TypeExpr.Object.t) =
-    let fields =
-      O.list t.fields ~f:(function
-        | Odoc_model.Lang.TypeExpr.Object.Method {name; type_} ->
-          O.txt (name ^ Syntax.Type.annotation_separator)
-          ++ type_expr type_
-          ++ O.txt Syntax.Obj.field_separator
-        | Inherit type_ ->
-            type_expr type_ ++ O.txt Syntax.Obj.field_separator)
-    in
-    let open_tag =
+    and te_object (t : Odoc_model.Lang.TypeExpr.Object.t) =
+      let fields =
+        O.list t.fields ~f:(function
+          | Odoc_model.Lang.TypeExpr.Object.Method { name; type_ } ->
+              O.txt (name ^ Syntax.Type.annotation_separator)
+              ++ type_expr type_
+              ++ O.txt Syntax.Obj.field_separator
+          | Inherit type_ -> type_expr type_ ++ O.txt Syntax.Obj.field_separator)
+      in
+      let open_tag =
         if t.open_ then O.txt Syntax.Obj.open_tag_extendable
         else O.txt Syntax.Obj.open_tag_closed
-    in
-    let close_tag =
+      in
+      let close_tag =
         if t.open_ then O.txt Syntax.Obj.close_tag_extendable
         else O.txt Syntax.Obj.close_tag_closed
-    in
-    open_tag ++ fields ++ close_tag
-
-  and format_type_path
-        ~delim (params : Odoc_model.Lang.TypeExpr.t list) (path : text) : text =
-    match params with
-    | [] -> path
-    | [param] ->
-        let param = (type_expr ~needs_parentheses:true param) in
-        let args =
-          if Syntax.Type.parenthesize_constructor
-          then O.txt "(" ++ param ++ O.txt ")"
-          else param
-        in
-      Syntax.Type.handle_constructor_params path args
-    | params  ->
-      let params =
-        O.list params ~sep:(O.txt ",\194\160")
-          ~f:type_expr
       in
-      let params = match delim with
-        | `parens   -> enclose ~l:"(" params ~r:")"
-        | `brackets -> enclose ~l:"[" params ~r:"]"
-      in
-      Syntax.Type.handle_constructor_params path params
+      open_tag ++ fields ++ close_tag
 
-  and type_expr
-        ?(needs_parentheses=false) (t : Odoc_model.Lang.TypeExpr.t) =
-    match t with
-    | Var s -> type_var (Syntax.Type.var_prefix ^ s)
-    | Any  -> type_var Syntax.Type.any
-    | Alias (te, alias) ->
-      type_expr ~needs_parentheses:true te ++
-      O.txt " " ++ O.keyword "as" ++ O.txt " '" ++ O.txt alias
-    | Arrow (None, src, dst) ->
-      let res =
-        type_expr ~needs_parentheses:true src ++
-        O.txt " " ++ Syntax.Type.arrow ++ O.txt " " ++ type_expr dst
-      in
-      if not needs_parentheses then
-        res
-      else
-        enclose ~l:"(" res ~r:")"
-    | Arrow (Some lbl, src, dst) ->
-      let res =
-        O.span (
-          label lbl ++ O.txt ":" ++ type_expr ~needs_parentheses:true src
-        ) ++ O.txt " " ++ Syntax.Type.arrow ++ O.txt " " ++ type_expr dst
-      in
-      if not needs_parentheses then
-        res
-      else
-        enclose ~l:"(" res ~r:")"
-    | Tuple lst ->
-      let res =
-        O.list
-          lst
-          ~sep:(O.txt Syntax.Type.Tuple.element_separator)
-          ~f:(type_expr ~needs_parentheses:true)
-      in
-      if Syntax.Type.Tuple.always_parenthesize || needs_parentheses then
-        enclose ~l:"(" res ~r:")"
-      else
-        res
-    | Constr (path, args) ->
-      let link = Link.from_path (path :> Paths.Path.t) in
-      format_type_path ~delim:(`parens) args link
-    | Polymorphic_variant v -> te_variant v
-    | Object o -> te_object o
-    | Class (path, args) ->
-      format_type_path ~delim:(`brackets) args
-        (Link.from_path (path :> Paths.Path.t))
-    | Poly (polyvars, t) ->
-      O.txt (String.concat " " polyvars ^ ". ") ++ type_expr t
-    | Package pkg ->
-      enclose ~l:"(" ~r:")" (
-         O.keyword "module" ++ O.txt " " ++
-           Link.from_path (pkg.path :> Paths.Path.t) ++
-         match pkg.substitutions with
-         | [] -> O.noop
-         | lst ->
-           O.txt " " ++ O.keyword "with" ++ O.txt " " ++
-           O.list
-             ~sep:(O.txt " " ++ O.keyword "and" ++ O.txt " ")
-             lst
-             ~f:(package_subst pkg.path)
-       )
+    and format_type_path ~delim (params : Odoc_model.Lang.TypeExpr.t list)
+        (path : text) : text =
+      match params with
+      | [] -> path
+      | [ param ] ->
+          let param = type_expr ~needs_parentheses:true param in
+          let args =
+            if Syntax.Type.parenthesize_constructor then
+              O.txt "(" ++ param ++ O.txt ")"
+            else param
+          in
+          Syntax.Type.handle_constructor_params path args
+      | params ->
+          let params = O.list params ~sep:(O.txt ",\194\160") ~f:type_expr in
+          let params =
+            match delim with
+            | `parens -> enclose ~l:"(" params ~r:")"
+            | `brackets -> enclose ~l:"[" params ~r:"]"
+          in
+          Syntax.Type.handle_constructor_params path params
 
-  and package_subst (pkg_path : Paths.Path.ModuleType.t)
-        (frag_typ, te : Paths.Fragment.Type.t * Odoc_model.Lang.TypeExpr.t)
-    : text =
-    let typath = match pkg_path with
-    | `Resolved rp ->
-      let base =
-        (Paths.Path.Resolved.ModuleType.identifier rp :> Paths.Identifier.Signature.t)
+    and type_expr ?(needs_parentheses = false) (t : Odoc_model.Lang.TypeExpr.t)
+        =
+      match t with
+      | Var s -> type_var (Syntax.Type.var_prefix ^ s)
+      | Any -> type_var Syntax.Type.any
+      | Alias (te, alias) ->
+          type_expr ~needs_parentheses:true te
+          ++ O.txt " " ++ O.keyword "as" ++ O.txt " '" ++ O.txt alias
+      | Arrow (None, src, dst) ->
+          let res =
+            type_expr ~needs_parentheses:true src
+            ++ O.txt " " ++ Syntax.Type.arrow ++ O.txt " " ++ type_expr dst
+          in
+          if not needs_parentheses then res else enclose ~l:"(" res ~r:")"
+      | Arrow (Some lbl, src, dst) ->
+          let res =
+            O.span
+              (label lbl ++ O.txt ":" ++ type_expr ~needs_parentheses:true src)
+            ++ O.txt " " ++ Syntax.Type.arrow ++ O.txt " " ++ type_expr dst
+          in
+          if not needs_parentheses then res else enclose ~l:"(" res ~r:")"
+      | Tuple lst ->
+          let res =
+            O.list lst
+              ~sep:(O.txt Syntax.Type.Tuple.element_separator)
+              ~f:(type_expr ~needs_parentheses:true)
+          in
+          if Syntax.Type.Tuple.always_parenthesize || needs_parentheses then
+            enclose ~l:"(" res ~r:")"
+          else res
+      | Constr (path, args) ->
+          let link = Link.from_path (path :> Paths.Path.t) in
+          format_type_path ~delim:`parens args link
+      | Polymorphic_variant v -> te_variant v
+      | Object o -> te_object o
+      | Class (path, args) ->
+          format_type_path ~delim:`brackets args
+            (Link.from_path (path :> Paths.Path.t))
+      | Poly (polyvars, t) ->
+          O.txt (String.concat " " polyvars ^ ". ") ++ type_expr t
+      | Package pkg ->
+          enclose ~l:"(" ~r:")"
+            ( O.keyword "module" ++ O.txt " "
+            ++ Link.from_path (pkg.path :> Paths.Path.t)
+            ++
+            match pkg.substitutions with
+            | [] -> O.noop
+            | lst ->
+                O.txt " " ++ O.keyword "with" ++ O.txt " "
+                ++ O.list
+                     ~sep:(O.txt " " ++ O.keyword "and" ++ O.txt " ")
+                     lst ~f:(package_subst pkg.path) )
+
+    and package_subst (pkg_path : Paths.Path.ModuleType.t)
+        ((frag_typ, te) : Paths.Fragment.Type.t * Odoc_model.Lang.TypeExpr.t) :
+        text =
+      let typath =
+        match pkg_path with
+        | `Resolved rp ->
+            let base =
+              ( Paths.Path.Resolved.ModuleType.identifier rp
+                :> Paths.Identifier.Signature.t )
+            in
+            Link.from_fragment ~base (frag_typ :> Paths.Fragment.t)
+        | _ -> O.txt (Link.render_fragment (frag_typ :> Paths.Fragment.t))
       in
-      Link.from_fragment ~base (frag_typ :> Paths.Fragment.t)
-    | _ ->
-      O.txt (Link.render_fragment (frag_typ :> Paths.Fragment.t))
-    in
-    O.keyword "type" ++
-    O.txt " " ++
-    typath ++
-      O.txt " = " ++
-      type_expr te
-end
-open Type_expression
+      O.keyword "type" ++ O.txt " " ++ typath ++ O.txt " = " ++ type_expr te
+  end
 
+  open Type_expression
 
-
-(* Also handles constructor declarations for exceptions and extensible
-   variants, and exposes a few helpers used in formatting classes and signature
-   constraints. *)
-module Type_declaration :
-sig
-  val type_decl :
-    ?is_substitution:bool -> Lang.Signature.recursive * Lang.TypeDecl.t ->
+  (* Also handles constructor declarations for exceptions and extensible
+     variants, and exposes a few helpers used in formatting classes and signature
+     constraints. *)
+  module Type_declaration : sig
+    val type_decl :
+      ?is_substitution:bool ->
+      Lang.Signature.recursive * Lang.TypeDecl.t ->
       Item.t
-  val extension : Lang.Extension.t -> Item.t
-  val exn : Lang.Exception.t -> Item.t
 
-  val format_params :
-    ?delim:[ `parens | `brackets ] ->
-    Lang.TypeDecl.param list -> text
+    val extension : Lang.Extension.t -> Item.t
 
-  val format_manifest : ?is_substitution:bool -> ?compact_variants:bool -> Lang.TypeDecl.Equation.t -> text * bool
+    val exn : Lang.Exception.t -> Item.t
 
-  val format_constraints : (Lang.TypeExpr.t * Lang.TypeExpr.t) list -> text
-end =
-struct
-  let record fields =
-    let field mutable_ id typ =
-      match Url.from_identifier ~stop_before:true id with
-      | Error e -> failwith (Url.Error.to_string e)
-      | Ok url ->
-        let name = Paths.Identifier.name id in
-        let attrs = ["def"; "record"; url.kind] in
-        let cell =
-          (* O.td ~a:[ O.a_class ["def"; kind ] ]
-           *   [O.a ~a:[O.a_href ("#" ^ anchor); O.a_class ["anchor"]] []
-           *   ; *)
-              O.code (
-                (if mutable_ then O.keyword "mutable" ++ O.txt " " else O.noop)
+    val format_params :
+      ?delim:[ `parens | `brackets ] -> Lang.TypeDecl.param list -> text
+
+    val format_manifest :
+      ?is_substitution:bool ->
+      ?compact_variants:bool ->
+      Lang.TypeDecl.Equation.t ->
+      text * bool
+
+    val format_constraints : (Lang.TypeExpr.t * Lang.TypeExpr.t) list -> text
+  end = struct
+    let record fields =
+      let field mutable_ id typ =
+        match Url.from_identifier ~stop_before:true id with
+        | Error e -> failwith (Url.Error.to_string e)
+        | Ok url ->
+            let name = Paths.Identifier.name id in
+            let attrs = [ "def"; "record"; url.kind ] in
+            let cell =
+              (* O.td ~a:[ O.a_class ["def"; kind ] ]
+               *   [O.a ~a:[O.a_href ("#" ^ anchor); O.a_class ["anchor"]] []
+               *   ; *)
+              O.code
+                ( (if mutable_ then O.keyword "mutable" ++ O.txt " " else O.noop)
                 ++ O.txt name
                 ++ O.txt Syntax.Type.annotation_separator
                 ++ type_expr typ
-                ++ O.txt Syntax.Type.Record.field_separator
-              )
-            (* ] *)
-        in
-        url, attrs, cell
-    in
-    let rows =
-      fields |> List.map (fun fld ->
-        let open Odoc_model.Lang.TypeDecl.Field in
-        let url, attrs, code =
-          field fld.mutable_ (fld.id :> Paths.Identifier.t) fld.type_
-        in
-        let anchor = Some url in
-        let rhs = Comment.to_ir fld.doc in
-        let doc = if not (Comment.has_doc fld.doc) then [] else rhs in
-        DocumentedSrc.Documented { anchor; attrs; code; doc }
-      )
-    in
-    let content =
-      O.documentedSrc (O.txt "{")
-      @ rows
-      @ O.documentedSrc (O.txt "}")
-    in
-    content
+                ++ O.txt Syntax.Type.Record.field_separator )
+              (* ] *)
+            in
+            (url, attrs, cell)
+      in
+      let rows =
+        fields
+        |> List.map (fun fld ->
+               let open Odoc_model.Lang.TypeDecl.Field in
+               let url, attrs, code =
+                 field fld.mutable_ (fld.id :> Paths.Identifier.t) fld.type_
+               in
+               let anchor = Some url in
+               let rhs = Comment.to_ir fld.doc in
+               let doc = if not (Comment.has_doc fld.doc) then [] else rhs in
+               DocumentedSrc.Documented { anchor; attrs; code; doc })
+      in
+      let content =
+        O.documentedSrc (O.txt "{") @ rows @ O.documentedSrc (O.txt "}")
+      in
+      content
 
-
-  let constructor
-    : Paths.Identifier.t -> Odoc_model.Lang.TypeDecl.Constructor.argument
-      -> Odoc_model.Lang.TypeExpr.t option
-      -> DocumentedSrc.t
-    = fun id args ret_type ->
+    let constructor :
+        Paths.Identifier.t ->
+        Odoc_model.Lang.TypeDecl.Constructor.argument ->
+        Odoc_model.Lang.TypeExpr.t option ->
+        DocumentedSrc.t =
+     fun id args ret_type ->
       let name = Paths.Identifier.name id in
       let kind = Url.kind id in
       let cstr = tag kind (O.txt name) in
       let is_gadt, ret_type =
         match ret_type with
-        | None -> false, O.noop
+        | None -> (false, O.noop)
         | Some te ->
-          let constant =
-            match args with
-            | Tuple [] -> true
-            | _ -> false
-          in
-          let ret_type =
-            O.txt " " ++
-              (if constant then O.txt ":" else Syntax.Type.GADT.arrow) ++
-              O.txt " " ++
-              type_expr te
-          in
-          true, ret_type
+            let constant = match args with Tuple [] -> true | _ -> false in
+            let ret_type =
+              O.txt " "
+              ++ (if constant then O.txt ":" else Syntax.Type.GADT.arrow)
+              ++ O.txt " " ++ type_expr te
+            in
+            (true, ret_type)
       in
       match args with
       | Tuple [] -> O.documentedSrc (cstr ++ ret_type)
       | Tuple lst ->
-        let params = O.list lst
-            ~sep:(O.txt Syntax.Type.Tuple.element_separator)
-            ~f:(type_expr ~needs_parentheses:is_gadt)
-        in
-        O.documentedSrc (cstr ++
-            (if Syntax.Type.Variant.parenthesize_params
-              then O.txt "(" ++ params ++ O.txt ")"
-              else
-                (if is_gadt then
-                    O.txt Syntax.Type.annotation_separator
-                  else
-                    O.txt " " ++ O.keyword "of" ++ O.txt " ") ++
-                  params
-            )
-          ++ ret_type)
+          let params =
+            O.list lst
+              ~sep:(O.txt Syntax.Type.Tuple.element_separator)
+              ~f:(type_expr ~needs_parentheses:is_gadt)
+          in
+          O.documentedSrc
+            ( cstr
+            ++ ( if Syntax.Type.Variant.parenthesize_params then
+                 O.txt "(" ++ params ++ O.txt ")"
+               else
+                 ( if is_gadt then O.txt Syntax.Type.annotation_separator
+                 else O.txt " " ++ O.keyword "of" ++ O.txt " " )
+                 ++ params )
+            ++ ret_type )
       | Record fields ->
-        if is_gadt then
-          O.documentedSrc (cstr ++ O.txt Syntax.Type.annotation_separator)
-          @ record fields
-          @ O.documentedSrc ret_type
-        else
-          O.documentedSrc (cstr ++ O.txt " " ++ O.keyword "of" ++ O.txt " ")
-          @ record fields
+          if is_gadt then
+            O.documentedSrc (cstr ++ O.txt Syntax.Type.annotation_separator)
+            @ record fields @ O.documentedSrc ret_type
+          else
+            O.documentedSrc (cstr ++ O.txt " " ++ O.keyword "of" ++ O.txt " ")
+            @ record fields
 
+    let variant cstrs : DocumentedSrc.t =
+      let constructor id args res =
+        match Url.from_identifier ~stop_before:true id with
+        | Error e -> failwith (Url.Error.to_string e)
+        | Ok url ->
+            let attrs = [ "def"; "variant"; url.kind ] in
+            let content =
+              let doc = constructor id args res in
+              O.documentedSrc (O.txt "| ") @ doc
+            in
+            (url, attrs, content)
+      in
+      match cstrs with
+      | [] -> O.documentedSrc (O.txt "|")
+      | _ :: _ ->
+          let rows =
+            cstrs
+            |> List.map (fun cstr ->
+                   let open Odoc_model.Lang.TypeDecl.Constructor in
+                   let url, attrs, code =
+                     constructor
+                       (cstr.id :> Paths.Identifier.t)
+                       cstr.args cstr.res
+                   in
+                   let anchor = Some url in
+                   let rhs = Comment.to_ir cstr.doc in
+                   let doc =
+                     if not (Comment.has_doc cstr.doc) then [] else rhs
+                   in
+                   DocumentedSrc.Nested { anchor; attrs; code; doc })
+          in
+          rows
 
-
-  let variant cstrs : DocumentedSrc.t =
-    let constructor id args res =
+    let extension_constructor (t : Odoc_model.Lang.Extension.Constructor.t) =
+      let id = (t.id :> Paths.Identifier.t) in
       match Url.from_identifier ~stop_before:true id with
       | Error e -> failwith (Url.Error.to_string e)
       | Ok url ->
-        let attrs = ["def" ; "variant" ; url.kind] in
-        let content =
-          let doc = constructor id args res in
-          O.documentedSrc (O.txt "| ") @ doc
-        in
-        url, attrs, content
-    in
-    match cstrs with
-    | [] -> O.documentedSrc (O.txt "|")
-    | _ :: _ ->
-      let rows =
-        cstrs |> List.map (fun cstr ->
-          let open Odoc_model.Lang.TypeDecl.Constructor in
-          let url, attrs, code =
-            constructor (cstr.id :> Paths.Identifier.t) cstr.args cstr.res
-          in
           let anchor = Some url in
-          let rhs = Comment.to_ir cstr.doc in
-          let doc = if not (Comment.has_doc cstr.doc) then [] else rhs in
+          let attrs = [ "def"; url.kind ] in
+          let code =
+            O.documentedSrc (O.txt "| ") @ constructor id t.args t.res
+          in
+          let doc = Comment.to_ir t.doc in
           DocumentedSrc.Nested { anchor; attrs; code; doc }
-        )
+
+    let extension (t : Odoc_model.Lang.Extension.t) =
+      let content =
+        O.documentedSrc
+          ( O.keyword "type" ++ O.txt " "
+          ++ Link.from_path (t.type_path :> Paths.Path.t)
+          ++ O.txt " += " )
+        @ List.map extension_constructor t.constructors
+        @ O.documentedSrc
+            (if Syntax.Type.type_def_semicolon then O.txt ";" else O.noop)
       in
-      rows
+      let kind = Some "extension" in
+      let anchor = None in
+      let doc = Comment.to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
 
+    let exn (t : Odoc_model.Lang.Exception.t) =
+      let cstr = constructor (t.id :> Paths.Identifier.t) t.args t.res in
+      let content =
+        O.documentedSrc (O.keyword "exception" ++ O.txt " ")
+        @ cstr
+        @ O.documentedSrc
+            (if Syntax.Type.Exception.semicolon then O.txt ";" else O.noop)
+      in
+      let kind = Some "exception" in
+      let anchor = path_to_id t.id in
+      let doc = Comment.to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
 
+    let polymorphic_variant ~type_ident
+        (t : Odoc_model.Lang.TypeExpr.Polymorphic_variant.t) =
+      let row item =
+        let kind_approx, cstr, doc =
+          match item with
+          | Odoc_model.Lang.TypeExpr.Polymorphic_variant.Type te ->
+              ("unknown", O.code (type_expr te), None)
+          | Constructor { constant; name; arguments; doc; _ } -> (
+              let cstr = "`" ^ name in
+              ( "constructor",
+                ( match arguments with
+                | [] -> O.code (O.txt cstr)
+                | _ ->
+                    (* Multiple arguments in a polymorphic variant constructor correspond
+                       to a conjunction of types, not a product: [`Lbl int&float].
+                       If constant is [true], the conjunction starts with an empty type,
+                       for instance [`Lbl &int].
+                    *)
+                    let wrapped_type_expr =
+                      (* type conjunction in Reason is printed as `Lbl (t1)&(t2)` *)
+                      if Syntax.Type.Variant.parenthesize_params then fun x ->
+                        O.txt "(" ++ type_expr x ++ O.txt ")"
+                      else fun x -> type_expr x
+                    in
+                    let params =
+                      O.list arguments ~sep:(O.txt " & ") ~f:wrapped_type_expr
+                    in
+                    let params =
+                      if constant then O.txt "& " ++ params else params
+                    in
+                    O.code
+                      ( O.txt cstr
+                      ++
+                      if Syntax.Type.Variant.parenthesize_params then params
+                      else O.txt " " ++ O.keyword "of" ++ O.txt " " ++ params )
+                ),
+                match doc with [] -> None | _ -> Some (Comment.to_ir doc) ) )
+        in
+        try
+          let url = Url.Anchor.polymorphic_variant ~type_ident item in
+          let attrs = [ "def"; url.kind ] in
+          let anchor = Some url in
+          let code = O.code (O.txt "| ") @ cstr in
+          let doc = match doc with None -> [] | Some doc -> doc in
+          DocumentedSrc.Documented { attrs; anchor; code; doc }
+        with Failure s ->
+          Printf.eprintf "ERROR: %s\n%!" s;
+          let code = O.code (O.txt "| ") @ cstr in
+          let attrs = [ "def"; kind_approx ] in
+          let doc = [] in
+          let anchor = None in
+          DocumentedSrc.Documented { attrs; anchor; code; doc }
+      in
+      let variants = List.map row t.elements in
+      let intro, ending =
+        match t.kind with
+        | Fixed -> (O.documentedSrc (O.txt "[ "), O.documentedSrc (O.txt " ]"))
+        | Open -> (O.documentedSrc (O.txt "[> "), O.documentedSrc (O.txt " ]"))
+        | Closed [] ->
+            (O.documentedSrc (O.txt "[< "), O.documentedSrc (O.txt " ]"))
+        | Closed lst ->
+            let constrs = String.concat " " lst in
+            ( O.documentedSrc (O.txt "[< "),
+              O.documentedSrc (O.txt (" " ^ constrs ^ " ]")) )
+      in
+      intro @ variants @ ending
 
-  let extension_constructor (t : Odoc_model.Lang.Extension.Constructor.t) =
-    let id = (t.id :> Paths.Identifier.t) in
-    match Url.from_identifier ~stop_before:true id with
-    | Error e -> failwith (Url.Error.to_string e)
-    | Ok url ->
-       let anchor = Some url in
-       let attrs = ["def"; url.kind] in
-       let code =
-         O.documentedSrc (O.txt "| ")
-         @ constructor id t.args t.res
-       in
-       let doc = Comment.to_ir t.doc in
-       DocumentedSrc.Nested { anchor; attrs; code; doc }
+    let format_params :
+          'row. ?delim:[ `parens | `brackets ] ->
+          Odoc_model.Lang.TypeDecl.param list -> text =
+     fun ?(delim = `parens) params ->
+      let format_param { Odoc_model.Lang.TypeDecl.desc; variance; injectivity }
+          =
+        let desc =
+          match desc with
+          | Odoc_model.Lang.TypeDecl.Any -> [ "_" ]
+          | Var s -> [ "'"; s ]
+        in
+        let var_desc =
+          match variance with
+          | None -> desc
+          | Some Odoc_model.Lang.TypeDecl.Pos -> "+" :: desc
+          | Some Odoc_model.Lang.TypeDecl.Neg -> "-" :: desc
+        in
+        let final = if injectivity then "!" :: var_desc else var_desc in
+        String.concat "" final
+      in
+      O.txt
+        ( match params with
+        | [] -> ""
+        | [ x ] -> format_param x |> Syntax.Type.handle_format_params
+        | lst -> (
+            let params = String.concat ", " (List.map format_param lst) in
+            (match delim with `parens -> "(" | `brackets -> "[")
+            ^ params
+            ^ match delim with `parens -> ")" | `brackets -> "]" ) )
 
-  let extension (t : Odoc_model.Lang.Extension.t) =
-    let content =
-      O.documentedSrc (O.keyword "type" ++
-          O.txt " " ++
-          Link.from_path (t.type_path :> Paths.Path.t) ++
-          O.txt " += ")
-      @ List.map extension_constructor t.constructors
-      @ O.documentedSrc
-          (if Syntax.Type.type_def_semicolon then O.txt ";" else O.noop)
-    in
-    let kind = Some "extension" in
-    let anchor = None in
-    let doc = Comment.to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
+    let format_constraints constraints =
+      O.list constraints ~f:(fun (t1, t2) ->
+          O.txt " " ++ O.keyword "constraint" ++ O.txt " " ++ type_expr t1
+          ++ O.txt " = " ++ type_expr t2)
 
+    let format_manifest :
+          'inner_row 'outer_row. ?is_substitution:bool ->
+          ?compact_variants:bool -> Odoc_model.Lang.TypeDecl.Equation.t ->
+          text * bool =
+     fun ?(is_substitution = false) ?(compact_variants = true) equation ->
+      let _ = compact_variants in
+      (* TODO *)
+      let private_ = equation.private_ in
+      match equation.manifest with
+      | None -> (O.noop, private_)
+      | Some t ->
+          let manifest =
+            O.txt (if is_substitution then " := " else " = ")
+            ++ ( if private_ then
+                 O.keyword Syntax.Type.private_keyword ++ O.txt " "
+               else O.noop )
+            ++ type_expr t
+          in
+          (manifest, false)
 
-
-  let exn (t : Odoc_model.Lang.Exception.t) =
-    let cstr = constructor (t.id :> Paths.Identifier.t) t.args t.res in
-    let content =
-      O.documentedSrc (O.keyword "exception" ++ O.txt " ")
-      @ cstr
-      @ O.documentedSrc
-          (if Syntax.Type.Exception.semicolon then O.txt ";" else O.noop)
-    in
-    let kind = Some "exception" in
-    let anchor = path_to_id t.id in
-    let doc = Comment.to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
-
-
-
-  let polymorphic_variant
-      ~type_ident (t : Odoc_model.Lang.TypeExpr.Polymorphic_variant.t) =
-    let row item =
-      let kind_approx, cstr, doc =
-        match item with
-        | Odoc_model.Lang.TypeExpr.Polymorphic_variant.Type te ->
-          "unknown", O.code (type_expr te), None
-        | Constructor {constant; name; arguments; doc; _} ->
-          let cstr = "`" ^ name in
-          "constructor",
-          begin match arguments with
-          | [] -> O.code (O.txt cstr)
-          | _ ->
-            (* Multiple arguments in a polymorphic variant constructor correspond
-               to a conjunction of types, not a product: [`Lbl int&float].
-               If constant is [true], the conjunction starts with an empty type,
-               for instance [`Lbl &int].
-            *)
-            let wrapped_type_expr =
-              (* type conjunction in Reason is printed as `Lbl (t1)&(t2)` *)
-              if Syntax.Type.Variant.parenthesize_params then
-                fun x -> O.txt "(" ++ type_expr x ++ O.txt ")"
-              else
-                fun x -> type_expr x
+    let type_decl ?(is_substitution = false)
+        ((recursive, t) : Lang.Signature.recursive * Lang.TypeDecl.t) =
+      let tyname = Paths.Identifier.name t.id in
+      let constraints = format_constraints t.equation.constraints in
+      let manifest, need_private =
+        match t.equation.manifest with
+        | Some (Odoc_model.Lang.TypeExpr.Polymorphic_variant variant) ->
+            let code =
+              polymorphic_variant
+                ~type_ident:(t.id :> Paths.Identifier.t)
+                variant
             in
-            let params = O.list arguments
-                ~sep:(O.txt " & ")
-                ~f:wrapped_type_expr
-            in
-            let params =
-              if constant then O.txt "& " ++ params else params in
-            O.code (
-              O.txt cstr ++
-                (
-                  if Syntax.Type.Variant.parenthesize_params
-                  then params
-                  else O.txt " " ++ O.keyword "of" ++ O.txt " " ++ params
-                )
-            )
-          end,
-          match doc with
-          | [] ->
-            None
-          | _ ->
-            Some (Comment.to_ir doc)
-      in
-      try
-        let url = Url.Anchor.polymorphic_variant ~type_ident item in
-        let attrs = ["def"; url.kind] in
-        let anchor = Some url in
-        let code =
-          O.code (O.txt "| ") @ cstr
-        in
-        let doc = match doc with
-          | None -> []
-          | Some doc -> doc
-        in
-        DocumentedSrc.Documented { attrs ; anchor ; code ; doc }
-      with Failure s ->
-        Printf.eprintf "ERROR: %s\n%!" s;
-        let code = O.code (O.txt "| " ) @ cstr in
-        let attrs = ["def"; kind_approx] in
-        let doc = [] in
-        let anchor = None in
-        DocumentedSrc.Documented { attrs ; anchor ; code ; doc }
-    in
-    let variants = List.map row t.elements in
-    let intro, ending = match t.kind with
-    | Fixed ->
-      O.documentedSrc (O.txt "[ "),
-      O.documentedSrc (O.txt " ]")
-    | Open ->
-      O.documentedSrc (O.txt "[> "),
-      O.documentedSrc (O.txt " ]")
-    | Closed [] ->
-      O.documentedSrc (O.txt "[< "),
-      O.documentedSrc (O.txt " ]")
-    | Closed lst ->
-      let constrs = String.concat " " lst in
-      O.documentedSrc (O.txt "[< "),
-      O.documentedSrc (O.txt (" " ^ constrs ^ " ]"))
-    in
-    intro @ variants @ ending
-
-  let format_params
-    : 'row. ?delim:[`parens | `brackets] -> Odoc_model.Lang.TypeDecl.param list
-    -> text
-  = fun ?(delim=`parens) params ->
-    let format_param {Odoc_model.Lang.TypeDecl.desc; variance; injectivity} =
-      let desc =
-        match desc with
-        | Odoc_model.Lang.TypeDecl.Any -> ["_"]
-        | Var s -> ["'"; s]
-      in
-      let var_desc = match variance with
-        | None -> desc
-        | Some Odoc_model.Lang.TypeDecl.Pos -> "+" :: desc
-        | Some Odoc_model.Lang.TypeDecl.Neg -> "-" ::desc in
-      let final = if injectivity then "!" :: var_desc else var_desc in
-      String.concat "" final
-    in
-    O.txt (
-      match params with
-      | [] -> ""
-      | [x] -> format_param x |> Syntax.Type.handle_format_params
-      | lst ->
-        let params = String.concat ", " (List.map format_param lst) in
-        (match delim with `parens -> "(" | `brackets -> "[")
-        ^ params ^
-        (match delim with `parens -> ")" | `brackets -> "]")
-    )
-
-  let format_constraints constraints =
-    O.list constraints ~f:begin fun (t1, t2) ->
-      O.txt " " ++
-      O.keyword "constraint" ++
-      O.txt " " ++
-      type_expr t1 ++
-      O.txt " = " ++
-      type_expr t2
-    end
-
-  let format_manifest
-    : 'inner_row 'outer_row. ?is_substitution:bool -> ?compact_variants:bool
-    -> Odoc_model.Lang.TypeDecl.Equation.t
-    -> text * bool
-  = fun ?(is_substitution=false) ?(compact_variants=true) equation ->
-    let _ = compact_variants in (* TODO *)
-    let private_ = equation.private_ in
-    match equation.manifest with
-    | None -> O.noop, private_
-    | Some t ->
-      let manifest =
-        O.txt (if is_substitution then " := " else " = ") ++
-        (if private_ then
-            O.keyword Syntax.Type.private_keyword ++ O.txt " "
-        else O.noop) ++
-        type_expr t
-      in
-      manifest, false
-
-
-
-  let type_decl ?(is_substitution=false) ((recursive, t) : Lang.Signature.recursive * Lang.TypeDecl.t) =
-    let tyname = Paths.Identifier.name t.id in
-    let constraints = format_constraints t.equation.constraints in
-    let manifest, need_private =
-      match t.equation.manifest with
-      | Some (Odoc_model.Lang.TypeExpr.Polymorphic_variant variant) ->
-        let code =
-          polymorphic_variant ~type_ident:(t.id :> Paths.Identifier.t) variant
-        in
-        let manifest =
-          O.documentedSrc
-            (O.txt (if is_substitution then " := " else " = ") ++
+            let manifest =
+              O.documentedSrc
+                ( O.txt (if is_substitution then " := " else " = ")
+                ++
                 if t.equation.private_ then
                   O.keyword Syntax.Type.private_keyword ++ O.txt " "
-                else
-                  O.noop)
-          @ code
-        in
-        manifest, false
-      | _ ->
-        let manifest, need_private =
-          format_manifest ~is_substitution t.equation
-        in
-        O.documentedSrc manifest, need_private
-    in
-    let representation =
-      match t.representation with
-      | None -> []
-      | Some repr ->
-        let content = match repr with
-          | Extensible -> O.documentedSrc (O.txt "..")
-          | Variant cstrs -> variant cstrs
-          | Record fields -> record fields
-        in
-        O.documentedSrc (
-          O.txt " = " ++
-          if need_private then
-            O.keyword Syntax.Type.private_keyword ++ O.txt " "
-          else
-            O.noop
-        ) @ content
-    in
-    let tconstr =
-      match t.equation.params with
-      | [] -> O.txt tyname
-      | l ->
-        let params = format_params l in
-        Syntax.Type.handle_constructor_params (O.txt tyname) params
-    in
-    let content =
-      let keyword' =
-        match recursive with
-        | Ordinary | Rec -> O.keyword "type"
-        | And -> O.keyword "and"
-        | Nonrec -> O.keyword "type" ++ O.txt " " ++ O.keyword "nonrec"
-      in
-      O.documentedSrc (keyword' ++ O.txt " " ++ tconstr)
-      @ manifest
-      @ representation
-      @ O.documentedSrc constraints
-      @ O.documentedSrc
-          (if Syntax.Type.type_def_semicolon then O.txt ";" else O.noop)
-    in
-    let kind = Some (if is_substitution then "type-subst" else "type") in
-    let anchor = path_to_id t.id in
-    let doc = Comment.to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
-end
-open Type_declaration
-
-
-
-module Value :
-sig
-  val value : Lang.Value.t -> Item.t
-  val external_ : Lang.External.t -> Item.t
-end =
-struct
-  let value (t : Odoc_model.Lang.Value.t) =
-    let name = Paths.Identifier.name t.id in
-    let content =
-      O.documentedSrc (
-        O.keyword Syntax.Value.variable_keyword ++
-          O.txt " " ++
-          O.txt name ++
-          O.txt Syntax.Type.annotation_separator ++
-          type_expr t.type_
-        ++ (if Syntax.Value.semicolon then O.txt ";" else O.noop)
-      )
-    in
-    let kind = Some "value" in
-    let anchor = path_to_id t.id in
-    let doc = Comment.to_ir t.doc in
-    Item.Declaration { kind ; anchor ; doc ; content}
-
-  let external_ (t : Odoc_model.Lang.External.t) =
-    let name = Paths.Identifier.name t.id in
-    let content =
-      O.documentedSrc (
-        O.keyword Syntax.Value.variable_keyword ++
-          O.txt " " ++
-          O.txt name ++
-          O.txt Syntax.Type.annotation_separator ++
-          type_expr t.type_
-        ++ (if Syntax.Type.External.semicolon then O.txt ";" else O.noop)
-      )
-    in
-    let kind = Some "external" in
-    let anchor = path_to_id t.id in
-    let doc = Comment.to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
-end
-open Value
-
-(* This chunk of code is responsible for sectioning list of items
-   according to headings by extracting headings as Items.
-
-   TODO: This sectioning would be better done as a pass on the model directly.
-*)
-module Sectioning :
-sig
-  open Odoc_model
-  val comment_items : Comment.docs -> Item.t list
-  val docs : Comment.docs -> Item.t list * Item.t list
-end =
-struct
-
-  let take_until_heading_or_end (docs : Odoc_model.Comment.docs) =
-    let content, _, rest =
-      Doctree.Take.until docs ~classify:(fun b ->
-        match b.Location.value with
-        | `Heading _ -> Stop_and_keep
-        | #Odoc_model.Comment.attached_block_element as doc ->
-          let content = Comment.attached_block_element doc in
-          Accum content
-      )
-    in
-    content, rest
-
-  let comment_items (input0 : Odoc_model.Comment.docs) =
-    let rec loop input_comment acc =
-      match input_comment with
-      | [] -> List.rev acc
-      | element::input_comment ->
-        match element.Location.value with
-        | `Heading (level, label, content) ->
-          let h = `Heading (level, label, content) in
-          let item = Comment.heading h in
-          loop input_comment (item :: acc)
+                else O.noop )
+              @ code
+            in
+            (manifest, false)
         | _ ->
-          let content, input_comment =
-            take_until_heading_or_end (element::input_comment)
-          in
-          let item = Item.Text content in
-          loop input_comment (item :: acc)
-    in
-    loop input0 []
-
-
-  (* For doc pages, we want the header to contain everything until
-     the first heading, then everything before the next heading which
-     is either lower, or a section.
-  *)
-  let docs input_comment =
-    let items = comment_items input_comment in
-    let until_first_heading, o, items =
-      Doctree.Take.until items ~classify:(function
-        | Item.Heading h as i ->
-          Stop_and_accum ([i], Some h.level)
-        | i -> Accum [i]
-      )
-    in
-    match o with
-    | None -> until_first_heading, items
-    | Some level ->
-      let max_level = if level = 1 then 2 else level in
-      let before_second_heading, _, items =
-      Doctree.Take.until items ~classify:(function
-        | Item.Heading h when h.level >= max_level -> Stop_and_keep
-        | i -> Accum [i]
-      )
+            let manifest, need_private =
+              format_manifest ~is_substitution t.equation
+            in
+            (O.documentedSrc manifest, need_private)
       in
-      let header = until_first_heading @ before_second_heading in
-      header, items
+      let representation =
+        match t.representation with
+        | None -> []
+        | Some repr ->
+            let content =
+              match repr with
+              | Extensible -> O.documentedSrc (O.txt "..")
+              | Variant cstrs -> variant cstrs
+              | Record fields -> record fields
+            in
+            O.documentedSrc
+              ( O.txt " = "
+              ++
+              if need_private then
+                O.keyword Syntax.Type.private_keyword ++ O.txt " "
+              else O.noop )
+            @ content
+      in
+      let tconstr =
+        match t.equation.params with
+        | [] -> O.txt tyname
+        | l ->
+            let params = format_params l in
+            Syntax.Type.handle_constructor_params (O.txt tyname) params
+      in
+      let content =
+        let keyword' =
+          match recursive with
+          | Ordinary | Rec -> O.keyword "type"
+          | And -> O.keyword "and"
+          | Nonrec -> O.keyword "type" ++ O.txt " " ++ O.keyword "nonrec"
+        in
+        O.documentedSrc (keyword' ++ O.txt " " ++ tconstr)
+        @ manifest @ representation
+        @ O.documentedSrc constraints
+        @ O.documentedSrc
+            (if Syntax.Type.type_def_semicolon then O.txt ";" else O.noop)
+      in
+      let kind = Some (if is_substitution then "type-subst" else "type") in
+      let anchor = path_to_id t.id in
+      let doc = Comment.to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
+  end
 
-end
+  open Type_declaration
 
-module Class :
-sig
-  val class_ : Lang.Class.t -> Item.t
+  module Value : sig
+    val value : Lang.Value.t -> Item.t
 
-  val class_type : Lang.ClassType.t -> Item.t
-end =
-struct
+    val external_ : Lang.External.t -> Item.t
+  end = struct
+    let value (t : Odoc_model.Lang.Value.t) =
+      let name = Paths.Identifier.name t.id in
+      let content =
+        O.documentedSrc
+          ( O.keyword Syntax.Value.variable_keyword
+          ++ O.txt " " ++ O.txt name
+          ++ O.txt Syntax.Type.annotation_separator
+          ++ type_expr t.type_
+          ++ if Syntax.Value.semicolon then O.txt ";" else O.noop )
+      in
+      let kind = Some "value" in
+      let anchor = path_to_id t.id in
+      let doc = Comment.to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
 
-  let class_type_expr (cte : Odoc_model.Lang.ClassType.expr) =
-    match cte with
-    | Constr (path, args) ->
-      let link = Link.from_path (path :> Paths.Path.t) in
-      format_type_path ~delim:(`brackets) args link
-    | Signature _ ->
-      Syntax.Class.open_tag
-      ++ O.txt " ... "
-      ++ Syntax.Class.close_tag
+    let external_ (t : Odoc_model.Lang.External.t) =
+      let name = Paths.Identifier.name t.id in
+      let content =
+        O.documentedSrc
+          ( O.keyword Syntax.Value.variable_keyword
+          ++ O.txt " " ++ O.txt name
+          ++ O.txt Syntax.Type.annotation_separator
+          ++ type_expr t.type_
+          ++ if Syntax.Type.External.semicolon then O.txt ";" else O.noop )
+      in
+      let kind = Some "external" in
+      let anchor = path_to_id t.id in
+      let doc = Comment.to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
+  end
 
-  let method_ (t : Odoc_model.Lang.Method.t) =
-    let name = Paths.Identifier.name t.id in
-    let virtual_ =
-      if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop in
-    let private_ =
-      if t.private_ then O.keyword "private" ++ O.txt " " else O.noop in
-    let content =
-      O.documentedSrc (
-        O.keyword "method" ++
-          O.txt " " ++
-          private_ ++
-          virtual_ ++
-          O.txt name ++
-          O.txt Syntax.Type.annotation_separator ++
-          type_expr t.type_
-      )
-    in
-    let kind = Some "method" in
-    let anchor = path_to_id t.id in
-    let doc = Comment.to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
+  open Value
 
-  let instance_variable (t : Odoc_model.Lang.InstanceVariable.t) =
-    let name = Paths.Identifier.name t.id in
-    let virtual_ =
-      if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop in
-    let mutable_ =
-      if t.mutable_ then O.keyword "mutable" ++ O.txt " " else O.noop in
-    let content =
-      O.documentedSrc (
-        O.keyword "val" ++
-          O.txt " " ++
-          mutable_ ++
-          virtual_ ++
-          O.txt name ++
-          O.txt Syntax.Type.annotation_separator ++
-          type_expr t.type_
-      )
-    in
-    let kind = Some "instance-variable" in
-    let anchor = path_to_id t.id in
-    let doc = Comment.to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
+  (* This chunk of code is responsible for sectioning list of items
+     according to headings by extracting headings as Items.
 
-  let inherit_ cte =
-    let content =
-      O.documentedSrc (
-        O.keyword "inherit" ++
-          O.txt " " ++
-          class_type_expr cte
-      )
-    in
-    let kind = Some "inherit" in
-    let anchor = None in
-    let doc = [] in
-    Item.Declaration {kind ; anchor ; doc ; content}
+     TODO: This sectioning would be better done as a pass on the model directly.
+  *)
+  module Sectioning : sig
+    open Odoc_model
 
-  let constraint_ t1 t2 =
-    let content =
-      O.documentedSrc (format_constraints [(t1, t2)])
-    in
-    let kind = None in
-    let anchor = None in
-    let doc = [] in
-    Item.Declaration {kind ; anchor ; doc ; content}
+    val comment_items : Comment.docs -> Item.t list
 
-  let class_signature (c : Lang.ClassSignature.t) =
-    let rec loop l acc_items =
-      match l with
-      | [] -> List.rev acc_items
-      | item :: rest ->
-        let continue item = loop rest (item :: acc_items) in
-        match (item : Lang.ClassSignature.item) with
-        | Inherit (Signature _) ->
-          assert false (* Bold. *)
-        | Inherit cty         -> continue @@ inherit_ cty
-        | Method m            -> continue @@ method_ m
-        | InstanceVariable v  -> continue @@ instance_variable v
-        | Constraint (t1, t2) -> continue @@ constraint_ t1 t2
-        | Comment `Stop ->
-          let rest = Utils.skip_until rest ~p:(function
-            | Lang.ClassSignature.Comment `Stop -> true
-            | _ -> false)
+    val docs : Comment.docs -> Item.t list * Item.t list
+  end = struct
+    let take_until_heading_or_end (docs : Odoc_model.Comment.docs) =
+      let content, _, rest =
+        Doctree.Take.until docs ~classify:(fun b ->
+            match b.Location.value with
+            | `Heading _ -> Stop_and_keep
+            | #Odoc_model.Comment.attached_block_element as doc ->
+                let content = Comment.attached_block_element doc in
+                Accum content)
+      in
+      (content, rest)
+
+    let comment_items (input0 : Odoc_model.Comment.docs) =
+      let rec loop input_comment acc =
+        match input_comment with
+        | [] -> List.rev acc
+        | element :: input_comment -> (
+            match element.Location.value with
+            | `Heading (level, label, content) ->
+                let h = `Heading (level, label, content) in
+                let item = Comment.heading h in
+                loop input_comment (item :: acc)
+            | _ ->
+                let content, input_comment =
+                  take_until_heading_or_end (element :: input_comment)
+                in
+                let item = Item.Text content in
+                loop input_comment (item :: acc) )
+      in
+      loop input0 []
+
+    (* For doc pages, we want the header to contain everything until
+       the first heading, then everything before the next heading which
+       is either lower, or a section.
+    *)
+    let docs input_comment =
+      let items = comment_items input_comment in
+      let until_first_heading, o, items =
+        Doctree.Take.until items ~classify:(function
+          | Item.Heading h as i -> Stop_and_accum ([ i ], Some h.level)
+          | i -> Accum [ i ])
+      in
+      match o with
+      | None -> (until_first_heading, items)
+      | Some level ->
+          let max_level = if level = 1 then 2 else level in
+          let before_second_heading, _, items =
+            Doctree.Take.until items ~classify:(function
+              | Item.Heading h when h.level >= max_level -> Stop_and_keep
+              | i -> Accum [ i ])
           in
-          loop rest acc_items
-        | Comment (`Docs c) ->
-          let items = Sectioning.comment_items c in
-          loop rest (List.rev_append items acc_items)
-    in
-    (* FIXME: use [t.self] *)
-    loop c.items []
+          let header = until_first_heading @ before_second_heading in
+          (header, items)
+  end
 
-  let rec class_decl (cd : Odoc_model.Lang.Class.decl) =
-    match cd with
-    | ClassType expr -> class_type_expr expr
-    (* TODO: factorize the following with [type_expr] *)
-    | Arrow (None, src, dst) ->
-      type_expr ~needs_parentheses:true src ++
-        O.txt " " ++ Syntax.Type.arrow ++ O.txt " " ++ class_decl dst
-    | Arrow (Some lbl, src, dst) ->
-      label lbl ++ O.txt ":" ++
-        type_expr ~needs_parentheses:true src ++
-        O.txt " " ++ Syntax.Type.arrow ++ O.txt " " ++ class_decl dst
+  module Class : sig
+    val class_ : Lang.Class.t -> Item.t
 
-  let class_ (t : Odoc_model.Lang.Class.t) =
-    let name = Paths.Identifier.name t.id in
-    let params = format_params ~delim:(`brackets) t.params in
-    let virtual_ =
-      if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop in
+    val class_type : Lang.ClassType.t -> Item.t
+  end = struct
+    let class_type_expr (cte : Odoc_model.Lang.ClassType.expr) =
+      match cte with
+      | Constr (path, args) ->
+          let link = Link.from_path (path :> Paths.Path.t) in
+          format_type_path ~delim:`brackets args link
+      | Signature _ ->
+          Syntax.Class.open_tag ++ O.txt " ... " ++ Syntax.Class.close_tag
 
-    let cname, expansion =
-      match t.expansion with
-      | None ->
-        O.documentedSrc @@ O.txt name,
-        None
-      | Some csig ->
-        let doc = Comment.standalone t.doc in
-        let items = class_signature csig in
-        let url = Url.Path.from_identifier t.id in
-        let header = format_title `Class (make_name_from_path url) @ doc in
-        let page = { Page.title = name ; header ; items ; url } in
-        O.documentedSrc @@ path url [inline @@ Text name],
-        Some page
-    in
-    let summary = O.txt Syntax.Type.annotation_separator ++ class_decl t.type_ in
-    let cd =
-      attach_expansion
-        (Syntax.Type.annotation_separator,"object","end") expansion summary
-    in
-    let content =
-      O.documentedSrc (
-        O.keyword "class" ++
-        O.txt " " ++
-        virtual_ ++
-        params ++
-        O.txt " ")
-      @ cname
-      @ cd
-    in
-    let kind = Some "class" in
-    let anchor = path_to_id t.id in
-    let doc = Comment.first_to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
+    let method_ (t : Odoc_model.Lang.Method.t) =
+      let name = Paths.Identifier.name t.id in
+      let virtual_ =
+        if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop
+      in
+      let private_ =
+        if t.private_ then O.keyword "private" ++ O.txt " " else O.noop
+      in
+      let content =
+        O.documentedSrc
+          ( O.keyword "method" ++ O.txt " " ++ private_ ++ virtual_ ++ O.txt name
+          ++ O.txt Syntax.Type.annotation_separator
+          ++ type_expr t.type_ )
+      in
+      let kind = Some "method" in
+      let anchor = path_to_id t.id in
+      let doc = Comment.to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
 
-  let class_type (t : Odoc_model.Lang.ClassType.t) =
-    let name = Paths.Identifier.name t.id in
-    let params = format_params ~delim:(`brackets) t.params in
-    let virtual_ =
-      if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop in
-    let cname, expansion =
-      match t.expansion with
-      | None ->
-        O.documentedSrc @@ O.txt name,
-        None
-      | Some csig ->
-        let url = Url.Path.from_identifier t.id in
-        let doc = Comment.standalone t.doc in
-        let items = class_signature csig in
-        let header = format_title `Cty (make_name_from_path url) @ doc in
-        let page = { Page.title = name ; header ; items ; url } in
-        O.documentedSrc @@ path url [inline @@ Text name],
-        Some page
-    in
-    let summary = O.txt " = " ++ class_type_expr t.expr in
-    let expr = attach_expansion (" = ","object","end") expansion summary in
-    let content =
-      O.documentedSrc (
-        O.keyword "class" ++ O.txt " " ++ O.keyword "type" ++
-        O.txt " " ++
-        virtual_ ++
-        params ++
-        O.txt " ")
-      @ cname
-      @ expr
-    in
-    let kind = Some "class-type" in
-    let anchor = path_to_id t.id in
-    let doc = Comment.first_to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
-end
-open Class
+    let instance_variable (t : Odoc_model.Lang.InstanceVariable.t) =
+      let name = Paths.Identifier.name t.id in
+      let virtual_ =
+        if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop
+      in
+      let mutable_ =
+        if t.mutable_ then O.keyword "mutable" ++ O.txt " " else O.noop
+      in
+      let content =
+        O.documentedSrc
+          ( O.keyword "val" ++ O.txt " " ++ mutable_ ++ virtual_ ++ O.txt name
+          ++ O.txt Syntax.Type.annotation_separator
+          ++ type_expr t.type_ )
+      in
+      let kind = Some "instance-variable" in
+      let anchor = path_to_id t.id in
+      let doc = Comment.to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
 
+    let inherit_ cte =
+      let content =
+        O.documentedSrc (O.keyword "inherit" ++ O.txt " " ++ class_type_expr cte)
+      in
+      let kind = Some "inherit" in
+      let anchor = None in
+      let doc = [] in
+      Item.Declaration { kind; anchor; doc; content }
 
+    let constraint_ t1 t2 =
+      let content = O.documentedSrc (format_constraints [ (t1, t2) ]) in
+      let kind = None in
+      let anchor = None in
+      let doc = [] in
+      Item.Declaration { kind; anchor; doc; content }
 
-module Module :
-sig
-  val signature : Lang.Signature.t -> Item.t list
-end =
-struct
-  let internal_module m =
-    let open Lang.Module in
-    match m.id with
-    | `Module (_, name) when ModuleName.is_internal name -> true
-    | _ -> false
+    let class_signature (c : Lang.ClassSignature.t) =
+      let rec loop l acc_items =
+        match l with
+        | [] -> List.rev acc_items
+        | item :: rest -> (
+            let continue item = loop rest (item :: acc_items) in
+            match (item : Lang.ClassSignature.item) with
+            | Inherit (Signature _) -> assert false (* Bold. *)
+            | Inherit cty -> continue @@ inherit_ cty
+            | Method m -> continue @@ method_ m
+            | InstanceVariable v -> continue @@ instance_variable v
+            | Constraint (t1, t2) -> continue @@ constraint_ t1 t2
+            | Comment `Stop ->
+                let rest =
+                  Utils.skip_until rest ~p:(function
+                    | Lang.ClassSignature.Comment `Stop -> true
+                    | _ -> false)
+                in
+                loop rest acc_items
+            | Comment (`Docs c) ->
+                let items = Sectioning.comment_items c in
+                loop rest (List.rev_append items acc_items) )
+      in
+      (* FIXME: use [t.self] *)
+      loop c.items []
 
-  let internal_type t =
-    let open Lang.TypeDecl in
-    match t.id with
-    | `Type (_, name) when TypeName.is_internal name -> true
-    | _ -> false
+    let rec class_decl (cd : Odoc_model.Lang.Class.decl) =
+      match cd with
+      | ClassType expr -> class_type_expr expr
+      (* TODO: factorize the following with [type_expr] *)
+      | Arrow (None, src, dst) ->
+          type_expr ~needs_parentheses:true src
+          ++ O.txt " " ++ Syntax.Type.arrow ++ O.txt " " ++ class_decl dst
+      | Arrow (Some lbl, src, dst) ->
+          label lbl ++ O.txt ":"
+          ++ type_expr ~needs_parentheses:true src
+          ++ O.txt " " ++ Syntax.Type.arrow ++ O.txt " " ++ class_decl dst
 
-  let internal_module_type t =
-    let open Lang.ModuleType in
-    match t.id with
-    | `ModuleType (_, name) when ModuleTypeName.is_internal name -> true
-    | _ -> false
+    let class_ (t : Odoc_model.Lang.Class.t) =
+      let name = Paths.Identifier.name t.id in
+      let params = format_params ~delim:`brackets t.params in
+      let virtual_ =
+        if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop
+      in
 
-  let internal_module_substitution t =
+      let cname, expansion =
+        match t.expansion with
+        | None -> (O.documentedSrc @@ O.txt name, None)
+        | Some csig ->
+            let doc = Comment.standalone t.doc in
+            let items = class_signature csig in
+            let url = Url.Path.from_identifier t.id in
+            let header = format_title `Class (make_name_from_path url) @ doc in
+            let page = { Page.title = name; header; items; url } in
+            (O.documentedSrc @@ path url [ inline @@ Text name ], Some page)
+      in
+      let summary =
+        O.txt Syntax.Type.annotation_separator ++ class_decl t.type_
+      in
+      let cd =
+        attach_expansion
+          (Syntax.Type.annotation_separator, "object", "end")
+          expansion summary
+      in
+      let content =
+        O.documentedSrc
+          (O.keyword "class" ++ O.txt " " ++ virtual_ ++ params ++ O.txt " ")
+        @ cname @ cd
+      in
+      let kind = Some "class" in
+      let anchor = path_to_id t.id in
+      let doc = Comment.first_to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
+
+    let class_type (t : Odoc_model.Lang.ClassType.t) =
+      let name = Paths.Identifier.name t.id in
+      let params = format_params ~delim:`brackets t.params in
+      let virtual_ =
+        if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop
+      in
+      let cname, expansion =
+        match t.expansion with
+        | None -> (O.documentedSrc @@ O.txt name, None)
+        | Some csig ->
+            let url = Url.Path.from_identifier t.id in
+            let doc = Comment.standalone t.doc in
+            let items = class_signature csig in
+            let header = format_title `Cty (make_name_from_path url) @ doc in
+            let page = { Page.title = name; header; items; url } in
+            (O.documentedSrc @@ path url [ inline @@ Text name ], Some page)
+      in
+      let summary = O.txt " = " ++ class_type_expr t.expr in
+      let expr = attach_expansion (" = ", "object", "end") expansion summary in
+      let content =
+        O.documentedSrc
+          ( O.keyword "class" ++ O.txt " " ++ O.keyword "type" ++ O.txt " "
+          ++ virtual_ ++ params ++ O.txt " " )
+        @ cname @ expr
+      in
+      let kind = Some "class-type" in
+      let anchor = path_to_id t.id in
+      let doc = Comment.first_to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
+  end
+
+  open Class
+
+  module Module : sig
+    val signature : Lang.Signature.t -> Item.t list
+  end = struct
+    let internal_module m =
+      let open Lang.Module in
+      match m.id with
+      | `Module (_, name) when ModuleName.is_internal name -> true
+      | _ -> false
+
+    let internal_type t =
+      let open Lang.TypeDecl in
+      match t.id with
+      | `Type (_, name) when TypeName.is_internal name -> true
+      | _ -> false
+
+    let internal_module_type t =
+      let open Lang.ModuleType in
+      match t.id with
+      | `ModuleType (_, name) when ModuleTypeName.is_internal name -> true
+      | _ -> false
+
+    let internal_module_substitution t =
       let open Lang.ModuleSubstitution in
       match t.id with
       | `Module (_, name) when ModuleName.is_internal name -> true
       | _ -> false
 
-  let rec signature s : Item.t list =
-    let rec loop l acc_items =
-      match l with
-      | [] -> List.rev acc_items
-      | item :: rest ->
-        let continue (item : Item.t) =
-          loop rest (item :: acc_items)
-        in
-        match (item : Lang.Signature.item) with
-        | Module (_, m) when internal_module m ->
-          loop rest acc_items
-        | Type (_, t) when internal_type t ->
-          loop rest acc_items
-        | ModuleType m when internal_module_type m ->
-          loop rest acc_items
-        | ModuleSubstitution m when internal_module_substitution m ->
-          loop rest acc_items
+    let rec signature s : Item.t list =
+      let rec loop l acc_items =
+        match l with
+        | [] -> List.rev acc_items
+        | item :: rest -> (
+            let continue (item : Item.t) = loop rest (item :: acc_items) in
+            match (item : Lang.Signature.item) with
+            | Module (_, m) when internal_module m -> loop rest acc_items
+            | Type (_, t) when internal_type t -> loop rest acc_items
+            | ModuleType m when internal_module_type m -> loop rest acc_items
+            | ModuleSubstitution m when internal_module_substitution m ->
+                loop rest acc_items
+            | Module (_recursive, m) -> continue @@ module_ m
+            | ModuleType m -> continue @@ module_type m
+            | Class (_recursive, c) -> continue @@ class_ c
+            | ClassType (_recursive, c) -> continue @@ class_type c
+            | Include m -> continue @@ include_ m
+            | ModuleSubstitution m -> continue @@ module_substitution m
+            | TypeSubstitution t ->
+                continue @@ type_decl ~is_substitution:true (Ordinary, t)
+            | Type (r, t) -> continue @@ type_decl (r, t)
+            | TypExt e -> continue @@ extension e
+            | Exception e -> continue @@ exn e
+            | Value v -> continue @@ value v
+            | External e -> continue @@ external_ e
+            | Open _ -> loop rest acc_items
+            | Comment `Stop ->
+                let rest =
+                  Utils.skip_until rest ~p:(function
+                    | Lang.Signature.Comment `Stop -> true
+                    | _ -> false)
+                in
+                loop rest acc_items
+            | Comment (`Docs c) ->
+                let items = Sectioning.comment_items c in
+                loop rest (List.rev_append items acc_items) )
+      in
+      loop s []
 
-        | Module (_recursive, m)    -> continue @@ module_ m
-        | ModuleType m             -> continue @@ module_type m
-        | Class (_recursive, c)     -> continue @@ class_ c
-        | ClassType (_recursive, c) -> continue @@ class_type c
-        | Include m                -> continue @@ include_ m
-        | ModuleSubstitution m     -> continue @@ module_substitution m
-
-        | TypeSubstitution t ->
-          continue @@ type_decl ~is_substitution:true (Ordinary, t)
-        | Type (r, t) -> continue @@ type_decl (r, t)
-        | TypExt e    -> continue @@ extension e
-        | Exception e -> continue @@ exn e
-        | Value v     -> continue @@ value v
-        | External e  -> continue @@ external_ e
-
-        | Open _ -> loop rest acc_items
-        | Comment `Stop ->
-          let rest = Utils.skip_until rest ~p:(function
-            | Lang.Signature.Comment `Stop -> true
-            | _ -> false)
-          in
-          loop rest acc_items
-        | Comment (`Docs c) ->
-          let items =
-            Sectioning.comment_items c
-          in
-          loop rest (List.rev_append items acc_items)
-    in
-    loop s []
-
-  and functor_parameter
-    : Odoc_model.Lang.FunctorParameter.parameter -> DocumentedSrc.t
-    = fun arg ->
+    and functor_parameter :
+        Odoc_model.Lang.FunctorParameter.parameter -> DocumentedSrc.t =
+     fun arg ->
       let open Odoc_model.Lang.FunctorParameter in
       let name = Paths.Identifier.name arg.id in
       let render_ty = arg.expr in
@@ -1226,125 +1101,122 @@ struct
       let modname, mod_decl =
         match expansion_of_module_type_expr arg.expr with
         | None ->
-          let modname = O.txt (Paths.Identifier.name arg.id) in
-          modname, O.documentedSrc modtyp
+            let modname = O.txt (Paths.Identifier.name arg.id) in
+            (modname, O.documentedSrc modtyp)
         | Some items ->
-          let url = Url.Path.from_identifier arg.id in
-          let modname = path url [inline @@ Text name] in
-          let type_with_expansion =
-            let header = format_title `Arg (make_name_from_path url) in
-            let title = name in
-            let content = { Page.items ; title ; header ; url } in
-            let summary = O.render modtyp in
-            let status = `Default in
-            let expansion =
-              O.documentedSrc
-                (O.txt Syntax.Type.annotation_separator ++ O.keyword "sig")
-              @ DocumentedSrc.[Subpage { content ; status }]
-              @ O.documentedSrc (O.keyword "end")
+            let url = Url.Path.from_identifier arg.id in
+            let modname = path url [ inline @@ Text name ] in
+            let type_with_expansion =
+              let header = format_title `Arg (make_name_from_path url) in
+              let title = name in
+              let content = { Page.items; title; header; url } in
+              let summary = O.render modtyp in
+              let status = `Default in
+              let expansion =
+                O.documentedSrc
+                  (O.txt Syntax.Type.annotation_separator ++ O.keyword "sig")
+                @ DocumentedSrc.[ Subpage { content; status } ]
+                @ O.documentedSrc (O.keyword "end")
+              in
+              DocumentedSrc.
+                [
+                  Alternative
+                    (Expansion { status = `Default; summary; url; expansion });
+                ]
             in
-            DocumentedSrc.[ Alternative (Expansion {status=`Default; summary; url; expansion })]
-          in
-          modname, type_with_expansion
+            (modname, type_with_expansion)
       in
       O.documentedSrc (O.keyword "module" ++ O.txt " ")
-      @ O.documentedSrc modname
-      @ mod_decl
+      @ O.documentedSrc modname @ mod_decl
 
-  and module_substitution (t : Odoc_model.Lang.ModuleSubstitution.t) =
-    let name = Paths.Identifier.name t.id in
-    let path = Link.from_path (t.manifest :> Paths.Path.t) in
-    let content =
-      O.documentedSrc (
-        O.keyword "module" ++
-          O.txt " " ++
-          O.txt name ++
-          O.txt " := " ++
-          path
-      )
-    in
-    let kind = Some "module-substitution" in
-    let anchor = path_to_id t.id in
-    let doc = Comment.to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
+    and module_substitution (t : Odoc_model.Lang.ModuleSubstitution.t) =
+      let name = Paths.Identifier.name t.id in
+      let path = Link.from_path (t.manifest :> Paths.Path.t) in
+      let content =
+        O.documentedSrc
+          (O.keyword "module" ++ O.txt " " ++ O.txt name ++ O.txt " := " ++ path)
+      in
+      let kind = Some "module-substitution" in
+      let anchor = path_to_id t.id in
+      let doc = Comment.to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
 
-  and simple_expansion
-    : Odoc_model.Lang.ModuleType.simple_expansion
-      -> Item.t list
-    = fun t ->
-      let rec extract_functor_params (f : Odoc_model.Lang.ModuleType.simple_expansion) =
+    and simple_expansion :
+        Odoc_model.Lang.ModuleType.simple_expansion -> Item.t list =
+     fun t ->
+      let rec extract_functor_params
+          (f : Odoc_model.Lang.ModuleType.simple_expansion) =
         match f with
-        | Signature sg -> None, sg
-        | Functor (p, expansion) -> (
-          let add_to params =
-            match p with
-            | Unit -> params
-            | Named p -> p :: params
-          in
-          let params, sg = extract_functor_params expansion in
-          let params = match params with | None -> [] | Some p -> p in
-          Some (add_to params), sg)
+        | Signature sg -> (None, sg)
+        | Functor (p, expansion) ->
+            let add_to params =
+              match p with Unit -> params | Named p -> p :: params
+            in
+            let params, sg = extract_functor_params expansion in
+            let params = match params with None -> [] | Some p -> p in
+            (Some (add_to params), sg)
       in
       match extract_functor_params t with
       | None, sg ->
-        let expansion = signature sg in
-        expansion
+          let expansion = signature sg in
+          expansion
       | Some params, sg ->
-        let content = signature sg in
-        let params =
-          Utils.flatmap params ~f:(fun arg ->
-              let content = functor_parameter arg in
-              let kind = Some "parameter" in
-              let anchor =
-                Utils.option_of_result @@
-                Url.Anchor.from_identifier (arg.id :> Paths.Identifier.t)
-              in
-              let doc = [] in
-              [Item.Declaration { content ; anchor ; kind ; doc }]
-          )
-        in
-        let prelude =
-          Item.Heading {
-            label = Some "parameters" ;
-            level = 1 ;
-            title = [inline @@ Text "Parameters"];
-          }
-          :: params
-        and content = 
-          Item.Heading {
-            label = Some "signature" ;
-            level = 1 ;
-            title = [inline @@ Text "Signature"];
-          }
-          :: content
-        in
-        prelude @ content
-  
-  and expansion_of_module_type_expr
-    : Odoc_model.Lang.ModuleType.expr -> Item.t list option
-    = fun t ->
-      let rec simple_expansion_of (t : Odoc_model.Lang.ModuleType.expr ) =
+          let content = signature sg in
+          let params =
+            Utils.flatmap params ~f:(fun arg ->
+                let content = functor_parameter arg in
+                let kind = Some "parameter" in
+                let anchor =
+                  Utils.option_of_result
+                  @@ Url.Anchor.from_identifier (arg.id :> Paths.Identifier.t)
+                in
+                let doc = [] in
+                [ Item.Declaration { content; anchor; kind; doc } ])
+          in
+          let prelude =
+            Item.Heading
+              {
+                label = Some "parameters";
+                level = 1;
+                title = [ inline @@ Text "Parameters" ];
+              }
+            :: params
+          and content =
+            Item.Heading
+              {
+                label = Some "signature";
+                level = 1;
+                title = [ inline @@ Text "Signature" ];
+              }
+            :: content
+          in
+          prelude @ content
+
+    and expansion_of_module_type_expr :
+        Odoc_model.Lang.ModuleType.expr -> Item.t list option =
+     fun t ->
+      let rec simple_expansion_of (t : Odoc_model.Lang.ModuleType.expr) =
         match t with
-        | Path {p_expansion=None ; _}
-        | TypeOf {t_expansion=None ; _}
-        | With {w_expansion=None ; _} -> None
-        | Path {p_expansion=Some e; _}
-        | TypeOf {t_expansion=Some e; _}
-        | With {w_expansion=Some e; _} -> Some e
+        | Path { p_expansion = None; _ }
+        | TypeOf { t_expansion = None; _ }
+        | With { w_expansion = None; _ } ->
+            None
+        | Path { p_expansion = Some e; _ }
+        | TypeOf { t_expansion = Some e; _ }
+        | With { w_expansion = Some e; _ } ->
+            Some e
         | Signature sg -> Some (Signature sg)
-        | Functor (f_parameter, e) ->
-          match simple_expansion_of e with
-          | Some e -> Some (Functor (f_parameter, e))
-          | None -> None
+        | Functor (f_parameter, e) -> (
+            match simple_expansion_of e with
+            | Some e -> Some (Functor (f_parameter, e))
+            | None -> None )
       in
       match simple_expansion_of t with
       | None -> None
       | Some e -> Some (simple_expansion e)
 
-  and module_
-    : Odoc_model.Lang.Module.t ->
-      Item.t
-    = fun t ->
+    and module_ : Odoc_model.Lang.Module.t -> Item.t =
+     fun t ->
       let modname = Paths.Identifier.name t.id in
       let expansion =
         match t.type_ with
@@ -1354,410 +1226,364 @@ struct
       in
       let modname, status, expansion =
         match expansion with
-        | None ->
-          O.documentedSrc (O.txt modname),
-          `Default,
-          None
+        | None -> (O.documentedSrc (O.txt modname), `Default, None)
         | Some items ->
-          let doc = Comment.standalone t.doc in
-          let status = match t.type_ with
-            | ModuleType (Signature _) -> `Inline | _ -> `Default
-          in
-          let url = Url.Path.from_identifier t.id in
-          let link = path url [inline @@ Text modname] in
-          let title = modname in
-          let header =
-            format_title `Mod (make_name_from_path url) @ doc
-          in
-          let page = {Page.items ; title ; header ; url } in
-          O.documentedSrc link, status, Some page
+            let doc = Comment.standalone t.doc in
+            let status =
+              match t.type_ with
+              | ModuleType (Signature _) -> `Inline
+              | _ -> `Default
+            in
+            let url = Url.Path.from_identifier t.id in
+            let link = path url [ inline @@ Text modname ] in
+            let title = modname in
+            let header = format_title `Mod (make_name_from_path url) @ doc in
+            let page = { Page.items; title; header; url } in
+            (O.documentedSrc link, status, Some page)
       in
-      let summary =
-        mdexpr_in_decl t.id t.type_
-      in
+      let summary = mdexpr_in_decl t.id t.type_ in
       let modexpr =
-        attach_expansion
-          ~status
-          (Syntax.Type.annotation_separator,"sig","end")
+        attach_expansion ~status
+          (Syntax.Type.annotation_separator, "sig", "end")
           expansion summary
       in
       let content =
         O.documentedSrc (O.keyword "module" ++ O.txt " ")
-        @ modname
-        @ modexpr
+        @ modname @ modexpr
         @ O.documentedSrc
             (if Syntax.Mod.close_tag_semicolon then O.txt ";" else O.noop)
       in
       let kind = Some "module" in
       let anchor = path_to_id t.id in
       let doc = Comment.first_to_ir t.doc in
-      Item.Declaration {kind ; anchor ; doc ; content}
+      Item.Declaration { kind; anchor; doc; content }
 
-  and mdexpr_in_decl (base : Paths.Identifier.Module.t) md =
-    let is_canonical p =
-      let i = Paths.Path.Resolved.Module.identifier p in
-      i = (base :> Paths.Identifier.Path.Module.t)
-    in
-    let sig_dotdotdot =
-      O.txt Syntax.Type.annotation_separator ++
-        Syntax.Mod.open_tag ++ O.txt " ... " ++
-        Syntax.Mod.close_tag
-    in
-    match md with
-    | Alias (`Resolved p, _) when is_canonical p -> sig_dotdotdot
-    | Alias (p, _) when not Paths.Path.(is_hidden (p :> t)) ->
-      O.txt " = " ++
-        mdexpr (base :> Paths.Identifier.Signature.t) md
-    | Alias _ -> sig_dotdotdot
-    | ModuleType mt ->
-      mty_in_decl (base :> Paths.Identifier.Signature.t) mt
+    and mdexpr_in_decl (base : Paths.Identifier.Module.t) md =
+      let is_canonical p =
+        let i = Paths.Path.Resolved.Module.identifier p in
+        i = (base :> Paths.Identifier.Path.Module.t)
+      in
+      let sig_dotdotdot =
+        O.txt Syntax.Type.annotation_separator
+        ++ Syntax.Mod.open_tag ++ O.txt " ... " ++ Syntax.Mod.close_tag
+      in
+      match md with
+      | Alias (`Resolved p, _) when is_canonical p -> sig_dotdotdot
+      | Alias (p, _) when not Paths.Path.(is_hidden (p :> t)) ->
+          O.txt " = " ++ mdexpr (base :> Paths.Identifier.Signature.t) md
+      | Alias _ -> sig_dotdotdot
+      | ModuleType mt -> mty_in_decl (base :> Paths.Identifier.Signature.t) mt
 
-  and extract_path_from_umt ~(default: Paths.Identifier.Signature.t) =
-    let open Odoc_model.Lang.ModuleType.U in
-    function
-    | With (_, umt) -> extract_path_from_umt ~default umt
-    | Path (`Resolved r) ->
-      (Paths.Path.Resolved.ModuleType.identifier r :> Paths.Identifier.Signature.t)
-    | TypeOf { t_desc = ModPath (`Resolved r); _ } 
-    | TypeOf { t_desc = StructInclude (`Resolved r); _ } ->
-      (Paths.Path.Resolved.Module.identifier r :> Paths.Identifier.Signature.t)
-    | _ -> default
+    and extract_path_from_umt ~(default : Paths.Identifier.Signature.t) =
+      let open Odoc_model.Lang.ModuleType.U in
+      function
+      | With (_, umt) -> extract_path_from_umt ~default umt
+      | Path (`Resolved r) ->
+          ( Paths.Path.Resolved.ModuleType.identifier r
+            :> Paths.Identifier.Signature.t )
+      | TypeOf { t_desc = ModPath (`Resolved r); _ }
+      | TypeOf { t_desc = StructInclude (`Resolved r); _ } ->
+          ( Paths.Path.Resolved.Module.identifier r
+            :> Paths.Identifier.Signature.t )
+      | _ -> default
 
-  and extract_path_from_mt ~(default: Paths.Identifier.Signature.t) =
-    let open Odoc_model.Lang.ModuleType in
-    function
-    | Path {p_path=`Resolved r; _} ->
-      (Paths.Path.Resolved.ModuleType.identifier r :> Paths.Identifier.Signature.t)
-    | With { w_expr; _ } -> extract_path_from_umt ~default w_expr
-    | TypeOf {t_desc=ModPath (`Resolved r); _}
-    | TypeOf {t_desc=StructInclude (`Resolved r); _} ->
-      (Paths.Path.Resolved.Module.identifier r :> Paths.Identifier.Signature.t)
-    | _ -> default
+    and extract_path_from_mt ~(default : Paths.Identifier.Signature.t) =
+      let open Odoc_model.Lang.ModuleType in
+      function
+      | Path { p_path = `Resolved r; _ } ->
+          ( Paths.Path.Resolved.ModuleType.identifier r
+            :> Paths.Identifier.Signature.t )
+      | With { w_expr; _ } -> extract_path_from_umt ~default w_expr
+      | TypeOf { t_desc = ModPath (`Resolved r); _ }
+      | TypeOf { t_desc = StructInclude (`Resolved r); _ } ->
+          ( Paths.Path.Resolved.Module.identifier r
+            :> Paths.Identifier.Signature.t )
+      | _ -> default
 
-  and mdexpr
-    : Paths.Identifier.Signature.t -> Odoc_model.Lang.Module.decl -> text =
-    fun base -> function
-      | Alias (mod_path, _) ->
-        Link.from_path (mod_path :> Paths.Path.t)
+    and mdexpr :
+        Paths.Identifier.Signature.t -> Odoc_model.Lang.Module.decl -> text =
+     fun base -> function
+      | Alias (mod_path, _) -> Link.from_path (mod_path :> Paths.Path.t)
       | ModuleType mt -> mty (extract_path_from_mt ~default:base mt) mt
 
-  and module_type (t : Odoc_model.Lang.ModuleType.t) =
-    let modname = Paths.Identifier.name t.id in
-    let expansion =
-      match t.expr with
-      | None -> None
-      | Some e -> expansion_of_module_type_expr e
-    in
-    let modname, expansion =
-      match expansion with
-      | None ->
-        O.documentedSrc @@ O.txt modname, None
-      | Some items ->
-        let doc = Comment.standalone t.doc in
-        let url = Url.Path.from_identifier t.id in
-        let link = path url [inline @@ Text modname] in
-        let title = modname in
-        let header =
-          format_title `Mty (make_name_from_path url) @ doc
-        in
-        let page = {Page.items ; title ; header ; url } in
-        O.documentedSrc link, Some page
-    in
-    let summary =
-      match t.expr with
-      | None -> O.noop
-      | Some expr ->
-        O.txt " = " ++ mty (t.id :> Paths.Identifier.Signature.t) expr
-    in
-    let mty =
-      attach_expansion (" = ","sig","end") expansion summary
-    in
-    let content =
-      O.documentedSrc (
-        O.keyword "module" ++
-          O.txt " " ++
-          O.keyword "type" ++
-          O.txt " ")
-      @ modname
-      @ mty
-      @ O.documentedSrc
-          (if Syntax.Mod.close_tag_semicolon then O.txt ";" else O.noop)
-    in
-    let kind = Some "module-type" in
-    let anchor = path_to_id t.id in
-    let doc = Comment.first_to_ir t.doc in
-    Item.Declaration {kind ; anchor ; doc ; content}
+    and module_type (t : Odoc_model.Lang.ModuleType.t) =
+      let modname = Paths.Identifier.name t.id in
+      let expansion =
+        match t.expr with
+        | None -> None
+        | Some e -> expansion_of_module_type_expr e
+      in
+      let modname, expansion =
+        match expansion with
+        | None -> (O.documentedSrc @@ O.txt modname, None)
+        | Some items ->
+            let doc = Comment.standalone t.doc in
+            let url = Url.Path.from_identifier t.id in
+            let link = path url [ inline @@ Text modname ] in
+            let title = modname in
+            let header = format_title `Mty (make_name_from_path url) @ doc in
+            let page = { Page.items; title; header; url } in
+            (O.documentedSrc link, Some page)
+      in
+      let summary =
+        match t.expr with
+        | None -> O.noop
+        | Some expr ->
+            O.txt " = " ++ mty (t.id :> Paths.Identifier.Signature.t) expr
+      in
+      let mty = attach_expansion (" = ", "sig", "end") expansion summary in
+      let content =
+        O.documentedSrc
+          (O.keyword "module" ++ O.txt " " ++ O.keyword "type" ++ O.txt " ")
+        @ modname @ mty
+        @ O.documentedSrc
+            (if Syntax.Mod.close_tag_semicolon then O.txt ";" else O.noop)
+      in
+      let kind = Some "module-type" in
+      let anchor = path_to_id t.id in
+      let doc = Comment.first_to_ir t.doc in
+      Item.Declaration { kind; anchor; doc; content }
 
-  and umty_hidden : Odoc_model.Lang.ModuleType.U.expr -> bool
-    = function
-    | Path p -> Paths.Path.(is_hidden (p :> t))
-    | With (_, expr) -> umty_hidden expr
-    | TypeOf { t_desc = ModPath m; _}
-    | TypeOf { t_desc = StructInclude m; _} ->
-      Paths.Path.(is_hidden (m :> t))
-    | Signature _ -> false
-  
-  and mty_hidden : Odoc_model.Lang.ModuleType.expr -> bool
-    = function
-    | Path { p_path = mty_path; _ } -> Paths.Path.(is_hidden (mty_path :> t))
-    | With { w_expr; _ } -> umty_hidden w_expr
-    | TypeOf { t_desc=ModPath m; _ } 
-    | TypeOf { t_desc=StructInclude m; _ } -> Paths.Path.(is_hidden (m :> t))
-    | _ -> false
+    and umty_hidden : Odoc_model.Lang.ModuleType.U.expr -> bool = function
+      | Path p -> Paths.Path.(is_hidden (p :> t))
+      | With (_, expr) -> umty_hidden expr
+      | TypeOf { t_desc = ModPath m; _ }
+      | TypeOf { t_desc = StructInclude m; _ } ->
+          Paths.Path.(is_hidden (m :> t))
+      | Signature _ -> false
 
-  and mty_with base subs expr =
-    umty base expr ++
-            O.txt " " ++
-            O.keyword "with" ++
-            O.txt " " ++
-            O.list
-              ~sep:(O.txt " " ++ O.keyword "and" ++ O.txt " ")
-              ~f:(substitution base)
-              subs
-  and mty_typeof t_desc =
-    match t_desc with
-    | Odoc_model.Lang.ModuleType.ModPath m ->
-      O.keyword "module" ++
-      O.txt " " ++
-      O.keyword "type" ++
-      O.txt " " ++
-      O.keyword "of" ++
-      O.txt " " ++
-      Link.from_path (m :> Paths.Path.t)
-    | StructInclude m ->
-      O.keyword "module" ++
-      O.txt " " ++
-      O.keyword "type" ++
-      O.txt " " ++
-      O.keyword "of" ++
-      O.txt " " ++
-      O.keyword "struct" ++
-      O.txt " " ++
-      O.keyword "include" ++
-      O.txt " " ++
-      Link.from_path (m :> Paths.Path.t) ++
-      O.txt " " ++
-      O.keyword "end"
+    and mty_hidden : Odoc_model.Lang.ModuleType.expr -> bool = function
+      | Path { p_path = mty_path; _ } -> Paths.Path.(is_hidden (mty_path :> t))
+      | With { w_expr; _ } -> umty_hidden w_expr
+      | TypeOf { t_desc = ModPath m; _ }
+      | TypeOf { t_desc = StructInclude m; _ } ->
+          Paths.Path.(is_hidden (m :> t))
+      | _ -> false
 
-  and umty
-    : Paths.Identifier.Signature.t -> Odoc_model.Lang.ModuleType.U.expr -> text
-    = fun base m ->
+    and mty_with base subs expr =
+      umty base expr ++ O.txt " " ++ O.keyword "with" ++ O.txt " "
+      ++ O.list
+           ~sep:(O.txt " " ++ O.keyword "and" ++ O.txt " ")
+           ~f:(substitution base) subs
+
+    and mty_typeof t_desc =
+      match t_desc with
+      | Odoc_model.Lang.ModuleType.ModPath m ->
+          O.keyword "module" ++ O.txt " " ++ O.keyword "type" ++ O.txt " "
+          ++ O.keyword "of" ++ O.txt " "
+          ++ Link.from_path (m :> Paths.Path.t)
+      | StructInclude m ->
+          O.keyword "module" ++ O.txt " " ++ O.keyword "type" ++ O.txt " "
+          ++ O.keyword "of" ++ O.txt " " ++ O.keyword "struct" ++ O.txt " "
+          ++ O.keyword "include" ++ O.txt " "
+          ++ Link.from_path (m :> Paths.Path.t)
+          ++ O.txt " " ++ O.keyword "end"
+
+    and umty :
+        Paths.Identifier.Signature.t ->
+        Odoc_model.Lang.ModuleType.U.expr ->
+        text =
+     fun base m ->
       match m with
       | Path p -> Link.from_path (p :> Paths.Path.t)
       | With (subs, expr) -> mty_with base subs expr
       | TypeOf { t_desc; _ } -> mty_typeof t_desc
       | Signature _ ->
-        Syntax.Mod.open_tag ++ O.txt " ... " ++ Syntax.Mod.close_tag
+          Syntax.Mod.open_tag ++ O.txt " ... " ++ Syntax.Mod.close_tag
 
-  and mty
-    : Paths.Identifier.Signature.t -> Odoc_model.Lang.ModuleType.expr -> text
-    = fun base m ->
-      if mty_hidden m
-      then Syntax.Mod.open_tag ++ O.txt " ... " ++ Syntax.Mod.close_tag
+    and mty :
+        Paths.Identifier.Signature.t -> Odoc_model.Lang.ModuleType.expr -> text
+        =
+     fun base m ->
+      if mty_hidden m then
+        Syntax.Mod.open_tag ++ O.txt " ... " ++ Syntax.Mod.close_tag
       else
         match m with
         | Path { p_path = mty_path; _ } ->
-          Link.from_path (mty_path :> Paths.Path.t)
+            Link.from_path (mty_path :> Paths.Path.t)
         | Functor (Unit, expr) ->
-          (if Syntax.Mod.functor_keyword then O.keyword "functor" else O.noop) ++
-            O.txt " () " ++ Syntax.Type.arrow ++ O.txt " " ++
-            mty base expr
+            (if Syntax.Mod.functor_keyword then O.keyword "functor" else O.noop)
+            ++ O.txt " () " ++ Syntax.Type.arrow ++ O.txt " " ++ mty base expr
         | Functor (Named arg, expr) ->
-          let arg_expr = arg.expr in
-          let stop_before = (expansion_of_module_type_expr arg_expr) = None in
-          let name =
-            let open Odoc_model.Lang.FunctorParameter in
-            let name = Paths.Identifier.name arg.id in
-            match
-              Url.from_identifier
-                ~stop_before (arg.id :> Paths.Identifier.t)
-            with
-            | Error _ -> O.txt name
-            | Ok href -> resolved href [inline @@ Text name]
-          in
-          (if Syntax.Mod.functor_keyword then O.keyword "functor" else O.noop) ++
-            O.txt " (" ++ name ++ O.txt Syntax.Type.annotation_separator ++
-            mty base arg_expr ++
-            O.txt ")" ++ O.txt " " ++ Syntax.Type.arrow ++ O.txt " " ++
-            mty base expr
-        | With { w_substitutions; w_expr; _ } ->
-          mty_with base w_substitutions w_expr
-        | TypeOf { t_desc; _ } ->
-          mty_typeof t_desc        
-        | Signature _ ->
-          Syntax.Mod.open_tag ++ O.txt " ... " ++ Syntax.Mod.close_tag
-
-  and mty_in_decl
-    : Paths.Identifier.Signature.t -> Odoc_model.Lang.ModuleType.expr -> text
-    = fun base -> function
-      | Path _
-      | Signature _
-      | With _
-      | TypeOf _
-        as m ->
-        O.txt Syntax.Type.annotation_separator ++ mty base m
-      | Functor _ as m when not Syntax.Mod.functor_contraction ->
-        O.txt Syntax.Type.annotation_separator ++ mty base m
-      | Functor (arg, expr) ->
-        let text_arg = match arg with
-          | Unit -> O.txt "()"
-          | Named arg ->
             let arg_expr = arg.expr in
-            let stop_before = (expansion_of_module_type_expr arg_expr) = None in
+            let stop_before = expansion_of_module_type_expr arg_expr = None in
             let name =
               let open Odoc_model.Lang.FunctorParameter in
               let name = Paths.Identifier.name arg.id in
               match
-                Url.from_identifier
-                  ~stop_before (arg.id :> Paths.Identifier.t)
+                Url.from_identifier ~stop_before (arg.id :> Paths.Identifier.t)
               with
               | Error _ -> O.txt name
-              | Ok href -> resolved href [inline @@ Text name]
+              | Ok href -> resolved href [ inline @@ Text name ]
             in
-            O.txt "(" ++ name ++ O.txt Syntax.Type.annotation_separator
-            ++ mty base arg.expr
-            ++ O.txt ")"
-        in
-        O.txt " " ++ text_arg ++ mty_in_decl base expr
+            (if Syntax.Mod.functor_keyword then O.keyword "functor" else O.noop)
+            ++ O.txt " (" ++ name
+            ++ O.txt Syntax.Type.annotation_separator
+            ++ mty base arg_expr ++ O.txt ")" ++ O.txt " " ++ Syntax.Type.arrow
+            ++ O.txt " " ++ mty base expr
+        | With { w_substitutions; w_expr; _ } ->
+            mty_with base w_substitutions w_expr
+        | TypeOf { t_desc; _ } -> mty_typeof t_desc
+        | Signature _ ->
+            Syntax.Mod.open_tag ++ O.txt " ... " ++ Syntax.Mod.close_tag
 
-  (* TODO : Centralize the list juggling for type parameters *)
-  and type_expr_in_subst ~base td typath =
-    let typath = Link.from_fragment ~base typath in
-    match td.Lang.TypeDecl.Equation.params with
-    | [] -> typath
-    | l -> Syntax.Type.handle_substitution_params typath (format_params l)
+    and mty_in_decl :
+        Paths.Identifier.Signature.t -> Odoc_model.Lang.ModuleType.expr -> text
+        =
+     fun base -> function
+      | (Path _ | Signature _ | With _ | TypeOf _) as m ->
+          O.txt Syntax.Type.annotation_separator ++ mty base m
+      | Functor _ as m when not Syntax.Mod.functor_contraction ->
+          O.txt Syntax.Type.annotation_separator ++ mty base m
+      | Functor (arg, expr) ->
+          let text_arg =
+            match arg with
+            | Unit -> O.txt "()"
+            | Named arg ->
+                let arg_expr = arg.expr in
+                let stop_before =
+                  expansion_of_module_type_expr arg_expr = None
+                in
+                let name =
+                  let open Odoc_model.Lang.FunctorParameter in
+                  let name = Paths.Identifier.name arg.id in
+                  match
+                    Url.from_identifier ~stop_before
+                      (arg.id :> Paths.Identifier.t)
+                  with
+                  | Error _ -> O.txt name
+                  | Ok href -> resolved href [ inline @@ Text name ]
+                in
+                O.txt "(" ++ name
+                ++ O.txt Syntax.Type.annotation_separator
+                ++ mty base arg.expr ++ O.txt ")"
+          in
+          O.txt " " ++ text_arg ++ mty_in_decl base expr
 
-  and substitution
-    : Paths.Identifier.Signature.t -> Odoc_model.Lang.ModuleType.substitution
-      -> text
-    = fun base -> function
+    (* TODO : Centralize the list juggling for type parameters *)
+    and type_expr_in_subst ~base td typath =
+      let typath = Link.from_fragment ~base typath in
+      match td.Lang.TypeDecl.Equation.params with
+      | [] -> typath
+      | l -> Syntax.Type.handle_substitution_params typath (format_params l)
+
+    and substitution :
+        Paths.Identifier.Signature.t ->
+        Odoc_model.Lang.ModuleType.substitution ->
+        text =
+     fun base -> function
       | ModuleEq (frag_mod, md) ->
-        O.keyword "module" ++
-          O.txt " " ++
-          Link.from_fragment ~base (frag_mod :> Paths.Fragment.t)
-        ++ O.txt " = " ++
-          mdexpr base md
+          O.keyword "module" ++ O.txt " "
+          ++ Link.from_fragment ~base (frag_mod :> Paths.Fragment.t)
+          ++ O.txt " = " ++ mdexpr base md
       | TypeEq (frag_typ, td) ->
-        O.keyword "type" ++
-          O.txt " " ++
-          type_expr_in_subst ~base td (frag_typ :> Paths.Fragment.t) ++
-          fst (format_manifest td) ++
-          format_constraints td.Odoc_model.Lang.TypeDecl.Equation.constraints
+          O.keyword "type" ++ O.txt " "
+          ++ type_expr_in_subst ~base td (frag_typ :> Paths.Fragment.t)
+          ++ fst (format_manifest td)
+          ++ format_constraints td.Odoc_model.Lang.TypeDecl.Equation.constraints
       | ModuleSubst (frag_mod, mod_path) ->
-        O.keyword "module" ++
-          O.txt " " ++
-          Link.from_fragment
-            ~base (frag_mod :> Paths.Fragment.t) ++
-          O.txt " := " ++
-          Link.from_path (mod_path :> Paths.Path.t)
-      | TypeSubst (frag_typ, td) ->
-        O.keyword "type" ++
-          O.txt " " ++
-          type_expr_in_subst ~base td (frag_typ :> Paths.Fragment.t) ++
-          O.txt " := " ++
+          O.keyword "module" ++ O.txt " "
+          ++ Link.from_fragment ~base (frag_mod :> Paths.Fragment.t)
+          ++ O.txt " := "
+          ++ Link.from_path (mod_path :> Paths.Path.t)
+      | TypeSubst (frag_typ, td) -> (
+          O.keyword "type" ++ O.txt " "
+          ++ type_expr_in_subst ~base td (frag_typ :> Paths.Fragment.t)
+          ++ O.txt " := "
+          ++
           match td.Lang.TypeDecl.Equation.manifest with
           | None -> assert false (* cf loader/cmti *)
-          | Some te ->
-            type_expr te
+          | Some te -> type_expr te )
 
-  and include_ (t : Odoc_model.Lang.Include.t) =
-    let decl_hidden =
-      match t.decl with
-      | Alias p -> Paths.Path.(is_hidden (p :> t))
-      | ModuleType mty -> umty_hidden mty
-    in
-    let status =
-      let is_open_tag element = element.Odoc_model.Location_.value = `Tag `Open in
-      let is_closed_tag element = element.Odoc_model.Location_.value = `Tag `Closed in
-      if t.inline || decl_hidden  then `Inline
-      else if List.exists is_open_tag t.doc then `Open
-      else if List.exists is_closed_tag t.doc then `Closed
-      else `Default
-    in
-
-    let include_decl =
-      match t.decl with
-      | Odoc_model.Lang.Include.Alias mod_path ->
-        Link.from_path (mod_path :> Paths.Path.t)
-      | ModuleType mt -> umty (extract_path_from_umt ~default:t.parent mt) mt
-    in
-
-    let content = signature t.expansion.content in
-    let summary =
-      O.render (
-        O.keyword "include" ++
-          O.txt " " ++
-          include_decl ++
-          (if Syntax.Mod.include_semicolon then O.keyword ";" else O.noop)
-      )
-    in
-    let content = {Include. content; status; summary} in
-    let kind = Some "include" in
-    let anchor = None in
-    let doc = Comment.first_to_ir t.doc in
-    Item.Include {kind ; anchor ; doc ; content}
-
-end
-open Module
-
-
-
-module Page :
-sig
-  val compilation_unit : Lang.Compilation_unit.t -> Page.t
-  val page : Lang.Page.t -> Page.t
-end =
-struct
-  let pack
-    : Odoc_model.Lang.Compilation_unit.Packed.t -> Item.t list
-  = fun t ->
-    let open Odoc_model.Lang in
-    let f x =
-      let id = x.Compilation_unit.Packed.id in
-      let modname = Paths.Identifier.name id in
-      let md_def =
-        O.keyword "module" ++
-          O.txt " " ++
-          O.txt modname ++
-          O.txt " = " ++
-          Link.from_path (x.path :> Paths.Path.t)
+    and include_ (t : Odoc_model.Lang.Include.t) =
+      let decl_hidden =
+        match t.decl with
+        | Alias p -> Paths.Path.(is_hidden (p :> t))
+        | ModuleType mty -> umty_hidden mty
       in
-      let content = O.documentedSrc md_def in
-      let anchor =
-        Utils.option_of_result @@
-        Url.Anchor.from_identifier (id :> Paths.Identifier.t)
+      let status =
+        let is_open_tag element =
+          element.Odoc_model.Location_.value = `Tag `Open
+        in
+        let is_closed_tag element =
+          element.Odoc_model.Location_.value = `Tag `Closed
+        in
+        if t.inline || decl_hidden then `Inline
+        else if List.exists is_open_tag t.doc then `Open
+        else if List.exists is_closed_tag t.doc then `Closed
+        else `Default
       in
-      let kind = Some "modules" in
-      let doc = [] in
-      let decl = {Item. anchor ; content ; kind ; doc } in
-      Item.Declaration decl
-    in
-    List.map f t
 
-  let compilation_unit (t : Odoc_model.Lang.Compilation_unit.t) : Page.t =
-    let title = Paths.Identifier.name t.id in
-    let header =
-      format_title `Mod title @ Comment.standalone t.doc
-    in
-    let url = Url.Path.from_identifier t.id in
-    let items =
-      match t.content with
-      | Module sign -> signature sign
-      | Pack packed -> pack packed
-    in
-    {Page. title ; header ; items ; url }
+      let include_decl =
+        match t.decl with
+        | Odoc_model.Lang.Include.Alias mod_path ->
+            Link.from_path (mod_path :> Paths.Path.t)
+        | ModuleType mt -> umty (extract_path_from_umt ~default:t.parent mt) mt
+      in
 
-  let page (t : Odoc_model.Lang.Page.t) : Page.t =
-    let name =
-      match t.name with
-      | `RootPage name
-      | `Page (_, name)
-      | `LeafPage (_, name) -> name
-    in
-    let title = Odoc_model.Names.PageName.to_string name in
-    let url = Url.Path.from_identifier t.name in
-    let header, items = Sectioning.docs t.content in
-    {Page. title ; header ; items ; url }
-end
-include Page
+      let content = signature t.expansion.content in
+      let summary =
+        O.render
+          ( O.keyword "include" ++ O.txt " " ++ include_decl
+          ++ if Syntax.Mod.include_semicolon then O.keyword ";" else O.noop )
+      in
+      let content = { Include.content; status; summary } in
+      let kind = Some "include" in
+      let anchor = None in
+      let doc = Comment.first_to_ir t.doc in
+      Item.Include { kind; anchor; doc; content }
+  end
+
+  open Module
+
+  module Page : sig
+    val compilation_unit : Lang.Compilation_unit.t -> Page.t
+
+    val page : Lang.Page.t -> Page.t
+  end = struct
+    let pack : Odoc_model.Lang.Compilation_unit.Packed.t -> Item.t list =
+     fun t ->
+      let open Odoc_model.Lang in
+      let f x =
+        let id = x.Compilation_unit.Packed.id in
+        let modname = Paths.Identifier.name id in
+        let md_def =
+          O.keyword "module" ++ O.txt " " ++ O.txt modname ++ O.txt " = "
+          ++ Link.from_path (x.path :> Paths.Path.t)
+        in
+        let content = O.documentedSrc md_def in
+        let anchor =
+          Utils.option_of_result
+          @@ Url.Anchor.from_identifier (id :> Paths.Identifier.t)
+        in
+        let kind = Some "modules" in
+        let doc = [] in
+        let decl = { Item.anchor; content; kind; doc } in
+        Item.Declaration decl
+      in
+      List.map f t
+
+    let compilation_unit (t : Odoc_model.Lang.Compilation_unit.t) : Page.t =
+      let title = Paths.Identifier.name t.id in
+      let header = format_title `Mod title @ Comment.standalone t.doc in
+      let url = Url.Path.from_identifier t.id in
+      let items =
+        match t.content with
+        | Module sign -> signature sign
+        | Pack packed -> pack packed
+      in
+      { Page.title; header; items; url }
+
+    let page (t : Odoc_model.Lang.Page.t) : Page.t =
+      let name =
+        match t.name with
+        | `RootPage name | `Page (_, name) | `LeafPage (_, name) -> name
+      in
+      let title = Odoc_model.Names.PageName.to_string name in
+      let url = Url.Path.from_identifier t.name in
+      let header, items = Sectioning.docs t.content in
+      { Page.title; header; items; url }
+  end
+
+  include Page
 end

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -1,50 +1,51 @@
 open Types
 module Lang = Odoc_model.Lang
 
-
-
 type rendered_item = DocumentedSrc.t
 
 type text = Format.formatter -> unit
 
 (** HTML generation syntax customization module. See {!To_re_html_tree} and
     {!To_ml_html_tree}. *)
-module type SYNTAX =
-sig
-  module Obj :
-  sig
+module type SYNTAX = sig
+  module Obj : sig
     val close_tag_closed : string
+
     val close_tag_extendable : string
+
     val field_separator : string
+
     val open_tag_closed : string
+
     val open_tag_extendable : string
   end
 
-  module Type :
-  sig
+  module Type : sig
     val annotation_separator : string
 
     val handle_constructor_params : text -> text -> text
+
     val handle_substitution_params : text -> text -> text
 
     val handle_format_params : string -> string
+
     val type_def_semicolon : bool
+
     val private_keyword : string
+
     val parenthesize_constructor : bool
 
-    module Variant :
-    sig
+    module Variant : sig
       val parenthesize_params : bool
     end
 
-    module Tuple :
-    sig
+    module Tuple : sig
       val element_separator : string
+
       val always_parenthesize : bool
     end
 
-    module Record :
-    sig
+    module Record : sig
       val field_separator : string
     end
 
@@ -54,48 +55,50 @@ sig
 
     val arrow : text
 
-    module Exception :
-    sig
+    module Exception : sig
       val semicolon : bool
     end
 
-    module GADT :
-    sig
+    module GADT : sig
       val arrow : text
     end
 
-    module External :
-    sig
+    module External : sig
       val semicolon : bool
-      val handle_primitives :
-        string list -> Inline.t
+
+      val handle_primitives : string list -> Inline.t
     end
   end
 
-  module Mod :
-  sig
+  module Mod : sig
     val open_tag : text
+
     val close_tag : text
+
     val close_tag_semicolon : bool
+
     val include_semicolon : bool
+
     val functor_keyword : bool
+
     val functor_contraction : bool
   end
 
-  module Class :
-  sig
+  module Class : sig
     val open_tag : text
+
     val close_tag : text
   end
 
-  module Value :
-  sig
+  module Value : sig
     val variable_keyword : string
+
     val semicolon : bool
   end
 end
 
 module type GENERATOR = sig
   val compilation_unit : Lang.Compilation_unit.t -> Page.t
+
   val page : Lang.Page.t -> Page.t
 end

--- a/src/document/reason.ml
+++ b/src/document/reason.ml
@@ -1,92 +1,100 @@
 open Types
-
 module O = Codefmt
 open O.Infix
 
 module Reason = Generator.Make (struct
-  module Obj =
-  struct
+  module Obj = struct
     let close_tag_closed = "}"
+
     let close_tag_extendable = "}"
+
     let field_separator = ", "
+
     let open_tag_closed = "{. "
+
     let open_tag_extendable = "{.. "
   end
 
-  module Type =
-  struct
+  module Type = struct
     let annotation_separator = ": "
+
     let handle_constructor_params name args = name ++ args
+
     let handle_substitution_params name args = name ++ args
+
     let handle_format_params p = "(" ^ p ^ ")"
+
     let type_def_semicolon = true
+
     let private_keyword = "pri"
 
     let parenthesize_constructor = true
 
-    module Variant =
-    struct
+    module Variant = struct
       let parenthesize_params = true
     end
 
-    module Tuple =
-    struct
+    module Tuple = struct
       let element_separator = ", "
+
       let always_parenthesize = true
     end
 
-    module Record =
-    struct
+    module Record = struct
       let field_separator = ","
     end
 
     let var_prefix = "'"
+
     let any = "_"
+
     let arrow = O.span (O.txt "=" ++ O.entity "gt")
 
-    module Exception =
-    struct
+    module Exception = struct
       let semicolon = true
     end
 
-    module GADT =
-    struct
+    module GADT = struct
       let arrow = O.txt ":"
     end
 
-    module External =
-    struct
+    module External = struct
       let semicolon = true
+
       let handle_primitives prims =
         List.fold_left
           (fun acc p ->
             let str =
               match acc with [] -> "\"" ^ p ^ "\"" | _ -> " \"" ^ p ^ "\""
             in
-            inline (Text str) :: acc )
+            inline (Text str) :: acc)
           [] prims
     end
   end
 
-  module Mod =
-  struct
+  module Mod = struct
     let open_tag = O.txt "{"
+
     let close_tag = O.txt "}"
+
     let close_tag_semicolon = true
+
     let include_semicolon = true
+
     let functor_keyword = false
+
     let functor_contraction = false
   end
 
-  module Class =
-  struct
+  module Class = struct
     let open_tag = O.txt "{"
+
     let close_tag = O.txt "}"
   end
 
-  module Value =
-  struct
+  module Value = struct
     let variable_keyword = "let"
+
     let semicolon = true
   end
 end)

--- a/src/document/reason.mli
+++ b/src/document/reason.mli
@@ -15,5 +15,6 @@
  *)
 
 val compilation_unit : Odoc_model.Lang.Compilation_unit.t -> Types.Page.t
+
 val page : Odoc_model.Lang.Page.t -> Types.Page.t
 (** Convert compilation unit or page models into a document *)

--- a/src/document/renderer.ml
+++ b/src/document/renderer.ml
@@ -2,14 +2,12 @@
 
 type syntax = OCaml | Reason
 
-let string_of_syntax = function
-  | OCaml -> "ml"
-  | Reason -> "re"
+let string_of_syntax = function OCaml -> "ml" | Reason -> "re"
 
 type page = {
   filename : Fpath.t;
   content : Format.formatter -> unit;
-  children : page list
+  children : page list;
 }
 
 let traverse ~f t =
@@ -20,15 +18,13 @@ let traverse ~f t =
   aux t
 
 type 'a t = {
-  name : string ;
-  render : 'a -> Types.Page.t -> page ;
-  files_of_url : Url.Path.t -> Fpath.t list ;
+  name : string;
+  render : 'a -> Types.Page.t -> page;
+  files_of_url : Url.Path.t -> Fpath.t list;
 }
 
 let document_of_page ~syntax v =
-  match syntax with
-  | Reason -> Reason.page v
-  | OCaml -> ML.page v
+  match syntax with Reason -> Reason.page v | OCaml -> ML.page v
 
 let document_of_compilation_unit ~syntax v =
   match syntax with

--- a/src/document/targets.ml
+++ b/src/document/targets.ml
@@ -3,38 +3,25 @@ open StdLabels
 let rec unit (t : Odoc_model.Lang.Compilation_unit.t) =
   let url = Url.Path.from_identifier t.id in
   let rest =
-    match t.content with
-    | Module sign -> signature sign
-    | Pack _ -> []
+    match t.content with Module sign -> signature sign | Pack _ -> []
   in
   url :: rest
 
 and signature (t : Odoc_model.Lang.Signature.t) =
   let rec add_items ~don't acc = function
     | [] -> List.concat (List.rev acc)
-    | i :: is ->
-      match i with
-      | Odoc_model.Lang.Signature.Comment `Stop ->
-        add_items ~don't:(not don't) acc is
-      | _ when don't ->
-        add_items ~don't acc is
-      | Module (_, md) ->
-        add_items ~don't (module_ md :: acc) is
-      | ModuleType mty ->
-        add_items ~don't (module_type mty :: acc) is
-      | Include incl ->
-        add_items ~don't (include_ incl :: acc) is
-      | Open _
-      | ModuleSubstitution _
-      | TypeSubstitution _
-      | Type _
-      | TypExt _
-      | Exception _
-      | Value _
-      | External _
-      | Class _
-      | ClassType _
-      | Comment (`Docs _) -> add_items ~don't acc is
+    | i :: is -> (
+        match i with
+        | Odoc_model.Lang.Signature.Comment `Stop ->
+            add_items ~don't:(not don't) acc is
+        | _ when don't -> add_items ~don't acc is
+        | Module (_, md) -> add_items ~don't (module_ md :: acc) is
+        | ModuleType mty -> add_items ~don't (module_type mty :: acc) is
+        | Include incl -> add_items ~don't (include_ incl :: acc) is
+        | Open _ | ModuleSubstitution _ | TypeSubstitution _ | Type _ | TypExt _
+        | Exception _ | Value _ | External _ | Class _ | ClassType _
+        | Comment (`Docs _) ->
+            add_items ~don't acc is )
   in
   add_items ~don't:false [] t
 
@@ -42,37 +29,32 @@ and simple_expansion (t : Odoc_model.Lang.ModuleType.simple_expansion) =
   match t with
   | Signature sg -> signature sg
   | Functor (p, expn) ->
-    let subpages =
-      match p with
-      | Unit -> []
-      | Named { expr; _ } -> module_type_expr expr
-    in
-    subpages @ simple_expansion expn
+      let subpages =
+        match p with Unit -> [] | Named { expr; _ } -> module_type_expr expr
+      in
+      subpages @ simple_expansion expn
 
 and module_type_expr (t : Odoc_model.Lang.ModuleType.expr) =
   let open Odoc_model.Lang.ModuleType in
   let opt_expansion e_opt =
-    match e_opt with
-    | Some e -> simple_expansion e
-    | None -> []
+    match e_opt with Some e -> simple_expansion e | None -> []
   in
   match t with
   | Signature sg -> signature sg
   | Functor (f_parameter, e) ->
-    let sub = 
-      match f_parameter with
-      | Unit -> []
-      | Named f -> module_type_expr f.expr
-    in
-    sub @ module_type_expr e
+      let sub =
+        match f_parameter with Unit -> [] | Named f -> module_type_expr f.expr
+      in
+      sub @ module_type_expr e
   | Path { p_expansion = e_opt; _ }
   | With { w_expansion = e_opt; _ }
-  | TypeOf {t_expansion = e_opt; _} ->
-    opt_expansion e_opt
+  | TypeOf { t_expansion = e_opt; _ } ->
+      opt_expansion e_opt
 
 and module_ (t : Odoc_model.Lang.Module.t) =
   let url = Url.Path.from_identifier t.id in
-  let subpages = match t.type_ with
+  let subpages =
+    match t.type_ with
     | Alias (_, Some e) -> simple_expansion e
     | Alias (_, None) -> []
     | ModuleType expr -> module_type_expr expr
@@ -83,13 +65,10 @@ and module_type (t : Odoc_model.Lang.ModuleType.t) =
   match t.expr with
   | None -> []
   | Some expr ->
-    let url = Url.Path.from_identifier t.id in
-    let subpages = module_type_expr expr in
-    url :: subpages
+      let url = Url.Path.from_identifier t.id in
+      let subpages = module_type_expr expr in
+      url :: subpages
 
-and include_ (t : Odoc_model.Lang.Include.t) =
-  signature t.expansion.content
+and include_ (t : Odoc_model.Lang.Include.t) = signature t.expansion.content
 
-and page (t : Odoc_model.Lang.Page.t) =
-  [Url.Path.from_identifier t.name]
-
+and page (t : Odoc_model.Lang.Page.t) = [ Url.Path.from_identifier t.name ]

--- a/src/document/targets.mli
+++ b/src/document/targets.mli
@@ -10,4 +10,3 @@ open Odoc_model.Lang
 val unit : Compilation_unit.t -> Url.Path.t list
 
 val page : Page.t -> Url.Path.t list
-

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -1,55 +1,43 @@
-type style = [
-  | `Bold
-  | `Italic
-  | `Emphasis
-  | `Superscript
-  | `Subscript
-]
+type style = [ `Bold | `Italic | `Emphasis | `Superscript | `Subscript ]
 
 module rec Class : sig
-
   type t = string list
-
-end = Class
+end =
+  Class
 
 and InternalLink : sig
-
   type resolved = Url.t * Inline.t
-  type unresolved = Inline.t
-  type t =
-    | Resolved of resolved
-    | Unresolved of Inline.t
 
-end = InternalLink
+  type unresolved = Inline.t
+
+  type t = Resolved of resolved | Unresolved of Inline.t
+end =
+  InternalLink
 
 and Raw_markup : sig
-
   type target = Odoc_model.Comment.raw_markup_target
-  and t = target * string
 
-end = Raw_markup
+  and t = target * string
+end =
+  Raw_markup
 
 and Source : sig
-
   type t = token list
-  and tag = string option
-  and token =
-    | Elt of Inline.t
-    | Tag of tag * t
 
-end = Source
+  and tag = string option
+
+  and token = Elt of Inline.t | Tag of tag * t
+end =
+  Source
 
 and Inline : sig
-
   type entity = string
+
   type href = string
 
   type t = one list
 
-  and one = {
-    attr : Class.t ;
-    desc : desc ;
-  }
+  and one = { attr : Class.t; desc : desc }
 
   and desc =
     | Text of string
@@ -60,27 +48,18 @@ and Inline : sig
     | InternalLink of InternalLink.t
     | Source of Source.t
     | Raw_markup of Raw_markup.t
-
-end = Inline
+end =
+  Inline
 
 and Heading : sig
-
-  type t = {
-    label : string option ;
-    level : int ;
-    title : Inline.t ;
-  }
-
-end = Heading
+  type t = { label : string option; level : int; title : Inline.t }
+end =
+  Heading
 
 and Block : sig
-
   type t = one list
 
-  and one = {
-    attr : Class.t ;
-    desc : desc ;
-  }
+  and one = { attr : Class.t; desc : desc }
 
   and desc =
     | Inline of Inline.t
@@ -91,74 +70,65 @@ and Block : sig
     | Verbatim of string
     | Raw_markup of Raw_markup.t
 
-  and list_type =
-    | Ordered
-    | Unordered
-
-end = Block
+  and list_type = Ordered | Unordered
+end =
+  Block
 
 and DocumentedSrc : sig
-
   type 'a documented = {
-    attrs : Class.t ;
-    anchor : Url.Anchor.t option ;
-    code : 'a ;
-    doc : Block.t ;
+    attrs : Class.t;
+    anchor : Url.Anchor.t option;
+    code : 'a;
+    doc : Block.t;
   }
 
   type t = one list
+
   and one =
     | Code of Source.t
     | Documented of Inline.t documented
     | Nested of t documented
     | Subpage of Subpage.t
     | Alternative of Alternative.t
-
-end = DocumentedSrc
+end =
+  DocumentedSrc
 
 and Alternative : sig
-  type expansion = { status:[ `Inline | `Open | `Closed | `Default ]; summary: Source.t; expansion: DocumentedSrc.t; url: Url.Path.t }
-  type t =
-    | Expansion of expansion
+  type expansion = {
+    status : [ `Inline | `Open | `Closed | `Default ];
+    summary : Source.t;
+    expansion : DocumentedSrc.t;
+    url : Url.Path.t;
+  }
 
+  type t = Expansion of expansion
 end =
   Alternative
 
 and Subpage : sig
-
   type status = [ `Inline | `Open | `Closed | `Default ]
 
-  type t = {
-    status : status ;
-    content : Page.t ;
-  }
-
-
-end = Subpage
+  type t = { status : status; content : Page.t }
+end =
+  Subpage
 
 and Include : sig
-
   type status = [ `Inline | `Open | `Closed | `Default ]
 
-  type t = {
-    status : status ;
-    content : Item.t list ;
-    summary: Source.t
-  }
-
-end = Include
-
+  type t = { status : status; content : Item.t list; summary : Source.t }
+end =
+  Include
 
 and Item : sig
-
   type 'a item = {
-    kind : string option ;
-    anchor : Url.Anchor.t option ;
-    content : 'a ;
-    doc : Block.t ;
+    kind : string option;
+    anchor : Url.Anchor.t option;
+    content : 'a;
+    doc : Block.t;
   }
 
   type declaration = DocumentedSrc.t item
+
   type text = Block.t
 
   type t =
@@ -166,19 +136,19 @@ and Item : sig
     | Heading of Heading.t
     | Declaration of DocumentedSrc.t item
     | Include of Include.t item
-
-end = Item
+end =
+  Item
 
 and Page : sig
-
   type t = {
-    title : string ;
-    header : Item.t list ;
-    items : Item.t list ;
-    url : Url.Path.t ;
+    title : string;
+    header : Item.t list;
+    items : Item.t list;
+    url : Url.Path.t;
   }
+end =
+  Page
 
-end = Page
+let inline ?(attr = []) desc = Inline.{ attr; desc }
 
-let inline ?(attr=[]) desc = Inline.{attr ; desc}
-let block ?(attr=[]) desc = Block.{attr ; desc}
+let block ?(attr = []) desc = Block.{ attr; desc }

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -6,10 +6,7 @@ module Root = Odoc_model.Root
 let functor_arg_pos (`Parameter (p, _)) =
   let rec inner_sig = function
     | `Result p -> 1 + inner_sig p
-    | `Module _
-    | `ModuleType _
-    | `Root _
-    | `Parameter _ -> 1
+    | `Module _ | `ModuleType _ | `Root _ | `Parameter _ -> 1
   in
   inner_sig p
 
@@ -25,29 +22,34 @@ let render_path : Odoc_model.Paths.Path.t -> string =
     | `SubstAlias (_, p) -> render_resolved (p :> t)
     | `SubstT (_, p) -> render_resolved (p :> t)
     | `Alias (p1, p2) ->
-      if Odoc_model.Paths.Path.is_hidden (`Resolved (p2 :> t))
-      then render_resolved (p1 :> t)
-      else render_resolved (p2 :> t)
+        if Odoc_model.Paths.Path.is_hidden (`Resolved (p2 :> t)) then
+          render_resolved (p1 :> t)
+        else render_resolved (p2 :> t)
     | `Hidden p -> render_resolved (p :> t)
-    | `Module (p, s) -> render_resolved (p :> t) ^ "." ^ (ModuleName.to_string s)
+    | `Module (p, s) -> render_resolved (p :> t) ^ "." ^ ModuleName.to_string s
     | `Canonical (_, `Resolved p) -> render_resolved (p :> t)
     | `Canonical (p, _) -> render_resolved (p :> t)
-    | `Apply (rp, p) -> render_resolved (rp :> t) ^ "(" ^ render_resolved (p :> Odoc_model.Paths.Path.Resolved.t) ^ ")"
-    | `ModuleType (p, s) -> render_resolved (p :> t) ^ "." ^ (ModuleTypeName.to_string s)
-    | `Type (p, s) -> render_resolved (p :> t) ^ "." ^ (TypeName.to_string s)
-    | `Class (p, s) -> render_resolved (p :> t) ^ "." ^ (ClassName.to_string s)
-    | `ClassType (p, s) -> render_resolved (p :> t) ^ "." ^ (ClassTypeName.to_string s)
-  and render_path : Odoc_model.Paths.Path.t -> string =
-    function
+    | `Apply (rp, p) ->
+        render_resolved (rp :> t)
+        ^ "("
+        ^ render_resolved (p :> Odoc_model.Paths.Path.Resolved.t)
+        ^ ")"
+    | `ModuleType (p, s) ->
+        render_resolved (p :> t) ^ "." ^ ModuleTypeName.to_string s
+    | `Type (p, s) -> render_resolved (p :> t) ^ "." ^ TypeName.to_string s
+    | `Class (p, s) -> render_resolved (p :> t) ^ "." ^ ClassName.to_string s
+    | `ClassType (p, s) ->
+        render_resolved (p :> t) ^ "." ^ ClassTypeName.to_string s
+  and render_path : Odoc_model.Paths.Path.t -> string = function
     | `Identifier (id, _) -> Identifier.name id
     | `Root root -> root
     | `Forward root -> root
     | `Dot (prefix, suffix) -> render_path (prefix :> t) ^ "." ^ suffix
-    | `Apply (p1, p2) -> render_path (p1 :> t) ^ "(" ^ render_path (p2 :> t) ^ ")"
+    | `Apply (p1, p2) ->
+        render_path (p1 :> t) ^ "(" ^ render_path (p2 :> t) ^ ")"
     | `Resolved rp -> render_resolved rp
   in
   render_path
-
 
 module Error = struct
   type nonrec t =
@@ -59,226 +61,217 @@ module Error = struct
   let to_string = function
     | Not_linkable s -> Printf.sprintf "Not_linkable %S" s
     | Uncaught_exn s -> Printf.sprintf "Uncaught_exn %S" s
-    | Unexpected_anchor s ->
-      Printf.sprintf "Unexpected_anchor %S" s
+    | Unexpected_anchor s -> Printf.sprintf "Unexpected_anchor %S" s
 end
 
-let (>>=) x f =
-  match x with
-  | Ok x -> f x
-  | Error _ as e -> e
+let ( >>= ) x f = match x with Ok x -> f x | Error _ as e -> e
 
 module Path = struct
+  type source =
+    [ Identifier.Page.t | Identifier.Signature.t | Identifier.ClassSignature.t ]
 
-  type source = [
-    | Identifier.Page.t
-    | Identifier.Signature.t
-    | Identifier.ClassSignature.t
-  ]
-
-  type t = {
-    kind : string ;
-    parent : t option ;
-    name : string ;
-  }
+  type t = { kind : string; parent : t option; name : string }
 
   let last t = t.name
 
-  let mk ?parent kind name = { kind ; parent ; name }
+  let mk ?parent kind name = { kind; parent; name }
 
   let rec from_identifier : source -> t = function
     | `Root (parent, unit_name) ->
-      let parent = from_identifier (parent :> source) in
-      let kind = "module" in
-      let page = ModuleName.to_string unit_name in
-      mk ~parent kind page
+        let parent = from_identifier (parent :> source) in
+        let kind = "module" in
+        let page = ModuleName.to_string unit_name in
+        mk ~parent kind page
     | `RootPage page_name ->
-      let kind = "container-page" in
-      let page = PageName.to_string page_name in
-      mk kind page
+        let kind = "container-page" in
+        let page = PageName.to_string page_name in
+        mk kind page
     | `Page (parent, page_name) ->
-      let parent = from_identifier (parent :> source) in
-      let kind = "container-page" in
-      let page = PageName.to_string page_name in
-      mk ~parent kind page
+        let parent = from_identifier (parent :> source) in
+        let kind = "container-page" in
+        let page = PageName.to_string page_name in
+        mk ~parent kind page
     | `LeafPage (parent, page_name) ->
-      let parent = from_identifier (parent :> source) in
-      let kind = "page" in
-      let page = PageName.to_string page_name in
-      mk ~parent kind page
+        let parent = from_identifier (parent :> source) in
+        let kind = "page" in
+        let page = PageName.to_string page_name in
+        mk ~parent kind page
     | `Module (parent, mod_name) ->
-      let parent = from_identifier (parent :> source) in
-      let kind = "module" in
-      let page = ModuleName.to_string mod_name in
-      mk ~parent kind page
+        let parent = from_identifier (parent :> source) in
+        let kind = "module" in
+        let page = ModuleName.to_string mod_name in
+        mk ~parent kind page
     | `Parameter (functor_id, arg_name) as p ->
-      let parent = from_identifier (functor_id :> source) in
-      let kind = "argument" in
-      let arg_num = functor_arg_pos p in
-      let page =
-        Printf.sprintf "%d-%s" arg_num (ParameterName.to_string arg_name)
-      in
-      mk ~parent kind page
+        let parent = from_identifier (functor_id :> source) in
+        let kind = "argument" in
+        let arg_num = functor_arg_pos p in
+        let page =
+          Printf.sprintf "%d-%s" arg_num (ParameterName.to_string arg_name)
+        in
+        mk ~parent kind page
     | `ModuleType (parent, modt_name) ->
-      let parent = from_identifier (parent :> source) in
-      let kind = "module-type" in
-      let page = ModuleTypeName.to_string modt_name in
-      mk ~parent kind page
+        let parent = from_identifier (parent :> source) in
+        let kind = "module-type" in
+        let page = ModuleTypeName.to_string modt_name in
+        mk ~parent kind page
     | `Class (parent, name) ->
-      let parent = from_identifier (parent :> source) in
-      let kind = "class" in
-      let page = ClassName.to_string name in
-      mk ~parent kind page
+        let parent = from_identifier (parent :> source) in
+        let kind = "class" in
+        let page = ClassName.to_string name in
+        mk ~parent kind page
     | `ClassType (parent, name) ->
-      let parent = from_identifier (parent :> source) in
-      let kind = "class-type" in
-      let page = ClassTypeName.to_string name in
-      mk ~parent kind page
+        let parent = from_identifier (parent :> source) in
+        let kind = "class-type" in
+        let page = ClassTypeName.to_string name in
+        mk ~parent kind page
     | `Result p -> from_identifier (p :> source)
 
-  let from_identifier p = from_identifier (p : [< source] :> source)
-
+  let from_identifier p = from_identifier (p : [< source ] :> source)
 end
 
-
 module Anchor = struct
+  type t = { page : Path.t; anchor : string; kind : string }
 
-  type t = {
-    page : Path.t ;
-    anchor : string;
-    kind : string;
-  }
-
-  let anchorify_path {Path. parent ; name ; kind} =
+  let anchorify_path { Path.parent; name; kind } =
     match parent with
     | None -> assert false (* We got a root, should never happen *)
     | Some page ->
-      let anchor = Printf.sprintf "%s-%s" kind name in
-      { page ; anchor ; kind }
+        let anchor = Printf.sprintf "%s-%s" kind name in
+        { page; anchor; kind }
 
-  let add_suffix ~kind { page ; anchor ; _ } suffix =
+  let add_suffix ~kind { page; anchor; _ } suffix =
     { page; anchor = anchor ^ "." ^ suffix; kind }
 
-  let rec from_identifier :
-    Identifier.t -> (t, Error.t) result =
-    let open Error in function
-      | `Module (parent, mod_name) ->
+  let rec from_identifier : Identifier.t -> (t, Error.t) result =
+    let open Error in
+    function
+    | `Module (parent, mod_name) ->
         let parent = Path.from_identifier (parent :> Path.source) in
         let kind = "module" in
-        let anchor = Printf.sprintf "%s-%s" kind (ModuleName.to_string mod_name) in
+        let anchor =
+          Printf.sprintf "%s-%s" kind (ModuleName.to_string mod_name)
+        in
         Ok { page = parent; anchor; kind }
-      | `Root _ as p ->
+    | `Root _ as p ->
         let page = Path.from_identifier (p :> Path.source) in
-        Ok { page ; kind = "module" ; anchor = "" }
-      | `RootPage _ as p ->
+        Ok { page; kind = "module"; anchor = "" }
+    | `RootPage _ as p ->
         let page = Path.from_identifier (p :> Path.source) in
-        Ok { page ; kind = "container-page" ; anchor = "" }
-      | `Page _ as p ->
+        Ok { page; kind = "container-page"; anchor = "" }
+    | `Page _ as p ->
         let page = Path.from_identifier (p :> Path.source) in
-        Ok { page ; kind = "container-page" ; anchor = "" }
-      | `LeafPage _ as p ->
+        Ok { page; kind = "container-page"; anchor = "" }
+    | `LeafPage _ as p ->
         let page = Path.from_identifier (p :> Path.source) in
-        Ok { page ; kind = "page" ; anchor = "" }
-      (* For all these identifiers, page names and anchors are the same *)
-      | `Parameter _
-      | `Result _
-      | `ModuleType _
-      | `Class _
-      | `ClassType _ as p ->
+        Ok { page; kind = "page"; anchor = "" }
+    (* For all these identifiers, page names and anchors are the same *)
+    | (`Parameter _ | `Result _ | `ModuleType _ | `Class _ | `ClassType _) as p
+      ->
         Ok (anchorify_path @@ Path.from_identifier p)
-      | `Type (parent, type_name) ->
+    | `Type (parent, type_name) ->
         let page = Path.from_identifier (parent :> Path.source) in
         let kind = "type" in
-        Ok { page;
-          anchor = Printf.sprintf "%s-%s" kind (TypeName.to_string type_name);
-          kind
-        }
-      | `CoreType ty_name ->
-        Error (Not_linkable ("core_type:"^ (TypeName.to_string ty_name)))
-      | `Extension (parent, name) ->
+        Ok
+          {
+            page;
+            anchor = Printf.sprintf "%s-%s" kind (TypeName.to_string type_name);
+            kind;
+          }
+    | `CoreType ty_name ->
+        Error (Not_linkable ("core_type:" ^ TypeName.to_string ty_name))
+    | `Extension (parent, name) ->
         let page = Path.from_identifier (parent :> Path.source) in
         let kind = "extension" in
-        Ok { page;
-          anchor = Printf.sprintf "%s-%s" kind (ExtensionName.to_string name);
-          kind }
-      | `Exception (parent, name) ->
+        Ok
+          {
+            page;
+            anchor = Printf.sprintf "%s-%s" kind (ExtensionName.to_string name);
+            kind;
+          }
+    | `Exception (parent, name) ->
         let page = Path.from_identifier (parent :> Path.source) in
         let kind = "exception" in
-        Ok { page;
-          anchor = Printf.sprintf "%s-%s" kind (ExceptionName.to_string name);
-          kind }
-      | `CoreException name ->
-        Error (Not_linkable ("core_exception:" ^ (ExceptionName.to_string name)))
-      | `Value (parent, name) ->
+        Ok
+          {
+            page;
+            anchor = Printf.sprintf "%s-%s" kind (ExceptionName.to_string name);
+            kind;
+          }
+    | `CoreException name ->
+        Error (Not_linkable ("core_exception:" ^ ExceptionName.to_string name))
+    | `Value (parent, name) ->
         let page = Path.from_identifier (parent :> Path.source) in
         let kind = "val" in
-        Ok { page;
-          anchor = Printf.sprintf "%s-%s" kind (ValueName.to_string name);
-          kind }
-      | `Method (parent, name) ->
+        Ok
+          {
+            page;
+            anchor = Printf.sprintf "%s-%s" kind (ValueName.to_string name);
+            kind;
+          }
+    | `Method (parent, name) ->
         let str_name = MethodName.to_string name in
         let page = Path.from_identifier (parent :> Path.source) in
         let kind = "method" in
         Ok { page; anchor = Printf.sprintf "%s-%s" kind str_name; kind }
-      | `InstanceVariable (parent, name) ->
+    | `InstanceVariable (parent, name) ->
         let str_name = InstanceVariableName.to_string name in
         let page = Path.from_identifier (parent :> Path.source) in
         let kind = "val" in
         Ok { page; anchor = Printf.sprintf "%s-%s" kind str_name; kind }
-      | `Constructor (parent, name) ->
+    | `Constructor (parent, name) ->
         from_identifier (parent :> Identifier.t) >>= fun page ->
         let kind = "constructor" in
         let suffix = ConstructorName.to_string name in
         Ok (add_suffix ~kind page suffix)
-      | `Field (parent, name) ->
+    | `Field (parent, name) ->
         from_identifier (parent :> Identifier.t) >>= fun page ->
         let kind = "field" in
         let suffix = FieldName.to_string name in
         Ok (add_suffix ~kind page suffix)
-      | `Label (parent, anchor') ->
+    | `Label (parent, anchor') -> (
         let anchor = LabelName.to_string anchor' in
-        from_identifier (parent :> Identifier.t)
-        >>= function
+        from_identifier (parent :> Identifier.t) >>= function
         | { page; anchor = _; kind } ->
-          (* Really ad-hoc and shitty, but it works. *)
-          if kind = "page" then Ok { page; anchor; kind }
-          else Ok {page; anchor; kind = "" }
-        (* | _ ->
-          Error (Unexpected_anchor ("label " ^ anchor)) *)
+            (* Really ad-hoc and shitty, but it works. *)
+            if kind = "page" then Ok { page; anchor; kind }
+            else Ok { page; anchor; kind = "" } )
+
+  (* | _ ->
+     Error (Unexpected_anchor ("label " ^ anchor)) *)
 
   let polymorphic_variant ~type_ident elt =
     let name_of_type_constr te =
       match te with
       | Odoc_model.Lang.TypeExpr.Constr (path, _) ->
-        render_path (path :> Odoc_model.Paths.Path.t)
+          render_path (path :> Odoc_model.Paths.Path.t)
       | _ ->
-        invalid_arg "DocOckHtml.Url.Polymorphic_variant_decl.name_of_type_constr"
+          invalid_arg
+            "DocOckHtml.Url.Polymorphic_variant_decl.name_of_type_constr"
     in
     match from_identifier type_ident with
     | Error e -> failwith (Error.to_string e)
-    | Ok url ->
-      match elt with
-      | Odoc_model.Lang.TypeExpr.Polymorphic_variant.Type te ->
-        let kind = "type" in
-        let suffix = name_of_type_constr te in
-        add_suffix ~kind url suffix
-      | Constructor {name; _} ->
-        let kind = "constructor" in
-        let suffix = name in
-        add_suffix ~kind url suffix
+    | Ok url -> (
+        match elt with
+        | Odoc_model.Lang.TypeExpr.Polymorphic_variant.Type te ->
+            let kind = "type" in
+            let suffix = name_of_type_constr te in
+            add_suffix ~kind url suffix
+        | Constructor { name; _ } ->
+            let kind = "constructor" in
+            let suffix = name in
+            add_suffix ~kind url suffix )
 end
 
 type t = Anchor.t
 
-let from_path page = {Anchor. page ; anchor = "" ; kind = page.kind }
+let from_path page = { Anchor.page; anchor = ""; kind = page.kind }
 
 let page x = x.Anchor.page
 
 let from_identifier ~stop_before = function
   | #Path.source as p when not stop_before ->
-    Ok (from_path @@ Path.from_identifier p)
-  | p ->
-    Anchor.from_identifier p
+      Ok (from_path @@ Path.from_identifier p)
+  | p -> Anchor.from_identifier p
 
 let from_identifier_exn ~stop_before id =
   match from_identifier ~stop_before id with
@@ -289,7 +282,6 @@ let kind id =
   match Anchor.from_identifier id with
   | Error e -> failwith (Error.to_string e)
   | Ok { kind; _ } -> kind
-
 
 (* module Of_path = struct
  *   let rec to_html : stop_before:bool -> Path.t -> _ =
@@ -316,57 +308,56 @@ let kind id =
  *         end
  * end *)
 
-
-  (* module Of_fragment = struct
-   *   let dot prefix suffix =
-   *     match prefix with
-   *     | "" -> suffix
-   *     | _  -> prefix ^ "." ^ suffix
-   *
-   *   let rec render_raw : Fragment.t -> string =
-   *     fun fragment ->
-   *       match fragment with
-   *       | `Resolved rr -> render_resolved rr
-   *       | `Dot (prefix, suffix) -> dot (render_raw (prefix :> Fragment.t)) suffix
-   *
-   *   and render_resolved : Fragment.Resolved.t -> string =
-   *     let open Fragment.Resolved in
-   *     fun fragment ->
-   *       match fragment with
-   *       | `Root -> ""
-   *       | `Subst (_, rr) -> render_resolved (rr :> t)
-   *       | `SubstAlias (_, rr) -> render_resolved (rr :> t)
-   *       | `Module (rr, s) -> dot (render_resolved (rr :> t)) (ModuleName.to_string s)
-   *       | `Type (rr, s) -> dot (render_resolved (rr :> t)) (TypeName.to_string s)
-   *       | `Class (rr, s) -> dot (render_resolved ( rr :> t)) (ClassName.to_string s)
-   *       | `ClassType (rr, s) -> dot (render_resolved (rr :> t)) (ClassTypeName.to_string s)
-   *
-   *   let rec to_html : stop_before:bool ->
-   *     Identifier.Signature.t -> Fragment.t -> _ =
-   *     fun ~stop_before id fragment ->
-   *       let open Fragment in
-   *       match fragment with
-   *       | `Resolved `Root ->
-   *         begin match Id.href ~stop_before:true (id :> Identifier.t) with
-   *         | href ->
-   *           [Html.a ~a:[Html.a_href href] [Html.txt (Identifier.name id)]]
-   *         | exception Id.Not_linkable -> [ Html.txt (Identifier.name id) ]
-   *         | exception exn ->
-   *           Printf.eprintf "[FRAG] Id.href failed: %S\n%!" (Printexc.to_string exn);
-   *           [ Html.txt (Identifier.name id) ]
-   *         end
-   *       | `Resolved rr ->
-   *         let id = Resolved.identifier id (rr :> Resolved.t) in
-   *         let txt = render_resolved rr in
-   *         begin match Id.href ~stop_before id with
-   *         | href ->
-   *           [ Html.a ~a:[ Html.a_href href ] [ Html.txt txt ] ]
-   *         | exception Id.Not_linkable -> [ Html.txt txt ]
-   *         | exception exn ->
-   *           Printf.eprintf "[FRAG] Id.href failed: %S\n%!" (Printexc.to_string exn);
-   *           [ Html.txt txt ]
-   *         end
-   *       | `Dot (prefix, suffix) ->
-   *         let link = to_html ~stop_before:true id (prefix :> Fragment.t) in
-   *         link @ [ Html.txt ("." ^ suffix) ]
-   * end *)
+(* module Of_fragment = struct
+ *   let dot prefix suffix =
+ *     match prefix with
+ *     | "" -> suffix
+ *     | _  -> prefix ^ "." ^ suffix
+ *
+ *   let rec render_raw : Fragment.t -> string =
+ *     fun fragment ->
+ *       match fragment with
+ *       | `Resolved rr -> render_resolved rr
+ *       | `Dot (prefix, suffix) -> dot (render_raw (prefix :> Fragment.t)) suffix
+ *
+ *   and render_resolved : Fragment.Resolved.t -> string =
+ *     let open Fragment.Resolved in
+ *     fun fragment ->
+ *       match fragment with
+ *       | `Root -> ""
+ *       | `Subst (_, rr) -> render_resolved (rr :> t)
+ *       | `SubstAlias (_, rr) -> render_resolved (rr :> t)
+ *       | `Module (rr, s) -> dot (render_resolved (rr :> t)) (ModuleName.to_string s)
+ *       | `Type (rr, s) -> dot (render_resolved (rr :> t)) (TypeName.to_string s)
+ *       | `Class (rr, s) -> dot (render_resolved ( rr :> t)) (ClassName.to_string s)
+ *       | `ClassType (rr, s) -> dot (render_resolved (rr :> t)) (ClassTypeName.to_string s)
+ *
+ *   let rec to_html : stop_before:bool ->
+ *     Identifier.Signature.t -> Fragment.t -> _ =
+ *     fun ~stop_before id fragment ->
+ *       let open Fragment in
+ *       match fragment with
+ *       | `Resolved `Root ->
+ *         begin match Id.href ~stop_before:true (id :> Identifier.t) with
+ *         | href ->
+ *           [Html.a ~a:[Html.a_href href] [Html.txt (Identifier.name id)]]
+ *         | exception Id.Not_linkable -> [ Html.txt (Identifier.name id) ]
+ *         | exception exn ->
+ *           Printf.eprintf "[FRAG] Id.href failed: %S\n%!" (Printexc.to_string exn);
+ *           [ Html.txt (Identifier.name id) ]
+ *         end
+ *       | `Resolved rr ->
+ *         let id = Resolved.identifier id (rr :> Resolved.t) in
+ *         let txt = render_resolved rr in
+ *         begin match Id.href ~stop_before id with
+ *         | href ->
+ *           [ Html.a ~a:[ Html.a_href href ] [ Html.txt txt ] ]
+ *         | exception Id.Not_linkable -> [ Html.txt txt ]
+ *         | exception exn ->
+ *           Printf.eprintf "[FRAG] Id.href failed: %S\n%!" (Printexc.to_string exn);
+ *           [ Html.txt txt ]
+ *         end
+ *       | `Dot (prefix, suffix) ->
+ *         let link = to_html ~stop_before:true id (prefix :> Fragment.t) in
+ *         link @ [ Html.txt ("." ^ suffix) ]
+ * end *)

--- a/src/document/url.mli
+++ b/src/document/url.mli
@@ -1,9 +1,7 @@
 open Result
-
 open Odoc_model.Paths
 
 val functor_arg_pos : Identifier.FunctorParameter.t -> int
-
 
 module Error : sig
   type nonrec t =
@@ -15,44 +13,33 @@ module Error : sig
   val to_string : t -> string
 end
 
-
 module Path : sig
+  type t = { kind : string; parent : t option; name : string }
 
-  type t = {
-    kind : string;
-    parent : t option;
-    name : string;
-  }
+  type source =
+    [ Identifier.Page.t | Identifier.Signature.t | Identifier.ClassSignature.t ]
 
-  type source = [
-    | Identifier.Page.t
-    | Identifier.Signature.t
-    | Identifier.ClassSignature.t
-  ]
-
-  val from_identifier : [< source] -> t
+  val from_identifier : [< source ] -> t
 
   val last : t -> string
 end
 
 module Anchor : sig
-
   type t = {
-    page : Path.t ;
+    page : Path.t;
     anchor : string;
-    (** Anchor in {!field-page} where the element is attached *)
-
+        (** Anchor in {!field-page} where the element is attached *)
     kind : string;
-    (** What kind of element the path points to.
+        (** What kind of element the path points to.
         e.g. "module", "module-type", "exception", ... *)
   }
 
   val from_identifier : Identifier.t -> (t, Error.t) result
 
-  val polymorphic_variant
-    : type_ident:Identifier.t
-    -> Odoc_model.Lang.TypeExpr.Polymorphic_variant.element
-    -> t
+  val polymorphic_variant :
+    type_ident:Identifier.t ->
+    Odoc_model.Lang.TypeExpr.Polymorphic_variant.element ->
+    t
 end
 
 type t = Anchor.t
@@ -60,6 +47,7 @@ type t = Anchor.t
 val from_path : Path.t -> t
 
 val from_identifier : stop_before:bool -> Identifier.t -> (t, Error.t) result
+
 val from_identifier_exn : stop_before:bool -> Identifier.t -> t
 
 val kind : Identifier.t -> string

--- a/src/document/utils.ml
+++ b/src/document/utils.ml
@@ -1,16 +1,12 @@
-let option_of_result = function
-  | Result.Ok x -> Some x
-  | Result.Error _ -> None
+let option_of_result = function Result.Ok x -> Some x | Result.Error _ -> None
 
 let rec flatmap ?sep ~f = function
   | [] -> []
-  | [x] -> f x
-  | x :: xs ->
-    let hd = f x in
-    let tl = flatmap ?sep ~f xs in
-    match sep with
-    | None -> hd @ tl
-    | Some sep -> hd @ sep @ tl
+  | [ x ] -> f x
+  | x :: xs -> (
+      let hd = f x in
+      let tl = flatmap ?sep ~f xs in
+      match sep with None -> hd @ tl | Some sep -> hd @ sep @ tl )
 
 let rec skip_until ~p = function
   | [] -> []

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -15,142 +15,135 @@
  *)
 
 open Odoc_document.Types
-
 module Html = Tyxml.Html
 module Doctree = Odoc_document.Doctree
 
 type any = Html_types.flow5
+
 type item = Html_types.flow5_without_header_footer
+
 type flow = Html_types.flow5_without_sectioning_heading_header_footer
+
 type phrasing = Html_types.phrasing
+
 type non_link_phrasing = Html_types.phrasing_without_interactive
 
 let mk_anchor_link id =
-  [ Html.a ~a:[Html.a_href ("#" ^ id); Html.a_class ["anchor"]] [] ]
-let mk_anchor anchor = match anchor with
-  | None -> [], []
-  | Some {Odoc_document.Url.Anchor. anchor ; _ } ->
-    let link = mk_anchor_link anchor in
-    let attrib = [ Html.a_id anchor; Html.a_class ["anchored"] ] in
-    attrib, link
+  [ Html.a ~a:[ Html.a_href ("#" ^ id); Html.a_class [ "anchor" ] ] [] ]
 
-let class_ (l : Class.t) =
-  if l = [] then [] else [Html.a_class l]
+let mk_anchor anchor =
+  match anchor with
+  | None -> ([], [])
+  | Some { Odoc_document.Url.Anchor.anchor; _ } ->
+      let link = mk_anchor_link anchor in
+      let attrib = [ Html.a_id anchor; Html.a_class [ "anchored" ] ] in
+      (attrib, link)
+
+let class_ (l : Class.t) = if l = [] then [] else [ Html.a_class l ]
 
 and raw_markup (t : Raw_markup.t) =
   let target, content = t in
   match Odoc_compat.String.lowercase_ascii target with
   | "html" ->
-    (* This is OK because we output *textual* HTML. 
-       In theory, we should try to parse the HTML with lambdasoup and rebuild
-       the HTML tree from there.
-    *)
-    [Html.Unsafe.data content]
+      (* This is OK because we output *textual* HTML.
+         In theory, we should try to parse the HTML with lambdasoup and rebuild
+         the HTML tree from there.
+      *)
+      [ Html.Unsafe.data content ]
   | _ -> []
 
 and source k ?a (t : Source.t) =
-  let rec token (x : Source.token) = match x with
+  let rec token (x : Source.token) =
+    match x with
     | Elt i -> k i
-    | Tag (None, l) -> [Html.span (tokens l)]
-    | Tag (Some s, l) -> [Html.span ~a:[Html.a_class [s]] (tokens l)]
-  and tokens t = Utils.list_concat_map t ~f:token
-  in
+    | Tag (None, l) -> [ Html.span (tokens l) ]
+    | Tag (Some s, l) -> [ Html.span ~a:[ Html.a_class [ s ] ] (tokens l) ]
+  and tokens t = Utils.list_concat_map t ~f:token in
   Utils.optional_elt Html.code ?a (tokens t)
 
-and styled style ~emph_level = match style with
+and styled style ~emph_level =
+  match style with
   | `Emphasis ->
-    let a = if emph_level mod 2 = 0 then [] else [Html.a_class ["odd"]] in
-    emph_level+1, Html.em ~a
-  | `Bold -> emph_level, Html.b ~a:[]
-  | `Italic -> emph_level, Html.i ~a:[]
-  | `Superscript -> emph_level, Html.sup ~a:[]
-  | `Subscript -> emph_level, Html.sub ~a:[]
+      let a = if emph_level mod 2 = 0 then [] else [ Html.a_class [ "odd" ] ] in
+      (emph_level + 1, Html.em ~a)
+  | `Bold -> (emph_level, Html.b ~a:[])
+  | `Italic -> (emph_level, Html.i ~a:[])
+  | `Superscript -> (emph_level, Html.sup ~a:[])
+  | `Subscript -> (emph_level, Html.sub ~a:[])
 
-let rec internallink
-    ~emph_level ~resolve
-    ?(a=[])
-    (t : InternalLink.t) = match t with
+let rec internallink ~emph_level ~resolve ?(a = []) (t : InternalLink.t) =
+  match t with
   | Resolved (uri, content) ->
-    let href = Link.href ~resolve uri in
-    let a = (a :> Html_types.a_attrib Html.attrib list) in
-    let elt = Html.a ~a:(Html.a_href href :: a)
-      (inline_nolink ~emph_level content) in
-    let elt = (elt :> phrasing Html.elt) in
-    [elt]
+      let href = Link.href ~resolve uri in
+      let a = (a :> Html_types.a_attrib Html.attrib list) in
+      let elt =
+        Html.a ~a:(Html.a_href href :: a) (inline_nolink ~emph_level content)
+      in
+      let elt = (elt :> phrasing Html.elt) in
+      [ elt ]
   | Unresolved content ->
-    (* let title =
-     *   Html.a_title (Printf.sprintf "unresolved reference to %S"
-     *       (ref_to_string ref)
-     * in *)
-    let a = Html.a_class ["xref-unresolved"] :: a in
-    let elt = Html.span ~a (inline ~emph_level ~resolve content) in
-    let elt = (elt :> phrasing Html.elt) in
-    [elt]
+      (* let title =
+       *   Html.a_title (Printf.sprintf "unresolved reference to %S"
+       *       (ref_to_string ref)
+       * in *)
+      let a = Html.a_class [ "xref-unresolved" ] :: a in
+      let elt = Html.span ~a (inline ~emph_level ~resolve content) in
+      let elt = (elt :> phrasing Html.elt) in
+      [ elt ]
 
-and internallink_nolink
-    ~emph_level
-    ~(a: Html_types.span_attrib Html.attrib list)
-    (t : InternalLink.t) = match t with
-  | Resolved (_, content)
-  | Unresolved content ->
-    [Html.span ~a (inline_nolink ~emph_level content)]
+and internallink_nolink ~emph_level
+    ~(a : Html_types.span_attrib Html.attrib list) (t : InternalLink.t) =
+  match t with
+  | Resolved (_, content) | Unresolved content ->
+      [ Html.span ~a (inline_nolink ~emph_level content) ]
 
-and inline
-    ?(emph_level=0) ~resolve (l : Inline.t) : phrasing Html.elt list =
+and inline ?(emph_level = 0) ~resolve (l : Inline.t) : phrasing Html.elt list =
   let one (t : Inline.one) =
     let a = class_ t.attr in
     match t.desc with
     | Text s ->
-      if a = [] then [Html.txt s] else [Html.span ~a [Html.txt s]]
+        if a = [] then [ Html.txt s ] else [ Html.span ~a [ Html.txt s ] ]
     | Entity s ->
-      if a = [] then [Html.entity s] else [Html.span ~a [Html.entity s]]
-    | Linebreak ->
-      [Html.br ~a ()]
+        if a = [] then [ Html.entity s ] else [ Html.span ~a [ Html.entity s ] ]
+    | Linebreak -> [ Html.br ~a () ]
     | Styled (style, c) ->
-      let emph_level, app_style = styled style ~emph_level in
-      [app_style @@ inline ~emph_level ~resolve c]
+        let emph_level, app_style = styled style ~emph_level in
+        [ app_style @@ inline ~emph_level ~resolve c ]
     | Link (href, c) ->
-      let a = (a :> Html_types.a_attrib Html.attrib list) in
-      let content = inline_nolink ~emph_level c in
-      [Html.a ~a:(Html.a_href href :: a) content]
-    | InternalLink c ->
-      internallink ~emph_level ~resolve ~a c
-    | Source c ->
-      source (inline ~emph_level ~resolve) ~a c
-    | Raw_markup r ->
-      raw_markup r
+        let a = (a :> Html_types.a_attrib Html.attrib list) in
+        let content = inline_nolink ~emph_level c in
+        [ Html.a ~a:(Html.a_href href :: a) content ]
+    | InternalLink c -> internallink ~emph_level ~resolve ~a c
+    | Source c -> source (inline ~emph_level ~resolve) ~a c
+    | Raw_markup r -> raw_markup r
   in
   Utils.list_concat_map ~f:one l
 
-and inline_nolink
-    ?(emph_level=0) (l : Inline.t) : non_link_phrasing Html.elt list =
+and inline_nolink ?(emph_level = 0) (l : Inline.t) :
+    non_link_phrasing Html.elt list =
   let one (t : Inline.one) =
     let a = class_ t.attr in
     match t.desc with
     | Text s ->
-      if a = [] then [Html.txt s] else [Html.span ~a [Html.txt s]]
+        if a = [] then [ Html.txt s ] else [ Html.span ~a [ Html.txt s ] ]
     | Entity s ->
-      if a = [] then [Html.entity s] else [Html.span ~a [Html.entity s]]
-    | Linebreak ->
-      [Html.br ~a ()]
+        if a = [] then [ Html.entity s ] else [ Html.span ~a [ Html.entity s ] ]
+    | Linebreak -> [ Html.br ~a () ]
     | Styled (style, c) ->
-      let emph_level, app_style = styled style ~emph_level in
-      [ app_style @@ inline_nolink ~emph_level c]
-    | Link (_, c) ->
-      inline_nolink ~emph_level c
-    | InternalLink c ->
-      internallink_nolink ~emph_level ~a c
-    | Source c ->
-      source (inline_nolink ~emph_level) ~a c
-    | Raw_markup r ->
-      raw_markup r
+        let emph_level, app_style = styled style ~emph_level in
+        [ app_style @@ inline_nolink ~emph_level c ]
+    | Link (_, c) -> inline_nolink ~emph_level c
+    | InternalLink c -> internallink_nolink ~emph_level ~a c
+    | Source c -> source (inline_nolink ~emph_level) ~a c
+    | Raw_markup r -> raw_markup r
   in
   Utils.list_concat_map ~f:one l
 
 let heading ~resolve (h : Heading.t) =
-  let a, anchor = match h.label with
-    | Some id -> [Html.a_id id], mk_anchor_link id
-    | None -> [], []
+  let a, anchor =
+    match h.label with
+    | Some id -> ([ Html.a_id id ], mk_anchor_link id)
+    | None -> ([], [])
   in
   let content = inline ~resolve h.title in
   let mk =
@@ -164,38 +157,32 @@ let heading ~resolve (h : Heading.t) =
   in
   mk ~a (anchor @ content)
 
-let rec block ~resolve (l: Block.t) : flow Html.elt list =
-  let as_flow x =
-    (x : phrasing Html.elt list :> flow Html.elt list)
-  in
+let rec block ~resolve (l : Block.t) : flow Html.elt list =
+  let as_flow x = (x : phrasing Html.elt list :> flow Html.elt list) in
   let one (t : Block.one) =
     let a = class_ t.attr in
     match t.desc with
     | Inline i ->
-      if a = [] then
-        as_flow @@ inline ~resolve i
-      else
-        [Html.span ~a (inline ~resolve i)]
-    | Paragraph i ->
-      [Html.p ~a (inline ~resolve i)]
+        if a = [] then as_flow @@ inline ~resolve i
+        else [ Html.span ~a (inline ~resolve i) ]
+    | Paragraph i -> [ Html.p ~a (inline ~resolve i) ]
     | List (typ, l) ->
-      let mk = match typ with Ordered -> Html.ol | Unordered -> Html.ul in
-      [mk ~a (List.map (fun x -> Html.li (block ~resolve x)) l)]
+        let mk = match typ with Ordered -> Html.ol | Unordered -> Html.ul in
+        [ mk ~a (List.map (fun x -> Html.li (block ~resolve x)) l) ]
     | Description l ->
-      [Html.dl ~a (Utils.list_concat_map l ~f:(fun (i,b) ->
-          let i =
-            (inline ~resolve i
-             : phrasing Html.elt list
-              :> flow Html.elt list)
-          in
-          [Html.dt i ; Html.dd (block ~resolve b) ]
-        ))]
-    | Raw_markup r ->
-      raw_markup r
-    | Verbatim s ->
-      [Html.pre ~a [Html.txt s]]
-    | Source c ->
-      [Html.pre ~a (source (inline ~resolve) c)]
+        [
+          Html.dl ~a
+            (Utils.list_concat_map l ~f:(fun (i, b) ->
+                 let i =
+                   ( inline ~resolve i
+                     : phrasing Html.elt list
+                     :> flow Html.elt list )
+                 in
+                 [ Html.dt i; Html.dd (block ~resolve b) ]));
+        ]
+    | Raw_markup r -> raw_markup r
+    | Verbatim s -> [ Html.pre ~a [ Html.txt s ] ]
+    | Source c -> [ Html.pre ~a (source (inline ~resolve) c) ]
   in
   Utils.list_concat_map l ~f:one
 
@@ -203,73 +190,68 @@ let rec block ~resolve (l: Block.t) : flow Html.elt list =
    See https://github.com/ocsigen/tyxml/pull/265 for details
    Can be replaced by a simple type coercion once this is fixed
 *)
-let flow_to_item
-  : flow Html.elt list -> item Html.elt list
-  = fun x -> Html.totl @@ Html.toeltl x
+let flow_to_item : flow Html.elt list -> item Html.elt list =
+ fun x -> Html.totl @@ Html.toeltl x
 
-let div
-  : ([< Html_types.div_attrib], [< item], [> Html_types.div]) Html.star
-  = Html.Unsafe.node "div"
+let div : ([< Html_types.div_attrib ], [< item ], [> Html_types.div ]) Html.star
+    =
+  Html.Unsafe.node "div"
 
 let rec is_only_text l =
   let is_text : Item.t -> _ = function
     | Heading _ | Text _ -> true
-    | Declaration _
-      -> false
-    | Include { content = { content; _ }; _ }
-      -> is_only_text content
+    | Declaration _ -> false
+    | Include { content = { content; _ }; _ } -> is_only_text content
   in
   List.for_all is_text l
 
-let class_of_kind kind = match kind with
-  | Some spec -> class_ ["spec"; spec]
-  | None -> []
+let class_of_kind kind =
+  match kind with Some spec -> class_ [ "spec"; spec ] | None -> []
 
 let rec documentedSrc ~resolve (t : DocumentedSrc.t) : item Html.elt list =
   let open DocumentedSrc in
   let take_code l =
     Doctree.Take.until l ~classify:(function
       | Code code -> Accum code
-      | Alternative (Expansion {summary; _}) -> Accum summary
-      | _ -> Stop_and_keep
-    )
+      | Alternative (Expansion { summary; _ }) -> Accum summary
+      | _ -> Stop_and_keep)
   in
   let take_descr l =
     Doctree.Take.until l ~classify:(function
-      | Documented { attrs; anchor; code; doc }  ->
-        Accum [{DocumentedSrc. attrs ; anchor ; code = `D code; doc }]
+      | Documented { attrs; anchor; code; doc } ->
+          Accum [ { DocumentedSrc.attrs; anchor; code = `D code; doc } ]
       | Nested { attrs; anchor; code; doc } ->
-        Accum [{DocumentedSrc. attrs ; anchor ; code = `N code; doc }]
-      | _ -> Stop_and_keep
-    )
+          Accum [ { DocumentedSrc.attrs; anchor; code = `N code; doc } ]
+      | _ -> Stop_and_keep)
   in
-  let rec to_html t : item Html.elt list = match t with
+  let rec to_html t : item Html.elt list =
+    match t with
     | [] -> []
     | (Code _ | Alternative _) :: _ ->
-      let code, _, rest = take_code t in
-      source (inline ~resolve) code
-      @ to_html rest
-    | Subpage subp :: _ ->
-      subpage ~resolve subp
+        let code, _, rest = take_code t in
+        source (inline ~resolve) code @ to_html rest
+    | Subpage subp :: _ -> subpage ~resolve subp
     | (Documented _ | Nested _) :: _ ->
-      let l, _, rest = take_descr t in
-      let one {DocumentedSrc. attrs ; anchor ; code ; doc } =
-        let content = match code with
-          | `D code -> (inline ~resolve code :> item Html.elt list)
-          | `N n -> to_html n
+        let l, _, rest = take_descr t in
+        let one { DocumentedSrc.attrs; anchor; code; doc } =
+          let content =
+            match code with
+            | `D code -> (inline ~resolve code :> item Html.elt list)
+            | `N n -> to_html n
+          in
+          let doc =
+            Utils.optional_elt Html.td
+              ~a:(class_ [ "doc" ])
+              (block ~resolve doc)
+          in
+          let a, link = mk_anchor anchor in
+          let content =
+            let c = link @ content in
+            Html.td ~a:(class_ attrs) (c :> any Html.elt list)
+          in
+          Html.tr ~a (content :: doc)
         in
-        let doc =
-          Utils.optional_elt
-            Html.td ~a:(class_ ["doc"]) (block ~resolve doc)
-        in
-        let a, link = mk_anchor anchor in
-        let content =
-          let c = link @ content in
-          Html.td ~a:(class_ attrs) (c :> any Html.elt list)
-        in 
-        Html.tr ~a (content :: doc)
-      in
-      Html.table (List.map one l) :: to_html rest
+        Html.table (List.map one l) :: to_html rest
   in
   to_html t
 
@@ -277,94 +259,90 @@ and subpage ~resolve (subp : Subpage.t) : item Html.elt list =
   items ~resolve subp.content.items
 
 and items ~resolve l : item Html.elt list =
-  let rec walk_items
-      ~only_text acc (t : Item.t list) : item Html.elt list =
+  let rec walk_items ~only_text acc (t : Item.t list) : item Html.elt list =
     let continue_with rest elts =
-      (walk_items[@tailcall]) ~only_text (List.rev_append elts acc) rest
+      (walk_items [@tailcall]) ~only_text (List.rev_append elts acc) rest
     in
     match t with
     | [] -> List.rev acc
     | Text _ :: _ as t ->
-      let text, _, rest = Doctree.Take.until t ~classify:(function
-        | Item.Text text -> Accum text
-        | _ -> Stop_and_keep)
-      in
-      let content = flow_to_item @@ block ~resolve text in
-      let elts = if only_text then
-          content
-        else
-          [Html.aside (content :> any Html.elt list)]
-      in
-      elts
-      |> (continue_with[@tailcall]) rest
-    | Heading h :: rest ->
-      [heading ~resolve h]
-      |> (continue_with[@tailcall]) rest
-    | Include
-        { kind; anchor; doc ; content = { summary; status; content } }
-      :: rest ->
-      let included_html = (items content :> any Html.elt list) in
-      let docs = (block ~resolve doc :> any Html.elt list) in
-      let summary = source (inline ~resolve) summary in
-      let content : any Html.elt list =
-        let mk b =
-          let a = if b then [Html.a_open ()] else [] in
-          [Html.details ~a
-              (Html.summary [Html.span ~a:[Html.a_class ["def"]] summary])
-              included_html]
+        let text, _, rest =
+          Doctree.Take.until t ~classify:(function
+            | Item.Text text -> Accum text
+            | _ -> Stop_and_keep)
         in
-        match status with
-        | `Inline -> included_html
-        | `Closed -> mk false
-        | `Open -> mk true
-        | `Default -> mk !Tree.open_details
-      in
-      let anchor_attrib, anchor_link = mk_anchor anchor in
-      let a = class_of_kind kind @ anchor_attrib in
-      (* TODO : Why double div ??? *)
-      [Html.div [Html.div ~a
-            (anchor_link @ [Html.div ~a:[Html.a_class ["doc"]]
-                (docs @ content)])]]
-      |> (continue_with[@tailcall]) rest
-
-    | Declaration {Item. kind; anchor ; content ; doc} :: rest ->
-      let anchor_attrib, anchor_link = mk_anchor anchor in
-      let a = class_of_kind kind @ anchor_attrib in
-      let content = anchor_link @ documentedSrc ~resolve content in
-      let elts = match doc with
-        | [] ->
-          [div ~a content]
-        | docs ->
-          [div [
-              div ~a content;
-              div (flow_to_item @@ block ~resolve docs);
-            ]]
-      in
-      (continue_with[@tailcall]) rest elts
-
+        let content = flow_to_item @@ block ~resolve text in
+        let elts =
+          if only_text then content
+          else [ Html.aside (content :> any Html.elt list) ]
+        in
+        elts |> (continue_with [@tailcall]) rest
+    | Heading h :: rest ->
+        [ heading ~resolve h ] |> (continue_with [@tailcall]) rest
+    | Include { kind; anchor; doc; content = { summary; status; content } }
+      :: rest ->
+        let included_html = (items content :> any Html.elt list) in
+        let docs = (block ~resolve doc :> any Html.elt list) in
+        let summary = source (inline ~resolve) summary in
+        let content : any Html.elt list =
+          let mk b =
+            let a = if b then [ Html.a_open () ] else [] in
+            [
+              Html.details ~a
+                (Html.summary
+                   [ Html.span ~a:[ Html.a_class [ "def" ] ] summary ])
+                included_html;
+            ]
+          in
+          match status with
+          | `Inline -> included_html
+          | `Closed -> mk false
+          | `Open -> mk true
+          | `Default -> mk !Tree.open_details
+        in
+        let anchor_attrib, anchor_link = mk_anchor anchor in
+        let a = class_of_kind kind @ anchor_attrib in
+        (* TODO : Why double div ??? *)
+        [
+          Html.div
+            [
+              Html.div ~a
+                ( anchor_link
+                @ [ Html.div ~a:[ Html.a_class [ "doc" ] ] (docs @ content) ] );
+            ];
+        ]
+        |> (continue_with [@tailcall]) rest
+    | Declaration { Item.kind; anchor; content; doc } :: rest ->
+        let anchor_attrib, anchor_link = mk_anchor anchor in
+        let a = class_of_kind kind @ anchor_attrib in
+        let content = anchor_link @ documentedSrc ~resolve content in
+        let elts =
+          match doc with
+          | [] -> [ div ~a content ]
+          | docs ->
+              [
+                div
+                  [ div ~a content; div (flow_to_item @@ block ~resolve docs) ];
+              ]
+        in
+        (continue_with [@tailcall]) rest elts
   and items l = walk_items ~only_text:(is_only_text l) [] l in
   items l
-
 
 module Toc = struct
   open Odoc_document.Doctree
 
   let render_toc ~resolve (toc : Toc.t) =
-    let rec section {Toc. url ; text ; children } =
+    let rec section { Toc.url; text; children } =
       let text = inline_nolink text in
       let text =
-        (text
-         : non_link_phrasing Html.elt list
-          :> (Html_types.flow5_without_interactive Html.elt) list)
+        ( text
+          : non_link_phrasing Html.elt list
+          :> Html_types.flow5_without_interactive Html.elt list )
       in
       let href = Link.href ~resolve url in
-      let link =
-        Html.a
-          ~a:[Html.a_href href] text
-      in
-      match children with
-      | [] -> [link]
-      | _ -> [link; sections children]
+      let link = Html.a ~a:[ Html.a_href href ] text in
+      match children with [] -> [ link ] | _ -> [ link; sections children ]
     and sections the_sections =
       the_sections
       |> List.map (fun the_section -> Html.li (section the_section))
@@ -372,42 +350,39 @@ module Toc = struct
     in
     match toc with
     | [] -> []
-    | _ -> [Html.nav ~a:[Html.a_class ["toc"]] [sections toc]]
+    | _ -> [ Html.nav ~a:[ Html.a_class [ "toc" ] ] [ sections toc ] ]
 
   let on_sub : Subpage.status -> bool = function
     | `Closed | `Open | `Default -> false
     | `Inline -> true
 
-  let from_items ~resolve ~path i = render_toc ~resolve @@ Toc.compute path ~on_sub i
+  let from_items ~resolve ~path i =
+    render_toc ~resolve @@ Toc.compute path ~on_sub i
 end
 
 module Page = struct
-
   let on_sub = function
     | `Page _ -> None
-    | `Include x -> begin match x.Include.status with
-      | `Closed | `Open | `Default -> None
-      | `Inline -> Some 0
-    end
+    | `Include x -> (
+        match x.Include.status with
+        | `Closed | `Open | `Default -> None
+        | `Inline -> Some 0 )
 
-  let rec include_ ?theme_uri {Subpage. content ; _} =
-    [page ?theme_uri content]
+  let rec include_ ?theme_uri { Subpage.content; _ } =
+    [ page ?theme_uri content ]
 
-  and subpages  ?theme_uri i =
+  and subpages ?theme_uri i =
     Utils.list_concat_map ~f:(include_ ?theme_uri) @@ Doctree.Subpages.compute i
 
-  and page ?theme_uri ({Page. title; header; items = i; url } as p) =
+  and page ?theme_uri ({ Page.title; header; items = i; url } as p) =
     let resolve = Link.Current url in
     let i = Doctree.Shift.compute ~on_sub i in
     let toc = Toc.from_items ~resolve ~path:url i in
     let subpages = subpages ?theme_uri p in
     let header = items ~resolve header in
     let content = (items ~resolve i :> any Html.elt list) in
-    let page =
-      Tree.make ?theme_uri ~header ~toc ~url title content subpages
-    in
+    let page = Tree.make ?theme_uri ~header ~toc ~url title content subpages in
     page
-
 end
 
 let render ?theme_uri page = Page.page ?theme_uri page

--- a/src/html/generator.mli
+++ b/src/html/generator.mli
@@ -1,11 +1,8 @@
 open Odoc_document
 
-val render :
-  ?theme_uri:Tree.uri ->
-  Types.Page.t -> Renderer.page
+val render : ?theme_uri:Tree.uri -> Types.Page.t -> Renderer.page
 
 val doc :
   xref_base_uri:string ->
   Types.Block.t ->
-  Html_types.flow5_without_sectioning_heading_header_footer
-    Tyxml.Html.elt list
+  Html_types.flow5_without_sectioning_heading_header_footer Tyxml.Html.elt list

--- a/src/html/link.ml
+++ b/src/html/link.ml
@@ -2,11 +2,10 @@ module Url = Odoc_document.Url
 
 (* Translation from Url.Path *)
 module Path = struct
-
   let to_list url =
-    let rec loop acc {Url.Path. parent ; name ; kind } =
+    let rec loop acc { Url.Path.parent; name; kind } =
       match parent with
-      | None -> (kind,name) :: acc
+      | None -> (kind, name) :: acc
       | Some p -> loop ((kind, name) :: acc) p
     in
     loop [] url
@@ -18,21 +17,19 @@ module Path = struct
     | "module" | "container-page" -> name
     | _ -> Printf.sprintf "%s-%s" kind name
 
-  let is_leaf_page url = (url.Url.Path.kind = "page")
+  let is_leaf_page url = url.Url.Path.kind = "page"
 
-  let rec get_dir {Url.Path. parent ; name ; kind} =
-    let ppath = match parent with | Some p -> get_dir p | None -> [] in
+  let rec get_dir { Url.Path.parent; name; kind } =
+    let ppath = match parent with Some p -> get_dir p | None -> [] in
     match kind with
     | "page" -> ppath
-    | _ -> ppath @ [segment_to_string (kind, name)]
+    | _ -> ppath @ [ segment_to_string (kind, name) ]
 
-  let get_file : Url.Path.t -> string = fun t ->
-    match t.kind with
-    | "page" -> t.name ^ ".html"
-    | _ -> "index.html"
+  let get_file : Url.Path.t -> string =
+   fun t -> match t.kind with "page" -> t.name ^ ".html" | _ -> "index.html"
 
-  let for_linking : Url.Path.t -> string list = fun url ->
-    get_dir url @ [get_file url]
+  let for_linking : Url.Path.t -> string list =
+   fun url -> get_dir url @ [ get_file url ]
 
   let as_filename (url : Url.Path.t) =
     Fpath.(v @@ String.concat Fpath.dir_sep @@ for_linking url)
@@ -40,61 +37,55 @@ end
 
 let semantic_uris = ref false
 
-type resolve =
-  | Current of Url.Path.t
-  | Base of string
+type resolve = Current of Url.Path.t | Base of string
 
 let rec drop_shared_prefix l1 l2 =
-  match l1, l2 with
-  | l1 :: l1s, l2 :: l2s when l1 = l2 ->
-    drop_shared_prefix l1s l2s
-  | _, _ -> l1, l2
+  match (l1, l2) with
+  | l1 :: l1s, l2 :: l2s when l1 = l2 -> drop_shared_prefix l1s l2s
+  | _, _ -> (l1, l2)
 
 let href ~resolve t =
-  let { Url.Anchor. page; anchor; _ } = t in
+  let { Url.Anchor.page; anchor; _ } = t in
 
   let target_loc = Path.for_linking page in
 
   (* If xref_base_uri is defined, do not perform relative URI resolution. *)
   match resolve with
-  | Base xref_base_uri ->
-    let page = xref_base_uri ^ (String.concat "/" target_loc) in
-    begin match anchor with
-    | "" -> page
-    | anchor -> page ^ "#" ^ anchor
-    end
-  | Current path ->
-    let current_loc = Path.for_linking path in
+  | Base xref_base_uri -> (
+      let page = xref_base_uri ^ String.concat "/" target_loc in
+      match anchor with "" -> page | anchor -> page ^ "#" ^ anchor )
+  | Current path -> (
+      let current_loc = Path.for_linking path in
 
-    let current_from_common_ancestor, target_from_common_ancestor =
-      drop_shared_prefix current_loc target_loc
-    in
+      let current_from_common_ancestor, target_from_common_ancestor =
+        drop_shared_prefix current_loc target_loc
+      in
 
-    let relative_target =
-      match current_from_common_ancestor with
-      | [] -> (* We're already on the right page *)
-        (* If we're already on the right page, the target from our common
-            ancestor can't be anything other than the empty list *)
-        assert(target_from_common_ancestor = []);
-        []
-      | [_] -> (* We're already in the right dir *)
-        target_from_common_ancestor
-      | l -> (* We need to go up some dirs *)
-        List.map (fun _ -> "..") (List.tl l)
-        @ target_from_common_ancestor
-    in
-    let remove_index_html l =
-      match List.rev l with
-      | "index.html" :: rest -> List.rev ("" :: rest)
-      | _ -> l
-    in
-    let relative_target =
-      if !semantic_uris
-      then remove_index_html relative_target
-      else relative_target
-    in
-    begin match relative_target, anchor with
-    | [], "" -> "#"
-    | page, "" -> String.concat "/" page
-    | page, anchor -> String.concat "/" page ^ "#" ^ anchor
-    end
+      let relative_target =
+        match current_from_common_ancestor with
+        | [] ->
+            (* We're already on the right page *)
+            (* If we're already on the right page, the target from our common
+                ancestor can't be anything other than the empty list *)
+            assert (target_from_common_ancestor = []);
+            []
+        | [ _ ] ->
+            (* We're already in the right dir *)
+            target_from_common_ancestor
+        | l ->
+            (* We need to go up some dirs *)
+            List.map (fun _ -> "..") (List.tl l) @ target_from_common_ancestor
+      in
+      let remove_index_html l =
+        match List.rev l with
+        | "index.html" :: rest -> List.rev ("" :: rest)
+        | _ -> l
+      in
+      let relative_target =
+        if !semantic_uris then remove_index_html relative_target
+        else relative_target
+      in
+      match (relative_target, anchor) with
+      | [], "" -> "#"
+      | page, "" -> String.concat "/" page
+      | page, anchor -> String.concat "/" page ^ "#" ^ anchor )

--- a/src/html/link.mli
+++ b/src/html/link.mli
@@ -5,15 +5,16 @@ module Url = Odoc_document.Url
 val semantic_uris : bool ref
 (** Whether to generate pretty/semantics links or not. *)
 
-type resolve =
-  | Current of Url.Path.t
-  | Base of string
+type resolve = Current of Url.Path.t | Base of string
 
 val href : resolve:resolve -> Url.t -> string
 
 module Path : sig
   val is_leaf_page : Url.Path.t -> bool
+
   val for_printing : Url.Path.t -> string list
+
   val for_linking : Url.Path.t -> string list
+
   val as_filename : Url.Path.t -> Fpath.t
 end

--- a/src/html/odoc_html.ml
+++ b/src/html/odoc_html.ml
@@ -1,4 +1,5 @@
-(** @canonical Odoc_html.Tree *)
 module Tree = Tree
+(** @canonical Odoc_html.Tree *)
+
 module Generator = Generator
 module Link = Link

--- a/src/html/tree.mli
+++ b/src/html/tree.mli
@@ -15,7 +15,6 @@
  *)
 
 open Odoc_document
-
 module Html = Tyxml.Html
 
 (** Supported languages for printing code parts. *)
@@ -23,7 +22,7 @@ module Html = Tyxml.Html
 type uri =
   | Absolute of string
   | Relative of string
-(** The type for absolute and relative URIs. The relative URIs are resolved
+      (** The type for absolute and relative URIs. The relative URIs are resolved
     using the HTML output directory as a target. *)
 
 (** {1 Page creator} *)
@@ -34,8 +33,9 @@ val make :
   header:Html_types.flow5_without_header_footer Html.elt list ->
   toc:Html_types.flow5 Html.elt list ->
   string ->
-  (Html_types.div_content Html.elt) list ->
-  Renderer.page list -> Renderer.page
+  Html_types.div_content Html.elt list ->
+  Renderer.page list ->
+  Renderer.page
 (** [make ?theme_uri (body, children)] calls "the page creator" to turn [body]
     into an [[ `Html ] elt]. If [theme_uri] is provided, it will be used to
     locate the theme files, otherwise the HTML output directory is used. *)

--- a/src/html/utils.ml
+++ b/src/html/utils.ml
@@ -1,18 +1,14 @@
 (* Shared utility functions *)
 
 (* = Option.fold *)
-let fold_option ~none ~some = function
-  | Some x -> some x
-  | None -> none
+let fold_option ~none ~some = function Some x -> some x | None -> none
 
 let rec list_concat_map ?sep ~f = function
   | [] -> []
-  | [x] -> f x
-  | x :: xs ->
-    let hd = f x in
-    let tl = list_concat_map ?sep ~f xs in
-    match sep with
-    | None -> hd @ tl
-    | Some sep -> hd @ sep :: tl
+  | [ x ] -> f x
+  | x :: xs -> (
+      let hd = f x in
+      let tl = list_concat_map ?sep ~f xs in
+      match sep with None -> hd @ tl | Some sep -> hd @ (sep :: tl) )
 
-let optional_elt f ?a = function [] -> [] | l -> [f ?a l]
+let optional_elt f ?a = function [] -> [] | l -> [ f ?a l ]

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -4,41 +4,35 @@ module Doctree = Odoc_document.Doctree
 
 let rec list_concat_map ?sep ~f = function
   | [] -> []
-  | [x] -> f x
-  | x :: xs ->
-    let hd = f x in
-    let tl = list_concat_map ?sep ~f xs in
-    match sep with
-    | None -> hd @ tl
-    | Some sep -> hd @ sep :: tl
+  | [ x ] -> f x
+  | x :: xs -> (
+      let hd = f x in
+      let tl = list_concat_map ?sep ~f xs in
+      match sep with None -> hd @ tl | Some sep -> hd @ (sep :: tl) )
 
 module Link = struct
-
-  let rec flatten_path ppf (x: Odoc_document.Url.Path.t) = match x.parent with
+  let rec flatten_path ppf (x : Odoc_document.Url.Path.t) =
+    match x.parent with
     | Some p -> Fmt.pf ppf "%a-%s-%s" flatten_path p x.kind x.name
     | None -> Fmt.pf ppf "%s-%s" x.kind x.name
 
- let page p =
-   Format.asprintf "%a" flatten_path p
+  let page p = Format.asprintf "%a" flatten_path p
 
+  let label (x : Odoc_document.Url.t) =
+    match x.anchor with
+    | "" -> page x.page
+    | anchor -> Format.asprintf "%a-%s" flatten_path x.page anchor
 
- let label (x:Odoc_document.Url.t) =
-   match x.anchor with
-   | "" -> page x.page
-   | anchor ->
-       Format.asprintf "%a-%s"
-       flatten_path x.page
-       anchor
-
-  let rec is_class_or_module_path (url : Odoc_document.Url.Path.t) = match url.kind with
-    | "module" | "page" | "class" | "container-page" ->
-      begin match url.parent with
-      | None -> true
-      | Some url -> is_class_or_module_path url
-      end
+  let rec is_class_or_module_path (url : Odoc_document.Url.Path.t) =
+    match url.kind with
+    | "module" | "page" | "class" | "container-page" -> (
+        match url.parent with
+        | None -> true
+        | Some url -> is_class_or_module_path url )
     | _ -> false
 
-  let should_inline status url = match status with
+  let should_inline status url =
+    match status with
     | `Inline | `Open -> true
     | `Closed -> false
     | `Default -> not @@ is_class_or_module_path url
@@ -46,21 +40,22 @@ module Link = struct
   let rec dir (url : Odoc_document.Url.Path.t) =
     match url.parent with
     | None -> Fpath.v url.name
-    | Some p ->
-      let pdir = dir p in
-      match url.kind with
-      | "container-page" -> Fpath.(pdir / url.name)
-      | _ -> pdir
+    | Some p -> (
+        let pdir = dir p in
+        match url.kind with
+        | "container-page" -> Fpath.(pdir / url.name)
+        | _ -> pdir )
 
   let file url =
     let rec l (url : Odoc_document.Url.Path.t) acc =
       match url.kind with
       | "container-page" -> acc
-      | _ ->
-        match url.parent with
-        | None -> assert false (* Only container-pages are allowed to have no parent *)
-        | Some p ->
-          l p (url.name :: acc)
+      | _ -> (
+          match url.parent with
+          | None ->
+              assert false
+              (* Only container-pages are allowed to have no parent *)
+          | Some p -> l p (url.name :: acc) )
     in
     String.concat "." (l url [])
 
@@ -68,11 +63,9 @@ module Link = struct
     let dir = dir url in
     let file = file url in
     Format.eprintf "dir=%a file=%s\n%!" Fpath.pp dir file;
-    if file = ""
-    then Fpath.add_ext "tex" dir
+    if file = "" then Fpath.add_ext "tex" dir
     else Fpath.(add_ext "tex" (dir / file))
 end
-
 
 let style = function
   | `Emphasis | `Italic -> Raw.emph
@@ -80,24 +73,26 @@ let style = function
   | `Subscript -> Raw.subscript
   | `Superscript -> Raw.superscript
 
-let  gen_hyperref pp r ppf =
-  match r.target, r.text with
+let gen_hyperref pp r ppf =
+  match (r.target, r.text) with
   | "", None -> ()
-  | "", Some content ->  Raw.inline_code pp ppf content
-  | s, None ->
-    Raw.ref ppf s
+  | "", Some content -> Raw.inline_code pp ppf content
+  | s, None -> Raw.ref ppf s
   | s, Some content ->
       let pp =
-        if r.short then Raw.inline_code pp else
-          fun ppf x -> Fmt.pf ppf "%a[p%a]" (Raw.inline_code pp) x Raw.pageref_star s in
-       Raw.hyperref s pp ppf content
+        if r.short then Raw.inline_code pp
+        else fun ppf x ->
+          Fmt.pf ppf "%a[p%a]" (Raw.inline_code pp) x Raw.pageref_star s
+      in
+      Raw.hyperref s pp ppf content
 
 let label = function
   | None -> []
-  | Some  x (* {Odoc_document.Url.Anchor.anchor ; page;  _ }*) -> [Label (Link.label  x)]
+  | Some x (* {Odoc_document.Url.Anchor.anchor ; page;  _ }*) ->
+      [ Label (Link.label x) ]
 
 let level_macro = function
-  | 0 ->  Raw.section
+  | 0 -> Raw.section
   | 1 -> Raw.subsection
   | 2 -> Raw.subsubsection
   | 3 | _ -> Raw.subsubsection
@@ -106,62 +101,61 @@ let none _ppf () = ()
 
 let list kind pp ppf x =
   let list =
-    match kind with
-    | Block.Ordered -> Raw.enumerate
-    | Unordered -> Raw.itemize in
+    match kind with Block.Ordered -> Raw.enumerate | Unordered -> Raw.itemize
+  in
   let elt ppf = Raw.item pp ppf in
   match x with
   | [] -> (* empty list are not supported *) ()
-  | _ ->
-  list
-    (Fmt.list ~sep:(fun ppf () -> Raw.break ppf Aesthetic) elt)
-    ppf
-    x
+  | _ -> list (Fmt.list ~sep:(fun ppf () -> Raw.break ppf Aesthetic) elt) ppf x
 
-
-let escape_entity  = function
+let escape_entity = function
   | "#45" -> "-"
   | "gt" -> ">"
   | "#8288" -> ""
   | s -> s
 
-
 let filter_map f x =
-  List.rev @@ List.fold_left (fun acc x ->
-    match f x with
-    | Some x -> x :: acc
-    | None -> acc)
-    [] x
+  List.rev
+  @@ List.fold_left
+       (fun acc x -> match f x with Some x -> x :: acc | None -> acc)
+       [] x
 
-let elt_size (x:elt) = match x with
-  | Txt _ | Internal_ref _ | External_ref _ | Label _ | Style _ | Inlined_code _ | Code_fragment _ | Tag _ | Break _ | Ligaturable _ -> Small
-  | List _ | Section _ | Verbatim _ | Raw _ | Code_block _ | Indented _ | Description _-> Large
-  | Table _  -> Huge
+let elt_size (x : elt) =
+  match x with
+  | Txt _ | Internal_ref _ | External_ref _ | Label _ | Style _ | Inlined_code _
+  | Code_fragment _ | Tag _ | Break _ | Ligaturable _ ->
+      Small
+  | List _ | Section _ | Verbatim _ | Raw _ | Code_block _ | Indented _
+  | Description _ ->
+      Large
+  | Table _ -> Huge
 
 let table = function
   | [] -> []
   | a :: _ as m ->
-    let start = List.map (fun _ -> Empty) a in
-    let content_size l = List.fold_left (fun s x -> max s (elt_size x)) Empty l in
-    let row mask l = List.map2 (fun x y -> max x @@ content_size y) mask l in
-    let mask = List.fold_left row start m in
-    let filter_empty = function Empty, _ -> None | (Small | Large | Huge), x -> Some x in
-    let filter_row row = filter_map filter_empty @@ List.combine mask row in
-    let row_size = List.fold_left max Empty mask in
-    [Table { row_size; tbl= List.map filter_row m }]
+      let start = List.map (fun _ -> Empty) a in
+      let content_size l =
+        List.fold_left (fun s x -> max s (elt_size x)) Empty l
+      in
+      let row mask l = List.map2 (fun x y -> max x @@ content_size y) mask l in
+      let mask = List.fold_left row start m in
+      let filter_empty = function
+        | Empty, _ -> None
+        | (Small | Large | Huge), x -> Some x
+      in
+      let filter_row row = filter_map filter_empty @@ List.combine mask row in
+      let row_size = List.fold_left max Empty mask in
+      [ Table { row_size; tbl = List.map filter_row m } ]
 
 let txt ~verbatim ~in_source ws =
-  if verbatim then [Txt ws] else
+  if verbatim then [ Txt ws ]
+  else
     let escaped = List.map (Raw.Escape.text ~code_hyphenation:in_source) ws in
-    match List.filter ( (<>) "" ) escaped with
-    | [] -> []
-    | l -> [ Txt l ]
+    match List.filter (( <> ) "") escaped with [] -> [] | l -> [ Txt l ]
 
 let entity ~in_source ~verbatim x =
-  if in_source && not verbatim then
-    Ligaturable (escape_entity x)
-  else
-    Txt [escape_entity x]
+  if in_source && not verbatim then Ligaturable (escape_entity x)
+  else Txt [ escape_entity x ]
 
 (** Tables with too many rows are hard to typeset correctly on
     the same page.
@@ -173,333 +167,301 @@ let entity ~in_source ~verbatim x =
 let small_table_height_limit = 10
 
 let rec pp_elt ppf = function
-  | Txt words ->
-    Fmt.list Fmt.string ~sep:none ppf words
-  | Section {level; label; content } ->
-    let with_label ppf (label,content) =
-      pp ppf content;
-      match label with
-      | None -> ()
-      | Some label -> Raw.label ppf label in
-    level_macro level with_label ppf (label,content)
+  | Txt words -> Fmt.list Fmt.string ~sep:none ppf words
+  | Section { level; label; content } ->
+      let with_label ppf (label, content) =
+        pp ppf content;
+        match label with None -> () | Some label -> Raw.label ppf label
+      in
+      level_macro level with_label ppf (label, content)
   | Break lvl -> Raw.break ppf lvl
   | Raw s -> Fmt.string ppf s
   | Verbatim s -> Raw.verbatim ppf s
   | Internal_ref r -> hyperref ppf r
-  | External_ref (l,x) -> href ppf (l,x)
-  | Style (s,x) -> style s pp ppf x
+  | External_ref (l, x) -> href ppf (l, x)
+  | Style (s, x) -> style s pp ppf x
   | Code_block [] -> ()
   | Code_block x -> Raw.code_block pp ppf x
   | Inlined_code x -> Raw.inline_code pp ppf x
   | Code_fragment x -> Raw.code_fragment pp ppf x
-  | List {typ; items} -> list typ pp ppf items
+  | List { typ; items } -> list typ pp ppf items
   | Description items -> Raw.description pp ppf items
-  | Table { row_size=Large|Huge; tbl } -> large_table ppf tbl
-  | Table { row_size=Small|Empty; tbl } ->
-    if List.length tbl <= small_table_height_limit then
-      Raw.small_table pp ppf tbl
-    else
-      large_table ppf tbl
+  | Table { row_size = Large | Huge; tbl } -> large_table ppf tbl
+  | Table { row_size = Small | Empty; tbl } ->
+      if List.length tbl <= small_table_height_limit then
+        Raw.small_table pp ppf tbl
+      else large_table ppf tbl
   | Label x -> Raw.label ppf x
-  | Indented x ->  Raw.indent pp ppf x
+  | Indented x -> Raw.indent pp ppf x
   | Ligaturable s -> Fmt.string ppf s
-  | Tag(s,t) -> tag s ppf t
+  | Tag (s, t) -> tag s ppf t
 
 and pp ppf = function
   | [] -> ()
   | Break _ :: (Table _ :: _ as q) -> pp ppf q
-  | Table _ as t :: Break _ :: q ->
-    pp ppf ( t :: q )
-  | Break a :: (Break b :: q) ->
-    pp ppf ( Break (max a b) :: q)
+  | (Table _ as t) :: Break _ :: q -> pp ppf (t :: q)
+  | Break a :: Break b :: q -> pp ppf (Break (max a b) :: q)
   | Ligaturable "-" :: Ligaturable ">" :: q ->
-     Raw.rightarrow ppf; pp ppf q
+      Raw.rightarrow ppf;
+      pp ppf q
   | a :: q ->
-    pp_elt ppf a; pp ppf q
+      pp_elt ppf a;
+      pp ppf q
 
 and hyperref ppf r = gen_hyperref pp r ppf
 
-and href ppf (l,txt) =
+and href ppf (l, txt) =
   match txt with
   | Some txt ->
-    Raw.href l pp ppf txt;  Raw.footnote ppf l
-  | None ->  Raw.url ppf l
+      Raw.href l pp ppf txt;
+      Raw.footnote ppf l
+  | None -> Raw.url ppf l
 
 and large_table ppf tbl =
-    let rec row ppf = function
-      | [] -> Raw.break ppf Line
-      | [a] -> pp ppf a; Raw.break ppf Line
-      | [a;b] ->
-        Fmt.pf ppf "%a%a%a"
-          pp a
-          Raw.break Aesthetic
-          (Raw.indent pp) b
-      | a :: (_ :: _ as q) ->
-        Fmt.pf ppf "%a%a%a"
-          pp a
-          Raw.break Aesthetic
-          (Raw.indent row) q  in
-    let matrix ppf m = List.iter (row ppf) m in
-    Raw.indent matrix ppf tbl
+  let rec row ppf = function
+    | [] -> Raw.break ppf Line
+    | [ a ] ->
+        pp ppf a;
+        Raw.break ppf Line
+    | [ a; b ] -> Fmt.pf ppf "%a%a%a" pp a Raw.break Aesthetic (Raw.indent pp) b
+    | a :: (_ :: _ as q) ->
+        Fmt.pf ppf "%a%a%a" pp a Raw.break Aesthetic (Raw.indent row) q
+  in
+  let matrix ppf m = List.iter (row ppf) m in
+  Raw.indent matrix ppf tbl
 
 and tag s ppf x = Raw.ocamltag s pp ppf x
 
 let raw_markup (t : Raw_markup.t) =
   let target, content = t in
   match Odoc_compat.String.lowercase_ascii target with
-  | "latex" | "tex" -> [Raw content]
+  | "latex" | "tex" -> [ Raw content ]
   | _ -> []
 
 let source k (t : Source.t) =
-  let rec token (x : Source.token) = match x with
+  let rec token (x : Source.token) =
+    match x with
     | Elt i -> k i
     | Tag (None, l) -> tokens l
-    | Tag(Some s,l) -> [Tag (s, tokens l)]
+    | Tag (Some s, l) -> [ Tag (s, tokens l) ]
   and tokens t = list_concat_map t ~f:token in
   tokens t
-
 
 let rec internalref ~verbatim ~in_source (t : InternalLink.t) =
   match t with
   | Resolved (uri, content) ->
-    let target = Link.label uri in
-    let text = Some (inline ~verbatim ~in_source content) in
-    let short = in_source in
-    Internal_ref { short; text; target }
+      let target = Link.label uri in
+      let text = Some (inline ~verbatim ~in_source content) in
+      let short = in_source in
+      Internal_ref { short; text; target }
   | Unresolved content ->
-    let target = "xref-unresolved" in
-    let text = Some (inline ~verbatim ~in_source content) in
-    let short = in_source in
-    Internal_ref { short; target; text }
+      let target = "xref-unresolved" in
+      let text = Some (inline ~verbatim ~in_source content) in
+      let short = in_source in
+      Internal_ref { short; target; text }
 
 and inline ~in_source ~verbatim (l : Inline.t) =
   let one (t : Inline.one) =
     match t.desc with
     | Text _s -> assert false
-    | Linebreak -> [Break Line]
-    | Styled (style, c) ->
-      [Style(style, inline ~verbatim ~in_source c)]
+    | Linebreak -> [ Break Line ]
+    | Styled (style, c) -> [ Style (style, inline ~verbatim ~in_source c) ]
     | Link (ext, c) ->
-      let content = inline ~verbatim:false ~in_source:false  c in
-      [External_ref(ext, Some content)]
-    | InternalLink c ->
-      [internalref ~in_source ~verbatim c]
+        let content = inline ~verbatim:false ~in_source:false c in
+        [ External_ref (ext, Some content) ]
+    | InternalLink c -> [ internalref ~in_source ~verbatim c ]
     | Source c ->
-      [Inlined_code (source (inline ~verbatim:false ~in_source:true) c)]
+        [ Inlined_code (source (inline ~verbatim:false ~in_source:true) c) ]
     | Raw_markup r -> raw_markup r
-    | Entity s -> [entity ~in_source ~verbatim s] in
-
-  let take_text (l: Inline.t) =
-    Doctree.Take.until l ~classify:(function
-      | { Inline.desc = Text code; _ } -> Accum [code]
-      | { desc = Entity e; _ } -> Accum [escape_entity e]
-      | _ -> Stop_and_keep
-    )
+    | Entity s -> [ entity ~in_source ~verbatim s ]
   in
-(* if in_source then block_code_txt s else if_not_empty (fun x -> Txt x) s *)
+
+  let take_text (l : Inline.t) =
+    Doctree.Take.until l ~classify:(function
+      | { Inline.desc = Text code; _ } -> Accum [ code ]
+      | { desc = Entity e; _ } -> Accum [ escape_entity e ]
+      | _ -> Stop_and_keep)
+  in
+  (* if in_source then block_code_txt s else if_not_empty (fun x -> Txt x) s *)
   let rec prettify = function
     | { Inline.desc = Inline.Text _; _ } :: _ as l ->
-      let words, _, rest = take_text l in
-      txt ~in_source ~verbatim words
-      @ prettify rest
+        let words, _, rest = take_text l in
+        txt ~in_source ~verbatim words @ prettify rest
     | o :: q -> one o @ prettify q
-    | [] -> [] in
+    | [] -> []
+  in
   prettify l
 
 let heading (h : Heading.t) =
   let content = inline ~in_source:false ~verbatim:false h.title in
-  [Section { label=h.label; level=h.level; content }; Break Aesthetic]
+  [ Section { label = h.label; level = h.level; content }; Break Aesthetic ]
 
-let non_empty_block_code  c =
+let non_empty_block_code c =
   let s = source (inline ~verbatim:true ~in_source:true) c in
   match s with
   | [] -> []
-  | _ :: _ as l -> [Break Separation; Code_block l; Break Separation]
-
+  | _ :: _ as l -> [ Break Separation; Code_block l; Break Separation ]
 
 let non_empty_code_fragment c =
   let s = source (inline ~verbatim:false ~in_source:true) c in
-  match s with
-  | [] -> []
-  | _ :: _ as l -> [Code_fragment l]
+  match s with [] -> [] | _ :: _ as l -> [ Code_fragment l ]
 
-let rec block ~in_source (l: Block.t)  =
+let rec block ~in_source (l : Block.t) =
   let one (t : Block.one) =
     match t.desc with
-    | Inline i ->
-      inline ~verbatim:false ~in_source:false i
+    | Inline i -> inline ~verbatim:false ~in_source:false i
     | Paragraph i ->
-      inline ~in_source:false ~verbatim:false i @ if in_source then [] else [Break Paragraph]
+        inline ~in_source:false ~verbatim:false i
+        @ if in_source then [] else [ Break Paragraph ]
     | List (typ, l) ->
-      [List { typ; items = List.map (block ~in_source:false) l }]
+        [ List { typ; items = List.map (block ~in_source:false) l } ]
     | Description l ->
-      [Description (List.map (fun (i,b) ->
-          inline ~in_source ~verbatim:false i,
-          block ~in_source b
-      ) l)]
-    | Raw_markup r ->
-       raw_markup r
-    | Verbatim s -> [Verbatim s]
+        [
+          Description
+            (List.map
+               (fun (i, b) ->
+                 (inline ~in_source ~verbatim:false i, block ~in_source b))
+               l);
+        ]
+    | Raw_markup r -> raw_markup r
+    | Verbatim s -> [ Verbatim s ]
     | Source c -> non_empty_block_code c
   in
   list_concat_map l ~f:one
 
-
 let rec is_only_text l =
   let is_text : Item.t -> _ = function
     | Heading _ | Text _ -> true
-    | Declaration _
-      -> false
-    |  Include { content = items; _ }
-      -> is_only_text items.content
+    | Declaration _ -> false
+    | Include { content = items; _ } -> is_only_text items.content
   in
   List.for_all is_text l
 
-
 let rec documentedSrc (t : DocumentedSrc.t) =
   let open DocumentedSrc in
-  let rec to_latex t = match t with
+  let rec to_latex t =
+    match t with
     | [] -> []
     | Code _ :: _ ->
-      let take_code l =
-        Doctree.Take.until l ~classify:(function
-          | Code code -> Accum code
-          | _ -> Stop_and_keep
-        )
-      in
-      let code, _, rest = take_code t in
-      non_empty_code_fragment code
-      @ to_latex rest
+        let take_code l =
+          Doctree.Take.until l ~classify:(function
+            | Code code -> Accum code
+            | _ -> Stop_and_keep)
+        in
+        let code, _, rest = take_code t in
+        non_empty_code_fragment code @ to_latex rest
     | Alternative (Expansion e) :: rest ->
-      begin if Link.should_inline e.status e.url then
-        to_latex e.expansion
-      else
-        non_empty_code_fragment e.summary
-    end
+        ( if Link.should_inline e.status e.url then to_latex e.expansion
+        else non_empty_code_fragment e.summary )
         @ to_latex rest
     | Subpage subp :: rest ->
-      Indented (items subp.content.items)
-      :: to_latex rest
+        Indented (items subp.content.items) :: to_latex rest
     | (Documented _ | Nested _) :: _ ->
-      let take_descr l =
-        Doctree.Take.until l ~classify:(function
-          | Documented { attrs; anchor; code; doc }  ->
-            Accum [{DocumentedSrc. attrs ; anchor ; code = `D code; doc }]
-          | Nested { attrs; anchor; code; doc } ->
-            Accum [{DocumentedSrc. attrs ; anchor ; code = `N code; doc }]
-          | _ -> Stop_and_keep
-        )
-      in
-      let l, _, rest = take_descr t in
-      let one dsrc =
-        let content = match dsrc.code with
-          | `D code -> inline ~verbatim:false ~in_source:true code
-          | `N n -> to_latex n
+        let take_descr l =
+          Doctree.Take.until l ~classify:(function
+            | Documented { attrs; anchor; code; doc } ->
+                Accum [ { DocumentedSrc.attrs; anchor; code = `D code; doc } ]
+            | Nested { attrs; anchor; code; doc } ->
+                Accum [ { DocumentedSrc.attrs; anchor; code = `N code; doc } ]
+            | _ -> Stop_and_keep)
         in
-        let doc = [block ~in_source:true dsrc.doc] in
-        (content @ label dsrc.anchor ) :: doc
-      in
-      table (List.map one l) @ to_latex rest
+        let l, _, rest = take_descr t in
+        let one dsrc =
+          let content =
+            match dsrc.code with
+            | `D code -> inline ~verbatim:false ~in_source:true code
+            | `N n -> to_latex n
+          in
+          let doc = [ block ~in_source:true dsrc.doc ] in
+          (content @ label dsrc.anchor) :: doc
+        in
+        table (List.map one l) @ to_latex rest
   in
   to_latex t
 
-
 and items l =
-  let rec walk_items
-      ~only_text acc (t : Item.t list) =
+  let rec walk_items ~only_text acc (t : Item.t list) =
     let continue_with rest elts =
       walk_items ~only_text (List.rev_append elts acc) rest
     in
     match t with
     | [] -> List.rev acc
     | Text _ :: _ as t ->
-      let text, _, rest = Doctree.Take.until t ~classify:(function
-        | Item.Text text -> Accum text
-        | _ -> Stop_and_keep)
-      in
-      let content = block ~in_source:false text in
-      let elts = content in
-      elts
-      |> continue_with rest
-    | Heading h :: rest ->
-      heading h
-      |> continue_with rest
+        let text, _, rest =
+          Doctree.Take.until t ~classify:(function
+            | Item.Text text -> Accum text
+            | _ -> Stop_and_keep)
+        in
+        let content = block ~in_source:false text in
+        let elts = content in
+        elts |> continue_with rest
+    | Heading h :: rest -> heading h |> continue_with rest
     | Include
-        { kind=_; anchor; doc ; content = { summary; status=_; content } }
+        { kind = _; anchor; doc; content = { summary; status = _; content } }
       :: rest ->
-      let included = items content  in
-      let docs = block ~in_source:true  doc in
-      let summary = source (inline ~verbatim:false ~in_source:true) summary in
-      let content = included in
-      (label anchor @ docs @ summary @ content)
-      |> continue_with rest
-
-    | Declaration {Item. kind=_; anchor ; content ; doc} :: rest ->
-      let content =  label anchor @ documentedSrc content in
-      let elts = match doc with
-        | [] -> content @ [Break Line]
-        | docs -> content @ [ Indented (block ~in_source:true docs); Break Separation]
-      in
-      continue_with rest elts
-
+        let included = items content in
+        let docs = block ~in_source:true doc in
+        let summary = source (inline ~verbatim:false ~in_source:true) summary in
+        let content = included in
+        label anchor @ docs @ summary @ content |> continue_with rest
+    | Declaration { Item.kind = _; anchor; content; doc } :: rest ->
+        let content = label anchor @ documentedSrc content in
+        let elts =
+          match doc with
+          | [] -> content @ [ Break Line ]
+          | docs ->
+              content
+              @ [ Indented (block ~in_source:true docs); Break Separation ]
+        in
+        continue_with rest elts
   and items l = walk_items ~only_text:(is_only_text l) [] l in
   items l
 
-
 module Doc = struct
+  let link_children ppf children =
+    let input_child ppf child =
+      Raw.input ppf child.Odoc_document.Renderer.filename
+    in
+    Fmt.list input_child ppf children
 
-
-let link_children ppf children =
-  let input_child ppf child =
-    Raw.input ppf child.Odoc_document.Renderer.filename
-  in
-  Fmt.list input_child ppf children
-
-let make ~with_children url content children =
-  let filename = Link.filename url in
-  let label = Label (Link.page url) in
-  let content = match content with
-    | [] -> [label]
-    | Section _ as s  :: q -> s :: label :: q
-    | q -> label :: q in
-  let children_input ppf =
-    if with_children then link_children ppf children else ()
-  in
-  let content ppf = Fmt.pf ppf "@[<v>%a@,%t@]@." pp content children_input in
-  {Odoc_document.Renderer. filename; content; children }
+  let make ~with_children url content children =
+    let filename = Link.filename url in
+    let label = Label (Link.page url) in
+    let content =
+      match content with
+      | [] -> [ label ]
+      | (Section _ as s) :: q -> s :: label :: q
+      | q -> label :: q
+    in
+    let children_input ppf =
+      if with_children then link_children ppf children else ()
+    in
+    let content ppf = Fmt.pf ppf "@[<v>%a@,%t@]@." pp content children_input in
+    { Odoc_document.Renderer.filename; content; children }
 end
 
 module Page = struct
+  let on_sub = function `Page _ -> Some 1 | `Include _ -> None
 
-  let on_sub = function
-    | `Page _ -> Some 1
-    | `Include _ -> None
-
-  let rec subpage ~with_children (p:Subpage.t) =
-    if Link.should_inline p.status p.content.url then
-      []
-    else
-      [ page ~with_children p.content ]
+  let rec subpage ~with_children (p : Subpage.t) =
+    if Link.should_inline p.status p.content.url then []
+    else [ page ~with_children p.content ]
 
   and subpages ~with_children i =
-    List.flatten @@ List.map (subpage ~with_children) @@ Doctree.Subpages.compute i
+    List.flatten
+    @@ List.map (subpage ~with_children)
+    @@ Doctree.Subpages.compute i
 
-  and page ~with_children ({Page. title = _; header; items = i; url } as p) =
+  and page ~with_children ({ Page.title = _; header; items = i; url } as p) =
     let i = Doctree.Shift.compute ~on_sub i in
     let subpages = subpages ~with_children p in
     let header = items header in
     let content = items i in
-    let page =
-      Doc.make ~with_children url (header@content) subpages
-    in
+    let page = Doc.make ~with_children url (header @ content) subpages in
     page
-
 end
 
 let render ~with_children page = Page.page ~with_children page
 
-
-  let files_of_url url =
-    if Link.is_class_or_module_path url then
-      [Link.filename url]
-    else []
+let files_of_url url =
+  if Link.is_class_or_module_path url then [ Link.filename url ] else []

--- a/src/latex/generator.mli
+++ b/src/latex/generator.mli
@@ -1,5 +1,6 @@
-val files_of_url :
-  Odoc_document.Url.Path.t -> Fpath.t list
+val files_of_url : Odoc_document.Url.Path.t -> Fpath.t list
 
 val render :
-  with_children:bool -> Odoc_document.Types.Page.t -> Odoc_document.Renderer.page
+  with_children:bool ->
+  Odoc_document.Types.Page.t ->
+  Odoc_document.Renderer.page

--- a/src/latex/raw.ml
+++ b/src/latex/raw.ml
@@ -5,81 +5,89 @@
 *)
 
 type pr = Format.formatter -> unit
+
 type 'a with_options = ?options:pr list -> 'a
-type ('a,'b) tr = 'a Fmt.t -> 'b Fmt.t
-type 'a t = ('a,'a) tr
+
+type ('a, 'b) tr = 'a Fmt.t -> 'b Fmt.t
+
+type 'a t = ('a, 'a) tr
 
 module Escape = struct
-  let text ~code_hyphenation  =
+  let text ~code_hyphenation =
     let b = Buffer.create 17 in
     fun s ->
       for i = 0 to String.length s - 1 do
         match s.[i] with
         | '{' -> Buffer.add_string b "\\{"
-        | '}' ->  Buffer.add_string b "\\}"
-        | '\\' ->  Buffer.add_string b "\\textbackslash{}"
-        | '%' ->  Buffer.add_string b "\\%"
-        | '~' ->  Buffer.add_string b "\\textasciitilde{}"
+        | '}' -> Buffer.add_string b "\\}"
+        | '\\' -> Buffer.add_string b "\\textbackslash{}"
+        | '%' -> Buffer.add_string b "\\%"
+        | '~' -> Buffer.add_string b "\\textasciitilde{}"
         | '^' -> Buffer.add_string b "\\textasciicircum{}"
         | '_' ->
-          if code_hyphenation then Buffer.add_string b {|\_\allowbreak{}|}
-          else Buffer.add_string b {|\_|}
-        | '.' when code_hyphenation ->  Buffer.add_string b {|.\allowbreak{}|}
-        | ';' when code_hyphenation ->  Buffer.add_string b {|;\allowbreak{}|}
-        | ',' when code_hyphenation ->  Buffer.add_string b {|,\allowbreak{}|}
-
-        | '&' ->  Buffer.add_string b "\\&"
-        | '#' ->  Buffer.add_string b "\\#"
-        | '$' ->  Buffer.add_string b "\\$"
-
-
-        | c ->  Buffer.add_char b c
+            if code_hyphenation then Buffer.add_string b {|\_\allowbreak{}|}
+            else Buffer.add_string b {|\_|}
+        | '.' when code_hyphenation -> Buffer.add_string b {|.\allowbreak{}|}
+        | ';' when code_hyphenation -> Buffer.add_string b {|;\allowbreak{}|}
+        | ',' when code_hyphenation -> Buffer.add_string b {|,\allowbreak{}|}
+        | '&' -> Buffer.add_string b "\\&"
+        | '#' -> Buffer.add_string b "\\#"
+        | '$' -> Buffer.add_string b "\\$"
+        | c -> Buffer.add_char b c
       done;
       let s = Buffer.contents b in
       Buffer.reset b;
       s
 
-  let pp ~code_hyphenation ppf x = Format.pp_print_string ppf (text ~code_hyphenation x)
+  let pp ~code_hyphenation ppf x =
+    Format.pp_print_string ppf (text ~code_hyphenation x)
 
   let ref ppf s =
     for i = 0 to String.length s - 1 do
       match s.[i] with
       | '~' -> Fmt.pf ppf "+t+"
-      | '_' -> Fmt.pf  ppf "+u+"
+      | '_' -> Fmt.pf ppf "+u+"
       | '+' -> Fmt.pf ppf "+++"
       | c -> Fmt.pf ppf "%c" c
     done
 end
 
 let option ppf pp = Fmt.pf ppf "[%t]" pp
-let create name ?(options=[]) pp ppf content =
-  Fmt.pf ppf {|\%s%a{%a}|} name
-    (Fmt.list option) options
-    pp content
+
+let create name ?(options = []) pp ppf content =
+  Fmt.pf ppf {|\%s%a{%a}|} name (Fmt.list option) options pp content
 
 let math name ppf = Fmt.pf ppf {|$\%s$|} name
-let create2 name ?(options=[]) pp_x pp_y ppf x y =
-  Fmt.pf ppf {|\%s%a{%a}{%a}|} name
-    (Fmt.list option) options
-    pp_x x pp_y y
 
+let create2 name ?(options = []) pp_x pp_y ppf x y =
+  Fmt.pf ppf {|\%s%a{%a}{%a}|} name (Fmt.list option) options pp_x x pp_y y
 
 let bind pp x ppf = pp ppf x
+
 let label ppf = create "label" Escape.ref ppf
+
 let mbegin ?options = create "begin" ?options Fmt.string
+
 let mend = create "end" Fmt.string
+
 let code_fragment pp = create "ocamlcodefragment" pp
+
 let break ppf level =
-  let pre: _ format6 = match level with
+  let pre : _ format6 =
+    match level with
     | Types.Aesthetic -> "%%"
     | Line -> {|\\|}
     | Separation -> {|\medbreak|}
-    | _ -> "" in
-  let post: _ format6 = match level with
+    | _ -> ""
+  in
+  let post : _ format6 =
+    match level with
     | Types.Line | Separation | Aesthetic | Simple -> ""
-    | Paragraph -> "@," in
+    | Paragraph -> "@,"
+  in
   Fmt.pf ppf (pre ^^ "@," ^^ post)
-let env name pp ?(with_break=false) ?(opts=[]) ?(args=[]) ppf content =
+
+let env name pp ?(with_break = false) ?(opts = []) ?(args = []) ppf content =
   mbegin ppf name;
   List.iter (Fmt.pf ppf "[%t]") opts;
   List.iter (Fmt.pf ppf "{%t}") args;
@@ -88,15 +96,23 @@ let env name pp ?(with_break=false) ?(opts=[]) ?(args=[]) ppf content =
   break ppf (if with_break then Simple else Aesthetic)
 
 let indent pp ppf x = env "ocamlindent" pp ppf x
+
 let inline_code pp = create "ocamlinlinecode" pp
+
 let verbatim ppf x = env "verbatim" Fmt.string ppf x
+
 let pageref_star x = create "pageref*" Escape.ref x
-let hyperref s = create "hyperref" ~options:[bind Escape.ref s]
+
+let hyperref s = create "hyperref" ~options:[ bind Escape.ref s ]
+
 let ref x = create "ref" Escape.ref x
 
 let emph pp = create "emph" pp
+
 let bold pp = create "bold" pp
+
 let subscript pp = create "textsubscript" pp
+
 let superscript pp = create "textsuperscript" pp
 
 let code_block pp ppf x =
@@ -108,55 +124,69 @@ let code_block pp ppf x =
   mend ppf name
 
 let section pp = create "section" pp
+
 let subsection pp = create "subsection" pp
+
 let subsubsection pp = create "subsubsection" pp
+
 let paragraph pp = create "paragraph" pp
 
 let enumerate pp ppf x = env "enumerate" pp ppf x
+
 let itemize pp ppf x = env "itemize" pp ppf x
+
 let raw_description pp ppf x = env "description" pp ppf x
-let href x pp ppf y  = create2 "href" (Escape.pp ~code_hyphenation:false) pp ppf x y
+
+let href x pp ppf y =
+  create2 "href" (Escape.pp ~code_hyphenation:false) pp ppf x y
+
 let item ?options = create "item" ?options
 
 let description pp ppf x =
-  let elt ppf (d,elt) = item ~options:[bind pp d] pp ppf elt in
+  let elt ppf (d, elt) = item ~options:[ bind pp d ] pp ppf elt in
   let all ppf x =
     Fmt.pf ppf
       {|\kern-\topsep
 \makeatletter\advance\%@topsepadd-\topsep\makeatother%% topsep is hardcoded
 |};
-    Fmt.list ~sep:(fun ppf () -> break ppf Aesthetic) elt ppf x in
+    Fmt.list ~sep:(fun ppf () -> break ppf Aesthetic) elt ppf x
+  in
   raw_description all ppf x
 
-let url ppf s = create "url" Fmt.string ppf (Escape.text ~code_hyphenation:false s)
+let url ppf s =
+  create "url" Fmt.string ppf (Escape.text ~code_hyphenation:false s)
+
 let footnote x = create "footnote" url x
+
 let rightarrow ppf = math "rightarrow" ppf
 
 (** Latex uses forward slash even on Windows. *)
 let latex_path ppf path =
   let path_s = String.concat "/" (Fpath.segs path) in
   Fmt.string ppf path_s
+
 let input ppf x = create "input" latex_path ppf x
 
 let ocamltabular ~column_desc pp ppf x =
-  env "ocamltabular"
-    ~args:[ column_desc ]
-    pp ppf x
+  env "ocamltabular" ~args:[ column_desc ] pp ppf x
 
 let small_table pp ppf tbl =
   let columns = List.length (List.hd tbl) in
   let row ppf x =
     let ampersand ppf () = Fmt.pf ppf "& " in
     Fmt.list ~sep:ampersand pp ppf x;
-    break ppf Line in
+    break ppf Line
+  in
   let matrix ppf m = List.iter (row ppf) m in
-  let rec repeat n s ppf = if n = 0 then () else
-      Fmt.pf ppf "%t%t" s (repeat (n - 1) s) in
-  let cell ppf = Fmt.pf ppf "p{%.3f\\textwidth}" (1.0 /. float_of_int columns) in
+  let rec repeat n s ppf =
+    if n = 0 then () else Fmt.pf ppf "%t%t" s (repeat (n - 1) s)
+  in
+  let cell ppf =
+    Fmt.pf ppf "p{%.3f\\textwidth}" (1.0 /. float_of_int columns)
+  in
   let table ppf tbl =
-    ocamltabular
-      ~column_desc:(repeat columns cell)
-      matrix ppf tbl in
+    ocamltabular ~column_desc:(repeat columns cell) matrix ppf tbl
+  in
   (* we add line breaks to never insert tables between delimiters,
      to avoid rendering:
           | `A
@@ -166,10 +196,9 @@ let small_table pp ppf tbl =
        field_1: int;
      { field_2: int;     }
        field_3: int;
-   *)
+  *)
   break ppf Line;
   table ppf tbl;
   break ppf Line
 
-let ocamltag tag pp ppf x =
-  create2 "ocamltag" Fmt.string pp ppf tag x
+let ocamltag tag pp ppf x = create2 "ocamltag" Fmt.string pp ppf tag x

--- a/src/latex/raw.mli
+++ b/src/latex/raw.mli
@@ -3,74 +3,93 @@
     - text escaping
 *)
 
-(** {1 Helper types } *)
 type pr = Format.formatter -> unit
+(** {1 Helper types } *)
+
 type 'a with_options = ?options:pr list -> 'a
-type ('a,'b) tr = 'a Fmt.t -> 'b Fmt.t
-type 'a t = ('a,'a) tr
+
+type ('a, 'b) tr = 'a Fmt.t -> 'b Fmt.t
+
+type 'a t = ('a, 'a) tr
 
 (** {1 Helper functions } *)
-module Escape: sig
-  val text: code_hyphenation:bool -> string -> string
-  val ref: string Fmt.t
+module Escape : sig
+  val text : code_hyphenation:bool -> string -> string
+
+  val ref : string Fmt.t
 end
 
-val break: Types.break_hierarchy Fmt.t
-val rightarrow: pr
+val break : Types.break_hierarchy Fmt.t
 
-val label: string Fmt.t
-val verbatim: string Fmt.t
+val rightarrow : pr
 
+val label : string Fmt.t
 
-val pageref_star: string Fmt.t
-val hyperref: string -> 'a t
-val href: string -> 'a t
-val ref: string Fmt.t
-val url: string Fmt.t
-val footnote: string Fmt.t
+val verbatim : string Fmt.t
 
-val emph: 'a t
-val bold: 'a t
-val subscript: 'a t
-val superscript: 'a  t
+val pageref_star : string Fmt.t
 
-val section: 'a t
-val subsection: 'a t
-val subsubsection: 'a t
-val paragraph: 'a t
+val hyperref : string -> 'a t
 
-val enumerate: 'a t
-val itemize: 'a t
-val description: ('a, ('a * 'a) list) tr
-val item: 'a t with_options
+val href : string -> 'a t
 
-val small_table: ('a, 'a list list) tr
+val ref : string Fmt.t
 
+val url : string Fmt.t
 
-val input: Fpath.t Fmt.t
+val footnote : string Fmt.t
+
+val emph : 'a t
+
+val bold : 'a t
+
+val subscript : 'a t
+
+val superscript : 'a t
+
+val section : 'a t
+
+val subsection : 'a t
+
+val subsubsection : 'a t
+
+val paragraph : 'a t
+
+val enumerate : 'a t
+
+val itemize : 'a t
+
+val description : ('a, ('a * 'a) list) tr
+
+val item : 'a t with_options
+
+val small_table : ('a, 'a list list) tr
+
+val input : Fpath.t Fmt.t
 
 (** {1 Required OCaml-specific primitives }
     All the macro should be implemented as "ocaml"-suffixed macro
     in the latex preamble
   *)
 
+val inline_code : 'a t
 (** {2 Code block customization} *)
-val inline_code: 'a t
-val code_fragment: 'a t
-val code_block: 'a t
+
+val code_fragment : 'a t
+
+val code_block : 'a t
 
 (** {2 Package-dependent primitives }*)
 
-val indent: 'a t
+val indent : 'a t
 (** expected to be implemented with changepage/adjustwidth*)
 
-val ocamltabular: column_desc:pr -> 'a t
+val ocamltabular : column_desc:pr -> 'a t
 (** Any tabular implementation that works well with at most 10 rows *)
-
 
 (** {2 Tags } *)
 
-val ocamltag: string -> 'a t
+val ocamltag : string -> 'a t
 (** tag (e.g keyword, type-var, ...) are rendered to
 {v \ocamltag{tagname}{content} v}
 *)

--- a/src/latex/types.ml
+++ b/src/latex/types.ml
@@ -1,17 +1,10 @@
-
-type break_hierarchy =
-  | Aesthetic
-  | Simple
-  | Line
-  | Paragraph
-  | Separation
-
+type break_hierarchy = Aesthetic | Simple | Line | Paragraph | Separation
 
 type row_size =
   | Empty
-  | Small (** text only *)
-  | Large (** No table *)
-  | Huge (** tables **)
+  | Small  (** text only *)
+  | Large  (** No table *)
+  | Huge  (** tables **)
 
 type elt =
   | Txt of string list
@@ -22,7 +15,7 @@ type elt =
   | Label of string
   | Raw of string
   | Tag of string * t
-  | Style of [`Emphasis|`Bold|`Superscript|`Subscript|`Italic] * t
+  | Style of [ `Emphasis | `Bold | `Superscript | `Subscript | `Italic ] * t
   | Code_block of t
   | Inlined_code of t
   | Code_fragment of t
@@ -33,10 +26,12 @@ type elt =
   | Table of table
   | Ligaturable of string
 
-and section = {level:int; label:string option; content:t }
-and list_info = { typ : Odoc_document.Types.Block.list_type; items: t list }
-and table = { row_size: row_size; tbl: t list list}
+and section = { level : int; label : string option; content : t }
 
+and list_info = { typ : Odoc_document.Types.Block.list_type; items : t list }
+
+and table = { row_size : row_size; tbl : t list list }
 
 and t = elt list
-and reference = { short:bool; target:string; text: t option }
+
+and reference = { short : bool; target : string; text : t option }

--- a/src/loader/dune
+++ b/src/loader/dune
@@ -1,5 +1,7 @@
 (library
  (name odoc_loader)
  (public_name odoc.loader)
- (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
+ (preprocess
+  (action
+   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
  (libraries compiler-libs.common odoc_model odoc_parser))

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -34,7 +34,6 @@ extra whitespaces and never output successive whitespaces at all.
 This makes the output much more consistent.
 *)
 module Roff = struct
-
   type t =
     | Concat of t list
     | Font of string * t
@@ -48,166 +47,175 @@ module Roff = struct
   let noop = Concat []
 
   let sp = Space
-  let break = Break
-  let vspace = Vspace
-  let append t1 t2 = match t1, t2 with
-    | Concat l1, Concat l2 -> Concat (l1@l2)
-    | Concat l1, e2 -> Concat (l1@[e2])
-    | e1, Concat l2 -> Concat (e1::l2)
-    | e1, e2 -> Concat [e1;e2]
-  let (++) = append
 
-  let concat = List.fold_left (++) (Concat [])
+  let break = Break
+
+  let vspace = Vspace
+
+  let append t1 t2 =
+    match (t1, t2) with
+    | Concat l1, Concat l2 -> Concat (l1 @ l2)
+    | Concat l1, e2 -> Concat (l1 @ [ e2 ])
+    | e1, Concat l2 -> Concat (e1 :: l2)
+    | e1, e2 -> Concat [ e1; e2 ]
+
+  let ( ++ ) = append
+
+  let concat = List.fold_left ( ++ ) (Concat [])
+
   let rec intersperse ~sep = function
     | [] -> []
-    | [h] -> [h]
-    | h1 :: (_ :: _ as t) ->
-      h1 :: sep :: intersperse ~sep t
-  let list ?(sep=Concat[]) l = concat @@ intersperse ~sep l
+    | [ h ] -> [ h ]
+    | h1 :: (_ :: _ as t) -> h1 :: sep :: intersperse ~sep t
+
+  let list ?(sep = Concat []) l = concat @@ intersperse ~sep l
 
   let indent i content = Indent (i, content)
-  let macro id fmt =
-    Format.ksprintf (fun s -> Macro (id, s)) fmt
+
+  let macro id fmt = Format.ksprintf (fun s -> Macro (id, s)) fmt
 
   (* copied from cmdliner *)
-  let escape s = (* escapes [s] from doc language. *)
-    let markup_text_need_esc =
-      function '.' | '\\' -> true | _ -> false
-    in
+  let escape s =
+    (* escapes [s] from doc language. *)
+    let markup_text_need_esc = function '.' | '\\' -> true | _ -> false in
     let max_i = String.length s - 1 in
     let rec escaped_len i l =
-      if i > max_i then l else
-      if markup_text_need_esc s.[i] then escaped_len (i + 1) (l + 2) else
-        escaped_len (i + 1) (l + 1)
+      if i > max_i then l
+      else if markup_text_need_esc s.[i] then escaped_len (i + 1) (l + 2)
+      else escaped_len (i + 1) (l + 1)
     in
     let escaped_len = escaped_len 0 0 in
-    if escaped_len = String.length s then s else
+    if escaped_len = String.length s then s
+    else
       let b = Bytes.create escaped_len in
       let rec loop i k =
-        if i > max_i then Bytes.unsafe_to_string b else
+        if i > max_i then Bytes.unsafe_to_string b
+        else
           let c = String.unsafe_get s i in
-          if not (markup_text_need_esc c)
-          then (Bytes.unsafe_set b k c; loop (i + 1) (k + 1))
-          else (Bytes.unsafe_set b k '\\'; Bytes.unsafe_set b (k + 1) c;
-            loop (i + 1) (k + 2))
+          if not (markup_text_need_esc c) then (
+            Bytes.unsafe_set b k c;
+            loop (i + 1) (k + 1) )
+          else (
+            Bytes.unsafe_set b k '\\';
+            Bytes.unsafe_set b (k + 1) c;
+            loop (i + 1) (k + 2) )
       in
       loop 0 0
 
-  let str fmt =
-    Format.ksprintf (fun s -> String (escape s)) fmt
-  let escaped fmt =
-    Format.ksprintf (fun s -> String s) fmt
+  let str fmt = Format.ksprintf (fun s -> String (escape s)) fmt
 
-  let env o c arg content =
-    macro o "%s" arg ++ content ++ macro c ""
+  let escaped fmt = Format.ksprintf (fun s -> String s) fmt
+
+  let env o c arg content = macro o "%s" arg ++ content ++ macro c ""
 
   let font s content = Font (s, content)
 
   let font_stack = Stack.create ()
+
   let pp_font ppf s fmt =
-    let command_f ppf s = if String.length s = 1 then
-        Format.fprintf ppf {|\f%s|} s
-      else
-        Format.fprintf ppf {|\f[%s]|} s
+    let command_f ppf s =
+      if String.length s = 1 then Format.fprintf ppf {|\f%s|} s
+      else Format.fprintf ppf {|\f[%s]|} s
     in
     Stack.push s font_stack;
     command_f ppf s;
-    Format.kfprintf (fun ppf ->
-      ignore @@ Stack.pop font_stack;
-      let s = if Stack.is_empty font_stack then "R" else Stack.top font_stack in
-      command_f ppf s)
+    Format.kfprintf
+      (fun ppf ->
+        ignore @@ Stack.pop font_stack;
+        let s =
+          if Stack.is_empty font_stack then "R" else Stack.top font_stack
+        in
+        command_f ppf s)
       ppf fmt
 
   let collapse x =
     let skip_spaces l =
-      let _, _, rest = Take.until l ~classify:(function
-        | Space -> Skip | _ -> Stop_and_keep)
+      let _, _, rest =
+        Take.until l ~classify:(function Space -> Skip | _ -> Stop_and_keep)
       in
       rest
     and skip_spaces_and_break l =
-      let _, _, rest = Take.until l ~classify:(function
-        | Space | Break -> Skip | _ -> Stop_and_keep)
+      let _, _, rest =
+        Take.until l ~classify:(function
+          | Space | Break -> Skip
+          | _ -> Stop_and_keep)
       in
       rest
     and skip_spaces_and_break_and_vspace l =
-      let _, _, rest = Take.until l ~classify:(function
-        | Space | Break | Vspace -> Skip | _ -> Stop_and_keep)
+      let _, _, rest =
+        Take.until l ~classify:(function
+          | Space | Break | Vspace -> Skip
+          | _ -> Stop_and_keep)
       in
       rest
     in
-    let rec loop acc l = match l with
+    let rec loop acc l =
+      match l with
       (* | (Space | Break) :: (Macro _ :: _ as t) ->
        *   loop acc t *)
       | Vspace :: _ ->
-        let rest = skip_spaces_and_break_and_vspace l in
-        loop (Vspace :: acc) rest
+          let rest = skip_spaces_and_break_and_vspace l in
+          loop (Vspace :: acc) rest
       | Break :: _ ->
-        let rest = skip_spaces_and_break l in
-        loop (Break :: acc) rest
+          let rest = skip_spaces_and_break l in
+          loop (Break :: acc) rest
       | Space :: _ ->
-        let rest = skip_spaces l in
-        loop (Space :: acc) rest
-      | Concat l :: rest ->
-        loop acc (l @ rest)
-      | Macro _ as h :: rest ->
-        let rest = skip_spaces rest in
-        loop (h :: acc) rest
+          let rest = skip_spaces l in
+          loop (Space :: acc) rest
+      | Concat l :: rest -> loop acc (l @ rest)
+      | (Macro _ as h) :: rest ->
+          let rest = skip_spaces rest in
+          loop (h :: acc) rest
       | [] -> acc
       | h :: t -> loop (h :: acc) t
     in
-    List.rev @@ loop [] [x]
+    List.rev @@ loop [] [ x ]
 
   let rec next_is_macro = function
     | (Vspace | Break | Macro _) :: _ -> true
     | Concat l :: _ -> next_is_macro l
-    | Font (_, content) :: _
-    | Indent (_, content) :: _ -> next_is_macro [content]
+    | Font (_, content) :: _ | Indent (_, content) :: _ ->
+        next_is_macro [ content ]
     | _ -> false
-  let pp_macro ppf s fmt =
-    Format.fprintf ppf
-      ("@\n.%s " ^^ fmt)
-      s
+
+  let pp_macro ppf s fmt = Format.fprintf ppf ("@\n.%s " ^^ fmt) s
+
   let pp_indent ppf indent =
     if indent = 0 then () else pp_macro ppf "ti" "+%d" indent
-  let newline_if ppf b =
-    if b then Format.pp_force_newline ppf () else ()
+
+  let newline_if ppf b = if b then Format.pp_force_newline ppf () else ()
 
   let pp ppf t =
-    let rec many ~indent ppf l = match l with
+    let rec many ~indent ppf l =
+      match l with
       | [] -> ()
       | h :: t ->
-        let is_macro = next_is_macro t in
-        begin match h with
-        | Concat l ->
-          many ~indent ppf l;
-        | String s ->
-          Format.pp_print_string ppf s
-        | Font (s, t) ->
-          pp_font ppf s "%a" (one ~indent) t
-        | Space ->
-          Format.fprintf ppf " "
-        | Break ->
-          pp_macro ppf "br" "";
-          pp_indent ppf indent;
-          newline_if ppf (not is_macro);
-        | Vspace ->
-          pp_macro ppf "sp" "";
-          pp_indent ppf indent;
-          newline_if ppf (not is_macro);
-        | Macro (s, args) ->
-          pp_macro ppf s "%s" args;
-          newline_if ppf (not is_macro);
-        | Indent (i, content) ->
-          let indent = indent + i in
-          one ~indent ppf content;
-        end;
-        many ~indent ppf t
-    and one ~indent ppf x = many ~indent ppf @@ collapse x
-    in
+          let is_macro = next_is_macro t in
+          ( match h with
+          | Concat l -> many ~indent ppf l
+          | String s -> Format.pp_print_string ppf s
+          | Font (s, t) -> pp_font ppf s "%a" (one ~indent) t
+          | Space -> Format.fprintf ppf " "
+          | Break ->
+              pp_macro ppf "br" "";
+              pp_indent ppf indent;
+              newline_if ppf (not is_macro)
+          | Vspace ->
+              pp_macro ppf "sp" "";
+              pp_indent ppf indent;
+              newline_if ppf (not is_macro)
+          | Macro (s, args) ->
+              pp_macro ppf s "%s" args;
+              newline_if ppf (not is_macro)
+          | Indent (i, content) ->
+              let indent = indent + i in
+              one ~indent ppf content );
+          many ~indent ppf t
+    and one ~indent ppf x = many ~indent ppf @@ collapse x in
     Format.pp_set_margin ppf max_int;
     one ~indent:0 ppf t
-
 end
+
 open Roff
 
 let style (style : style) content =
@@ -215,49 +223,47 @@ let style (style : style) content =
   | `Bold -> font "B" content
   | `Italic -> font "I" content
   (* We ignore those *)
-  | `Emphasis
-  | `Superscript
-  | `Subscript -> content
+  | `Emphasis | `Superscript | `Subscript -> content
 
 (* Striped content should be rendered in one line, without styling *)
 let strip l =
   let rec loop acc = function
     | [] -> acc
-    | h :: t ->
-      match h.Inline.desc with
-      | Text _
-      | Entity _
-      | Raw_markup _
-        -> loop (h :: acc) t
-      | Linebreak
-        -> loop acc t
-      | Styled (sty, content) ->
-        let h = {h with desc = Styled (sty, List.rev @@ loop [] content)} in
-        loop (h :: acc) t
-      | Link (_, content)
-      | InternalLink (Resolved (_, content))
-      | InternalLink (Unresolved content) ->
-        let acc = loop acc content in
-        loop acc t
-      | Source code ->
-        let acc = loop_source acc code in
-        loop acc t
+    | h :: t -> (
+        match h.Inline.desc with
+        | Text _ | Entity _ | Raw_markup _ -> loop (h :: acc) t
+        | Linebreak -> loop acc t
+        | Styled (sty, content) ->
+            let h =
+              { h with desc = Styled (sty, List.rev @@ loop [] content) }
+            in
+            loop (h :: acc) t
+        | Link (_, content)
+        | InternalLink (Resolved (_, content))
+        | InternalLink (Unresolved content) ->
+            let acc = loop acc content in
+            loop acc t
+        | Source code ->
+            let acc = loop_source acc code in
+            loop acc t )
   and loop_source acc = function
     | [] -> acc
-    | Source.Elt content :: t ->
-      loop_source (List.rev_append content acc) t
+    | Source.Elt content :: t -> loop_source (List.rev_append content acc) t
     | Source.Tag (_, content) :: t ->
-      let acc = loop_source acc content in
-      loop_source acc t
+        let acc = loop_source acc content in
+        loop_source acc t
   in
   List.rev @@ loop [] l
 
 (* Partial support for now *)
-let entity e = match e with
+let entity e =
+  match e with
   | "#45" -> escaped "\\-"
   | "gt" -> str ">"
   | "#8288" -> noop
-  | s -> str "&%s;" s (* Should hopefully make people notice and report *)
+  | s -> str "&%s;" s
+
+(* Should hopefully make people notice and report *)
 
 let raw_markup (t : Raw_markup.t) =
   let target, content = t in
@@ -268,263 +274,223 @@ let raw_markup (t : Raw_markup.t) =
 let rec source_code (s : Source.t) =
   match s with
   | [] -> noop
-  | h :: t ->
-    match h with
-    | Source.Elt i ->
-      inline (strip i)
-      ++ source_code t
-    | Tag (None, s) ->
-      source_code s
-      ++ source_code t
-    | Tag (Some _, s) ->
-      font "CB" (source_code s)
-      ++ source_code t
+  | h :: t -> (
+      match h with
+      | Source.Elt i -> inline (strip i) ++ source_code t
+      | Tag (None, s) -> source_code s ++ source_code t
+      | Tag (Some _, s) -> font "CB" (source_code s) ++ source_code t )
 
-and inline (l : Inline.t) = match l with
+and inline (l : Inline.t) =
+  match l with
   | [] -> noop
-  | i :: rest ->
-    match i.desc with
-    | Text "" ->
-      inline rest
-    | Text _ ->
-      let l, _ , rest = Doctree.Take.until l ~classify:(function
-        | {Inline.desc = Text s ; _} -> Accum [s] | _ -> Stop_and_keep
-      ) in
-      str {|%s|} (String.concat "" l)
-      ++ inline rest
-    | Entity e ->
-      let x = entity e in
-      x ++ inline rest
-    | Linebreak ->
-      break
-      ++ inline rest
-    | Styled (sty, content) ->
-      style sty (inline content)
-      ++ inline rest
-    | Link (href, content) ->
-      env "UR" "UE" href (inline @@ strip content)
-      ++ inline rest
-    | InternalLink (Resolved (_,content) | Unresolved content) ->
-      font "CI" (inline @@ strip content)
-      ++ inline rest
-    | Source content ->
-      source_code content
-      ++ inline rest
-    | Raw_markup t ->
-      raw_markup t
-      ++ inline rest
+  | i :: rest -> (
+      match i.desc with
+      | Text "" -> inline rest
+      | Text _ ->
+          let l, _, rest =
+            Doctree.Take.until l ~classify:(function
+              | { Inline.desc = Text s; _ } -> Accum [ s ]
+              | _ -> Stop_and_keep)
+          in
+          str {|%s|} (String.concat "" l) ++ inline rest
+      | Entity e ->
+          let x = entity e in
+          x ++ inline rest
+      | Linebreak -> break ++ inline rest
+      | Styled (sty, content) -> style sty (inline content) ++ inline rest
+      | Link (href, content) ->
+          env "UR" "UE" href (inline @@ strip content) ++ inline rest
+      | InternalLink (Resolved (_, content) | Unresolved content) ->
+          font "CI" (inline @@ strip content) ++ inline rest
+      | Source content -> source_code content ++ inline rest
+      | Raw_markup t -> raw_markup t ++ inline rest )
 
-let rec block (l : Block.t) = match l with
+let rec block (l : Block.t) =
+  match l with
   | [] -> noop
-  | b :: rest ->
-    let continue r = if r = [] then noop else vspace ++ block r in
-    match b.desc with
-    | Inline i ->
-      inline i
-      ++ continue rest
-    | Paragraph i ->
-      inline i
-      ++ continue rest
-    | List (list_typ, l) ->
-      let f n b =
-        let bullet = match list_typ with
-          | Unordered -> escaped {|\(bu|}
-          | Ordered -> str "%d)" (n+1)
-        in
-        indent 2 (bullet ++ sp ++ block b)
-      in
-      list ~sep:break (List.mapi f l)
-      ++ continue rest
-    | Description _  ->
-      let descrs, _, rest = Take.until l ~classify:(function
-        | {Block.desc = Description l ; _ } -> Accum l | _ -> Stop_and_keep)
-      in
-      let f (i, b) =
-        indent 2 (str "@" ++ inline i ++ str ":" ++ sp ++ block b)
-      in
-      list ~sep:break (List.map f descrs)
-      ++ continue rest
-    | Source content ->
-      env "EX" "EE" "" (source_code content)
-      ++ continue rest
-    | Verbatim content ->
-      env "EX" "EE" "" (str "%s" content)
-      ++ continue rest
-    | Raw_markup t ->
-      raw_markup t
-      ++ continue rest
+  | b :: rest -> (
+      let continue r = if r = [] then noop else vspace ++ block r in
+      match b.desc with
+      | Inline i -> inline i ++ continue rest
+      | Paragraph i -> inline i ++ continue rest
+      | List (list_typ, l) ->
+          let f n b =
+            let bullet =
+              match list_typ with
+              | Unordered -> escaped {|\(bu|}
+              | Ordered -> str "%d)" (n + 1)
+            in
+            indent 2 (bullet ++ sp ++ block b)
+          in
+          list ~sep:break (List.mapi f l) ++ continue rest
+      | Description _ ->
+          let descrs, _, rest =
+            Take.until l ~classify:(function
+              | { Block.desc = Description l; _ } -> Accum l
+              | _ -> Stop_and_keep)
+          in
+          let f (i, b) =
+            indent 2 (str "@" ++ inline i ++ str ":" ++ sp ++ block b)
+          in
+          list ~sep:break (List.map f descrs) ++ continue rest
+      | Source content ->
+          env "EX" "EE" "" (source_code content) ++ continue rest
+      | Verbatim content -> env "EX" "EE" "" (str "%s" content) ++ continue rest
+      | Raw_markup t -> raw_markup t ++ continue rest )
 
 let next_heading, reset_heading =
   let heading_stack = ref [] in
-  let rec succ_heading i l = match i, l with
-    | 1, [] -> [1]
-    | _, [] -> 1 :: succ_heading (i-1) []
-    | 1, n :: _ -> [n+1]
-    | i, n :: t -> n :: succ_heading (i-1) t
+  let rec succ_heading i l =
+    match (i, l) with
+    | 1, [] -> [ 1 ]
+    | _, [] -> 1 :: succ_heading (i - 1) []
+    | 1, n :: _ -> [ n + 1 ]
+    | i, n :: t -> n :: succ_heading (i - 1) t
   in
   let print_heading l = String.concat "." @@ List.map string_of_int l in
   let next level =
     let new_heading = succ_heading level !heading_stack in
     heading_stack := new_heading;
     print_heading new_heading
-  and reset () =
-    heading_stack := []
-  in
-  next, reset
+  and reset () = heading_stack := [] in
+  (next, reset)
 
-let heading ~nested {Heading. label = _ ; level ; title } =
+let heading ~nested { Heading.label = _; level; title } =
   let prefix =
     if level = 0 then noop
     else if level <= 3 then str "%s " (next_heading level)
     else noop
   in
   if not nested then
-    macro "in" "%d" (level+2)
+    macro "in" "%d" (level + 2)
     ++ font "B" (prefix ++ inline (strip title))
     ++ macro "in" ""
-  else
-    font "B" (prefix ++ inline (strip title))
+  else font "B" (prefix ++ inline (strip title))
 
 let expansion_not_inlined url = not (Link.should_inline url)
 
 let take_code l =
-  let c, _, rest = Take.until l ~classify:(function
-    | DocumentedSrc.Code c -> Accum c
-    | DocumentedSrc.Alternative (Expansion e)
-      when expansion_not_inlined e.url -> Accum e.summary
-    | _ -> Stop_and_keep)
+  let c, _, rest =
+    Take.until l ~classify:(function
+      | DocumentedSrc.Code c -> Accum c
+      | DocumentedSrc.Alternative (Expansion e) when expansion_not_inlined e.url
+        ->
+          Accum e.summary
+      | _ -> Stop_and_keep)
   in
-  c, rest
+  (c, rest)
 
 let inline_subpage = function
   | `Inline | `Open | `Default -> true
   | `Closed -> false
 
-let rec documentedSrc (l : DocumentedSrc.t) = match l with
+let rec documentedSrc (l : DocumentedSrc.t) =
+  match l with
   | [] -> noop
-  | line :: rest ->
-    let break_if_nonempty r = if r = [] then noop else break in
-    let continue r = documentedSrc r in
-    match line with
-    | Code _ ->
-      let c, rest = take_code l in
-      source_code c
-      ++ continue rest
-    | Alternative alt -> begin
-        match alt with
-        | Expansion { expansion; url; _ } ->
-          if expansion_not_inlined url then
-            let c, rest = take_code l in
-            source_code c
-            ++ continue rest
-          else
-            documentedSrc expansion
-      end
-    | Subpage p ->
-       subpage p.content
-       ++ continue rest
-    | Documented _
-    | Nested _ ->
-      let lines, _, rest = Take.until l ~classify:(function
-        | DocumentedSrc.Documented { code; doc; _ } ->
-          Accum [(`D code, doc)]
-        | DocumentedSrc.Nested { code; doc; _ } ->
-          Accum [(`N code, doc)]
-        | _ -> Stop_and_keep)
-      in
-      let f (content, doc) =
-        let doc = match doc with
-          | [] -> noop
-          | doc ->
-            indent 2 (break ++ str "(*" ++ sp ++ block doc ++ sp ++ str "*)")
-        in
-        let content = match content with
-          | `D code -> inline code
-          | `N l -> indent 2 (documentedSrc l)
-        in
-        content ++ doc
-      in
-      let l = list ~sep:break (List.map f lines) in
-      indent 2 (break ++ l)
-      ++ break_if_nonempty rest
-      ++ continue rest
+  | line :: rest -> (
+      let break_if_nonempty r = if r = [] then noop else break in
+      let continue r = documentedSrc r in
+      match line with
+      | Code _ ->
+          let c, rest = take_code l in
+          source_code c ++ continue rest
+      | Alternative alt -> (
+          match alt with
+          | Expansion { expansion; url; _ } ->
+              if expansion_not_inlined url then
+                let c, rest = take_code l in
+                source_code c ++ continue rest
+              else documentedSrc expansion )
+      | Subpage p -> subpage p.content ++ continue rest
+      | Documented _ | Nested _ ->
+          let lines, _, rest =
+            Take.until l ~classify:(function
+              | DocumentedSrc.Documented { code; doc; _ } ->
+                  Accum [ (`D code, doc) ]
+              | DocumentedSrc.Nested { code; doc; _ } ->
+                  Accum [ (`N code, doc) ]
+              | _ -> Stop_and_keep)
+          in
+          let f (content, doc) =
+            let doc =
+              match doc with
+              | [] -> noop
+              | doc ->
+                  indent 2
+                    (break ++ str "(*" ++ sp ++ block doc ++ sp ++ str "*)")
+            in
+            let content =
+              match content with
+              | `D code -> inline code
+              | `N l -> indent 2 (documentedSrc l)
+            in
+            content ++ doc
+          in
+          let l = list ~sep:break (List.map f lines) in
+          indent 2 (break ++ l) ++ break_if_nonempty rest ++ continue rest )
 
-and subpage { title = _; header = _ ; items; url = _ } =
+and subpage { title = _; header = _; items; url = _ } =
   let content = items in
   let surround body =
-    if content = [] then sp
-    else
-      indent 2 (break ++ body)
-      ++ break
+    if content = [] then sp else indent 2 (break ++ body) ++ break
   in
   surround @@ item ~nested:true content
 
-
-and item ~nested (l : Item.t list) = match l with
+and item ~nested (l : Item.t list) =
+  match l with
   | [] -> noop
-  | i :: rest ->
-    let continue r = if r = [] then noop else vspace ++ item ~nested r in
-    match i with
-    | Text b ->
-      let d = env "fi" "nf" "" (block b) in
-      d ++ continue rest
-    | Heading h ->
-      let h = heading ~nested h in
-      vspace ++ h ++ vspace ++ item ~nested rest
-    | Declaration { kind = _; anchor = _; content; doc } ->
-      let decl =
-        documentedSrc content
-      in
-      let doc = match doc with
-        | [] -> noop
-        | doc -> env "fi" "nf" "" (indent 2 (break ++ block doc))
-      in
-      decl ++ doc ++ continue rest
-    | Include { kind = _; anchor = _;
-      content = { summary; status; content }; doc } ->
-      let d = if inline_subpage status then
-          item ~nested content
-        else
-          let s = source_code summary in
-          match doc with
-          | [] -> s
-          | doc -> s ++ indent 2 (break ++ block doc)
-      in
-      d ++ continue rest
+  | i :: rest -> (
+      let continue r = if r = [] then noop else vspace ++ item ~nested r in
+      match i with
+      | Text b ->
+          let d = env "fi" "nf" "" (block b) in
+          d ++ continue rest
+      | Heading h ->
+          let h = heading ~nested h in
+          vspace ++ h ++ vspace ++ item ~nested rest
+      | Declaration { kind = _; anchor = _; content; doc } ->
+          let decl = documentedSrc content in
+          let doc =
+            match doc with
+            | [] -> noop
+            | doc -> env "fi" "nf" "" (indent 2 (break ++ block doc))
+          in
+          decl ++ doc ++ continue rest
+      | Include
+          { kind = _; anchor = _; content = { summary; status; content }; doc }
+        ->
+          let d =
+            if inline_subpage status then item ~nested content
+            else
+              let s = source_code summary in
+              match doc with
+              | [] -> s
+              | doc -> s ++ indent 2 (break ++ block doc)
+          in
+          d ++ continue rest )
 
 let on_sub subp =
   match subp with
-  | `Page p ->
-    if Link.should_inline p.Subpage.content.url then Some 1 else None
-  | `Include incl ->
-    if inline_subpage incl.Include.status then Some 0 else None
+  | `Page p -> if Link.should_inline p.Subpage.content.url then Some 1 else None
+  | `Include incl -> if inline_subpage incl.Include.status then Some 0 else None
 
-let page {Page. title ; header ; items = i ; url} =
+let page { Page.title; header; items = i; url } =
   reset_heading ();
   let header = Shift.compute ~on_sub header in
   let i = Shift.compute ~on_sub i in
   macro "TH" {|%s 3 "" "Odoc" "OCaml Library"|} title
   ++ macro "SH" "Name"
   ++ str "%s" (String.concat "." @@ Link.for_printing url)
-  ++ macro "SH" "Synopsis" ++ vspace
-  ++ item ~nested:false header
-  ++ macro "SH" "Documentation" ++ vspace
-  ++ macro "nf" ""
+  ++ macro "SH" "Synopsis" ++ vspace ++ item ~nested:false header
+  ++ macro "SH" "Documentation" ++ vspace ++ macro "nf" ""
   ++ item ~nested:false i
 
 let rec subpage subp =
   let p = subp.Subpage.content in
-  if Link.should_inline p.url then
-    []
-  else
-    [render p]
+  if Link.should_inline p.url then [] else [ render p ]
 
 and render (p : Page.t) =
-  let content ppf =
-    Format.fprintf ppf "%a@." Roff.pp (page p)
-  in
-  let children =
-    Utils.flatmap ~f:subpage @@ Subpages.compute p
-  in
+  let content ppf = Format.fprintf ppf "%a@." Roff.pp (page p) in
+  let children = Utils.flatmap ~f:subpage @@ Subpages.compute p in
   let filename = Link.as_filename p.url in
-  {Renderer. filename; content; children }
+  { Renderer.filename; content; children }

--- a/src/manpage/link.ml
+++ b/src/manpage/link.ml
@@ -1,9 +1,9 @@
 open Odoc_document
 
 let to_list url =
-  let rec loop acc {Url.Path. parent ; name ; kind } =
+  let rec loop acc { Url.Path.parent; name; kind } =
     match parent with
-    | None -> (kind,name) :: acc
+    | None -> (kind, name) :: acc
     | Some p -> loop ((kind, name) :: acc) p
   in
   loop [] url
@@ -11,34 +11,33 @@ let to_list url =
 let for_printing url = List.map snd @@ to_list url
 
 let segment_to_string (kind, name) =
-  if kind = "module" || kind = "container-page" || kind="page" || kind = "class" || kind = "page"
+  if
+    kind = "module" || kind = "container-page" || kind = "page"
+    || kind = "class" || kind = "page"
   then name
   else Printf.sprintf "%s-%s" kind name
 
 let as_filename (url : Url.Path.t) =
-  let rec get_components {Url.Path. parent ; name ; kind } =
+  let rec get_components { Url.Path.parent; name; kind } =
     match parent with
-    | None -> name, []
+    | None -> (name, [])
     | Some p ->
-      let dir, path = get_components p in
-      dir, segment_to_string (kind, name)::path
+        let dir, path = get_components p in
+        (dir, segment_to_string (kind, name) :: path)
   in
   let dir, path = get_components url in
   let s = String.concat "." @@ List.rev path in
-  Fpath.(v dir / s + ".3o")
+  Fpath.((v dir / s) + ".3o")
 
-let rec is_class_or_module_path (url : Url.Path.t) = match url.kind with
-  | "module" | "page" | "container-page" | "class" ->
-    begin match url.parent with
-    | None -> true
-    | Some url -> is_class_or_module_path url
-    end
+let rec is_class_or_module_path (url : Url.Path.t) =
+  match url.kind with
+  | "module" | "page" | "container-page" | "class" -> (
+      match url.parent with
+      | None -> true
+      | Some url -> is_class_or_module_path url )
   | _ -> false
 
 let should_inline x = not @@ is_class_or_module_path x
 
 let files_of_url url =
-  if is_class_or_module_path url then
-    [as_filename url]
-  else
-    []
+  if is_class_or_module_path url then [ as_filename url ] else []

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -4,93 +4,73 @@ module Identifier = Paths.Identifier
 
 type 'a with_location = 'a Location_.with_location
 
-
-type style = [
-  | `Bold
-  | `Italic
-  | `Emphasis
-  | `Superscript
-  | `Subscript
-]
+type style = [ `Bold | `Italic | `Emphasis | `Superscript | `Subscript ]
 
 type raw_markup_target = string
 
-type leaf_inline_element = [
-  | `Space
+type leaf_inline_element =
+  [ `Space
   | `Word of string
   | `Code_span of string
-  | `Raw_markup of raw_markup_target * string
-]
+  | `Raw_markup of raw_markup_target * string ]
 
-type non_link_inline_element = [
-  | leaf_inline_element
-  | `Styled of style * (non_link_inline_element with_location) list
-]
+type non_link_inline_element =
+  [ leaf_inline_element
+  | `Styled of style * non_link_inline_element with_location list ]
 
 (* The cross-referencer stores section heading text, and sometimes pastes it
    into link contents. This type alias is provided for use by the
    cross-referencer. *)
-type link_content = (non_link_inline_element with_location) list
+type link_content = non_link_inline_element with_location list
 
-type inline_element = [
-  | leaf_inline_element
-  | `Styled of style * (inline_element with_location) list
+type inline_element =
+  [ leaf_inline_element
+  | `Styled of style * inline_element with_location list
   | `Reference of Reference.t * link_content
-  | `Link of string * link_content
-]
+  | `Link of string * link_content ]
 
-type nestable_block_element = [
-  | `Paragraph of (inline_element with_location) list
+type nestable_block_element =
+  [ `Paragraph of inline_element with_location list
   | `Code_block of string
   | `Verbatim of string
   | `Modules of Reference.Module.t list
   | `List of
-    [ `Unordered | `Ordered ] *
-    ((nestable_block_element with_location) list) list
-]
+    [ `Unordered | `Ordered ] * nestable_block_element with_location list list
+  ]
 
-type tag = [
-  | `Author of string
-  | `Deprecated of (nestable_block_element with_location) list
-  | `Param of string * (nestable_block_element with_location) list
-  | `Raise of string * (nestable_block_element with_location) list
-  | `Return of (nestable_block_element with_location) list
+type tag =
+  [ `Author of string
+  | `Deprecated of nestable_block_element with_location list
+  | `Param of string * nestable_block_element with_location list
+  | `Raise of string * nestable_block_element with_location list
+  | `Return of nestable_block_element with_location list
   | `See of
-      [ `Url | `File | `Document ] *
-      string *
-      (nestable_block_element with_location) list
+    [ `Url | `File | `Document ]
+    * string
+    * nestable_block_element with_location list
   | `Since of string
-  | `Before of string * (nestable_block_element with_location) list
+  | `Before of string * nestable_block_element with_location list
   | `Version of string
   | `Canonical of Path.Module.t * Reference.Module.t
   | `Inline
   | `Open
-  | `Closed
-]
+  | `Closed ]
 
-type heading_level = [
-  | `Title
+type heading_level =
+  [ `Title
   | `Section
   | `Subsection
   | `Subsubsection
   | `Paragraph
-  | `Subparagraph
-]
+  | `Subparagraph ]
 
-type attached_block_element = [
-  | nestable_block_element
-  | `Tag of tag
-]
+type attached_block_element = [ nestable_block_element | `Tag of tag ]
 
-type block_element = [
-  | nestable_block_element
+type block_element =
+  [ nestable_block_element
   | `Heading of heading_level * Identifier.Label.t * link_content
-  | `Tag of tag
-]
+  | `Tag of tag ]
 
-type docs = (block_element with_location) list
+type docs = block_element with_location list
 
-type docs_or_stop = [
-  | `Docs of docs
-  | `Stop
-]
+type docs_or_stop = [ `Docs of docs | `Stop ]

--- a/src/model/dune
+++ b/src/model/dune
@@ -1,17 +1,29 @@
 (rule
  (targets ident_env.ml)
-  (deps   (:x ident_env.cppo.ml))
-  (action (chdir %{workspace_root} (run %{bin:cppo} -V OCAML:%{ocaml_version} %{x} -o %{targets}))))
+ (deps
+  (:x ident_env.cppo.ml))
+ (action
+  (chdir
+   %{workspace_root}
+   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{x} -o %{targets}))))
 
 (rule
  (targets ident_env.mli)
-  (deps (:x ident_env.cppo.mli))
-  (action (chdir %{workspace_root} (run %{bin:cppo} -V OCAML:%{ocaml_version} %{x} -o %{targets}))))
+ (deps
+  (:x ident_env.cppo.mli))
+ (action
+  (chdir
+   %{workspace_root}
+   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{x} -o %{targets}))))
 
 (rule
  (targets compat.ml)
-  (deps   (:x compat.cppo.ml))
-  (action (chdir %{workspace_root} (run %{bin:cppo} -V OCAML:%{ocaml_version} %{x} -o %{targets}))))
+ (deps
+  (:x compat.cppo.ml))
+ (action
+  (chdir
+   %{workspace_root}
+   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{x} -o %{targets}))))
 
 (library
  (name odoc_model)

--- a/src/model/error.ml
+++ b/src/model/error.ml
@@ -1,90 +1,65 @@
 open Result
 
+type full_location_payload = { location : Location_.span; message : string }
 
+type filename_only_payload = { file : string; message : string }
 
-type full_location_payload = {
-  location : Location_.span;
-  message : string;
-}
-
-type filename_only_payload = {
-  file : string;
-  message : string;
-}
-
-type t = [
-  | `With_full_location of full_location_payload
-  | `With_filename_only of filename_only_payload
-]
+type t =
+  [ `With_full_location of full_location_payload
+  | `With_filename_only of filename_only_payload ]
 
 let kasprintf k fmt =
   Format.(kfprintf (fun _ -> k (flush_str_formatter ())) str_formatter fmt)
 
 let kmake k ?suggestion format =
-  format |>
-  kasprintf (fun message ->
-    match suggestion with
-    | None -> k message
-    | Some suggestion -> k (message ^ "\nSuggestion: " ^ suggestion))
+  format
+  |> kasprintf (fun message ->
+         match suggestion with
+         | None -> k message
+         | Some suggestion -> k (message ^ "\nSuggestion: " ^ suggestion))
 
 let make ?suggestion format =
-  let k message location = `With_full_location {location; message} in
+  let k message location = `With_full_location { location; message } in
   kmake k ?suggestion format
 
 let filename_only ?suggestion format =
-  let k message file = `With_filename_only {file; message} in
+  let k message file = `With_filename_only { file; message } in
   kmake k ?suggestion format
 
 let to_string = function
-  | `With_full_location {location; message} ->
-    let location_string =
-      if location.start.line = location.end_.line then
-        Printf.sprintf "line %i, characters %i-%i"
-          location.start.line
-          location.start.column
-          location.end_.column
-      else
-        Printf.sprintf "line %i, character %i to line %i, character %i"
-          location.start.line
-          location.start.column
-          location.end_.line
-          location.end_.column
-    in
-    Printf.sprintf "File \"%s\", %s:\n%s" location.file location_string message
-
-  | `With_filename_only {file; message} ->
-    Printf.sprintf "File \"%s\":\n%s" file message
-
+  | `With_full_location { location; message } ->
+      let location_string =
+        if location.start.line = location.end_.line then
+          Printf.sprintf "line %i, characters %i-%i" location.start.line
+            location.start.column location.end_.column
+        else
+          Printf.sprintf "line %i, character %i to line %i, character %i"
+            location.start.line location.start.column location.end_.line
+            location.end_.column
+      in
+      Printf.sprintf "File \"%s\", %s:\n%s" location.file location_string
+        message
+  | `With_filename_only { file; message } ->
+      Printf.sprintf "File \"%s\":\n%s" file message
 
 exception Conveyed_by_exception of t
 
-let raise_exception error =
-  raise (Conveyed_by_exception error)
+let raise_exception error = raise (Conveyed_by_exception error)
 
-let to_exception = function
-  | Ok v -> v
-  | Error error -> raise_exception error
+let to_exception = function Ok v -> v | Error error -> raise_exception error
 
-let catch f =
-  try Ok (f ())
-  with Conveyed_by_exception error -> Error error
+let catch f = try Ok (f ()) with Conveyed_by_exception error -> Error error
 
-
-
-type 'a with_warnings = {
-  value : 'a;
-  warnings : t list;
-}
+type 'a with_warnings = { value : 'a; warnings : t list }
 
 type warning_accumulator = t list ref
 
 let accumulate_warnings f =
   let warnings = ref [] in
   let value = f warnings in
-  {value; warnings = List.rev !warnings}
+  { value; warnings = List.rev !warnings }
 
-let warning accumulator error =
-  accumulator := error::!accumulator
+let warning accumulator error = accumulator := error :: !accumulator
 
 let with_ref r f =
   let saved = !r in
@@ -109,16 +84,14 @@ let catch_warnings f =
       let warnings = List.rev !raised_warnings in
       { value; warnings })
 
-let catch_errors_and_warnings f =
-  catch_warnings (fun () -> catch f)
+let catch_errors_and_warnings f = catch_warnings (fun () -> catch f)
 
 let print_warnings = List.iter (fun w -> prerr_endline (to_string w))
 
 (* When there is warnings. *)
 let handle_warn_error ~warn_error warnings ok =
   print_warnings warnings;
-  if warn_error then Error (`Msg "Warnings have been generated.")
-  else Ok ok
+  if warn_error then Error (`Msg "Warnings have been generated.") else Ok ok
 
 let handle_warnings ~warn_error ww =
   match ww.warnings with
@@ -127,7 +100,7 @@ let handle_warnings ~warn_error ww =
 
 let handle_errors_and_warnings ~warn_error = function
   | { value = Error e; warnings } ->
-    print_warnings warnings;
-    Error (`Msg (to_string e))
-  | { value = (Ok _ as ok); warnings = [] } -> ok
+      print_warnings warnings;
+      Error (`Msg (to_string e))
+  | { value = Ok _ as ok; warnings = [] } -> ok
   | { value = Ok ok; warnings } -> handle_warn_error ~warn_error warnings ok

--- a/src/model/error.mli
+++ b/src/model/error.mli
@@ -1,24 +1,27 @@
 type t
 
 val make :
-  ?suggestion:string -> ('a, Format.formatter, unit, Location_.span -> t) format4 -> 'a
+  ?suggestion:string ->
+  ('a, Format.formatter, unit, Location_.span -> t) format4 ->
+  'a
+
 val filename_only :
   ?suggestion:string -> ('a, Format.formatter, unit, string -> t) format4 -> 'a
 
 val to_string : t -> string
 
 val raise_exception : t -> _
+
 val to_exception : ('a, t) Result.result -> 'a
+
 val catch : (unit -> 'a) -> ('a, t) Result.result
 
-type 'a with_warnings = {
-  value : 'a;
-  warnings : t list;
-}
+type 'a with_warnings = { value : 'a; warnings : t list }
 
 type warning_accumulator
 
 val accumulate_warnings : (warning_accumulator -> 'a) -> 'a with_warnings
+
 val warning : warning_accumulator -> t -> unit
 
 val raise_warnings : 'a with_warnings -> 'a

--- a/src/model/ident_env.cppo.mli
+++ b/src/model/ident_env.cppo.mli
@@ -21,7 +21,8 @@ val empty : t
 val add_parameter :
   Paths.Identifier.Signature.t -> Ident.t -> Names.ParameterName.t -> t -> t
 
-val handle_signature_type_items : Paths.Identifier.Signature.t -> Compat.signature -> t -> t
+val handle_signature_type_items :
+  Paths.Identifier.Signature.t -> Compat.signature -> t -> t
 
 val add_signature_tree_items :
   Paths.Identifier.Signature.t -> Typedtree.signature -> t -> t
@@ -54,6 +55,7 @@ val find_class_identifier : t -> Ident.t -> Paths.Identifier.Class.t
 val is_shadowed : t -> Ident.t -> bool
 
 val find_class_type_identifier : t -> Ident.t -> Paths.Identifier.ClassType.t
+
 module Fragment : sig
   val read_module : Longident.t -> Paths.Fragment.Module.t
 

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -63,32 +63,32 @@ and ModuleType : sig
   type simple_expansion =
     | Signature of Signature.t
     | Functor of FunctorParameter.t * simple_expansion
-  
+
   type typeof_t = {
     t_desc : type_of_desc;
-    t_expansion : simple_expansion option
+    t_expansion : simple_expansion option;
   }
-  
+
   module U : sig
     type expr =
-        | Path of Path.ModuleType.t
-        | Signature of Signature.t
-        | With of substitution list * expr
-        | TypeOf of typeof_t (* Nb. this may have an expansion! *)
+      | Path of Path.ModuleType.t
+      | Signature of Signature.t
+      | With of substitution list * expr
+      | TypeOf of typeof_t
+
+    (* Nb. this may have an expansion! *)
   end
-  
 
   type path_t = {
     p_expansion : simple_expansion option;
-    p_path : Path.ModuleType.t
+    p_path : Path.ModuleType.t;
   }
 
   type with_t = {
     w_substitutions : substitution list;
     w_expansion : simple_expansion option;
-    w_expr : U.expr
+    w_expr : U.expr;
   }
-
 
   type expr =
     | Path of path_t
@@ -158,13 +158,11 @@ and Include : sig
   type expansion = {
     resolved : bool;
     shadowed : shadowed;
-    content : Signature.t
+    content : Signature.t;
   }
 
   (* Explicitly unexpanded decl *)
-  type decl =
-    | Alias of Path.Module.t
-    | ModuleType of ModuleType.U.expr
+  type decl = Alias of Path.Module.t | ModuleType of ModuleType.U.expr
 
   type t = {
     parent : Identifier.Signature.t;
@@ -210,7 +208,11 @@ and TypeDecl : sig
 
   type param_desc = Any | Var of string
 
-  type param = { desc: param_desc; variance:variance option; injectivity:bool }
+  type param = {
+    desc : param_desc;
+    variance : variance option;
+    injectivity : bool;
+  }
 
   module Equation : sig
     type t = {
@@ -415,7 +417,7 @@ end =
 module rec Compilation_unit : sig
   module Import : sig
     type t =
-        Unresolved of string * Digest.t option
+      | Unresolved of string * Digest.t option
       | Resolved of Root.t * Names.ModuleName.t
   end
 
@@ -457,10 +459,9 @@ module rec Page : sig
 end =
   Page
 
-let umty_of_mty : ModuleType.expr -> ModuleType.U.expr =
-  function
+let umty_of_mty : ModuleType.expr -> ModuleType.U.expr = function
   | Signature sg -> Signature sg
-  | Path { p_path; _} -> Path p_path
+  | Path { p_path; _ } -> Path p_path
   | Functor _ -> assert false
   | TypeOf t -> TypeOf t
-  | With {w_substitutions; w_expr; _ } -> With (w_substitutions, w_expr)
+  | With { w_substitutions; w_expr; _ } -> With (w_substitutions, w_expr)

--- a/src/model/location_.ml
+++ b/src/model/location_.ml
@@ -1,68 +1,41 @@
-type point = {
-  line : int;
-  column : int;
-}
+type point = { line : int; column : int }
 
-type span = {
-  file : string;
-  start : point;
-  end_ : point;
-}
+type span = { file : string; start : point; end_ : point }
 
-type +'a with_location = {
-  location : span;
-  value : 'a;
-}
+type +'a with_location = { location : span; value : 'a }
 
-let at location value =
-  {location; value}
+let at location value = { location; value }
 
-let location {location; _} =
-  location
+let location { location; _ } = location
 
-let value {value; _} =
-  value
+let value { value; _ } = value
 
-let map f annotated =
-  {annotated with value = f annotated.value}
+let map f annotated = { annotated with value = f annotated.value }
 
-let same annotated value =
-  {annotated with value}
+let same annotated value = { annotated with value }
 
 let span spans =
   match spans with
   | [] ->
-    {
-      file = "_none_";
-      start = {
-        line = 1;
-        column = 0;
-      };
-      end_ = {
-        line = 1;
-        column = 0;
-      };
-    }
-  | first::spans ->
-    let last = List.fold_left (fun _ span -> span) first spans in
-    {
-      file = first.file;
-      start = first.start;
-      end_ = last.end_;
-    }
+      {
+        file = "_none_";
+        start = { line = 1; column = 0 };
+        end_ = { line = 1; column = 0 };
+      }
+  | first :: spans ->
+      let last = List.fold_left (fun _ span -> span) first spans in
+      { file = first.file; start = first.start; end_ = last.end_ }
 
 let nudge_start offset span =
-  {span with start = {span.start with column = span.start.column + offset}}
+  { span with start = { span.start with column = span.start.column + offset } }
 
 let set_end_as_offset_from_start offset span =
-  {span with end_ = {span.start with column = span.start.column + offset}}
+  { span with end_ = { span.start with column = span.start.column + offset } }
 
 let point_in_string s offset point =
   let rec scan_string line column index =
-    if index >= offset then
-      (line, column)
-    else if index >= String.length s then
-      (line, column)
+    if index >= offset then (line, column)
+    else if index >= String.length s then (line, column)
     else
       match s.[index] with
       | '\n' -> scan_string (line + 1) 0 (index + 1)
@@ -71,11 +44,13 @@ let point_in_string s offset point =
 
   let line, column = scan_string 0 0 0 in
 
-  {line = point.line + line; column = point.column + column}
+  { line = point.line + line; column = point.column + column }
 
 (* Calling this repeatedly on the same string can be optimized, but there is no
    evidence yet that performance of this is a problem. *)
 let in_string s ~offset ~length s_span =
-  {s_span with
+  {
+    s_span with
     start = point_in_string s offset s_span.start;
-    end_ = point_in_string s (offset + length) s_span.start}
+    end_ = point_in_string s (offset + length) s_span.start;
+  }

--- a/src/model/location_.mli
+++ b/src/model/location_.mli
@@ -1,25 +1,17 @@
-type point = {
-  line : int;
-  column : int;
-}
+type point = { line : int; column : int }
 
-type span = {
-  file : string;
-  start : point;
-  end_ : point;
-}
+type span = { file : string; start : point; end_ : point }
 
-type +'a with_location = {
-  location : span;
-  value : 'a;
-}
+type +'a with_location = { location : span; value : 'a }
 
 val at : span -> 'a -> 'a with_location
 
 val location : 'a with_location -> span
+
 val value : 'a with_location -> 'a
 
 val map : ('a -> 'b) -> 'a with_location -> 'b with_location
+
 val same : _ with_location -> 'b -> 'b with_location
 
 val span : span list -> span
@@ -27,5 +19,7 @@ val span : span list -> span
 (* This adjusts only the column number, implicitly assuming that the offset does
    not move the location across a newline character. *)
 val nudge_start : int -> span -> span
+
 val set_end_as_offset_from_start : int -> span -> span
+
 val in_string : string -> offset:int -> length:int -> span -> span

--- a/src/model/names.ml
+++ b/src/model/names.ml
@@ -1,154 +1,132 @@
 module type Name = sig
+  type t
 
-    type t
+  val to_string : t -> string
 
-    val to_string : t -> string
+  val to_string_unsafe : t -> string
 
-    val to_string_unsafe : t -> string
+  val of_string : string -> t
 
-    val of_string : string -> t
+  val of_ident : Ident.t -> t
 
-    val of_ident : Ident.t -> t
+  val internal_of_string : string -> t
 
-    val internal_of_string : string -> t
+  val internal_of_ident : Ident.t -> t
 
-    val internal_of_ident : Ident.t -> t
+  val is_internal : t -> bool
 
-    val is_internal : t -> bool
+  val equal : t -> t -> bool
 
-    val equal : t -> t -> bool
+  val compare : t -> t -> int
 
-    val compare : t -> t -> int
+  val fmt : Format.formatter -> t -> unit
 
-    val fmt : Format.formatter -> t -> unit
-
-    val is_hidden : t -> bool
+  val is_hidden : t -> bool
 end
 
 let internal_counter = ref 0
 
 module Name : Name = struct
+  type t = Internal of string * int | Std of string
 
-    type t =
-        | Internal of string * int
-        | Std of string
+  let to_string = function
+    | Std s -> s
+    | Internal (s, i) -> Printf.sprintf "$%s$%d" s i
 
-    let to_string = function
-        | Std s -> s
-        | Internal (s,i) -> Printf.sprintf "$%s$%d" s i
+  let to_string_unsafe = function Std s -> s | Internal (s, _i) -> s
 
-    let to_string_unsafe = function
-        | Std s -> s
-        | Internal (s,_i) -> s
+  let of_string s =
+    if String.length s > 0 && s.[0] = '$' then raise (Invalid_argument s)
+    else Std s
 
-    let of_string s =
-      if String.length s > 0 && s.[0] = '$' then begin
-        raise (Invalid_argument s)
-      end else Std s
+  let of_ident id = of_string (Ident.name id)
 
-    let of_ident id = of_string (Ident.name id)
+  let internal_of_string id =
+    incr internal_counter;
+    Internal (id, !internal_counter)
 
-    let internal_of_string id = incr internal_counter; Internal (id, !internal_counter)
+  let internal_of_ident id = internal_of_string (Ident.name id)
 
-    let internal_of_ident id = internal_of_string (Ident.name id)
+  let is_internal = function Std _ -> false | Internal _ -> true
 
-    let is_internal = function | Std _ -> false | Internal _ -> true
+  let equal (x : t) (y : t) = x = y
 
-    let equal (x : t) (y : t) = x = y
+  let compare x y =
+    match (x, y) with
+    | Internal (x, _), Internal (y, _) -> String.compare x y
+    | Std x, Std y -> String.compare x y
+    | Internal _, Std _ -> -1
+    | Std _, Internal _ -> 1
 
-    let compare x y =
-        match x, y with
-        | Internal (x, _), Internal (y, _) -> String.compare x y
-        | Std x, Std y -> String.compare x y
-        | Internal _, Std _ -> -1
-        | Std _, Internal _ -> 1
+  let fmt ppf x = Format.fprintf ppf "%s" (to_string x)
 
-    let fmt ppf x = Format.fprintf ppf "%s" (to_string x)
-
-    let is_hidden = function
-        | Std s ->
-            let len = String.length s in
-            let rec aux i =
-                if i > len - 2 then false else
-                if s.[i] = '_' && s.[i + 1] = '_' then true
-                else aux (i + 1)
-            in aux 0
-        | Internal _ -> true
+  let is_hidden = function
+    | Std s ->
+        let len = String.length s in
+        let rec aux i =
+          if i > len - 2 then false
+          else if s.[i] = '_' && s.[i + 1] = '_' then true
+          else aux (i + 1)
+        in
+        aux 0
+    | Internal _ -> true
 end
 
 module type SimpleName = sig
+  type t
 
-    type t
+  val to_string : t -> string
 
-    val to_string : t -> string
+  val of_string : string -> t
 
-    val of_string : string -> t
+  val of_ident : Ident.t -> t
 
-    val of_ident : Ident.t -> t
+  val equal : t -> t -> bool
 
-    val equal : t -> t -> bool
+  val compare : t -> t -> int
 
-    val compare : t -> t -> int
+  val fmt : Format.formatter -> t -> unit
 
-    val fmt : Format.formatter -> t -> unit
-
-    val is_hidden : t -> bool
-
+  val is_hidden : t -> bool
 end
 
 module SimpleName : SimpleName = struct
+  type t = string
 
-    type t = string
+  let to_string s = s
 
-    let to_string s = s
+  let of_string s = s
 
-    let of_string s = s
+  let of_ident id = of_string (Ident.name id)
 
-    let of_ident id = of_string (Ident.name id)
+  let equal (x : t) (y : t) = x = y
 
-    let equal (x : t) (y : t) = x = y
+  let compare x y = String.compare x y
 
-    let compare x y = String.compare x y
+  let fmt ppf t = Format.pp_print_string ppf (to_string t)
 
-    let fmt ppf t = Format.pp_print_string ppf (to_string t)
-
-    let is_hidden s =
-        let len = String.length s in
-        let rec aux i =
-            if i > len - 2 then false else
-            if s.[i] = '_' && s.[i + 1] = '_' then true
-            else aux (i + 1)
-        in aux 0
+  let is_hidden s =
+    let len = String.length s in
+    let rec aux i =
+      if i > len - 2 then false
+      else if s.[i] = '_' && s.[i + 1] = '_' then true
+      else aux (i + 1)
+    in
+    aux 0
 end
 
 module ModuleName = Name
-
 module ParameterName = Name
-
 module ModuleTypeName = Name
-
 module TypeName = Name
-
 module ConstructorName = SimpleName
-
 module FieldName = SimpleName
-
 module ExtensionName = SimpleName
-
 module ExceptionName = SimpleName
-
 module ValueName = SimpleName
-
 module ClassName = Name
-
 module ClassTypeName = Name
-
 module MethodName = SimpleName
-
 module InstanceVariableName = SimpleName
-
 module LabelName = SimpleName
-
 module PageName = SimpleName
-
-

--- a/src/model/names.mli
+++ b/src/model/names.mli
@@ -17,56 +17,53 @@
     and hence the 'safe' [to_string] will not currently raise an exception. When
     the model is updated to handle this the exception will be reinstated. *)
 module type Name = sig
+  type t
 
-    type t
+  val to_string : t -> string
 
-    val to_string : t -> string
-
-    (** [to_string_unsafe] will allow even internal names to be turned into
+  val to_string_unsafe : t -> string
+  (** [to_string_unsafe] will allow even internal names to be turned into
         strings. Use with caution. *)
-    val to_string_unsafe : t -> string
 
-    val of_string : string -> t
+  val of_string : string -> t
 
-    val of_ident : Ident.t -> t
+  val of_ident : Ident.t -> t
 
-    val internal_of_string : string -> t
+  val internal_of_string : string -> t
 
-    val internal_of_ident : Ident.t -> t
+  val internal_of_ident : Ident.t -> t
 
-    val is_internal : t -> bool
+  val is_internal : t -> bool
 
-    val equal : t -> t -> bool
+  val equal : t -> t -> bool
 
-    val compare : t -> t -> int
+  val compare : t -> t -> int
 
-    val fmt : Format.formatter -> t -> unit
+  val fmt : Format.formatter -> t -> unit
 
-    (** Hidden names are those that contain a double underscore, e.g.
+  val is_hidden : t -> bool
+  (** Hidden names are those that contain a double underscore, e.g.
         [Hidden__module] *)
-    val is_hidden : t -> bool
 end
 
 (** Some named objects can't have internal names, so they have this simpler
     module. *)
 module type SimpleName = sig
+  type t
 
-    type t
+  val to_string : t -> string
 
-    val to_string : t -> string
+  val of_string : string -> t
 
-    val of_string : string -> t
+  val of_ident : Ident.t -> t
 
-    val of_ident : Ident.t -> t
+  val equal : t -> t -> bool
 
-    val equal : t -> t -> bool
+  val compare : t -> t -> int
 
-    val compare : t -> t -> int
+  val fmt : Format.formatter -> t -> unit
 
-    val fmt : Format.formatter -> t -> unit
-
-    val is_hidden : t -> bool
-
+  val is_hidden : t -> bool
 end
 
 module ModuleName : Name

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -17,33 +17,32 @@
 open Names
 
 module Identifier = struct
-
   type t = Paths_types.Identifier.any
 
   let rec name_aux : t -> string = function
-    | `Root(_, name) -> ModuleName.to_string name
+    | `Root (_, name) -> ModuleName.to_string name
     | `RootPage name -> PageName.to_string name
-    | `Page(_, name) -> PageName.to_string name
-    | `LeafPage(_, name) -> PageName.to_string name
-    | `Module(_, name) -> ModuleName.to_string name
-    | `Parameter(_, name) -> ParameterName.to_string name
+    | `Page (_, name) -> PageName.to_string name
+    | `LeafPage (_, name) -> PageName.to_string name
+    | `Module (_, name) -> ModuleName.to_string name
+    | `Parameter (_, name) -> ParameterName.to_string name
     | `Result x -> name_aux (x :> t)
-    | `ModuleType(_, name) -> ModuleTypeName.to_string name
-    | `Type(_, name) -> TypeName.to_string name
+    | `ModuleType (_, name) -> ModuleTypeName.to_string name
+    | `Type (_, name) -> TypeName.to_string name
     | `CoreType name -> TypeName.to_string name
-    | `Constructor(_, name) -> ConstructorName.to_string name
-    | `Field(_, name) -> FieldName.to_string name
-    | `Extension(_, name) -> ExtensionName.to_string name
-    | `Exception(_, name) -> ExceptionName.to_string name
+    | `Constructor (_, name) -> ConstructorName.to_string name
+    | `Field (_, name) -> FieldName.to_string name
+    | `Extension (_, name) -> ExtensionName.to_string name
+    | `Exception (_, name) -> ExceptionName.to_string name
     | `CoreException name -> ExceptionName.to_string name
-    | `Value(_, name) -> ValueName.to_string name
-    | `Class(_, name) -> ClassName.to_string name
-    | `ClassType(_, name) -> ClassTypeName.to_string name
-    | `Method(_, name) -> MethodName.to_string name
-    | `InstanceVariable(_, name) -> InstanceVariableName.to_string name
-    | `Label(_, name) -> LabelName.to_string name
+    | `Value (_, name) -> ValueName.to_string name
+    | `Class (_, name) -> ClassName.to_string name
+    | `ClassType (_, name) -> ClassTypeName.to_string name
+    | `Method (_, name) -> MethodName.to_string name
+    | `InstanceVariable (_, name) -> InstanceVariableName.to_string name
+    | `Label (_, name) -> LabelName.to_string name
 
-  let name : [< t] -> string = fun n -> name_aux (n :> t)
+  let name : [< t ] -> string = fun n -> name_aux (n :> t)
 
   let rec label_parent_aux =
     let open Paths_types.Identifier in
@@ -76,92 +75,119 @@ module Identifier = struct
   let rec hash (id : t) =
     let open Paths_types.Identifier in
     match id with
-    | `Root(r, s) ->
-      Hashtbl.hash (1, hash (r : container_page :> any), s)
-    | `RootPage s ->
-      Hashtbl.hash (2, s)
-    | `Page(r, s) ->
-      Hashtbl.hash (0, hash (r : container_page :> any), s)
-    | `LeafPage(r, s) ->
-      Hashtbl.hash (20, hash (r : container_page :> any), s)
-    | `Module(id, s) ->
-      Hashtbl.hash (3, hash (id : signature :> any), s)
-    | `Parameter(id, s) ->
-      Hashtbl.hash (4, hash (id : signature :> any), s)
-    | `Result(s) ->
-      Hashtbl.hash (5, hash (s : signature :> any))
-    | `ModuleType(id, s) ->
-      Hashtbl.hash (6, hash (id : signature :> any), s)
-    | `Type(id, s) ->
-      Hashtbl.hash (7, hash (id : signature :> any), s)
-    | `CoreType s ->
-      Hashtbl.hash (8, s)
-    | `Constructor(id, s) ->
-      Hashtbl.hash (9, hash (id : type_ :> any), s)
-    | `Field(id, s) ->
-      Hashtbl.hash (10, hash (id : parent :> any), s)
-    | `Extension(id, s) ->
-      Hashtbl.hash (11, hash (id : signature :> any), s)
-    | `Exception(id, s) ->
-      Hashtbl.hash (12, hash (id : signature :> any), s)
-    | `CoreException s ->
-      Hashtbl.hash (13, s)
-    | `Value(id, s) ->
-      Hashtbl.hash (14, hash (id : signature :> any), s)
-    | `Class(id, s) ->
-      Hashtbl.hash (15, hash (id : signature :> any), s)
-    | `ClassType(id, s) ->
-      Hashtbl.hash (16, hash (id : signature :> any), s)
-    | `Method(id, s) ->
-      Hashtbl.hash (17, hash (id : class_signature :> any), s)
-    | `InstanceVariable(id, s) ->
-      Hashtbl.hash (18, hash (id : class_signature :> any), s)
-    | `Label(id, s) ->
-      Hashtbl.hash (19, hash (id : label_parent :> any ), s)
+    | `Root (r, s) -> Hashtbl.hash (1, hash (r : container_page :> any), s)
+    | `RootPage s -> Hashtbl.hash (2, s)
+    | `Page (r, s) -> Hashtbl.hash (0, hash (r : container_page :> any), s)
+    | `LeafPage (r, s) -> Hashtbl.hash (20, hash (r : container_page :> any), s)
+    | `Module (id, s) -> Hashtbl.hash (3, hash (id : signature :> any), s)
+    | `Parameter (id, s) -> Hashtbl.hash (4, hash (id : signature :> any), s)
+    | `Result s -> Hashtbl.hash (5, hash (s : signature :> any))
+    | `ModuleType (id, s) -> Hashtbl.hash (6, hash (id : signature :> any), s)
+    | `Type (id, s) -> Hashtbl.hash (7, hash (id : signature :> any), s)
+    | `CoreType s -> Hashtbl.hash (8, s)
+    | `Constructor (id, s) -> Hashtbl.hash (9, hash (id : type_ :> any), s)
+    | `Field (id, s) -> Hashtbl.hash (10, hash (id : parent :> any), s)
+    | `Extension (id, s) -> Hashtbl.hash (11, hash (id : signature :> any), s)
+    | `Exception (id, s) -> Hashtbl.hash (12, hash (id : signature :> any), s)
+    | `CoreException s -> Hashtbl.hash (13, s)
+    | `Value (id, s) -> Hashtbl.hash (14, hash (id : signature :> any), s)
+    | `Class (id, s) -> Hashtbl.hash (15, hash (id : signature :> any), s)
+    | `ClassType (id, s) -> Hashtbl.hash (16, hash (id : signature :> any), s)
+    | `Method (id, s) -> Hashtbl.hash (17, hash (id : class_signature :> any), s)
+    | `InstanceVariable (id, s) ->
+        Hashtbl.hash (18, hash (id : class_signature :> any), s)
+    | `Label (id, s) -> Hashtbl.hash (19, hash (id : label_parent :> any), s)
 
   let constructor_id : t -> int = function
-    | `Root _ -> 1 | `RootPage _ -> 2 | `Module _ -> 3 | `Parameter _ -> 4
-    | `Result _ -> 5 | `ModuleType _ -> 6 | `Type _ -> 7 | `CoreType _ -> 8
-    | `Constructor _ -> 9 | `Field _ -> 10 | `Extension _ -> 11 | `Exception _ -> 12
-    | `CoreException _ -> 13 | `Value _ -> 14 | `Class _ -> 15 | `ClassType _ -> 16
-    | `Method _ -> 17 | `InstanceVariable _ -> 18 | `Label _ -> 19 | `Page _ -> 20
+    | `Root _ -> 1
+    | `RootPage _ -> 2
+    | `Module _ -> 3
+    | `Parameter _ -> 4
+    | `Result _ -> 5
+    | `ModuleType _ -> 6
+    | `Type _ -> 7
+    | `CoreType _ -> 8
+    | `Constructor _ -> 9
+    | `Field _ -> 10
+    | `Extension _ -> 11
+    | `Exception _ -> 12
+    | `CoreException _ -> 13
+    | `Value _ -> 14
+    | `Class _ -> 15
+    | `ClassType _ -> 16
+    | `Method _ -> 17
+    | `InstanceVariable _ -> 18
+    | `Label _ -> 19
+    | `Page _ -> 20
     | `LeafPage _ -> 21
 
   let std_compare = compare
 
   let rec compare : t -> t -> int =
-    fun x y ->
-      match x,y with
-      | `Root(r, s), `Root(r', s') -> let s = ModuleName.compare s s' in if s<>0 then s else compare (r :> t) (r' :> t)
-      | `RootPage s, `RootPage s' -> PageName.compare s s'
-      | `Page(r, s), `Page(r', s') -> let s = PageName.compare s s' in if s<>0 then s else compare (r :> t) (r' :> t)
-      | `LeafPage(r, s), `LeafPage(r', s') -> let s = PageName.compare s s' in if s<>0 then s else compare (r :> t) (r' :> t)
-      | `Module (p, s), `Module (p', s') -> let s = ModuleName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `Parameter (p, s), `Parameter (p', s') -> let s = ParameterName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `Result p, `Result p' -> compare (p :> t) (p' :> t)
-      | `ModuleType (p, s), `ModuleType (p', s') -> let s = ModuleTypeName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `Type(p, s), `Type(p', s') -> let s = TypeName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `CoreType s, `CoreType s' -> TypeName.compare s s' 
-      | `Constructor(p, s), `Constructor(p', s') -> let s = ConstructorName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `Field(p, s), `Field(p', s') -> let s = FieldName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `Extension(p, s), `Extension(p', s') -> let s = ExtensionName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `Exception(p, s), `Exception(p', s') -> let s = ExceptionName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `CoreException s, `CoreException s' -> ExceptionName.compare s s'
-      | `Value(p, s), `Value(p', s')  -> let s = ValueName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `Class(p, s), `Class(p', s') -> let s = ClassName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `ClassType(p, s), `ClassType(p', s') -> let s = ClassTypeName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `Method(p, s), `Method(p', s') -> let s = MethodName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `InstanceVariable(p, s), `InstanceVariable(p', s')  -> let s = InstanceVariableName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | `Label(p, s), `Label(p', s') -> let s = LabelName.compare s s' in if s<>0 then s else compare (p :> t) (p' :> t)
-      | x, y -> std_compare (constructor_id x) (constructor_id y)
+   fun x y ->
+    match (x, y) with
+    | `Root (r, s), `Root (r', s') ->
+        let s = ModuleName.compare s s' in
+        if s <> 0 then s else compare (r :> t) (r' :> t)
+    | `RootPage s, `RootPage s' -> PageName.compare s s'
+    | `Page (r, s), `Page (r', s') ->
+        let s = PageName.compare s s' in
+        if s <> 0 then s else compare (r :> t) (r' :> t)
+    | `LeafPage (r, s), `LeafPage (r', s') ->
+        let s = PageName.compare s s' in
+        if s <> 0 then s else compare (r :> t) (r' :> t)
+    | `Module (p, s), `Module (p', s') ->
+        let s = ModuleName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `Parameter (p, s), `Parameter (p', s') ->
+        let s = ParameterName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `Result p, `Result p' -> compare (p :> t) (p' :> t)
+    | `ModuleType (p, s), `ModuleType (p', s') ->
+        let s = ModuleTypeName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `Type (p, s), `Type (p', s') ->
+        let s = TypeName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `CoreType s, `CoreType s' -> TypeName.compare s s'
+    | `Constructor (p, s), `Constructor (p', s') ->
+        let s = ConstructorName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `Field (p, s), `Field (p', s') ->
+        let s = FieldName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `Extension (p, s), `Extension (p', s') ->
+        let s = ExtensionName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `Exception (p, s), `Exception (p', s') ->
+        let s = ExceptionName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `CoreException s, `CoreException s' -> ExceptionName.compare s s'
+    | `Value (p, s), `Value (p', s') ->
+        let s = ValueName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `Class (p, s), `Class (p', s') ->
+        let s = ClassName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `ClassType (p, s), `ClassType (p', s') ->
+        let s = ClassTypeName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `Method (p, s), `Method (p', s') ->
+        let s = MethodName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `InstanceVariable (p, s), `InstanceVariable (p', s') ->
+        let s = InstanceVariableName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | `Label (p, s), `Label (p', s') ->
+        let s = LabelName.compare s s' in
+        if s <> 0 then s else compare (p :> t) (p' :> t)
+    | x, y -> std_compare (constructor_id x) (constructor_id y)
 
-  let equal : t -> t -> bool =
-    fun x y -> compare x y = 0
+  let equal : t -> t -> bool = fun x y -> compare x y = 0
 
   type any = t
 
-  module Signature =
-  struct
+  module Signature = struct
     type t = Paths_types.Identifier.signature
 
     let equal x y = equal (x :> any) (y :> any)
@@ -171,9 +197,8 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module ClassSignature =
-  struct
-    type t = Paths_types.Identifier.class_signature 
+  module ClassSignature = struct
+    type t = Paths_types.Identifier.class_signature
 
     let equal x y = equal (x :> any) (y :> any)
 
@@ -182,8 +207,7 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module DataType =
-  struct
+  module DataType = struct
     type t = Paths_types.Identifier.datatype
 
     let equal x y = equal (x :> any) (y :> any)
@@ -191,88 +215,79 @@ module Identifier = struct
     let hash x = hash (x :> any)
 
     let compare x y = compare (x :> any) (y :> any)
-
   end
 
-  module Parent =
-  struct
+  module Parent = struct
     type t = Paths_types.Identifier.parent
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
 
     let compare x y = compare (x :> any) (y :> any)
-
   end
 
-  module LabelParent =
-  struct
+  module LabelParent = struct
     type t = Paths_types.Identifier.label_parent
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
 
     let compare x y = compare (x :> any) (y :> any)
-
   end
 
-  module RootModule =
-  struct
+  module RootModule = struct
     type t = Paths_types.Identifier.root_module
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
 
     let compare x y = compare (x :> any) (y :> any)
-
   end
 
-  module Module =
-  struct
+  module Module = struct
     type t = Paths_types.Identifier.module_
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
 
     let compare x y = compare (x :> any) (y :> any)
-
   end
 
-  module FunctorParameter =
-  struct
+  module FunctorParameter = struct
     type t = Paths_types.Identifier.functor_parameter
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
 
     let compare x y = compare (x :> any) (y :> any)
-
   end
 
-  module ModuleType =
-  struct
+  module ModuleType = struct
     type t = Paths_types.Identifier.module_type
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
 
     let compare x y = compare (x :> any) (y :> any)
-
   end
 
-  module Type =
-  struct
+  module Type = struct
     type t = Paths_types.Identifier.type_
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
 
     let compare x y = compare (x :> any) (y :> any)
-
   end
 
-  module Constructor =
-  struct
+  module Constructor = struct
     type t = Paths_types.Identifier.constructor
 
     let equal x y = equal (x :> any) (y :> any)
@@ -282,8 +297,7 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module Field =
-  struct
+  module Field = struct
     type t = Paths_types.Identifier.field
 
     let equal x y = equal (x :> any) (y :> any)
@@ -293,8 +307,7 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module Extension =
-  struct
+  module Extension = struct
     type t = Paths_types.Identifier.extension
 
     let equal x y = equal (x :> any) (y :> any)
@@ -304,20 +317,19 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module Exception =
-  struct
+  module Exception = struct
     type t = Paths_types.Identifier.exception_
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
 
     let compare x y = compare (x :> any) (y :> any)
-
   end
 
-  module Value =
-  struct
+  module Value = struct
     type t = Paths_types.Identifier.value
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
@@ -325,9 +337,9 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module Class =
-  struct
+  module Class = struct
     type t = Paths_types.Identifier.class_
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
@@ -335,9 +347,9 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module ClassType =
-  struct
+  module ClassType = struct
     type t = Paths_types.Identifier.class_type
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
@@ -345,9 +357,9 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module Method =
-  struct
+  module Method = struct
     type t = Paths_types.Identifier.method_
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
@@ -355,9 +367,9 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module InstanceVariable =
-  struct
+  module InstanceVariable = struct
     type t = Paths_types.Identifier.instance_variable
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
@@ -365,9 +377,9 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module Label =
-  struct
+  module Label = struct
     type t = Paths_types.Identifier.label
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
@@ -375,9 +387,9 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module Page =
-  struct
+  module Page = struct
     type t = Paths_types.Identifier.page
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
@@ -385,9 +397,9 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module ContainerPage =
-  struct
+  module ContainerPage = struct
     type t = Paths_types.Identifier.container_page
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
@@ -395,9 +407,9 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module OdocId =
-  struct
+  module OdocId = struct
     type t = Paths_types.Identifier.odoc_id
+
     let equal x y = equal (x :> any) (y :> any)
 
     let hash x = hash (x :> any)
@@ -405,331 +417,325 @@ module Identifier = struct
     let compare x y = compare (x :> any) (y :> any)
   end
 
-  module Path =
-  struct
-    module Module =
-    struct
+  module Path = struct
+    module Module = struct
       type t = Paths_types.Identifier.path_module
+
       let equal x y = equal (x :> any) (y :> any)
 
       let hash x = hash (x :> any)
-  
+
       let compare x y = compare (x :> any) (y :> any)
-  
     end
 
-    module ModuleType =
-    struct
+    module ModuleType = struct
       type t = Paths_types.Identifier.path_module_type
+
       let equal x y = equal (x :> any) (y :> any)
 
       let hash x = hash (x :> any)
-  
+
       let compare x y = compare (x :> any) (y :> any)
-  
     end
 
-    module Type =
-    struct
+    module Type = struct
       type t = Paths_types.Identifier.path_type
+
       let equal x y = equal (x :> any) (y :> any)
 
       let hash x = hash (x :> any)
-  
-      let compare x y = compare (x :> any) (y :> any)
-      end
 
-    module ClassType =
-    struct
+      let compare x y = compare (x :> any) (y :> any)
+    end
+
+    module ClassType = struct
       type t = Paths_types.Identifier.path_class_type
+
       let equal x y = equal (x :> any) (y :> any)
 
       let hash x = hash (x :> any)
-  
+
       let compare x y = compare (x :> any) (y :> any)
-      end
+    end
 
     type t = Paths_types.Identifier.path_any
   end
 
   module Sets = struct
-    module Signature = Set.Make(Signature)
-    module ClassSignature = Set.Make(ClassSignature)
-    module DataType = Set.Make(DataType)
-    module Parent = Set.Make(Parent)
-    module LabelParent = Set.Make(LabelParent)
-    module RootModule = Set.Make(RootModule)
-    module FunctorParameter = Set.Make(FunctorParameter)
-    module Module = Set.Make(Module)
-    module ModuleType = Set.Make(ModuleType)
-    module Type = Set.Make(Type)
-    module Constructor = Set.Make(Constructor)
-    module Field = Set.Make(Field)
-    module Extension = Set.Make(Extension)
-    module Exception = Set.Make(Exception)
-    module Value = Set.Make(Value)
-    module Class = Set.Make(Class)
-    module ClassType = Set.Make(ClassType)
-    module Method = Set.Make(Method)
-    module InstanceVariable = Set.Make(InstanceVariable)
-    module Label = Set.Make(Label)
-    module Page = Set.Make(Page)
-    module ContainerPage = Set.Make(ContainerPage)
+    module Signature = Set.Make (Signature)
+    module ClassSignature = Set.Make (ClassSignature)
+    module DataType = Set.Make (DataType)
+    module Parent = Set.Make (Parent)
+    module LabelParent = Set.Make (LabelParent)
+    module RootModule = Set.Make (RootModule)
+    module FunctorParameter = Set.Make (FunctorParameter)
+    module Module = Set.Make (Module)
+    module ModuleType = Set.Make (ModuleType)
+    module Type = Set.Make (Type)
+    module Constructor = Set.Make (Constructor)
+    module Field = Set.Make (Field)
+    module Extension = Set.Make (Extension)
+    module Exception = Set.Make (Exception)
+    module Value = Set.Make (Value)
+    module Class = Set.Make (Class)
+    module ClassType = Set.Make (ClassType)
+    module Method = Set.Make (Method)
+    module InstanceVariable = Set.Make (InstanceVariable)
+    module Label = Set.Make (Label)
+    module Page = Set.Make (Page)
+    module ContainerPage = Set.Make (ContainerPage)
+
     module Path = struct
-      module Module = Set.Make(Path.Module)
-      module ModuleType = Set.Make(Path.ModuleType)
-      module Type = Set.Make(Path.Type)
-      module ClassType = Set.Make(Path.ClassType)
+      module Module = Set.Make (Path.Module)
+      module ModuleType = Set.Make (Path.ModuleType)
+      module Type = Set.Make (Path.Type)
+      module ClassType = Set.Make (Path.ClassType)
     end
   end
 
   module Maps = struct
-    module Signature = Map.Make(Signature)
-    module ClassSignature = Map.Make(ClassSignature)
-    module DataType = Map.Make(DataType)
-    module Parent = Map.Make(Parent)
-    module LabelParent = Map.Make(LabelParent)
-    module RootModule = Map.Make(RootModule)
-    module FunctorParameter = Map.Make(FunctorParameter)
-    module Module = Map.Make(Module)
-    module ModuleType = Map.Make(ModuleType)
-    module Type = Map.Make(Type)
-    module Constructor = Map.Make(Constructor)
-    module Field = Map.Make(Field)
-    module Extension = Map.Make(Extension)
-    module Exception = Map.Make(Exception)
-    module Value = Map.Make(Value)
-    module Class = Map.Make(Class)
-    module ClassType = Map.Make(ClassType)
-    module Method = Map.Make(Method)
-    module InstanceVariable = Map.Make(InstanceVariable)
-    module Label = Map.Make(Label)
-    module Page = Map.Make(Page)
-    module ContainerPage = Map.Make(ContainerPage)
+    module Signature = Map.Make (Signature)
+    module ClassSignature = Map.Make (ClassSignature)
+    module DataType = Map.Make (DataType)
+    module Parent = Map.Make (Parent)
+    module LabelParent = Map.Make (LabelParent)
+    module RootModule = Map.Make (RootModule)
+    module FunctorParameter = Map.Make (FunctorParameter)
+    module Module = Map.Make (Module)
+    module ModuleType = Map.Make (ModuleType)
+    module Type = Map.Make (Type)
+    module Constructor = Map.Make (Constructor)
+    module Field = Map.Make (Field)
+    module Extension = Map.Make (Extension)
+    module Exception = Map.Make (Exception)
+    module Value = Map.Make (Value)
+    module Class = Map.Make (Class)
+    module ClassType = Map.Make (ClassType)
+    module Method = Map.Make (Method)
+    module InstanceVariable = Map.Make (InstanceVariable)
+    module Label = Map.Make (Label)
+    module Page = Map.Make (Page)
+    module ContainerPage = Map.Make (ContainerPage)
+
     module Path = struct
-      module Module = Map.Make(Path.Module)
-      module ModuleType = Map.Make(Path.ModuleType)
-      module Type = Map.Make(Path.Type)
-      module ClassType = Map.Make(Path.ClassType)
+      module Module = Map.Make (Path.Module)
+      module ModuleType = Map.Make (Path.ModuleType)
+      module Type = Map.Make (Path.Type)
+      module ClassType = Map.Make (Path.ClassType)
     end
   end
-
-
 end
 
-
-
 module Path = struct
-
   type t = Paths_types.Path.any
 
   let rec is_resolved_hidden : Paths_types.Resolved_path.any -> bool =
     let open Paths_types.Resolved_path in
     let rec inner = function
-    | `Identifier (`ModuleType (_, m)) when Names.ModuleTypeName.is_internal m -> true
-    | `Identifier (`Type (_, t)) when Names.TypeName.is_internal t -> true
-    | `Identifier (`Module (_, m)) when Names.ModuleName.is_internal m -> true
-    | `Identifier _ -> false
-    | `Canonical (_, `Resolved _) -> false
-    | `Canonical (x, _) -> inner (x : module_ :> any)
-    | `Hidden _ -> true
-    | `Subst(p1, p2) -> inner (p1 : module_type :> any) || inner (p2 : module_ :> any)
-    | `SubstAlias(p1, p2) -> inner (p1 : module_ :> any) || inner (p2 : module_ :> any)
-    | `Module (p, _) -> inner (p : module_ :> any)
-    | `Apply (p, _) -> inner (p : module_ :> any)
-    | `ModuleType (_, m) when Names.ModuleTypeName.is_internal m -> true
-    | `ModuleType (p, _) -> inner (p : module_ :> any)
-    | `Type (_, t) when Names.TypeName.is_internal t -> true
-    | `Type (p, _) -> inner (p : module_ :> any)
-    | `Class (p, _) -> inner (p : module_ :> any)
-    | `ClassType (p, _) -> inner (p : module_ :> any)
-    | `Alias (p1, p2) -> inner (p1 : module_ :> any) && (inner (p2 : module_ :> any))
-    | `SubstT (p1, p2) -> inner (p1 :> any) || inner (p2 :> any)
-    | `OpaqueModule m -> inner (m :> any)
-    | `OpaqueModuleType mt -> inner (mt :> any)
-    in inner
+      | `Identifier (`ModuleType (_, m)) when Names.ModuleTypeName.is_internal m
+        ->
+          true
+      | `Identifier (`Type (_, t)) when Names.TypeName.is_internal t -> true
+      | `Identifier (`Module (_, m)) when Names.ModuleName.is_internal m -> true
+      | `Identifier _ -> false
+      | `Canonical (_, `Resolved _) -> false
+      | `Canonical (x, _) -> inner (x : module_ :> any)
+      | `Hidden _ -> true
+      | `Subst (p1, p2) ->
+          inner (p1 : module_type :> any) || inner (p2 : module_ :> any)
+      | `SubstAlias (p1, p2) ->
+          inner (p1 : module_ :> any) || inner (p2 : module_ :> any)
+      | `Module (p, _) -> inner (p : module_ :> any)
+      | `Apply (p, _) -> inner (p : module_ :> any)
+      | `ModuleType (_, m) when Names.ModuleTypeName.is_internal m -> true
+      | `ModuleType (p, _) -> inner (p : module_ :> any)
+      | `Type (_, t) when Names.TypeName.is_internal t -> true
+      | `Type (p, _) -> inner (p : module_ :> any)
+      | `Class (p, _) -> inner (p : module_ :> any)
+      | `ClassType (p, _) -> inner (p : module_ :> any)
+      | `Alias (p1, p2) ->
+          inner (p1 : module_ :> any) && inner (p2 : module_ :> any)
+      | `SubstT (p1, p2) -> inner (p1 :> any) || inner (p2 :> any)
+      | `OpaqueModule m -> inner (m :> any)
+      | `OpaqueModuleType mt -> inner (mt :> any)
+    in
+    inner
 
   and is_path_hidden : Paths_types.Path.any -> bool =
     let open Paths_types.Path in
     function
     | `Resolved r -> is_resolved_hidden r
-    | `Identifier (_,hidden) -> hidden
+    | `Identifier (_, hidden) -> hidden
     | `Root _ -> false
     | `Forward _ -> false
-    | `Dot(p, _) -> is_path_hidden (p : module_ :> any)
-    | `Apply(p1, p2) -> is_path_hidden (p1 : module_ :> any) || is_path_hidden (p2 : module_ :> any)
+    | `Dot (p, _) -> is_path_hidden (p : module_ :> any)
+    | `Apply (p1, p2) ->
+        is_path_hidden (p1 : module_ :> any)
+        || is_path_hidden (p2 : module_ :> any)
 
   module Resolved = struct
-
-
     type t = Paths_types.Resolved_path.any
 
-    let rec parent_module_type_identifier : Paths_types.Resolved_path.module_type -> Identifier.Signature.t = function
-      | `Identifier id -> (id : Identifier.ModuleType.t :> Identifier.Signature.t)
-      | `ModuleType(m, n) -> `ModuleType(parent_module_identifier m, n)
-      | `SubstT(m, _n) -> parent_module_type_identifier m
+    let rec parent_module_type_identifier :
+        Paths_types.Resolved_path.module_type -> Identifier.Signature.t =
+      function
+      | `Identifier id ->
+          (id : Identifier.ModuleType.t :> Identifier.Signature.t)
+      | `ModuleType (m, n) -> `ModuleType (parent_module_identifier m, n)
+      | `SubstT (m, _n) -> parent_module_type_identifier m
       | `OpaqueModuleType mt -> parent_module_type_identifier mt
 
-    and parent_module_identifier : Paths_types.Resolved_path.module_ -> Identifier.Signature.t = function
-      | `Identifier id -> (id : Identifier.Path.Module.t :> Identifier.Signature.t)
-      | `Subst(sub, _) -> parent_module_type_identifier sub
-      | `SubstAlias(sub, _) -> parent_module_identifier sub
+    and parent_module_identifier :
+        Paths_types.Resolved_path.module_ -> Identifier.Signature.t = function
+      | `Identifier id ->
+          (id : Identifier.Path.Module.t :> Identifier.Signature.t)
+      | `Subst (sub, _) -> parent_module_type_identifier sub
+      | `SubstAlias (sub, _) -> parent_module_identifier sub
       | `Hidden p -> parent_module_identifier p
-      | `Module(m, n) -> `Module(parent_module_identifier m, n)
-      | `Canonical(_, `Resolved p) -> parent_module_identifier p
-      | `Canonical(p, _) -> parent_module_identifier p
-      | `Apply(m, _) -> parent_module_identifier m
-      | `Alias(sub, orig) ->
-        if is_path_hidden (`Resolved (sub :> t))
-        then parent_module_identifier orig
-        else parent_module_identifier sub
+      | `Module (m, n) -> `Module (parent_module_identifier m, n)
+      | `Canonical (_, `Resolved p) -> parent_module_identifier p
+      | `Canonical (p, _) -> parent_module_identifier p
+      | `Apply (m, _) -> parent_module_identifier m
+      | `Alias (sub, orig) ->
+          if is_path_hidden (`Resolved (sub :> t)) then
+            parent_module_identifier orig
+          else parent_module_identifier sub
       | `OpaqueModule m -> parent_module_identifier m
 
     module Module = struct
-
       type t = Paths_types.Resolved_path.module_
 
       let of_ident id = `Identifier id
 
-      let is_hidden m = is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
+      let is_hidden m =
+        is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
 
-        let rec identifier : t -> Identifier.Path.Module.t = function
+      let rec identifier : t -> Identifier.Path.Module.t = function
         | `Identifier id -> id
-        | `Subst(_, p) -> identifier p
-        | `SubstAlias(_, p) -> identifier p
+        | `Subst (_, p) -> identifier p
+        | `SubstAlias (_, p) -> identifier p
         | `Hidden p -> identifier p
-        | `Module(m, n) -> `Module(parent_module_identifier m, n)
-        | `Canonical(_, `Resolved p) -> identifier p
-        | `Canonical(p, _) -> identifier p
-        | `Apply(m, _) -> identifier m
-        | `Alias(sub,orig) ->
-          if is_path_hidden (`Resolved (sub :> Paths_types.Resolved_path.any))
-          then identifier orig
-          else identifier sub
+        | `Module (m, n) -> `Module (parent_module_identifier m, n)
+        | `Canonical (_, `Resolved p) -> identifier p
+        | `Canonical (p, _) -> identifier p
+        | `Apply (m, _) -> identifier m
+        | `Alias (sub, orig) ->
+            if is_path_hidden (`Resolved (sub :> Paths_types.Resolved_path.any))
+            then identifier orig
+            else identifier sub
         | `OpaqueModule m -> identifier m
 
       let rec canonical_ident : t -> Identifier.Path.Module.t option = function
         | `Identifier _id -> None
-        | `Subst(_,_) -> None
-        | `SubstAlias(_,_) -> None
+        | `Subst (_, _) -> None
+        | `SubstAlias (_, _) -> None
         | `Hidden p -> canonical_ident p
-        | `Module(p, n) -> begin
-            match canonical_ident p with | Some x -> Some (`Module((x :>Identifier.Signature.t), n)) | None -> None
-        end 
-        | `Canonical(_, `Resolved p) -> Some (identifier p)
-        | `Canonical(_, _) -> None
-        | `Apply(_,_) -> None
-        | `Alias(_,_) -> None
+        | `Module (p, n) -> (
+            match canonical_ident p with
+            | Some x -> Some (`Module ((x :> Identifier.Signature.t), n))
+            | None -> None )
+        | `Canonical (_, `Resolved p) -> Some (identifier p)
+        | `Canonical (_, _) -> None
+        | `Apply (_, _) -> None
+        | `Alias (_, _) -> None
         | `OpaqueModule m -> canonical_ident m
     end
 
     module ModuleType = struct
-
       type t = Paths_types.Resolved_path.module_type
 
       let of_ident id = `Identifier id
 
-      let is_hidden m = is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
+      let is_hidden m =
+        is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
 
       let rec identifier : t -> Identifier.ModuleType.t = function
         | `Identifier id -> id
-        | `ModuleType(m, n) -> `ModuleType(parent_module_identifier m, n)
-        | `SubstT(s,_) -> identifier s
+        | `ModuleType (m, n) -> `ModuleType (parent_module_identifier m, n)
+        | `SubstT (s, _) -> identifier s
         | `OpaqueModuleType mt -> identifier mt
 
       let rec canonical_ident : t -> Identifier.ModuleType.t option = function
         | `Identifier _id -> None
-        | `ModuleType (p, n) -> begin
-            match Module.canonical_ident p with | Some x -> Some (`ModuleType((x :>Identifier.Signature.t), n)) | None -> None
-        end 
+        | `ModuleType (p, n) -> (
+            match Module.canonical_ident p with
+            | Some x -> Some (`ModuleType ((x :> Identifier.Signature.t), n))
+            | None -> None )
         | `SubstT (_, _) -> None
-        | `OpaqueModuleType m ->
-          canonical_ident (m :> t)
-
+        | `OpaqueModuleType m -> canonical_ident (m :> t)
     end
 
     module Type = struct
-
       type t = Paths_types.Resolved_path.type_
 
       let of_ident id = `Identifier id
 
-      let is_hidden m = is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
+      let is_hidden m =
+        is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
 
       let identifier = function
         | `Identifier id -> id
-        | `Type(m, n) -> `Type(parent_module_identifier m, n)
-        | `Class(m, n) -> `Class(parent_module_identifier m, n)
-        | `ClassType(m, n) -> `ClassType(parent_module_identifier m, n)
-
+        | `Type (m, n) -> `Type (parent_module_identifier m, n)
+        | `Class (m, n) -> `Class (parent_module_identifier m, n)
+        | `ClassType (m, n) -> `ClassType (parent_module_identifier m, n)
     end
 
     module ClassType = struct
-
       type t = Paths_types.Resolved_path.class_type
 
       let of_ident id = `Identifier id
 
-      let is_hidden m = is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
+      let is_hidden m =
+        is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
 
       let identifier = function
         | `Identifier id -> id
-        | `Class(m, n) -> `Class(parent_module_identifier m, n)
-        | `ClassType(m, n) -> `ClassType(parent_module_identifier m, n)
+        | `Class (m, n) -> `Class (parent_module_identifier m, n)
+        | `ClassType (m, n) -> `ClassType (parent_module_identifier m, n)
     end
+
     let rec identifier : t -> Identifier.t = function
       | `Identifier id -> id
-      | `Subst(_, p) -> identifier (p :> t)
-      | `SubstAlias(_, p) -> identifier (p :> t)
+      | `Subst (_, p) -> identifier (p :> t)
+      | `SubstAlias (_, p) -> identifier (p :> t)
       | `Hidden p -> identifier (p :> t)
-      | `Module(m, n) -> `Module(parent_module_identifier m, n)
-      | `Canonical(_, `Resolved p) -> identifier (p :> t)
-      | `Canonical(p, _) -> identifier (p :> t)
-      | `Apply(m, _) -> identifier (m :> t)
-      | `Type(m, n) -> `Type(parent_module_identifier m, n)
-      | `ModuleType(m, n) -> `ModuleType(parent_module_identifier m, n)
-      | `Class(m, n) -> `Class(parent_module_identifier m, n)
-      | `ClassType(m, n) -> `ClassType(parent_module_identifier m, n)
-      | `Alias(sub, orig) ->
-        if is_path_hidden (`Resolved (sub :> t))
-        then identifier (orig :> t)
-        else identifier (sub :> t)
-      | `SubstT(p, _) -> identifier (p :> t)
+      | `Module (m, n) -> `Module (parent_module_identifier m, n)
+      | `Canonical (_, `Resolved p) -> identifier (p :> t)
+      | `Canonical (p, _) -> identifier (p :> t)
+      | `Apply (m, _) -> identifier (m :> t)
+      | `Type (m, n) -> `Type (parent_module_identifier m, n)
+      | `ModuleType (m, n) -> `ModuleType (parent_module_identifier m, n)
+      | `Class (m, n) -> `Class (parent_module_identifier m, n)
+      | `ClassType (m, n) -> `ClassType (parent_module_identifier m, n)
+      | `Alias (sub, orig) ->
+          if is_path_hidden (`Resolved (sub :> t)) then identifier (orig :> t)
+          else identifier (sub :> t)
+      | `SubstT (p, _) -> identifier (p :> t)
       | `OpaqueModule m -> identifier (m :> t)
       | `OpaqueModuleType mt -> identifier (mt :> t)
-
   end
 
-  module Module =
-  struct
+  module Module = struct
     type t = Paths_types.Path.module_
-
   end
 
-  module ModuleType =
-  struct
+  module ModuleType = struct
     type t = Paths_types.Path.module_type
   end
 
-  module Type =
-  struct
+  module Type = struct
     type t = Paths_types.Path.type_
   end
 
-  module ClassType =
-  struct
+  module ClassType = struct
     type t = Paths_types.Path.class_type
   end
 
   let is_hidden = is_path_hidden
 end
 
-
-
 module Fragment = struct
-
   module Resolved = struct
-
     type t = Paths_types.Resolved_fragment.any
 
     type root = Paths_types.Resolved_fragment.root
@@ -742,100 +748,89 @@ module Fragment = struct
       | Base of root
       | Branch of ModuleName.t * Paths_types.Resolved_fragment.signature
 
-    let rec split_parent : Paths_types.Resolved_fragment.signature -> base_name = function
+    let rec split_parent : Paths_types.Resolved_fragment.signature -> base_name
+        = function
       | `Root i -> Base i
-      | `Subst(_, p) -> split_parent (sig_of_mod p)
-      | `SubstAlias(_, p) -> split_parent (sig_of_mod p)
+      | `Subst (_, p) -> split_parent (sig_of_mod p)
+      | `SubstAlias (_, p) -> split_parent (sig_of_mod p)
       | `OpaqueModule m -> split_parent (sig_of_mod m)
-      | `Module(p, name) ->
-        match split_parent p with
-        | Base i -> Branch(name, `Root i)
-        | Branch(base, m) -> Branch(base, `Module(m, name))
+      | `Module (p, name) -> (
+          match split_parent p with
+          | Base i -> Branch (name, `Root i)
+          | Branch (base, m) -> Branch (base, `Module (m, name)) )
 
-
-    module Signature =
-    struct
+    module Signature = struct
       type t = Paths_types.Resolved_fragment.signature
 
       let rec split : t -> string * t option = function
-        | `Root _ -> "", None
-        | `Subst(_,p) -> split (sig_of_mod p)
-        | `SubstAlias(_,p) -> split (sig_of_mod p)
+        | `Root _ -> ("", None)
+        | `Subst (_, p) -> split (sig_of_mod p)
+        | `SubstAlias (_, p) -> split (sig_of_mod p)
         | `OpaqueModule m -> split (sig_of_mod m)
-        | `Module (m, name) -> begin
+        | `Module (m, name) -> (
             match split_parent m with
             | Base _ -> (ModuleName.to_string name, None)
-            | Branch(base,m) -> ModuleName.to_string base, Some (`Module(m,name))
-          end
+            | Branch (base, m) ->
+                (ModuleName.to_string base, Some (`Module (m, name))) )
 
-      let rec identifier : t -> Identifier.Signature.t =
-        function
-          | `Root (`ModuleType i) -> (Path.Resolved.ModuleType.identifier i :> Identifier.Signature.t)
-          | `Root (`Module i) -> (Path.Resolved.Module.identifier i :> Identifier.Signature.t)
-          | `Subst(s, _) -> (Path.Resolved.ModuleType.identifier s :> Identifier.Signature.t)
-          | `SubstAlias(i, _) -> (Path.Resolved.Module.identifier i :> Identifier.Signature.t)
-          | `Module(m, n) -> `Module (identifier m, n)
-          | `OpaqueModule m -> identifier (sig_of_mod m)
-
+      let rec identifier : t -> Identifier.Signature.t = function
+        | `Root (`ModuleType i) ->
+            (Path.Resolved.ModuleType.identifier i :> Identifier.Signature.t)
+        | `Root (`Module i) ->
+            (Path.Resolved.Module.identifier i :> Identifier.Signature.t)
+        | `Subst (s, _) ->
+            (Path.Resolved.ModuleType.identifier s :> Identifier.Signature.t)
+        | `SubstAlias (i, _) ->
+            (Path.Resolved.Module.identifier i :> Identifier.Signature.t)
+        | `Module (m, n) -> `Module (identifier m, n)
+        | `OpaqueModule m -> identifier (sig_of_mod m)
     end
 
-    module Module =
-    struct
+    module Module = struct
       type t = Paths_types.Resolved_fragment.module_
 
       let rec split : t -> string * t option = function
-        | `Subst(_,p) -> split p
-        | `SubstAlias(_,p) -> split p
-        | `Module (m, name) -> begin
+        | `Subst (_, p) -> split p
+        | `SubstAlias (_, p) -> split p
+        | `Module (m, name) -> (
             match split_parent m with
             | Base _ -> (ModuleName.to_string name, None)
-            | Branch(base,m) -> ModuleName.to_string base, Some (`Module(m,name))
-          end
-        | `OpaqueModule m ->
-            split m
-
+            | Branch (base, m) ->
+                (ModuleName.to_string base, Some (`Module (m, name))) )
+        | `OpaqueModule m -> split m
     end
 
-    module Type =
-    struct
+    module Type = struct
       type t = Paths_types.Resolved_fragment.type_
 
-      let split : t -> string * t option =
-        function
-        | `Type (m,name) -> begin
+      let split : t -> string * t option = function
+        | `Type (m, name) -> (
             match split_parent m with
-            | Base _ -> TypeName.to_string name, None
-            | Branch(base, m) -> ModuleName.to_string base, Some (`Type(m, name))
-          end
-        | `Class(m, name) -> begin
+            | Base _ -> (TypeName.to_string name, None)
+            | Branch (base, m) ->
+                (ModuleName.to_string base, Some (`Type (m, name))) )
+        | `Class (m, name) -> (
             match split_parent m with
-            | Base _ -> ClassName.to_string name, None
-            | Branch(base, m) -> ModuleName.to_string base, Some (`Class(m, name))
-          end
-        | `ClassType(m, name) -> begin
+            | Base _ -> (ClassName.to_string name, None)
+            | Branch (base, m) ->
+                (ModuleName.to_string base, Some (`Class (m, name))) )
+        | `ClassType (m, name) -> (
             match split_parent m with
-            | Base _ -> ClassTypeName.to_string name, None
-            | Branch(base, m) -> ModuleName.to_string base, Some (`ClassType(m, name))
-          end
-
-
+            | Base _ -> (ClassTypeName.to_string name, None)
+            | Branch (base, m) ->
+                (ModuleName.to_string base, Some (`ClassType (m, name))) )
     end
 
-    let rec identifier : t -> Identifier.t =
-       function
-        | `Root (`ModuleType _r) -> assert false
-        | `Root (`Module _r) -> assert false
-        | `Subst(s, _) ->
-          Path.Resolved.identifier (s :> Path.Resolved.t)
-        | `SubstAlias(p, _) ->
-          (Path.Resolved.Module.identifier p :> Identifier.t)
-        | `Module(m, n) -> `Module (Signature.identifier m, n)
-        | `Type(m, n) -> `Type(Signature.identifier m, n)
-        | `Class(m, n) -> `Class(Signature.identifier m, n)
-        | `ClassType(m, n) -> `ClassType(Signature.identifier m, n)
-        | `OpaqueModule m -> identifier (m :> t)
-
-
+    let rec identifier : t -> Identifier.t = function
+      | `Root (`ModuleType _r) -> assert false
+      | `Root (`Module _r) -> assert false
+      | `Subst (s, _) -> Path.Resolved.identifier (s :> Path.Resolved.t)
+      | `SubstAlias (p, _) -> (Path.Resolved.Module.identifier p :> Identifier.t)
+      | `Module (m, n) -> `Module (Signature.identifier m, n)
+      | `Type (m, n) -> `Type (Signature.identifier m, n)
+      | `Class (m, n) -> `Class (Signature.identifier m, n)
+      | `ClassType (m, n) -> `ClassType (Signature.identifier m, n)
+      | `OpaqueModule m -> identifier (m :> t)
   end
 
   type t = Paths_types.Fragment.any
@@ -844,39 +839,33 @@ module Fragment = struct
     | Base of Resolved.root option
     | Branch of ModuleName.t * Paths_types.Fragment.signature
 
-  let rec split_parent : Paths_types.Fragment.signature -> base_name =
-    function
+  let rec split_parent : Paths_types.Fragment.signature -> base_name = function
     | `Root -> Base None
-    | `Resolved r -> begin
+    | `Resolved r -> (
         match Resolved.split_parent r with
         | Resolved.Base i -> Base (Some i)
-        | Resolved.Branch(base, m) -> Branch(base, `Resolved m)
-      end
-    | `Dot(m,name) -> begin
+        | Resolved.Branch (base, m) -> Branch (base, `Resolved m) )
+    | `Dot (m, name) -> (
         match split_parent m with
-        | Base None -> Branch(ModuleName.of_string name,`Root)
-        | Base (Some i) -> Branch(ModuleName.of_string name, `Resolved (`Root i))
-        | Branch(base,m) -> Branch(base, `Dot(m,name))
-      end
+        | Base None -> Branch (ModuleName.of_string name, `Root)
+        | Base (Some i) ->
+            Branch (ModuleName.of_string name, `Resolved (`Root i))
+        | Branch (base, m) -> Branch (base, `Dot (m, name)) )
 
   module Signature = struct
     type t = Paths_types.Fragment.signature
 
     let split : t -> string * t option = function
-      | `Root -> "", None
+      | `Root -> ("", None)
       | `Resolved r ->
-        let base, m = Resolved.Signature.split r in
-        let m =
-          match m with
-          | None -> None
-          | Some m -> Some (`Resolved m)
-        in
-        base, m
-      | `Dot(m, name) ->
-        match split_parent m with
-        | Base _ -> name, None
-        | Branch(base, m) -> ModuleName.to_string base, Some(`Dot(m, name))
-      
+          let base, m = Resolved.Signature.split r in
+          let m = match m with None -> None | Some m -> Some (`Resolved m) in
+          (base, m)
+      | `Dot (m, name) -> (
+          match split_parent m with
+          | Base _ -> (name, None)
+          | Branch (base, m) ->
+              (ModuleName.to_string base, Some (`Dot (m, name))) )
   end
 
   module Module = struct
@@ -884,18 +873,14 @@ module Fragment = struct
 
     let split : t -> string * t option = function
       | `Resolved r ->
-        let base, m = Resolved.Module.split r in
-        let m =
-          match m with
-          | None -> None
-          | Some m -> Some (`Resolved m)
-        in
-        base, m
-      | `Dot(m, name) ->
-        match split_parent m with
-        | Base _ -> name, None
-        | Branch(base, m) -> ModuleName.to_string base, Some(`Dot(m, name))
-
+          let base, m = Resolved.Module.split r in
+          let m = match m with None -> None | Some m -> Some (`Resolved m) in
+          (base, m)
+      | `Dot (m, name) -> (
+          match split_parent m with
+          | Base _ -> (name, None)
+          | Branch (base, m) ->
+              (ModuleName.to_string base, Some (`Dot (m, name))) )
   end
 
   module Type = struct
@@ -903,22 +888,16 @@ module Fragment = struct
 
     let split : t -> string * t option = function
       | `Resolved r ->
-        let base, m = Resolved.Type.split r in
-        let m =
-          match m with
-          | None -> None
-          | Some m -> Some (`Resolved m)
-        in
-        base, m
-      | `Dot(m, name) ->
-        match split_parent m with
-        | Base _ -> name, None
-        | Branch(base, m) -> ModuleName.to_string base, Some(`Dot(m, name))
-
+          let base, m = Resolved.Type.split r in
+          let m = match m with None -> None | Some m -> Some (`Resolved m) in
+          (base, m)
+      | `Dot (m, name) -> (
+          match split_parent m with
+          | Base _ -> (name, None)
+          | Branch (base, m) ->
+              (ModuleName.to_string base, Some (`Dot (m, name))) )
   end
-
 end
-
 
 module Reference = struct
   module Resolved = struct
@@ -930,269 +909,210 @@ module Reference = struct
       function
       | `Identifier id -> id
       | `Hidden s -> parent_signature_identifier (s :> signature)
-      | `SubstAlias(sub, orig) -> 
-        if Path.Resolved.Module.is_hidden sub
-        then parent_signature_identifier (orig :> signature)
-        else (Path.Resolved.Module.identifier sub :> Identifier.Signature.t)
-      | `Module(m, n) -> `Module(parent_signature_identifier m, n)
-      | `Canonical(_, `Resolved r) ->
-        parent_signature_identifier (r : module_ :> signature)
-      | `Canonical (r, _) -> parent_signature_identifier (r : module_ :> signature)
-      | `ModuleType(m, s) -> `ModuleType(parent_signature_identifier m, s)
+      | `SubstAlias (sub, orig) ->
+          if Path.Resolved.Module.is_hidden sub then
+            parent_signature_identifier (orig :> signature)
+          else (Path.Resolved.Module.identifier sub :> Identifier.Signature.t)
+      | `Module (m, n) -> `Module (parent_signature_identifier m, n)
+      | `Canonical (_, `Resolved r) ->
+          parent_signature_identifier (r : module_ :> signature)
+      | `Canonical (r, _) ->
+          parent_signature_identifier (r : module_ :> signature)
+      | `ModuleType (m, s) -> `ModuleType (parent_signature_identifier m, s)
 
-    and parent_type_identifier : datatype -> Identifier.DataType.t =
-      function
+    and parent_type_identifier : datatype -> Identifier.DataType.t = function
       | `Identifier id -> id
-      | `Type(sg, s) -> `Type(parent_signature_identifier sg, s)
+      | `Type (sg, s) -> `Type (parent_signature_identifier sg, s)
 
     and parent_class_signature_identifier :
-      class_signature -> Identifier.ClassSignature.t =
-      function
+        class_signature -> Identifier.ClassSignature.t = function
       | `Identifier id -> id
-      | `Class(sg, s) -> `Class(parent_signature_identifier sg, s)
-      | `ClassType(sg, s) -> `ClassType(parent_signature_identifier sg, s)
+      | `Class (sg, s) -> `Class (parent_signature_identifier sg, s)
+      | `ClassType (sg, s) -> `ClassType (parent_signature_identifier sg, s)
 
-    and parent_identifier : parent -> Identifier.Parent.t =
-      function
+    and parent_identifier : parent -> Identifier.Parent.t = function
       | `Identifier id -> id
-      | `Hidden _ 
-      | `SubstAlias _
-      | `Module _
-      | `Canonical _
-      | `ModuleType _  as sg -> (parent_signature_identifier sg :> Identifier.Parent.t)
+      | (`Hidden _ | `SubstAlias _ | `Module _ | `Canonical _ | `ModuleType _)
+        as sg ->
+          (parent_signature_identifier sg :> Identifier.Parent.t)
       | `Type _ as t -> (parent_type_identifier t :> Identifier.Parent.t)
-      | `Class _
-      | `ClassType _ as c -> (parent_class_signature_identifier c :> Identifier.Parent.t)
+      | (`Class _ | `ClassType _) as c ->
+          (parent_class_signature_identifier c :> Identifier.Parent.t)
 
     and label_parent_identifier : label_parent -> Identifier.LabelParent.t =
       function
       | `Identifier id -> id
-      | `Hidden _ 
-      | `SubstAlias _
-      | `Module _
-      | `Canonical _
-      | `ModuleType _
-      | `Type _
-      | `Class _
-      | `ClassType _ as r -> (parent_identifier r :> Identifier.LabelParent.t) 
+      | ( `Hidden _ | `SubstAlias _ | `Module _ | `Canonical _ | `ModuleType _
+        | `Type _ | `Class _ | `ClassType _ ) as r ->
+          (parent_identifier r :> Identifier.LabelParent.t)
 
     and identifier : t -> Identifier.t = function
       | `Identifier id -> id
-      | `SubstAlias _
-      | `Module _
-      | `Canonical _ 
-      | `Hidden _
-      | `Type _
-      | `Class _
-      | `ClassType _
-      | `ModuleType _ as r -> (label_parent_identifier r :> Identifier.t)
-      | `Field(p, n) -> `Field(parent_identifier p, n)
-      | `Constructor(s, n) -> `Constructor(parent_type_identifier s, n)
-      | `Extension(p,q) -> `Extension(parent_signature_identifier p, q)
-      | `Exception(p,q) -> `Exception(parent_signature_identifier p, q)
-      | `Value(p,q) -> `Value(parent_signature_identifier p, q)
-      | `Method(p,q) -> `Method(parent_class_signature_identifier p, q)
-      | `InstanceVariable(p,q) -> `InstanceVariable(parent_class_signature_identifier p, q)
-      | `Label(p,q) -> `Label(label_parent_identifier p, q)
+      | ( `SubstAlias _ | `Module _ | `Canonical _ | `Hidden _ | `Type _
+        | `Class _ | `ClassType _ | `ModuleType _ ) as r ->
+          (label_parent_identifier r :> Identifier.t)
+      | `Field (p, n) -> `Field (parent_identifier p, n)
+      | `Constructor (s, n) -> `Constructor (parent_type_identifier s, n)
+      | `Extension (p, q) -> `Extension (parent_signature_identifier p, q)
+      | `Exception (p, q) -> `Exception (parent_signature_identifier p, q)
+      | `Value (p, q) -> `Value (parent_signature_identifier p, q)
+      | `Method (p, q) -> `Method (parent_class_signature_identifier p, q)
+      | `InstanceVariable (p, q) ->
+          `InstanceVariable (parent_class_signature_identifier p, q)
+      | `Label (p, q) -> `Label (label_parent_identifier p, q)
 
-
-    module Signature =
-    struct
+    module Signature = struct
       type t = Paths_types.Resolved_reference.signature
     end
 
-    module ClassSignature =
-    struct
+    module ClassSignature = struct
       type t = Paths_types.Resolved_reference.class_signature
     end
 
-
-    module DataType =
-    struct
+    module DataType = struct
       type t = Paths_types.Resolved_reference.datatype
     end
 
-
-    module Parent =
-    struct
+    module Parent = struct
       type t = Paths_types.Resolved_reference.parent
     end
 
-
-    module LabelParent =
-    struct
+    module LabelParent = struct
       type t = Paths_types.Resolved_reference.label_parent
     end
 
-    module Module =
-    struct
+    module Module = struct
       type t = Paths_types.Resolved_reference.module_
     end
 
-  module ModuleType =
-    struct
+    module ModuleType = struct
       type t = Paths_types.Resolved_reference.module_type
     end
 
-    module Type =
-    struct
+    module Type = struct
       type t = Paths_types.Resolved_reference.type_
     end
 
-    module Constructor =
-    struct
+    module Constructor = struct
       type t = Paths_types.Resolved_reference.constructor
     end
 
-    module Field =
-    struct
+    module Field = struct
       type t = Paths_types.Resolved_reference.field
     end
 
-    module Extension =
-    struct
+    module Extension = struct
       type t = Paths_types.Resolved_reference.extension
     end
 
-    module Exception =
-    struct
+    module Exception = struct
       type t = Paths_types.Resolved_reference.exception_
     end
 
-    module Value =
-    struct
+    module Value = struct
       type t = Paths_types.Resolved_reference.value
     end
 
-    module Class =
-    struct
+    module Class = struct
       type t = Paths_types.Resolved_reference.class_
     end
 
-    module ClassType =
-    struct
+    module ClassType = struct
       type t = Paths_types.Resolved_reference.class_type
     end
 
-
-    module Method =
-    struct
+    module Method = struct
       type t = Paths_types.Resolved_reference.method_
     end
 
-    module InstanceVariable =
-    struct
+    module InstanceVariable = struct
       type t = Paths_types.Resolved_reference.instance_variable
     end
 
-    module Label =
-    struct
+    module Label = struct
       type t = Paths_types.Resolved_reference.label
     end
 
-    module Page =
-    struct
+    module Page = struct
       type t = Paths_types.Resolved_reference.page
     end
-
   end
+
   type t = Paths_types.Reference.any
 
-
-  module Signature =
-  struct
+  module Signature = struct
     type t = Paths_types.Reference.signature
   end
 
-  module ClassSignature =
-  struct
+  module ClassSignature = struct
     type t = Paths_types.Reference.class_signature
   end
 
-  module DataType =
-  struct
+  module DataType = struct
     type t = Paths_types.Reference.datatype
   end
 
-  module Parent =
-  struct
+  module Parent = struct
     type t = Paths_types.Reference.parent
   end
 
-  module LabelParent =
-  struct
+  module LabelParent = struct
     type t = Paths_types.Reference.label_parent
   end
 
-  module Module =
-  struct
+  module Module = struct
     type t = Paths_types.Reference.module_
   end
 
-  module ModuleType =
-  struct
+  module ModuleType = struct
     type t = Paths_types.Reference.module_type
-    
   end
 
-  module Type =
-  struct
+  module Type = struct
     type t = Paths_types.Reference.type_
   end
 
-  module Constructor =
-  struct
+  module Constructor = struct
     type t = Paths_types.Reference.constructor
   end
 
-  module Field =
-  struct
+  module Field = struct
     type t = Paths_types.Reference.field
   end
 
-  module Extension =
-  struct
+  module Extension = struct
     type t = Paths_types.Reference.extension
   end
 
-  module Exception =
-  struct
+  module Exception = struct
     type t = Paths_types.Reference.exception_
   end
 
-  module Value =
-  struct
+  module Value = struct
     type t = Paths_types.Reference.value
   end
 
-  module Class =
-  struct
+  module Class = struct
     type t = Paths_types.Reference.class_
   end
 
-  module ClassType =
-  struct
+  module ClassType = struct
     type t = Paths_types.Reference.class_type
   end
 
-  module Method =
-  struct
+  module Method = struct
     type t = Paths_types.Reference.method_
   end
 
-  module InstanceVariable =
-  struct
+  module InstanceVariable = struct
     type t = Paths_types.Reference.instance_variable
   end
 
-  module Label =
-  struct
+  module Label = struct
     type t = Paths_types.Reference.label
   end
 
-  module Page =
-  struct
+  module Page = struct
     type t = Paths_types.Reference.page
   end
-
 end

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -23,259 +23,380 @@ module Identifier : sig
     type t = Paths_types.Identifier.signature
 
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module ClassSignature : sig
     type t = Paths_types.Identifier.class_signature
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module DataType : sig
     type t = Paths_types.Identifier.datatype
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Parent : sig
     type t = Paths_types.Identifier.parent
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module LabelParent : sig
     type t = Paths_types.Identifier.label_parent
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module RootModule : sig
     type t = Paths_types.Identifier.root_module
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Module : sig
     type t = Paths_types.Identifier.module_
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module FunctorParameter : sig
     type t = Paths_types.Identifier.functor_parameter
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module ModuleType : sig
     type t = Paths_types.Identifier.module_type
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Type : sig
     type t = Paths_types.Identifier.type_
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Constructor : sig
     type t = Paths_types.Identifier.constructor
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Field : sig
     type t = Paths_types.Identifier.field
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Extension : sig
     type t = Paths_types.Identifier.extension
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Exception : sig
     type t = Paths_types.Identifier.exception_
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Value : sig
     type t = Paths_types.Identifier.value
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Class : sig
     type t = Paths_types.Identifier.class_
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module ClassType : sig
     type t = Paths_types.Identifier.class_type
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Method : sig
     type t = Paths_types.Identifier.method_
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module InstanceVariable : sig
     type t = Paths_types.Identifier.instance_variable
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Label : sig
     type t = Paths_types.Identifier.label
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module Page : sig
     type t = Paths_types.Identifier.page
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module ContainerPage : sig
     type t = Paths_types.Identifier.container_page
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
   end
 
   module OdocId : sig
     type t = Paths_types.Identifier.odoc_id
+
     val equal : t -> t -> bool
+
     val hash : t -> int
+
     val compare : t -> t -> int
-    end
+  end
 
   module Path : sig
-
     module Module : sig
       type t = Paths_types.Identifier.path_module
+
       val equal : t -> t -> bool
+
       val hash : t -> int
+
       val compare : t -> t -> int
-      end
+    end
 
     module ModuleType : sig
       type t = Paths_types.Identifier.path_module_type
+
       val equal : t -> t -> bool
+
       val hash : t -> int
+
       val compare : t -> t -> int
-      end
+    end
 
     module Type : sig
       type t = Paths_types.Identifier.path_type
+
       val equal : t -> t -> bool
+
       val hash : t -> int
+
       val compare : t -> t -> int
-      end
+    end
 
     module ClassType : sig
       type t = Paths_types.Identifier.path_class_type
+
       val equal : t -> t -> bool
+
       val hash : t -> int
+
       val compare : t -> t -> int
-      end
+    end
 
     type t = Paths_types.Identifier.path_any
-    
   end
 
   type t = Paths_types.Identifier.any
 
   val hash : t -> int
 
-  val name : [< t] -> string
+  val name : [< t ] -> string
 
   val compare : t -> t -> int
 
   val equal : t -> t -> bool
 
-  val label_parent : [< t] -> LabelParent.t
+  val label_parent : [< t ] -> LabelParent.t
 
   module Sets : sig
     module Signature : Set.S with type elt = Signature.t
+
     module ClassSignature : Set.S with type elt = ClassSignature.t
-    module DataType: Set.S with type elt = DataType.t
-    module Parent: Set.S with type elt = Parent.t
-    module LabelParent: Set.S with type elt = LabelParent.t
-    module Module: Set.S with type elt = Module.t
-    module ModuleType: Set.S with type elt = ModuleType.t
-    module Type: Set.S with type elt = Type.t
-    module Constructor: Set.S with type elt = Constructor.t
-    module Field: Set.S with type elt = Field.t
-    module Extension: Set.S with type elt = Extension.t
-    module Exception: Set.S with type elt = Exception.t
-    module Value: Set.S with type elt = Value.t
-    module Class: Set.S with type elt = Class.t
-    module ClassType: Set.S with type elt = ClassType.t
-    module Method: Set.S with type elt = Method.t
-    module InstanceVariable: Set.S with type elt = InstanceVariable.t
-    module Label: Set.S with type elt = Label.t
-    module Page: Set.S with type elt = Page.t
-    module ContainerPage: Set.S with type elt = ContainerPage.t
+
+    module DataType : Set.S with type elt = DataType.t
+
+    module Parent : Set.S with type elt = Parent.t
+
+    module LabelParent : Set.S with type elt = LabelParent.t
+
+    module Module : Set.S with type elt = Module.t
+
+    module ModuleType : Set.S with type elt = ModuleType.t
+
+    module Type : Set.S with type elt = Type.t
+
+    module Constructor : Set.S with type elt = Constructor.t
+
+    module Field : Set.S with type elt = Field.t
+
+    module Extension : Set.S with type elt = Extension.t
+
+    module Exception : Set.S with type elt = Exception.t
+
+    module Value : Set.S with type elt = Value.t
+
+    module Class : Set.S with type elt = Class.t
+
+    module ClassType : Set.S with type elt = ClassType.t
+
+    module Method : Set.S with type elt = Method.t
+
+    module InstanceVariable : Set.S with type elt = InstanceVariable.t
+
+    module Label : Set.S with type elt = Label.t
+
+    module Page : Set.S with type elt = Page.t
+
+    module ContainerPage : Set.S with type elt = ContainerPage.t
   end
 
   module Maps : sig
     module Signature : Map.S with type key = Signature.t
+
     module ClassSignature : Map.S with type key = ClassSignature.t
-    module DataType: Map.S with type key = DataType.t
-    module Parent: Map.S with type key = Parent.t
-    module LabelParent: Map.S with type key = LabelParent.t
+
+    module DataType : Map.S with type key = DataType.t
+
+    module Parent : Map.S with type key = Parent.t
+
+    module LabelParent : Map.S with type key = LabelParent.t
+
     module FunctorParameter : Map.S with type key = FunctorParameter.t
-    module Module: Map.S with type key = Module.t
-    module ModuleType: Map.S with type key = ModuleType.t
-    module Type: Map.S with type key = Type.t
-    module Constructor: Map.S with type key = Constructor.t
-    module Field: Map.S with type key = Field.t
-    module Extension: Map.S with type key = Extension.t
-    module Exception: Map.S with type key = Exception.t
-    module Value: Map.S with type key = Value.t
-    module Class: Map.S with type key = Class.t
-    module ClassType: Map.S with type key = ClassType.t
-    module Method: Map.S with type key = Method.t
-    module InstanceVariable: Map.S with type key = InstanceVariable.t
-    module Label: Map.S with type key = Label.t
-    module Page: Map.S with type key = Page.t
+
+    module Module : Map.S with type key = Module.t
+
+    module ModuleType : Map.S with type key = ModuleType.t
+
+    module Type : Map.S with type key = Type.t
+
+    module Constructor : Map.S with type key = Constructor.t
+
+    module Field : Map.S with type key = Field.t
+
+    module Extension : Map.S with type key = Extension.t
+
+    module Exception : Map.S with type key = Exception.t
+
+    module Value : Map.S with type key = Value.t
+
+    module Class : Map.S with type key = Class.t
+
+    module ClassType : Map.S with type key = ClassType.t
+
+    module Method : Map.S with type key = Method.t
+
+    module InstanceVariable : Map.S with type key = InstanceVariable.t
+
+    module Label : Map.S with type key = Label.t
+
+    module Page : Map.S with type key = Page.t
+
     module ContainerPage : Map.S with type key = ContainerPage.t
+
     module Path : sig
-      module Module: Map.S with type key = Path.Module.t
-      module ModuleType: Map.S with type key = Path.ModuleType.t
-      module Type: Map.S with type key = Path.Type.t
+      module Module : Map.S with type key = Path.Module.t
+
+      module ModuleType : Map.S with type key = Path.ModuleType.t
+
+      module Type : Map.S with type key = Path.Type.t
+
       module ClassType : Map.S with type key = Path.ClassType.t
     end
   end
@@ -283,9 +404,7 @@ end
 
 (** Normal OCaml paths (i.e. the ones present in types) *)
 module rec Path : sig
-
   module Resolved : sig
-
     module Module : sig
       type t = Paths_types.Resolved_path.module_
 
@@ -308,7 +427,6 @@ module rec Path : sig
       val identifier : t -> Identifier.Path.ModuleType.t
 
       val canonical_ident : t -> Identifier.Path.ModuleType.t option
-
     end
 
     module Type : sig
@@ -319,7 +437,6 @@ module rec Path : sig
       val is_hidden : t -> bool
 
       val identifier : t -> Identifier.Path.Type.t
-
     end
 
     module ClassType : sig
@@ -330,7 +447,6 @@ module rec Path : sig
       val is_hidden : t -> bool
 
       val identifier : t -> Identifier.Path.ClassType.t
-
     end
 
     type t = Paths_types.Resolved_path.any
@@ -361,9 +477,7 @@ end
 
 (** OCaml path fragments for specifying module substitutions *)
 module Fragment : sig
-
   module Resolved : sig
-
     module Signature : sig
       type t = Paths_types.Resolved_fragment.signature
 
@@ -380,13 +494,11 @@ module Fragment : sig
       type t = Paths_types.Resolved_fragment.type_
 
       val split : t -> string * t option
-
     end
 
     type t = Paths_types.Resolved_fragment.any
 
     val identifier : t -> Identifier.t
-
   end
 
   module Signature : sig
@@ -410,10 +522,8 @@ module Fragment : sig
   type t = Paths_types.Fragment.any
 end
 
-
 (** References present in documentation comments ([{!Foo.Bar}]) *)
 module rec Reference : sig
-
   module Resolved : sig
     module Signature : sig
       type t = Paths_types.Resolved_reference.signature
@@ -435,7 +545,7 @@ module rec Reference : sig
       type t = Paths_types.Resolved_reference.label_parent
     end
 
-    module Module : sig 
+    module Module : sig
       type t = Paths_types.Resolved_reference.module_
     end
 
@@ -496,82 +606,81 @@ module rec Reference : sig
     val identifier : t -> Identifier.t
   end
 
-    module Signature : sig 
-      type t = Paths_types.Reference.signature
-    end
+  module Signature : sig
+    type t = Paths_types.Reference.signature
+  end
 
-    module ClassSignature : sig
-      type t = Paths_types.Reference.class_signature
-    end
+  module ClassSignature : sig
+    type t = Paths_types.Reference.class_signature
+  end
 
-    module DataType : sig
-      type t = Paths_types.Reference.datatype
-    end
+  module DataType : sig
+    type t = Paths_types.Reference.datatype
+  end
 
-    module Parent : sig
-      type t = Paths_types.Reference.parent
-    end
+  module Parent : sig
+    type t = Paths_types.Reference.parent
+  end
 
-    module LabelParent : sig
-      type t = Paths_types.Reference.label_parent
-    end
+  module LabelParent : sig
+    type t = Paths_types.Reference.label_parent
+  end
 
-    module Module : sig 
-      type t = Paths_types.Reference.module_
-    end
+  module Module : sig
+    type t = Paths_types.Reference.module_
+  end
 
-    module ModuleType : sig
-      type t = Paths_types.Reference.module_type
-    end
+  module ModuleType : sig
+    type t = Paths_types.Reference.module_type
+  end
 
-    module Type : sig
-      type t = Paths_types.Reference.type_
-    end
+  module Type : sig
+    type t = Paths_types.Reference.type_
+  end
 
-    module Constructor : sig
-      type t = Paths_types.Reference.constructor
-    end
+  module Constructor : sig
+    type t = Paths_types.Reference.constructor
+  end
 
-    module Field : sig
-      type t = Paths_types.Reference.field
-    end
+  module Field : sig
+    type t = Paths_types.Reference.field
+  end
 
-    module Extension : sig
-      type t = Paths_types.Reference.extension
-    end
+  module Extension : sig
+    type t = Paths_types.Reference.extension
+  end
 
-    module Exception : sig
-      type t = Paths_types.Reference.exception_
-    end
+  module Exception : sig
+    type t = Paths_types.Reference.exception_
+  end
 
-    module Value : sig
-      type t = Paths_types.Reference.value
-    end
+  module Value : sig
+    type t = Paths_types.Reference.value
+  end
 
-    module Class : sig
-      type t = Paths_types.Reference.class_
-    end
+  module Class : sig
+    type t = Paths_types.Reference.class_
+  end
 
-    module ClassType : sig
-      type t = Paths_types.Reference.class_type
-    end
+  module ClassType : sig
+    type t = Paths_types.Reference.class_type
+  end
 
-    module Method : sig
-      type t = Paths_types.Reference.method_
-    end
+  module Method : sig
+    type t = Paths_types.Reference.method_
+  end
 
-    module InstanceVariable : sig
-      type t = Paths_types.Reference.instance_variable
-    end
+  module InstanceVariable : sig
+    type t = Paths_types.Reference.instance_variable
+  end
 
-    module Label : sig
-      type t = Paths_types.Reference.label
-    end
+  module Label : sig
+    type t = Paths_types.Reference.label
+  end
 
-    module Page : sig
-      type t = Paths_types.Reference.page
-    end
+  module Page : sig
+    type t = Paths_types.Reference.page
+  end
 
-    type t = Paths_types.Reference.any
+  type t = Paths_types.Reference.any
 end
-

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -1,52 +1,30 @@
-(** {1 Paths} *)
 open Names
+(** {1 Paths} *)
 
-module Identifier =
-struct
+module Identifier = struct
+  type container_page =
+    [ `RootPage of PageName.t | `Page of container_page * PageName.t ]
 
-  type container_page = [
-    | `RootPage of PageName.t
-    | `Page of container_page * PageName.t
-  ]
+  type page = [ container_page | `LeafPage of container_page * PageName.t ]
 
-  type page = [
-    | container_page
-    | `LeafPage of container_page * PageName.t
-  ]
+  type odoc_id = [ page | `Root of container_page * ModuleName.t ]
 
-  type odoc_id = [
-    | page
-    | `Root of container_page * ModuleName.t
-  ]
-
-  type signature = [
-    | `Root of container_page * ModuleName.t
+  type signature =
+    [ `Root of container_page * ModuleName.t
     | `Module of signature * ModuleName.t
     | `Parameter of signature * ParameterName.t
     | `Result of signature
-    | `ModuleType of signature * ModuleTypeName.t
-  ]
+    | `ModuleType of signature * ModuleTypeName.t ]
 
-  type class_signature = [
-    | `Class of signature * ClassName.t
-    | `ClassType of signature * ClassTypeName.t
-  ]
+  type class_signature =
+    [ `Class of signature * ClassName.t
+    | `ClassType of signature * ClassTypeName.t ]
 
-  type datatype = [
-    | `Type of signature * TypeName.t
-    | `CoreType of TypeName.t
-  ]
+  type datatype = [ `Type of signature * TypeName.t | `CoreType of TypeName.t ]
 
-  type parent = [
-    | signature
-    | datatype
-    | class_signature
-  ]
+  type parent = [ signature | datatype | class_signature ]
 
-  type label_parent = [
-    | parent
-    | page
-  ]
+  type label_parent = [ parent | page ]
 
   type root_module = [ `Root of container_page * ModuleName.t ]
 
@@ -56,58 +34,35 @@ struct
 
   type functor_result = [ `Result of signature ]
 
-  type module_type = [
-    | `ModuleType of signature * ModuleTypeName.t
-  ]
+  type module_type = [ `ModuleType of signature * ModuleTypeName.t ]
 
-  type type_ = [
-    | `Type of signature * TypeName.t
-    | `CoreType of TypeName.t
-  ]
+  type type_ = [ `Type of signature * TypeName.t | `CoreType of TypeName.t ]
 
-  type constructor = [
-    | `Constructor of type_ * ConstructorName.t
-  ]
+  type constructor = [ `Constructor of type_ * ConstructorName.t ]
 
-  type field = [
-    | `Field of parent * FieldName.t
-  ]
+  type field = [ `Field of parent * FieldName.t ]
 
-  type extension = [
-    | `Extension of signature * ExtensionName.t
-  ]
+  type extension = [ `Extension of signature * ExtensionName.t ]
 
-  type exception_ = [
-    | `Exception of signature * ExceptionName.t
-    | `CoreException of ExceptionName.t
-  ]
+  type exception_ =
+    [ `Exception of signature * ExceptionName.t
+    | `CoreException of ExceptionName.t ]
 
-  type value = [
-    | `Value of signature * ValueName.t
-  ]
+  type value = [ `Value of signature * ValueName.t ]
 
-  type class_ = [
-    | `Class of signature * ClassName.t
-  ]
+  type class_ = [ `Class of signature * ClassName.t ]
 
-  type class_type = [
-    | `ClassType of signature * ClassTypeName.t
-  ]
+  type class_type = [ `ClassType of signature * ClassTypeName.t ]
 
-  type method_ = [
-    | `Method of class_signature * MethodName.t
-  ]
+  type method_ = [ `Method of class_signature * MethodName.t ]
 
-  type instance_variable = [
-    | `InstanceVariable of class_signature * InstanceVariableName.t
-  ]
+  type instance_variable =
+    [ `InstanceVariable of class_signature * InstanceVariableName.t ]
 
-  type label = [
-    | `Label of label_parent * LabelName.t
-  ]
+  type label = [ `Label of label_parent * LabelName.t ]
 
-  type any = [
-    | signature
+  type any =
+    [ signature
     | class_signature
     | datatype
     | parent
@@ -127,307 +82,233 @@ struct
     | method_
     | instance_variable
     | label
-    | page
-  ]
+    | page ]
 
-  type path_module = [
-    | module_
-    | functor_parameter
-    | functor_result
-  ]
+  type path_module = [ module_ | functor_parameter | functor_result ]
 
   type path_module_type = module_type
 
-  type path_type = [
-    | type_
-    | class_
-    | class_type
-  ]
+  type path_type = [ type_ | class_ | class_type ]
 
-  type path_class_type = [
-    | class_
-    | class_type
-  ]
+  type path_class_type = [ class_ | class_type ]
 
-  type path_any = [
-    | path_module
-    | path_module_type
-    | path_type
-    | path_class_type
-  ]
+  type path_any =
+    [ path_module | path_module_type | path_type | path_class_type ]
 
   type fragment_module = path_module
+
   type fragment_type = path_type
 
   type reference_module = path_module
+
   type reference_module_type = path_module_type
+
   type reference_type = path_type
-  type reference_constructor = [
-    | constructor
-    | extension
-    | exception_
-  ]
+
+  type reference_constructor = [ constructor | extension | exception_ ]
+
   type reference_field = field
-  type reference_extension = [
-    | extension
-    | exception_
-  ]
+
+  type reference_extension = [ extension | exception_ ]
+
   type reference_exception = exception_
+
   type reference_value = value
+
   type reference_class = class_
-  type reference_class_type = [
-    | class_
-    | class_type
-  ]
+
+  type reference_class_type = [ class_ | class_type ]
+
   type reference_method = method_
+
   type reference_instance_variable = instance_variable
+
   type reference_label = label
+
   type reference_page = page
 end
 
-module rec Path :
-sig
-  type module_ = [
-    | `Resolved of Resolved_path.module_
+module rec Path : sig
+  type module_ =
+    [ `Resolved of Resolved_path.module_
     | `Identifier of Identifier.path_module * bool
     | `Root of string
     | `Forward of string
     | `Dot of module_ * string
-    | `Apply of module_ * module_
-  ]
-  type module_type = [
-    | `Resolved of Resolved_path.module_type
+    | `Apply of module_ * module_ ]
+
+  type module_type =
+    [ `Resolved of Resolved_path.module_type
     | `Identifier of Identifier.path_module_type * bool
-    | `Dot of module_ * string
-  ]
-  type type_ = [
-    | `Resolved of Resolved_path.type_
+    | `Dot of module_ * string ]
+
+  type type_ =
+    [ `Resolved of Resolved_path.type_
     | `Identifier of Identifier.path_type * bool
-    | `Dot of module_ * string
-  ]
-  type class_type = [
-    | `Resolved of Resolved_path.class_type
+    | `Dot of module_ * string ]
+
+  type class_type =
+    [ `Resolved of Resolved_path.class_type
     | `Identifier of Identifier.path_class_type * bool
-    | `Dot of module_ * string
-  ]
-  type any = [
-    | `Resolved of Resolved_path.any
+    | `Dot of module_ * string ]
+
+  type any =
+    [ `Resolved of Resolved_path.any
     | `Identifier of Identifier.path_any * bool
     | `Root of string
     | `Forward of string
     | `Dot of module_ * string
-    | `Apply of module_ * module_
-  ]
-end = Path
+    | `Apply of module_ * module_ ]
+end =
+  Path
 
-and Resolved_path :
-sig
-  type module_ = [
-    | `Identifier of Identifier.path_module
+and Resolved_path : sig
+  type module_ =
+    [ `Identifier of Identifier.path_module
     | `Subst of module_type * module_
     | `SubstAlias of module_ * module_
     | `Hidden of module_
     | `Module of module_ * ModuleName.t
-    (* TODO: The canonical path should be a reference not a path *)
-    | `Canonical of module_ * Path.module_
+    | (* TODO: The canonical path should be a reference not a path *)
+      `Canonical of
+      module_ * Path.module_
     | `Apply of module_ * module_
     | `Alias of module_ * module_
-    | `OpaqueModule of module_
-    ]
+    | `OpaqueModule of module_ ]
 
-  and module_type = [
-    | `Identifier of Identifier.path_module_type
+  and module_type =
+    [ `Identifier of Identifier.path_module_type
     | `SubstT of module_type * module_type
     | `ModuleType of module_ * ModuleTypeName.t
-    | `OpaqueModuleType of module_type
-  ]
+    | `OpaqueModuleType of module_type ]
 
-  type module_no_id = [
-    | `Subst of module_type * module_
+  type module_no_id =
+    [ `Subst of module_type * module_
     | `SubstAlias of module_ * module_
     | `Hidden of module_
     | `Module of module_ * ModuleName.t
     | `Canonical of module_ * Path.module_
     | `Apply of module_ * module_
     | `Alias of module_ * module_
-    | `OpaqueModule of module_
-    ]
+    | `OpaqueModule of module_ ]
 
-  type module_type_no_id = [
-    | `ModuleType of module_ * ModuleTypeName.t
+  type module_type_no_id =
+    [ `ModuleType of module_ * ModuleTypeName.t
     | `SubstT of module_type * module_type
-    | `OpaqueModuleType of module_type
-  ]
+    | `OpaqueModuleType of module_type ]
 
-  type type_no_id = [
-    | `Type of module_ * TypeName.t
+  type type_no_id =
+    [ `Type of module_ * TypeName.t
     | `Class of module_ * ClassName.t
-    | `ClassType of module_ * ClassTypeName.t
-  ]
+    | `ClassType of module_ * ClassTypeName.t ]
 
-  type type_ = [
-    | `Identifier of Identifier.path_type
-    | type_no_id
-  ]
+  type type_ = [ `Identifier of Identifier.path_type | type_no_id ]
 
-  type class_type_no_id = [
-    | `Class of module_ * ClassName.t
-    | `ClassType of module_ * ClassTypeName.t
-  ]
+  type class_type_no_id =
+    [ `Class of module_ * ClassName.t | `ClassType of module_ * ClassTypeName.t ]
 
-  type class_type = [
-    | `Identifier of Identifier.path_class_type
-    | class_type_no_id
-  ]
+  type class_type =
+    [ `Identifier of Identifier.path_class_type | class_type_no_id ]
 
-  type any = [
-    | `Identifier of Identifier.any
+  type any =
+    [ `Identifier of Identifier.any
     | module_no_id
     | module_type_no_id
     | type_no_id
-    | class_type_no_id
-  ]
-end = Resolved_path
+    | class_type_no_id ]
+end =
+  Resolved_path
 
-module rec Fragment :
-sig
-  type signature = [
-    | `Resolved of Resolved_fragment.signature
+module rec Fragment : sig
+  type signature =
+    [ `Resolved of Resolved_fragment.signature
     | `Dot of signature * string
-    | `Root
-  ]
+    | `Root ]
 
-  type module_ = [
-    | `Resolved of Resolved_fragment.module_
-    | `Dot of signature * string
-  ]
+  type module_ =
+    [ `Resolved of Resolved_fragment.module_ | `Dot of signature * string ]
 
-  type type_ = [
-    | `Resolved of Resolved_fragment.type_
-    | `Dot of signature * string
-  ]
+  type type_ =
+    [ `Resolved of Resolved_fragment.type_ | `Dot of signature * string ]
 
-  type any = [
-    | `Resolved of Resolved_fragment.any
-    | `Dot of signature * string
-    | `Root
-  ]
-end = Fragment
+  type any =
+    [ `Resolved of Resolved_fragment.any | `Dot of signature * string | `Root ]
+end =
+  Fragment
 
-and Resolved_fragment :
-sig
-  type root = [
-    | `ModuleType of Resolved_path.module_type
-    | `Module of Resolved_path.module_
-  ]
+and Resolved_fragment : sig
+  type root =
+    [ `ModuleType of Resolved_path.module_type
+    | `Module of Resolved_path.module_ ]
 
-  type signature = [
-    | `Root of root
+  type signature =
+    [ `Root of root
     | `Subst of Resolved_path.module_type * module_
     | `SubstAlias of Resolved_path.module_ * module_
     | `Module of signature * ModuleName.t
-    | `OpaqueModule of module_
-  ]
+    | `OpaqueModule of module_ ]
 
-  and module_ = [
-    | `Subst of Resolved_path.module_type * module_
+  and module_ =
+    [ `Subst of Resolved_path.module_type * module_
     | `SubstAlias of Resolved_path.module_ * module_
     | `Module of signature * ModuleName.t
-    | `OpaqueModule of module_
-  ]
+    | `OpaqueModule of module_ ]
 
-  type type_ = [
-    | `Type of signature * TypeName.t
+  type type_ =
+    [ `Type of signature * TypeName.t
     | `Class of signature * ClassName.t
-    | `ClassType of signature * ClassTypeName.t
-  ]
+    | `ClassType of signature * ClassTypeName.t ]
 
   (* Absence of `Root here might make coersions annoying *)
-  type any = [
-    | `Root of root
+  type any =
+    [ `Root of root
     | `Subst of Resolved_path.module_type * module_
     | `SubstAlias of Resolved_path.module_ * module_
     | `Module of signature * ModuleName.t
     | `Type of signature * TypeName.t
     | `Class of signature * ClassName.t
     | `ClassType of signature * ClassTypeName.t
-    | `OpaqueModule of module_
-  ]
-end = Resolved_fragment
+    | `OpaqueModule of module_ ]
+end =
+  Resolved_fragment
 
-module rec Reference :
-sig
+module rec Reference : sig
+  type tag_only_module = [ `TModule ]
 
-  type tag_only_module = [
-    | `TModule
-   ]
+  type tag_only_module_type = [ `TModuleType ]
 
-  type tag_only_module_type = [
-    | `TModuleType
-  ]
+  type tag_only_type = [ `TType ]
 
-  type tag_only_type = [
-    | `TType
-  ]
+  type tag_only_constructor = [ `TConstructor ]
 
-  type tag_only_constructor = [
-    | `TConstructor
-  ]
+  type tag_only_field = [ `TField ]
 
-  type tag_only_field = [
-    | `TField
-  ]
+  type tag_only_extension = [ `TExtension ]
 
-  type tag_only_extension = [
-    | `TExtension
-  ]
+  type tag_only_exception = [ `TException ]
 
-  type tag_only_exception = [
-    | `TException
-  ]
+  type tag_only_value = [ `TValue ]
 
-  type tag_only_value = [
-    | `TValue
-  ]
+  type tag_only_class = [ `TClass ]
 
-  type tag_only_class = [
-    | `TClass
-  ]
+  type tag_only_class_type = [ `TClassType ]
 
-  type tag_only_class_type = [
-    | `TClassType
-  ]
+  type tag_only_method = [ `TMethod ]
 
-  type tag_only_method = [
-    | `TMethod
-  ]
+  type tag_only_instance_variable = [ `TInstanceVariable ]
 
-  type tag_only_instance_variable = [
-    | `TInstanceVariable
-  ]
+  type tag_only_label = [ `TLabel ]
 
-  type tag_only_label = [
-    | `TLabel
-  ]
+  type tag_only_page = [ `TPage ]
 
-  type tag_only_page = [
-    | `TPage
-  ]
+  type tag_unknown = [ `TUnknown ]
 
-  type tag_unknown = [
-    `TUnknown
-  ]
+  type tag_only_child_page = [ `TChildPage ]
 
-  type tag_only_child_page = [
-    `TChildPage
-  ]
+  type tag_only_child_module = [ `TChildModule ]
 
-  type tag_only_child_module = [
-    `TChildModule
-  ]
-
-  type tag_any = [
-    | tag_only_module
+  type tag_any =
+    [ tag_only_module
     | tag_only_module_type
     | tag_only_type
     | tag_only_constructor
@@ -443,37 +324,25 @@ sig
     | tag_only_page
     | tag_only_child_page
     | tag_only_child_module
-    | tag_unknown
-  ]
+    | tag_unknown ]
 
-  type tag_signature = [
-    | tag_unknown
-    | tag_only_module
-    | tag_only_module_type
-  ]
+  type tag_signature = [ tag_unknown | tag_only_module | tag_only_module_type ]
 
-  type tag_class_signature = [
-    | tag_unknown
-    | tag_only_class
-    | tag_only_class_type
-  ]
+  type tag_class_signature =
+    [ tag_unknown | tag_only_class | tag_only_class_type ]
 
-  type tag_datatype = [
-    | tag_unknown
-    | tag_only_type
-  ]
+  type tag_datatype = [ tag_unknown | tag_only_type ]
 
-  type tag_parent = [
-    | tag_unknown
+  type tag_parent =
+    [ tag_unknown
     | tag_only_module
     | tag_only_module_type
     | tag_only_class
     | tag_only_class_type
-    | tag_only_type
-  ]
+    | tag_only_type ]
 
-  type tag_label_parent = [
-    | tag_unknown
+  type tag_label_parent =
+    [ tag_unknown
     | tag_only_module
     | tag_only_module_type
     | tag_only_class
@@ -481,233 +350,172 @@ sig
     | tag_only_type
     | tag_only_page
     | tag_only_child_page
-    | tag_only_child_module
-  ]
+    | tag_only_child_module ]
 
-  type signature = [
-    | `Resolved of Resolved_reference.signature
+  type signature =
+    [ `Resolved of Resolved_reference.signature
     | `Root of string * tag_signature
     | `Dot of label_parent * string
     | `Module of signature * ModuleName.t
-    | `ModuleType of signature * ModuleTypeName.t
-  ]
+    | `ModuleType of signature * ModuleTypeName.t ]
 
-  and class_signature = [
-    | `Resolved of Resolved_reference.class_signature
+  and class_signature =
+    [ `Resolved of Resolved_reference.class_signature
     | `Root of string * tag_class_signature
     | `Dot of label_parent * string
     | `Class of signature * ClassName.t
-    | `ClassType of signature * ClassTypeName.t
-  ]
+    | `ClassType of signature * ClassTypeName.t ]
 
-  and datatype = [
-    | `Resolved of Resolved_reference.datatype
+  and datatype =
+    [ `Resolved of Resolved_reference.datatype
     | `Root of string * tag_datatype
     | `Dot of label_parent * string
-    | `Type of signature * TypeName.t
-  ]
+    | `Type of signature * TypeName.t ]
 
-  and parent = [
-    | `Resolved of Resolved_reference.parent
+  and parent =
+    [ `Resolved of Resolved_reference.parent
     | `Root of string * tag_parent
     | `Dot of label_parent * string
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Class of signature * ClassName.t
     | `ClassType of signature * ClassTypeName.t
-    | `Type of signature * TypeName.t
-  ]
+    | `Type of signature * TypeName.t ]
 
-  and label_parent = [
-    | `Resolved of Resolved_reference.label_parent
+  and label_parent =
+    [ `Resolved of Resolved_reference.label_parent
     | `Root of string * tag_label_parent
     | `Dot of label_parent * string
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Class of signature * ClassName.t
     | `ClassType of signature * ClassTypeName.t
-    | `Type of signature * TypeName.t
-  ]
+    | `Type of signature * TypeName.t ]
 
-  type tag_module = [
-    | tag_only_module
-    | tag_unknown
-  ]
+  type tag_module = [ tag_only_module | tag_unknown ]
 
-  type module_ = [
-    | `Resolved of Resolved_reference.module_
+  type module_ =
+    [ `Resolved of Resolved_reference.module_
     | `Root of string * tag_module
     | `Dot of label_parent * string
-    | `Module of signature * ModuleName.t
-  ]
+    | `Module of signature * ModuleName.t ]
 
-  type tag_module_type = [
-    | tag_only_module_type
-    | tag_unknown
-  ]
-  type module_type = [
-    | `Resolved of Resolved_reference.module_type
+  type tag_module_type = [ tag_only_module_type | tag_unknown ]
+
+  type module_type =
+    [ `Resolved of Resolved_reference.module_type
     | `Root of string * tag_module_type
     | `Dot of label_parent * string
-    | `ModuleType of signature * ModuleTypeName.t
-  ]
+    | `ModuleType of signature * ModuleTypeName.t ]
 
-  type tag_type = [
-    | tag_only_type
-    | tag_only_class
-    | tag_only_class_type
-    | tag_unknown
-  ]
+  type tag_type =
+    [ tag_only_type | tag_only_class | tag_only_class_type | tag_unknown ]
 
-  type type_ = [
-    | `Resolved of Resolved_reference.type_
+  type type_ =
+    [ `Resolved of Resolved_reference.type_
     | `Root of string * tag_type
     | `Dot of label_parent * string
     | `Class of signature * ClassName.t
     | `ClassType of signature * ClassTypeName.t
-    | `Type of signature * TypeName.t
-  ]
+    | `Type of signature * TypeName.t ]
 
-  type tag_constructor = [
-    | tag_only_constructor
+  type tag_constructor =
+    [ tag_only_constructor
     | tag_only_extension
     | tag_only_exception
-    | tag_unknown
-  ]
+    | tag_unknown ]
 
-  type constructor = [
-    | `Resolved of Resolved_reference.constructor
+  type constructor =
+    [ `Resolved of Resolved_reference.constructor
     | `Root of string * tag_constructor
     | `Dot of label_parent * string
     | `Constructor of datatype * ConstructorName.t
     | `Extension of signature * ExtensionName.t
-    | `Exception of signature * ExceptionName.t
-  ]
+    | `Exception of signature * ExceptionName.t ]
 
-  type tag_field = [
-    | tag_only_field
-    | tag_unknown
-  ]
+  type tag_field = [ tag_only_field | tag_unknown ]
 
-  type field = [
-    | `Resolved of Resolved_reference.field
+  type field =
+    [ `Resolved of Resolved_reference.field
     | `Root of string * tag_field
     | `Dot of label_parent * string
-    | `Field of parent * FieldName.t
-  ]
+    | `Field of parent * FieldName.t ]
 
-  type tag_extension = [
-    | tag_only_extension
-    | tag_only_exception
-    | tag_unknown
-  ]
-  type extension = [
-    | `Resolved of Resolved_reference.extension
+  type tag_extension = [ tag_only_extension | tag_only_exception | tag_unknown ]
+
+  type extension =
+    [ `Resolved of Resolved_reference.extension
     | `Root of string * tag_extension
     | `Dot of label_parent * string
     | `Extension of signature * ExtensionName.t
-    | `Exception of signature * ExceptionName.t
-  ]
+    | `Exception of signature * ExceptionName.t ]
 
-  type tag_exception = [
-    | tag_only_exception
-    | tag_unknown
-  ]
+  type tag_exception = [ tag_only_exception | tag_unknown ]
 
-  type exception_ = [
-    | `Resolved of Resolved_reference.exception_
+  type exception_ =
+    [ `Resolved of Resolved_reference.exception_
     | `Root of string * tag_exception
     | `Dot of label_parent * string
-    | `Exception of signature * ExceptionName.t
-  ]
+    | `Exception of signature * ExceptionName.t ]
 
-  type tag_value = [
-    | tag_only_value
-    | tag_unknown
-  ]
+  type tag_value = [ tag_only_value | tag_unknown ]
 
-  type value = [
-    | `Resolved of Resolved_reference.value
+  type value =
+    [ `Resolved of Resolved_reference.value
     | `Root of string * tag_value
     | `Dot of label_parent * string
-    | `Value of signature * ValueName.t
-  ]
+    | `Value of signature * ValueName.t ]
 
-  type tag_class = [
-    | tag_only_class
-    | tag_unknown
-  ]
+  type tag_class = [ tag_only_class | tag_unknown ]
 
-  type class_ = [
-    | `Resolved of Resolved_reference.class_
+  type class_ =
+    [ `Resolved of Resolved_reference.class_
     | `Root of string * tag_class
     | `Dot of label_parent * string
-    | `Class of signature * ClassName.t
-  ]
+    | `Class of signature * ClassName.t ]
 
-  type tag_class_type = [
-    | tag_only_class
-    | tag_only_class_type
-    | tag_unknown
-  ]
+  type tag_class_type = [ tag_only_class | tag_only_class_type | tag_unknown ]
 
-  type class_type = [
-    | `Resolved of Resolved_reference.class_type
+  type class_type =
+    [ `Resolved of Resolved_reference.class_type
     | `Root of string * tag_class_type
     | `Dot of label_parent * string
     | `Class of signature * ClassName.t
-    | `ClassType of signature * ClassTypeName.t
-  ]
+    | `ClassType of signature * ClassTypeName.t ]
 
-  type tag_method = [
-    | tag_only_method
-    | tag_unknown
-  ]
+  type tag_method = [ tag_only_method | tag_unknown ]
 
-  type method_ = [
-    | `Resolved of Resolved_reference.method_
+  type method_ =
+    [ `Resolved of Resolved_reference.method_
     | `Root of string * tag_method
     | `Dot of label_parent * string
-    | `Method of class_signature * MethodName.t
-  ]
+    | `Method of class_signature * MethodName.t ]
 
-  type tag_instance_variable = [
-    | tag_only_instance_variable
-    | tag_unknown
-  ]
+  type tag_instance_variable = [ tag_only_instance_variable | tag_unknown ]
 
-  type instance_variable = [
-    | `Resolved of Resolved_reference.instance_variable
+  type instance_variable =
+    [ `Resolved of Resolved_reference.instance_variable
     | `Root of string * tag_instance_variable
     | `Dot of label_parent * string
-    | `InstanceVariable of class_signature * InstanceVariableName.t
-  ]
+    | `InstanceVariable of class_signature * InstanceVariableName.t ]
 
-  type tag_label = [
-    | tag_only_label
-    | tag_unknown
-  ]
+  type tag_label = [ tag_only_label | tag_unknown ]
 
-  type label = [
-    | `Resolved of Resolved_reference.label
+  type label =
+    [ `Resolved of Resolved_reference.label
     | `Root of string * tag_label
     | `Dot of label_parent * string
-    | `Label of label_parent * LabelName.t
-  ]
+    | `Label of label_parent * LabelName.t ]
 
-  type tag_page = [
-    | tag_only_page
-    | tag_unknown
-  ]
+  type tag_page = [ tag_only_page | tag_unknown ]
 
-  type page = [
-    | `Resolved of Resolved_reference.page
+  type page =
+    [ `Resolved of Resolved_reference.page
     | `Root of string * tag_page
-    | `Dot of label_parent * string
-  ]
+    | `Dot of label_parent * string ]
 
-  type any = [
-    | `Resolved of Resolved_reference.any
+  type any =
+    [ `Resolved of Resolved_reference.any
     | `Root of string * tag_any
     | `Dot of label_parent * string
     | `Module of signature * ModuleName.t
@@ -722,220 +530,162 @@ sig
     | `ClassType of signature * ClassTypeName.t
     | `Method of class_signature * MethodName.t
     | `InstanceVariable of class_signature * InstanceVariableName.t
-    | `Label of label_parent * LabelName.t
-  ]
-end = Reference
+    | `Label of label_parent * LabelName.t ]
+end =
+  Reference
 
-and Resolved_reference :
-sig
-
+and Resolved_reference : sig
   (* Note - many of these are effectively unions of previous types,
-    but they are declared here explicitly because OCaml isn't yet
-    smart enough to accept the more natural expression of this. Hence
-    we define here all those types that ever appear on the right hand
-    side of the constructors and then below we redefine many with
-    the actual hierarchy made more explicit. *)
-  type datatype = [
-    | `Identifier of Identifier.datatype
+     but they are declared here explicitly because OCaml isn't yet
+     smart enough to accept the more natural expression of this. Hence
+     we define here all those types that ever appear on the right hand
+     side of the constructors and then below we redefine many with
+     the actual hierarchy made more explicit. *)
+  type datatype =
+    [ `Identifier of Identifier.datatype | `Type of signature * TypeName.t ]
 
-    | `Type of signature * TypeName.t
-  ]
-
-  and module_ = [
-    | `Identifier of Identifier.path_module
+  and module_ =
+    [ `Identifier of Identifier.path_module
     | `Hidden of module_
     | `SubstAlias of Resolved_path.module_ * module_
     | `Module of signature * ModuleName.t
-    | `Canonical of module_ * Reference.module_
-  ]
+    | `Canonical of module_ * Reference.module_ ]
 
   (* Signature is [ module | moduletype ] *)
-  and signature = [
-    | `Identifier of Identifier.signature
+  and signature =
+    [ `Identifier of Identifier.signature
     | `Hidden of module_
     | `SubstAlias of Resolved_path.module_ * module_
     | `Module of signature * ModuleName.t
     | `Canonical of module_ * Reference.module_
+    | `ModuleType of signature * ModuleTypeName.t ]
 
-    | `ModuleType of signature * ModuleTypeName.t
-  ]
-
-  and class_signature = [
-    | `Identifier of Identifier.class_signature
-
+  and class_signature =
+    [ `Identifier of Identifier.class_signature
     | `Class of signature * ClassName.t
-    | `ClassType of signature * ClassTypeName.t
-  ]
+    | `ClassType of signature * ClassTypeName.t ]
 
   (* parent is [ signature | class_signature ] *)
-  and parent = [
-    | `Identifier of Identifier.parent
-
+  and parent =
+    [ `Identifier of Identifier.parent
     | `SubstAlias of Resolved_path.module_ * module_
     | `Module of signature * ModuleName.t
     | `Hidden of module_
     | `Canonical of module_ * Reference.module_
-
     | `ModuleType of signature * ModuleTypeName.t
-
     | `Class of signature * ClassName.t
     | `ClassType of signature * ClassTypeName.t
-
-    | `Type of signature * TypeName.t
-  ]
+    | `Type of signature * TypeName.t ]
 
   (* The only difference between parent and label_parent
      is that the Identifier allows more types *)
-  and label_parent = [
-    | `Identifier of Identifier.label_parent
-
+  and label_parent =
+    [ `Identifier of Identifier.label_parent
     | `SubstAlias of Resolved_path.module_ * module_
     | `Module of signature * ModuleName.t
     | `Hidden of module_
     | `Canonical of module_ * Reference.module_
-
     | `ModuleType of signature * ModuleTypeName.t
-
     | `Class of signature * ClassName.t
     | `ClassType of signature * ClassTypeName.t
-
-    | `Type of signature * TypeName.t
-  ]
+    | `Type of signature * TypeName.t ]
 
   type s_substalias = [ `SubstAlias of Resolved_path.module_ * module_ ]
+
   type s_module = [ `Module of signature * ModuleName.t ]
+
   type s_canonical = [ `Canonical of module_ * Reference.module_ ]
+
   type s_module_type = [ `ModuleType of signature * ModuleTypeName.t ]
-  type s_type =[ `Type of signature * TypeName.t ]
+
+  type s_type = [ `Type of signature * TypeName.t ]
+
   type s_hidden = [ `Hidden of module_ ]
+
   type s_constructor = [ `Constructor of datatype * ConstructorName.t ]
+
   type s_field = [ `Field of parent * FieldName.t ]
+
   type s_extension = [ `Extension of signature * ExtensionName.t ]
+
   type s_exception = [ `Exception of signature * ExceptionName.t ]
+
   type s_value = [ `Value of signature * ValueName.t ]
+
   type s_class = [ `Class of signature * ClassName.t ]
+
   type s_class_type = [ `ClassType of signature * ClassTypeName.t ]
+
   type s_method = [ `Method of class_signature * MethodName.t ]
-  type s_instance_variable = [ `InstanceVariable of class_signature * InstanceVariableName.t ]
+
+  type s_instance_variable =
+    [ `InstanceVariable of class_signature * InstanceVariableName.t ]
+
   type s_label = [ `Label of label_parent * LabelName.t ]
+
   type s_childpage = [ `ChildPage of Identifier.page ]
+
   type s_childmodule = [ `ChildModule of Identifier.module_ ]
 
-  type module_no_id = [
-    | s_substalias
-    | s_module
-    | s_hidden
-    | s_canonical
-  ]
+  type module_no_id = [ s_substalias | s_module | s_hidden | s_canonical ]
 
-  type signature_no_id = [
-    | module_no_id
-    | s_module_type
-  ]
+  type signature_no_id = [ module_no_id | s_module_type ]
 
-  type class_signature_no_id = [
-    | s_class
-    | s_class_type
-  ]
+  type class_signature_no_id = [ s_class | s_class_type ]
 
-  type datatype_no_id = [
-    | s_type
-  ]
+  type datatype_no_id = [ | s_type ]
 
-  type parent_no_id = [
-    | signature_no_id
-    | class_signature_no_id
-    | datatype_no_id
-  ]
+  type parent_no_id =
+    [ signature_no_id | class_signature_no_id | datatype_no_id ]
 
-  type module_type = [
-    | `Identifier of Identifier.reference_module_type
-    | s_module_type
-  ]
+  type module_type =
+    [ `Identifier of Identifier.reference_module_type | s_module_type ]
 
-  type type_ = [
-    | `Identifier of Identifier.reference_type
+  type type_ =
+    [ `Identifier of Identifier.reference_type
     | s_type
     | s_class
-    | s_class_type
-  ]
+    | s_class_type ]
 
-  type constructor = [
-    | `Identifier of Identifier.reference_constructor
+  type constructor =
+    [ `Identifier of Identifier.reference_constructor
     | s_constructor
     | s_extension
-    | s_exception
-  ]
+    | s_exception ]
 
-  type constructor_no_id = [
-    | s_constructor
-    | s_extension
-    | s_exception
-  ]
+  type constructor_no_id = [ s_constructor | s_extension | s_exception ]
 
-  type field = [
-    | `Identifier of Identifier.reference_field
-    | s_field
-  ]
+  type field = [ `Identifier of Identifier.reference_field | s_field ]
 
-  type extension = [
-    | `Identifier of Identifier.reference_extension
-    | s_exception
-    | s_extension
-  ]
+  type extension =
+    [ `Identifier of Identifier.reference_extension | s_exception | s_extension ]
 
-  type extension_no_id = [
-    | s_exception
-    | s_extension
-  ]
+  type extension_no_id = [ s_exception | s_extension ]
 
-  type exception_ = [
-    | `Identifier of Identifier.reference_exception
-    | s_exception
-  ]
+  type exception_ =
+    [ `Identifier of Identifier.reference_exception | s_exception ]
 
-  type value = [
-    | `Identifier of Identifier.reference_value
-    | s_value
-  ]
+  type value = [ `Identifier of Identifier.reference_value | s_value ]
 
-  type class_ = [
-    | `Identifier of Identifier.reference_class
-    | s_class
-  ]
+  type class_ = [ `Identifier of Identifier.reference_class | s_class ]
 
-  type class_type = [
-    | `Identifier of Identifier.reference_class_type
-    | s_class
-    | s_class_type
-  ]
+  type class_type =
+    [ `Identifier of Identifier.reference_class_type | s_class | s_class_type ]
 
-  type class_type_no_id = [
-    | s_class
-    | s_class_type
-  ]
+  type class_type_no_id = [ s_class | s_class_type ]
 
-  type method_ = [
-    | `Identifier of Identifier.reference_method
-    | s_method
-  ]
+  type method_ = [ `Identifier of Identifier.reference_method | s_method ]
 
-  type instance_variable = [
-    | `Identifier of Identifier.reference_instance_variable
-    | s_instance_variable
-  ]
+  type instance_variable =
+    [ `Identifier of Identifier.reference_instance_variable
+    | s_instance_variable ]
 
-  type label = [
-    | `Identifier of Identifier.reference_label
-    | s_label
-  ]
+  type label = [ `Identifier of Identifier.reference_label | s_label ]
 
-  type page = [
-    | `Identifier of Identifier.reference_page
-  ]
+  type page = [ `Identifier of Identifier.reference_page ]
 
-  type any = [
-    | `Identifier of Identifier.any
+  type any =
+    [ `Identifier of Identifier.any
     | s_substalias
     | s_module
     | s_hidden
@@ -951,6 +701,6 @@ sig
     | s_class_type
     | s_method
     | s_instance_variable
-    | s_label
-  ]
-end = Resolved_reference
+    | s_label ]
+end =
+  Resolved_reference

--- a/src/model/predefined.ml
+++ b/src/model/predefined.ml
@@ -18,20 +18,10 @@ open Lang
 open Names
 
 let predefined_location =
-  let point =
-    {
-      Location_.line = 1;
-      column = 0;
-    }
-  in
-  {
-    Location_.file = "predefined";
-    start = point;
-    end_ = point;
-  }
+  let point = { Location_.line = 1; column = 0 } in
+  { Location_.file = "predefined"; start = point; end_ = point }
 
-let empty_doc =
-  []
+let empty_doc = []
 
 let nullary_equation =
   let open TypeDecl.Equation in
@@ -39,64 +29,114 @@ let nullary_equation =
   let private_ = false in
   let manifest = None in
   let constraints = [] in
-    {params; private_; manifest; constraints}
+  { params; private_; manifest; constraints }
 
 let covariant_equation =
   let open TypeDecl in
   let open TypeDecl.Equation in
-  let params = [{desc=Var "'a"; variance=Some Pos; injectivity=true}] in
+  let params =
+    [ { desc = Var "'a"; variance = Some Pos; injectivity = true } ]
+  in
   let private_ = false in
   let manifest = None in
   let constraints = [] in
-    {params; private_; manifest; constraints}
+  { params; private_; manifest; constraints }
 
 let invariant_equation =
   let open TypeDecl in
   let open TypeDecl.Equation in
-  let params = [{ desc =Var "'a"; variance=None; injectivity = true}] in
+  let params = [ { desc = Var "'a"; variance = None; injectivity = true } ] in
   let private_ = false in
   let manifest = None in
   let constraints = [] in
-    {params; private_; manifest; constraints}
+  { params; private_; manifest; constraints }
 
 let bool_identifier = `CoreType (TypeName.of_string "bool")
+
 let int_identifier = `CoreType (TypeName.of_string "int")
+
 let char_identifier = `CoreType (TypeName.of_string "char")
+
 let bytes_identifier = `CoreType (TypeName.of_string "bytes")
+
 let string_identifier = `CoreType (TypeName.of_string "string")
+
 let float_identifier = `CoreType (TypeName.of_string "float")
+
 let unit_identifier = `CoreType (TypeName.of_string "unit")
+
 let exn_identifier = `CoreType (TypeName.of_string "exn")
+
 let array_identifier = `CoreType (TypeName.of_string "array")
+
 let list_identifier = `CoreType (TypeName.of_string "list")
+
 let option_identifier = `CoreType (TypeName.of_string "option")
+
 let int32_identifier = `CoreType (TypeName.of_string "int32")
+
 let int64_identifier = `CoreType (TypeName.of_string "int64")
+
 let nativeint_identifier = `CoreType (TypeName.of_string "nativeint")
+
 let lazy_t_identifier = `CoreType (TypeName.of_string "lazy_t")
-let extension_constructor_identifier = `CoreType (TypeName.of_string "extension_constructor")
+
+let extension_constructor_identifier =
+  `CoreType (TypeName.of_string "extension_constructor")
+
 let floatarray_identifier = `CoreType (TypeName.of_string "floatarray")
 
+let false_identifier =
+  `Constructor (bool_identifier, ConstructorName.of_string "false")
 
-let false_identifier = `Constructor(bool_identifier, ConstructorName.of_string "false")
-let true_identifier = `Constructor(bool_identifier, ConstructorName.of_string "true")
-let void_identifier = `Constructor(unit_identifier, ConstructorName.of_string "()")
-let nil_identifier = `Constructor(list_identifier, ConstructorName.of_string "([])")
-let cons_identifier = `Constructor(list_identifier, ConstructorName.of_string "(::)")
-let none_identifier = `Constructor(option_identifier, ConstructorName.of_string "None")
-let some_identifier = `Constructor(option_identifier, ConstructorName.of_string "Some")
+let true_identifier =
+  `Constructor (bool_identifier, ConstructorName.of_string "true")
 
-let match_failure_identifier = `CoreException (ExceptionName.of_string "Match_failure")
-let assert_failure_identifier = `CoreException (ExceptionName.of_string "Assert_failure")
-let invalid_argument_identifier = `CoreException (ExceptionName.of_string "Invalid_argument")
+let void_identifier =
+  `Constructor (unit_identifier, ConstructorName.of_string "()")
+
+let nil_identifier =
+  `Constructor (list_identifier, ConstructorName.of_string "([])")
+
+let cons_identifier =
+  `Constructor (list_identifier, ConstructorName.of_string "(::)")
+
+let none_identifier =
+  `Constructor (option_identifier, ConstructorName.of_string "None")
+
+let some_identifier =
+  `Constructor (option_identifier, ConstructorName.of_string "Some")
+
+let match_failure_identifier =
+  `CoreException (ExceptionName.of_string "Match_failure")
+
+let assert_failure_identifier =
+  `CoreException (ExceptionName.of_string "Assert_failure")
+
+let invalid_argument_identifier =
+  `CoreException (ExceptionName.of_string "Invalid_argument")
+
 let failure_identifier = `CoreException (ExceptionName.of_string "Failure")
+
 let not_found_identifier = `CoreException (ExceptionName.of_string "Not_found")
-let out_of_memory_identifier = `CoreException (ExceptionName.of_string "Out_of_memory")
-let stack_overflow_identifier = `CoreException (ExceptionName.of_string "Stack_overflow")
+
+let out_of_memory_identifier =
+  `CoreException (ExceptionName.of_string "Out_of_memory")
+
+let stack_overflow_identifier =
+  `CoreException (ExceptionName.of_string "Stack_overflow")
+
 let sys_error_identifier = `CoreException (ExceptionName.of_string "Sys_error")
-let end_of_file_identifier = `CoreException (ExceptionName.of_string "End_of_file")
-let division_by_zero_identifier = `CoreException (ExceptionName.of_string "Division_by_zero")
-let sys_blocked_io_identifier = `CoreException (ExceptionName.of_string "Sys_blocked_io")
+
+let end_of_file_identifier =
+  `CoreException (ExceptionName.of_string "End_of_file")
+
+let division_by_zero_identifier =
+  `CoreException (ExceptionName.of_string "Division_by_zero")
+
+let sys_blocked_io_identifier =
+  `CoreException (ExceptionName.of_string "Sys_blocked_io")
+
 let undefined_recursive_module_identifier =
   `CoreException (ExceptionName.of_string "Undefined_recursive_module")
 
@@ -147,64 +187,114 @@ let core_constructor_identifier = function
   | "Some" -> Some some_identifier
   | _ -> None
 
-
 let bool_path = `Resolved (`Identifier bool_identifier)
+
 let int_path = `Resolved (`Identifier int_identifier)
+
 let char_path = `Resolved (`Identifier char_identifier)
+
 let bytes_path = `Resolved (`Identifier bytes_identifier)
+
 let string_path = `Resolved (`Identifier string_identifier)
+
 let float_path = `Resolved (`Identifier float_identifier)
+
 let unit_path = `Resolved (`Identifier unit_identifier)
+
 let exn_path = `Resolved (`Identifier exn_identifier)
+
 let array_path = `Resolved (`Identifier array_identifier)
+
 let list_path = `Resolved (`Identifier list_identifier)
+
 let option_path = `Resolved (`Identifier option_identifier)
+
 let int32_path = `Resolved (`Identifier int32_identifier)
+
 let int64_path = `Resolved (`Identifier int64_identifier)
+
 let nativeint_path = `Resolved (`Identifier nativeint_identifier)
+
 let lazy_t_path = `Resolved (`Identifier lazy_t_identifier)
+
 let extension_constructor_path =
   `Resolved (`Identifier extension_constructor_identifier)
+
 let _floatarray_path = `Resolved (`Identifier floatarray_identifier)
 
 let bool_reference = `Resolved (`Identifier bool_identifier)
+
 let int_reference = `Resolved (`Identifier int_identifier)
+
 let char_reference = `Resolved (`Identifier char_identifier)
+
 let bytes_reference = `Resolved (`Identifier bytes_identifier)
+
 let string_reference = `Resolved (`Identifier string_identifier)
+
 let float_reference = `Resolved (`Identifier float_identifier)
+
 let unit_reference = `Resolved (`Identifier unit_identifier)
+
 let exn_reference = `Resolved (`Identifier exn_identifier)
+
 let array_reference = `Resolved (`Identifier array_identifier)
+
 let list_reference = `Resolved (`Identifier list_identifier)
+
 let option_reference = `Resolved (`Identifier option_identifier)
+
 let int32_reference = `Resolved (`Identifier int32_identifier)
+
 let int64_reference = `Resolved (`Identifier int64_identifier)
+
 let nativeint_reference = `Resolved (`Identifier nativeint_identifier)
+
 let lazy_t_reference = `Resolved (`Identifier lazy_t_identifier)
+
 let extension_constructor_reference =
   `Resolved (`Identifier extension_constructor_identifier)
+
 let _floatarray_reference = `Resolved (`Identifier floatarray_identifier)
 
 let false_reference = `Resolved (`Identifier false_identifier)
+
 let true_reference = `Resolved (`Identifier true_identifier)
+
 let void_reference = `Resolved (`Identifier void_identifier)
+
 let nil_reference = `Resolved (`Identifier nil_identifier)
+
 let cons_reference = `Resolved (`Identifier cons_identifier)
+
 let none_reference = `Resolved (`Identifier none_identifier)
+
 let some_reference = `Resolved (`Identifier some_identifier)
 
 let match_failure_reference = `Resolved (`Identifier match_failure_identifier)
+
 let assert_failure_reference = `Resolved (`Identifier assert_failure_identifier)
-let invalid_argument_reference = `Resolved (`Identifier invalid_argument_identifier)
+
+let invalid_argument_reference =
+  `Resolved (`Identifier invalid_argument_identifier)
+
 let failure_reference = `Resolved (`Identifier failure_identifier)
+
 let not_found_reference = `Resolved (`Identifier not_found_identifier)
+
 let out_of_memory_reference = `Resolved (`Identifier out_of_memory_identifier)
+
 let stack_overflow_reference = `Resolved (`Identifier stack_overflow_identifier)
+
 let sys_error_reference = `Resolved (`Identifier sys_error_identifier)
+
 let end_of_file_reference = `Resolved (`Identifier end_of_file_identifier)
-let division_by_zero_reference = `Resolved (`Identifier division_by_zero_identifier)
+
+let division_by_zero_reference =
+  `Resolved (`Identifier division_by_zero_identifier)
+
 let sys_blocked_io_reference = `Resolved (`Identifier sys_blocked_io_identifier)
+
 let undefined_recursive_module_reference =
   `Resolved (`Identifier undefined_recursive_module_identifier)
 
@@ -213,53 +303,52 @@ let false_decl =
   let doc = empty_doc in
   let args = Tuple [] in
   let res = None in
-    {id = false_identifier; doc; args; res}
+  { id = false_identifier; doc; args; res }
 
 let true_decl =
   let open TypeDecl.Constructor in
   let doc = empty_doc in
   let args = Tuple [] in
   let res = None in
-    {id = true_identifier; doc; args; res}
+  { id = true_identifier; doc; args; res }
 
 let void_decl =
   let open TypeDecl.Constructor in
   let doc = empty_doc in
   let args = Tuple [] in
   let res = None in
-    {id = void_identifier; doc; args; res}
+  { id = void_identifier; doc; args; res }
 
 let nil_decl =
   let open TypeDecl.Constructor in
   let doc = empty_doc in
   let args = Tuple [] in
   let res = None in
-    {id = nil_identifier; doc; args; res}
+  { id = nil_identifier; doc; args; res }
 
 let cons_decl =
   let open TypeDecl.Constructor in
   let doc = empty_doc in
   let head = TypeExpr.Var "'a" in
-  let tail = TypeExpr.(Constr(list_path, [head])) in
-  let args = Tuple [head; tail] in
+  let tail = TypeExpr.(Constr (list_path, [ head ])) in
+  let args = Tuple [ head; tail ] in
   let res = None in
-    {id = cons_identifier; doc; args; res}
+  { id = cons_identifier; doc; args; res }
 
 let none_decl =
   let open TypeDecl.Constructor in
   let doc = empty_doc in
   let args = Tuple [] in
   let res = None in
-    {id = none_identifier; doc; args; res}
+  { id = none_identifier; doc; args; res }
 
 let some_decl =
   let open TypeDecl.Constructor in
   let doc = empty_doc in
   let var = TypeExpr.Var "'a" in
-  let args = Tuple [var] in
+  let args = Tuple [ var ] in
   let res = None in
-    {id = some_identifier; doc; args; res}
-
+  { id = some_identifier; doc; args; res }
 
 let int_decl =
   let open TypeDecl in
@@ -271,7 +360,7 @@ let int_decl =
   let doc = empty_doc in
   let equation = nullary_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let char_decl =
   let open TypeDecl in
@@ -283,7 +372,7 @@ let char_decl =
   let doc = empty_doc in
   let equation = nullary_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let bytes_decl =
   let open TypeDecl in
@@ -294,7 +383,7 @@ let bytes_decl =
   let doc = empty_doc in
   let equation = nullary_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let string_decl =
   let open TypeDecl in
@@ -305,7 +394,7 @@ let string_decl =
   let doc = empty_doc in
   let equation = nullary_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let float_decl =
   let open TypeDecl in
@@ -316,7 +405,7 @@ let float_decl =
   let doc = empty_doc in
   let equation = nullary_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let bool_decl =
   let open TypeDecl in
@@ -327,8 +416,8 @@ let bool_decl =
   (* let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let equation = nullary_equation in
-  let representation = Some (Variant [false_decl; true_decl]) in
-    {id; doc; equation; representation}
+  let representation = Some (Variant [ false_decl; true_decl ]) in
+  { id; doc; equation; representation }
 
 let unit_decl =
   let open TypeDecl in
@@ -339,8 +428,8 @@ let unit_decl =
   (* let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let equation = nullary_equation in
-  let representation = Some (Variant [void_decl]) in
-    {id; doc; equation; representation}
+  let representation = Some (Variant [ void_decl ]) in
+  { id; doc; equation; representation }
 
 let exn_decl =
   let open TypeDecl in
@@ -352,22 +441,22 @@ let exn_decl =
   let doc = empty_doc in
   let equation = nullary_equation in
   let representation = Some Extensible in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let array_decl =
   let open TypeDecl in
   (* let open Odoc_model.Comment in *)
   let id = array_identifier in
   (* let text =
-    [Raw "The type of arrays whose elements have type ";
-     Code "'a";
-     Raw "."]
-  in *)
+       [Raw "The type of arrays whose elements have type ";
+        Code "'a";
+        Raw "."]
+     in *)
   (* let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let equation = invariant_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let list_decl =
   let open TypeDecl in
@@ -375,15 +464,15 @@ let list_decl =
   (* let open Odoc_model.Comment in *)
   let id = list_identifier in
   (* let text =
-    [Raw "The type of lists whose elements have type ";
-     Code "'a";
-     Raw "."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "The type of lists whose elements have type ";
+        Code "'a";
+        Raw "."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let equation = covariant_equation in
-  let representation = Some (Variant [nil_decl; cons_decl]) in
-    {id; doc; equation; representation}
+  let representation = Some (Variant [ nil_decl; cons_decl ]) in
+  { id; doc; equation; representation }
 
 let option_decl =
   let open TypeDecl in
@@ -391,212 +480,220 @@ let option_decl =
   (* let open Odoc_model.Comment in *)
   let id = option_identifier in
   (* let text =
-    [Raw "The type of optional values of type ";
-     Code "'a";
-     Raw "."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "The type of optional values of type ";
+        Code "'a";
+        Raw "."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let equation = covariant_equation in
-  let representation = Some (Variant [none_decl; some_decl]) in
-    {id; doc; equation; representation}
+  let representation = Some (Variant [ none_decl; some_decl ]) in
+  { id; doc; equation; representation }
 
 let int32_decl =
   let open TypeDecl in
   (* let open Odoc_model.Comment in *)
   let id = int32_identifier in
   (* let text =
-    [Raw "The type of signed 32-bit integers. See the ";
-     Reference(Element(Root("Int32", TModule)), None);
-     Raw " module."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "The type of signed 32-bit integers. See the ";
+        Reference(Element(Root("Int32", TModule)), None);
+        Raw " module."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let equation = nullary_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let int64_decl =
   let open TypeDecl in
   (* let open Odoc_model.Comment in *)
   let id = int64_identifier in
   (* let text =
-    [Raw "The type of signed 64-bit integers. See the ";
-     Reference(Element(Root("Int64", TModule)), None);
-     Raw " module."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "The type of signed 64-bit integers. See the ";
+        Reference(Element(Root("Int64", TModule)), None);
+        Raw " module."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let equation = nullary_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let nativeint_decl =
   let open TypeDecl in
   (* let open Odoc_model.Comment in *)
   let id = nativeint_identifier in
   (* let text =
-    [Raw "The type of signed, platform-native integers (32 bits on \
-          32-bit processors, 64 bits on 64-bit processors). See the ";
-     Reference(Element(Root("Nativeint", TModule)), None);
-     Raw " module."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "The type of signed, platform-native integers (32 bits on \
+             32-bit processors, 64 bits on 64-bit processors). See the ";
+        Reference(Element(Root("Nativeint", TModule)), None);
+        Raw " module."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let equation = nullary_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let lazy_t_decl =
   let open TypeDecl in
   (* let open Odoc_model.Comment in *)
   let id = lazy_t_identifier in
   (* let text =
-    [Raw "This type is used to implement the ";
-     Reference(Element(Root("Lazy", TModule)), None);
-     Raw " module. It should not be used directly."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "This type is used to implement the ";
+        Reference(Element(Root("Lazy", TModule)), None);
+        Raw " module. It should not be used directly."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let equation = covariant_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let extension_constructor_decl =
   let open TypeDecl in
   (* let open Odoc_model.Comment in *)
   let id = extension_constructor_identifier in
   (* let text =
-    [Raw "cf. ";
-     Reference(Element(Root("Obj", TModule)), None);
-     Raw " module. It should not be used directly."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "cf. ";
+        Reference(Element(Root("Obj", TModule)), None);
+        Raw " module. It should not be used directly."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let equation = covariant_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let floatarray_decl =
   let open TypeDecl in
   let id = floatarray_identifier in
   let words ss =
     ss
-    |> List.rev_map (fun s -> [`Space; `Word s])
-    |> List.flatten
-    |> List.tl
-    |> List.rev
+    |> List.rev_map (fun s -> [ `Space; `Word s ])
+    |> List.flatten |> List.tl |> List.rev
   in
   let doc =
-    [`Paragraph (
-      words ["This"; "type"; "is"; "used"; "to"; "implement"; "the"] @
-      [`Space;
-       `Reference (`Module (`Root ("Array", `TModule), ModuleName.of_string "Floatarray"), []);
-       `Space] @
-      words ["module."; "It"; "should"; "not"; "be"; "used"; "directly."]
-      |> List.map (Location_.at predefined_location)
-    )]
+    [
+      `Paragraph
+        ( words [ "This"; "type"; "is"; "used"; "to"; "implement"; "the" ]
+          @ [
+              `Space;
+              `Reference
+                ( `Module
+                    ( `Root ("Array", `TModule),
+                      ModuleName.of_string "Floatarray" ),
+                  [] );
+              `Space;
+            ]
+          @ words
+              [ "module."; "It"; "should"; "not"; "be"; "used"; "directly." ]
+        |> List.map (Location_.at predefined_location) );
+    ]
     |> List.map (Location_.at predefined_location)
   in
   let equation = covariant_equation in
   let representation = None in
-    {id; doc; equation; representation}
+  { id; doc; equation; representation }
 
 let match_failure_decl =
   let open Lang.Exception in
   (* let open Odoc_model.Comment in *)
   let id = match_failure_identifier in
   (* let text =
-    [Raw "Exception raised when none of the cases of a pattern matching apply. \
-          The arguments are the location of the ";
-     Code "match";
-     Raw " keyword in the source code (file name, line number, column number)."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised when none of the cases of a pattern matching apply. \
+             The arguments are the location of the ";
+        Code "match";
+        Raw " keyword in the source code (file name, line number, column number)."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
-  let string_expr = TypeExpr.Constr(string_path, []) in
-  let int_expr = TypeExpr.Constr(int_path, []) in
+  let string_expr = TypeExpr.Constr (string_path, []) in
+  let int_expr = TypeExpr.Constr (int_path, []) in
   let args =
-    TypeDecl.Constructor.Tuple [TypeExpr.Tuple[string_expr; int_expr; int_expr]]
+    TypeDecl.Constructor.Tuple
+      [ TypeExpr.Tuple [ string_expr; int_expr; int_expr ] ]
   in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 let assert_failure_decl =
   let open Lang.Exception in
   (* let open Odoc_model.Comment in *)
   let id = assert_failure_identifier in
   (* let text =
-    [Raw "Exception raised when and assertion fails. \
-          The arguments are the location of the ";
-     Code "assert";
-     Raw " keyword in the source code (file name, line number, column number)."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised when and assertion fails. \
+             The arguments are the location of the ";
+        Code "assert";
+        Raw " keyword in the source code (file name, line number, column number)."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
-  let string_expr = TypeExpr.Constr(string_path, []) in
-  let int_expr = TypeExpr.Constr(int_path, []) in
+  let string_expr = TypeExpr.Constr (string_path, []) in
+  let int_expr = TypeExpr.Constr (int_path, []) in
   let args =
-    TypeDecl.Constructor.Tuple [TypeExpr.Tuple[string_expr; int_expr; int_expr]]
+    TypeDecl.Constructor.Tuple
+      [ TypeExpr.Tuple [ string_expr; int_expr; int_expr ] ]
   in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 let invalid_argument_decl =
   let open Lang.Exception in
   (* let open Odoc_model.Comment in *)
   let id = invalid_argument_identifier in
   (* let text =
-    [Raw "Exception raised by library functions to signal that the given \
-          arguments do not make sense."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised by library functions to signal that the given \
+             arguments do not make sense."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
-  let args = TypeDecl.Constructor.Tuple [TypeExpr.Constr(string_path, [])] in
+  let args = TypeDecl.Constructor.Tuple [ TypeExpr.Constr (string_path, []) ] in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 let failure_decl =
   let open Lang.Exception in
   (* let open Odoc_model.Comment in *)
   let id = failure_identifier in
   (* let text =
-    [Raw "Exception raised by library functions to signal that they are \
-          undefined on the given arguments."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised by library functions to signal that they are \
+             undefined on the given arguments."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
-  let args = TypeDecl.Constructor.Tuple [TypeExpr.Constr(string_path, [])] in
+  let args = TypeDecl.Constructor.Tuple [ TypeExpr.Constr (string_path, []) ] in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 let not_found_decl =
   let open Lang.Exception in
   (* let open Odoc_model.Comment in *)
   let id = not_found_identifier in
   (* let text =
-    [Raw "Exception raised by search functions when the desired object \
-          could not be found."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised by search functions when the desired object \
+             could not be found."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let args = TypeDecl.Constructor.Tuple [] in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 let out_of_memory_decl =
   let open Lang.Exception in
   (* let open Odoc_model.Comment in *)
   let id = out_of_memory_identifier in
   (* let text =
-    [Raw "Exception raised by the garbage collector when there is \
-          insufficient memory to complete the computation."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised by the garbage collector when there is \
+             insufficient memory to complete the computation."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let args = TypeDecl.Constructor.Tuple [] in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 (* TODO: Provide reference to the OCaml manual *)
 let stack_overflow_decl =
@@ -604,74 +701,74 @@ let stack_overflow_decl =
   (* let open Odoc_model.Comment in *)
   let id = stack_overflow_identifier in
   (* let text =
-    [Raw "Exception raised by the bytecode interpreter when the evaluation \
-          stack reaches its maximal size. This often indicates infinite or \
-          excessively deep recursion in the user's program. (Not fully \
-          implemented by the native-code compiler; see section 11.5 of \
-          the OCaml manual.)"]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised by the bytecode interpreter when the evaluation \
+             stack reaches its maximal size. This often indicates infinite or \
+             excessively deep recursion in the user's program. (Not fully \
+             implemented by the native-code compiler; see section 11.5 of \
+             the OCaml manual.)"]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let args = TypeDecl.Constructor.Tuple [] in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 let sys_error_decl =
   let open Lang.Exception in
   (* let open Odoc_model.Comment in *)
   let id = sys_error_identifier in
   (* let text =
-    [Raw "Exception raised by the input/output functions to report an \
-          operating system error."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised by the input/output functions to report an \
+             operating system error."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
-  let args = TypeDecl.Constructor.Tuple [TypeExpr.Constr(string_path, [])] in
+  let args = TypeDecl.Constructor.Tuple [ TypeExpr.Constr (string_path, []) ] in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 let end_of_file_decl =
   let open Lang.Exception in
   (* let open Odoc_model.Comment in *)
   let id = end_of_file_identifier in
   (* let text =
-    [Raw "Exception raised by input functions to signal that the end of \
-          file has been reached."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised by input functions to signal that the end of \
+             file has been reached."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let args = TypeDecl.Constructor.Tuple [] in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 let division_by_zero_decl =
   let open Lang.Exception in
   (* let open Odoc_model.Comment in *)
   let id = division_by_zero_identifier in
   (* let text =
-    [Raw "Exception raised by integer division and remainder operations \
-          when their second argument is zero."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised by integer division and remainder operations \
+             when their second argument is zero."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let args = TypeDecl.Constructor.Tuple [] in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 let sys_blocked_io_decl =
   let open Lang.Exception in
   (* let open Odoc_model.Comment in *)
   let id = sys_blocked_io_identifier in
   (* let text =
-    [Raw "A special case of ";
-     Reference(Element sys_error_reference, None);
-     Raw " raised when no I/O is possible on a non-blocking I/O channel."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "A special case of ";
+        Reference(Element sys_error_reference, None);
+        Raw " raised when no I/O is possible on a non-blocking I/O channel."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
   let args = TypeDecl.Constructor.Tuple [] in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 (* TODO: Provide reference to the OCaml manual *)
 let undefined_recursive_module_decl =
@@ -679,28 +776,55 @@ let undefined_recursive_module_decl =
   (* let open Odoc_model.Comment in *)
   let id = undefined_recursive_module_identifier in
   (* let text =
-    [Raw "Exception raised when an ill-founded recursive module definition \
-          is evaluated. (See section 7.8 of the OCaml manual.) The arguments \
-          are the location of the definition in the source code \
-          (file name, line number, column number)."]
-  in
-  let doc = Ok {empty_doc with text} in *)
+       [Raw "Exception raised when an ill-founded recursive module definition \
+             is evaluated. (See section 7.8 of the OCaml manual.) The arguments \
+             are the location of the definition in the source code \
+             (file name, line number, column number)."]
+     in
+     let doc = Ok {empty_doc with text} in *)
   let doc = empty_doc in
-  let string_expr = TypeExpr.Constr(string_path, []) in
-  let int_expr = TypeExpr.Constr(int_path, []) in
+  let string_expr = TypeExpr.Constr (string_path, []) in
+  let int_expr = TypeExpr.Constr (int_path, []) in
   let args =
-    TypeDecl.Constructor.Tuple [TypeExpr.Tuple[string_expr; int_expr; int_expr]]
+    TypeDecl.Constructor.Tuple
+      [ TypeExpr.Tuple [ string_expr; int_expr; int_expr ] ]
   in
   let res = None in
-    {id; doc; args; res}
+  { id; doc; args; res }
 
 let core_types =
-  [int_decl; char_decl; bytes_decl; string_decl; float_decl; bool_decl;
-   unit_decl; exn_decl; array_decl; list_decl; option_decl; int32_decl;
-   int64_decl; nativeint_decl; lazy_t_decl; extension_constructor_decl; floatarray_decl]
+  [
+    int_decl;
+    char_decl;
+    bytes_decl;
+    string_decl;
+    float_decl;
+    bool_decl;
+    unit_decl;
+    exn_decl;
+    array_decl;
+    list_decl;
+    option_decl;
+    int32_decl;
+    int64_decl;
+    nativeint_decl;
+    lazy_t_decl;
+    extension_constructor_decl;
+    floatarray_decl;
+  ]
 
 let core_exceptions =
-  [match_failure_decl; assert_failure_decl; invalid_argument_decl;
-   failure_decl; not_found_decl; out_of_memory_decl; stack_overflow_decl;
-   sys_error_decl; end_of_file_decl; division_by_zero_decl;
-   sys_blocked_io_decl; undefined_recursive_module_decl]
+  [
+    match_failure_decl;
+    assert_failure_decl;
+    invalid_argument_decl;
+    failure_decl;
+    not_found_decl;
+    out_of_memory_decl;
+    stack_overflow_decl;
+    sys_error_decl;
+    end_of_file_decl;
+    division_by_zero_decl;
+    sys_blocked_io_decl;
+    undefined_recursive_module_decl;
+  ]

--- a/src/model/predefined.mli
+++ b/src/model/predefined.mli
@@ -19,138 +19,247 @@ open Paths
 (** {3 Identifiers} *)
 
 val bool_identifier : Identifier.Type.t
+
 val int_identifier : Identifier.Type.t
+
 val char_identifier : Identifier.Type.t
+
 val bytes_identifier : Identifier.Type.t
+
 val string_identifier : Identifier.Type.t
+
 val float_identifier : Identifier.Type.t
+
 val unit_identifier : Identifier.Type.t
+
 val exn_identifier : Identifier.Type.t
+
 val array_identifier : Identifier.Type.t
+
 val list_identifier : Identifier.Type.t
+
 val option_identifier : Identifier.Type.t
+
 val int32_identifier : Identifier.Type.t
+
 val int64_identifier : Identifier.Type.t
+
 val nativeint_identifier : Identifier.Type.t
+
 val lazy_t_identifier : Identifier.Type.t
+
 val extension_constructor_identifier : Identifier.Type.t
-val floatarray_identifier: Identifier.Type.t
+
+val floatarray_identifier : Identifier.Type.t
 
 val false_identifier : Identifier.Constructor.t
+
 val true_identifier : Identifier.Constructor.t
+
 val void_identifier : Identifier.Constructor.t
+
 val nil_identifier : Identifier.Constructor.t
+
 val cons_identifier : Identifier.Constructor.t
+
 val none_identifier : Identifier.Constructor.t
+
 val some_identifier : Identifier.Constructor.t
 
 val match_failure_identifier : Identifier.Exception.t
+
 val assert_failure_identifier : Identifier.Exception.t
+
 val invalid_argument_identifier : Identifier.Exception.t
+
 val failure_identifier : Identifier.Exception.t
+
 val not_found_identifier : Identifier.Exception.t
+
 val out_of_memory_identifier : Identifier.Exception.t
+
 val stack_overflow_identifier : Identifier.Exception.t
+
 val sys_error_identifier : Identifier.Exception.t
+
 val end_of_file_identifier : Identifier.Exception.t
+
 val division_by_zero_identifier : Identifier.Exception.t
+
 val sys_blocked_io_identifier : Identifier.Exception.t
+
 val undefined_recursive_module_identifier : Identifier.Exception.t
 
 val core_type_identifier : string -> Identifier.Type.t option
+
 val core_exception_identifier : string -> Identifier.Exception.t option
+
 val core_constructor_identifier : string -> Identifier.Constructor.t option
 
 (** {3 Paths} *)
 
 val bool_path : Path.Type.t
+
 val int_path : Path.Type.t
+
 val char_path : Path.Type.t
+
 val bytes_path : Path.Type.t
+
 val string_path : Path.Type.t
+
 val float_path : Path.Type.t
+
 val unit_path : Path.Type.t
+
 val exn_path : Path.Type.t
+
 val array_path : Path.Type.t
+
 val list_path : Path.Type.t
+
 val option_path : Path.Type.t
+
 val int32_path : Path.Type.t
+
 val int64_path : Path.Type.t
+
 val nativeint_path : Path.Type.t
+
 val lazy_t_path : Path.Type.t
+
 val extension_constructor_path : Path.Type.t
 
 (** {3 References} *)
 
 val bool_reference : Reference.Type.t
+
 val int_reference : Reference.Type.t
+
 val char_reference : Reference.Type.t
+
 val bytes_reference : Reference.Type.t
+
 val string_reference : Reference.Type.t
+
 val float_reference : Reference.Type.t
+
 val unit_reference : Reference.Type.t
+
 val exn_reference : Reference.Type.t
+
 val array_reference : Reference.Type.t
+
 val list_reference : Reference.Type.t
+
 val option_reference : Reference.Type.t
+
 val int32_reference : Reference.Type.t
+
 val int64_reference : Reference.Type.t
+
 val nativeint_reference : Reference.Type.t
+
 val lazy_t_reference : Reference.Type.t
+
 val extension_constructor_reference : Reference.Type.t
 
 val false_reference : Reference.Constructor.t
+
 val true_reference : Reference.Constructor.t
+
 val void_reference : Reference.Constructor.t
+
 val nil_reference : Reference.Constructor.t
+
 val cons_reference : Reference.Constructor.t
+
 val none_reference : Reference.Constructor.t
+
 val some_reference : Reference.Constructor.t
 
 val match_failure_reference : Reference.Exception.t
+
 val assert_failure_reference : Reference.Exception.t
+
 val invalid_argument_reference : Reference.Exception.t
+
 val failure_reference : Reference.Exception.t
+
 val not_found_reference : Reference.Exception.t
+
 val out_of_memory_reference : Reference.Exception.t
+
 val stack_overflow_reference : Reference.Exception.t
+
 val sys_error_reference : Reference.Exception.t
+
 val end_of_file_reference : Reference.Exception.t
+
 val division_by_zero_reference : Reference.Exception.t
+
 val sys_blocked_io_reference : Reference.Exception.t
+
 val undefined_recursive_module_reference : Reference.Exception.t
 
 (** {3 Declarations} *)
 
 val int_decl : Lang.TypeDecl.t
+
 val char_decl : Lang.TypeDecl.t
+
 val bytes_decl : Lang.TypeDecl.t
+
 val string_decl : Lang.TypeDecl.t
+
 val float_decl : Lang.TypeDecl.t
+
 val bool_decl : Lang.TypeDecl.t
+
 val unit_decl : Lang.TypeDecl.t
+
 val exn_decl : Lang.TypeDecl.t
+
 val array_decl : Lang.TypeDecl.t
+
 val list_decl : Lang.TypeDecl.t
+
 val option_decl : Lang.TypeDecl.t
+
 val int32_decl : Lang.TypeDecl.t
+
 val int64_decl : Lang.TypeDecl.t
+
 val nativeint_decl : Lang.TypeDecl.t
+
 val lazy_t_decl : Lang.TypeDecl.t
+
 val extension_constructor_decl : Lang.TypeDecl.t
 
 val match_failure_decl : Lang.Exception.t
+
 val assert_failure_decl : Lang.Exception.t
+
 val invalid_argument_decl : Lang.Exception.t
+
 val failure_decl : Lang.Exception.t
+
 val not_found_decl : Lang.Exception.t
+
 val out_of_memory_decl : Lang.Exception.t
+
 val stack_overflow_decl : Lang.Exception.t
+
 val sys_error_decl : Lang.Exception.t
+
 val end_of_file_decl : Lang.Exception.t
+
 val division_by_zero_decl : Lang.Exception.t
+
 val sys_blocked_io_decl : Lang.Exception.t
+
 val undefined_recursive_module_decl : Lang.Exception.t
 
 val core_types : Lang.TypeDecl.t list
+
 val core_exceptions : Lang.Exception.t list

--- a/src/model/root.ml
+++ b/src/model/root.ml
@@ -17,40 +17,36 @@
 let contains_double_underscore s =
   let len = String.length s in
   let rec aux i =
-    if i > len - 2 then false else
-    if s.[i] = '_' && s.[i + 1] = '_' then true
+    if i > len - 2 then false
+    else if s.[i] = '_' && s.[i + 1] = '_' then true
     else aux (i + 1)
   in
   aux 0
 
-module Package =
-struct
+module Package = struct
   type t = string
 
-  module Table = Hashtbl.Make(struct
+  module Table = Hashtbl.Make (struct
     type nonrec t = t
-    let equal : t -> t -> bool = (=)
+
+    let equal : t -> t -> bool = ( = )
+
     let hash : t -> int = Hashtbl.hash
   end)
 end
 
-module Odoc_file =
-struct
-  type compilation_unit = {name : string; hidden : bool}
+module Odoc_file = struct
+  type compilation_unit = { name : string; hidden : bool }
 
-  type t =
-    | Page of string
-    | Compilation_unit of compilation_unit
+  type t = Page of string | Compilation_unit of compilation_unit
 
   let create_unit ~force_hidden name =
     let hidden = force_hidden || contains_double_underscore name in
-    Compilation_unit {name; hidden}
+    Compilation_unit { name; hidden }
 
   let create_page name = Page name
 
-  let name = function
-    | Page name
-    | Compilation_unit {name; _} -> name
+  let name = function Page name | Compilation_unit { name; _ } -> name
 end
 
 type t = {
@@ -59,29 +55,32 @@ type t = {
   digest : Digest.t;
 }
 
-let equal : t -> t -> bool = (=)
+let equal : t -> t -> bool = ( = )
+
 let hash : t -> int = Hashtbl.hash
 
 let to_string t =
   let rec pp fmt (id : Paths.Identifier.OdocId.t) =
     match id with
     | `RootPage p -> Format.fprintf fmt "%a" Names.PageName.fmt p
-    | `LeafPage (parent, name)
-    | `Page (parent, name) ->
-      Format.fprintf fmt "%a::%a" pp (parent :> Paths.Identifier.OdocId.t) Names.PageName.fmt name
+    | `LeafPage (parent, name) | `Page (parent, name) ->
+        Format.fprintf fmt "%a::%a" pp
+          (parent :> Paths.Identifier.OdocId.t)
+          Names.PageName.fmt name
     | `Root (parent, name) ->
-      Format.fprintf fmt "%a::%a" pp (parent :> Paths.Identifier.OdocId.t) Names.ModuleName.fmt name
+        Format.fprintf fmt "%a::%a" pp
+          (parent :> Paths.Identifier.OdocId.t)
+          Names.ModuleName.fmt name
   in
 
-  Format.asprintf "%a"
-    pp t.id
+  Format.asprintf "%a" pp t.id
 
 let compare x y = String.compare x.digest y.digest
 
-module Hash_table =
-  Hashtbl.Make
-    (struct
-      type nonrec t = t
-      let equal = equal
-      let hash = hash
-    end)
+module Hash_table = Hashtbl.Make (struct
+  type nonrec t = t
+
+  let equal = equal
+
+  let hash = hash
+end)

--- a/src/model/root.mli
+++ b/src/model/root.mli
@@ -21,20 +21,17 @@
     file.
 *)
 
-module Package :
-sig
+module Package : sig
   type t = string
 end
 
-module Odoc_file :
-sig
-  type compilation_unit = {name : string; hidden : bool}
+module Odoc_file : sig
+  type compilation_unit = { name : string; hidden : bool }
 
-  type t =
-    | Page of string
-    | Compilation_unit of compilation_unit
+  type t = Page of string | Compilation_unit of compilation_unit
 
   val create_unit : force_hidden:bool -> string -> t
+
   val create_page : string -> t
 
   val name : t -> string
@@ -47,7 +44,9 @@ type t = {
 }
 
 val equal : t -> t -> bool
+
 val hash : t -> int
+
 val compare : t -> t -> int
 
 val to_string : t -> string
@@ -55,4 +54,5 @@ val to_string : t -> string
 module Hash_table : Hashtbl.S with type key = t
 
 val contains_double_underscore : string -> bool
+
 (* not the best place for this but. *)

--- a/src/model_desc/comment_desc.ml
+++ b/src/model_desc/comment_desc.ml
@@ -64,8 +64,7 @@ let rec inline_element : general_inline_element t =
     | `Space -> C0 "`Space"
     | `Word x -> C ("`Word", x, string)
     | `Code_span x -> C ("`Code_span", x, string)
-    | `Raw_markup (x1, x2) ->
-        C ("`Raw_markup", (x1, x2), Pair (string, string))
+    | `Raw_markup (x1, x2) -> C ("`Raw_markup", (x1, x2), Pair (string, string))
     | `Styled (x1, x2) -> C ("`Styled", (x1, x2), Pair (style, link_content))
     | `Reference (x1, x2) ->
         C ("`Reference", (x1, x2), Pair (reference, link_content))

--- a/src/model_desc/comment_desc.mli
+++ b/src/model_desc/comment_desc.mli
@@ -1,2 +1,3 @@
 val docs : Odoc_model.Comment.docs Type_desc.t
+
 val docs_or_stop : Odoc_model.Comment.docs_or_stop Type_desc.t

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -14,7 +14,11 @@ let rec module_decl =
   let open Lang.Module in
   Variant
     (function
-    | Alias (x, y) -> C ("Alias", ((x :> Paths.Path.t), y), Pair (path, Option simple_expansion))
+    | Alias (x, y) ->
+        C
+          ( "Alias",
+            ((x :> Paths.Path.t), y),
+            Pair (path, Option simple_expansion) )
     | ModuleType x -> C ("ModuleType", x, moduletype_expr))
 
 and module_t =
@@ -52,13 +56,26 @@ and moduletype_substitution =
   let open Lang.ModuleType in
   Variant
     (function
-    | ModuleEq (x1, x2) -> C ("ModuleEq", ((x1 :> Paths.Fragment.t), x2), Pair (fragment, module_decl))
+    | ModuleEq (x1, x2) ->
+        C
+          ( "ModuleEq",
+            ((x1 :> Paths.Fragment.t), x2),
+            Pair (fragment, module_decl) )
     | TypeEq (x1, x2) ->
-        C ("TypeEq", ((x1 :> Paths.Fragment.t), x2), Pair (fragment, typedecl_equation))
+        C
+          ( "TypeEq",
+            ((x1 :> Paths.Fragment.t), x2),
+            Pair (fragment, typedecl_equation) )
     | ModuleSubst (x1, x2) ->
-        C ("ModuleSubst", ((x1 :> Paths.Fragment.t), (x2 :> Paths.Path.t)), Pair (fragment, path))
+        C
+          ( "ModuleSubst",
+            ((x1 :> Paths.Fragment.t), (x2 :> Paths.Path.t)),
+            Pair (fragment, path) )
     | TypeSubst (x1, x2) ->
-        C ("TypeSubst", ((x1 :> Paths.Fragment.t), x2), Pair (fragment, typedecl_equation)))
+        C
+          ( "TypeSubst",
+            ((x1 :> Paths.Fragment.t), x2),
+            Pair (fragment, typedecl_equation) ))
 
 and moduletype_type_of_desc =
   let open Lang.ModuleType in
@@ -72,7 +89,8 @@ and simple_expansion =
   Variant
     (function
     | Signature sg -> C ("Signature", sg, signature_t)
-    | Functor (p, e) -> C ("Functor", (p, e), Pair (functorparameter_t, simple_expansion)))
+    | Functor (p, e) ->
+        C ("Functor", (p, e), Pair (functorparameter_t, simple_expansion)))
 
 and moduletype_path_t =
   let open Lang.ModuleType in
@@ -86,7 +104,10 @@ and moduletype_with_t =
   let open Lang.ModuleType in
   Record
     [
-      F ("w_substitutions", (fun t -> t.w_substitutions), List moduletype_substitution);
+      F
+        ( "w_substitutions",
+          (fun t -> t.w_substitutions),
+          List moduletype_substitution );
       F ("w_expansion", (fun t -> t.w_expansion), Option simple_expansion);
       F ("w_expr", (fun t -> t.w_expr), moduletype_u_expr);
     ]
@@ -107,8 +128,7 @@ and moduletype_expr =
     | Signature x -> C ("Signature", x, signature_t)
     | Functor (x1, x2) ->
         C ("Functor", (x1, x2), Pair (functorparameter_t, moduletype_expr))
-    | With t ->
-        C ( "With", t, moduletype_with_t)
+    | With t -> C ("With", t, moduletype_with_t)
     | TypeOf x -> C ("TypeOf", x, moduletype_typeof_t))
 
 and moduletype_u_expr =
@@ -118,7 +138,10 @@ and moduletype_u_expr =
     | Path x -> C ("Path", (x :> Paths.Path.t), path)
     | Signature x -> C ("Signature", x, signature_t)
     | With (t, e) ->
-      C ("With", (t, e), Pair (List moduletype_substitution, moduletype_u_expr))
+        C
+          ( "With",
+            (t, e),
+            Pair (List moduletype_substitution, moduletype_u_expr) )
     | TypeOf x -> C ("TypeOf", x, moduletype_typeof_t))
 
 and moduletype_t =
@@ -209,6 +232,7 @@ and include_expansion =
       F ("shadowed", (fun t -> t.shadowed), include_shadowed);
       F ("content", (fun t -> t.content), signature_t);
     ]
+
 and include_decl =
   let open Lang.Include in
   Variant
@@ -528,7 +552,8 @@ and typeexpr_package =
       F ("path", (fun t -> (t.path :> Paths.Path.t)), path);
       F
         ( "substitutions",
-          (fun t -> (t.substitutions :> (Paths.Fragment.t * Lang.TypeExpr.t) list)),
+          (fun t ->
+            (t.substitutions :> (Paths.Fragment.t * Lang.TypeExpr.t) list)),
           List typeexpr_package_substitution );
     ]
 
@@ -569,8 +594,7 @@ and compilation_unit_import =
     (function
     | Unresolved (x1, x2) ->
         C ("Unresolved", (x1, x2), Pair (string, Option Digest.t))
-    | Resolved (x1, x2) ->
-        C ("Resolved", (x1, x2), Pair (root, modulename)))
+    | Resolved (x1, x2) -> C ("Resolved", (x1, x2), Pair (root, modulename)))
 
 and compilation_unit_source =
   let open Lang.Compilation_unit.Source in

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -37,44 +37,119 @@ module Names = struct
   let pagename = To_string PageName.to_string
 
   let parametername = To_string ParameterName.to_string
-
 end
 
 module General_paths = struct
   (** Simplified paths types that can be coerced to. *)
 
   type p = Paths.Path.t
+
   type rp = Paths.Path.Resolved.t
+
   type f = Paths.Fragment.t
+
   type rf = Paths.Fragment.Resolved.t
+
   type r = Paths.Reference.t
+
   type rr = Paths.Reference.Resolved.t
+
   type id_t = Paths.Identifier.t
+
   type tag = Paths_types.Reference.tag_any
+
   let rec identifier : Paths.Identifier.t t =
     Variant
       (function
-        | `RootPage (name) -> C ("`RootPage", name, Names.pagename)
-        | `Page (parent, name) -> C ("`Page", ((parent :> id_t), name), Pair ( identifier, Names.pagename))
-        | `LeafPage (parent, name) -> C ("`LeafPage", ((parent :> id_t), name), Pair (identifier, Names.pagename))
-        | `Root (parent, name) -> C ("`Root", ((parent :> id_t), name), Pair ( identifier, Names.modulename))
-        | `Module (parent, name) -> C ("`Module", ((parent :> id_t), name), Pair ( identifier, Names.modulename))
-        | `Parameter (parent, name) -> C ("`Parameter", ((parent :> id_t), name), Pair ( identifier, Names.parametername))
-        | `Result r -> C ("`Result", (r :> id_t), identifier)
-        | `ModuleType (parent, name) -> C ("`ModuleType", ((parent :> id_t), name), Pair ( identifier, Names.moduletypename))
-        | `Class (parent, name) -> C ("`Class", ((parent :> id_t), name), Pair ( identifier, Names.classname))
-        | `ClassType (parent, name) -> C ("`ClassType", ((parent :> id_t), name), Pair ( identifier, Names.classtypename))
-        | `Type (parent, name) -> C ("`Type", ((parent :> id_t), name), Pair ( identifier, Names.typename))
-        | `CoreType name -> C ("`CoreType", name, Names.typename)
-        | `Constructor (parent, name) -> C ("`Constructor", ((parent :> id_t), name), Pair ( identifier, Names.constructorname))
-        | `Field (parent, name) -> C ("`Field", ((parent :> id_t), name), Pair ( identifier, Names.fieldname))
-        | `Extension (parent, name) -> C ("`Extension", ((parent :> id_t), name), Pair ( identifier, Names.extensionname))
-        | `Exception (parent, name) -> C ("`Exception", ((parent :> id_t), name), Pair ( identifier, Names.exceptionname))
-        | `CoreException name -> C ("`CoreException", name, Names.exceptionname)
-        | `Value (parent, name) -> C ("`Value", ((parent :> id_t), name), Pair (identifier, Names.valuename))
-        | `Method (parent, name) -> C ("`Method", ((parent :> id_t), name), Pair (identifier, Names.methodname))
-        | `InstanceVariable (parent, name) -> C ("`InstanceVariable", ((parent :> id_t), name), Pair (identifier, Names.instancevariablename))
-        | `Label (parent, name) -> C ("`Label", ((parent :> id_t), name), Pair (identifier, Names.labelname)) )
+      | `RootPage name -> C ("`RootPage", name, Names.pagename)
+      | `Page (parent, name) ->
+          C
+            ( "`Page",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.pagename) )
+      | `LeafPage (parent, name) ->
+          C
+            ( "`LeafPage",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.pagename) )
+      | `Root (parent, name) ->
+          C
+            ( "`Root",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.modulename) )
+      | `Module (parent, name) ->
+          C
+            ( "`Module",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.modulename) )
+      | `Parameter (parent, name) ->
+          C
+            ( "`Parameter",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.parametername) )
+      | `Result r -> C ("`Result", (r :> id_t), identifier)
+      | `ModuleType (parent, name) ->
+          C
+            ( "`ModuleType",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.moduletypename) )
+      | `Class (parent, name) ->
+          C
+            ( "`Class",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.classname) )
+      | `ClassType (parent, name) ->
+          C
+            ( "`ClassType",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.classtypename) )
+      | `Type (parent, name) ->
+          C
+            ( "`Type",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.typename) )
+      | `CoreType name -> C ("`CoreType", name, Names.typename)
+      | `Constructor (parent, name) ->
+          C
+            ( "`Constructor",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.constructorname) )
+      | `Field (parent, name) ->
+          C
+            ( "`Field",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.fieldname) )
+      | `Extension (parent, name) ->
+          C
+            ( "`Extension",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.extensionname) )
+      | `Exception (parent, name) ->
+          C
+            ( "`Exception",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.exceptionname) )
+      | `CoreException name -> C ("`CoreException", name, Names.exceptionname)
+      | `Value (parent, name) ->
+          C
+            ( "`Value",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.valuename) )
+      | `Method (parent, name) ->
+          C
+            ( "`Method",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.methodname) )
+      | `InstanceVariable (parent, name) ->
+          C
+            ( "`InstanceVariable",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.instancevariablename) )
+      | `Label (parent, name) ->
+          C
+            ( "`Label",
+              ((parent :> id_t), name),
+              Pair (identifier, Names.labelname) ))
 
   let reference_tag : tag t =
     Variant
@@ -95,7 +170,7 @@ module General_paths = struct
       | `TUnknown -> C0 "`TUnknown"
       | `TValue -> C0 "`TValue"
       | `TChildPage -> C0 "`TChildPage"
-      | `TChildModule -> C0 "`TChildModule" )
+      | `TChildModule -> C0 "`TChildModule")
 
   let rec path : p t =
     Variant
@@ -106,37 +181,59 @@ module General_paths = struct
       | `Root x -> C ("`Root", x, string)
       | `Forward x -> C ("`Forward", x, string)
       | `Dot (x1, x2) -> C ("`Dot", ((x1 :> p), x2), Pair (path, string))
-      | `Apply (x1, x2) -> C ("`Apply", ((x1 :> p), (x2 :> p)), Pair (path, path)))
+      | `Apply (x1, x2) ->
+          C ("`Apply", ((x1 :> p), (x2 :> p)), Pair (path, path)))
 
   and resolved_path : rp t =
     Variant
       (function
       | `Identifier x -> C ("`Identifier", x, identifier)
       | `Subst (x1, x2) ->
-          C ("`Subst", ((x1 :> rp), (x2 :> rp)), Pair (resolved_path, resolved_path))
+          C
+            ( "`Subst",
+              ((x1 :> rp), (x2 :> rp)),
+              Pair (resolved_path, resolved_path) )
       | `SubstAlias (x1, x2) ->
-          C ("`SubstAlias", ((x1 :> rp), (x2 :> rp)), Pair (resolved_path, resolved_path))
+          C
+            ( "`SubstAlias",
+              ((x1 :> rp), (x2 :> rp)),
+              Pair (resolved_path, resolved_path) )
       | `Hidden x -> C ("`Hidden", (x :> rp), resolved_path)
       | `Module (x1, x2) ->
           C ("`Module", ((x1 :> rp), x2), Pair (resolved_path, Names.modulename))
       | `Canonical (x1, x2) ->
           C ("`Canonical", ((x1 :> rp), (x2 :> p)), Pair (resolved_path, path))
       | `Apply (x1, x2) ->
-          C ("`Apply", ((x1 :> rp), (x2 :> rp)), Pair (resolved_path, resolved_path))
+          C
+            ( "`Apply",
+              ((x1 :> rp), (x2 :> rp)),
+              Pair (resolved_path, resolved_path) )
       | `Alias (x1, x2) ->
-          C ("`Alias", ((x1 :> rp), (x2 :> rp)), Pair (resolved_path, resolved_path))
+          C
+            ( "`Alias",
+              ((x1 :> rp), (x2 :> rp)),
+              Pair (resolved_path, resolved_path) )
       | `OpaqueModule x -> C ("`OpaqueModule", (x :> rp), resolved_path)
       | `ModuleType (x1, x2) ->
-          C ("`ModuleType", ((x1 :> rp), x2), Pair (resolved_path, Names.moduletypename))
+          C
+            ( "`ModuleType",
+              ((x1 :> rp), x2),
+              Pair (resolved_path, Names.moduletypename) )
       | `SubstT (x1, x2) ->
-          C ("`SubstT", ((x1 :> rp), (x2 :> rp)), Pair (resolved_path, resolved_path))
+          C
+            ( "`SubstT",
+              ((x1 :> rp), (x2 :> rp)),
+              Pair (resolved_path, resolved_path) )
       | `OpaqueModuleType x -> C ("`OpaqueModuleType", (x :> rp), resolved_path)
       | `Type (x1, x2) ->
           C ("`Type", ((x1 :> rp), x2), Pair (resolved_path, Names.typename))
       | `Class (x1, x2) ->
           C ("`Class", ((x1 :> rp), x2), Pair (resolved_path, Names.classname))
       | `ClassType (x1, x2) ->
-          C ("`ClassType", ((x1 :> rp), x2), Pair (resolved_path, Names.classtypename)))
+          C
+            ( "`ClassType",
+              ((x1 :> rp), x2),
+              Pair (resolved_path, Names.classtypename) ))
 
   and reference : r t =
     Variant
@@ -147,22 +244,38 @@ module General_paths = struct
       | `Module (x1, x2) ->
           C ("`Module", ((x1 :> r), x2), Pair (reference, Names.modulename))
       | `ModuleType (x1, x2) ->
-          C ("`ModuleType", ((x1 :> r), x2), Pair (reference, Names.moduletypename))
-      | `Type (x1, x2) -> C ("`Type", ((x1 :> r), x2), Pair (reference, Names.typename))
+          C
+            ( "`ModuleType",
+              ((x1 :> r), x2),
+              Pair (reference, Names.moduletypename) )
+      | `Type (x1, x2) ->
+          C ("`Type", ((x1 :> r), x2), Pair (reference, Names.typename))
       | `Constructor (x1, x2) ->
-          C ("`Constructor", ((x1 :> r), x2), Pair (reference, Names.constructorname))
+          C
+            ( "`Constructor",
+              ((x1 :> r), x2),
+              Pair (reference, Names.constructorname) )
       | `Field (x1, x2) ->
           C ("`Field", ((x1 :> r), x2), Pair (reference, Names.fieldname))
       | `Extension (x1, x2) ->
-          C ("`Extension", ((x1 :> r), x2), Pair (reference, Names.extensionname))
+          C
+            ( "`Extension",
+              ((x1 :> r), x2),
+              Pair (reference, Names.extensionname) )
       | `Exception (x1, x2) ->
-          C ("`Exception", ((x1 :> r), x2), Pair (reference, Names.exceptionname))
+          C
+            ( "`Exception",
+              ((x1 :> r), x2),
+              Pair (reference, Names.exceptionname) )
       | `Value (x1, x2) ->
           C ("`Value", ((x1 :> r), x2), Pair (reference, Names.valuename))
       | `Class (x1, x2) ->
           C ("`Class", ((x1 :> r), x2), Pair (reference, Names.classname))
       | `ClassType (x1, x2) ->
-          C ("`ClassType", ((x1 :> r), x2), Pair (reference, Names.classtypename))
+          C
+            ( "`ClassType",
+              ((x1 :> r), x2),
+              Pair (reference, Names.classtypename) )
       | `Method (x1, x2) ->
           C ("`Method", ((x1 :> r), x2), Pair (reference, Names.methodname))
       | `InstanceVariable (x1, x2) ->
@@ -177,9 +290,15 @@ module General_paths = struct
     Variant
       (function
       | `Canonical (x1, x2) ->
-          C ("`Canonical", ((x1 :> rr), (x2 :> r)), Pair (resolved_reference, reference))
+          C
+            ( "`Canonical",
+              ((x1 :> rr), (x2 :> r)),
+              Pair (resolved_reference, reference) )
       | `Class (x1, x2) ->
-          C ("`Class", ((x1 :> rr), x2), Pair (resolved_reference, Names.classname))
+          C
+            ( "`Class",
+              ((x1 :> rr), x2),
+              Pair (resolved_reference, Names.classname) )
       | `ClassType (x1, x2) ->
           C
             ( "`ClassType",
@@ -201,7 +320,10 @@ module General_paths = struct
               ((x1 :> rr), x2),
               Pair (resolved_reference, Names.extensionname) )
       | `Field (x1, x2) ->
-          C ("`Field", ((x1 :> rr), x2), Pair (resolved_reference, Names.fieldname))
+          C
+            ( "`Field",
+              ((x1 :> rr), x2),
+              Pair (resolved_reference, Names.fieldname) )
       | `Hidden x -> C ("`Hidden", (x :> rr), resolved_reference)
       | `Identifier x -> C ("`Identifier", (x :> id_t), identifier)
       | `InstanceVariable (x1, x2) ->
@@ -210,22 +332,40 @@ module General_paths = struct
               ((x1 :> rr), x2),
               Pair (resolved_reference, Names.instancevariablename) )
       | `Label (x1, x2) ->
-          C ("`Label", ((x1 :> rr), x2), Pair (resolved_reference, Names.labelname))
+          C
+            ( "`Label",
+              ((x1 :> rr), x2),
+              Pair (resolved_reference, Names.labelname) )
       | `Method (x1, x2) ->
-          C ("`Method", ((x1 :> rr), x2), Pair (resolved_reference, Names.methodname))
+          C
+            ( "`Method",
+              ((x1 :> rr), x2),
+              Pair (resolved_reference, Names.methodname) )
       | `Module (x1, x2) ->
-          C ("`Module", ((x1 :> rr), x2), Pair (resolved_reference, Names.modulename))
+          C
+            ( "`Module",
+              ((x1 :> rr), x2),
+              Pair (resolved_reference, Names.modulename) )
       | `ModuleType (x1, x2) ->
           C
             ( "`ModuleType",
               ((x1 :> rr), x2),
               Pair (resolved_reference, Names.moduletypename) )
       | `SubstAlias (x1, x2) ->
-          C ("`SubstAlias", ((x1 :> rp), (x2 :> rr)), Pair (resolved_path, resolved_reference))
+          C
+            ( "`SubstAlias",
+              ((x1 :> rp), (x2 :> rr)),
+              Pair (resolved_path, resolved_reference) )
       | `Type (x1, x2) ->
-          C ("`Type", ((x1 :> rr), x2), Pair (resolved_reference, Names.typename))
+          C
+            ( "`Type",
+              ((x1 :> rr), x2),
+              Pair (resolved_reference, Names.typename) )
       | `Value (x1, x2) ->
-          C ("`Value", ((x1 :> rr), x2), Pair (resolved_reference, Names.valuename)))
+          C
+            ( "`Value",
+              ((x1 :> rr), x2),
+              Pair (resolved_reference, Names.valuename) ))
 
   let resolved_fragment_root : Paths_types.Resolved_fragment.root t =
     Variant
@@ -238,15 +378,27 @@ module General_paths = struct
       (function
       | `Root x -> C ("`Root", x, resolved_fragment_root)
       | `Subst (x1, x2) ->
-          C ("`Subst", ((x1 :> rp), (x2 :> rf)), Pair (resolved_path, resolved_fragment))
+          C
+            ( "`Subst",
+              ((x1 :> rp), (x2 :> rf)),
+              Pair (resolved_path, resolved_fragment) )
       | `SubstAlias (x1, x2) ->
-          C ("`SubstAlias", ((x1 :> rp), (x2 :> rf)), Pair (resolved_path, resolved_fragment))
+          C
+            ( "`SubstAlias",
+              ((x1 :> rp), (x2 :> rf)),
+              Pair (resolved_path, resolved_fragment) )
       | `Module (x1, x2) ->
-          C ("`Module", ((x1 :> rf), x2), Pair (resolved_fragment, Names.modulename))
+          C
+            ( "`Module",
+              ((x1 :> rf), x2),
+              Pair (resolved_fragment, Names.modulename) )
       | `Type (x1, x2) ->
           C ("`Type", ((x1 :> rf), x2), Pair (resolved_fragment, Names.typename))
       | `Class (x1, x2) ->
-          C ("`Class", ((x1 :> rf), x2), Pair (resolved_fragment, Names.classname))
+          C
+            ( "`Class",
+              ((x1 :> rf), x2),
+              Pair (resolved_fragment, Names.classname) )
       | `ClassType (x1, x2) ->
           C
             ( "`ClassType",
@@ -263,32 +415,24 @@ module General_paths = struct
 end
 
 let root = Root.t
+
 let modulename = Names.modulename
 
 (* Indirection seems to be required to make the type open. *)
-let identifier : [< Paths.Identifier.t] Type_desc.t = Indirect ((fun n -> (n :> Paths.Identifier.t)), General_paths.identifier)
+let identifier : [< Paths.Identifier.t ] Type_desc.t =
+  Indirect ((fun n -> (n :> Paths.Identifier.t)), General_paths.identifier)
 
-let resolved_path : [< Paths.Path.Resolved.t] Type_desc.t =
-  Indirect
-    ( (fun n -> (n :> General_paths.rp)),
-      General_paths.resolved_path )
+let resolved_path : [< Paths.Path.Resolved.t ] Type_desc.t =
+  Indirect ((fun n -> (n :> General_paths.rp)), General_paths.resolved_path)
 
-let path : [< Paths.Path.t] Type_desc.t =
-  Indirect
-    ((fun n -> (n :> General_paths.p)), General_paths.path)
+let path : [< Paths.Path.t ] Type_desc.t =
+  Indirect ((fun n -> (n :> General_paths.p)), General_paths.path)
 
 let resolved_fragment =
-  Indirect
-    ( (fun n ->
-        (n :> General_paths.rf)),
-      General_paths.resolved_fragment )
+  Indirect ((fun n -> (n :> General_paths.rf)), General_paths.resolved_fragment)
 
 let fragment =
-  Indirect
-    ( (fun n -> (n :> General_paths.f)),
-      General_paths.fragment )
+  Indirect ((fun n -> (n :> General_paths.f)), General_paths.fragment)
 
 let reference =
-  Indirect
-    ( (fun n -> (n :> General_paths.r)),
-      General_paths.reference )
+  Indirect ((fun n -> (n :> General_paths.r)), General_paths.reference)

--- a/src/model_desc/paths_desc.mli
+++ b/src/model_desc/paths_desc.mli
@@ -4,14 +4,14 @@ val root : Odoc_model.Root.t Type_desc.t
 
 val modulename : Odoc_model.Names.ModuleName.t Type_desc.t
 
-val identifier : [< Identifier.t] Type_desc.t
+val identifier : [< Identifier.t ] Type_desc.t
 
-val resolved_path : [< Path.Resolved.t] Type_desc.t 
+val resolved_path : [< Path.Resolved.t ] Type_desc.t
 
-val path : [< Path.t] Type_desc.t
+val path : [< Path.t ] Type_desc.t
 
 val resolved_fragment : [< Fragment.Resolved.t ] Type_desc.t
-  
+
 val fragment : [< Fragment.t ] Type_desc.t
-  
+
 val reference : [< Reference.t ] Type_desc.t

--- a/src/model_desc/type_desc.ml
+++ b/src/model_desc/type_desc.ml
@@ -13,9 +13,7 @@ type 'a t =
 
 and 'a field = F : string * ('a -> 'b) * 'b t -> 'a field
 
-and case =
-  | C : string * 'b * 'b t -> case
-  | C0 : string -> case
+and case = C : string * 'b * 'b t -> case | C0 : string -> case
 
 let bool : bool t = To_string string_of_bool
 

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -9,21 +9,21 @@ open Cmdliner
 let convert_syntax : Odoc_document.Renderer.syntax Arg.converter =
   let syntax_parser str =
     match str with
-  | "ml" | "ocaml" -> `Ok Odoc_document.Renderer.OCaml
-  | "re" | "reason" -> `Ok Odoc_document.Renderer.Reason
-  | s -> `Error (Printf.sprintf "Unknown syntax '%s'" s)
+    | "ml" | "ocaml" -> `Ok Odoc_document.Renderer.OCaml
+    | "re" | "reason" -> `Ok Odoc_document.Renderer.Reason
+    | s -> `Error (Printf.sprintf "Unknown syntax '%s'" s)
   in
   let syntax_printer fmt syntax =
     Format.pp_print_string fmt (Odoc_document.Renderer.string_of_syntax syntax)
   in
   (syntax_parser, syntax_printer)
 
-let convert_directory ?(create=false) () : Fs.Directory.t Arg.converter =
-  let (dir_parser, dir_printer) = Arg.string in
+let convert_directory ?(create = false) () : Fs.Directory.t Arg.converter =
+  let dir_parser, dir_printer = Arg.string in
   let odoc_dir_parser str =
     let () = if create then Fs.Directory.(mkdir_p (of_string str)) in
     match dir_parser str with
-    | `Ok res  -> `Ok (Fs.Directory.of_string res)
+    | `Ok res -> `Ok (Fs.Directory.of_string res)
     | `Error e -> `Error e
   in
   let odoc_dir_printer fmt dir = dir_printer fmt (Fs.Directory.to_string dir) in
@@ -32,133 +32,157 @@ let convert_directory ?(create=false) () : Fs.Directory.t Arg.converter =
 let handle_error = function
   | Result.Ok () -> ()
   | Error (`Cli_error msg) ->
-    Printf.eprintf "%s\n%!" msg;
-    exit 2
+      Printf.eprintf "%s\n%!" msg;
+      exit 2
   | Error (`Msg msg) ->
-    Printf.eprintf "ERROR: %s\n%!" msg;
-    exit 1
+      Printf.eprintf "ERROR: %s\n%!" msg;
+      exit 1
 
 let docs = "ARGUMENTS"
 
 let odoc_file_directories =
   let doc =
-    "Where to look for required .odoc files. \
-     (Can be present several times)."
+    "Where to look for required .odoc files. (Can be present several times)."
   in
-  Arg.(value & opt_all (convert_directory ()) [] &
-    info ~docs ~docv:"DIR" ~doc ["I"])
+  Arg.(
+    value
+    & opt_all (convert_directory ()) []
+    & info ~docs ~docv:"DIR" ~doc [ "I" ])
 
 let hidden =
   let doc =
-    "Mark the unit as hidden. \
-     (Useful for files included in module packs)."
+    "Mark the unit as hidden. (Useful for files included in module packs)."
   in
-  Arg.(value & flag & info ~docs ~doc ["hidden"])
+  Arg.(value & flag & info ~docs ~doc [ "hidden" ])
 
 let warn_error =
   let doc = "Turn warnings into errors." in
   let env = Arg.env_var "ODOC_WARN_ERROR" ~doc:(doc ^ " See option $(opt).") in
-  Arg.(value & flag & info ~docs ~doc ~env ["warn-error"])
+  Arg.(value & flag & info ~docs ~doc ~env [ "warn-error" ])
 
 let dst ?create () =
   let doc = "Output directory where the HTML tree is expected to be saved." in
-  Arg.(required & opt (some (convert_directory ?create ())) None &
-       info ~docs ~docv:"DIR" ~doc ["o"; "output-dir"])
+  Arg.(
+    required
+    & opt (some (convert_directory ?create ())) None
+    & info ~docs ~docv:"DIR" ~doc [ "o"; "output-dir" ])
 
 module Compile : sig
   val output_file : dst:string option -> input:Fs.file -> Fs.file
+
   val input : string Term.t
+
   val dst : string option Term.t
+
   val cmd : unit Term.t
-  val info: Term.info
+
+  val info : Term.info
 end = struct
   let has_page_prefix file =
-    file
-    |> Fs.File.basename
-    |> Fs.File.to_string
+    file |> Fs.File.basename |> Fs.File.to_string
     |> Astring.String.is_prefix ~affix:"page-"
 
-  let output_file ~dst ~input = match dst with
-  | Some file ->
-      let output = Fs.File.of_string file in
-      if Fs.File.has_ext ".mld" input && not (has_page_prefix output)
-      then (
-        Printf.eprintf "ERROR: the name of the .odoc file produced from a \
-                        .mld must start with 'page-'\n%!";
-        exit 1
-      );
-      output
-  | None ->
-      let output =
-        if Fs.File.has_ext ".mld" input && not (has_page_prefix input)
-        then
-          let directory = Fs.File.dirname input in
-          let name = Fs.File.basename input in
-          let name = "page-" ^ Fs.File.to_string name in
-          Fs.File.create ~directory ~name
-        else input
-      in
-      Fs.File.(set_ext ".odoc" output)
+  let output_file ~dst ~input =
+    match dst with
+    | Some file ->
+        let output = Fs.File.of_string file in
+        if Fs.File.has_ext ".mld" input && not (has_page_prefix output) then (
+          Printf.eprintf
+            "ERROR: the name of the .odoc file produced from a .mld must start \
+             with 'page-'\n\
+             %!";
+          exit 1 );
+        output
+    | None ->
+        let output =
+          if Fs.File.has_ext ".mld" input && not (has_page_prefix input) then
+            let directory = Fs.File.dirname input in
+            let name = Fs.File.basename input in
+            let name = "page-" ^ Fs.File.to_string name in
+            Fs.File.create ~directory ~name
+          else input
+        in
+        Fs.File.(set_ext ".odoc" output)
 
-  let compile hidden directories resolve_fwd_refs dst package_opt parent_name_opt open_modules children input warn_error =
+  let compile hidden directories resolve_fwd_refs dst package_opt
+      parent_name_opt open_modules children input warn_error =
     let open Or_error in
     let env =
-      Env.create ~important_digests:(not resolve_fwd_refs) ~directories ~open_modules
+      Env.create ~important_digests:(not resolve_fwd_refs) ~directories
+        ~open_modules
     in
     let input = Fs.File.of_string input in
     let output = output_file ~dst ~input in
     let parent_cli_spec =
-      match parent_name_opt, package_opt with
+      match (parent_name_opt, package_opt) with
       | Some p, None -> Ok (Compile.CliParent p)
       | None, Some p -> Ok (Compile.CliPackage p)
-      | None, None -> Ok (Compile.CliNoparent)
-      | Some _, Some _ -> Error (`Cli_error "Either --package or --parent should be specified, not both")
+      | None, None -> Ok Compile.CliNoparent
+      | Some _, Some _ ->
+          Error
+            (`Cli_error
+              "Either --package or --parent should be specified, not both")
     in
     parent_cli_spec >>= fun parent_cli_spec ->
     Fs.Directory.mkdir_p (Fs.File.dirname output);
-    Compile.compile ~env ~directories ~parent_cli_spec ~hidden ~children ~output ~warn_error input
+    Compile.compile ~env ~directories ~parent_cli_spec ~hidden ~children ~output
+      ~warn_error input
 
   let input =
     let doc = "Input cmti, cmt, cmi or mld file" in
     Arg.(required & pos 0 (some file) None & info ~doc ~docv:"FILE" [])
 
   let dst =
-    let doc = "Output file path. Non-existing intermediate directories are
-                 created. If absent outputs a $(i,BASE).odoc file in the same
-                 directory as the input file where $(i,BASE) is the basename
-                 of the input file (for mld files the \"page-\" prefix will be
-                 added if not already present in the input basename)."
+    let doc =
+      "Output file path. Non-existing intermediate directories are\n\
+      \                 created. If absent outputs a $(i,BASE).odoc file in \
+       the same\n\
+      \                 directory as the input file where $(i,BASE) is the \
+       basename\n\
+      \                 of the input file (for mld files the \"page-\" prefix \
+       will be\n\
+      \                 added if not already present in the input basename)."
     in
-    Arg.(value & opt (some string) None & info ~docs ~docv:"PATH" ~doc ["o"])
+    Arg.(value & opt (some string) None & info ~docs ~docv:"PATH" ~doc [ "o" ])
 
   let open_modules =
     let doc = "Initially open module. Can be used more than once" in
-    let default = []
-    in
-    Arg.(value & opt_all string default & info ~docv:"MODULE" ~doc ["open"])
+    let default = [] in
+    Arg.(value & opt_all string default & info ~docv:"MODULE" ~doc [ "open" ])
 
   let children =
-    let doc = "Specify the odoc file as a child. Can be used multiple times. Only applies to mld files" in
+    let doc =
+      "Specify the odoc file as a child. Can be used multiple times. Only \
+       applies to mld files"
+    in
     let default = [] in
-    Arg.(value & opt_all string default & info ~docv:"CHILD" ~doc ["c"; "child"])
+    Arg.(
+      value & opt_all string default & info ~docv:"CHILD" ~doc [ "c"; "child" ])
 
   let cmd =
     let package_opt =
       let doc = "Package the input is part of (deprecated - use '--parent')" in
-      Arg.(value & opt (some string) None &
-           info ~docs ~docv:"PKG" ~doc ["package"; "pkg"])
+      Arg.(
+        value
+        & opt (some string) None
+        & info ~docs ~docv:"PKG" ~doc [ "package"; "pkg" ])
     in
     let parent_opt =
       let doc = "Parent page or subpage" in
-      Arg.(value & opt (some string) None &
-           info ~docs ~docv:"PARENT" ~doc ["parent"])
+      Arg.(
+        value
+        & opt (some string) None
+        & info ~docs ~docv:"PARENT" ~doc [ "parent" ])
     in
     let resolve_fwd_refs =
       let doc = "Try resolving forward references" in
-      Arg.(value & flag & info ~doc ["r";"resolve-fwd-refs"])
+      Arg.(value & flag & info ~doc [ "r"; "resolve-fwd-refs" ])
     in
-    Term.(const handle_error $ (const compile $ hidden $ odoc_file_directories $
-          resolve_fwd_refs $ dst $ package_opt $ parent_opt $ open_modules $ children $ input $ warn_error))
+    Term.(
+      const handle_error
+      $ ( const compile $ hidden $ odoc_file_directories $ resolve_fwd_refs
+        $ dst $ package_opt $ parent_opt $ open_modules $ children $ input
+        $ warn_error ))
 
   let info =
     Term.info "compile"
@@ -171,10 +195,9 @@ module Support_files_command = struct
 
   let without_theme =
     let doc = "Don't copy the default theme to output directory." in
-    Arg.(value & flag & info ~doc ["without-theme"])
+    Arg.(value & flag & info ~doc [ "without-theme" ])
 
-  let cmd =
-    Term.(const support_files $ without_theme $ dst ~create:true ())
+  let cmd = Term.(const support_files $ without_theme $ dst ~create:true ())
 
   let info =
     let doc =
@@ -197,237 +220,269 @@ end
 
 module Odoc_link : sig
   val cmd : unit Term.t
+
   val info : Term.info
 end = struct
-  let get_output_file ~output_file ~input = match output_file with
-  | Some file -> Fs.File.of_string file
-  | None -> Fs.File.(set_ext ".odocl" input)
+  let get_output_file ~output_file ~input =
+    match output_file with
+    | Some file -> Fs.File.of_string file
+    | None -> Fs.File.(set_ext ".odocl" input)
 
   let link directories input_file output_file warn_error =
     let input = Fs.File.of_string input_file in
     let output = get_output_file ~output_file ~input in
-    let env = Env.create ~important_digests:false ~directories ~open_modules:[] in
+    let env =
+      Env.create ~important_digests:false ~directories ~open_modules:[]
+    in
     Odoc_link.from_odoc ~env ~warn_error input output
 
-
   let dst =
-    let doc = "Output file path. Non-existing intermediate directories are
-                 created. If absent outputs a .odocl file in the same
-                 directory as the input file."
+    let doc =
+      "Output file path. Non-existing intermediate directories are\n\
+      \                 created. If absent outputs a .odocl file in the same\n\
+      \                 directory as the input file."
     in
-    Arg.(value & opt (some string) None & info ~docs ~docv:"PATH" ~doc ["o"])
+    Arg.(value & opt (some string) None & info ~docs ~docv:"PATH" ~doc [ "o" ])
 
   let cmd =
     let input =
       let doc = "Input file" in
       Arg.(required & pos 0 (some file) None & info ~doc ~docv:"file.odoc" [])
     in
-    Term.(const handle_error $ (const link $ odoc_file_directories $ input $ dst $ warn_error))
+    Term.(
+      const handle_error
+      $ (const link $ odoc_file_directories $ input $ dst $ warn_error))
 
-  let info =
-    Term.info ~doc:"Link odoc files together" "link"
+  let info = Term.info ~doc:"Link odoc files together" "link"
 end
 
 module type S = sig
   type args
+
   val renderer : args Odoc_document.Renderer.t
+
   val extra_args : args Cmdliner.Term.t
 end
 
 module Make_renderer (R : S) : sig
   val process : unit Term.t * Term.info
+
   val targets : unit Term.t * Term.info
+
   val generate : unit Term.t * Term.info
 end = struct
-
   let input =
     let doc = "Input file" in
     Arg.(required & pos 0 (some file) None & info ~doc ~docv:"file.odoc" [])
 
   module Process = struct
-    let process extra _hidden directories output_dir
-        syntax input_file warn_error =
+    let process extra _hidden directories output_dir syntax input_file
+        warn_error =
       let env =
         Env.create ~important_digests:false ~directories ~open_modules:[]
       in
       let file = Fs.File.of_string input_file in
-      Rendering.render_odoc
-        ~renderer:R.renderer
-        ~env ~warn_error ~syntax ~output:output_dir extra file
+      Rendering.render_odoc ~renderer:R.renderer ~env ~warn_error ~syntax
+        ~output:output_dir extra file
 
     let cmd =
       let syntax =
         let doc = "Available options: ml | re" in
-        let env = Arg.env_var "ODOC_SYNTAX"
-        in
-        Arg.(value & opt (pconv convert_syntax) (Odoc_document.Renderer.OCaml) @@
-        info ~docv:"SYNTAX" ~doc ~env ["syntax"])
+        let env = Arg.env_var "ODOC_SYNTAX" in
+        Arg.(
+          value
+          & opt (pconv convert_syntax) Odoc_document.Renderer.OCaml
+            @@ info ~docv:"SYNTAX" ~doc ~env [ "syntax" ])
       in
-      Term.(const handle_error $ (const process $ R.extra_args $ hidden $
-          odoc_file_directories $ dst ~create:true () $ syntax $
-          input $ warn_error))
+      Term.(
+        const handle_error
+        $ ( const process $ R.extra_args $ hidden $ odoc_file_directories
+          $ dst ~create:true () $ syntax $ input $ warn_error ))
 
     let info =
-      let doc = Format.sprintf "Render %s files from an odoc one" R.renderer.name in
+      let doc =
+        Format.sprintf "Render %s files from an odoc one" R.renderer.name
+      in
       Term.info ~doc R.renderer.name
   end
+
   let process = Process.(cmd, info)
 
   module Generate = struct
-    let generate extra _hidden output_dir
-        syntax input_file =
+    let generate extra _hidden output_dir syntax input_file =
       let file = Fs.File.of_string input_file in
-      Rendering.generate_odoc
-        ~renderer:R.renderer
-        ~syntax ~output:output_dir extra file
+      Rendering.generate_odoc ~renderer:R.renderer ~syntax ~output:output_dir
+        extra file
 
     let cmd =
       let syntax =
         let doc = "Available options: ml | re" in
-        let env = Arg.env_var "ODOC_SYNTAX"
-        in
-        Arg.(value & opt (pconv convert_syntax) (Odoc_document.Renderer.OCaml) @@
-        info ~docv:"SYNTAX" ~doc ~env ["syntax"])
+        let env = Arg.env_var "ODOC_SYNTAX" in
+        Arg.(
+          value
+          & opt (pconv convert_syntax) Odoc_document.Renderer.OCaml
+            @@ info ~docv:"SYNTAX" ~doc ~env [ "syntax" ])
       in
-      Term.(const handle_error $ (const generate $ R.extra_args $ hidden $
-          dst ~create:true () $ syntax $
-          input))
+      Term.(
+        const handle_error
+        $ ( const generate $ R.extra_args $ hidden $ dst ~create:true ()
+          $ syntax $ input ))
 
     let info =
-      let doc = Format.sprintf "Generate %s files from an odocl one"
-          R.renderer.name in
+      let doc =
+        Format.sprintf "Generate %s files from an odocl one" R.renderer.name
+      in
       Term.info ~doc (R.renderer.name ^ "-generate")
   end
-  let generate = Generate.(cmd, info)    
-  
+
+  let generate = Generate.(cmd, info)
+
   module Targets = struct
     let list_targets output_dir _ extra odoc_file =
       let odoc_file = Fs.File.of_string odoc_file in
-      Rendering.targets_odoc ~renderer:R.renderer ~output:output_dir ~extra odoc_file
-    
+      Rendering.targets_odoc ~renderer:R.renderer ~output:output_dir ~extra
+        odoc_file
+
     let back_compat =
-      let doc =
-        "For backwards compatibility. Ignored."
-      in
-      Arg.(value & opt_all (convert_directory ()) [] &
-        info ~docs ~docv:"DIR" ~doc ["I"])
+      let doc = "For backwards compatibility. Ignored." in
+      Arg.(
+        value
+        & opt_all (convert_directory ()) []
+        & info ~docs ~docv:"DIR" ~doc [ "I" ])
 
     let cmd =
-      Term.(const handle_error $ (const list_targets $ dst () $ back_compat $ R.extra_args $ input))
-    
-    let info =
-      Term.info (R.renderer.name ^ "-targets") ~doc:"TODO: Fill in."
+      Term.(
+        const handle_error
+        $ (const list_targets $ dst () $ back_compat $ R.extra_args $ input))
+
+    let info = Term.info (R.renderer.name ^ "-targets") ~doc:"TODO: Fill in."
   end
+
   let targets = Targets.(cmd, info)
-  
 end
 
-module Odoc_html = Make_renderer(struct
+module Odoc_html = Make_renderer (struct
   type args = Html_page.args
 
   let renderer = Html_page.renderer
 
   let semantic_uris =
     let doc = "Generate pretty (semantic) links" in
-    Arg.(value & flag (info ~doc ["semantic-uris";"pretty-uris"]))
+    Arg.(value & flag (info ~doc [ "semantic-uris"; "pretty-uris" ]))
+
   let closed_details =
-    let doc = "If this flag is passed <details> tags (used for includes) will \
-               be closed by default."
+    let doc =
+      "If this flag is passed <details> tags (used for includes) will be \
+       closed by default."
     in
-    Arg.(value & flag (info ~doc ["closed-details"]))
+    Arg.(value & flag (info ~doc [ "closed-details" ]))
 
   (* Very basic validation and normalization for URI paths. *)
   let convert_uri : Odoc_html.Tree.uri Arg.converter =
     let parser str =
-      if String.length str = 0 then
-        `Error "invalid URI"
+      if String.length str = 0 then `Error "invalid URI"
       else
         (* The URI is absolute if it starts with a scheme or with '/'. *)
         let is_absolute =
-          List.exists ["http"; "https"; "file"; "data"; "ftp"]
-            ~f:(fun scheme -> Astring.String.is_prefix ~affix:(scheme ^ ":") str)
-          || String.get str 0 = '/'
+          List.exists [ "http"; "https"; "file"; "data"; "ftp" ]
+            ~f:(fun scheme ->
+              Astring.String.is_prefix ~affix:(scheme ^ ":") str)
+          || str.[0] = '/'
         in
-        let last_char = String.get str (String.length str - 1) in
+        let last_char = str.[String.length str - 1] in
         let str = if last_char <> '/' then str ^ "/" else str in
         `Ok Odoc_html.Tree.(if is_absolute then Absolute str else Relative str)
     in
     let printer ppf = function
-      | Odoc_html.Tree.Absolute uri
-      | Odoc_html.Tree.Relative uri -> Format.pp_print_string ppf uri
+      | Odoc_html.Tree.Absolute uri | Odoc_html.Tree.Relative uri ->
+          Format.pp_print_string ppf uri
     in
     (parser, printer)
+
   let theme_uri =
-    let doc = "Where to look for theme files (e.g. `URI/odoc.css'). \
-               Relative URIs are resolved using `--output-dir' as a target." in
+    let doc =
+      "Where to look for theme files (e.g. `URI/odoc.css'). Relative URIs are \
+       resolved using `--output-dir' as a target."
+    in
     let default = Odoc_html.Tree.Relative "./" in
-    Arg.(value & opt convert_uri default & info ~docv:"URI" ~doc ["theme-uri"])
+    Arg.(
+      value & opt convert_uri default & info ~docv:"URI" ~doc [ "theme-uri" ])
 
   let extra_args =
-      let f semantic_uris closed_details theme_uri =
-        {Html_page. semantic_uris ; closed_details ; theme_uri }
-      in
-      Term.(const f $ semantic_uris $ closed_details $ theme_uri)
+    let f semantic_uris closed_details theme_uri =
+      { Html_page.semantic_uris; closed_details; theme_uri }
+    in
+    Term.(const f $ semantic_uris $ closed_details $ theme_uri)
 end)
 
 module Html_fragment : sig
   val cmd : unit Term.t
-  val info: Term.info
-end = struct
 
-  let html_fragment directories xref_base_uri output_file input_file warn_error =
-    let env = Env.create ~important_digests:false ~directories ~open_modules:[] in
+  val info : Term.info
+end = struct
+  let html_fragment directories xref_base_uri output_file input_file warn_error
+      =
+    let env =
+      Env.create ~important_digests:false ~directories ~open_modules:[]
+    in
     let input_file = Fs.File.of_string input_file in
     let output_file = Fs.File.of_string output_file in
     let xref_base_uri =
       if xref_base_uri = "" then xref_base_uri
       else
-        let last_char = String.get xref_base_uri (String.length xref_base_uri - 1) in
+        let last_char = xref_base_uri.[String.length xref_base_uri - 1] in
         if last_char <> '/' then xref_base_uri ^ "/" else xref_base_uri
     in
-    Html_fragment.from_mld ~env ~xref_base_uri ~output:output_file ~warn_error input_file
+    Html_fragment.from_mld ~env ~xref_base_uri ~output:output_file ~warn_error
+      input_file
 
   let cmd =
     let output =
       let doc = "Output HTML fragment file" in
-      Arg.(value & opt string "/dev/stdout" &
-          info ~docs ~docv:"file.html" ~doc ["o"; "output-file"])
-        in
+      Arg.(
+        value & opt string "/dev/stdout"
+        & info ~docs ~docv:"file.html" ~doc [ "o"; "output-file" ])
+    in
     let input =
       let doc = "Input documentation page file" in
       Arg.(required & pos 0 (some file) None & info ~doc ~docv:"file.mld" [])
     in
     let xref_base_uri =
-      let doc = "Base URI used to resolve cross-references. Set this to the \
-                 root of the global docset during local development. By default \
-                 `.' is used." in
-      Arg.(value & opt string "" & info ~docv:"URI" ~doc ["xref-base-uri"])
+      let doc =
+        "Base URI used to resolve cross-references. Set this to the root of \
+         the global docset during local development. By default `.' is used."
+      in
+      Arg.(value & opt string "" & info ~docv:"URI" ~doc [ "xref-base-uri" ])
     in
-    Term.(const handle_error $ (const html_fragment $ odoc_file_directories $
-          xref_base_uri $ output $ input $ warn_error))
+    Term.(
+      const handle_error
+      $ ( const html_fragment $ odoc_file_directories $ xref_base_uri $ output
+        $ input $ warn_error ))
 
   let info =
-    Term.info ~doc:"Generates an html fragment file from an mld one" "html-fragment"
+    Term.info ~doc:"Generates an html fragment file from an mld one"
+      "html-fragment"
 end
 
-module Odoc_manpage = Make_renderer(struct
+module Odoc_manpage = Make_renderer (struct
   type args = unit
+
   let renderer = Man_page.renderer
+
   let extra_args = Term.const ()
 end)
 
+module Odoc_latex = Make_renderer (struct
+  type args = Latex.args
 
-module Odoc_latex = Make_renderer(struct
-  type args = Latex.args 
   let renderer = Latex.renderer
+
   let with_children =
     let doc = "Include children at the end of the page" in
-    Arg.(value & opt bool true & info ~docv:"BOOL" ~doc ["with-children"])
+    Arg.(value & opt bool true & info ~docv:"BOOL" ~doc [ "with-children" ])
 
   let extra_args =
-    let f with_children =
-      {Latex. with_children }
-    in
+    let f with_children = { Latex.with_children } in
     Term.(const f $ with_children)
 end)
 
@@ -435,51 +490,57 @@ module Depends = struct
   module Compile = struct
     let list_dependencies input_file =
       let deps = Depends.for_compile_step (Fs.File.of_string input_file) in
-      List.iter ~f:(fun t ->
-        Printf.printf "%s %s\n"
-          (Depends.Compile.name t)
-          (Digest.to_hex @@ Depends.Compile.digest t)
-      ) deps;
+      List.iter
+        ~f:(fun t ->
+          Printf.printf "%s %s\n" (Depends.Compile.name t)
+            (Digest.to_hex @@ Depends.Compile.digest t))
+        deps;
       flush stdout
 
-  let cmd =
-    let input =
-      let doc = "Input file" in
-      Arg.(required & pos 0 (some file) None & info ~doc ~docv:"file.cm{i,t,ti}" [])
-    in
-    Term.(const list_dependencies $ input)
+    let cmd =
+      let input =
+        let doc = "Input file" in
+        Arg.(
+          required
+          & pos 0 (some file) None
+          & info ~doc ~docv:"file.cm{i,t,ti}" [])
+      in
+      Term.(const list_dependencies $ input)
 
-  let info =
-    Term.info "compile-deps"
-      ~doc:"List units (with their digest) which needs to be compiled in order \
-            to compile this one. The unit itself and its digest is also \
-            reported in the output."
+    let info =
+      Term.info "compile-deps"
+        ~doc:
+          "List units (with their digest) which needs to be compiled in order \
+           to compile this one. The unit itself and its digest is also \
+           reported in the output."
   end
 
   module Link = struct
     let rec fmt_page pp page =
       match page with
-      | `RootPage name -> Format.fprintf pp "%a" Odoc_model.Names.PageName.fmt name
-      | `Page (parent, name) -> Format.fprintf pp "%a/%a" fmt_page parent Odoc_model.Names.PageName.fmt name
-      | `LeafPage (parent, name) -> Format.fprintf pp "%a/%a" fmt_page parent Odoc_model.Names.PageName.fmt name
-  
+      | `RootPage name ->
+          Format.fprintf pp "%a" Odoc_model.Names.PageName.fmt name
+      | `Page (parent, name) ->
+          Format.fprintf pp "%a/%a" fmt_page parent
+            Odoc_model.Names.PageName.fmt name
+      | `LeafPage (parent, name) ->
+          Format.fprintf pp "%a/%a" fmt_page parent
+            Odoc_model.Names.PageName.fmt name
+
     let list_dependencies input_file =
       let open Or_error in
-      Depends.for_rendering_step
-        (Fs.Directory.of_string input_file) >>= fun depends ->
-      List.iter depends
-        ~f:(fun (root : Odoc_model.Root.t) ->
+      Depends.for_rendering_step (Fs.Directory.of_string input_file)
+      >>= fun depends ->
+      List.iter depends ~f:(fun (root : Odoc_model.Root.t) ->
           match root.id with
           | `Root (p, _) ->
-            Format.printf "%a %s %s\n"
-              fmt_page p
-              (Odoc_model.Root.Odoc_file.name root.file)
-              (Digest.to_hex root.digest)
+              Format.printf "%a %s %s\n" fmt_page p
+                (Odoc_model.Root.Odoc_file.name root.file)
+                (Digest.to_hex root.digest)
           | _ ->
-            Format.printf "none %s %s\n"
-              (Odoc_model.Root.Odoc_file.name root.file)
-              (Digest.to_hex root.digest)
-        );
+              Format.printf "none %s %s\n"
+                (Odoc_model.Root.Odoc_file.name root.file)
+                (Digest.to_hex root.digest));
       Ok ()
 
     let cmd =
@@ -491,18 +552,18 @@ module Depends = struct
 
     let info =
       Term.info "link-deps"
-        ~doc:"lists the packages which need to be in odoc's load path to link \
-              the .odoc files in the given directory"
+        ~doc:
+          "lists the packages which need to be in odoc's load path to link the \
+           .odoc files in the given directory"
   end
 
   module Odoc_html = struct
-
     let includes =
-      let doc =
-        "For backwards compatibility. Ignored."
-    in
-    Arg.(value & opt_all (convert_directory ()) [] &
-      info ~docs ~docv:"DIR" ~doc ["I"])
+      let doc = "For backwards compatibility. Ignored." in
+      Arg.(
+        value
+        & opt_all (convert_directory ()) []
+        & info ~docs ~docv:"DIR" ~doc [ "I" ])
 
     let cmd =
       let input =
@@ -512,9 +573,7 @@ module Depends = struct
       let cmd _ = Link.list_dependencies in
       Term.(const handle_error $ (const cmd $ includes $ input))
 
-    let info =
-      Term.info "html-deps"
-        ~doc:"DEPRECATED: alias for link-deps"
+    let info = Term.info "html-deps" ~doc:"DEPRECATED: alias for link-deps"
   end
 end
 
@@ -526,15 +585,12 @@ module Targets = struct
       Printf.printf "%s\n" (Fs.File.to_string output);
       flush stdout
 
-    let cmd =
-      Term.(const list_targets $ Compile.dst $ Compile.input)
+    let cmd = Term.(const list_targets $ Compile.dst $ Compile.input)
 
-    let info =
-      Term.info "compile-targets" ~doc:"TODO: Fill in."
+    let info = Term.info "compile-targets" ~doc:"TODO: Fill in."
   end
 
-  module Support_files =
-  struct
+  module Support_files = struct
     let list_targets without_theme output_directory =
       Support_files.print_filenames ~without_theme output_directory
 
@@ -550,25 +606,26 @@ end
 let () =
   Printexc.record_backtrace true;
   let subcommands =
-    [ Compile.(cmd, info)
-    ; Odoc_html.process
-    ; Odoc_html.targets
-    ; Odoc_html.generate
-    ; Odoc_manpage.process
-    ; Odoc_manpage.targets
-    ; Odoc_manpage.generate
-    ; Odoc_latex.process
-    ; Odoc_latex.targets
-    ; Odoc_latex.generate
-    ; Html_fragment.(cmd, info)
-    ; Support_files_command.(cmd, info)
-    ; Css.(cmd, info)
-    ; Depends.Compile.(cmd, info)
-    ; Depends.Link.(cmd, info)
-    ; Depends.Odoc_html.(cmd, info)
-    ; Targets.Compile.(cmd, info)
-    ; Targets.Support_files.(cmd, info)
-    ; Odoc_link.(cmd, info)
+    [
+      Compile.(cmd, info);
+      Odoc_html.process;
+      Odoc_html.targets;
+      Odoc_html.generate;
+      Odoc_manpage.process;
+      Odoc_manpage.targets;
+      Odoc_manpage.generate;
+      Odoc_latex.process;
+      Odoc_latex.targets;
+      Odoc_latex.generate;
+      Html_fragment.(cmd, info);
+      Support_files_command.(cmd, info);
+      Css.(cmd, info);
+      Depends.Compile.(cmd, info);
+      Depends.Link.(cmd, info);
+      Depends.Odoc_html.(cmd, info);
+      Targets.Compile.(cmd, info);
+      Targets.Support_files.(cmd, info);
+      Odoc_link.(cmd, info);
     ]
   in
   let default =
@@ -576,15 +633,15 @@ let () =
       let available_subcommands =
         List.map subcommands ~f:(fun (_, info) -> Term.name info)
       in
-      Printf.printf "Available subcommands: %s\n\
-                     See --help for more information.\n%!"
+      Printf.printf
+        "Available subcommands: %s\nSee --help for more information.\n%!"
         (String.concat ~sep:", " available_subcommands)
     in
-    Term.(const print_default $ const ()),
-    Term.info ~version:"%%VERSION%%" "odoc"
+    ( Term.(const print_default $ const ()),
+      Term.info ~version:"%%VERSION%%" "odoc" )
   in
   match Term.eval_choice ~err:Format.err_formatter default subcommands with
   | `Error _ ->
-    Format.pp_print_flush Format.err_formatter ();
-    exit 2
+      Format.pp_print_flush Format.err_formatter ();
+      exit 2
   | _ -> ()

--- a/src/odoc/compilation_unit.ml
+++ b/src/odoc/compilation_unit.ml
@@ -27,12 +27,11 @@ let save file t =
 
 let units_cache = Hashtbl.create 23 (* because. *)
 
-let load =
-  fun file ->
-    let file = Fs.File.to_string file in
-    match Hashtbl.find units_cache file with
-    | unit -> Ok unit
-    | exception Not_found ->
+let load file =
+  let file = Fs.File.to_string file in
+  match Hashtbl.find units_cache file with
+  | unit -> Ok unit
+  | exception Not_found -> (
       try
         let ic = open_in_bin file in
         let _root = Root.load file ic in
@@ -43,8 +42,6 @@ let load =
       with exn ->
         let msg =
           Printf.sprintf "Error while unmarshalling %S: %s\n%!" file
-            (match exn with
-              | Failure s -> s
-              | _ -> Printexc.to_string exn)
+            (match exn with Failure s -> s | _ -> Printexc.to_string exn)
         in
-        Error (`Msg msg)
+        Error (`Msg msg) )

--- a/src/odoc/compilation_unit.mli
+++ b/src/odoc/compilation_unit.mli
@@ -26,4 +26,4 @@ val units_cache : (string, t) Hashtbl.t
 
 (** {2 Deserialization} *)
 
-val load : Fs.File.t -> (t, [> msg]) result
+val load : Fs.File.t -> (t, [> msg ]) result

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -19,7 +19,9 @@ open Odoc_compat
  *)
 
 type parent_spec =
-  | Explicit of Odoc_model.Paths.Identifier.ContainerPage.t * Odoc_model.Paths.Reference.t list
+  | Explicit of
+      Odoc_model.Paths.Identifier.ContainerPage.t
+      * Odoc_model.Paths.Reference.t list
   | Package of Odoc_model.Paths.Identifier.ContainerPage.t
   | Noparent
 
@@ -30,95 +32,102 @@ type parent_cli_spec =
 
 let parent directories parent_cli_spec =
   let ap = Env.Accessible_paths.create ~directories in
-  let find_parent : Odoc_model.Paths.Reference.t -> (Odoc_model.Root.t, [> `Msg of string ]) Result.result = fun r ->
+  let find_parent :
+      Odoc_model.Paths.Reference.t ->
+      (Odoc_model.Root.t, [> `Msg of string ]) Result.result =
+   fun r ->
     match r with
-    | `Root (p, `TPage)
-    | `Root (p, `TUnknown) -> begin
-      match Env.lookup_page ap p with
-      | Some r -> Ok r
-      | None -> Error (`Msg "Couldn't find specified parent page")
-      end
-    | _ ->
-      Error (`Msg "Expecting page as parent")
+    | `Root (p, `TPage) | `Root (p, `TUnknown) -> (
+        match Env.lookup_page ap p with
+        | Some r -> Ok r
+        | None -> Error (`Msg "Couldn't find specified parent page") )
+    | _ -> Error (`Msg "Expecting page as parent")
   in
   let extract_parent = function
-    | `RootPage _
-    | `Page _ as container -> Ok container
+    | (`RootPage _ | `Page _) as container -> Ok container
     | _ -> Error (`Msg "Specified parent is not a parent of this file")
   in
   match parent_cli_spec with
   | CliParent f ->
-    Odoc_parser.parse_reference f >>= fun r ->
-    find_parent r >>= fun r ->
-    extract_parent r.id >>= fun parent ->
-    Env.fetch_page ap r >>= fun page ->
-    Ok (Explicit (parent, page.children))
+      Odoc_parser.parse_reference f >>= fun r ->
+      find_parent r >>= fun r ->
+      extract_parent r.id >>= fun parent ->
+      Env.fetch_page ap r >>= fun page -> Ok (Explicit (parent, page.children))
   | CliPackage package -> Ok (Package (`RootPage (PageName.of_string package)))
   | CliNoparent -> Ok Noparent
 
-let resolve_and_substitute ~env ~output ~warn_error parent input_file read_file =
+let resolve_and_substitute ~env ~output ~warn_error parent input_file read_file
+    =
   let filename = Fs.File.to_string input_file in
 
-  read_file ~parent ~filename |> Odoc_model.Error.handle_errors_and_warnings ~warn_error >>= fun unit ->
-
-  if not unit.Odoc_model.Lang.Compilation_unit.interface then (
+  read_file ~parent ~filename
+  |> Odoc_model.Error.handle_errors_and_warnings ~warn_error
+  >>= fun unit ->
+  if not unit.Odoc_model.Lang.Compilation_unit.interface then
     Printf.eprintf "WARNING: not processing the \"interface\" file.%s\n%!"
-      (if not (Filename.check_suffix filename "cmt") then "" (* ? *)
-       else
-        Printf.sprintf
-          " Using %S while you should use the .cmti file" filename)
-  );
+      ( if not (Filename.check_suffix filename "cmt") then "" (* ? *)
+      else
+        Printf.sprintf " Using %S while you should use the .cmti file" filename
+      );
   let env = Env.build env (`Unit unit) in
 
   Odoc_xref2.Compile.compile env unit
   |> Odoc_xref2.Lookup_failures.handle_failures ~warn_error ~filename
   >>= fun compiled ->
-
   (* [expand unit] fetches [unit] from [env] to get the expansion of local, previously
      defined, elements. We'd rather it got back the resolved bit so we rebuild an
      environment with the resolved unit.
      Note that this is bad and once rewritten expand should not fetch the unit it is
      working on. *)
-(*    let expand_env = Env.build env (`Unit resolved) in*)
-(*    let expanded = Odoc_xref2.Expand.expand (Env.expander expand_env) resolved in *)
+  (*    let expand_env = Env.build env (`Unit resolved) in*)
+  (*    let expanded = Odoc_xref2.Expand.expand (Env.expander expand_env) resolved in *)
   Compilation_unit.save output compiled;
   Ok ()
 
 let root_of_compilation_unit ~parent_spec ~hidden ~output ~module_name ~digest =
   let open Odoc_model.Root in
-  let filename = Filename.chop_extension (Fs.File.(to_string @@ basename output)) in
-  let result parent = 
-    let file_representation : Odoc_file.t =
-    Odoc_file.create_unit ~force_hidden:hidden module_name in
-    Ok {id = `Root (parent, ModuleName.of_string module_name); file = file_representation; digest}
+  let filename =
+    Filename.chop_extension Fs.File.(to_string @@ basename output)
   in
-  let check_child : Odoc_model.Paths.Reference.t -> bool = fun c ->
+  let result parent =
+    let file_representation : Odoc_file.t =
+      Odoc_file.create_unit ~force_hidden:hidden module_name
+    in
+    Ok
+      {
+        id = `Root (parent, ModuleName.of_string module_name);
+        file = file_representation;
+        digest;
+      }
+  in
+  let check_child : Odoc_model.Paths.Reference.t -> bool =
+   fun c ->
     match c with
-    | `Root (n, `TUnknown)
-    | `Root (n, `TModule) ->
-      String.uncapitalize_ascii n = String.uncapitalize_ascii filename
-    | _ ->
-      false
+    | `Root (n, `TUnknown) | `Root (n, `TModule) ->
+        String.uncapitalize_ascii n = String.uncapitalize_ascii filename
+    | _ -> false
   in
   match parent_spec with
   | Noparent -> Error (`Msg "Compilation units require a parent")
   | Explicit (parent, children) ->
-    if List.exists check_child children
-    then result parent
-    else Error (`Msg "Specified parent is not a parent of this file")
+      if List.exists check_child children then result parent
+      else Error (`Msg "Specified parent is not a parent of this file")
   | Package parent -> result parent
 
 let mld ~parent_spec ~output ~children ~warn_error input =
-  List.fold_left (fun acc child_str ->
-    match acc, Odoc_parser.parse_reference child_str with
-    | Ok acc, Ok r -> Ok (r::acc)
-    | Error m, _ -> Error m
-    | _, Error (`Msg m) -> Error (`Msg ("Failed to parse child reference: " ^ m))
-    | _, Error (_) -> Error (`Msg ("Unknown failure parsing child reference"))) (Ok []) children
+  List.fold_left
+    (fun acc child_str ->
+      match (acc, Odoc_parser.parse_reference child_str) with
+      | Ok acc, Ok r -> Ok (r :: acc)
+      | Error m, _ -> Error m
+      | _, Error (`Msg m) ->
+          Error (`Msg ("Failed to parse child reference: " ^ m))
+      | _, Error _ -> Error (`Msg "Unknown failure parsing child reference"))
+    (Ok []) children
   >>= fun children ->
   let root_name =
     let page_dash_root =
-      Filename.chop_extension (Fs.File.(to_string @@ basename output))
+      Filename.chop_extension Fs.File.(to_string @@ basename output)
     in
     String.sub page_dash_root (String.length "page-")
       (String.length page_dash_root - String.length "page-")
@@ -126,33 +135,33 @@ let mld ~parent_spec ~output ~children ~warn_error input =
   let input_s = Fs.File.to_string input in
   let digest = Digest.file input_s in
   let page_name = PageName.of_string root_name in
-  let check_child : Odoc_model.Paths.Reference.t -> bool = fun c ->
+  let check_child : Odoc_model.Paths.Reference.t -> bool =
+   fun c ->
     match c with
-    | `Root (n, `TUnknown)
-    | `Root (n, `TPage) ->
-      root_name = n
-    | _ ->
-      false
+    | `Root (n, `TUnknown) | `Root (n, `TPage) -> root_name = n
+    | _ -> false
   in
   let name =
     let check parents_children v =
-      if List.exists check_child parents_children
-      then Ok v
+      if List.exists check_child parents_children then Ok v
       else Error (`Msg "Specified parent is not a parent of this file")
     in
-    match parent_spec, children with
-    | Explicit (p, cs), [] ->
-      check cs @@ `LeafPage (p, page_name)
-    | Explicit (p, cs), _ ->
-      check cs @@ `Page (p, page_name )
+    match (parent_spec, children) with
+    | Explicit (p, cs), [] -> check cs @@ `LeafPage (p, page_name)
+    | Explicit (p, cs), _ -> check cs @@ `Page (p, page_name)
     | Package parent, [] -> Ok (`LeafPage (parent, page_name))
-    | Package parent, _ -> Ok (`Page (parent, page_name)) (* This is a bit odd *)
-    | Noparent, _ -> Ok (`RootPage (page_name))
+    | Package parent, _ ->
+        Ok (`Page (parent, page_name)) (* This is a bit odd *)
+    | Noparent, _ -> Ok (`RootPage page_name)
   in
   name >>= fun name ->
   let root =
     let file = Odoc_model.Root.Odoc_file.create_page root_name in
-    {Odoc_model.Root.id = (name :> Odoc_model.Paths.Identifier.OdocId.t); file; digest}
+    {
+      Odoc_model.Root.id = (name :> Odoc_model.Paths.Identifier.OdocId.t);
+      file;
+      digest;
+    }
   in
   let resolve content =
     let page = Odoc_model.Lang.Page.{ name; root; children; content; digest } in
@@ -160,27 +169,35 @@ let mld ~parent_spec ~output ~children ~warn_error input =
     Ok ()
   in
   Fs.File.read input >>= fun str ->
-  Odoc_loader.read_string (name :> Odoc_model.Paths.Identifier.LabelParent.t) input_s str |> Odoc_model.Error.handle_errors_and_warnings ~warn_error
+  Odoc_loader.read_string
+    (name :> Odoc_model.Paths.Identifier.LabelParent.t)
+    input_s str
+  |> Odoc_model.Error.handle_errors_and_warnings ~warn_error
   >>= function
   | `Stop -> resolve [] (* TODO: Error? *)
   | `Docs content -> resolve content
 
-let compile ~env ~directories ~parent_cli_spec ~hidden ~children ~output ~warn_error input =
+let compile ~env ~directories ~parent_cli_spec ~hidden ~children ~output
+    ~warn_error input =
   parent directories parent_cli_spec >>= fun parent_spec ->
   let ext = Fs.File.get_ext input in
-  if ext = ".mld"
-  then mld ~parent_spec ~output ~warn_error ~children input
+  if ext = ".mld" then mld ~parent_spec ~output ~warn_error ~children input
   else
-    (match ext with
-      | ".cmti" -> Ok Odoc_loader.read_cmti
-      | ".cmt" -> Ok Odoc_loader.read_cmt
-      | ".cmi" -> Ok Odoc_loader.read_cmi
-      | _ -> Error (`Msg "Unknown extension, expected one of: cmti, cmt, cmi or mld.")) >>= fun loader ->
-    let parent = match parent_spec with
+    ( match ext with
+    | ".cmti" -> Ok Odoc_loader.read_cmti
+    | ".cmt" -> Ok Odoc_loader.read_cmt
+    | ".cmi" -> Ok Odoc_loader.read_cmi
+    | _ ->
+        Error
+          (`Msg "Unknown extension, expected one of: cmti, cmt, cmi or mld.") )
+    >>= fun loader ->
+    let parent =
+      match parent_spec with
       | Noparent -> Error (`Msg "Compilation unit requires a parent")
       | Explicit (parent, _) -> Ok parent
       | Package parent -> Ok parent
     in
     parent >>= fun parent ->
     let make_root = root_of_compilation_unit ~parent_spec ~hidden ~output in
-    resolve_and_substitute ~env ~output ~warn_error parent input (loader ~make_root)
+    resolve_and_substitute ~env ~output ~warn_error parent input
+      (loader ~make_root)

--- a/src/odoc/compile.mli
+++ b/src/odoc/compile.mli
@@ -24,8 +24,12 @@ type parent_cli_spec =
 (** Produces .odoc files out of [.cm{i,t,ti}] or .mld files. *)
 
 val compile :
-  env:Env.builder -> directories:(Fs.Directory.t list) ->
+  env:Env.builder ->
+  directories:Fs.Directory.t list ->
   parent_cli_spec:parent_cli_spec ->
-  hidden:bool -> children:string list ->
-  output:Fs.File.t -> warn_error:bool -> Fs.File.t ->
-  (unit, [> msg]) result
+  hidden:bool ->
+  children:string list ->
+  output:Fs.File.t ->
+  warn_error:bool ->
+  Fs.File.t ->
+  (unit, [> msg ]) result

--- a/src/odoc/depends.ml
+++ b/src/odoc/depends.ml
@@ -18,18 +18,16 @@ open StdLabels
 open Or_error
 
 module Compile = struct
-  type t = {
-    unit_name : string;
-    digest : Digest.t;
-  }
+  type t = { unit_name : string; digest : Digest.t }
 
   let name t = t.unit_name
+
   let digest t = t.digest
 end
 
 let add_dep acc = function
-| _, None -> acc (* drop module aliases *)
-| unit_name, Some digest ->  { Compile.unit_name; digest } :: acc
+  | _, None -> acc (* drop module aliases *)
+  | unit_name, Some digest -> { Compile.unit_name; digest } :: acc
 
 let for_compile_step_cmt file =
   let cmt_infos = Cmt_format.read_cmt (Fs.File.to_string file) in
@@ -39,9 +37,10 @@ let for_compile_step_cmi_or_cmti file =
   let cmi_infos = Cmi_format.read_cmi (Fs.File.to_string file) in
   List.fold_left ~f:add_dep ~init:[] cmi_infos.Cmi_format.cmi_crcs
 
-let for_compile_step file = match Fs.File.has_ext "cmt" file with
-| true -> for_compile_step_cmt file
-| false -> for_compile_step_cmi_or_cmti file
+let for_compile_step file =
+  match Fs.File.has_ext "cmt" file with
+  | true -> for_compile_step_cmt file
+  | false -> for_compile_step_cmi_or_cmti file
 
 module Hash_set : sig
   type t
@@ -55,31 +54,31 @@ end = struct
   type t = unit Odoc_model.Root.Hash_table.t
 
   let add t elt =
-    if Odoc_model.Root.Hash_table.mem t elt then
-      ()
-    else
-      Odoc_model.Root.Hash_table.add t elt ()
+    if Odoc_model.Root.Hash_table.mem t elt then ()
+    else Odoc_model.Root.Hash_table.add t elt ()
 
   let create () = Odoc_model.Root.Hash_table.create 42
 
-  let elements t = Odoc_model.Root.Hash_table.fold (fun s () acc -> s :: acc) t []
+  let elements t =
+    Odoc_model.Root.Hash_table.fold (fun s () acc -> s :: acc) t []
 end
 
 let deps_of_odoc_file ~deps input =
   Root.read input >>= function
-  | { file = Page _; _ } -> Ok () (* XXX something should certainly be done here *)
+  | { file = Page _; _ } ->
+      Ok () (* XXX something should certainly be done here *)
   | { file = Compilation_unit _; _ } ->
-    Compilation_unit.load input >>= fun odoctree ->
-    List.iter odoctree.Odoc_model.Lang.Compilation_unit.imports ~f:(fun import ->
-        match import with
-        | Odoc_model.Lang.Compilation_unit.Import.Unresolved _  -> ()
-        | Odoc_model.Lang.Compilation_unit.Import.Resolved(root, _) ->
-            Hash_set.add deps root
-      );
-    Ok ()
+      Compilation_unit.load input >>= fun odoctree ->
+      List.iter odoctree.Odoc_model.Lang.Compilation_unit.imports
+        ~f:(fun import ->
+          match import with
+          | Odoc_model.Lang.Compilation_unit.Import.Unresolved _ -> ()
+          | Odoc_model.Lang.Compilation_unit.Import.Resolved (root, _) ->
+              Hash_set.add deps root);
+      Ok ()
 
 let for_rendering_step pkg_dir =
   let deps = Hash_set.create () in
   let add_deps () file = deps_of_odoc_file ~deps file in
-  Fs.Directory.fold_files_rec_result ~ext:".odoc" add_deps () pkg_dir >>= fun () ->
-  Ok (Hash_set.elements deps)
+  Fs.Directory.fold_files_rec_result ~ext:".odoc" add_deps () pkg_dir
+  >>= fun () -> Ok (Hash_set.elements deps)

--- a/src/odoc/depends.mli
+++ b/src/odoc/depends.mli
@@ -23,13 +23,15 @@ module Compile : sig
   type t
 
   val name : t -> string
+
   val digest : t -> Digest.t
 end
 
 val for_compile_step : Fs.File.t -> Compile.t list
 (** Takes a [.cm{i,t,ti}] file and returns the list of its dependencies. *)
 
-val for_rendering_step : Fs.Directory.t -> (Odoc_model.Root.t list, [> msg]) result
+val for_rendering_step :
+  Fs.Directory.t -> (Odoc_model.Root.t list, [> msg ]) result
 (** Takes the directory where the .odoc files of a given package are stored and
     returns the list of roots that need to be in odoc's load path to
     render these .odoc files. *)

--- a/src/odoc/env.ml
+++ b/src/odoc/env.ml
@@ -16,7 +16,6 @@ open Odoc_compat
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-
 (* We are slightly more flexible here than OCaml usually is, and allow
    'linking' of modules that have the same name. This is because we do
    documentation at a package level - it's perfectly acceptable to have
@@ -44,25 +43,26 @@ module Accessible_paths = struct
   }
 
   let create ~directories =
-    { root_map = Odoc_model.Root.Hash_table.create 42
-    ; file_map = Hashtbl.create 42
-    ; directories }
+    {
+      root_map = Odoc_model.Root.Hash_table.create 42;
+      file_map = Hashtbl.create 42;
+      directories;
+    }
 
   let find_file_by_name t name =
     let uname = String.capitalize_ascii name ^ ".odoc" in
     let lname = String.uncapitalize_ascii name ^ ".odoc" in
     let rec loop acc = function
       | [] -> acc
-      | directory :: dirs ->
-        let lfile = Fs.File.create ~directory ~name:lname in
-        match Unix.stat (Fs.File.to_string lfile) with
-        | _ -> loop (lfile::acc) dirs
-        | exception Unix.Unix_error _ ->
-          let ufile = Fs.File.create ~directory ~name:uname in
-          match Unix.stat (Fs.File.to_string ufile) with
-          | _ -> loop (ufile::acc) dirs
-          | exception Unix.Unix_error _ ->
-            loop acc dirs
+      | directory :: dirs -> (
+          let lfile = Fs.File.create ~directory ~name:lname in
+          match Unix.stat (Fs.File.to_string lfile) with
+          | _ -> loop (lfile :: acc) dirs
+          | exception Unix.Unix_error _ -> (
+              let ufile = Fs.File.create ~directory ~name:uname in
+              match Unix.stat (Fs.File.to_string ufile) with
+              | _ -> loop (ufile :: acc) dirs
+              | exception Unix.Unix_error _ -> loop acc dirs ) )
     in
     loop [] t.directories
 
@@ -70,41 +70,51 @@ module Accessible_paths = struct
      we can check the digest right now. If there's more than one, we defer
      until further up the call stack *)
   let check_optional_digest ?digest filename (roots : Odoc_model.Root.t list) =
-    match roots, digest with
-    | [root], Some d when Digest.compare d root.digest <> 0 ->
-      let warning = Odoc_model.Error.filename_only "Digest mismatch" filename in
-      prerr_endline (Odoc_model.Error.to_string warning);
-      roots
-    | _ ->
-      roots
+    match (roots, digest) with
+    | [ root ], Some d when Digest.compare d root.digest <> 0 ->
+        let warning =
+          Odoc_model.Error.filename_only "Digest mismatch" filename
+        in
+        prerr_endline (Odoc_model.Error.to_string warning);
+        roots
+    | _ -> roots
 
   let find_root t ~filename =
     match Hashtbl.find t.file_map filename with
     | roots -> roots
     | exception Not_found ->
-      let paths = find_file_by_name t filename in
-      (* This could be the empty list *)
-      let filter_map f l =
-        List.fold_right (fun x acc -> match f x with | Some y -> y::acc | None -> acc) l []
-      in
-      let safe_read file =
-        match Root.read file with
-        | Ok root -> Some (root, file)
-        | Error (`Msg msg) ->
-          let warning = Odoc_model.Error.filename_only "%s" msg (Fs.File.to_string file) in
-          prerr_endline (Odoc_model.Error.to_string warning);
-          None
-        | exception End_of_file ->
-          let warning = Odoc_model.Error.filename_only "End_of_file while reading" (Fs.File.to_string file) in
-          prerr_endline (Odoc_model.Error.to_string warning);
-          None
-      in
-      let roots_paths = filter_map safe_read paths in
-      let roots = List.map fst roots_paths in
-      Hashtbl.add t.file_map filename roots;
-      List.iter (fun (root, path) ->
-        Odoc_model.Root.Hash_table.add t.root_map root path) roots_paths;
-      roots
+        let paths = find_file_by_name t filename in
+        (* This could be the empty list *)
+        let filter_map f l =
+          List.fold_right
+            (fun x acc -> match f x with Some y -> y :: acc | None -> acc)
+            l []
+        in
+        let safe_read file =
+          match Root.read file with
+          | Ok root -> Some (root, file)
+          | Error (`Msg msg) ->
+              let warning =
+                Odoc_model.Error.filename_only "%s" msg (Fs.File.to_string file)
+              in
+              prerr_endline (Odoc_model.Error.to_string warning);
+              None
+          | exception End_of_file ->
+              let warning =
+                Odoc_model.Error.filename_only "End_of_file while reading"
+                  (Fs.File.to_string file)
+              in
+              prerr_endline (Odoc_model.Error.to_string warning);
+              None
+        in
+        let roots_paths = filter_map safe_read paths in
+        let roots = List.map fst roots_paths in
+        Hashtbl.add t.file_map filename roots;
+        List.iter
+          (fun (root, path) ->
+            Odoc_model.Root.Hash_table.add t.root_map root path)
+          roots_paths;
+        roots
 
   let file_of_root t root =
     try Odoc_model.Root.Hash_table.find t.root_map root
@@ -112,149 +122,149 @@ module Accessible_paths = struct
       let _roots =
         match root.file with
         | Page page_name ->
-          let filename = "page-" ^ page_name in
-          check_optional_digest ~digest:root.digest filename @@ find_root t ~filename
+            let filename = "page-" ^ page_name in
+            check_optional_digest ~digest:root.digest filename
+            @@ find_root t ~filename
         | Compilation_unit { name; _ } ->
-          check_optional_digest ~digest:root.digest name @@ find_root t ~filename:name
+            check_optional_digest ~digest:root.digest name
+            @@ find_root t ~filename:name
       in
       Odoc_model.Root.Hash_table.find t.root_map root
 end
 
-module StringMap = Map.Make(String)
+module StringMap = Map.Make (String)
 
 let build_imports_map imports =
   List.fold_left
     (fun map import ->
-       match import with
-       | Odoc_model.Lang.Compilation_unit.Import.Unresolved (name, _) ->
-         StringMap.add name import map
-       | Odoc_model.Lang.Compilation_unit.Import.Resolved (_, name) ->
-         StringMap.add (Odoc_model.Names.ModuleName.to_string name) import map)
+      match import with
+      | Odoc_model.Lang.Compilation_unit.Import.Unresolved (name, _) ->
+          StringMap.add name import map
+      | Odoc_model.Lang.Compilation_unit.Import.Resolved (_, name) ->
+          StringMap.add (Odoc_model.Names.ModuleName.to_string name) import map)
     StringMap.empty imports
 
 let lookup_unit ~important_digests ap target_name import_map =
-  let handle_root (root : Odoc_model.Root.t) = match root.file with
-    | Compilation_unit {hidden; _} -> Odoc_xref2.Env.Found {root; hidden}
+  let handle_root (root : Odoc_model.Root.t) =
+    match root.file with
+    | Compilation_unit { hidden; _ } -> Odoc_xref2.Env.Found { root; hidden }
     | Page _ -> assert false
   in
   let find_root ~digest =
-    match Accessible_paths.find_root ap ~filename:target_name, digest with
-    | [], _ ->
-       Odoc_xref2.Env.Not_found
-    | [r], _ -> handle_root r (* Already checked the digest, if one's been specified *)
+    match (Accessible_paths.find_root ap ~filename:target_name, digest) with
+    | [], _ -> Odoc_xref2.Env.Not_found
+    | [ r ], _ ->
+        handle_root r (* Already checked the digest, if one's been specified *)
     | r :: rs, None ->
-      Printf.fprintf stderr "Warning, ambiguous lookup. Please wrap your libraries. Possible files:\n%!";
-      let files_strs =
-        List.map (fun root ->
-          Accessible_paths.file_of_root ap root
-          |> Fs.File.to_string
-          |> Printf.sprintf "  %s") (r::rs)
-      in
-      prerr_endline (String.concat "\n" files_strs);
-      (* We've not specified a digest, let's try the first one *)
-      handle_root r
-    | roots, Some d ->
-      (* If we can't find a module that matches the digest, return Not_found *)
-      try handle_root @@ List.find (fun root -> root.Odoc_model.Root.digest = d) roots
-      with Not_found -> Odoc_xref2.Env.Not_found
+        Printf.fprintf stderr
+          "Warning, ambiguous lookup. Please wrap your libraries. Possible \
+           files:\n\
+           %!";
+        let files_strs =
+          List.map
+            (fun root ->
+              Accessible_paths.file_of_root ap root
+              |> Fs.File.to_string |> Printf.sprintf "  %s")
+            (r :: rs)
+        in
+        prerr_endline (String.concat "\n" files_strs);
+        (* We've not specified a digest, let's try the first one *)
+        handle_root r
+    | roots, Some d -> (
+        try
+          (* If we can't find a module that matches the digest, return Not_found *)
+          handle_root
+          @@ List.find (fun root -> root.Odoc_model.Root.digest = d) roots
+        with Not_found -> Odoc_xref2.Env.Not_found )
   in
   match StringMap.find target_name import_map with
-  | Odoc_model.Lang.Compilation_unit.Import.Unresolved (_, digest) -> begin
+  | Odoc_model.Lang.Compilation_unit.Import.Unresolved (_, digest) -> (
       match digest with
       | None when important_digests -> Odoc_xref2.Env.Forward_reference
-      | _ -> find_root ~digest
-    end
-  | Odoc_model.Lang.Compilation_unit.Import.Resolved(root, _) -> begin
+      | _ -> find_root ~digest )
+  | Odoc_model.Lang.Compilation_unit.Import.Resolved (root, _) -> (
       match root.file with
-      | Compilation_unit {hidden; _} -> Found {root; hidden}
-      | Page _ -> assert false
-    end
+      | Compilation_unit { hidden; _ } -> Found { root; hidden }
+      | Page _ -> assert false )
   | exception Not_found ->
-    if important_digests then Odoc_xref2.Env.Not_found
-    else find_root ~digest:None
+      if important_digests then Odoc_xref2.Env.Not_found
+      else find_root ~digest:None
 
 let lookup_page ap target_name =
   match Accessible_paths.find_root ap ~filename:("page-" ^ target_name) with
   | [] -> None
-  | [root] -> Some root
+  | [ root ] -> Some root
   | root :: _roots -> Some root
 
 let fetch_page ap root =
   match Accessible_paths.file_of_root ap root with
   | path -> Page.load path
   | exception Not_found ->
-    let msg =
-      Printf.sprintf "No unit for root: %s\n%!" (Odoc_model.Root.to_string root)
-    in
-    Error (`Msg msg)
+      let msg =
+        Printf.sprintf "No unit for root: %s\n%!"
+          (Odoc_model.Root.to_string root)
+      in
+      Error (`Msg msg)
 
 let fetch_unit ap root =
   match Accessible_paths.file_of_root ap root with
   | path -> Compilation_unit.load path
   | exception Not_found ->
-    let msg =
-      Printf.sprintf "No unit for root: %s\n%!" (Odoc_model.Root.to_string root)
-    in
-    Error (`Msg msg)
-
+      let msg =
+        Printf.sprintf "No unit for root: %s\n%!"
+          (Odoc_model.Root.to_string root)
+      in
+      Error (`Msg msg)
 
 type t = Odoc_xref2.Env.resolver
 
 type builder = [ `Unit of Compilation_unit.t | `Page of Page.t ] -> t
 
-let create ?(important_digests=true) ~directories ~open_modules : builder =
+let create ?(important_digests = true) ~directories ~open_modules : builder =
   let ap = Accessible_paths.create ~directories in
   fun unit_or_page ->
     let lookup_unit =
-    match unit_or_page with
-    | `Page _ ->
-      fun target_name ->
-        lookup_unit ~important_digests:false ap target_name StringMap.empty
-    | `Unit unit ->
-        let imports_map =
-          build_imports_map unit.Odoc_model.Lang.Compilation_unit.imports
-        in
-        fun target_name ->
-          let lookup_result =
-            lookup_unit
-              ~important_digests
-              ap
-              target_name
-              imports_map
+      match unit_or_page with
+      | `Page _ ->
+          fun target_name ->
+            lookup_unit ~important_digests:false ap target_name StringMap.empty
+      | `Unit unit -> (
+          let imports_map =
+            build_imports_map unit.Odoc_model.Lang.Compilation_unit.imports
           in
-          match lookup_result with
-          | Not_found -> begin
-              let root = unit.root in
-              match root.file with
-              | Page _ -> assert false
-              | Compilation_unit {name;hidden} when target_name = name ->
-                Found { root; hidden }
-              | Compilation_unit _ -> Not_found
-            end
-          | x -> x
+          fun target_name ->
+            let lookup_result =
+              lookup_unit ~important_digests ap target_name imports_map
+            in
+            match lookup_result with
+            | Not_found -> (
+                let root = unit.root in
+                match root.file with
+                | Page _ -> assert false
+                | Compilation_unit { name; hidden } when target_name = name ->
+                    Found { root; hidden }
+                | Compilation_unit _ -> Not_found )
+            | x -> x )
     in
-    let fetch_unit root : (Odoc_model.Lang.Compilation_unit.t, _) Result.result =
+    let fetch_unit root : (Odoc_model.Lang.Compilation_unit.t, _) Result.result
+        =
       match unit_or_page with
       | `Page _ -> fetch_unit ap root
       | `Unit unit ->
-        let current_root = unit.root in
-        if Odoc_model.Root.equal root current_root then
-          Ok unit
-        else
-          fetch_unit ap root
+          let current_root = unit.root in
+          if Odoc_model.Root.equal root current_root then Ok unit
+          else fetch_unit ap root
     in
     let lookup_page target_name = lookup_page ap target_name in
     let fetch_page root : (Odoc_model.Lang.Page.t, _) Result.result =
       match unit_or_page with
       | `Unit _ -> fetch_page ap root
       | `Page page ->
-        let current_root = page.Odoc_model.Lang.Page.root in
-        if Odoc_model.Root.equal root current_root then
-          Ok page
-        else
-          fetch_page ap root
+          let current_root = page.Odoc_model.Lang.Page.root in
+          if Odoc_model.Root.equal root current_root then Ok page
+          else fetch_page ap root
     in
-    Odoc_xref2.Compile.build_resolver open_modules lookup_unit fetch_unit lookup_page fetch_page
+    Odoc_xref2.Compile.build_resolver open_modules lookup_unit fetch_unit
+      lookup_page fetch_page
 
-let build builder unit =
-  builder unit
+let build builder unit = builder unit

--- a/src/odoc/env.mli
+++ b/src/odoc/env.mli
@@ -21,18 +21,26 @@
 
 module Accessible_paths : sig
   type t
+
   val create : directories:Fs.directory list -> t
 end
 
 val lookup_page : Accessible_paths.t -> string -> Odoc_model.Root.t option
-val fetch_page : Accessible_paths.t -> Odoc_model.Root.t -> (Page.t, [> `Msg of string ]) Result.result
+
+val fetch_page :
+  Accessible_paths.t ->
+  Odoc_model.Root.t ->
+  (Page.t, [> `Msg of string ]) Result.result
 
 type t = Odoc_xref2.Env.resolver
 
 type builder
 
 val create :
-  ?important_digests:bool -> directories:(Fs.Directory.t list) -> open_modules:string list -> builder
+  ?important_digests:bool ->
+  directories:Fs.Directory.t list ->
+  open_modules:string list ->
+  builder
 (** Prepare the environment for a given list of
     {{!Fs.Directory.t} include directories}
 

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -23,12 +23,12 @@ type file = Fpath.t
 type directory
 
 module Directory : sig
-
   open Or_error
 
   type t = directory
 
   val dirname : t -> t
+
   val basename : t -> t
 
   val append : t -> t -> t
@@ -39,10 +39,15 @@ module Directory : sig
   val mkdir_p : t -> unit
 
   val of_string : string -> t
+
   val to_string : t -> string
 
-  val fold_files_rec_result : ?ext:string ->
-    ('a -> file -> ('a, msg) result) -> 'a -> t -> ('a, [> msg ]) result
+  val fold_files_rec_result :
+    ?ext:string ->
+    ('a -> file -> ('a, msg) result) ->
+    'a ->
+    t ->
+    ('a, [> msg ]) result
   (** [fold_files_rec_result ~ext f acc d] recursively folds [f] over the files
       with extension matching [ext] (defaults to [""]) contained in [d]
       and its sub directories. Stop as soon as [f] returns [Error _]. *)
@@ -51,21 +56,24 @@ module Directory : sig
 end
 
 module File : sig
-
   type t = file
 
   val create : directory:Directory.t -> name:string -> t
 
   val dirname : t -> Directory.t
+
   val basename : t -> t
 
   val append : Directory.t -> t -> t
 
   val set_ext : string -> t -> t
+
   val has_ext : string -> t -> bool
+
   val get_ext : t -> string
 
   val of_string : string -> t
+
   val to_string : t -> string
 
   val read : t -> (string, [> msg ]) result

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -8,16 +8,17 @@ let from_mld ~xref_base_uri ~env ~output ~warn_error input =
   let digest = Digest.file input_s in
   let root =
     let file = Odoc_model.Root.Odoc_file.create_page page_name in
-    {Odoc_model.Root.id; file; digest}
+    { Odoc_model.Root.id; file; digest }
   in
   let to_html content =
     (* This is a mess. *)
-    let page = Odoc_model.Lang.Page.{ name=id; root; content; children=[]; digest } in
+    let page =
+      Odoc_model.Lang.Page.{ name = id; root; content; children = []; digest }
+    in
     let resolve_env = Env.build env (`Page page) in
     Odoc_xref2.Link.resolve_page resolve_env page
     |> Odoc_xref2.Lookup_failures.handle_failures ~warn_error ~filename:input_s
     >>= fun resolved ->
-
     let page = Odoc_document.Comment.to_ir resolved.content in
     let html = Odoc_html.Generator.doc ~xref_base_uri page in
     let oc = open_out (Fs.File.to_string output) in
@@ -28,9 +29,11 @@ let from_mld ~xref_base_uri ~env ~output ~warn_error input =
   in
   match Fs.File.read input with
   | Error _ as e -> e
-  | Ok str ->
-    Odoc_loader.read_string id input_s str
-    |> Odoc_model.Error.handle_errors_and_warnings ~warn_error
-    >>= function
-    |`Docs content -> to_html content
-    |`Stop -> to_html [] (* TODO: Error? *)
+  | Ok str -> (
+      Odoc_loader.read_string id input_s str
+      |> Odoc_model.Error.handle_errors_and_warnings ~warn_error
+      >>= function
+      | `Docs content -> to_html content
+      | `Stop -> to_html [] )
+
+(* TODO: Error? *)

--- a/src/odoc/html_fragment.mli
+++ b/src/odoc/html_fragment.mli
@@ -18,8 +18,13 @@ open Or_error
 
 (** Produces html fragment files from a mld file. *)
 
-val from_mld : xref_base_uri:string -> env:Env.builder -> output:Fs.File.t ->
-  warn_error:bool -> Fs.File.t -> (unit, [> msg]) result
+val from_mld :
+  xref_base_uri:string ->
+  env:Env.builder ->
+  output:Fs.File.t ->
+  warn_error:bool ->
+  Fs.File.t ->
+  (unit, [> msg ]) result
 (** [from_mld ~xref_base_uri ~env ~output input] parses the content of the [input]
     file as a documentation page ({e i.e.} the ocamldoc syntax), generates the
     equivalent HTML representation and writes the result into the [output]

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -17,9 +17,9 @@
 open Odoc_document
 
 type args = {
-  semantic_uris : bool ;
-  closed_details : bool ;
-  theme_uri : Odoc_html.Tree.uri ;
+  semantic_uris : bool;
+  closed_details : bool;
+  theme_uri : Odoc_html.Tree.uri;
 }
 
 let render args page =
@@ -27,11 +27,6 @@ let render args page =
   Odoc_html.Tree.open_details := not args.closed_details;
   Odoc_html.Generator.render ~theme_uri:args.theme_uri page
 
-let files_of_url url =
-  [Odoc_html.Link.Path.as_filename url]
+let files_of_url url = [ Odoc_html.Link.Path.as_filename url ]
 
-let renderer = {Renderer.
-  name = "html" ;
-  render ;
-  files_of_url ;
-}
+let renderer = { Renderer.name = "html"; render; files_of_url }

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -17,10 +17,9 @@
 open Odoc_document
 
 type args = {
-  semantic_uris : bool ;
-  closed_details : bool ;
-  theme_uri : Odoc_html.Tree.uri ;
+  semantic_uris : bool;
+  closed_details : bool;
+  theme_uri : Odoc_html.Tree.uri;
 }
-
 
 val renderer : args Renderer.t

--- a/src/odoc/latex.ml
+++ b/src/odoc/latex.ml
@@ -1,17 +1,10 @@
 open Odoc_document
 
-type args = {
-  with_children : bool ;
-}
+type args = { with_children : bool }
 
 let render args page =
   Odoc_latex.Generator.render ~with_children:args.with_children page
 
-let files_of_url url =
-  Odoc_latex.Generator.files_of_url url
+let files_of_url url = Odoc_latex.Generator.files_of_url url
 
-let renderer = {Renderer.
-  name = "latex" ;
-  render ;
-  files_of_url ;
-}
+let renderer = { Renderer.name = "latex"; render; files_of_url }

--- a/src/odoc/man_page.ml
+++ b/src/odoc/man_page.ml
@@ -4,8 +4,4 @@ let render _ page = Odoc_manpage.Generator.render page
 
 let files_of_url url = Odoc_manpage.Link.files_of_url url
 
-let renderer = {Renderer.
-  name = "man" ;
-  render ;
-  files_of_url ;
-}
+let renderer = { Renderer.name = "man"; render; files_of_url }

--- a/src/odoc/odoc_link.ml
+++ b/src/odoc/odoc_link.ml
@@ -5,27 +5,32 @@ let from_odoc ~env ~warn_error input output =
   let input_s = Fs.File.to_string input in
   match root.file with
   | Page _ ->
-    Page.load input >>= fun page ->
-    let resolve_env = Env.build env (`Page page) in
-    Odoc_xref2.Link.resolve_page resolve_env page
-    |> Odoc_xref2.Lookup_failures.handle_failures ~warn_error ~filename:input_s
-    >>= fun odoctree ->
-    Page.save output odoctree;
+      Page.load input >>= fun page ->
+      let resolve_env = Env.build env (`Page page) in
+      Odoc_xref2.Link.resolve_page resolve_env page
+      |> Odoc_xref2.Lookup_failures.handle_failures ~warn_error
+           ~filename:input_s
+      >>= fun odoctree ->
+      Page.save output odoctree;
 
-    Ok ()
-  | Compilation_unit {hidden; _} ->
-    Compilation_unit.load input >>= fun unit ->
-    let unit =
-      if hidden
-      then {unit with content = Odoc_model.Lang.Compilation_unit.Module []; expansion=None }
-      else unit
-    in
+      Ok ()
+  | Compilation_unit { hidden; _ } ->
+      Compilation_unit.load input >>= fun unit ->
+      let unit =
+        if hidden then
+          {
+            unit with
+            content = Odoc_model.Lang.Compilation_unit.Module [];
+            expansion = None;
+          }
+        else unit
+      in
 
-    let env = Env.build env (`Unit unit) in
-    Odoc_xref2.Link.link env unit
-    |> Odoc_xref2.Lookup_failures.handle_failures ~warn_error ~filename:input_s
-    >>= fun odoctree ->
+      let env = Env.build env (`Unit unit) in
+      Odoc_xref2.Link.link env unit
+      |> Odoc_xref2.Lookup_failures.handle_failures ~warn_error
+           ~filename:input_s
+      >>= fun odoctree ->
+      Compilation_unit.save output odoctree;
 
-    Compilation_unit.save output odoctree;
-
-    Ok ()
+      Ok ()

--- a/src/odoc/or_error.ml
+++ b/src/odoc/or_error.ml
@@ -1,10 +1,5 @@
-type ('a, 'e) result = ('a, 'e) Result.result =
-  | Ok of 'a
-  | Error of 'e
+type ('a, 'e) result = ('a, 'e) Result.result = Ok of 'a | Error of 'e
 
 type msg = [ `Msg of string ]
 
-let (>>=) r f =
-  match r with
-  | Ok v -> f v
-  | Error _ as e -> e
+let ( >>= ) r f = match r with Ok v -> f v | Error _ as e -> e

--- a/src/odoc/or_error.mli
+++ b/src/odoc/or_error.mli
@@ -1,8 +1,6 @@
 (** Re-export for compatibility with 4.02 *)
-type ('a, 'e) result = ('a, 'e) Result.result =
-  | Ok of 'a
-  | Error of 'e
+type ('a, 'e) result = ('a, 'e) Result.result = Ok of 'a | Error of 'e
 
 type msg = [ `Msg of string ]
 
-val (>>=) : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result
+val ( >>= ) : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result

--- a/src/odoc/rendering.ml
+++ b/src/odoc/rendering.ml
@@ -1,65 +1,67 @@
 open Odoc_document
 open Or_error
 
-
 let document_of_odocl ~syntax input =
   Root.read input >>= fun root ->
   match root.file with
   | Page _ ->
-    Page.load input >>= fun odoctree ->
-    Ok (Renderer.document_of_page ~syntax odoctree)
+      Page.load input >>= fun odoctree ->
+      Ok (Renderer.document_of_page ~syntax odoctree)
   | Compilation_unit _ ->
-    Compilation_unit.load input >>= fun odoctree ->
-    Ok (Renderer.document_of_compilation_unit ~syntax odoctree)
+      Compilation_unit.load input >>= fun odoctree ->
+      Ok (Renderer.document_of_compilation_unit ~syntax odoctree)
 
 let document_of_input ~env ~warn_error ~syntax input =
   Root.read input >>= fun root ->
   let input_s = Fs.File.to_string input in
   match root.file with
   | Page _ ->
-    Page.load input >>= fun page ->
-    let resolve_env = Env.build env (`Page page) in
-    Odoc_xref2.Link.resolve_page resolve_env page
-    |> Odoc_xref2.Lookup_failures.handle_failures ~warn_error ~filename:input_s
-    >>= fun odoctree ->
-    Ok (Renderer.document_of_page ~syntax odoctree)
-  | Compilation_unit {hidden; _} ->
-    (* If hidden, we should not generate HTML. See
-         https://github.com/ocaml/odoc/issues/99. *)
-    Compilation_unit.load input >>= fun unit ->
-    let unit =
-      if hidden
-      then {unit with content = Odoc_model.Lang.Compilation_unit.Module []; expansion=None }
-      else unit
-    in
-    let env = Env.build env (`Unit unit) in
-    (* let startlink = Unix.gettimeofday () in *)
-    (* Format.fprintf Format.err_formatter "**** Link...\n%!"; *)
-    let linked = Odoc_xref2.Link.link env unit in
-    (* let finishlink = Unix.gettimeofday () in *)
-    (* Format.fprintf Format.err_formatter "**** Finished: Link=%f\n%!" (finishlink -. startlink); *)
-    (* Printf.fprintf stderr "num_times: %d\n%!" !Odoc_xref2.Tools.num_times; *)
-    linked
-    |> Odoc_xref2.Lookup_failures.handle_failures ~warn_error ~filename:input_s
-    >>= fun odoctree ->
+      Page.load input >>= fun page ->
+      let resolve_env = Env.build env (`Page page) in
+      Odoc_xref2.Link.resolve_page resolve_env page
+      |> Odoc_xref2.Lookup_failures.handle_failures ~warn_error
+           ~filename:input_s
+      >>= fun odoctree -> Ok (Renderer.document_of_page ~syntax odoctree)
+  | Compilation_unit { hidden; _ } ->
+      (* If hidden, we should not generate HTML. See
+           https://github.com/ocaml/odoc/issues/99. *)
+      Compilation_unit.load input >>= fun unit ->
+      let unit =
+        if hidden then
+          {
+            unit with
+            content = Odoc_model.Lang.Compilation_unit.Module [];
+            expansion = None;
+          }
+        else unit
+      in
+      let env = Env.build env (`Unit unit) in
+      (* let startlink = Unix.gettimeofday () in *)
+      (* Format.fprintf Format.err_formatter "**** Link...\n%!"; *)
+      let linked = Odoc_xref2.Link.link env unit in
+      (* let finishlink = Unix.gettimeofday () in *)
+      (* Format.fprintf Format.err_formatter "**** Finished: Link=%f\n%!" (finishlink -. startlink); *)
+      (* Printf.fprintf stderr "num_times: %d\n%!" !Odoc_xref2.Tools.num_times; *)
+      linked
+      |> Odoc_xref2.Lookup_failures.handle_failures ~warn_error
+           ~filename:input_s
+      >>= fun odoctree ->
+      Odoc_xref2.Tools.reset_caches ();
+      Hashtbl.clear Compilation_unit.units_cache;
 
-    Odoc_xref2.Tools.reset_caches ();
-    Hashtbl.clear Compilation_unit.units_cache;
-
-    Compilation_unit.save Fs.File.(set_ext ".odocl" input) odoctree;
-    Ok (Renderer.document_of_compilation_unit ~syntax odoctree)
+      Compilation_unit.save Fs.File.(set_ext ".odocl" input) odoctree;
+      Ok (Renderer.document_of_compilation_unit ~syntax odoctree)
 
 let render_document renderer ~output:root_dir ~extra odoctree =
   let pages = renderer.Renderer.render extra odoctree in
   Renderer.traverse pages ~f:(fun filename content ->
-    let filename = Fpath.normalize @@ Fs.File.append root_dir filename in
-    let directory = Fs.File.dirname filename in
-    Fs.Directory.mkdir_p directory;
-    let oc = open_out (Fs.File.to_string filename) in
-    let fmt = Format.formatter_of_out_channel oc in
-    Format.fprintf fmt "%t@?" content;
-    close_out oc
-  );
+      let filename = Fpath.normalize @@ Fs.File.append root_dir filename in
+      let directory = Fs.File.dirname filename in
+      Fs.Directory.mkdir_p directory;
+      let oc = open_out (Fs.File.to_string filename) in
+      let fmt = Format.formatter_of_out_channel oc in
+      Format.fprintf fmt "%t@?" content;
+      close_out oc);
   Ok ()
 
 let render_odoc ~env ~warn_error ~syntax ~renderer ~output extra file =
@@ -67,15 +69,12 @@ let render_odoc ~env ~warn_error ~syntax ~renderer ~output extra file =
   >>= render_document renderer ~output ~extra
 
 let generate_odoc ~syntax ~renderer ~output extra file =
-  document_of_odocl ~syntax file
-  >>= render_document renderer ~output ~extra
+  document_of_odocl ~syntax file >>= render_document renderer ~output ~extra
 
 let targets_odoc ~renderer ~output:root_dir ~extra odoctree =
-  document_of_odocl ~syntax:OCaml odoctree
-  >>= fun odoctree ->
+  document_of_odocl ~syntax:OCaml odoctree >>= fun odoctree ->
   let pages = renderer.Renderer.render extra odoctree in
   Renderer.traverse pages ~f:(fun filename _content ->
-    let filename = Fpath.normalize @@ Fs.File.append root_dir filename in
-    Format.printf "%a\n" Fpath.pp filename);
+      let filename = Fpath.normalize @@ Fs.File.append root_dir filename in
+      Format.printf "%a\n" Fpath.pp filename);
   Ok ()
-

--- a/src/odoc/rendering.mli
+++ b/src/odoc/rendering.mli
@@ -1,15 +1,27 @@
 open Odoc_document
 open Or_error
 
-val render_odoc: env:Env.builder ->
-    warn_error:bool ->
-    syntax:Renderer.syntax ->
-    renderer:'a Renderer.t ->
-    output:Fs.directory -> 'a -> Fpath.t -> (unit, [> msg ]) result
+val render_odoc :
+  env:Env.builder ->
+  warn_error:bool ->
+  syntax:Renderer.syntax ->
+  renderer:'a Renderer.t ->
+  output:Fs.directory ->
+  'a ->
+  Fpath.t ->
+  (unit, [> msg ]) result
 
-val generate_odoc : syntax:Renderer.syntax ->
-    renderer:'a Renderer.t ->
-    output:Fs.directory -> 'a -> Fpath.t -> (unit, [> msg ]) result
+val generate_odoc :
+  syntax:Renderer.syntax ->
+  renderer:'a Renderer.t ->
+  output:Fs.directory ->
+  'a ->
+  Fpath.t ->
+  (unit, [> msg ]) result
 
-val targets_odoc : renderer:'a Renderer.t ->
-    output:Fs.directory -> extra:'a -> Fpath.t -> (unit, [> msg ]) result
+val targets_odoc :
+  renderer:'a Renderer.t ->
+  output:Fs.directory ->
+  extra:'a ->
+  Fpath.t ->
+  (unit, [> msg ]) result

--- a/src/odoc/root.ml
+++ b/src/odoc/root.ml
@@ -20,12 +20,10 @@ let magic = "odoc-%%VERSION%%"
 
 let load file ic =
   let m = really_input_string ic (String.length magic) in
-  if m = magic then
-    Ok (Marshal.from_channel ic)
+  if m = magic then Ok (Marshal.from_channel ic)
   else
     let msg =
-      Printf.sprintf "%s: invalid magic number %S, expected %S\n%!"
-        file m magic
+      Printf.sprintf "%s: invalid magic number %S, expected %S\n%!" file m magic
     in
     Error (`Msg msg)
 

--- a/src/odoc/root.mli
+++ b/src/odoc/root.mli
@@ -16,7 +16,6 @@
 
 open Or_error
 
-
 val load : string -> in_channel -> (Odoc_model.Root.t, [> msg ]) result
 (** [load fn ic] reads a {!t} from [ic].
     [fn] is the name of the file [ic] is "watching", and is used for error

--- a/src/odoc/support_files.ml
+++ b/src/odoc/support_files.ml
@@ -1,23 +1,18 @@
 let iter_files f ?(without_theme = false) output_directory =
   let file name content =
     let name =
-      Fs.File.create ~directory:output_directory ~name
-      |> Fs.File.to_string
+      Fs.File.create ~directory:output_directory ~name |> Fs.File.to_string
     in
     f name content
   in
 
-  if not without_theme then begin
-    file "odoc.css" Css_file.content
-  end;
+  if not without_theme then file "odoc.css" Css_file.content;
   file "highlight.pack.js" Highlight_js.content
 
 let write =
-  iter_files begin fun name content ->
-    let channel = open_out name in
-    output_string channel content;
-    close_out channel
-  end
+  iter_files (fun name content ->
+      let channel = open_out name in
+      output_string channel content;
+      close_out channel)
 
-let print_filenames =
-  iter_files (fun name _content -> print_endline name)
+let print_filenames = iter_files (fun name _content -> print_endline name)

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -1,66 +1,52 @@
 type 'a with_location = 'a Odoc_model.Location_.with_location
 
-
-
-type style = [
-  | `Bold
-  | `Italic
-  | `Emphasis
-  | `Superscript
-  | `Subscript
-]
+type style = [ `Bold | `Italic | `Emphasis | `Superscript | `Subscript ]
 
 type reference_kind = [ `Simple | `With_text ]
 
-type inline_element = [
-  | `Space of string
+type inline_element =
+  [ `Space of string
   | `Word of string
   | `Code_span of string
   | `Raw_markup of string option * string
-  | `Styled of style * (inline_element with_location) list
+  | `Styled of style * inline_element with_location list
   | `Reference of
-      reference_kind * string with_location * (inline_element with_location) list
-  | `Link of string * (inline_element with_location) list
-]
+    reference_kind * string with_location * inline_element with_location list
+  | `Link of string * inline_element with_location list ]
 
-type nestable_block_element = [
-  | `Paragraph of (inline_element with_location) list
+type nestable_block_element =
+  [ `Paragraph of inline_element with_location list
   | `Code_block of string
   | `Verbatim of string
   | `Modules of string with_location list
   | `List of
-    [ `Unordered | `Ordered ] *
-    [ `Light | `Heavy ] *
-    ((nestable_block_element with_location) list) list
-]
+    [ `Unordered | `Ordered ]
+    * [ `Light | `Heavy ]
+    * nestable_block_element with_location list list ]
 
-type tag = [
-  | `Author of string
-  | `Deprecated of (nestable_block_element with_location) list
-  | `Param of string * (nestable_block_element with_location) list
-  | `Raise of string * (nestable_block_element with_location) list
-  | `Return of (nestable_block_element with_location) list
+type tag =
+  [ `Author of string
+  | `Deprecated of nestable_block_element with_location list
+  | `Param of string * nestable_block_element with_location list
+  | `Raise of string * nestable_block_element with_location list
+  | `Return of nestable_block_element with_location list
   | `See of
-      [ `Url | `File | `Document ] *
-      string *
-      (nestable_block_element with_location) list
+    [ `Url | `File | `Document ]
+    * string
+    * nestable_block_element with_location list
   | `Since of string
-  | `Before of string * (nestable_block_element with_location) list
+  | `Before of string * nestable_block_element with_location list
   | `Version of string
   | `Canonical of string with_location
   | `Inline
   | `Open
-  | `Closed
-]
+  | `Closed ]
 
-type block_element = [
-  | nestable_block_element
-  | `Heading of int * string option * (inline_element with_location) list
-  | `Tag of tag
-]
+type block_element =
+  [ nestable_block_element
+  | `Heading of int * string option * inline_element with_location list
+  | `Tag of tag ]
 
-type docs = (block_element with_location) list
-
-
+type docs = block_element with_location list
 
 type sections_allowed = [ `All | `No_titles | `None ]

--- a/src/parser/odoc_parser.mli
+++ b/src/parser/odoc_parser.mli
@@ -3,13 +3,14 @@ module Ast = Ast
 val parse_comment_raw :
   location:Lexing.position ->
   text:string ->
-    Ast.docs Odoc_model.Error.with_warnings
+  Ast.docs Odoc_model.Error.with_warnings
 
 val parse_comment :
   sections_allowed:Ast.sections_allowed ->
   containing_definition:Odoc_model.Paths.Identifier.LabelParent.t ->
   location:Lexing.position ->
   text:string ->
-    Odoc_model.Comment.docs Odoc_model.Error.with_warnings
+  Odoc_model.Comment.docs Odoc_model.Error.with_warnings
 
-val parse_reference : string -> (Odoc_model.Paths.Reference.t, [> `Msg of string ]) Result.result
+val parse_reference :
+  string -> (Odoc_model.Paths.Reference.t, [> `Msg of string ]) Result.result

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -1,13 +1,9 @@
 module Location = Odoc_model.Location_
 module Error = Odoc_model.Error
-
 open Odoc_compat
 
-
-
 let bad_markup : ?suggestion:string -> string -> Location.span -> Error.t =
-    fun ?suggestion ->
-  Error.make ?suggestion "'%s': bad markup."
+ fun ?suggestion -> Error.make ?suggestion "'%s': bad markup."
 
 let bad_heading_level : int -> Location.span -> Error.t =
   Error.make "'%d': bad heading level (0-5 allowed)."
@@ -15,26 +11,29 @@ let bad_heading_level : int -> Location.span -> Error.t =
 let leading_zero_in_heading_level : string -> Location.span -> Error.t =
   Error.make "'%s': leading zero in heading level."
 
-let should_not_be_empty : what:string -> Location.span -> Error.t = fun ~what ->
+let should_not_be_empty : what:string -> Location.span -> Error.t =
+ fun ~what ->
   Error.make "%s should not be empty." (String.capitalize_ascii what)
 
 let should_begin_on_its_own_line : what:string -> Location.span -> Error.t =
-    fun ~what ->
+ fun ~what ->
   Error.make "%s should begin on its own line." (String.capitalize_ascii what)
 
 let should_be_followed_by_whitespace : what:string -> Location.span -> Error.t =
-    fun ~what ->
-  Error.make
-    "%s should be followed by space, a tab, or a new line."
+ fun ~what ->
+  Error.make "%s should be followed by space, a tab, or a new line."
     (String.capitalize_ascii what)
 
-let not_allowed
-    : ?suggestion:string -> what:string -> in_what:string -> Location.span ->
-        Error.t =
-    fun ?suggestion ~what ~in_what ->
-  Error.make
-    ?suggestion "%s is not allowed in %s."
-    (String.capitalize_ascii what) in_what
+let not_allowed :
+    ?suggestion:string ->
+    what:string ->
+    in_what:string ->
+    Location.span ->
+    Error.t =
+ fun ?suggestion ~what ~in_what ->
+  Error.make ?suggestion "%s is not allowed in %s."
+    (String.capitalize_ascii what)
+    in_what
 
 let no_leading_whitespace_in_verbatim : Location.span -> Error.t =
   Error.make "'{v' should be followed by whitespace."
@@ -45,13 +44,12 @@ let no_trailing_whitespace_in_verbatim : Location.span -> Error.t =
 let page_heading_required : string -> Error.t =
   Error.filename_only "Pages (.mld files) should start with a heading."
 
-let heading_level_should_be_lower_than_top_level
-    : int -> int -> Location.span -> Error.t =
-    fun this_heading_level top_heading_level ->
-  Error.make
-    "%s: heading level should be lower than top heading level '%d'."
+let heading_level_should_be_lower_than_top_level :
+    int -> int -> Location.span -> Error.t =
+ fun this_heading_level top_heading_level ->
+  Error.make "%s: heading level should be lower than top heading level '%d'."
     (String.capitalize_ascii
-      (Token.print (`Begin_section_heading (this_heading_level, None))))
+       (Token.print (`Begin_section_heading (this_heading_level, None))))
     top_heading_level
 
 let headings_not_allowed : Location.span -> Error.t =
@@ -60,8 +58,7 @@ let headings_not_allowed : Location.span -> Error.t =
 let titles_not_allowed : Location.span -> Error.t =
   Error.make "Title-level headings {0 ...} are only allowed in pages."
 
-let stray_at : Location.span -> Error.t =
-  Error.make "Stray '@'."
+let stray_at : Location.span -> Error.t = Error.make "Stray '@'."
 
 let stray_cr : Location.span -> Error.t =
   Error.make "Stray '\\r' (carriage return character)."
@@ -92,7 +89,7 @@ let invalid_raw_markup_target : string -> Location.span -> Error.t =
   Error.make
     ~suggestion:
       (Printf.sprintf "try %s." (Token.print (`Raw_markup (Some "html", ""))))
-      "'{%%%s:': bad raw markup target."
+    "'{%%%s:': bad raw markup target."
 
 let default_raw_markup_target_not_supported : Location.span -> Error.t =
   Error.make
@@ -101,8 +98,7 @@ let default_raw_markup_target_not_supported : Location.span -> Error.t =
     "%s needs a target language."
     (Token.describe (`Raw_markup (None, "")))
 
-let expected : string -> Location.span -> Error.t =
-  Error.make "Expected %s."
+let expected : string -> Location.span -> Error.t = Error.make "Expected %s."
 
 let unknown_reference_qualifier : string -> Location.span -> Error.t =
   Error.make "Unknown reference qualifier '%s'."
@@ -110,6 +106,6 @@ let unknown_reference_qualifier : string -> Location.span -> Error.t =
 let deprecated_reference_kind : string -> string -> Location.span -> Error.t =
   Error.make "'%s' is deprecated, use '%s' instead."
 
-let reference_kinds_do_not_match
-    : string -> string -> Location.span -> Error.t =
+let reference_kinds_do_not_match : string -> string -> Location.span -> Error.t
+    =
   Error.make "Old-style reference kind ('%s:') does not match new ('%s-')."

--- a/src/parser/reference.ml
+++ b/src/parser/reference.ml
@@ -7,43 +7,55 @@ let deprecated_reference_kind warnings location kind replacement =
   |> Error.warning warnings
 
 (* http://caml.inria.fr/pub/docs/manual-ocaml/ocamldoc.html#sec359. *)
-let match_ocamldoc_reference_kind (_warnings as w) (_location as loc) s
-    : (Odoc_model.Paths_types.Reference.tag_any) option =
+let match_ocamldoc_reference_kind (_warnings as w) (_location as loc) s :
+    Odoc_model.Paths_types.Reference.tag_any option =
   let d = deprecated_reference_kind in
   match s with
   | Some "module" -> Some `TModule
-  | Some "modtype" -> d w loc "modtype" "module-type"; Some `TModuleType
+  | Some "modtype" ->
+      d w loc "modtype" "module-type";
+      Some `TModuleType
   | Some "class" -> Some `TClass
-  | Some "classtype" -> d w loc "classtype" "class-type"; Some `TClassType
+  | Some "classtype" ->
+      d w loc "classtype" "class-type";
+      Some `TClassType
   | Some "val" -> Some `TValue
   | Some "type" -> Some `TType
   | Some "exception" -> Some `TException
   | Some "attribute" -> None
   | Some "method" -> Some `TMethod
   | Some "section" -> Some `TLabel
-  | Some "const" -> d w loc "const" "constructor"; Some `TConstructor
-  | Some "recfield" -> d w loc "recfield" "field"; Some `TField
+  | Some "const" ->
+      d w loc "const" "constructor";
+      Some `TConstructor
+  | Some "recfield" ->
+      d w loc "recfield" "field";
+      Some `TField
   | Some "childpage" -> Some `TChildPage
   | Some "childmodule" -> Some `TChildModule
   | _ -> None
 
-let match_extra_odoc_reference_kind (_warnings as w) (_location as loc) s
-    : (Odoc_model.Paths_types.Reference.tag_any) option =
+let match_extra_odoc_reference_kind (_warnings as w) (_location as loc) s :
+    Odoc_model.Paths_types.Reference.tag_any option =
   let d = deprecated_reference_kind in
   match s with
   | Some "class-type" -> Some `TClassType
   | Some "constructor" -> Some `TConstructor
-  | Some "exn" -> d w loc "exn" "exception"; Some `TException
+  | Some "exn" ->
+      d w loc "exn" "exception";
+      Some `TException
   | Some "extension" -> Some `TExtension
   | Some "field" -> Some `TField
   | Some "instance-variable" -> Some `TInstanceVariable
-  | Some "label" -> d w loc "label" "section"; Some `TLabel
+  | Some "label" ->
+      d w loc "label" "section";
+      Some `TLabel
   | Some "module-type" -> Some `TModuleType
   | Some "page" -> Some `TPage
-  | Some "value" -> d w loc "value" "val"; Some `TValue
+  | Some "value" ->
+      d w loc "value" "val";
+      Some `TValue
   | _ -> None
-
-
 
 (* Ideally, [tokenize] would call this on every reference kind annotation during
    tokenization, when generating the token list. However, that constrains the
@@ -54,20 +66,21 @@ let match_extra_odoc_reference_kind (_warnings as w) (_location as loc) s
 
    A secondary reason to delay parsing, and store strings in the token list, is
    that we need the strings for user-friendly error reporting. *)
-let match_reference_kind warnings location s : Odoc_model.Paths_types.Reference.tag_any =
+let match_reference_kind warnings location s :
+    Odoc_model.Paths_types.Reference.tag_any =
   match s with
   | None -> `TUnknown
-  | Some s as wrapped ->
-    let result =
-      match match_ocamldoc_reference_kind warnings location wrapped with
-      | Some kind -> Some kind
-      | None -> match_extra_odoc_reference_kind warnings location wrapped
-    in
-    match result with
-    | Some kind -> kind
-    | None ->
-      Parse_error.unknown_reference_qualifier s location
-      |> Error.raise_exception
+  | Some s as wrapped -> (
+      let result =
+        match match_ocamldoc_reference_kind warnings location wrapped with
+        | Some kind -> Some kind
+        | None -> match_extra_odoc_reference_kind warnings location wrapped
+      in
+      match result with
+      | Some kind -> kind
+      | None ->
+          Parse_error.unknown_reference_qualifier s location
+          |> Error.raise_exception )
 
 (* The string is scanned right-to-left, because we are interested in right-most
    hyphens. The tokens are also returned in right-to-left order, because the
@@ -77,193 +90,205 @@ let tokenize location s =
   let rec scan_identifier started_at open_parenthesis_count index tokens =
     match s.[index] with
     | exception Invalid_argument _ ->
-      let identifier, location = identifier_ended started_at index in
-      (None, identifier, location)::tokens
-
+        let identifier, location = identifier_ended started_at index in
+        (None, identifier, location) :: tokens
     | '-' when open_parenthesis_count = 0 ->
-      let identifier, location = identifier_ended started_at index in
-      scan_kind identifier location index (index - 1) tokens
-
+        let identifier, location = identifier_ended started_at index in
+        scan_kind identifier location index (index - 1) tokens
     | '.' when open_parenthesis_count = 0 ->
-      let identifier, location = identifier_ended started_at index in
-      scan_identifier index 0 (index - 1) ((None, identifier, location)::tokens)
-
+        let identifier, location = identifier_ended started_at index in
+        scan_identifier index 0 (index - 1)
+          ((None, identifier, location) :: tokens)
     | ')' ->
-      scan_identifier
-        started_at (open_parenthesis_count + 1) (index - 1) tokens
-
+        scan_identifier started_at
+          (open_parenthesis_count + 1)
+          (index - 1) tokens
     | '(' when open_parenthesis_count > 0 ->
-      scan_identifier
-        started_at (open_parenthesis_count - 1) (index - 1) tokens
-
-    | _ ->
-      scan_identifier
-        started_at open_parenthesis_count (index - 1) tokens
-
+        scan_identifier started_at
+          (open_parenthesis_count - 1)
+          (index - 1) tokens
+    | _ -> scan_identifier started_at open_parenthesis_count (index - 1) tokens
   and identifier_ended started_at index =
     let offset = index + 1 in
     let length = started_at - offset in
     let identifier = String.trim (String.sub s offset length) in
     let location = Location_.in_string s ~offset ~length location in
 
-    if identifier = "" then begin
+    if identifier = "" then
       Parse_error.should_not_be_empty ~what:"Identifier in reference" location
-      |> Error.raise_exception
-    end;
+      |> Error.raise_exception;
 
     (identifier, location)
-
   and scan_kind identifier identifier_location started_at index tokens =
     match s.[index] with
     | exception Invalid_argument _ ->
-      let kind, location = kind_ended identifier_location started_at index in
-      (kind, identifier, location)::tokens
-
+        let kind, location = kind_ended identifier_location started_at index in
+        (kind, identifier, location) :: tokens
     | '.' ->
-      let kind, location = kind_ended identifier_location started_at index in
-      scan_identifier index 0 (index - 1) ((kind, identifier, location)::tokens)
-
+        let kind, location = kind_ended identifier_location started_at index in
+        scan_identifier index 0 (index - 1)
+          ((kind, identifier, location) :: tokens)
     | _ ->
-      scan_kind identifier identifier_location started_at (index - 1) tokens
-
+        scan_kind identifier identifier_location started_at (index - 1) tokens
   and kind_ended identifier_location started_at index =
     let offset = index + 1 in
     let length = started_at - offset in
     let kind = Some (String.sub s offset length) in
     let location = Location_.in_string s ~offset ~length location in
-    let location = Location_.span [location; identifier_location] in
+    let location = Location_.span [ location; identifier_location ] in
     (kind, location)
-
   in
 
-  scan_identifier (String.length s) 0 (String.length s - 1) []
-  |> List.rev
+  scan_identifier (String.length s) 0 (String.length s - 1) [] |> List.rev
 
 let expected allowed location =
   let unqualified = "or an unqualified reference" in
   let allowed =
     match allowed with
-    | [one] ->
-      Printf.sprintf "'%s-' %s" one unqualified
+    | [ one ] -> Printf.sprintf "'%s-' %s" one unqualified
     | _ ->
-      String.concat
-        ", " ((List.map (Printf.sprintf "'%s-'") allowed) @ [unqualified])
+        String.concat ", "
+          (List.map (Printf.sprintf "'%s-'") allowed @ [ unqualified ])
   in
   Parse_error.expected allowed location
 
-let parse warnings whole_reference_location s : (Paths.Reference.t, Error.t) Result.result =
+let parse warnings whole_reference_location s :
+    (Paths.Reference.t, Error.t) Result.result =
   let open Paths.Reference in
   let open Odoc_model.Names in
-
   let rec signature (kind, identifier, location) tokens : Signature.t =
     let kind = match_reference_kind warnings location kind in
     match tokens with
-    | [] ->
-      begin match kind with
-      | `TUnknown | `TModule | `TModuleType as kind -> `Root (identifier, kind)
-      | _ ->
-        expected ["module"; "module-type"] location |> Error.raise_exception
-      end
-    | next_token::tokens ->
-      begin match kind with
-      | `TUnknown ->
-        `Dot ((parent next_token tokens :> LabelParent.t), identifier)
-      | `TModule -> `Module (signature next_token tokens, ModuleName.of_string identifier)
-      | `TModuleType -> `ModuleType (signature next_token tokens, ModuleTypeName.of_string identifier)
-      | _ ->
-        expected ["module"; "module-type"] location |> Error.raise_exception
-      end
-
+    | [] -> (
+        match kind with
+        | (`TUnknown | `TModule | `TModuleType) as kind ->
+            `Root (identifier, kind)
+        | _ ->
+            expected [ "module"; "module-type" ] location
+            |> Error.raise_exception )
+    | next_token :: tokens -> (
+        match kind with
+        | `TUnknown ->
+            `Dot ((parent next_token tokens :> LabelParent.t), identifier)
+        | `TModule ->
+            `Module
+              (signature next_token tokens, ModuleName.of_string identifier)
+        | `TModuleType ->
+            `ModuleType
+              (signature next_token tokens, ModuleTypeName.of_string identifier)
+        | _ ->
+            expected [ "module"; "module-type" ] location
+            |> Error.raise_exception )
   and parent (kind, identifier, location) tokens : Parent.t =
     let kind = match_reference_kind warnings location kind in
     match tokens with
-    | [] ->
-      begin match kind with
-      | `TUnknown | `TModule | `TModuleType | `TType | `TClass
-      | `TClassType as kind -> `Root (identifier, kind)
-      | _ ->
-        expected
-          ["module"; "module-type"; "type"; "class"; "class-type"] location
-        |> Error.raise_exception
-      end
-    | next_token::tokens ->
-      begin match kind with
-      | `TUnknown ->
-        `Dot ((parent next_token tokens :> LabelParent.t), identifier)
-      | `TModule -> `Module (signature next_token tokens, ModuleName.of_string identifier)
-      | `TModuleType -> `ModuleType (signature next_token tokens, ModuleTypeName.of_string identifier)
-      | `TType -> `Type (signature next_token tokens, TypeName.of_string identifier)
-      | `TClass -> `Class (signature next_token tokens, ClassName.of_string identifier)
-      | `TClassType -> `ClassType (signature next_token tokens, ClassTypeName.of_string identifier)
-      | _ ->
-        expected
-          ["module"; "module-type"; "type"; "class"; "class-type"] location
-        |> Error.raise_exception
-      end
-
+    | [] -> (
+        match kind with
+        | (`TUnknown | `TModule | `TModuleType | `TType | `TClass | `TClassType)
+          as kind ->
+            `Root (identifier, kind)
+        | _ ->
+            expected
+              [ "module"; "module-type"; "type"; "class"; "class-type" ]
+              location
+            |> Error.raise_exception )
+    | next_token :: tokens -> (
+        match kind with
+        | `TUnknown ->
+            `Dot ((parent next_token tokens :> LabelParent.t), identifier)
+        | `TModule ->
+            `Module
+              (signature next_token tokens, ModuleName.of_string identifier)
+        | `TModuleType ->
+            `ModuleType
+              (signature next_token tokens, ModuleTypeName.of_string identifier)
+        | `TType ->
+            `Type (signature next_token tokens, TypeName.of_string identifier)
+        | `TClass ->
+            `Class (signature next_token tokens, ClassName.of_string identifier)
+        | `TClassType ->
+            `ClassType
+              (signature next_token tokens, ClassTypeName.of_string identifier)
+        | _ ->
+            expected
+              [ "module"; "module-type"; "type"; "class"; "class-type" ]
+              location
+            |> Error.raise_exception )
   in
 
   let class_signature (kind, identifier, location) tokens : ClassSignature.t =
     let kind = match_reference_kind warnings location kind in
     match tokens with
-    | [] ->
-      begin match kind with
-      | `TUnknown | `TClass | `TClassType as kind -> `Root (identifier, kind)
-      | _ -> expected ["class"; "class-type"] location |> Error.raise_exception
-      end
-    | next_token::tokens ->
-      begin match kind with
-      | `TUnknown ->
-        `Dot ((parent next_token tokens :> LabelParent.t), identifier)
-      | `TClass -> `Class (signature next_token tokens, ClassName.of_string identifier)
-      | `TClassType -> `ClassType (signature next_token tokens, ClassTypeName.of_string identifier)
-      | _ -> expected ["class"; "class-type"] location |> Error.raise_exception
-      end
+    | [] -> (
+        match kind with
+        | (`TUnknown | `TClass | `TClassType) as kind -> `Root (identifier, kind)
+        | _ ->
+            expected [ "class"; "class-type" ] location |> Error.raise_exception
+        )
+    | next_token :: tokens -> (
+        match kind with
+        | `TUnknown ->
+            `Dot ((parent next_token tokens :> LabelParent.t), identifier)
+        | `TClass ->
+            `Class (signature next_token tokens, ClassName.of_string identifier)
+        | `TClassType ->
+            `ClassType
+              (signature next_token tokens, ClassTypeName.of_string identifier)
+        | _ ->
+            expected [ "class"; "class-type" ] location |> Error.raise_exception
+        )
   in
 
   let datatype (kind, identifier, location) tokens : DataType.t =
     let kind = match_reference_kind warnings location kind in
     match tokens with
-    | [] ->
-      begin match kind with
-      | `TUnknown | `TType as kind -> `Root (identifier, kind)
-      | _ -> expected ["type"] location |> Error.raise_exception
-      end
-    | next_token::tokens ->
-      begin match kind with
-      | `TUnknown ->
-        `Dot ((parent next_token tokens :> LabelParent.t), identifier)
-      | `TType -> `Type (signature next_token tokens, TypeName.of_string identifier)
-      | _ -> expected ["type"] location |> Error.raise_exception
-      end
+    | [] -> (
+        match kind with
+        | (`TUnknown | `TType) as kind -> `Root (identifier, kind)
+        | _ -> expected [ "type" ] location |> Error.raise_exception )
+    | next_token :: tokens -> (
+        match kind with
+        | `TUnknown ->
+            `Dot ((parent next_token tokens :> LabelParent.t), identifier)
+        | `TType ->
+            `Type (signature next_token tokens, TypeName.of_string identifier)
+        | _ -> expected [ "type" ] location |> Error.raise_exception )
   in
 
   let rec label_parent (kind, identifier, location) tokens : LabelParent.t =
     let kind = match_reference_kind warnings location kind in
     match tokens with
-    | [] ->
-      begin match kind with
-      | `TUnknown | `TModule | `TModuleType | `TType | `TClass | `TClassType
-      | `TPage as kind -> `Root (identifier, kind)
-      | _ ->
-        expected
-          ["module"; "module-type"; "type"; "class"; "class-type"; "page"]
-          location
-        |> Error.raise_exception
-      end
-    | next_token::tokens ->
-      begin match kind with
-      | `TUnknown -> `Dot (label_parent next_token tokens, identifier)
-      | `TModule -> `Module (signature next_token tokens, ModuleName.of_string identifier)
-      | `TModuleType -> `ModuleType (signature next_token tokens, ModuleTypeName.of_string identifier)
-      | `TType -> `Type (signature next_token tokens, TypeName.of_string identifier)
-      | `TClass -> `Class (signature next_token tokens, ClassName.of_string identifier)
-      | `TClassType -> `ClassType (signature next_token tokens, ClassTypeName.of_string identifier)
-      | _ ->
-        expected
-          ["module"; "module-type"; "type"; "class"; "class-type"] location
-        |> Error.raise_exception
-      end
+    | [] -> (
+        match kind with
+        | ( `TUnknown | `TModule | `TModuleType | `TType | `TClass | `TClassType
+          | `TPage ) as kind ->
+            `Root (identifier, kind)
+        | _ ->
+            expected
+              [ "module"; "module-type"; "type"; "class"; "class-type"; "page" ]
+              location
+            |> Error.raise_exception )
+    | next_token :: tokens -> (
+        match kind with
+        | `TUnknown -> `Dot (label_parent next_token tokens, identifier)
+        | `TModule ->
+            `Module
+              (signature next_token tokens, ModuleName.of_string identifier)
+        | `TModuleType ->
+            `ModuleType
+              (signature next_token tokens, ModuleTypeName.of_string identifier)
+        | `TType ->
+            `Type (signature next_token tokens, TypeName.of_string identifier)
+        | `TClass ->
+            `Class (signature next_token tokens, ClassName.of_string identifier)
+        | `TClassType ->
+            `ClassType
+              (signature next_token tokens, ClassTypeName.of_string identifier)
+        | _ ->
+            expected
+              [ "module"; "module-type"; "type"; "class"; "class-type" ]
+              location
+            |> Error.raise_exception )
   in
 
   let start_from_last_component (kind, identifier, location) old_kind tokens =
@@ -271,133 +296,147 @@ let parse warnings whole_reference_location s : (Paths.Reference.t, Error.t) Res
     let kind =
       match old_kind with
       | None -> new_kind
-      | Some (old_kind_string, old_kind_location) ->
-        let old_kind =
-          match_reference_kind
-            warnings old_kind_location (Some old_kind_string)
-        in
-        match new_kind with
-        | `TUnknown -> old_kind
-        | _ ->
-          if old_kind <> new_kind then begin
-            let new_kind_string =
-              match kind with
-              | Some s -> s
-              | None -> ""
-            in
-            Parse_error.reference_kinds_do_not_match
-              old_kind_string new_kind_string whole_reference_location
-            |> Error.warning warnings
-          end;
-          new_kind
+      | Some (old_kind_string, old_kind_location) -> (
+          let old_kind =
+            match_reference_kind warnings old_kind_location
+              (Some old_kind_string)
+          in
+          match new_kind with
+          | `TUnknown -> old_kind
+          | _ ->
+              ( if old_kind <> new_kind then
+                let new_kind_string =
+                  match kind with Some s -> s | None -> ""
+                in
+                Parse_error.reference_kinds_do_not_match old_kind_string
+                  new_kind_string whole_reference_location
+                |> Error.warning warnings );
+              new_kind )
     in
 
     match tokens with
     | [] -> `Root (identifier, kind)
-    | next_token::tokens ->
-      match kind with
-      | `TUnknown -> `Dot (label_parent next_token tokens, identifier)
-      | `TModule -> `Module (signature next_token tokens, ModuleName.of_string identifier)
-      | `TModuleType -> `ModuleType (signature next_token tokens, ModuleTypeName.of_string identifier)
-      | `TType -> `Type (signature next_token tokens, TypeName.of_string identifier)
-      | `TConstructor -> `Constructor (datatype next_token tokens, ConstructorName.of_string identifier)
-      | `TField -> `Field (parent next_token tokens, FieldName.of_string identifier)
-      | `TExtension -> `Extension (signature next_token tokens, ExtensionName.of_string identifier)
-      | `TException -> `Exception (signature next_token tokens, ExceptionName.of_string identifier)
-      | `TValue -> `Value (signature next_token tokens, ValueName.of_string identifier)
-      | `TClass -> `Class (signature next_token tokens, ClassName.of_string identifier)
-      | `TClassType -> `ClassType (signature next_token tokens, ClassTypeName.of_string identifier)
-      | `TMethod -> `Method (class_signature next_token tokens, MethodName.of_string identifier)
-      | `TInstanceVariable ->
-        `InstanceVariable (class_signature next_token tokens, InstanceVariableName.of_string identifier)
-      | `TLabel -> `Label (label_parent next_token tokens, LabelName.of_string identifier)
-      | `TChildPage | `TChildModule ->
-        let suggestion =
-          Printf.sprintf "'child-%s' should be first." identifier in
-        Parse_error.not_allowed
-          ~what:"Child label"
-          ~in_what:"the last component of a reference path"
-          ~suggestion
-          location
-        |> Error.raise_exception
-      | `TPage ->
-        let suggestion =
-          Printf.sprintf "'page-%s' should be first." identifier in
-        Parse_error.not_allowed
-          ~what:"Page label"
-          ~in_what:"the last component of a reference path"
-          ~suggestion
-          location
-        |> Error.raise_exception
+    | next_token :: tokens -> (
+        match kind with
+        | `TUnknown -> `Dot (label_parent next_token tokens, identifier)
+        | `TModule ->
+            `Module
+              (signature next_token tokens, ModuleName.of_string identifier)
+        | `TModuleType ->
+            `ModuleType
+              (signature next_token tokens, ModuleTypeName.of_string identifier)
+        | `TType ->
+            `Type (signature next_token tokens, TypeName.of_string identifier)
+        | `TConstructor ->
+            `Constructor
+              (datatype next_token tokens, ConstructorName.of_string identifier)
+        | `TField ->
+            `Field (parent next_token tokens, FieldName.of_string identifier)
+        | `TExtension ->
+            `Extension
+              (signature next_token tokens, ExtensionName.of_string identifier)
+        | `TException ->
+            `Exception
+              (signature next_token tokens, ExceptionName.of_string identifier)
+        | `TValue ->
+            `Value (signature next_token tokens, ValueName.of_string identifier)
+        | `TClass ->
+            `Class (signature next_token tokens, ClassName.of_string identifier)
+        | `TClassType ->
+            `ClassType
+              (signature next_token tokens, ClassTypeName.of_string identifier)
+        | `TMethod ->
+            `Method
+              ( class_signature next_token tokens,
+                MethodName.of_string identifier )
+        | `TInstanceVariable ->
+            `InstanceVariable
+              ( class_signature next_token tokens,
+                InstanceVariableName.of_string identifier )
+        | `TLabel ->
+            `Label
+              (label_parent next_token tokens, LabelName.of_string identifier)
+        | `TChildPage | `TChildModule ->
+            let suggestion =
+              Printf.sprintf "'child-%s' should be first." identifier
+            in
+            Parse_error.not_allowed ~what:"Child label"
+              ~in_what:"the last component of a reference path" ~suggestion
+              location
+            |> Error.raise_exception
+        | `TPage ->
+            let suggestion =
+              Printf.sprintf "'page-%s' should be first." identifier
+            in
+            Parse_error.not_allowed ~what:"Page label"
+              ~in_what:"the last component of a reference path" ~suggestion
+              location
+            |> Error.raise_exception )
   in
 
   let old_kind, s, location =
     let rec find_old_reference_kind_separator index =
       match s.[index] with
-      | ':' ->
-        index
-      | ')' ->
-        begin match String.rindex_from s index '(' with
-        | index -> find_old_reference_kind_separator (index - 1)
-        | exception (Not_found as exn) -> raise exn
-        end
-      | _ ->
-        find_old_reference_kind_separator (index - 1)
-      | exception Invalid_argument _ ->
-        raise Not_found
+      | ':' -> index
+      | ')' -> (
+          match String.rindex_from s index '(' with
+          | index -> find_old_reference_kind_separator (index - 1)
+          | exception (Not_found as exn) -> raise exn )
+      | _ -> find_old_reference_kind_separator (index - 1)
+      | exception Invalid_argument _ -> raise Not_found
     in
     match find_old_reference_kind_separator (String.length s - 1) with
     | index ->
-      let old_kind = String.trim (String.sub s 0 index) in
-      let old_kind_location =
-        Location_.set_end_as_offset_from_start index whole_reference_location in
-      let s = String.sub s (index + 1) (String.length s - (index + 1)) in
-      let location =
-        Location_.nudge_start (index + 1) whole_reference_location in
-      (Some (old_kind, old_kind_location), s, location)
-    | exception Not_found ->
-      (None, s, whole_reference_location)
+        let old_kind = String.trim (String.sub s 0 index) in
+        let old_kind_location =
+          Location_.set_end_as_offset_from_start index whole_reference_location
+        in
+        let s = String.sub s (index + 1) (String.length s - (index + 1)) in
+        let location =
+          Location_.nudge_start (index + 1) whole_reference_location
+        in
+        (Some (old_kind, old_kind_location), s, location)
+    | exception Not_found -> (None, s, whole_reference_location)
   in
 
-  Error.catch begin fun () ->
-    match tokenize location s with
-    | last_token::tokens -> start_from_last_component last_token old_kind tokens
-    | [] ->
-      Parse_error.should_not_be_empty
-        ~what:"reference target" whole_reference_location
-      |> Error.raise_exception
-  end
+  Error.catch (fun () ->
+      match tokenize location s with
+      | last_token :: tokens ->
+          start_from_last_component last_token old_kind tokens
+      | [] ->
+          Parse_error.should_not_be_empty ~what:"reference target"
+            whole_reference_location
+          |> Error.raise_exception)
 
 let read_path_longident location s =
   let open Paths.Path in
   let rec loop : string -> int -> Module.t option =
-    fun s pos ->
-      try
-        let idx = String.rindex_from s pos '.' in
-        let name = String.sub s (idx + 1) (pos - idx) in
-        if String.length name = 0 then None
-        else
-          match loop s (idx - 1) with
-          | None -> None
-          | Some parent -> Some (`Dot(parent, name))
-      with Not_found ->
-        let name = String.sub s 0 (pos + 1) in
-        if String.length name = 0 then None
-        else Some (`Root name)
+   fun s pos ->
+    try
+      let idx = String.rindex_from s pos '.' in
+      let name = String.sub s (idx + 1) (pos - idx) in
+      if String.length name = 0 then None
+      else
+        match loop s (idx - 1) with
+        | None -> None
+        | Some parent -> Some (`Dot (parent, name))
+    with Not_found ->
+      let name = String.sub s 0 (pos + 1) in
+      if String.length name = 0 then None else Some (`Root name)
   in
   match loop s (String.length s - 1) with
   | Some r -> Result.Ok r
   | None -> Result.Error (Parse_error.expected "a valid path" location)
 
-let read_mod_longident
-    warnings location lid : (Paths.Reference.Module.t, Error.t) Result.result
-  =
+let read_mod_longident warnings location lid :
+    (Paths.Reference.Module.t, Error.t) Result.result =
   match parse warnings location lid with
   | Error _ as e -> e
-  | Ok p ->
+  | Ok p -> (
       match p with
-      | `Root (_, (`TUnknown | `TModule))
-      | `Dot (_, _)
-      | `Module (_, _) as r -> Result.Ok r
+      | (`Root (_, (`TUnknown | `TModule)) | `Dot (_, _) | `Module (_, _)) as r
+        ->
+          Result.Ok r
       | _ ->
           Result.Error (Parse_error.expected "a reference to a module" location)
+      )

--- a/src/parser/reference.mli
+++ b/src/parser/reference.mli
@@ -3,13 +3,16 @@ module Location_ = Odoc_model.Location_
 module Paths = Odoc_model.Paths
 
 val parse :
-  Error.warning_accumulator -> Location_.span -> string ->
-    (Paths.Reference.t, Error.t) Result.result
+  Error.warning_accumulator ->
+  Location_.span ->
+  string ->
+  (Paths.Reference.t, Error.t) Result.result
 
 val read_path_longident :
-  Location_.span -> string ->
-    (Paths.Path.Module.t, Error.t) Result.result
+  Location_.span -> string -> (Paths.Path.Module.t, Error.t) Result.result
 
 val read_mod_longident :
-  Error.warning_accumulator -> Location_.span -> string ->
-    (Paths.Reference.Module.t, Error.t) Result.result
+  Error.warning_accumulator ->
+  Location_.span ->
+  string ->
+  (Paths.Reference.Module.t, Error.t) Result.result

--- a/src/parser/semantics.ml
+++ b/src/parser/semantics.ml
@@ -1,21 +1,15 @@
 open Odoc_compat
-
 module Location = Odoc_model.Location_
 module Error = Odoc_model.Error
 module Comment = Odoc_model.Comment
 
 type 'a with_location = 'a Location.with_location
 
-
-
-type ast_leaf_inline_element = [
-  | `Space of string
+type ast_leaf_inline_element =
+  [ `Space of string
   | `Word of string
   | `Code_span of string
-  | `Raw_markup of string option * string
-]
-
-
+  | `Raw_markup of string option * string ]
 
 type status = {
   warnings : Error.warning_accumulator;
@@ -23,206 +17,163 @@ type status = {
   parent_of_sections : Odoc_model.Paths.Identifier.LabelParent.t;
 }
 
-
-
 (* TODO This and Token.describe probably belong in Parse_error. *)
 let describe_element = function
-  | `Reference (`Simple, _, _) ->
-    Token.describe (`Simple_reference "")
+  | `Reference (`Simple, _, _) -> Token.describe (`Simple_reference "")
   | `Reference (`With_text, _, _) ->
-    Token.describe (`Begin_reference_with_replacement_text "")
-  | `Link _ ->
-    Token.describe (`Begin_link_with_replacement_text "")
+      Token.describe (`Begin_reference_with_replacement_text "")
+  | `Link _ -> Token.describe (`Begin_link_with_replacement_text "")
   | `Heading (level, _, _) ->
-    Token.describe (`Begin_section_heading (level, None))
+      Token.describe (`Begin_section_heading (level, None))
 
-
-
-let leaf_inline_element
-    : status -> ast_leaf_inline_element with_location ->
-        Comment.leaf_inline_element with_location =
-    fun status element ->
-
+let leaf_inline_element :
+    status ->
+    ast_leaf_inline_element with_location ->
+    Comment.leaf_inline_element with_location =
+ fun status element ->
   match element with
-  | { value = (`Word _ | `Code_span _); _ } as element ->
-    element
+  | { value = `Word _ | `Code_span _; _ } as element -> element
+  | { value = `Space _; _ } -> Location.same element `Space
+  | { value = `Raw_markup (target, s); location } -> (
+      match target with
+      | Some invalid_target
+        when String.trim invalid_target = ""
+             || String.contains invalid_target '%'
+             || String.contains invalid_target '}' ->
+          Error.warning status.warnings
+            (Parse_error.invalid_raw_markup_target invalid_target location);
+          Location.same element (`Code_span s)
+      | None ->
+          Error.warning status.warnings
+            (Parse_error.default_raw_markup_target_not_supported location);
+          Location.same element (`Code_span s)
+      | Some target -> Location.same element (`Raw_markup (target, s)) )
 
-  | { value = `Space _; _ } ->
-    Location.same element `Space
-
-  | { value = `Raw_markup (target, s); location } ->
-    begin match target with
-    | Some invalid_target when
-        String.trim invalid_target = ""
-      || String.contains invalid_target '%'
-      || String.contains invalid_target '}'
-      ->
-      Error.warning status.warnings
-        (Parse_error.invalid_raw_markup_target invalid_target location);
-      Location.same element (`Code_span s)
-    | None ->
-      Error.warning status.warnings 
-        (Parse_error.default_raw_markup_target_not_supported location);
-      Location.same element (`Code_span s)
-    | Some target -> 
-      Location.same element (`Raw_markup (target, s))
-    end
-
-
-
-let rec non_link_inline_element
-    : status -> surrounding:_ -> Ast.inline_element with_location ->
-        Comment.non_link_inline_element with_location =
-    fun status ~surrounding element ->
-
+let rec non_link_inline_element :
+    status ->
+    surrounding:_ ->
+    Ast.inline_element with_location ->
+    Comment.non_link_inline_element with_location =
+ fun status ~surrounding element ->
   match element with
-  | {value = #ast_leaf_inline_element; _} as element ->
-    (leaf_inline_element status element
-     :> Comment.non_link_inline_element with_location)
+  | { value = #ast_leaf_inline_element; _ } as element ->
+      ( leaf_inline_element status element
+        :> Comment.non_link_inline_element with_location )
+  | { value = `Styled (style, content); _ } ->
+      `Styled (style, non_link_inline_elements status ~surrounding content)
+      |> Location.same element
+  | ( { value = `Reference (_, _, content); _ }
+    | { value = `Link (_, content); _ } ) as element ->
+      Parse_error.not_allowed
+        ~what:(describe_element element.value)
+        ~in_what:(describe_element surrounding)
+        element.location
+      |> Error.warning status.warnings;
 
-  | {value = `Styled (style, content); _} ->
-    `Styled (style, non_link_inline_elements status ~surrounding content)
-    |> Location.same element
-
-  | {value = `Reference (_, _, content); _}
-  | {value = `Link (_, content); _} as element ->
-    Parse_error.not_allowed
-      ~what:(describe_element element.value)
-      ~in_what:(describe_element surrounding)
-      element.location
-    |> Error.warning status.warnings;
-
-    `Styled (`Emphasis, non_link_inline_elements status ~surrounding content)
-    |> Location.same element
+      `Styled (`Emphasis, non_link_inline_elements status ~surrounding content)
+      |> Location.same element
 
 and non_link_inline_elements status ~surrounding elements =
   List.map (non_link_inline_element status ~surrounding) elements
 
-
-
-let rec inline_element
-    : status -> Ast.inline_element with_location ->
-        Comment.inline_element with_location =
-    fun status element ->
-
+let rec inline_element :
+    status ->
+    Ast.inline_element with_location ->
+    Comment.inline_element with_location =
+ fun status element ->
   match element with
-  | {value = #ast_leaf_inline_element; _} as element ->
-    (leaf_inline_element status element
-     :> Comment.inline_element with_location)
-
-  | {value = `Styled (style, content); location} ->
-    `Styled (style, inline_elements status content)
-    |> Location.at location
-
-  | {value = `Reference (kind, target, content) as value; location} ->
-    let {Location.value = target; location = target_location} = target in
-    begin match Reference.parse status.warnings target_location target with
+  | { value = #ast_leaf_inline_element; _ } as element ->
+      ( leaf_inline_element status element
+        :> Comment.inline_element with_location )
+  | { value = `Styled (style, content); location } ->
+      `Styled (style, inline_elements status content) |> Location.at location
+  | { value = `Reference (kind, target, content) as value; location } -> (
+      let { Location.value = target; location = target_location } = target in
+      match Reference.parse status.warnings target_location target with
       | Result.Ok target ->
-        let content = non_link_inline_elements status ~surrounding:value content in
-        Location.at location (`Reference (target, content))
-
+          let content =
+            non_link_inline_elements status ~surrounding:value content
+          in
+          Location.at location (`Reference (target, content))
       | Result.Error error ->
-        Error.warning status.warnings error;
-        let placeholder =
-          match kind with
-          | `Simple -> `Code_span target
-          | `With_text -> `Styled (`Emphasis, content)
-        in
-        inline_element status (Location.at location placeholder)
-    end
+          Error.warning status.warnings error;
+          let placeholder =
+            match kind with
+            | `Simple -> `Code_span target
+            | `With_text -> `Styled (`Emphasis, content)
+          in
+          inline_element status (Location.at location placeholder) )
+  | { value = `Link (target, content) as value; location } ->
+      `Link (target, non_link_inline_elements status ~surrounding:value content)
+      |> Location.at location
 
-  | {value = `Link (target, content) as value; location} ->
-    `Link (target, non_link_inline_elements status ~surrounding:value content)
-    |> Location.at location
+and inline_elements status elements = List.map (inline_element status) elements
 
-and inline_elements status elements =
-  List.map (inline_element status) elements
-
-
-
-let rec nestable_block_element
-    : status -> Ast.nestable_block_element with_location ->
-        Comment.nestable_block_element with_location =
-    fun status element ->
-
+let rec nestable_block_element :
+    status ->
+    Ast.nestable_block_element with_location ->
+    Comment.nestable_block_element with_location =
+ fun status element ->
   match element with
-  | {value = `Paragraph content; location} ->
-    Location.at location (`Paragraph (inline_elements status content))
-
-  | {value = `Code_block _; _}
-  | {value = `Verbatim _; _} as element ->
-    element
-
-  | {value = `Modules modules; location} ->
-    let modules =
-      List.fold_left (fun acc {Location.value; location} ->
-          match Reference.read_mod_longident status.warnings location value with
-          | Result.Ok r ->
-            r :: acc
-          | Result.Error error ->
-            Error.warning status.warnings error;
-            acc
-        ) [] modules
-      |> List.rev
-    in
-    Location.at location (`Modules modules)
-
-  | {value = `List (kind, _syntax, items); location} ->
-    `List (kind, List.map (nestable_block_elements status) items)
-    |> Location.at location
+  | { value = `Paragraph content; location } ->
+      Location.at location (`Paragraph (inline_elements status content))
+  | ({ value = `Code_block _; _ } | { value = `Verbatim _; _ }) as element ->
+      element
+  | { value = `Modules modules; location } ->
+      let modules =
+        List.fold_left
+          (fun acc { Location.value; location } ->
+            match
+              Reference.read_mod_longident status.warnings location value
+            with
+            | Result.Ok r -> r :: acc
+            | Result.Error error ->
+                Error.warning status.warnings error;
+                acc)
+          [] modules
+        |> List.rev
+      in
+      Location.at location (`Modules modules)
+  | { value = `List (kind, _syntax, items); location } ->
+      `List (kind, List.map (nestable_block_elements status) items)
+      |> Location.at location
 
 and nestable_block_elements status elements =
   List.map (nestable_block_element status) elements
 
-
-
-let tag
-    : location:Location.span -> status -> Ast.tag ->
-        (Comment.block_element with_location, Ast.block_element with_location) Result.result =
-    fun ~location status tag ->
+let tag :
+    location:Location.span ->
+    status ->
+    Ast.tag ->
+    ( Comment.block_element with_location,
+      Ast.block_element with_location )
+    Result.result =
+ fun ~location status tag ->
   let ok t = Result.Ok (Location.at location (`Tag t)) in
   match tag with
-  | `Author _
-  | `Since _
-  | `Version _
-  | `Inline
-  | `Open
-  | `Closed as tag ->
-    ok tag
-
-  | `Canonical {value = s; location = r_location} ->
-    let path = Reference.read_path_longident r_location s in
-    let module_ = Reference.read_mod_longident status.warnings r_location s in
-    begin match path, module_ with
-    | Result.Ok path, Result.Ok module_ ->
-      ok (`Canonical (path, module_))
-    | Result.Error e, _
-    | Result.Ok _, Result.Error e ->
-      Error.warning status.warnings e;
-      let placeholder = [`Word "@canonical"; `Space " "; `Code_span s] in
-      let placeholder = List.map (Location.at location) placeholder in
-      Error (Location.at location (`Paragraph placeholder))
-    end
-
+  | (`Author _ | `Since _ | `Version _ | `Inline | `Open | `Closed) as tag ->
+      ok tag
+  | `Canonical { value = s; location = r_location } -> (
+      let path = Reference.read_path_longident r_location s in
+      let module_ = Reference.read_mod_longident status.warnings r_location s in
+      match (path, module_) with
+      | Result.Ok path, Result.Ok module_ -> ok (`Canonical (path, module_))
+      | Result.Error e, _ | Result.Ok _, Result.Error e ->
+          Error.warning status.warnings e;
+          let placeholder = [ `Word "@canonical"; `Space " "; `Code_span s ] in
+          let placeholder = List.map (Location.at location) placeholder in
+          Error (Location.at location (`Paragraph placeholder)) )
   | `Deprecated content ->
-    ok (`Deprecated (nestable_block_elements status content))
-
+      ok (`Deprecated (nestable_block_elements status content))
   | `Param (name, content) ->
-    ok (`Param (name, nestable_block_elements status content))
-
+      ok (`Param (name, nestable_block_elements status content))
   | `Raise (name, content) ->
-    ok (`Raise (name, nestable_block_elements status content))
-
-  | `Return content ->
-    ok (`Return (nestable_block_elements status content))
-
+      ok (`Raise (name, nestable_block_elements status content))
+  | `Return content -> ok (`Return (nestable_block_elements status content))
   | `See (kind, target, content) ->
-    ok (`See (kind, target, nestable_block_elements status content))
-
+      ok (`See (kind, target, nestable_block_elements status content))
   | `Before (version, content) ->
-    ok (`Before (version, nestable_block_elements status content))
-
-
+      ok (`Before (version, nestable_block_elements status content))
 
 (* When the user does not give a section heading a label (anchor), we generate
    one from the text in the heading. This is the common case. This involves
@@ -231,58 +182,52 @@ let tag
 
    This must be done in the parser (i.e. early, not at HTML/other output
    generation time), so that the cross-referencer can see these anchors. *)
-let generate_heading_label : Comment.link_content -> string = fun content ->
-
+let generate_heading_label : Comment.link_content -> string =
+ fun content ->
   (* Code spans can contain spaces, so we need to replace them with hyphens. We
      also lowercase all the letters, for consistency with the rest of this
      procedure. *)
   let replace_spaces_with_hyphens_and_lowercase s =
     let result = Bytes.create (String.length s) in
-    s |> String.iteri begin fun index c ->
-      let c =
-        match c with
-        | ' ' | '\t' | '\r' | '\n' -> '-'
-        | _ -> Char.lowercase_ascii c
-      in
-      Bytes.set result index c
-    end;
+    s
+    |> String.iteri (fun index c ->
+           let c =
+             match c with
+             | ' ' | '\t' | '\r' | '\n' -> '-'
+             | _ -> Char.lowercase_ascii c
+           in
+           Bytes.set result index c);
     Bytes.unsafe_to_string result
   in
 
   (* Perhaps this should be done using a [Buffer.t]; we can switch to that as
      needed. *)
   let rec scan_inline_elements anchor = function
-    | [] ->
-      anchor
-    | element::more ->
-      let anchor =
-        match element.Location.value with
-        | `Space ->
-          anchor ^ "-"
-        | `Word w ->
-          anchor ^ (String.lowercase_ascii w)
-        | `Code_span c ->
-          anchor ^ (replace_spaces_with_hyphens_and_lowercase c)
-        | `Raw_markup _ ->
-          (* TODO Perhaps having raw markup in a section heading should be an
-             error? *)
-          anchor
-        | `Styled (_, content) ->
-          scan_inline_elements anchor content
-      in
-      scan_inline_elements anchor more
+    | [] -> anchor
+    | element :: more ->
+        let anchor =
+          match element.Location.value with
+          | `Space -> anchor ^ "-"
+          | `Word w -> anchor ^ String.lowercase_ascii w
+          | `Code_span c -> anchor ^ replace_spaces_with_hyphens_and_lowercase c
+          | `Raw_markup _ ->
+              (* TODO Perhaps having raw markup in a section heading should be an
+                 error? *)
+              anchor
+          | `Styled (_, content) -> scan_inline_elements anchor content
+        in
+        scan_inline_elements anchor more
   in
   scan_inline_elements "" content
 
-let section_heading
-    : status ->
-      top_heading_level:int option ->
-      Location.span ->
-      [ `Heading of _ ] ->
-        int option * (Comment.block_element with_location) =
-    fun status ~top_heading_level location heading ->
-
-  let `Heading (level, label, content) = heading in
+let section_heading :
+    status ->
+    top_heading_level:int option ->
+    Location.span ->
+    [ `Heading of _ ] ->
+    int option * Comment.block_element with_location =
+ fun status ~top_heading_level location heading ->
+  let (`Heading (level, label, content)) = heading in
 
   let content = non_link_inline_elements status ~surrounding:heading content in
 
@@ -291,142 +236,120 @@ let section_heading
     | Some label -> label
     | None -> generate_heading_label content
   in
-  let label = `Label (status.parent_of_sections, Odoc_model.Names.LabelName.of_string label) in
+  let label =
+    `Label
+      (status.parent_of_sections, Odoc_model.Names.LabelName.of_string label)
+  in
 
-  match status.sections_allowed, level with
+  match (status.sections_allowed, level) with
   | `None, _any_level ->
-    Error.warning status.warnings (Parse_error.headings_not_allowed location);
-    let content = (content :> (Comment.inline_element with_location) list) in
-    let element =
-      Location.at location
-        (`Paragraph [Location.at location
-          (`Styled (`Bold, content))])
-    in
-    top_heading_level, element
-
+      Error.warning status.warnings (Parse_error.headings_not_allowed location);
+      let content = (content :> Comment.inline_element with_location list) in
+      let element =
+        Location.at location
+          (`Paragraph [ Location.at location (`Styled (`Bold, content)) ])
+      in
+      (top_heading_level, element)
   | `No_titles, 0 ->
-    Error.warning status.warnings (Parse_error.titles_not_allowed location);
-    let element = `Heading (`Title, label, content) in
-    let element = Location.at location element in
-    let top_heading_level =
-      match top_heading_level with
-      | None -> Some level
-      | some -> some
-    in
-    top_heading_level, element
-
+      Error.warning status.warnings (Parse_error.titles_not_allowed location);
+      let element = `Heading (`Title, label, content) in
+      let element = Location.at location element in
+      let top_heading_level =
+        match top_heading_level with None -> Some level | some -> some
+      in
+      (top_heading_level, element)
   | _, level ->
-    let level' =
-      match level with
-      | 0 -> `Title
-      | 1 -> `Section
-      | 2 -> `Subsection
-      | 3 -> `Subsubsection
-      | 4 -> `Paragraph
-      | 5 -> `Subparagraph
-      | _ ->
-        Error.warning status.warnings
-          (Parse_error.bad_heading_level level location);
-        (* Implicitly promote to level-5. *)
-        `Subparagraph
-    in
-    begin match top_heading_level with
-    | Some top_level when
-        status.sections_allowed = `All && level <= top_level && level <= 5 ->
-      Error.warning status.warnings
-        (Parse_error.heading_level_should_be_lower_than_top_level
-          level top_level location)
-    | _ -> ()
-    end;
-    let element = `Heading (level', label, content) in
-    let element = Location.at location element in
-    let top_heading_level =
-      match top_heading_level with
-      | None -> Some level
-      | some -> some
-    in
-    top_heading_level, element
-
+      let level' =
+        match level with
+        | 0 -> `Title
+        | 1 -> `Section
+        | 2 -> `Subsection
+        | 3 -> `Subsubsection
+        | 4 -> `Paragraph
+        | 5 -> `Subparagraph
+        | _ ->
+            Error.warning status.warnings
+              (Parse_error.bad_heading_level level location);
+            (* Implicitly promote to level-5. *)
+            `Subparagraph
+      in
+      ( match top_heading_level with
+      | Some top_level
+        when status.sections_allowed = `All && level <= top_level && level <= 5
+        ->
+          Error.warning status.warnings
+            (Parse_error.heading_level_should_be_lower_than_top_level level
+               top_level location)
+      | _ -> () );
+      let element = `Heading (level', label, content) in
+      let element = Location.at location element in
+      let top_heading_level =
+        match top_heading_level with None -> Some level | some -> some
+      in
+      (top_heading_level, element)
 
 let validate_first_page_heading status ast_element =
   match status.parent_of_sections with
-  | `RootPage name
-  | `Page (_, name)
-  | `LeafPage (_, name) ->
-    begin match ast_element with
-      | {Location.value = `Heading (_, _, _); _} -> ()
+  | `RootPage name | `Page (_, name) | `LeafPage (_, name) -> (
+      match ast_element with
+      | { Location.value = `Heading (_, _, _); _ } -> ()
       | _invalid_ast_element ->
-        let filename = Odoc_model.Names.PageName.to_string name ^ ".mld" in
-        Error.warning status.warnings
-          (Parse_error.page_heading_required filename)
-    end
+          let filename = Odoc_model.Names.PageName.to_string name ^ ".mld" in
+          Error.warning status.warnings
+            (Parse_error.page_heading_required filename) )
   | _not_a_page -> ()
 
-
-let top_level_block_elements
-    : status -> (Ast.block_element with_location) list ->
-        (Comment.block_element with_location) list =
-    fun status ast_elements ->
-
-  let rec traverse
-      : top_heading_level:int option ->
-        (Comment.block_element with_location) list ->
-        (Ast.block_element with_location) list ->
-          (Comment.block_element with_location) list =
-      fun ~top_heading_level comment_elements_acc ast_elements ->
-
+let top_level_block_elements :
+    status ->
+    Ast.block_element with_location list ->
+    Comment.block_element with_location list =
+ fun status ast_elements ->
+  let rec traverse :
+      top_heading_level:int option ->
+      Comment.block_element with_location list ->
+      Ast.block_element with_location list ->
+      Comment.block_element with_location list =
+   fun ~top_heading_level comment_elements_acc ast_elements ->
     match ast_elements with
-    | [] ->
-      List.rev comment_elements_acc
+    | [] -> List.rev comment_elements_acc
+    | ast_element :: ast_elements -> (
+        (* The first [ast_element] in pages must be a title or section heading. *)
+        if status.sections_allowed = `All && top_heading_level = None then
+          validate_first_page_heading status ast_element;
 
-    | ast_element::ast_elements ->
-      (* The first [ast_element] in pages must be a title or section heading. *)
-      if status.sections_allowed = `All && top_heading_level = None then begin
-        validate_first_page_heading status ast_element
-      end;
-
-      match ast_element with
-      | {value = #Ast.nestable_block_element; _} as element ->
-        let element = nestable_block_element status element in
-        let element = (element :> Comment.block_element with_location) in
-        traverse ~top_heading_level (element::comment_elements_acc) ast_elements
-
-      | {value = `Tag the_tag; location} ->
-        begin match tag ~location status the_tag with
-          | Result.Ok element ->
-            traverse ~top_heading_level (element::comment_elements_acc) ast_elements
-          | Result.Error placeholder ->
-            traverse ~top_heading_level comment_elements_acc (placeholder::ast_elements)
-        end
-
-      | {value = `Heading _ as heading; _} ->
-        let top_heading_level, element =
-          section_heading
-            status
-            ~top_heading_level
-            ast_element.Location.location
-            heading
-        in
-        traverse ~top_heading_level (element::comment_elements_acc) ast_elements
+        match ast_element with
+        | { value = #Ast.nestable_block_element; _ } as element ->
+            let element = nestable_block_element status element in
+            let element = (element :> Comment.block_element with_location) in
+            traverse ~top_heading_level
+              (element :: comment_elements_acc)
+              ast_elements
+        | { value = `Tag the_tag; location } -> (
+            match tag ~location status the_tag with
+            | Result.Ok element ->
+                traverse ~top_heading_level
+                  (element :: comment_elements_acc)
+                  ast_elements
+            | Result.Error placeholder ->
+                traverse ~top_heading_level comment_elements_acc
+                  (placeholder :: ast_elements) )
+        | { value = `Heading _ as heading; _ } ->
+            let top_heading_level, element =
+              section_heading status ~top_heading_level
+                ast_element.Location.location heading
+            in
+            traverse ~top_heading_level
+              (element :: comment_elements_acc)
+              ast_elements )
   in
   let top_heading_level =
     (* Non-page documents have a generated title. *)
     match status.parent_of_sections with
-    | `RootPage _
-    | `Page _
-    | `LeafPage _ -> None
+    | `RootPage _ | `Page _ | `LeafPage _ -> None
     | _parent_with_generated_title -> Some 0
   in
   traverse ~top_heading_level [] ast_elements
 
-
-
 let ast_to_comment warnings ~sections_allowed ~parent_of_sections ast =
-  let status =
-    {
-      warnings;
-      sections_allowed;
-      parent_of_sections;
-    }
-  in
+  let status = { warnings; sections_allowed; parent_of_sections } in
   top_level_block_elements status ast

--- a/src/parser/semantics.mli
+++ b/src/parser/semantics.mli
@@ -3,4 +3,4 @@ val ast_to_comment :
   sections_allowed:Ast.sections_allowed ->
   parent_of_sections:Odoc_model.Paths.Identifier.LabelParent.t ->
   Ast.docs ->
-    Odoc_model.Comment.docs
+  Odoc_model.Comment.docs

--- a/src/parser/syntax.ml
+++ b/src/parser/syntax.ml
@@ -17,20 +17,16 @@
      sequence of block elements, so [block_element_list] is the top-level
      parser. It is also used for list item and tag content. *)
 
-
-
 module Location = Odoc_model.Location_
 module Error = Odoc_model.Error
 module Comment = Odoc_model.Comment
 
 type 'a with_location = 'a Location.with_location
 
-
-
 (* {2 Input} *)
 
 type input = {
-  tokens : (Token.t Location.with_location) Stream.t;
+  tokens : Token.t Location.with_location Stream.t;
   warnings : Error.warning_accumulator;
 }
 
@@ -40,30 +36,28 @@ let peek input =
   match Stream.peek input.tokens with
   | Some token -> token
   | None -> assert false
-  (* The last token in the stream is always [`End], and it is never consumed by
-     the parser, so the [None] case is impossible. *)
+
+(* The last token in the stream is always [`End], and it is never consumed by
+   the parser, so the [None] case is impossible. *)
 
 let npeek n input = Stream.npeek n input.tokens
-
-
 
 (* {2 Non-link inline elements} *)
 
 (* Convenient abbreviation for use in patterns. *)
-type token_that_always_begins_an_inline_element = [
-  | `Word of string
+type token_that_always_begins_an_inline_element =
+  [ `Word of string
   | `Code_span of string
   | `Raw_markup of string option * string
   | `Begin_style of Comment.style
   | `Simple_reference of string
   | `Begin_reference_with_replacement_text of string
   | `Simple_link of string
-  | `Begin_link_with_replacement_text of string
-]
+  | `Begin_link_with_replacement_text of string ]
 
 (* Check that the token constructors above actually are all in [Token.t]. *)
 let _check_subset : token_that_always_begins_an_inline_element -> Token.t =
-  fun t -> (t :> Token.t)
+ fun t -> (t :> Token.t)
 
 (* Consumes tokens that make up a single non-link inline element:
 
@@ -85,125 +79,112 @@ let _check_subset : token_that_always_begins_an_inline_element -> Token.t =
    the first non-whitespace tokens on their line).
 
    This function consumes exactly the tokens that make up the element. *)
-let rec inline_element
-    : input -> Location.span -> _ -> Ast.inline_element with_location =
-    fun input location next_token ->
-
+let rec inline_element :
+    input -> Location.span -> _ -> Ast.inline_element with_location =
+ fun input location next_token ->
   match next_token with
   | `Space _ as token ->
-    junk input;
-    Location.at location token
-
+      junk input;
+      Location.at location token
   | `Word _ as token ->
-    junk input;
-    Location.at location token
-    (* This is actually the same memory representation as the token, complete
-       with location, and is probably the most common case. Perhaps the token
-       can be reused somehow. The same is true of [`Space], [`Code_span]. *)
-
+      junk input;
+      Location.at location token
+      (* This is actually the same memory representation as the token, complete
+         with location, and is probably the most common case. Perhaps the token
+         can be reused somehow. The same is true of [`Space], [`Code_span]. *)
   | `Minus ->
-    junk input;
-    Location.at location (`Word "-")
-
+      junk input;
+      Location.at location (`Word "-")
   | `Plus ->
-    junk input;
-    Location.at location (`Word "+")
-
+      junk input;
+      Location.at location (`Word "+")
   | `Code_span c ->
-    junk input;
-    Location.at location (`Code_span c)
-
+      junk input;
+      Location.at location (`Code_span c)
   | `Raw_markup (raw_markup_target, s) ->
-    junk input;
-    Location.at location (`Raw_markup (raw_markup_target, s))
-
+      junk input;
+      Location.at location (`Raw_markup (raw_markup_target, s))
   | `Begin_style s as parent_markup ->
-    junk input;
+      junk input;
 
-    let requires_leading_whitespace =
-      match s with
-      | `Bold | `Italic | `Emphasis -> true
-      | `Superscript | `Subscript -> false
-    in
-    let content, brace_location =
-      delimited_inline_element_list
-        ~parent_markup
-        ~parent_markup_location:location
-        ~requires_leading_whitespace
-        input
-    in
+      let requires_leading_whitespace =
+        match s with
+        | `Bold | `Italic | `Emphasis -> true
+        | `Superscript | `Subscript -> false
+      in
+      let content, brace_location =
+        delimited_inline_element_list ~parent_markup
+          ~parent_markup_location:location ~requires_leading_whitespace input
+      in
 
-    let location = Location.span [location; brace_location] in
+      let location = Location.span [ location; brace_location ] in
 
-    if content = [] then
-      Parse_error.should_not_be_empty
-        ~what:(Token.describe parent_markup) location
-      |> Error.warning input.warnings;
+      if content = [] then
+        Parse_error.should_not_be_empty
+          ~what:(Token.describe parent_markup)
+          location
+        |> Error.warning input.warnings;
 
-    Location.at location (`Styled (s, content))
-
+      Location.at location (`Styled (s, content))
   | `Simple_reference r ->
-    junk input;
+      junk input;
 
-    let r_location = Location.nudge_start (String.length "{!") location in
-    let r = Location.at r_location r in
+      let r_location = Location.nudge_start (String.length "{!") location in
+      let r = Location.at r_location r in
 
-    Location.at location (`Reference (`Simple, r, []))
-
+      Location.at location (`Reference (`Simple, r, []))
   | `Begin_reference_with_replacement_text r as parent_markup ->
-    junk input;
+      junk input;
 
-    let r_location = Location.nudge_start (String.length "{{!") location in
-    let r = Location.at r_location r in
+      let r_location = Location.nudge_start (String.length "{{!") location in
+      let r = Location.at r_location r in
 
-    let content, brace_location =
-      delimited_inline_element_list
-        ~parent_markup
-        ~parent_markup_location:location
-        ~requires_leading_whitespace:false
-        input
-    in
+      let content, brace_location =
+        delimited_inline_element_list ~parent_markup
+          ~parent_markup_location:location ~requires_leading_whitespace:false
+          input
+      in
 
-    let location = Location.span [location; brace_location] in
+      let location = Location.span [ location; brace_location ] in
 
-    if content = [] then
-      Parse_error.should_not_be_empty
-        ~what:(Token.describe parent_markup) location
-      |> Error.warning input.warnings;
+      if content = [] then
+        Parse_error.should_not_be_empty
+          ~what:(Token.describe parent_markup)
+          location
+        |> Error.warning input.warnings;
 
-    Location.at location (`Reference (`With_text, r, content))
-
+      Location.at location (`Reference (`With_text, r, content))
   | `Simple_link u ->
-    junk input;
+      junk input;
 
-    let u = String.trim u in
+      let u = String.trim u in
 
-    if u = "" then
-      Parse_error.should_not_be_empty ~what:(Token.describe next_token) location
-      |> Error.warning input.warnings;
+      if u = "" then
+        Parse_error.should_not_be_empty
+          ~what:(Token.describe next_token)
+          location
+        |> Error.warning input.warnings;
 
-    Location.at location (`Link (u, []))
-
+      Location.at location (`Link (u, []))
   | `Begin_link_with_replacement_text u as parent_markup ->
-    junk input;
+      junk input;
 
-    let u = String.trim u in
+      let u = String.trim u in
 
-    if u = "" then
-      Parse_error.should_not_be_empty
-        ~what:(Token.describe parent_markup) location
-      |> Error.warning input.warnings;
+      if u = "" then
+        Parse_error.should_not_be_empty
+          ~what:(Token.describe parent_markup)
+          location
+        |> Error.warning input.warnings;
 
-    let content, brace_location =
-      delimited_inline_element_list
-        ~parent_markup
-        ~parent_markup_location:location
-        ~requires_leading_whitespace:false
-        input
-    in
+      let content, brace_location =
+        delimited_inline_element_list ~parent_markup
+          ~parent_markup_location:location ~requires_leading_whitespace:false
+          input
+      in
 
-    `Link (u, content)
-    |> Location.at (Location.span [location; brace_location])
+      `Link (u, content)
+      |> Location.at (Location.span [ location; brace_location ])
 
 (* Consumes tokens that make up a sequence of inline elements that is ended by
    a '}', a [`Right_brace] token. The brace token is also consumed.
@@ -227,32 +208,26 @@ let rec inline_element
 
    The [~parent_markup] and [~parent_markup_location] arguments are used for
    generating error messages. *)
-and delimited_inline_element_list
-    : parent_markup:[< Token.t ] ->
-      parent_markup_location:Location.span ->
-      requires_leading_whitespace:bool ->
-      input ->
-        (Ast.inline_element with_location) list * Location.span =
-    fun
-      ~parent_markup
-      ~parent_markup_location
-      ~requires_leading_whitespace
-      input ->
-
+and delimited_inline_element_list :
+    parent_markup:[< Token.t ] ->
+    parent_markup_location:Location.span ->
+    requires_leading_whitespace:bool ->
+    input ->
+    Ast.inline_element with_location list * Location.span =
+ fun ~parent_markup ~parent_markup_location ~requires_leading_whitespace input ->
   (* [~at_start_of_line] is used to interpret [`Minus] and [`Plus]. These are
      word tokens if not the first non-whitespace tokens on their line. Then,
      they are allowed in a non-link element list. *)
-  let rec consume_elements
-      : at_start_of_line:bool -> (Ast.inline_element with_location) list ->
-          (Ast.inline_element with_location) list * Location.span =
-      fun ~at_start_of_line acc ->
-
+  let rec consume_elements :
+      at_start_of_line:bool ->
+      Ast.inline_element with_location list ->
+      Ast.inline_element with_location list * Location.span =
+   fun ~at_start_of_line acc ->
     let next_token = peek input in
     match next_token.value with
     | `Right_brace ->
-      junk input;
-      List.rev acc, next_token.location
-
+        junk input;
+        (List.rev acc, next_token.location)
     (* The [`Space] token is not space at the beginning or end of line, because
        that is combined into [`Single_newline] or [`Blank_line] tokens. It is
        also not at the beginning of markup (after e.g. '{b'), because that is
@@ -261,103 +236,85 @@ and delimited_inline_element_list
        because that is combined into the [`Right_brace] token by the lexer. So,
        it is an internal space, and we want to add it to the non-link inline
        element list. *)
-    | `Space _
-    | #token_that_always_begins_an_inline_element as token ->
-      let acc = (inline_element input next_token.location token)::acc in
-      consume_elements ~at_start_of_line:false acc
-
+    | (`Space _ | #token_that_always_begins_an_inline_element) as token ->
+        let acc = inline_element input next_token.location token :: acc in
+        consume_elements ~at_start_of_line:false acc
     | `Single_newline ws ->
-      junk input;
-      let element = Location.same next_token (`Space ws) in
-      consume_elements ~at_start_of_line:true (element::acc)
-
+        junk input;
+        let element = Location.same next_token (`Space ws) in
+        consume_elements ~at_start_of_line:true (element :: acc)
     | `Blank_line ws as blank ->
-      Parse_error.not_allowed
-        ~what:(Token.describe blank)
-        ~in_what:(Token.describe parent_markup)
-        next_token.location
-      |> Error.warning input.warnings;
-
-      junk input;
-      let element = Location.same next_token (`Space ws) in
-      consume_elements ~at_start_of_line:true (element::acc)
-
-    | `Minus
-    | `Plus as bullet ->
-      if at_start_of_line then begin
-        let suggestion =
-          Printf.sprintf
-            "move %s so it isn't the first thing on the line."
-            (Token.print bullet)
-        in
-        Parse_error.not_allowed
-          ~what:(Token.describe bullet)
+        Parse_error.not_allowed ~what:(Token.describe blank)
           ~in_what:(Token.describe parent_markup)
-          ~suggestion
           next_token.location
-        |> Error.warning input.warnings
-      end;
+        |> Error.warning input.warnings;
 
-      let acc = (inline_element input next_token.location bullet)::acc in
-      consume_elements ~at_start_of_line:false acc
+        junk input;
+        let element = Location.same next_token (`Space ws) in
+        consume_elements ~at_start_of_line:true (element :: acc)
+    | (`Minus | `Plus) as bullet ->
+        ( if at_start_of_line then
+          let suggestion =
+            Printf.sprintf "move %s so it isn't the first thing on the line."
+              (Token.print bullet)
+          in
+          Parse_error.not_allowed ~what:(Token.describe bullet)
+            ~in_what:(Token.describe parent_markup)
+            ~suggestion next_token.location
+          |> Error.warning input.warnings );
 
+        let acc = inline_element input next_token.location bullet :: acc in
+        consume_elements ~at_start_of_line:false acc
     | other_token ->
-      Parse_error.not_allowed
-        ~what:(Token.describe other_token)
-        ~in_what:(Token.describe parent_markup)
-        next_token.location
-      |> Error.warning input.warnings;
+        Parse_error.not_allowed
+          ~what:(Token.describe other_token)
+          ~in_what:(Token.describe parent_markup)
+          next_token.location
+        |> Error.warning input.warnings;
 
-      let last_location =
-        match acc with
-        | last_token::_ -> last_token.location
-        | [] -> parent_markup_location
-      in
+        let last_location =
+          match acc with
+          | last_token :: _ -> last_token.location
+          | [] -> parent_markup_location
+        in
 
-      List.rev acc, last_location
+        (List.rev acc, last_location)
   in
 
   let first_token = peek input in
   match first_token.value with
   | `Space _ ->
-    junk input;
-    consume_elements ~at_start_of_line:false []
-    (* [~at_start_of_line] is [false] here because the preceding token was some
-       some markup like '{b', and we didn't move to the next line, so the next
-       token will not be the first non-whitespace token on its line. *)
-
+      junk input;
+      consume_elements ~at_start_of_line:false []
+      (* [~at_start_of_line] is [false] here because the preceding token was some
+         some markup like '{b', and we didn't move to the next line, so the next
+         token will not be the first non-whitespace token on its line. *)
   | `Single_newline _ ->
-    junk input;
-    consume_elements ~at_start_of_line:true []
-
+      junk input;
+      consume_elements ~at_start_of_line:true []
   | `Blank_line _ as blank ->
-    (* In case the markup is immediately followed by a blank line, the error
-       message printed by the catch-all case below can be confusing, as it will
-       suggest that the markup must be followed by a newline (which it is). It
-       just must not be followed by two newlines. To explain that clearly,
-       handle that case specifically. *)
-    Parse_error.not_allowed
-      ~what:(Token.describe blank)
-      ~in_what:(Token.describe parent_markup)
-      first_token.location
-    |> Error.warning input.warnings;
+      (* In case the markup is immediately followed by a blank line, the error
+         message printed by the catch-all case below can be confusing, as it will
+         suggest that the markup must be followed by a newline (which it is). It
+         just must not be followed by two newlines. To explain that clearly,
+         handle that case specifically. *)
+      Parse_error.not_allowed ~what:(Token.describe blank)
+        ~in_what:(Token.describe parent_markup)
+        first_token.location
+      |> Error.warning input.warnings;
 
-    junk input;
-    consume_elements ~at_start_of_line:true []
-
+      junk input;
+      consume_elements ~at_start_of_line:true []
   | `Right_brace ->
-    junk input;
-    [], first_token.location
-
+      junk input;
+      ([], first_token.location)
   | _ ->
-    if requires_leading_whitespace then begin
-      Parse_error.should_be_followed_by_whitespace
-        ~what:(Token.print parent_markup) parent_markup_location
-      |> Error.warning input.warnings
-    end;
-    consume_elements ~at_start_of_line:false []
-
-
+      if requires_leading_whitespace then
+        Parse_error.should_be_followed_by_whitespace
+          ~what:(Token.print parent_markup)
+          parent_markup_location
+        |> Error.warning input.warnings;
+      consume_elements ~at_start_of_line:false []
 
 (* {2 Paragraphs} *)
 
@@ -373,55 +330,44 @@ and delimited_inline_element_list
    line. If that line also begins with an inline element, it parses that line,
    and so on. *)
 let paragraph : input -> Ast.nestable_block_element with_location =
-    fun input ->
-
+ fun input ->
   (* Parses a single line of a paragraph, consisting of inline elements. The
      only valid ways to end a paragraph line are with [`End], [`Single_newline],
      [`Blank_line], and [`Right_brace]. Everything else either belongs in the
      paragraph, or signifies an attempt to begin a block element inside a
      paragraph line, which is an error. These errors are caught elsewhere; the
      paragraph parser just stops. *)
-  let rec paragraph_line
-      : (Ast.inline_element with_location) list ->
-          (Ast.inline_element with_location) list =
-      fun acc ->
-
+  let rec paragraph_line :
+      Ast.inline_element with_location list ->
+      Ast.inline_element with_location list =
+   fun acc ->
     let next_token = peek input in
     match next_token.value with
-    | `Space _
-    | `Minus
-    | `Plus
-    | #token_that_always_begins_an_inline_element as token ->
-      let element = inline_element input next_token.location token in
-      paragraph_line (element::acc)
-
-    | _ ->
-      acc
+    | (`Space _ | `Minus | `Plus | #token_that_always_begins_an_inline_element)
+      as token ->
+        let element = inline_element input next_token.location token in
+        paragraph_line (element :: acc)
+    | _ -> acc
   in
 
   (* After each line is parsed, decides whether to parse more lines. *)
-  let rec additional_lines
-      : (Ast.inline_element with_location) list ->
-          (Ast.inline_element with_location) list =
-      fun acc ->
-
+  let rec additional_lines :
+      Ast.inline_element with_location list ->
+      Ast.inline_element with_location list =
+   fun acc ->
     match npeek 2 input with
-    | {value = `Single_newline ws; location}::
-      {value = #token_that_always_begins_an_inline_element; _}::_ ->
-      junk input;
-      let acc = (Location.at location (`Space ws))::acc in
-      let acc = paragraph_line acc in
-      additional_lines acc
-
-    | _ ->
-      List.rev acc
+    | { value = `Single_newline ws; location }
+      :: { value = #token_that_always_begins_an_inline_element; _ } :: _ ->
+        junk input;
+        let acc = Location.at location (`Space ws) :: acc in
+        let acc = paragraph_line acc in
+        additional_lines acc
+    | _ -> List.rev acc
   in
 
   let elements = paragraph_line [] |> additional_lines in
   `Paragraph elements
   |> Location.at (Location.span (List.map Location.location elements))
-
-
 
 (* {2 Block elements} *)
 
@@ -456,13 +402,12 @@ let paragraph : input -> Ast.nestable_block_element with_location =
   For example, the [paragraph] parser always stops on the same line as the last
   significant token that is in the paragraph it consumed, so the location must
   be [`After_text]. *)
-type where_in_line = [
-  | `At_start_of_line
+type where_in_line =
+  [ `At_start_of_line
   | `After_tag
   | `After_shorthand_bullet
   | `After_explicit_list_bullet
-  | `After_text
-]
+  | `After_text ]
 
 (* The block parsing loop, function [block_element_list], stops when it
    encounters certain tokens.
@@ -483,23 +428,20 @@ type where_in_line = [
    [implicit_stop stream_head]. This allows the calling parsers to write precise
    cases for exactly the tokens that might be at the front of the stream after
    the block parser returns. *)
-type stops_at_delimiters = [
-  | `End
-  | `Right_brace
-]
+type stops_at_delimiters = [ `End | `Right_brace ]
 
-type stopped_implicitly = [
-  | `End
+type stopped_implicitly =
+  [ `End
   | `Blank_line of string
   | `Right_brace
   | `Minus
   | `Plus
   | Token.section_heading
-  | Token.tag
-]
+  | Token.tag ]
 
 (* Ensure that the above two types are really subsets of [Token.t]. *)
 let _check_subset : stops_at_delimiters -> Token.t = fun t -> (t :> Token.t)
+
 let _check_subset : stopped_implicitly -> Token.t = fun t -> (t :> Token.t)
 
 (* The different contexts in which the block parser [block_element_list] can be
@@ -516,23 +458,19 @@ let _check_subset : stopped_implicitly -> Token.t = fun t -> (t :> Token.t)
      [block_element] are only allowed at the comment top level.
    - The type of token that the block parser stops at. See discussion above. *)
 type ('block, 'stops_at_which_tokens) context =
-  | Top_level :
-      (Ast.block_element, stops_at_delimiters) context
-  | In_shorthand_list :
-      (Ast.nestable_block_element, stopped_implicitly) context
-  | In_explicit_list :
-      (Ast.nestable_block_element, stops_at_delimiters) context
-  | In_tag :
-      (Ast.nestable_block_element, Token.t) context
+  | Top_level : (Ast.block_element, stops_at_delimiters) context
+  | In_shorthand_list : (Ast.nestable_block_element, stopped_implicitly) context
+  | In_explicit_list : (Ast.nestable_block_element, stops_at_delimiters) context
+  | In_tag : (Ast.nestable_block_element, Token.t) context
 
 (* This is a no-op. It is needed to prove to the type system that nestable block
    elements are acceptable block elements in all contexts. *)
-let accepted_in_all_contexts
-    : type block stops_at_which_tokens.
-      (block, stops_at_which_tokens) context ->
-      Ast.nestable_block_element ->
-        block =
-    fun context block ->
+let accepted_in_all_contexts :
+    type block stops_at_which_tokens.
+    (block, stops_at_which_tokens) context ->
+    Ast.nestable_block_element ->
+    block =
+ fun context block ->
   match context with
   | Top_level -> (block :> Ast.block_element)
   | In_shorthand_list -> block
@@ -542,21 +480,21 @@ let accepted_in_all_contexts
 (* Converts a tag to a series of words. This is used in error recovery, when a
    tag cannot be generated. *)
 let tag_to_words = function
-  | `Author s -> [`Word "@author"; `Space " "; `Word s]
-  | `Before s -> [`Word "@before"; `Space " "; `Word s]
-  | `Canonical s -> [`Word "@canonical"; `Space " "; `Word s]
-  | `Deprecated -> [`Word "@deprecated"]
-  | `Inline -> [`Word "@inline"]
-  | `Open -> [`Word "@open"]
-  | `Closed -> [`Word "@closed"]
-  | `Param s -> [`Word "@param"; `Space " "; `Word s]
-  | `Raise s -> [`Word "@raise"; `Space " "; `Word s]
-  | `Return -> [`Word "@return"]
-  | `See (`Document, s) -> [`Word "@see"; `Space " "; `Word ("\"" ^ s ^ "\"")]
-  | `See (`File, s) -> [`Word "@see"; `Space " "; `Word ("'" ^ s ^ "'")]
-  | `See (`Url, s) -> [`Word "@see"; `Space " "; `Word ("<" ^ s ^ ">")]
-  | `Since s -> [`Word "@since"; `Space " "; `Word s]
-  | `Version s -> [`Word "@version"; `Space " "; `Word s]
+  | `Author s -> [ `Word "@author"; `Space " "; `Word s ]
+  | `Before s -> [ `Word "@before"; `Space " "; `Word s ]
+  | `Canonical s -> [ `Word "@canonical"; `Space " "; `Word s ]
+  | `Deprecated -> [ `Word "@deprecated" ]
+  | `Inline -> [ `Word "@inline" ]
+  | `Open -> [ `Word "@open" ]
+  | `Closed -> [ `Word "@closed" ]
+  | `Param s -> [ `Word "@param"; `Space " "; `Word s ]
+  | `Raise s -> [ `Word "@raise"; `Space " "; `Word s ]
+  | `Return -> [ `Word "@return" ]
+  | `See (`Document, s) -> [ `Word "@see"; `Space " "; `Word ("\"" ^ s ^ "\"") ]
+  | `See (`File, s) -> [ `Word "@see"; `Space " "; `Word ("'" ^ s ^ "'") ]
+  | `See (`Url, s) -> [ `Word "@see"; `Space " "; `Word ("<" ^ s ^ ">") ]
+  | `Since s -> [ `Word "@since"; `Space " "; `Word s ]
+  | `Version s -> [ `Word "@version"; `Space " "; `Word s ]
 
 (* {3 Block element lists} *)
 
@@ -567,457 +505,394 @@ let tag_to_words = function
    - verbatim text blocks,
    - lists, and
    - section headings. *)
-let rec block_element_list
-    : type block stops_at_which_tokens.
-      (block, stops_at_which_tokens) context ->
-      parent_markup:[< Token.t | `Comment ] ->
-      input ->
-        (block with_location) list *
-        stops_at_which_tokens with_location *
-        where_in_line =
-    fun context ~parent_markup input ->
-
-  let rec consume_block_elements
-      : parsed_a_tag:bool ->
-        where_in_line ->
-        (block with_location) list ->
-          (block with_location) list *
-          stops_at_which_tokens with_location *
-          where_in_line =
-      fun ~parsed_a_tag where_in_line acc ->
-
+let rec block_element_list :
+    type block stops_at_which_tokens.
+    (block, stops_at_which_tokens) context ->
+    parent_markup:[< Token.t | `Comment ] ->
+    input ->
+    block with_location list
+    * stops_at_which_tokens with_location
+    * where_in_line =
+ fun context ~parent_markup input ->
+  let rec consume_block_elements :
+      parsed_a_tag:bool ->
+      where_in_line ->
+      block with_location list ->
+      block with_location list
+      * stops_at_which_tokens with_location
+      * where_in_line =
+   fun ~parsed_a_tag where_in_line acc ->
     let describe token =
       match token with
       | #token_that_always_begins_an_inline_element -> "paragraph"
       | _ -> Token.describe token
     in
 
-    let warn_if_after_text {Location.location; value = token} =
+    let warn_if_after_text { Location.location; value = token } =
       if where_in_line = `After_text then
         Parse_error.should_begin_on_its_own_line ~what:(describe token) location
         |> Error.warning input.warnings
     in
 
-    let warn_if_after_tags {Location.location; value = token} =
+    let warn_if_after_tags { Location.location; value = token } =
       if parsed_a_tag then
         let suggestion =
-          Printf.sprintf
-            "move %s before any tags." (Token.describe token)
+          Printf.sprintf "move %s before any tags." (Token.describe token)
         in
-        Parse_error.not_allowed
-          ~what:(describe token)
-          ~in_what:"the tags section"
-          ~suggestion
-          location
+        Parse_error.not_allowed ~what:(describe token)
+          ~in_what:"the tags section" ~suggestion location
         |> Error.warning input.warnings
     in
 
-    let warn_because_not_at_top_level {Location.location; value = token} =
+    let warn_because_not_at_top_level { Location.location; value = token } =
       let suggestion =
-        Printf.sprintf
-          "move %s outside of any other markup." (Token.print token)
+        Printf.sprintf "move %s outside of any other markup."
+          (Token.print token)
       in
-      Parse_error.not_allowed
-        ~what:(Token.describe token)
+      Parse_error.not_allowed ~what:(Token.describe token)
         ~in_what:(Token.describe parent_markup)
-        ~suggestion
-        location
+        ~suggestion location
       |> Error.warning input.warnings
     in
 
-
-
     match peek input with
     (* Terminators: the two tokens that terminate anything. *)
-    | {value = `End; _}
-    | {value = `Right_brace; _} as next_token ->
-      (* This little absurdity is needed to satisfy the type system. Without it,
-         OCaml is unable to prove that [stream_head] has the right type for all
-         possible values of [context]. *)
-      begin match context with
-      | Top_level ->
-        List.rev acc, next_token, where_in_line
-      | In_shorthand_list ->
-        List.rev acc, next_token, where_in_line
-      | In_explicit_list ->
-        List.rev acc, next_token, where_in_line
-      | In_tag ->
-        List.rev acc, next_token, where_in_line
-      end
-
-
-
+    | ({ value = `End; _ } | { value = `Right_brace; _ }) as next_token -> (
+        (* This little absurdity is needed to satisfy the type system. Without it,
+           OCaml is unable to prove that [stream_head] has the right type for all
+           possible values of [context]. *)
+        match context with
+        | Top_level -> (List.rev acc, next_token, where_in_line)
+        | In_shorthand_list -> (List.rev acc, next_token, where_in_line)
+        | In_explicit_list -> (List.rev acc, next_token, where_in_line)
+        | In_tag -> (List.rev acc, next_token, where_in_line) )
     (* Whitespace. This can terminate some kinds of block elements. It is also
        necessary to track it to interpret [`Minus] and [`Plus] correctly, as
        well as to ensure that all block elements begin on their own line. *)
-    | {value = `Space _; _} ->
-      junk input;
-      consume_block_elements ~parsed_a_tag where_in_line acc
-
-    | {value = `Single_newline _; _} ->
-      junk input;
-      consume_block_elements ~parsed_a_tag `At_start_of_line acc
-
-    | {value = `Blank_line _; _} as next_token ->
-      begin match context with
-      (* Blank lines terminate shorthand lists ([- foo]). They also terminate
-         paragraphs, but the paragraph parser is aware of that internally. *)
-      | In_shorthand_list ->
-        List.rev acc, next_token, where_in_line
-      (* Otherwise, blank lines are pretty much like single newlines. *)
-      | _ ->
+    | { value = `Space _; _ } ->
+        junk input;
+        consume_block_elements ~parsed_a_tag where_in_line acc
+    | { value = `Single_newline _; _ } ->
         junk input;
         consume_block_elements ~parsed_a_tag `At_start_of_line acc
-      end
-
-
-
+    | { value = `Blank_line _; _ } as next_token -> (
+        match context with
+        (* Blank lines terminate shorthand lists ([- foo]). They also terminate
+           paragraphs, but the paragraph parser is aware of that internally. *)
+        | In_shorthand_list -> (List.rev acc, next_token, where_in_line)
+        (* Otherwise, blank lines are pretty much like single newlines. *)
+        | _ ->
+            junk input;
+            consume_block_elements ~parsed_a_tag `At_start_of_line acc )
     (* Explicit list items ([{li ...}] and [{- ...}]) can never appear directly
        in block content. They can only appear inside [{ul ...}] and [{ol ...}].
        So, catch those. *)
-    | {value = `Begin_list_item _ as token; location} ->
-      let suggestion =
-        Printf.sprintf
-          "move %s into %s, or use %s."
-          (Token.print token)
-          (Token.describe (`Begin_list `Unordered))
-          (Token.describe (`Minus))
-      in
-      Parse_error.not_allowed
-        ~what:(Token.describe token)
-        ~in_what:(Token.describe parent_markup)
-        ~suggestion
-        location
-      |> Error.warning input.warnings;
+    | { value = `Begin_list_item _ as token; location } ->
+        let suggestion =
+          Printf.sprintf "move %s into %s, or use %s." (Token.print token)
+            (Token.describe (`Begin_list `Unordered))
+            (Token.describe `Minus)
+        in
+        Parse_error.not_allowed ~what:(Token.describe token)
+          ~in_what:(Token.describe parent_markup)
+          ~suggestion location
+        |> Error.warning input.warnings;
 
-      junk input;
-      consume_block_elements ~parsed_a_tag where_in_line acc
-
-
-
+        junk input;
+        consume_block_elements ~parsed_a_tag where_in_line acc
     (* Tags. These can appear at the top level only. Also, once one tag is seen,
        the only top-level elements allowed are more tags. *)
-    | {value = `Tag tag as token; location} as next_token ->
-      let recover_when_not_at_top_level context =
-        warn_because_not_at_top_level next_token;
-        junk input;
-        let words = List.map (Location.at location) (tag_to_words tag) in
-        let paragraph =
-          `Paragraph words
-          |> accepted_in_all_contexts context
-          |> Location.at location
+    | { value = `Tag tag as token; location } as next_token -> (
+        let recover_when_not_at_top_level context =
+          warn_because_not_at_top_level next_token;
+          junk input;
+          let words = List.map (Location.at location) (tag_to_words tag) in
+          let paragraph =
+            `Paragraph words
+            |> accepted_in_all_contexts context
+            |> Location.at location
+          in
+          consume_block_elements ~parsed_a_tag `At_start_of_line
+            (paragraph :: acc)
         in
-        consume_block_elements ~parsed_a_tag `At_start_of_line (paragraph::acc)
-      in
 
-      begin match context with
-      (* Tags cannot make sense in an explicit list ([{ul {li ...}}]). *)
-      | In_explicit_list ->
-        recover_when_not_at_top_level context
-      (* If a tag starts at the beginning of a line, it terminates the preceding
-         tag and/or the current shorthand list. In this case, return to the
-         caller, and let the caller decide how to interpret the tag token. *)
-      | In_shorthand_list ->
-        if where_in_line = `At_start_of_line then
-          List.rev acc, next_token, where_in_line
-        else
-          recover_when_not_at_top_level context
-      | In_tag ->
-        if where_in_line = `At_start_of_line then
-          List.rev acc, next_token, where_in_line
-        else
-          recover_when_not_at_top_level context
+        match context with
+        (* Tags cannot make sense in an explicit list ([{ul {li ...}}]). *)
+        | In_explicit_list -> recover_when_not_at_top_level context
+        (* If a tag starts at the beginning of a line, it terminates the preceding
+           tag and/or the current shorthand list. In this case, return to the
+           caller, and let the caller decide how to interpret the tag token. *)
+        | In_shorthand_list ->
+            if where_in_line = `At_start_of_line then
+              (List.rev acc, next_token, where_in_line)
+            else recover_when_not_at_top_level context
+        | In_tag ->
+            if where_in_line = `At_start_of_line then
+              (List.rev acc, next_token, where_in_line)
+            else recover_when_not_at_top_level context
+        (* If this is the top-level call to [block_element_list], parse the
+           tag. *)
+        | Top_level -> (
+            if where_in_line <> `At_start_of_line then
+              Parse_error.should_begin_on_its_own_line
+                ~what:(Token.describe token) location
+              |> Error.warning input.warnings;
 
-      (* If this is the top-level call to [block_element_list], parse the
-         tag. *)
-      | Top_level ->
-        if where_in_line <> `At_start_of_line then
-          Parse_error.should_begin_on_its_own_line
-            ~what:(Token.describe token) location
-          |> Error.warning input.warnings;
+            junk input;
 
-        junk input;
-
-        begin match tag with
-        | `Author s | `Since s | `Version s | `Canonical s as tag ->
-          let s = String.trim s in
-          if s = "" then
-            Parse_error.should_not_be_empty
-              ~what:(Token.describe token) location
-            |> Error.warning input.warnings;
-          let tag =
             match tag with
-            | `Author _ -> `Author s
-            | `Since _ -> `Since s
-            | `Version _ -> `Version s
-            | `Canonical _ ->
-              (* TODO The location is only approximate, as we need lexer
-                 cooperation to get the real location. *)
-              let r_location =
-                Location.nudge_start (String.length "@canonical ") location in
-              `Canonical (Location.at r_location s)
-          in
+            | (`Author s | `Since s | `Version s | `Canonical s) as tag ->
+                let s = String.trim s in
+                if s = "" then
+                  Parse_error.should_not_be_empty ~what:(Token.describe token)
+                    location
+                  |> Error.warning input.warnings;
+                let tag =
+                  match tag with
+                  | `Author _ -> `Author s
+                  | `Since _ -> `Since s
+                  | `Version _ -> `Version s
+                  | `Canonical _ ->
+                      (* TODO The location is only approximate, as we need lexer
+                         cooperation to get the real location. *)
+                      let r_location =
+                        Location.nudge_start
+                          (String.length "@canonical ")
+                          location
+                      in
+                      `Canonical (Location.at r_location s)
+                in
 
-          let tag = Location.at location (`Tag tag) in
-          consume_block_elements ~parsed_a_tag:true `After_text (tag::acc)
+                let tag = Location.at location (`Tag tag) in
+                consume_block_elements ~parsed_a_tag:true `After_text
+                  (tag :: acc)
+            | (`Deprecated | `Return) as tag ->
+                let content, _stream_head, where_in_line =
+                  block_element_list In_tag ~parent_markup:token input
+                in
+                let tag =
+                  match tag with
+                  | `Deprecated -> `Deprecated content
+                  | `Return -> `Return content
+                in
+                let location =
+                  location :: List.map Location.location content
+                  |> Location.span
+                in
+                let tag = Location.at location (`Tag tag) in
+                consume_block_elements ~parsed_a_tag:true where_in_line
+                  (tag :: acc)
+            | (`Param _ | `Raise _ | `Before _) as tag ->
+                let content, _stream_head, where_in_line =
+                  block_element_list In_tag ~parent_markup:token input
+                in
+                let tag =
+                  match tag with
+                  | `Param s -> `Param (s, content)
+                  | `Raise s -> `Raise (s, content)
+                  | `Before s -> `Before (s, content)
+                in
+                let location =
+                  location :: List.map Location.location content
+                  |> Location.span
+                in
+                let tag = Location.at location (`Tag tag) in
+                consume_block_elements ~parsed_a_tag:true where_in_line
+                  (tag :: acc)
+            | `See (kind, target) ->
+                let content, _next_token, where_in_line =
+                  block_element_list In_tag ~parent_markup:token input
+                in
+                let location =
+                  location :: List.map Location.location content
+                  |> Location.span
+                in
+                let tag = `Tag (`See (kind, target, content)) in
+                let tag = Location.at location tag in
+                consume_block_elements ~parsed_a_tag:true where_in_line
+                  (tag :: acc)
+            | (`Inline | `Open | `Closed) as tag ->
+                let tag = Location.at location (`Tag tag) in
+                consume_block_elements ~parsed_a_tag:true `After_text
+                  (tag :: acc) ) )
+    | { value = #token_that_always_begins_an_inline_element; _ } as next_token
+      ->
+        warn_if_after_tags next_token;
+        warn_if_after_text next_token;
 
-        | `Deprecated | `Return as tag ->
-          let content, _stream_head, where_in_line =
-            block_element_list In_tag ~parent_markup:token input in
-          let tag =
-            match tag with
-            | `Deprecated -> `Deprecated content
-            | `Return -> `Return content
-          in
-          let location =
-            location::(List.map Location.location content)
-            |> Location.span
-          in
-          let tag = Location.at location (`Tag tag) in
-          consume_block_elements ~parsed_a_tag:true where_in_line (tag::acc)
-
-        | `Param _ | `Raise _ | `Before _ as tag ->
-          let content, _stream_head, where_in_line =
-            block_element_list In_tag ~parent_markup:token input in
-          let tag =
-            match tag with
-            | `Param s -> `Param (s, content)
-            | `Raise s -> `Raise (s, content)
-            | `Before s -> `Before (s, content)
-          in
-          let location =
-            location::(List.map Location.location content)
-            |> Location.span
-          in
-          let tag = Location.at location (`Tag tag) in
-          consume_block_elements ~parsed_a_tag:true where_in_line (tag::acc)
-
-        | `See (kind, target) ->
-          let content, _next_token, where_in_line =
-            block_element_list In_tag ~parent_markup:token input in
-          let location =
-            location::(List.map Location.location content)
-            |> Location.span
-          in
-          let tag = `Tag (`See (kind, target, content)) in
-          let tag = Location.at location tag in
-          consume_block_elements ~parsed_a_tag:true where_in_line (tag::acc)
-
-        | `Inline | `Open | `Closed as tag ->
-          let tag = Location.at location (`Tag tag) in
-          consume_block_elements ~parsed_a_tag:true `After_text (tag::acc)
-        end
-      end
-
-
-
-    | {value = #token_that_always_begins_an_inline_element; _} as next_token ->
-      warn_if_after_tags next_token;
-      warn_if_after_text next_token;
-
-      let block = paragraph input in
-      let block =
-        Odoc_model.Location_.map (accepted_in_all_contexts context) block in
-      let acc = block::acc in
-      consume_block_elements ~parsed_a_tag `After_text acc
-
-    | {value = `Code_block s | `Verbatim s as token; location} as next_token ->
-      warn_if_after_tags next_token;
-      warn_if_after_text next_token;
-      if s = "" then
-        Parse_error.should_not_be_empty ~what:(Token.describe token) location
-        |> Error.warning input.warnings;
-
-      junk input;
-      let block =
-        match token with
-        | `Code_block _ -> `Code_block s
-        | `Verbatim _ -> `Verbatim s
-      in
-      let block = accepted_in_all_contexts context block in
-      let block = Location.at location block in
-      let acc = block::acc in
-      consume_block_elements ~parsed_a_tag `After_text acc
-
-    | {value = `Modules s as token; location} as next_token ->
-      warn_if_after_tags next_token;
-      warn_if_after_text next_token;
-
-      junk input;
-
-      (* TODO Use some library for a splitting function, or move this out into a
-         Util module. *)
-      let split_string delimiters s =
-        let rec scan_delimiters acc index =
-          if index >= String.length s then
-            List.rev acc
-          else
-            if String.contains delimiters s.[index] then
-              scan_delimiters acc (index + 1)
-            else
-              scan_word acc index (index + 1)
-
-        and scan_word acc start_index index =
-          if index >= String.length s then
-            let word = String.sub s start_index (index - start_index) in
-            List.rev (word::acc)
-          else
-            if String.contains delimiters s.[index] then
-              let word = String.sub s start_index (index - start_index) in
-              scan_delimiters (word::acc) (index + 1)
-            else
-              scan_word acc start_index (index + 1)
-
+        let block = paragraph input in
+        let block =
+          Odoc_model.Location_.map (accepted_in_all_contexts context) block
         in
-
-        scan_delimiters [] 0
-      in
-
-      (* TODO Correct locations await a full implementation of {!modules}
-         parsing. *)
-      let modules =
-        split_string " \t\r\n" s
-        |> List.map (fun r -> Location.at location r)
-      in
-
-      if modules = [] then
-        Parse_error.should_not_be_empty ~what:(Token.describe token) location
-        |> Error.warning input.warnings;
-
-      let block = accepted_in_all_contexts context (`Modules modules) in
-      let block = Location.at location block in
-      let acc = block::acc in
-      consume_block_elements ~parsed_a_tag `After_text acc
-
-
-
-    | {value = `Begin_list kind as token; location} as next_token ->
-      warn_if_after_tags next_token;
-      warn_if_after_text next_token;
-
-      junk input;
-
-      let items, brace_location =
-        explicit_list_items ~parent_markup:token input in
-      if items = [] then
-        Parse_error.should_not_be_empty ~what:(Token.describe token) location
-        |> Error.warning input.warnings;
-
-      let location = Location.span [location; brace_location] in
-      let block = `List (kind, `Heavy, items) in
-      let block = accepted_in_all_contexts context block in
-      let block = Location.at location block in
-      let acc = block::acc in
-      consume_block_elements ~parsed_a_tag `After_text acc
-
-
-
-    | {value = `Minus | `Plus as token; location} as next_token ->
-      begin match where_in_line with
-      | `After_text | `After_shorthand_bullet ->
-        Parse_error.should_begin_on_its_own_line
-          ~what:(Token.describe token) location
-        |> Error.warning input.warnings
-      | _ ->
-        ()
-      end;
-
-      warn_if_after_tags next_token;
-
-      begin match context with
-      | In_shorthand_list ->
-        List.rev acc, next_token, where_in_line
-      | _ ->
-        let items, where_in_line =
-          shorthand_list_items next_token where_in_line input in
-        let kind =
-          match token with
-          | `Minus -> `Unordered
-          | `Plus -> `Ordered
-        in
-        let location =
-          location::(List.map Location.location (List.flatten items))
-          |> Location.span
-        in
-        let block = `List (kind, `Light, items) in
-        let block = accepted_in_all_contexts context block in
-        let block = Location.at location block in
-        let acc = block::acc in
-        consume_block_elements ~parsed_a_tag where_in_line acc
-      end
-
-
-
-    | {value = `Begin_section_heading (level, label) as token; location}
-        as next_token ->
-
-      warn_if_after_tags next_token;
-
-      let recover_when_not_at_top_level context =
-        warn_because_not_at_top_level next_token;
-        junk input;
-        let content, brace_location =
-          delimited_inline_element_list
-            ~parent_markup:token
-            ~parent_markup_location:location
-            ~requires_leading_whitespace:true
-            input
-        in
-        let location = Location.span [location; brace_location] in
-        let paragraph =
-          `Paragraph content
-          |> accepted_in_all_contexts context
-          |> Location.at location
-        in
-        consume_block_elements ~parsed_a_tag `At_start_of_line (paragraph::acc)
-      in
-
-      begin match context with
-      | In_shorthand_list ->
-        if where_in_line = `At_start_of_line then
-          List.rev acc, next_token, where_in_line
-        else
-          recover_when_not_at_top_level context
-      | In_explicit_list ->
-        recover_when_not_at_top_level context
-      | In_tag ->
-        recover_when_not_at_top_level context
-
-      | Top_level ->
-        if where_in_line <> `At_start_of_line then
-          Parse_error.should_begin_on_its_own_line
-            ~what:(Token.describe token) location
-          |> Error.warning input.warnings;
-
-        let label =
-          match label with
-          | Some "" ->
-            Parse_error.should_not_be_empty ~what:"heading label" location
-            |> Error.warning input.warnings;
-            None
-          | _ ->
-            label
-        in
-
-        junk input;
-
-        let content, brace_location =
-          delimited_inline_element_list
-            ~parent_markup:token
-            ~parent_markup_location:location
-            ~requires_leading_whitespace:true
-            input
-        in
-        if content = [] then
+        let acc = block :: acc in
+        consume_block_elements ~parsed_a_tag `After_text acc
+    | { value = (`Code_block s | `Verbatim s) as token; location } as next_token
+      ->
+        warn_if_after_tags next_token;
+        warn_if_after_text next_token;
+        if s = "" then
           Parse_error.should_not_be_empty ~what:(Token.describe token) location
           |> Error.warning input.warnings;
 
-        let location = Location.span [location; brace_location] in
-        let heading = `Heading (level, label, content) in
-        let heading = Location.at location heading in
-        let acc = heading::acc in
+        junk input;
+        let block =
+          match token with
+          | `Code_block _ -> `Code_block s
+          | `Verbatim _ -> `Verbatim s
+        in
+        let block = accepted_in_all_contexts context block in
+        let block = Location.at location block in
+        let acc = block :: acc in
         consume_block_elements ~parsed_a_tag `After_text acc
-      end
+    | { value = `Modules s as token; location } as next_token ->
+        warn_if_after_tags next_token;
+        warn_if_after_text next_token;
+
+        junk input;
+
+        (* TODO Use some library for a splitting function, or move this out into a
+           Util module. *)
+        let split_string delimiters s =
+          let rec scan_delimiters acc index =
+            if index >= String.length s then List.rev acc
+            else if String.contains delimiters s.[index] then
+              scan_delimiters acc (index + 1)
+            else scan_word acc index (index + 1)
+          and scan_word acc start_index index =
+            if index >= String.length s then
+              let word = String.sub s start_index (index - start_index) in
+              List.rev (word :: acc)
+            else if String.contains delimiters s.[index] then
+              let word = String.sub s start_index (index - start_index) in
+              scan_delimiters (word :: acc) (index + 1)
+            else scan_word acc start_index (index + 1)
+          in
+
+          scan_delimiters [] 0
+        in
+
+        (* TODO Correct locations await a full implementation of {!modules}
+           parsing. *)
+        let modules =
+          split_string " \t\r\n" s |> List.map (fun r -> Location.at location r)
+        in
+
+        if modules = [] then
+          Parse_error.should_not_be_empty ~what:(Token.describe token) location
+          |> Error.warning input.warnings;
+
+        let block = accepted_in_all_contexts context (`Modules modules) in
+        let block = Location.at location block in
+        let acc = block :: acc in
+        consume_block_elements ~parsed_a_tag `After_text acc
+    | { value = `Begin_list kind as token; location } as next_token ->
+        warn_if_after_tags next_token;
+        warn_if_after_text next_token;
+
+        junk input;
+
+        let items, brace_location =
+          explicit_list_items ~parent_markup:token input
+        in
+        if items = [] then
+          Parse_error.should_not_be_empty ~what:(Token.describe token) location
+          |> Error.warning input.warnings;
+
+        let location = Location.span [ location; brace_location ] in
+        let block = `List (kind, `Heavy, items) in
+        let block = accepted_in_all_contexts context block in
+        let block = Location.at location block in
+        let acc = block :: acc in
+        consume_block_elements ~parsed_a_tag `After_text acc
+    | { value = (`Minus | `Plus) as token; location } as next_token -> (
+        ( match where_in_line with
+        | `After_text | `After_shorthand_bullet ->
+            Parse_error.should_begin_on_its_own_line
+              ~what:(Token.describe token) location
+            |> Error.warning input.warnings
+        | _ -> () );
+
+        warn_if_after_tags next_token;
+
+        match context with
+        | In_shorthand_list -> (List.rev acc, next_token, where_in_line)
+        | _ ->
+            let items, where_in_line =
+              shorthand_list_items next_token where_in_line input
+            in
+            let kind =
+              match token with `Minus -> `Unordered | `Plus -> `Ordered
+            in
+            let location =
+              location :: List.map Location.location (List.flatten items)
+              |> Location.span
+            in
+            let block = `List (kind, `Light, items) in
+            let block = accepted_in_all_contexts context block in
+            let block = Location.at location block in
+            let acc = block :: acc in
+            consume_block_elements ~parsed_a_tag where_in_line acc )
+    | { value = `Begin_section_heading (level, label) as token; location } as
+      next_token -> (
+        warn_if_after_tags next_token;
+
+        let recover_when_not_at_top_level context =
+          warn_because_not_at_top_level next_token;
+          junk input;
+          let content, brace_location =
+            delimited_inline_element_list ~parent_markup:token
+              ~parent_markup_location:location ~requires_leading_whitespace:true
+              input
+          in
+          let location = Location.span [ location; brace_location ] in
+          let paragraph =
+            `Paragraph content
+            |> accepted_in_all_contexts context
+            |> Location.at location
+          in
+          consume_block_elements ~parsed_a_tag `At_start_of_line
+            (paragraph :: acc)
+        in
+
+        match context with
+        | In_shorthand_list ->
+            if where_in_line = `At_start_of_line then
+              (List.rev acc, next_token, where_in_line)
+            else recover_when_not_at_top_level context
+        | In_explicit_list -> recover_when_not_at_top_level context
+        | In_tag -> recover_when_not_at_top_level context
+        | Top_level ->
+            if where_in_line <> `At_start_of_line then
+              Parse_error.should_begin_on_its_own_line
+                ~what:(Token.describe token) location
+              |> Error.warning input.warnings;
+
+            let label =
+              match label with
+              | Some "" ->
+                  Parse_error.should_not_be_empty ~what:"heading label" location
+                  |> Error.warning input.warnings;
+                  None
+              | _ -> label
+            in
+
+            junk input;
+
+            let content, brace_location =
+              delimited_inline_element_list ~parent_markup:token
+                ~parent_markup_location:location
+                ~requires_leading_whitespace:true input
+            in
+            if content = [] then
+              Parse_error.should_not_be_empty ~what:(Token.describe token)
+                location
+              |> Error.warning input.warnings;
+
+            let location = Location.span [ location; brace_location ] in
+            let heading = `Heading (level, label, content) in
+            let heading = Location.at location heading in
+            let acc = heading :: acc in
+            consume_block_elements ~parsed_a_tag `After_text acc )
   in
 
   let where_in_line =
@@ -1042,53 +917,43 @@ let rec block_element_list
    [`Plus]. It consumes that token, and calls the block element parser (see
    above). That parser returns to [implicit_list_items] only on [`Blank_line],
    [`End], [`Minus] or [`Plus] at the start of a line, or [`Right_brace]. *)
-and shorthand_list_items
-    : [ `Minus | `Plus ] with_location ->
-      where_in_line ->
-      input ->
-        ((Ast.nestable_block_element with_location) list) list *
-        where_in_line =
-    fun first_token where_in_line input ->
-
+and shorthand_list_items :
+    [ `Minus | `Plus ] with_location ->
+    where_in_line ->
+    input ->
+    Ast.nestable_block_element with_location list list * where_in_line =
+ fun first_token where_in_line input ->
   let bullet_token = first_token.value in
 
-  let rec consume_list_items
-      : [> ] with_location ->
-        where_in_line ->
-        ((Ast.nestable_block_element with_location) list) list ->
-          ((Ast.nestable_block_element with_location) list) list *
-          where_in_line =
-      fun next_token where_in_line acc ->
-
+  let rec consume_list_items :
+      [> ] with_location ->
+      where_in_line ->
+      Ast.nestable_block_element with_location list list ->
+      Ast.nestable_block_element with_location list list * where_in_line =
+   fun next_token where_in_line acc ->
     match next_token.value with
-    | `End
-    | `Right_brace
-    | `Blank_line _
-    | `Tag _
-    | `Begin_section_heading _ ->
-      List.rev acc, where_in_line
+    | `End | `Right_brace | `Blank_line _ | `Tag _ | `Begin_section_heading _ ->
+        (List.rev acc, where_in_line)
+    | (`Minus | `Plus) as bullet ->
+        if bullet = bullet_token then (
+          junk input;
 
-    | `Minus
-    | `Plus as bullet ->
-      if bullet = bullet_token then begin
-        junk input;
+          let content, stream_head, where_in_line =
+            block_element_list In_shorthand_list ~parent_markup:bullet input
+          in
+          if content = [] then
+            Parse_error.should_not_be_empty ~what:(Token.describe bullet)
+              next_token.location
+            |> Error.warning input.warnings;
 
-        let content, stream_head, where_in_line =
-          block_element_list In_shorthand_list ~parent_markup:bullet input in
-        if content = [] then
-          Parse_error.should_not_be_empty
-            ~what:(Token.describe bullet) next_token.location
-          |> Error.warning input.warnings;
-
-        let acc = content::acc in
-        consume_list_items stream_head where_in_line acc
-      end
-      else
-        List.rev acc, where_in_line
+          let acc = content :: acc in
+          consume_list_items stream_head where_in_line acc )
+        else (List.rev acc, where_in_line)
   in
 
   consume_list_items
-    (first_token :> stopped_implicitly with_location) where_in_line []
+    (first_token :> stopped_implicitly with_location)
+    where_in_line []
 
 (* Consumes a sequence of explicit list items (starting with '{li ...}' and
    '{-...}', which are represented by [`Begin_list_item _] tokens).
@@ -1100,140 +965,118 @@ and shorthand_list_items
    Whitespace inside the list, but outside list items, is not significant – this
    parsing function consumes all of it. Otherwise, only list item start tokens
    are accepted. Everything else is an error. *)
-and explicit_list_items
-    : parent_markup:[< Token.t ] ->
-      input ->
-        ((Ast.nestable_block_element with_location) list) list *
-        Location.span =
-    fun ~parent_markup input ->
-
-  let rec consume_list_items
-      : ((Ast.nestable_block_element with_location) list) list ->
-          ((Ast.nestable_block_element with_location) list) list *
-          Location.span =
-      fun acc ->
-
+and explicit_list_items :
+    parent_markup:[< Token.t ] ->
+    input ->
+    Ast.nestable_block_element with_location list list * Location.span =
+ fun ~parent_markup input ->
+  let rec consume_list_items :
+      Ast.nestable_block_element with_location list list ->
+      Ast.nestable_block_element with_location list list * Location.span =
+   fun acc ->
     let next_token = peek input in
     match next_token.value with
     | `End ->
-      Parse_error.not_allowed
-        next_token.location
-        ~what:(Token.describe `End)
-        ~in_what:(Token.describe parent_markup)
-      |> Error.warning input.warnings;
-      List.rev acc, next_token.location
-
+        Parse_error.not_allowed next_token.location
+          ~what:(Token.describe `End)
+          ~in_what:(Token.describe parent_markup)
+        |> Error.warning input.warnings;
+        (List.rev acc, next_token.location)
     | `Right_brace ->
-      junk input;
-      List.rev acc, next_token.location
-
-    | `Space _
-    | `Single_newline _
-    | `Blank_line _ ->
-      junk input;
-      consume_list_items acc
-
+        junk input;
+        (List.rev acc, next_token.location)
+    | `Space _ | `Single_newline _ | `Blank_line _ ->
+        junk input;
+        consume_list_items acc
     | `Begin_list_item kind as token ->
-      junk input;
+        junk input;
 
-      (* '{li', represented by [`Begin_list_item `Li], must be followed by
-         whitespace. *)
-      if kind = `Li then begin
-        match (peek input).value with
-        | `Space _ | `Single_newline _ | `Blank_line _ | `Right_brace ->
-          ()
-          (* The presence of [`Right_brace] above requires some explanation:
+        (* '{li', represented by [`Begin_list_item `Li], must be followed by
+           whitespace. *)
+        ( if kind = `Li then
+          match (peek input).value with
+          | `Space _ | `Single_newline _ | `Blank_line _ | `Right_brace ->
+              ()
+              (* The presence of [`Right_brace] above requires some explanation:
 
-             - It is better to be silent about missing whitespace if the next
-               token is [`Right_brace], because the error about an empty list
-               item will be generated below, and that error is more important to
-               the user.
-             - The [`Right_brace] token also happens to include all whitespace
-               before it, as a convenience for the rest of the parser. As a
-               result, not ignoring it could be wrong: there could in fact be
-               whitespace in the concrete syntax immediately after '{li', just
-               it is not represented as [`Space], [`Single_newline], or
-               [`Blank_line]. *)
-        | _ ->
-          Parse_error.should_be_followed_by_whitespace
-            next_token.location ~what:(Token.print token)
-          |> Error.warning input.warnings
-      end;
+                 - It is better to be silent about missing whitespace if the next
+                   token is [`Right_brace], because the error about an empty list
+                   item will be generated below, and that error is more important to
+                   the user.
+                 - The [`Right_brace] token also happens to include all whitespace
+                   before it, as a convenience for the rest of the parser. As a
+                   result, not ignoring it could be wrong: there could in fact be
+                   whitespace in the concrete syntax immediately after '{li', just
+                   it is not represented as [`Space], [`Single_newline], or
+                   [`Blank_line]. *)
+          | _ ->
+              Parse_error.should_be_followed_by_whitespace next_token.location
+                ~what:(Token.print token)
+              |> Error.warning input.warnings );
 
-      let content, token_after_list_item, _where_in_line =
-        block_element_list In_explicit_list ~parent_markup:token input in
+        let content, token_after_list_item, _where_in_line =
+          block_element_list In_explicit_list ~parent_markup:token input
+        in
 
-      if content = [] then
-        Parse_error.should_not_be_empty
-          next_token.location ~what:(Token.describe token)
+        if content = [] then
+          Parse_error.should_not_be_empty next_token.location
+            ~what:(Token.describe token)
+          |> Error.warning input.warnings;
+
+        ( match token_after_list_item.value with
+        | `Right_brace -> junk input
+        | `End ->
+            Parse_error.not_allowed token_after_list_item.location
+              ~what:(Token.describe `End)
+              ~in_what:(Token.describe token)
+            |> Error.warning input.warnings );
+
+        let acc = content :: acc in
+        consume_list_items acc
+    | token ->
+        let suggestion =
+          match token with
+          | `Begin_section_heading _ | `Tag _ ->
+              Printf.sprintf "move %s outside the list." (Token.describe token)
+          | _ ->
+              Printf.sprintf "move %s into a list item, %s or %s."
+                (Token.describe token)
+                (Token.print (`Begin_list_item `Li))
+                (Token.print (`Begin_list_item `Dash))
+        in
+        Parse_error.not_allowed next_token.location ~what:(Token.describe token)
+          ~in_what:(Token.describe parent_markup)
+          ~suggestion
         |> Error.warning input.warnings;
 
-      begin match token_after_list_item.value with
-      | `Right_brace ->
-        junk input
-      | `End ->
-        Parse_error.not_allowed
-          token_after_list_item.location
-          ~what:(Token.describe `End)
-          ~in_what:(Token.describe token)
-        |> Error.warning input.warnings
-      end;
-
-      let acc = content::acc in
-      consume_list_items acc
-
-    | token ->
-      let suggestion =
-        match token with
-        | `Begin_section_heading _ | `Tag _ ->
-          Printf.sprintf "move %s outside the list." (Token.describe token)
-        | _ ->
-          Printf.sprintf
-            "move %s into a list item, %s or %s."
-            (Token.describe token)
-            (Token.print (`Begin_list_item `Li))
-            (Token.print (`Begin_list_item `Dash))
-      in
-      Parse_error.not_allowed
-        next_token.location
-        ~what:(Token.describe token)
-        ~in_what:(Token.describe parent_markup)
-        ~suggestion
-      |> Error.warning input.warnings;
-
-      junk input;
-      consume_list_items acc
+        junk input;
+        consume_list_items acc
   in
 
   consume_list_items []
 
-
-
 (* {2 Entry point} *)
 
 let parse warnings tokens =
-  let input = {tokens; warnings} in
+  let input = { tokens; warnings } in
 
   let rec parse_block_elements () =
     let elements, last_token, _where_in_line =
-      block_element_list
-        Top_level ~parent_markup:`Comment input
+      block_element_list Top_level ~parent_markup:`Comment input
     in
 
     match last_token.value with
-    | `End ->
-      elements
-
+    | `End -> elements
     | `Right_brace ->
-      Parse_error.unpaired_right_brace last_token.location
-      |> Error.warning input.warnings;
+        Parse_error.unpaired_right_brace last_token.location
+        |> Error.warning input.warnings;
 
-      let block =
-        Location.same last_token
-          (`Paragraph [Location.same last_token (`Word "}")])
-      in
+        let block =
+          Location.same last_token
+            (`Paragraph [ Location.same last_token (`Word "}") ])
+        in
 
-      junk input;
-      elements @ (block::(parse_block_elements ()))
+        junk input;
+        elements @ (block :: parse_block_elements ())
   in
   parse_block_elements ()

--- a/src/parser/syntax.mli
+++ b/src/parser/syntax.mli
@@ -1,4 +1,4 @@
 val parse :
   Odoc_model.Error.warning_accumulator ->
-  (Token.t Odoc_model.Location_.with_location) Stream.t ->
-    Ast.docs
+  Token.t Odoc_model.Location_.with_location Stream.t ->
+  Ast.docs

--- a/src/parser/token.ml
+++ b/src/parser/token.ml
@@ -2,15 +2,11 @@
    the comment syntax parser. It also contains two functions that format tokens
    for error messages. *)
 
+type section_heading = [ `Begin_section_heading of int * string option ]
 
-
-type section_heading = [
-  `Begin_section_heading of int * string option
-]
-
-type tag = [
-  | `Tag of [
-    | `Author of string
+type tag =
+  [ `Tag of
+    [ `Author of string
     | `Deprecated
     | `Param of string
     | `Raise of string
@@ -22,209 +18,130 @@ type tag = [
     | `Canonical of string
     | `Inline
     | `Open
-    | `Closed
-  ]
-]
+    | `Closed ] ]
 
-type t = [
-  (* End of input. *)
-  | `End
+type t =
+  [ (* End of input. *)
+    `End
+  | (* Runs of whitespace. [Blank_line] is any run of whitespace that contains two
+       or more newline characters. [Single_newline] is any run of whitespace that
+       contains exactly one newline character. [Space] is any run of whitespace
+       that contains no newline characters.
 
-  (* Runs of whitespace. [Blank_line] is any run of whitespace that contains two
-     or more newline characters. [Single_newline] is any run of whitespace that
-     contains exactly one newline character. [Space] is any run of whitespace
-     that contains no newline characters.
-
-     It is an important invariant in the parser that no adjacent whitespace
-     tokens are emitted by the lexer. Otherwise, there would be the need for
-     unbounded lookahead, a (co-?)ambiguity between
-     [Single_newline Single_newline] and [Blank_line], and other problems. *)
-  | `Space of string
+       It is an important invariant in the parser that no adjacent whitespace
+       tokens are emitted by the lexer. Otherwise, there would be the need for
+       unbounded lookahead, a (co-?)ambiguity between
+       [Single_newline Single_newline] and [Blank_line], and other problems. *)
+    `Space of
+    string
   | `Single_newline of string
   | `Blank_line of string
+  | (* A right curly brace ([}]), i.e. end of markup. *)
+    `Right_brace
+  | (* Words are anything that is not whitespace or markup. Markup symbols can be
+       be part of words if escaped.
 
-  (* A right curly brace ([}]), i.e. end of markup. *)
-  | `Right_brace
-
-  (* Words are anything that is not whitespace or markup. Markup symbols can be
-     be part of words if escaped.
-
-     Words can contain plus and minus symbols, but those are emitted as [Plus]
-     and [Minus] tokens. The parser combines plus and minus into words, except
-     when they appear first on a line, in which case the tokens are list item
-     bullets. *)
-  | `Word of string
+       Words can contain plus and minus symbols, but those are emitted as [Plus]
+       and [Minus] tokens. The parser combines plus and minus into words, except
+       when they appear first on a line, in which case the tokens are list item
+       bullets. *)
+    `Word of
+    string
   | `Code_span of string
   | `Raw_markup of string option * string
   | `Begin_style of Odoc_model.Comment.style
-
-  (* Other inline element markup. *)
-  | `Simple_reference of string
+  | (* Other inline element markup. *)
+    `Simple_reference of string
   | `Begin_reference_with_replacement_text of string
   | `Simple_link of string
   | `Begin_link_with_replacement_text of string
-
-  (* Leaf block element markup. *)
-  | `Code_block of string
+  | (* Leaf block element markup. *)
+    `Code_block of string
   | `Verbatim of string
   | `Modules of string
-
-  (* List markup. *)
-  | `Begin_list of [ `Unordered | `Ordered ]
+  | (* List markup. *)
+    `Begin_list of [ `Unordered | `Ordered ]
   | `Begin_list_item of [ `Li | `Dash ]
   | `Minus
   | `Plus
-
   | section_heading
-  | tag
-]
-
-
+  | tag ]
 
 let print : [< t ] -> string = function
-  | `Begin_style `Bold ->
-    "'{b'"
-  | `Begin_style `Italic ->
-    "'{i'"
-  | `Begin_style `Emphasis ->
-    "'{e'"
-  | `Begin_style `Superscript ->
-    "'{^'"
-  | `Begin_style `Subscript ->
-    "'{_'"
-  | `Begin_reference_with_replacement_text _ ->
-    "'{{!'"
-  | `Begin_link_with_replacement_text _ ->
-    "'{{:'"
-  | `Begin_list_item `Li ->
-    "'{li ...}'"
-  | `Begin_list_item `Dash ->
-    "'{- ...}'"
-  | `Minus ->
-    "'-'"
-  | `Plus ->
-    "'+'"
+  | `Begin_style `Bold -> "'{b'"
+  | `Begin_style `Italic -> "'{i'"
+  | `Begin_style `Emphasis -> "'{e'"
+  | `Begin_style `Superscript -> "'{^'"
+  | `Begin_style `Subscript -> "'{_'"
+  | `Begin_reference_with_replacement_text _ -> "'{{!'"
+  | `Begin_link_with_replacement_text _ -> "'{{:'"
+  | `Begin_list_item `Li -> "'{li ...}'"
+  | `Begin_list_item `Dash -> "'{- ...}'"
+  | `Minus -> "'-'"
+  | `Plus -> "'+'"
   | `Begin_section_heading (level, label) ->
-    let label =
-      match label with
-      | None -> ""
-      | Some label -> ":" ^ label
-    in
-    Printf.sprintf "'{%i%s'" level label
-  | `Tag (`Author _) ->
-    "'@author'"
-  | `Tag `Deprecated ->
-    "'@deprecated'"
-  | `Tag (`Param _) ->
-    "'@param'"
-  | `Tag (`Raise _) ->
-    "'@raise'"
-  | `Tag `Return ->
-    "'@return'"
-  | `Tag (`See _) ->
-    "'@see'"
-  | `Tag (`Since _) ->
-    "'@since'"
-  | `Tag (`Before _) ->
-    "'@before'"
-  | `Tag (`Version _) ->
-    "'@version'"
-  | `Tag (`Canonical _) ->
-    "'@canonical'"
-  | `Tag `Inline ->
-    "'@inline'"
-  | `Tag `Open ->
-    "'@open'"
-  | `Tag `Closed ->
-    "'@closed'"
-  | `Raw_markup (None, _) ->
-    "'{%...%}'"
-  | `Raw_markup (Some target, _) ->
-    "'{%" ^ target ^ ":...%}'"
+      let label = match label with None -> "" | Some label -> ":" ^ label in
+      Printf.sprintf "'{%i%s'" level label
+  | `Tag (`Author _) -> "'@author'"
+  | `Tag `Deprecated -> "'@deprecated'"
+  | `Tag (`Param _) -> "'@param'"
+  | `Tag (`Raise _) -> "'@raise'"
+  | `Tag `Return -> "'@return'"
+  | `Tag (`See _) -> "'@see'"
+  | `Tag (`Since _) -> "'@since'"
+  | `Tag (`Before _) -> "'@before'"
+  | `Tag (`Version _) -> "'@version'"
+  | `Tag (`Canonical _) -> "'@canonical'"
+  | `Tag `Inline -> "'@inline'"
+  | `Tag `Open -> "'@open'"
+  | `Tag `Closed -> "'@closed'"
+  | `Raw_markup (None, _) -> "'{%...%}'"
+  | `Raw_markup (Some target, _) -> "'{%" ^ target ^ ":...%}'"
 
 (* [`Minus] and [`Plus] are interpreted as if they start list items. Therefore,
    for error messages based on [Token.describe] to be accurate, formatted
    [`Minus] and [`Plus] should always be plausibly list item bullets. *)
 let describe : [< t | `Comment ] -> string = function
-  | `Word w ->
-    Printf.sprintf "'%s'" w
-  | `Code_span _ ->
-    "'[...]' (code)"
-  | `Raw_markup _ ->
-    "'{%...%}' (raw markup)"
-  | `Begin_style `Bold ->
-    "'{b ...}' (boldface text)"
-  | `Begin_style `Italic ->
-    "'{i ...}' (italic text)"
-  | `Begin_style `Emphasis ->
-    "'{e ...}' (emphasized text)"
-  | `Begin_style `Superscript ->
-    "'{^...}' (superscript)"
-  | `Begin_style `Subscript ->
-    "'{_...}' (subscript)"
-  | `Simple_reference _ ->
-    "'{!...}' (cross-reference)"
+  | `Word w -> Printf.sprintf "'%s'" w
+  | `Code_span _ -> "'[...]' (code)"
+  | `Raw_markup _ -> "'{%...%}' (raw markup)"
+  | `Begin_style `Bold -> "'{b ...}' (boldface text)"
+  | `Begin_style `Italic -> "'{i ...}' (italic text)"
+  | `Begin_style `Emphasis -> "'{e ...}' (emphasized text)"
+  | `Begin_style `Superscript -> "'{^...}' (superscript)"
+  | `Begin_style `Subscript -> "'{_...}' (subscript)"
+  | `Simple_reference _ -> "'{!...}' (cross-reference)"
   | `Begin_reference_with_replacement_text _ ->
-    "'{{!...} ...}' (cross-reference)"
-  | `Simple_link _ ->
-    "'{:...} (external link)'"
-  | `Begin_link_with_replacement_text _ ->
-    "'{{:...} ...}' (external link)"
-  | `End ->
-    "end of text"
-  | `Space _ ->
-    "whitespace"
-  | `Single_newline _ ->
-    "line break"
-  | `Blank_line _ ->
-    "blank line"
-  | `Right_brace ->
-    "'}'"
-  | `Code_block _ ->
-    "'{[...]}' (code block)"
-  | `Verbatim _ ->
-    "'{v ... v}' (verbatim text)"
-  | `Modules _ ->
-    "'{!modules ...}'"
-  | `Begin_list `Unordered ->
-    "'{ul ...}' (bulleted list)"
-  | `Begin_list `Ordered ->
-    "'{ol ...}' (numbered list)"
-  | `Begin_list_item `Li ->
-    "'{li ...}' (list item)"
-  | `Begin_list_item `Dash ->
-    "'{- ...}' (list item)"
-  | `Minus ->
-    "'-' (bulleted list item)"
-  | `Plus ->
-    "'+' (numbered list item)"
+      "'{{!...} ...}' (cross-reference)"
+  | `Simple_link _ -> "'{:...} (external link)'"
+  | `Begin_link_with_replacement_text _ -> "'{{:...} ...}' (external link)"
+  | `End -> "end of text"
+  | `Space _ -> "whitespace"
+  | `Single_newline _ -> "line break"
+  | `Blank_line _ -> "blank line"
+  | `Right_brace -> "'}'"
+  | `Code_block _ -> "'{[...]}' (code block)"
+  | `Verbatim _ -> "'{v ... v}' (verbatim text)"
+  | `Modules _ -> "'{!modules ...}'"
+  | `Begin_list `Unordered -> "'{ul ...}' (bulleted list)"
+  | `Begin_list `Ordered -> "'{ol ...}' (numbered list)"
+  | `Begin_list_item `Li -> "'{li ...}' (list item)"
+  | `Begin_list_item `Dash -> "'{- ...}' (list item)"
+  | `Minus -> "'-' (bulleted list item)"
+  | `Plus -> "'+' (numbered list item)"
   | `Begin_section_heading (level, _) ->
-    Printf.sprintf "'{%i ...}' (section heading)" level
-  | `Tag (`Author _) ->
-    "'@author'"
-  | `Tag `Deprecated ->
-    "'@deprecated'"
-  | `Tag (`Param _) ->
-    "'@param'"
-  | `Tag (`Raise _) ->
-    "'@raise'"
-  | `Tag `Return ->
-    "'@return'"
-  | `Tag (`See _) ->
-    "'@see'"
-  | `Tag (`Since _) ->
-    "'@since'"
-  | `Tag (`Before _) ->
-    "'@before'"
-  | `Tag (`Version _) ->
-    "'@version'"
-  | `Tag (`Canonical _) ->
-    "'@canonical'"
-  | `Tag `Inline ->
-    "'@inline'"
-  | `Tag `Open ->
-    "'@open'"
-  | `Tag `Closed ->
-    "'@closed'"
-  | `Comment ->
-    "top-level text"
+      Printf.sprintf "'{%i ...}' (section heading)" level
+  | `Tag (`Author _) -> "'@author'"
+  | `Tag `Deprecated -> "'@deprecated'"
+  | `Tag (`Param _) -> "'@param'"
+  | `Tag (`Raise _) -> "'@raise'"
+  | `Tag `Return -> "'@return'"
+  | `Tag (`See _) -> "'@see'"
+  | `Tag (`Since _) -> "'@since'"
+  | `Tag (`Before _) -> "'@before'"
+  | `Tag (`Version _) -> "'@version'"
+  | `Tag (`Canonical _) -> "'@canonical'"
+  | `Tag `Inline -> "'@inline'"
+  | `Tag `Open -> "'@open'"
+  | `Tag `Closed -> "'@closed'"
+  | `Comment -> "top-level text"

--- a/src/xref2/cfrag.ml
+++ b/src/xref2/cfrag.ml
@@ -112,17 +112,18 @@ let type_split : type_ -> string * type_ option = function
       | Branch (base, m) -> (ModuleName.to_string base, Some (`Dot (m, name))) )
 
 let rec unresolve_module : resolved_module -> module_ = function
-    | `OpaqueModule m | `Subst (_, m) | `SubstAlias (_, m) ->
-        unresolve_module m
-    | `Module (parent, m) ->
-        `Dot (unresolve_signature parent, ModuleName.to_string m)
-  and unresolve_signature : resolved_signature -> signature = function
-    | #resolved_module as m -> (unresolve_module m :> signature)
-    | `Root _ -> `Root
-  and unresolve_type : resolved_type -> type_ = function
-    | `Type (parent, name) ->
-        `Dot (unresolve_signature parent, TypeName.to_string name)
-    | `ClassType (parent, name) ->
-        `Dot (unresolve_signature parent, ClassTypeName.to_string name)
-    | `Class (parent, name) ->
-        `Dot (unresolve_signature parent, ClassName.to_string name)
+  | `OpaqueModule m | `Subst (_, m) | `SubstAlias (_, m) -> unresolve_module m
+  | `Module (parent, m) ->
+      `Dot (unresolve_signature parent, ModuleName.to_string m)
+
+and unresolve_signature : resolved_signature -> signature = function
+  | #resolved_module as m -> (unresolve_module m :> signature)
+  | `Root _ -> `Root
+
+and unresolve_type : resolved_type -> type_ = function
+  | `Type (parent, name) ->
+      `Dot (unresolve_signature parent, TypeName.to_string name)
+  | `ClassType (parent, name) ->
+      `Dot (unresolve_signature parent, ClassTypeName.to_string name)
+  | `Class (parent, name) ->
+      `Dot (unresolve_signature parent, ClassName.to_string name)

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -15,43 +15,43 @@ let type_path : Env.t -> Paths.Path.Type.t -> Paths.Path.Type.t =
  fun env p ->
   match p with
   | `Resolved _ -> p
-  | _ ->
-    let cp = Component.Of_Lang.(type_path empty p) in
-    match Tools.resolve_type_path env cp with
-    | Ok p' -> `Resolved (Cpath.resolved_type_path_of_cpath p')
-    | Error _ -> p
+  | _ -> (
+      let cp = Component.Of_Lang.(type_path empty p) in
+      match Tools.resolve_type_path env cp with
+      | Ok p' -> `Resolved (Cpath.resolved_type_path_of_cpath p')
+      | Error _ -> p )
 
 and module_type_path :
     Env.t -> Paths.Path.ModuleType.t -> Paths.Path.ModuleType.t =
  fun env p ->
   match p with
   | `Resolved _ -> p
-  | _ ->
-    let cp = Component.Of_Lang.(module_type_path empty p) in
-    match Tools.resolve_module_type_path env cp with
-    | Ok p' -> `Resolved (Cpath.resolved_module_type_path_of_cpath p')
-    | Error _ -> p
+  | _ -> (
+      let cp = Component.Of_Lang.(module_type_path empty p) in
+      match Tools.resolve_module_type_path env cp with
+      | Ok p' -> `Resolved (Cpath.resolved_module_type_path_of_cpath p')
+      | Error _ -> p )
 
 and module_path : Env.t -> Paths.Path.Module.t -> Paths.Path.Module.t =
  fun env p ->
   match p with
   | `Resolved _ -> p
-  | _ ->
-    let cp = Component.Of_Lang.(module_path empty p) in
-    match Tools.resolve_module_path env cp with
-    | Ok p' -> `Resolved (Cpath.resolved_module_path_of_cpath p')
-    | Error _ -> p
+  | _ -> (
+      let cp = Component.Of_Lang.(module_path empty p) in
+      match Tools.resolve_module_path env cp with
+      | Ok p' -> `Resolved (Cpath.resolved_module_path_of_cpath p')
+      | Error _ -> p )
 
 and class_type_path : Env.t -> Paths.Path.ClassType.t -> Paths.Path.ClassType.t
     =
  fun env p ->
   match p with
   | `Resolved _ -> p
-  | _ ->
-    let cp = Component.Of_Lang.(class_type_path empty p) in
-    match Tools.resolve_class_type_path env cp with
-    | Ok p' -> `Resolved (Cpath.resolved_class_type_path_of_cpath p')
-    | Error _ -> Cpath.class_type_path_of_cpath cp
+  | _ -> (
+      let cp = Component.Of_Lang.(class_type_path empty p) in
+      match Tools.resolve_class_type_path env cp with
+      | Ok p' -> `Resolved (Cpath.resolved_class_type_path_of_cpath p')
+      | Error _ -> Cpath.class_type_path_of_cpath cp )
 
 let rec unit (resolver : Env.resolver) t =
   let open Compilation_unit in
@@ -62,8 +62,8 @@ and content env id =
   let open Compilation_unit in
   function
   | Module m ->
-    let sg = Type_of.signature env m in
-    Module (signature env (id :> Id.Signature.t) sg)
+      let sg = Type_of.signature env m in
+      Module (signature env (id :> Id.Signature.t) sg)
   | Pack _ -> failwith "Unhandled content"
 
 and value_ env parent t =
@@ -228,22 +228,16 @@ and module_ : Env.t -> Module.t -> Module.t =
  fun env m ->
   let open Module in
   if m.hidden then m
-  else
-        {
-          m with
-          type_ = module_decl env (m.id :> Id.Signature.t) m.type_;
-          }
+  else { m with type_ = module_decl env (m.id :> Id.Signature.t) m.type_ }
 
-and module_decl : Env.t -> Id.Signature.t -> Module.decl -> Module.decl
-    =
+and module_decl : Env.t -> Id.Signature.t -> Module.decl -> Module.decl =
  fun env id decl ->
   let open Module in
   match decl with
   | ModuleType expr -> ModuleType (module_type_expr env id expr)
   | Alias (p, expn) -> Alias (module_path env p, expn)
 
-and include_decl : Env.t -> Id.Signature.t -> Include.decl -> Include.decl
-    =
+and include_decl : Env.t -> Id.Signature.t -> Include.decl -> Include.decl =
  fun env id decl ->
   let open Include in
   match decl with
@@ -260,8 +254,7 @@ and module_type : Env.t -> ModuleType.t -> ModuleType.t =
     | None -> None
     | Some e -> Some (module_type_expr env sg_id e)
   in
-  {m with expr}
-
+  { m with expr }
 
 and include_ : Env.t -> Include.t -> Include.t =
  fun env i ->
@@ -274,43 +267,50 @@ and include_ : Env.t -> Include.t -> Include.t =
   let get_expansion () =
     match
       let open Utils.ResultMonad in
-      (match decl with
+      match decl with
       | Alias p ->
-        Expand_tools.aux_expansion_of_module_alias env ~strengthen:true p
-        >>= Expand_tools.assert_not_functor
-      | ModuleType mty -> Expand_tools.aux_expansion_of_u_module_type_expr env mty)
+          Expand_tools.aux_expansion_of_module_alias env ~strengthen:true p
+          >>= Expand_tools.assert_not_functor
+      | ModuleType mty ->
+          Expand_tools.aux_expansion_of_u_module_type_expr env mty
     with
-  | Error e ->
-      Errors.report ~what:(`Include decl) ~tools_error:e `Expand;
-      i.expansion
-  | Ok (sg) ->
-      let map = { Lang_of.empty with shadowed = i.expansion.shadowed } in
-      let e = Lang_of.(simple_expansion map i.parent (Signature sg)) in
+    | Error e ->
+        Errors.report ~what:(`Include decl) ~tools_error:e `Expand;
+        i.expansion
+    | Ok sg ->
+        let map = { Lang_of.empty with shadowed = i.expansion.shadowed } in
+        let e = Lang_of.(simple_expansion map i.parent (Signature sg)) in
 
-      let expansion_sg =
-        match e with
-        | ModuleType.Signature sg -> sg
-        | _ -> failwith "Expansion shouldn't be anything other than a signature"
-      in
-      {
+        let expansion_sg =
+          match e with
+          | ModuleType.Signature sg -> sg
+          | _ ->
+              failwith "Expansion shouldn't be anything other than a signature"
+        in
+        {
           resolved = true;
           shadowed = i.expansion.shadowed;
           content =
             remove_top_doc_from_signature (signature env i.parent expansion_sg);
         }
-    in
-    let expansion =
-      if i.expansion.resolved then i.expansion else get_expansion () in
-    { i with decl = include_decl env i.parent i.decl; expansion }
+  in
+  let expansion =
+    if i.expansion.resolved then i.expansion else get_expansion ()
+  in
+  { i with decl = include_decl env i.parent i.decl; expansion }
 
-and simple_expansion : Env.t -> Id.Signature.t -> ModuleType.simple_expansion -> ModuleType.simple_expansion
-    =
-  fun env id e ->
-    match e with
-    | Signature sg -> Signature (signature env id sg)
-    | Functor (param, sg) ->
-        let env' = Env.add_functor_parameter param env in
-        Functor (functor_parameter env param, simple_expansion env' (`Result id) sg)
+and simple_expansion :
+    Env.t ->
+    Id.Signature.t ->
+    ModuleType.simple_expansion ->
+    ModuleType.simple_expansion =
+ fun env id e ->
+  match e with
+  | Signature sg -> Signature (signature env id sg)
+  | Functor (param, sg) ->
+      let env' = Env.add_functor_parameter param env in
+      Functor
+        (functor_parameter env param, simple_expansion env' (`Result id) sg)
 
 and functor_parameter : Env.t -> FunctorParameter.t -> FunctorParameter.t =
  fun env param ->
@@ -324,123 +324,126 @@ and functor_parameter_parameter :
   { a with expr = module_type_expr env (a.id :> Id.Signature.t) a.expr }
 
 and module_type_expr_sub id ~fragment_root (sg_res, env, subs) lsub =
-let open Utils.ResultMonad in
-match sg_res with
-| Error _ -> (sg_res, env, lsub :: subs)
-| Ok sg -> (
-    (* Format.eprintf "compile.module_type_expr: sig=%a\n%!" Component.Fmt.signature sg; *)
-    let lang_of_map = Lang_of.with_fragment_root fragment_root in
-    let env = Env.add_fragment_root sg env in
-    let sg_and_sub =
-      match lsub with
-      | Odoc_model.Lang.ModuleType.ModuleEq (frag, decl) ->
-          let cfrag = Component.Of_Lang.(module_fragment empty frag) in
-          let cfrag', frag' =
-            match
-              Tools.resolve_module_fragment env (fragment_root, sg) cfrag
-            with
-            | Some cfrag' ->
-                ( `Resolved cfrag',
-                  `Resolved
-                    (Lang_of.Path.resolved_module_fragment lang_of_map
-                       cfrag') )
-            | None ->
-                Errors.report ~what:(`With_module cfrag) `Resolve;
-                (cfrag, frag)
-          in
-          let decl' = module_decl env id decl in
-          let cdecl' = Component.Of_Lang.(module_decl empty decl') in
-          let resolved_csub =
-            Component.ModuleType.ModuleEq (cfrag', cdecl')
-          in
-          Tools.fragmap ~mark_substituted:true env resolved_csub sg
-          >>= fun sg' -> Ok (sg', Odoc_model.Lang.ModuleType.ModuleEq (frag', decl'))
-      | TypeEq (frag, eqn) ->
-          let cfrag = Component.Of_Lang.(type_fragment empty frag) in
-          let cfrag', frag' =
-            match
-              Tools.resolve_type_fragment env (fragment_root, sg) cfrag
-            with
-            | Some cfrag' ->
-                ( `Resolved cfrag',
-                  `Resolved
-                    (Lang_of.Path.resolved_type_fragment lang_of_map cfrag')
-                )
-            | None ->
-                Errors.report ~what:(`With_type cfrag) `Compile;
-                (cfrag, frag)
-          in
-          let eqn' = type_decl_equation env (id :> Id.Parent.t) eqn in
-          let ceqn' = Component.Of_Lang.(type_equation empty eqn') in
-          Tools.fragmap ~mark_substituted:true env
-            (Component.ModuleType.TypeEq (cfrag', ceqn'))
-            sg
-          >>= fun sg' -> Ok (sg', Odoc_model.Lang.ModuleType.TypeEq (frag', eqn'))
-      | ModuleSubst (frag, mpath) ->
-          let cfrag = Component.Of_Lang.(module_fragment empty frag) in
-          let cfrag', frag' =
-            match
-              Tools.resolve_module_fragment env (fragment_root, sg) cfrag
-            with
-            | Some cfrag ->
-                ( `Resolved cfrag,
-                  `Resolved
-                    (Lang_of.Path.resolved_module_fragment lang_of_map
-                       cfrag) )
-            | None ->
-                Errors.report ~what:(`With_module cfrag) `Resolve;
-                (cfrag, frag)
-          in
-          let mpath' = module_path env mpath in
-          let cmpath' = Component.Of_Lang.(module_path empty mpath') in
-          Tools.fragmap ~mark_substituted:true env
-            (Component.ModuleType.ModuleSubst (cfrag', cmpath'))
-            sg
-          >>= fun sg' -> Ok (sg', Odoc_model.Lang.ModuleType.ModuleSubst (frag', mpath'))
-      | TypeSubst (frag, eqn) ->
-          let cfrag = Component.Of_Lang.(type_fragment empty frag) in
-          let cfrag', frag' =
-            match
-              Tools.resolve_type_fragment env (fragment_root, sg) cfrag
-            with
-            | Some cfrag ->
-                ( `Resolved cfrag,
-                  `Resolved
-                    (Lang_of.Path.resolved_type_fragment lang_of_map cfrag)
-                )
-            | None ->
-                Errors.report ~what:(`With_type cfrag) `Compile;
-                (cfrag, frag)
-          in
-          let eqn' = type_decl_equation env (id :> Id.Parent.t) eqn in
-          let ceqn' = Component.Of_Lang.(type_equation empty eqn') in
-          Tools.fragmap ~mark_substituted:true env
-            (Component.ModuleType.TypeSubst (cfrag', ceqn'))
-            sg
-          >>= fun sg' -> Ok (sg', Odoc_model.Lang.ModuleType.TypeSubst (frag', eqn'))
-    in
-    match sg_and_sub with
-    | Ok (sg', sub') -> (Ok sg', env, sub' :: subs)
-    | Error _ -> (sg_res, env, lsub :: subs) )
+  let open Utils.ResultMonad in
+  match sg_res with
+  | Error _ -> (sg_res, env, lsub :: subs)
+  | Ok sg -> (
+      (* Format.eprintf "compile.module_type_expr: sig=%a\n%!" Component.Fmt.signature sg; *)
+      let lang_of_map = Lang_of.with_fragment_root fragment_root in
+      let env = Env.add_fragment_root sg env in
+      let sg_and_sub =
+        match lsub with
+        | Odoc_model.Lang.ModuleType.ModuleEq (frag, decl) ->
+            let cfrag = Component.Of_Lang.(module_fragment empty frag) in
+            let cfrag', frag' =
+              match
+                Tools.resolve_module_fragment env (fragment_root, sg) cfrag
+              with
+              | Some cfrag' ->
+                  ( `Resolved cfrag',
+                    `Resolved
+                      (Lang_of.Path.resolved_module_fragment lang_of_map cfrag')
+                  )
+              | None ->
+                  Errors.report ~what:(`With_module cfrag) `Resolve;
+                  (cfrag, frag)
+            in
+            let decl' = module_decl env id decl in
+            let cdecl' = Component.Of_Lang.(module_decl empty decl') in
+            let resolved_csub =
+              Component.ModuleType.ModuleEq (cfrag', cdecl')
+            in
+            Tools.fragmap ~mark_substituted:true env resolved_csub sg
+            >>= fun sg' ->
+            Ok (sg', Odoc_model.Lang.ModuleType.ModuleEq (frag', decl'))
+        | TypeEq (frag, eqn) ->
+            let cfrag = Component.Of_Lang.(type_fragment empty frag) in
+            let cfrag', frag' =
+              match
+                Tools.resolve_type_fragment env (fragment_root, sg) cfrag
+              with
+              | Some cfrag' ->
+                  ( `Resolved cfrag',
+                    `Resolved
+                      (Lang_of.Path.resolved_type_fragment lang_of_map cfrag')
+                  )
+              | None ->
+                  Errors.report ~what:(`With_type cfrag) `Compile;
+                  (cfrag, frag)
+            in
+            let eqn' = type_decl_equation env (id :> Id.Parent.t) eqn in
+            let ceqn' = Component.Of_Lang.(type_equation empty eqn') in
+            Tools.fragmap ~mark_substituted:true env
+              (Component.ModuleType.TypeEq (cfrag', ceqn'))
+              sg
+            >>= fun sg' ->
+            Ok (sg', Odoc_model.Lang.ModuleType.TypeEq (frag', eqn'))
+        | ModuleSubst (frag, mpath) ->
+            let cfrag = Component.Of_Lang.(module_fragment empty frag) in
+            let cfrag', frag' =
+              match
+                Tools.resolve_module_fragment env (fragment_root, sg) cfrag
+              with
+              | Some cfrag ->
+                  ( `Resolved cfrag,
+                    `Resolved
+                      (Lang_of.Path.resolved_module_fragment lang_of_map cfrag)
+                  )
+              | None ->
+                  Errors.report ~what:(`With_module cfrag) `Resolve;
+                  (cfrag, frag)
+            in
+            let mpath' = module_path env mpath in
+            let cmpath' = Component.Of_Lang.(module_path empty mpath') in
+            Tools.fragmap ~mark_substituted:true env
+              (Component.ModuleType.ModuleSubst (cfrag', cmpath'))
+              sg
+            >>= fun sg' ->
+            Ok (sg', Odoc_model.Lang.ModuleType.ModuleSubst (frag', mpath'))
+        | TypeSubst (frag, eqn) ->
+            let cfrag = Component.Of_Lang.(type_fragment empty frag) in
+            let cfrag', frag' =
+              match
+                Tools.resolve_type_fragment env (fragment_root, sg) cfrag
+              with
+              | Some cfrag ->
+                  ( `Resolved cfrag,
+                    `Resolved
+                      (Lang_of.Path.resolved_type_fragment lang_of_map cfrag) )
+              | None ->
+                  Errors.report ~what:(`With_type cfrag) `Compile;
+                  (cfrag, frag)
+            in
+            let eqn' = type_decl_equation env (id :> Id.Parent.t) eqn in
+            let ceqn' = Component.Of_Lang.(type_equation empty eqn') in
+            Tools.fragmap ~mark_substituted:true env
+              (Component.ModuleType.TypeSubst (cfrag', ceqn'))
+              sg
+            >>= fun sg' ->
+            Ok (sg', Odoc_model.Lang.ModuleType.TypeSubst (frag', eqn'))
+      in
+      match sg_and_sub with
+      | Ok (sg', sub') -> (Ok sg', env, sub' :: subs)
+      | Error _ -> (sg_res, env, lsub :: subs) )
 
 and module_type_map_subs env id cexpr subs =
-let rec find_parent : Component.ModuleType.U.expr -> Cfrag.root option =
-  fun expr ->
-   match expr with
-   | Component.ModuleType.U.Signature _ -> None
-   | Path (`Resolved p) -> Some (`ModuleType p)
-   | Path _ -> None
-   | With (_, e) -> find_parent e
-   | TypeOf {t_desc = ModPath (`Resolved p); _}
-   | TypeOf { t_desc = StructInclude (`Resolved p); _ } -> Some (`Module p)
-   | TypeOf _ -> None
-in
+  let rec find_parent : Component.ModuleType.U.expr -> Cfrag.root option =
+   fun expr ->
+    match expr with
+    | Component.ModuleType.U.Signature _ -> None
+    | Path (`Resolved p) -> Some (`ModuleType p)
+    | Path _ -> None
+    | With (_, e) -> find_parent e
+    | TypeOf { t_desc = ModPath (`Resolved p); _ }
+    | TypeOf { t_desc = StructInclude (`Resolved p); _ } ->
+        Some (`Module p)
+    | TypeOf _ -> None
+  in
   match find_parent cexpr with
   | None -> None
   | Some parent -> (
       match
-        Tools.signature_of_u_module_type_expr ~mark_substituted:true env
-          cexpr
+        Tools.signature_of_u_module_type_expr ~mark_substituted:true env cexpr
       with
       | Error e ->
           Errors.report ~what:(`Module_type id) ~tools_error:e `Lookup;
@@ -455,95 +458,86 @@ in
               (Ok sg, env, []) subs
           in
           let subs = List.rev subs in
-          Some subs)
+          Some subs )
 
 and u_module_type_expr :
     Env.t -> Id.Signature.t -> ModuleType.U.expr -> ModuleType.U.expr =
  fun env id expr ->
   let open ModuleType in
-  let rec inner : U.expr -> U.expr =
-    function
-    | Signature s ->
-      Signature s
+  let rec inner : U.expr -> U.expr = function
+    | Signature s -> Signature s
     | Path p -> Path (module_type_path env p)
-    | With (_, Signature _) as u -> begin
+    | With (_, Signature _) as u -> (
         (* Explicitly handle 'sig ... end with ...' - replace with a plain signature *)
         let cu = Component.Of_Lang.(u_module_type_expr empty u) in
-        let result =
-          Expand_tools.aux_expansion_of_u_module_type_expr env cu
-        in
+        let result = Expand_tools.aux_expansion_of_u_module_type_expr env cu in
         match result with
-        | Ok sg -> Signature (Lang_of.(signature id empty sg))
-        | _ -> u
-      end
+        | Ok sg -> Signature Lang_of.(signature id empty sg)
+        | _ -> u )
     | With (subs, expr) -> (
         let expr = inner expr in
         let cexpr = Component.Of_Lang.(u_module_type_expr empty expr) in
         (* Format.eprintf "Handling with expression (%a)\n%!"
-          Component.Fmt.module_type_expr cexpr; *)
+           Component.Fmt.module_type_expr cexpr; *)
         let subs' = module_type_map_subs env id cexpr subs in
-        match subs' with
-        | None -> With (subs, expr)
-        | Some s -> With (s, expr))
+        match subs' with None -> With (subs, expr) | Some s -> With (s, expr) )
     | TypeOf { t_desc; t_expansion } ->
-      let t_desc = match t_desc with
-        | ModPath p -> ModPath (module_path env p)
-        | StructInclude p -> StructInclude (module_path env p)
-      in
-      TypeOf { t_desc; t_expansion }
+        let t_desc =
+          match t_desc with
+          | ModPath p -> ModPath (module_path env p)
+          | StructInclude p -> StructInclude (module_path env p)
+        in
+        TypeOf { t_desc; t_expansion }
   in
   inner expr
 
 and module_type_expr :
-  Env.t -> Id.Signature.t -> ModuleType.expr -> ModuleType.expr =
-  fun env id expr ->
+    Env.t -> Id.Signature.t -> ModuleType.expr -> ModuleType.expr =
+ fun env id expr ->
   let get_expansion cur e =
     match cur with
     | Some e -> Some (simple_expansion env id e)
-    | None ->
-      let ce = Component.Of_Lang.(module_type_expr empty e) in
-      match Expand_tools.expansion_of_module_type_expr env id ce with
-      | Ok (_, _, ce) ->
-          let e = Lang_of.simple_expansion Lang_of.empty id ce in
-          Some (simple_expansion env id e)
-      | Error e ->
-        Errors.report ~what:(`Module_type_expr ce) ~tools_error:e `Expand;
-        None
+    | None -> (
+        let ce = Component.Of_Lang.(module_type_expr empty e) in
+        match Expand_tools.expansion_of_module_type_expr env id ce with
+        | Ok (_, _, ce) ->
+            let e = Lang_of.simple_expansion Lang_of.empty id ce in
+            Some (simple_expansion env id e)
+        | Error e ->
+            Errors.report ~what:(`Module_type_expr ce) ~tools_error:e `Expand;
+            None )
   in
   match expr with
   | Signature s -> Signature (signature env id s)
   | Path { p_path; p_expansion } as e ->
-    let p_expansion = get_expansion p_expansion e in
-    Path { p_path = module_type_path env p_path; p_expansion }
-  | With { w_expansion; w_expr=Signature _; _} as e -> (
+      let p_expansion = get_expansion p_expansion e in
+      Path { p_path = module_type_path env p_path; p_expansion }
+  | With { w_expansion; w_expr = Signature _; _ } as e -> (
       let w_expansion = get_expansion w_expansion e in
-      match w_expansion with
-      | Some (Signature sg) -> Signature sg
-      | _ -> e
-    )
-  | With { w_substitutions; w_expansion; w_expr} as e -> (
-    let w_expansion = get_expansion w_expansion e in
-    let w_expr = u_module_type_expr env id w_expr in
-    let cexpr = Component.Of_Lang.(u_module_type_expr empty w_expr) in
-    (* Format.eprintf "Handling with expression (%a)\n%!"
-      Component.Fmt.module_type_expr cexpr; *)
-    let subs' = module_type_map_subs env id cexpr w_substitutions in
-    match subs' with
-    | None -> With {w_substitutions; w_expansion; w_expr}
-    | Some s -> With {w_substitutions=s; w_expansion; w_expr})
-
+      match w_expansion with Some (Signature sg) -> Signature sg | _ -> e )
+  | With { w_substitutions; w_expansion; w_expr } as e -> (
+      let w_expansion = get_expansion w_expansion e in
+      let w_expr = u_module_type_expr env id w_expr in
+      let cexpr = Component.Of_Lang.(u_module_type_expr empty w_expr) in
+      (* Format.eprintf "Handling with expression (%a)\n%!"
+         Component.Fmt.module_type_expr cexpr; *)
+      let subs' = module_type_map_subs env id cexpr w_substitutions in
+      match subs' with
+      | None -> With { w_substitutions; w_expansion; w_expr }
+      | Some s -> With { w_substitutions = s; w_expansion; w_expr } )
   | Functor (param, res) ->
-    let param' = functor_parameter env param in
-    let env' = Env.add_functor_parameter param env in
-    let res' = module_type_expr env' id res in
-    Functor (param', res')
-  | TypeOf {t_desc; t_expansion } as e ->
-    let t_expansion = get_expansion t_expansion e in
-    let t_desc = match t_desc with
-      | ModPath p -> ModuleType.ModPath (module_path env p)
-      | StructInclude p -> StructInclude (module_path env p)
-    in
-    TypeOf {t_desc; t_expansion}
+      let param' = functor_parameter env param in
+      let env' = Env.add_functor_parameter param env in
+      let res' = module_type_expr env' id res in
+      Functor (param', res')
+  | TypeOf { t_desc; t_expansion } as e ->
+      let t_expansion = get_expansion t_expansion e in
+      let t_desc =
+        match t_desc with
+        | ModPath p -> ModuleType.ModPath (module_path env p)
+        | StructInclude p -> StructInclude (module_path env p)
+      in
+      TypeOf { t_desc; t_expansion }
 
 and type_decl : Env.t -> TypeDecl.t -> TypeDecl.t =
  fun env t ->
@@ -699,14 +693,14 @@ let build_resolver :
     match resolve_unit root with
     | Ok unit -> unit
     | Error (`Msg s) ->
-      Format.eprintf "Fetch_failed: %s\n%!" s;
-      raise (Fetch_failed (`Msg s))
+        Format.eprintf "Fetch_failed: %s\n%!" s;
+        raise (Fetch_failed (`Msg s))
   and resolve_page root =
     match resolve_page root with
     | Ok page -> page
     | Error (`Msg s) ->
-    Format.eprintf "Fetch_failed (resolving page): %s\n%!" s;
-    raise (Fetch_failed (`Msg s))
+        Format.eprintf "Fetch_failed (resolving page): %s\n%!" s;
+        raise (Fetch_failed (`Msg s))
   in
   { Env.lookup_unit; resolve_unit; lookup_page; resolve_page; open_units }
 

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -61,8 +61,9 @@ end
 *)
 
 module rec Module : sig
-
-  type decl = Alias of Cpath.module_ * ModuleType.simple_expansion option | ModuleType of ModuleType.expr
+  type decl =
+    | Alias of Cpath.module_ * ModuleType.simple_expansion option
+    | ModuleType of ModuleType.expr
 
   type t = {
     doc : CComment.docs;
@@ -152,10 +153,7 @@ and Exception : sig
 end
 
 and FunctorParameter : sig
-  type parameter = {
-    id : Ident.functor_parameter;
-    expr : ModuleType.expr;
-  }
+  type parameter = { id : Ident.functor_parameter; expr : ModuleType.expr }
 
   type t = Named of parameter | Unit
 end
@@ -174,23 +172,23 @@ and ModuleType : sig
   type simple_expansion =
     | Signature of Signature.t
     | Functor of FunctorParameter.t * simple_expansion
-  
+
   type typeof_t = {
     t_desc : type_of_desc;
-    t_expansion : simple_expansion option
+    t_expansion : simple_expansion option;
   }
-  
+
   module U : sig
     type expr =
-    | Path of Cpath.module_type
-    | Signature of Signature.t
-    | With of substitution list * expr
-    | TypeOf of typeof_t
+      | Path of Cpath.module_type
+      | Signature of Signature.t
+      | With of substitution list * expr
+      | TypeOf of typeof_t
   end
 
   type path_t = {
     p_expansion : simple_expansion option;
-    p_path : Cpath.module_type
+    p_path : Cpath.module_type;
   }
 
   type with_t = {
@@ -199,7 +197,6 @@ and ModuleType : sig
     w_expr : U.expr;
   }
 
-
   type expr =
     | Path of path_t
     | Signature of Signature.t
@@ -207,10 +204,7 @@ and ModuleType : sig
     | Functor of FunctorParameter.t * expr
     | TypeOf of typeof_t
 
-  type t = {
-    doc : CComment.docs;
-    expr : expr option;
-  }
+  type t = { doc : CComment.docs; expr : expr option }
 end
 
 and TypeDecl : sig
@@ -488,9 +482,10 @@ module Fmt : sig
   val module_type : Format.formatter -> ModuleType.t -> unit
 
   val simple_expansion : Format.formatter -> ModuleType.simple_expansion -> unit
-  
-  val module_type_type_of_desc : Format.formatter -> ModuleType.type_of_desc -> unit
-  
+
+  val module_type_type_of_desc :
+    Format.formatter -> ModuleType.type_of_desc -> unit
+
   val u_module_type_expr : Format.formatter -> ModuleType.U.expr -> unit
 
   val module_type_expr : Format.formatter -> ModuleType.expr -> unit
@@ -706,7 +701,7 @@ module Of_Lang : sig
   val exception_ : map -> Odoc_model.Lang.Exception.t -> Exception.t
 
   val u_module_type_expr :
-  map -> Odoc_model.Lang.ModuleType.U.expr -> ModuleType.U.expr
+    map -> Odoc_model.Lang.ModuleType.U.expr -> ModuleType.U.expr
 
   val module_type_expr :
     map -> Odoc_model.Lang.ModuleType.expr -> ModuleType.expr

--- a/src/xref2/cpath.ml
+++ b/src/xref2/cpath.ml
@@ -102,7 +102,8 @@ let rec resolved_module_hash : Resolved.module_ -> int = function
   | `Module (m, n) -> Hashtbl.hash (6, resolved_parent_hash m, n)
   | `Canonical (m, m2) ->
       Hashtbl.hash (7, resolved_module_hash m, module_hash m2)
-  | `Apply (m1, m2) -> Hashtbl.hash (8, resolved_module_hash m1, resolved_module_hash m2)
+  | `Apply (m1, m2) ->
+      Hashtbl.hash (8, resolved_module_hash m1, resolved_module_hash m2)
   | `Alias (m1, m2) ->
       Hashtbl.hash (9, resolved_module_hash m1, resolved_module_hash m2)
   | `OpaqueModule m -> Hashtbl.hash (10, resolved_module_hash m)
@@ -384,7 +385,8 @@ and is_resolved_module_type_hidden : Resolved.module_type -> bool = function
 
 and is_type_hidden : type_ -> bool = function
   | `Resolved r -> is_resolved_type_hidden r
-  | `Identifier (id, b) -> b || is_resolved_type_hidden (`Identifier (id :> Identifier.Path.Type.t))
+  | `Identifier (id, b) ->
+      b || is_resolved_type_hidden (`Identifier (id :> Identifier.Path.Type.t))
   | `Local (_, b) -> b
   | `Substituted p -> is_type_hidden p
   | `Dot (p, _) -> is_module_hidden p

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -110,7 +110,6 @@ val add_method :
   t ->
   t
 
-
 val add_module_functor_args :
   Component.Module.t -> Odoc_model.Paths_types.Identifier.path_module -> t -> t
 
@@ -141,7 +140,7 @@ type 'a scope constraint 'a = [< Component.Element.any ]
 (** Target of a lookup *)
 
 type 'a maybe_ambiguous =
-  ('a, [ `Ambiguous of ('a * 'a list) | `Not_found ]) Result.result
+  ('a, [ `Ambiguous of 'a * 'a list | `Not_found ]) Result.result
 
 val lookup_by_name : 'a scope -> string -> t -> 'a maybe_ambiguous
 (** Lookup an element in Env depending on the given [scope].

--- a/src/xref2/errors.ml
+++ b/src/xref2/errors.ml
@@ -140,34 +140,34 @@ module Tools_error = struct
     | `Fragment_root -> Format.fprintf fmt "Fragment root"
 end
 
- (* Ugh. we need to determine whether this was down to an unexpanded module type error. This is horrendous. *)
- let is_unexpanded_module_type_of =
+(* Ugh. we need to determine whether this was down to an unexpanded module type error. This is horrendous. *)
+let is_unexpanded_module_type_of =
   let open Tools_error in
   let rec inner : any -> bool = function
-  | `Local _ -> false
-  | `Find_failure -> false
-  | `Lookup_failure _ -> false
-  | `Unresolved_apply -> false
-  | `Lookup_failure_root _ -> false
-  | `Parent p -> inner (p :> any)
-  | `Parent_sig p -> inner (p :> any)
-  | `Parent_module_type p -> inner (p :> any)
-  | `Parent_expr p -> inner (p :> any)
-  | `Parent_module p -> inner (p :> any)
-  | `Fragment_root -> false
-  | `OpaqueModule -> false
-  | `UnresolvedForwardPath -> false
-  | `UnexpandedTypeOf _ -> true (* woo *)
-  | `LocalMT _ -> false
-  | `Lookup_failureMT _ -> false
-  | `ApplyNotFunctor -> false
-  | `UnresolvedPath (`Module (_, e)) -> inner (e :> any)
-  | `UnresolvedPath (`ModuleType (_, e)) -> inner (e :> any)
-  | `Lookup_failureT _ -> false
-  | `LocalType _ -> false
-  | `Class_replaced -> false
-  in inner
-
+    | `Local _ -> false
+    | `Find_failure -> false
+    | `Lookup_failure _ -> false
+    | `Unresolved_apply -> false
+    | `Lookup_failure_root _ -> false
+    | `Parent p -> inner (p :> any)
+    | `Parent_sig p -> inner (p :> any)
+    | `Parent_module_type p -> inner (p :> any)
+    | `Parent_expr p -> inner (p :> any)
+    | `Parent_module p -> inner (p :> any)
+    | `Fragment_root -> false
+    | `OpaqueModule -> false
+    | `UnresolvedForwardPath -> false
+    | `UnexpandedTypeOf _ -> true (* woo *)
+    | `LocalMT _ -> false
+    | `Lookup_failureMT _ -> false
+    | `ApplyNotFunctor -> false
+    | `UnresolvedPath (`Module (_, e)) -> inner (e :> any)
+    | `UnresolvedPath (`ModuleType (_, e)) -> inner (e :> any)
+    | `Lookup_failureT _ -> false
+    | `LocalType _ -> false
+    | `Class_replaced -> false
+  in
+  inner
 
 (** To use as [Lookup_failures.kind]. *)
 let rec kind_of_module_cpath = function
@@ -196,8 +196,9 @@ let rec kind_of_error = function
   | _ -> None
 
 open Paths
-type what = [
-  | `Functor_parameter of Identifier.FunctorParameter.t
+
+type what =
+  [ `Functor_parameter of Identifier.FunctorParameter.t
   | `Value of Identifier.Value.t
   | `Class of Identifier.Class.t
   | `Class_type of Identifier.ClassType.t
@@ -214,10 +215,9 @@ type what = [
   | `With_type of Cfrag.type_
   | `Module_type_expr of Component.ModuleType.expr
   | `Module_type_u_expr of Component.ModuleType.U.expr
-  | `Child of Reference.t
-]
+  | `Child of Reference.t ]
 
-let report ~(what:what) ?tools_error action =
+let report ~(what : what) ?tools_error action =
   let kind =
     match tools_error with
     | Some e -> kind_of_error (e :> Tools_error.any)
@@ -263,5 +263,6 @@ let report ~(what:what) ?tools_error action =
   | `With_module frag -> r "module substitution" module_fragment frag
   | `With_type frag -> r "type substitution" type_fragment frag
   | `Module_type_expr cexpr -> r "module type expression" module_type_expr cexpr
-  | `Module_type_u_expr cexpr -> r "module type u expression" u_module_type_expr cexpr
+  | `Module_type_u_expr cexpr ->
+      r "module type u expression" u_module_type_expr cexpr
   | `Child rf -> r "child reference" model_reference rf

--- a/src/xref2/expand_tools.ml
+++ b/src/xref2/expand_tools.ml
@@ -114,8 +114,7 @@ and aux_expansion_of_u_module_type_expr env expr :
   match expr with
   | Component.ModuleType.U.Path p ->
       Tools.resolve_module_type ~mark_substituted:false env p
-      |> map_error (fun e : signature_of_module_error ->
-             `UnresolvedPath (`ModuleType (p, e)))
+      |> map_error (fun e -> `UnresolvedPath (`ModuleType (p, e)))
       >>= fun (_, mt) ->
       aux_expansion_of_module_type env mt >>= assert_not_functor
   | Signature sg -> Ok sg
@@ -131,8 +130,7 @@ and aux_expansion_of_module_type_expr env expr :
   match expr with
   | Path { p_path; _ } ->
       Tools.resolve_module_type ~mark_substituted:false env p_path
-      |> map_error (fun e : signature_of_module_error ->
-             `UnresolvedPath (`ModuleType (p_path, e)))
+      |> map_error (fun e -> `UnresolvedPath (`ModuleType (p_path, e)))
       >>= fun (_, mt) -> aux_expansion_of_module_type env mt
   | Signature s -> Ok (Signature s)
   | With { w_substitutions; w_expr; _ } ->

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -11,7 +11,8 @@ type class_ =
   [ `FClass of ClassName.t * Class.t
   | `FClassType of ClassTypeName.t * ClassType.t ]
 
-type value = [ `FExternal of ValueName.t * External.t | `FValue of ValueName.t * Value.t ]
+type value =
+  [ `FExternal of ValueName.t * External.t | `FValue of ValueName.t * Value.t ]
 
 type label = [ `FLabel of Ident.label ]
 
@@ -46,7 +47,8 @@ type any_in_sig =
   | substitution
   | any_in_type_in_sig ]
 
-type instance_variable = [ `FInstance_variable of InstanceVariableName.t * InstanceVariable.t ]
+type instance_variable =
+  [ `FInstance_variable of InstanceVariableName.t * InstanceVariable.t ]
 
 type method_ = [ `FMethod of MethodName.t * Method.t ]
 
@@ -103,7 +105,8 @@ let class_in_sig sg name =
         Some (`FClassType (N.class_type' id, c))
     | _ -> None)
 
-type removed_type = [ `FType_removed of TypeName.t * TypeExpr.t * TypeDecl.Equation.t ]
+type removed_type =
+  [ `FType_removed of TypeName.t * TypeExpr.t * TypeDecl.Equation.t ]
 
 type careful_module = [ module_ | `FModule_removed of Cpath.Resolved.module_ ]
 
@@ -205,9 +208,12 @@ let any_in_sig sg name =
     | Type (id, _, t) when N.type_ id = name ->
         Some (`FType (N.type' id, Delayed.get t))
     | TypeSubstitution (id, ts) when N.type_ id = name -> Some (`FType_subst ts)
-    | Exception (id, exc) when N.exception_ id = name -> Some (`FExn (N.typed_exception id, exc))
-    | Value (id, v) when N.value id = name -> Some (`FValue (N.typed_value id, Delayed.get v))
-    | External (id, vex) when N.value id = name -> Some (`FExternal (N.typed_value id, vex))
+    | Exception (id, exc) when N.exception_ id = name ->
+        Some (`FExn (N.typed_exception id, exc))
+    | Value (id, v) when N.value id = name ->
+        Some (`FValue (N.typed_value id, Delayed.get v))
+    | External (id, vex) when N.value id = name ->
+        Some (`FExternal (N.typed_value id, vex))
     | Class (id, _, c) when N.class_ id = name ->
         Some (`FClass (N.class' id, c))
     | ClassType (id, _, ct) when N.class_type id = name ->
@@ -239,7 +245,8 @@ let value_in_sig sg name =
   filter_in_sig sg (function
     | Signature.Value (id, m) when N.value id = name ->
         Some (`FValue (N.typed_value id, Delayed.get m))
-    | External (id, e) when N.value id = name -> Some (`FExternal (N.typed_value id, e))
+    | External (id, e) when N.value id = name ->
+        Some (`FExternal (N.typed_value id, e))
     | _ -> None)
 
 let label_in_sig sg name =
@@ -249,7 +256,8 @@ let label_in_sig sg name =
 
 let exception_in_sig sg name =
   find_in_sig sg (function
-    | Signature.Exception (id, e) when N.exception_ id = name -> Some (`FExn (N.typed_exception id, e))
+    | Signature.Exception (id, e) when N.exception_ id = name ->
+        Some (`FExn (N.typed_exception id, e))
     | _ -> None)
 
 let extension_in_sig sg name =

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -12,7 +12,8 @@ type class_ =
   [ `FClass of ClassName.t * Class.t
   | `FClassType of ClassTypeName.t * ClassType.t ]
 
-type value = [ `FExternal of ValueName.t * External.t | `FValue of ValueName.t * Value.t ]
+type value =
+  [ `FExternal of ValueName.t * External.t | `FValue of ValueName.t * Value.t ]
 
 type label = [ `FLabel of Ident.label ]
 
@@ -46,7 +47,8 @@ type any_in_sig =
   | substitution
   | any_in_type_in_sig ]
 
-type instance_variable = [ `FInstance_variable of InstanceVariableName.t * InstanceVariable.t ]
+type instance_variable =
+  [ `FInstance_variable of InstanceVariableName.t * InstanceVariable.t ]
 
 type method_ = [ `FMethod of MethodName.t * Method.t ]
 
@@ -95,7 +97,8 @@ val any_in_class_signature : ClassSignature.t -> string -> any_in_class_sig list
 
 (** Lookup removed items *)
 
-type removed_type = [ `FType_removed of TypeName.t * TypeExpr.t * TypeDecl.Equation.t ]
+type removed_type =
+  [ `FType_removed of TypeName.t * TypeExpr.t * TypeDecl.Equation.t ]
 
 type careful_module = [ module_ | `FModule_removed of Cpath.Resolved.module_ ]
 

--- a/src/xref2/ident.ml
+++ b/src/xref2/ident.ml
@@ -18,7 +18,11 @@ type datatype = [ `LType of TypeName.t * int | `LCoreType of TypeName.t ]
 
 type parent = [ signature | datatype | class_signature ]
 
-type label_parent = [ parent | `LRootPage of PageName.t * int | `LPage of PageName.t * int | `LLeafPage of PageName.t * int ]
+type label_parent =
+  [ parent
+  | `LRootPage of PageName.t * int
+  | `LPage of PageName.t * int
+  | `LLeafPage of PageName.t * int ]
 
 type module_ = [ `LRoot of ModuleName.t * int | `LModule of ModuleName.t * int ]
 
@@ -55,9 +59,10 @@ type instance_variable = [ `LInstanceVariable of InstanceVariableName.t * int ]
 
 type label = [ `LLabel of LabelName.t * int ]
 
-type page = [ `LRootPage of PageName.t * int 
-            | `LPage of PageName.t * int
-            | `LLeafPage of PageName.t * int ]
+type page =
+  [ `LRootPage of PageName.t * int
+  | `LPage of PageName.t * int
+  | `LLeafPage of PageName.t * int ]
 
 type any =
   [ signature
@@ -214,7 +219,6 @@ module Of_Identifier = struct
     | `RootPage n -> `LRootPage (n, fresh_int ())
     | `Page (_, n) -> `LPage (n, fresh_int ())
     | `LeafPage (_, n) -> `LLeafPage (n, fresh_int ())
-
 end
 
 module Name = struct
@@ -414,7 +418,6 @@ let rec fmt_aux ppf (id : any) =
   | `LRootPage (n, i) -> Format.fprintf ppf "%s/%d" (PageName.to_string n) i
   | `LPage (n, i) -> Format.fprintf ppf "%s/%d" (PageName.to_string n) i
   | `LLeafPage (n, i) -> Format.fprintf ppf "%s/%d" (PageName.to_string n) i
-
 
 let fmt : Format.formatter -> [< any ] -> unit =
  fun ppf id -> fmt_aux ppf (id :> any)

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -8,15 +8,13 @@ type maps = {
   functor_parameter :
     (Ident.functor_parameter * Identifier.FunctorParameter.t) list;
   type_ : Identifier.Type.t Component.TypeMap.t;
-  path_type :
-    Identifier.Path.Type.t Component.PathTypeMap.t;
+  path_type : Identifier.Path.Type.t Component.PathTypeMap.t;
   class_ : (Ident.class_ * Identifier.Class.t) list;
   class_type : (Ident.class_type * Identifier.ClassType.t) list;
-  path_class_type :
-    Identifier.Path.ClassType.t Component.PathClassTypeMap.t;
+  path_class_type : Identifier.Path.ClassType.t Component.PathClassTypeMap.t;
   fragment_root : Cfrag.root option;
   (* Shadowed items *)
-  shadowed : Lang.Include.shadowed
+  shadowed : Lang.Include.shadowed;
 }
 
 let empty_shadow =
@@ -28,6 +26,7 @@ let empty_shadow =
     s_classes = [];
     s_class_types = [];
   }
+
 let empty =
   {
     module_ = Component.ModuleMap.empty;
@@ -80,7 +79,8 @@ module Path = struct
     | `Substituted x -> module_type map x
     | `Identifier ((#Odoc_model.Paths.Identifier.ModuleType.t as y), b) ->
         `Identifier (y, b)
-    | `Local (id, b) -> `Identifier (Component.ModuleTypeMap.find id map.module_type, b)
+    | `Local (id, b) ->
+        `Identifier (Component.ModuleTypeMap.find id map.module_type, b)
     | `Resolved x -> `Resolved (resolved_module_type map x)
     | `Dot (p, n) -> `Dot (module_ map p, n)
     | `ModuleType (`Module p, n) ->
@@ -92,7 +92,8 @@ module Path = struct
     | `Substituted x -> type_ map x
     | `Identifier ((#Odoc_model.Paths_types.Identifier.path_type as y), b) ->
         `Identifier (y, b)
-    | `Local (id, b) -> `Identifier (Component.PathTypeMap.find id map.path_type, b)
+    | `Local (id, b) ->
+        `Identifier (Component.PathTypeMap.find id map.path_type, b)
     | `Resolved x -> `Resolved (resolved_type map x)
     | `Dot (p, n) -> `Dot (module_ map p, n)
     | `Type (`Module p, n) ->
@@ -110,7 +111,8 @@ module Path = struct
     | `Identifier ((#Odoc_model.Paths_types.Identifier.path_class_type as y), b)
       ->
         `Identifier (y, b)
-    | `Local (id, b) -> `Identifier (Component.PathClassTypeMap.find id map.path_class_type, b)
+    | `Local (id, b) ->
+        `Identifier (Component.PathClassTypeMap.find id map.path_class_type, b)
     | `Resolved x -> `Resolved (resolved_class_type map x)
     | `Dot (p, n) -> `Dot (module_ map p, n)
     | `Class (`Module p, n) ->
@@ -177,7 +179,8 @@ module Path = struct
     match p with
     | `Identifier (#Odoc_model.Paths_types.Identifier.path_class_type as y) ->
         `Identifier y
-    | `Local id -> `Identifier (Component.PathClassTypeMap.find id map.path_class_type)
+    | `Local id ->
+        `Identifier (Component.PathClassTypeMap.find id map.path_class_type)
     | `Class (p, name) -> `Class (resolved_parent map p, name)
     | `ClassType (p, name) -> `ClassType (resolved_parent map p, name)
     | `Substituted s -> resolved_class_type map s
@@ -243,23 +246,26 @@ module ExtractIDs = struct
   let rec type_decl parent map id =
     let name = Ident.Name.type_ id in
     let identifier =
-      if List.mem_assoc name map.shadowed.s_types then List.assoc name map.shadowed.s_types
+      if List.mem_assoc name map.shadowed.s_types then
+        List.assoc name map.shadowed.s_types
       else `Type (parent, Ident.Name.typed_type id)
     in
     {
       map with
-      type_ = Component.TypeMap. add id identifier map.type_;
-      path_type = Component.PathTypeMap.add 
-      (id :> Ident.path_type) (identifier :> Identifier.Path.Type.t)
-        map.path_type;
+      type_ = Component.TypeMap.add id identifier map.type_;
+      path_type =
+        Component.PathTypeMap.add
+          (id :> Ident.path_type)
+          (identifier :> Identifier.Path.Type.t)
+          map.path_type;
     }
 
   and module_ parent map id =
     let name' = Ident.Name.typed_module id in
     let name = ModuleName.to_string name' in
     let identifier =
-      if List.mem_assoc name map.shadowed.s_modules
-      then List.assoc name map.shadowed.s_modules
+      if List.mem_assoc name map.shadowed.s_modules then
+        List.assoc name map.shadowed.s_modules
       else `Module (parent, name')
     in
     { map with module_ = Component.ModuleMap.add id identifier map.module_ }
@@ -271,24 +277,31 @@ module ExtractIDs = struct
         List.assoc name map.shadowed.s_module_types
       else `ModuleType (parent, Ident.Name.typed_module_type id)
     in
-    { map with module_type = Component.ModuleTypeMap.add id identifier map.module_type }
+    {
+      map with
+      module_type = Component.ModuleTypeMap.add id identifier map.module_type;
+    }
 
   and class_ parent map id =
     let name = Ident.Name.class_ id in
     let identifier =
-      if List.mem_assoc name map.shadowed.s_classes then List.assoc name map.shadowed.s_classes
+      if List.mem_assoc name map.shadowed.s_classes then
+        List.assoc name map.shadowed.s_classes
       else `Class (parent, Ident.Name.typed_class id)
     in
     {
       map with
       class_ = (id, identifier) :: map.class_;
-      path_class_type = Component.PathClassTypeMap.add 
-        (id :> Ident.path_class_type)
-        (identifier :> Identifier.Path.ClassType.t)
-        map.path_class_type;
-      path_type = Component.PathTypeMap.add 
-        (id :> Ident.path_type) (identifier :> Identifier.Path.Type.t)
-        map.path_type;
+      path_class_type =
+        Component.PathClassTypeMap.add
+          (id :> Ident.path_class_type)
+          (identifier :> Identifier.Path.ClassType.t)
+          map.path_class_type;
+      path_type =
+        Component.PathTypeMap.add
+          (id :> Ident.path_type)
+          (identifier :> Identifier.Path.Type.t)
+          map.path_type;
     }
 
   and class_type parent map (id : Ident.class_type) =
@@ -301,17 +314,19 @@ module ExtractIDs = struct
     {
       map with
       class_type = ((id :> Ident.class_type), identifier) :: map.class_type;
-      path_class_type = Component.PathClassTypeMap.add
-        (id :> Ident.path_class_type)
-        (identifier :> Identifier.Path.ClassType.t)
-        map.path_class_type;
-      path_type = Component.PathTypeMap.add 
-        (id :> Ident.path_type) (identifier :> Identifier.Path.Type.t)
-        map.path_type;
+      path_class_type =
+        Component.PathClassTypeMap.add
+          (id :> Ident.path_class_type)
+          (identifier :> Identifier.Path.ClassType.t)
+          map.path_class_type;
+      path_type =
+        Component.PathTypeMap.add
+          (id :> Ident.path_type)
+          (identifier :> Identifier.Path.Type.t)
+          map.path_type;
     }
 
-  and include_ parent map i =
-    signature parent map i.Include.expansion_
+  and include_ parent map i = signature parent map i.Include.expansion_
 
   and open_ parent map o = signature parent map o.Open.expansion
 
@@ -353,7 +368,7 @@ let rec signature_items id map items =
     match items with
     | [] -> List.rev acc
     | Module (id, r, m) :: rest ->
-      let m = Component.Delayed.get m in
+        let m = Component.Delayed.get m in
         inner rest
           (Odoc_model.Lang.Signature.Module (r, module_ map parent id m) :: acc)
     | ModuleType (id, m) :: rest ->
@@ -361,7 +376,7 @@ let rec signature_items id map items =
           ( Odoc_model.Lang.Signature.ModuleType (module_type map parent id m)
           :: acc )
     | Type (id, r, t) :: rest ->
-      let t = Component.Delayed.get t in
+        let t = Component.Delayed.get t in
         inner rest (Type (r, type_decl map parent id t) :: acc)
     | Exception (id', e) :: rest ->
         inner rest
@@ -372,7 +387,7 @@ let rec signature_items id map items =
           :: acc )
     | TypExt t :: rest -> inner rest (TypExt (typ_ext map id t) :: acc)
     | Value (id, v) :: rest ->
-      let v = Component.Delayed.get v in
+        let v = Component.Delayed.get v in
         inner rest (Value (value_ map parent id v) :: acc)
     | Include i :: rest -> inner rest (Include (include_ id map i) :: acc)
     | Open o :: rest -> inner rest (Open (open_ id map o) :: acc)
@@ -531,27 +546,27 @@ and simple_expansion :
       in
       let arg = functor_parameter map arg in
       Functor (Named arg, simple_expansion map identifier sg)
-  | Functor (Unit, sg) ->
-      Functor (Unit, simple_expansion map (`Result id) sg)
+  | Functor (Unit, sg) -> Functor (Unit, simple_expansion map (`Result id) sg)
 
 and combine_shadowed s1 s2 =
   let open Odoc_model.Lang.Include in
-  { s_modules = s1.s_modules @ s2.s_modules;
-    s_module_types = s1.s_module_types @ s2.s_module_types; 
+  {
+    s_modules = s1.s_modules @ s2.s_modules;
+    s_module_types = s1.s_module_types @ s2.s_module_types;
     s_types = s1.s_types @ s2.s_types;
     s_classes = s1.s_classes @ s2.s_classes;
-    s_class_types = s1.s_class_types @ s2.s_class_types }
+    s_class_types = s1.s_class_types @ s2.s_class_types;
+  }
 
 and include_decl :
-maps ->
-Odoc_model.Paths_types.Identifier.signature ->
-Component.Include.decl ->
-Odoc_model.Lang.Include.decl =
-fun map identifier d ->
-match d with
-| Alias p ->
-  Alias (Path.module_ map p)
-| ModuleType mty -> ModuleType (u_module_type_expr map identifier mty)
+    maps ->
+    Odoc_model.Paths_types.Identifier.signature ->
+    Component.Include.decl ->
+    Odoc_model.Lang.Include.decl =
+ fun map identifier d ->
+  match d with
+  | Alias p -> Alias (Path.module_ map p)
+  | ModuleType mty -> ModuleType (u_module_type_expr map identifier mty)
 
 and include_ parent map i =
   let open Component.Include in
@@ -563,7 +578,10 @@ and include_ parent map i =
       {
         resolved = false;
         shadowed = i.shadowed;
-        content = signature parent { map with shadowed = combine_shadowed map.shadowed i.shadowed } i.expansion_;
+        content =
+          signature parent
+            { map with shadowed = combine_shadowed map.shadowed i.shadowed }
+            i.expansion_;
       };
     inline = false;
   }
@@ -606,7 +624,9 @@ and extension_constructor map parent c =
 and module_ map parent id m =
   try
     let open Component.Module in
-    let id = (Component.ModuleMap.find id map.module_ :> Paths_types.Identifier.module_) in
+    let id =
+      (Component.ModuleMap.find id map.module_ :> Paths_types.Identifier.module_)
+    in
     let identifier = (id :> Odoc_model.Paths_types.Identifier.signature) in
     let canonical = function
       | Some (p, r) -> Some (Path.module_ map p, r)
@@ -643,7 +663,8 @@ and module_decl :
  fun map identifier d ->
   match d with
   | Component.Module.Alias (p, s) ->
-      Odoc_model.Lang.Module.Alias (Path.module_ map p, Opt.map (simple_expansion map identifier) s)
+      Odoc_model.Lang.Module.Alias
+        (Path.module_ map p, Opt.map (simple_expansion map identifier) s)
   | ModuleType mty -> ModuleType (module_type_expr map identifier mty)
 
 and mty_substitution map identifier = function
@@ -661,31 +682,51 @@ and mty_substitution map identifier = function
         ( Path.type_fragment map frag,
           type_decl_equation map (identifier :> Identifier.Parent.t) eqn )
 
-and u_module_type_expr map identifier =
-  function
+and u_module_type_expr map identifier = function
   | Component.ModuleType.U.Path p_path ->
       Odoc_model.Lang.ModuleType.U.Path (Path.module_type map p_path)
   | Signature s ->
       Signature
         (signature
-          (identifier :> Odoc_model.Paths.Identifier.Signature.t)
-          map s)
+           (identifier :> Odoc_model.Paths.Identifier.Signature.t)
+           map s)
   | With (subs, expr) ->
-      With (List.map (mty_substitution map identifier) subs, u_module_type_expr map identifier expr)
-  | TypeOf { t_desc = ModPath p; t_expansion } -> TypeOf { t_desc = ModPath (Path.module_ map p); t_expansion = Opt.map (simple_expansion map identifier) t_expansion }
-  | TypeOf { t_desc = StructInclude p; t_expansion }-> TypeOf { t_desc = StructInclude (Path.module_ map p); t_expansion = Opt.map (simple_expansion map identifier) t_expansion }
+      With
+        ( List.map (mty_substitution map identifier) subs,
+          u_module_type_expr map identifier expr )
+  | TypeOf { t_desc = ModPath p; t_expansion } ->
+      TypeOf
+        {
+          t_desc = ModPath (Path.module_ map p);
+          t_expansion = Opt.map (simple_expansion map identifier) t_expansion;
+        }
+  | TypeOf { t_desc = StructInclude p; t_expansion } ->
+      TypeOf
+        {
+          t_desc = StructInclude (Path.module_ map p);
+          t_expansion = Opt.map (simple_expansion map identifier) t_expansion;
+        }
 
-and module_type_expr map identifier =
-  function
-  | Component.ModuleType.Path {p_path; p_expansion} ->
-      Odoc_model.Lang.ModuleType.Path {p_path=Path.module_type map p_path; p_expansion=Opt.map (simple_expansion map identifier) p_expansion}
+and module_type_expr map identifier = function
+  | Component.ModuleType.Path { p_path; p_expansion } ->
+      Odoc_model.Lang.ModuleType.Path
+        {
+          p_path = Path.module_type map p_path;
+          p_expansion = Opt.map (simple_expansion map identifier) p_expansion;
+        }
   | Signature s ->
       Signature
         (signature
            (identifier :> Odoc_model.Paths.Identifier.Signature.t)
            map s)
-  | With {w_substitutions; w_expansion; w_expr} ->
-      With {w_substitutions = List.map (mty_substitution map identifier) w_substitutions; w_expansion=Opt.map (simple_expansion map identifier) w_expansion; w_expr = u_module_type_expr map identifier w_expr }
+  | With { w_substitutions; w_expansion; w_expr } ->
+      With
+        {
+          w_substitutions =
+            List.map (mty_substitution map identifier) w_substitutions;
+          w_expansion = Opt.map (simple_expansion map identifier) w_expansion;
+          w_expr = u_module_type_expr map identifier w_expr;
+        }
   | Functor (Named arg, expr) ->
       let name = Ident.Name.typed_functor_parameter arg.id in
       let identifier' = `Parameter (identifier, name) in
@@ -700,8 +741,18 @@ and module_type_expr map identifier =
           module_type_expr map (`Result identifier) expr )
   | Functor (Unit, expr) ->
       Functor (Unit, module_type_expr map (`Result identifier) expr)
-  | TypeOf {t_desc=ModPath p; t_expansion} -> TypeOf {t_desc=ModPath (Path.module_ map p); t_expansion=Opt.map (simple_expansion map identifier) t_expansion}
-  | TypeOf {t_desc=StructInclude p; t_expansion} -> TypeOf {t_desc=StructInclude (Path.module_ map p); t_expansion=Opt.map (simple_expansion map identifier) t_expansion}
+  | TypeOf { t_desc = ModPath p; t_expansion } ->
+      TypeOf
+        {
+          t_desc = ModPath (Path.module_ map p);
+          t_expansion = Opt.map (simple_expansion map identifier) t_expansion;
+        }
+  | TypeOf { t_desc = StructInclude p; t_expansion } ->
+      TypeOf
+        {
+          t_desc = StructInclude (Path.module_ map p);
+          t_expansion = Opt.map (simple_expansion map identifier) t_expansion;
+        }
 
 and module_type :
     maps ->

--- a/src/xref2/lang_of.mli
+++ b/src/xref2/lang_of.mli
@@ -7,12 +7,10 @@ type maps = {
   functor_parameter :
     (Ident.functor_parameter * Identifier.FunctorParameter.t) list;
   type_ : Identifier.Type.t Component.TypeMap.t;
-  path_type :
-    Identifier.Path.Type.t Component.PathTypeMap.t;
+  path_type : Identifier.Path.Type.t Component.PathTypeMap.t;
   class_ : (Ident.class_ * Identifier.Class.t) list;
   class_type : (Ident.class_type * Identifier.ClassType.t) list;
-  path_class_type :
-    Identifier.Path.ClassType.t Component.PathClassTypeMap.t;
+  path_class_type : Identifier.Path.ClassType.t Component.PathClassTypeMap.t;
   fragment_root : Cfrag.root option;
   (* Shadowed items *)
   shadowed : Odoc_model.Lang.Include.shadowed;

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -263,8 +263,8 @@ module DT = struct
   let in_signature _env ((parent', parent_cp, sg) : signature_lookup_result)
       name : t option =
     let sg = Tools.prefix_signature (parent_cp, sg) in
-    Find.datatype_in_sig sg name
-    >>= fun (`FType (name, t)) -> Some (`Type (parent', name), t)
+    Find.datatype_in_sig sg name >>= fun (`FType (name, t)) ->
+    Some (`Type (parent', name), t)
 end
 
 module T = struct
@@ -535,8 +535,7 @@ let rec resolve_label_parent_reference :
         resolve_label_parent_reference env parent
         >>= signature_lookup_result_of_label_parent
         >>= fun p -> LP.in_signature env p name
-    | `Root (name, `TPage)
-    | `Root (name, `TChildPage) ->
+    | `Root (name, `TPage) | `Root (name, `TChildPage) ->
         Env.lookup_page name env >>= fun p ->
         let labels =
           List.fold_right
@@ -549,7 +548,8 @@ let rec resolve_label_parent_reference :
         in
         return (`Page (`Identifier p.Odoc_model.Lang.Page.name, labels))
     | `Root (name, `TChildModule) ->
-        resolve_signature_reference env (`Root (name, `TModule)) >>= label_parent_res_of_sig_res
+        resolve_signature_reference env (`Root (name, `TModule))
+        >>= label_parent_res_of_sig_res
 
 and resolve_signature_reference :
     Env.t -> Signature.t -> signature_lookup_result option =
@@ -667,7 +667,8 @@ let resolve_reference_dot_sg env ~parent_path ~parent_ref ~parent_sg name =
   | `FClassType (name, ct) ->
       CT.of_component env ct ~parent_ref name >>= resolved2
   | `FValue (name, _) -> V.of_component env ~parent_ref name >>= resolved1
-  | `FExternal (name, _) -> V.external_of_component env ~parent_ref name >>= resolved1
+  | `FExternal (name, _) ->
+      V.external_of_component env ~parent_ref name >>= resolved1
   | `FLabel label -> L.of_component env ~parent_ref label >>= resolved1
   | `FExn (name, _) -> EX.of_component env ~parent_ref name >>= resolved1
   | `FExt _ -> EC.of_component env ~parent_ref name >>= resolved1
@@ -690,7 +691,8 @@ let resolve_reference_dot_class env p name =
   type_lookup_to_class_signature_lookup env p >>= fun (parent_ref, cs) ->
   find_ambiguous Find.any_in_class_signature cs name >>= function
   | `FMethod (name, _) -> MM.of_component env parent_ref name >>= resolved1
-  | `FInstance_variable (name, _) -> MV.of_component env parent_ref name >>= resolved1
+  | `FInstance_variable (name, _) ->
+      MV.of_component env parent_ref name >>= resolved1
 
 let resolve_reference_dot env parent name =
   resolve_label_parent_reference env parent >>= function
@@ -722,19 +724,16 @@ let resolve_reference : Env.t -> t -> Resolved.t option =
         | `Exception (id, _) -> identifier id
         | `Extension (id, _) -> identifier id
         | `Field (id, _) -> identifier id )
-    | `Root (name, `TChildPage) -> begin
+    | `Root (name, `TChildPage) -> (
         match Env.lookup_page name env with
-        | Some p ->
-          Some (`Identifier (p.name :> Identifier.t))
-        | None -> None
-      end
-    | `Root (name, `TChildModule) -> begin
+        | Some p -> Some (`Identifier (p.name :> Identifier.t))
+        | None -> None )
+    | `Root (name, `TChildModule) -> (
         match Env.lookup_root_module name env with
-        | Some (Resolved (_, id, _, _)) -> Some (`Identifier (id :> Identifier.t))
-        | Some Forward
-        | None -> None
-      end
-  | `Resolved r -> Some r
+        | Some (Resolved (_, id, _, _)) ->
+            Some (`Identifier (id :> Identifier.t))
+        | Some Forward | None -> None )
+    | `Resolved r -> Some r
     | `Root (name, `TModule) -> M.in_env env name >>= resolved
     | `Module (parent, name) ->
         resolve_signature_reference env parent >>= fun p ->

--- a/src/xref2/subst.mli
+++ b/src/xref2/subst.mli
@@ -23,7 +23,8 @@ val add_class :
 val add_class_type :
   Ident.class_type -> Cpath.class_type -> Cpath.Resolved.class_type -> t -> t
 
-val add_type_replacement : Ident.path_type -> TypeExpr.t -> TypeDecl.Equation.t -> t -> t
+val add_type_replacement :
+  Ident.path_type -> TypeExpr.t -> TypeDecl.Equation.t -> t -> t
 
 val add_module_substitution : Ident.path_module -> t -> t
 

--- a/src/xref2/tools.mli
+++ b/src/xref2/tools.mli
@@ -222,11 +222,11 @@ val signature_of_module_type_expr :
     during the link phase. *)
 
 val signature_of_u_module_type_expr :
-    mark_substituted:bool ->
-    Env.t ->
-    Component.ModuleType.U.expr ->
-    (Component.Signature.t, signature_of_module_error) Result.result
-  (** The following functions are use for the resolution of {{!type:Odoc_model.Paths.Fragment.t}Fragments}
+  mark_substituted:bool ->
+  Env.t ->
+  Component.ModuleType.U.expr ->
+  (Component.Signature.t, signature_of_module_error) Result.result
+(** The following functions are use for the resolution of {{!type:Odoc_model.Paths.Fragment.t}Fragments}
       Whilst resolving fragments it is necessary to process them in order, applying
       the 'with' expression of module or type equality or substitution, before resolving
       the next fragment. The function [signature_of_module_type_expr] is used to supply
@@ -234,7 +234,7 @@ val signature_of_u_module_type_expr :
       be [true]. As for the path resolution functions above, the resolve functions may
       be called during compile or link, whereas the reresolve functions should only be called
       during the link phase. *)
-  
+
 val resolve_module_fragment :
   Env.t ->
   Cfrag.root * Component.Signature.t ->

--- a/src/xref2/type_of.ml
+++ b/src/xref2/type_of.ml
@@ -9,76 +9,91 @@ module Id = Odoc_model.Paths.Identifier
 let again = ref false
 
 let rec signature : Env.t -> Signature.t -> Signature.t =
-  fun env sg ->
-    let env = Env.open_signature sg env in
-    signature_items env sg
+ fun env sg ->
+  let env = Env.open_signature sg env in
+  signature_items env sg
 
 and signature_items : Env.t -> Signature.t -> Signature.t =
-    fun env s ->
-     let open Signature in
-     List.map
-       (fun item ->
-         match item with
-         | Module (r, m) -> Module (r, module_ env m)
-         | ModuleType mt -> ModuleType (module_type env mt)
-         | Include i -> Include (include_ env i)
-         | item -> item)
-       s
+ fun env s ->
+  let open Signature in
+  List.map
+    (fun item ->
+      match item with
+      | Module (r, m) -> Module (r, module_ env m)
+      | ModuleType mt -> ModuleType (module_type env mt)
+      | Include i -> Include (include_ env i)
+      | item -> item)
+    s
 
 and module_ env m =
   match m.type_ with
   | Alias _ -> m
-  | ModuleType expr -> { m with type_ = ModuleType (module_type_expr env (m.id :> Id.Signature.t) expr) }
+  | ModuleType expr ->
+      {
+        m with
+        type_ = ModuleType (module_type_expr env (m.id :> Id.Signature.t) expr);
+      }
 
 and module_type env m =
   match m.expr with
   | None -> m
-  | Some expr -> { m with expr = Some (module_type_expr env (m.id :> Id.Signature.t) expr) }
+  | Some expr ->
+      {
+        m with
+        expr = Some (module_type_expr env (m.id :> Id.Signature.t) expr);
+      }
 
 and module_type_expr_typeof env (id : Id.Signature.t) t =
   let open Odoc_model.Lang.ModuleType in
   let p, strengthen =
-    match t.t_desc with
-    | ModPath p -> p, false
-    | StructInclude p -> p, true
+    match t.t_desc with ModPath p -> (p, false) | StructInclude p -> (p, true)
   in
   let cp = Component.Of_Lang.(module_path empty p) in
   let open Expand_tools in
   let open Utils.ResultMonad in
-  aux_expansion_of_module_alias env ~strengthen cp
-  >>= handle_expansion env id
-  >>= fun (_env, e) -> Ok e 
+  aux_expansion_of_module_alias env ~strengthen cp >>= handle_expansion env id
+  >>= fun (_env, e) -> Ok e
 
 and module_type_expr env (id : Id.Signature.t) expr =
   match expr with
   | Path _ -> expr
   | Functor (Unit, expr) -> Functor (Unit, module_type_expr env id expr)
   | Functor (Named p, expr) ->
-    let env = Env.add_functor_parameter (Named p) env in
-    Functor (Named (functor_parameter env p), module_type_expr env id expr)
+      let env = Env.add_functor_parameter (Named p) env in
+      Functor (Named (functor_parameter env p), module_type_expr env id expr)
   | Signature sg -> Signature (signature env sg)
-  | With w -> With {w with w_expr = u_module_type_expr env id w.w_expr }
-  | TypeOf t ->
-    match module_type_expr_typeof env id t with
-    | Ok e -> TypeOf {t with t_expansion = Some (Lang_of.(simple_expansion empty id e)) }
-    | Error e when Errors.is_unexpanded_module_type_of (e :> Errors.Tools_error.any) -> again := true; expr
-    | Error _e ->
-      expr
+  | With w -> With { w with w_expr = u_module_type_expr env id w.w_expr }
+  | TypeOf t -> (
+      match module_type_expr_typeof env id t with
+      | Ok e ->
+          TypeOf
+            { t with t_expansion = Some Lang_of.(simple_expansion empty id e) }
+      | Error e
+        when Errors.is_unexpanded_module_type_of (e :> Errors.Tools_error.any)
+        ->
+          again := true;
+          expr
+      | Error _e -> expr )
 
 and u_module_type_expr env id expr =
   match expr with
   | Path _ -> expr
   | Signature sg -> Signature (signature env sg)
-  | With (subs, w) -> With ( subs, u_module_type_expr env id w)
-  | TypeOf t ->
-    match module_type_expr_typeof env id t with
-    | Ok e -> TypeOf {t with t_expansion = Some (Lang_of.(simple_expansion empty id e)) }
-    | Error e when Errors.is_unexpanded_module_type_of (e :> Errors.Tools_error.any) -> again := true; expr
-    | Error _e ->
-      expr
+  | With (subs, w) -> With (subs, u_module_type_expr env id w)
+  | TypeOf t -> (
+      match module_type_expr_typeof env id t with
+      | Ok e ->
+          TypeOf
+            { t with t_expansion = Some Lang_of.(simple_expansion empty id e) }
+      | Error e
+        when Errors.is_unexpanded_module_type_of (e :> Errors.Tools_error.any)
+        ->
+          again := true;
+          expr
+      | Error _e -> expr )
 
 and functor_parameter env p =
-  { p with expr = module_type_expr env (p.id :> Id.Signature.t) p.expr}
+  { p with expr = module_type_expr env (p.id :> Id.Signature.t) p.expr }
 
 and include_ env i =
   let decl =
@@ -86,15 +101,17 @@ and include_ env i =
     | Alias _ -> i.decl
     | ModuleType t -> ModuleType (u_module_type_expr env i.parent t)
   in
-  { i with expansion = { i.expansion with content = signature env i.expansion.content }; decl }
+  {
+    i with
+    expansion = { i.expansion with content = signature env i.expansion.content };
+    decl;
+  }
 
 let signature env =
   let rec loop sg =
     again := false;
     let sg' = signature env sg in
     Tools.reset_caches ();
-    if !again
-    then begin
-      if sg' = sg then sg else loop sg'
-    end else sg' in
+    if !again then if sg' = sg then sg else loop sg' else sg'
+  in
   loop

--- a/src/xref2/type_of.mli
+++ b/src/xref2/type_of.mli
@@ -1,9 +1,9 @@
+open Odoc_model.Lang
 (** The purpose of this module is to expand module type
     expressions of the form [module type of]. This is necessary
     so odoc can keep track of these expressions but mainting the
     semantics of the underlying OCaml. *)
-open Odoc_model.Lang
 
+val signature : Env.t -> Signature.t -> Signature.t
 (** Expand all of the [module type of] expressions within the
     given signature *)
-val signature : Env.t -> Signature.t -> Signature.t

--- a/test/cases/.ocamlformat
+++ b/test/cases/.ocamlformat
@@ -1,0 +1,1 @@
+disable = true

--- a/test/html/dune
+++ b/test/html/dune
@@ -4,7 +4,8 @@
 
 (rule
  (alias runtest)
- (action (run %{exe:test.exe}))
+ (action
+  (run %{exe:test.exe}))
  (deps
   test.exe
   %{workspace_root}/src/odoc/bin/main.exe

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -3,13 +3,13 @@ open Printf
 
 (* Utils *)
 
-let (//) = Filename.concat
+let ( // ) = Filename.concat
 
 let command label =
   Printf.ksprintf (fun s ->
-    let exit_code = Sys.command s in
-    if exit_code <> 0 then
-      Alcotest.failf "'%s' exited with %i" label exit_code)
+      let exit_code = Sys.command s in
+      if exit_code <> 0 then
+        Alcotest.failf "'%s' exited with %i" label exit_code)
 
 (* Filename.extension is only available on 4.04. *)
 module Filename = struct
@@ -20,11 +20,11 @@ module Filename = struct
     String.sub filename dot_index (String.length filename - dot_index)
 end
 
-
 (* Testing environment *)
 
 module Env = struct
   let package = "test_package"
+
   let odoc = "../../src/odoc/bin/main.exe"
 
   let path ?(from_root = false) = function
@@ -36,20 +36,17 @@ module Env = struct
     | `cases -> "../cases"
 
   let running_in_travis_tidy_row =
-    match Sys.getenv "TRAVIS", Sys.getenv "TIDY" with
+    match (Sys.getenv "TRAVIS", Sys.getenv "TIDY") with
     | "true", "YES" -> true
     | _ -> false
     | exception Not_found -> false
 
-  let init () = begin
-    if running_in_travis_tidy_row && not Tidy.is_present_in_path then begin
-      Alcotest.failf "Could not find `tidy` in $PATH in a CI environment"
-    end;
+  let init () =
+    if running_in_travis_tidy_row && not Tidy.is_present_in_path then
+      Alcotest.failf "Could not find `tidy` in $PATH in a CI environment";
 
     Unix.mkdir (path `scratch) 0o755
-  end
 end
-
 
 (* Test case type and helpers *)
 
@@ -60,11 +57,11 @@ end
    All paths defined in this module are relative to the build directory. *)
 module Case = struct
   type t = {
-    name: string;
-    kind: [ `mli | `mld | `ml ];
-    theme_uri: string option;
-    syntax: [ `ml | `re ];
-    outputs: string list;
+    name : string;
+    kind : [ `mli | `mld | `ml ];
+    theme_uri : string option;
+    syntax : [ `ml | `re ];
+    outputs : string list;
   }
 
   let make ?theme_uri ?(syntax = `ml) (input, outputs) =
@@ -75,31 +72,35 @@ module Case = struct
       | ".mld" -> `mld
       | ".ml" -> `ml
       | _ ->
-        invalid_arg (sprintf "Expected mli, mld, or ml files, got %s" input)
+          invalid_arg (sprintf "Expected mli, mld, or ml files, got %s" input)
     in
     { name; kind; theme_uri; syntax; outputs }
 
   let name case = case.name
+
   let kind case = case.kind
+
   let theme_uri case = case.theme_uri
 
-  let string_of_syntax = function
-    | `re -> "re"
-    | `ml -> "ml"
+  let string_of_syntax = function `re -> "re" | `ml -> "ml"
 
   (* The package name is enriched with test case options. *)
   let package case =
-    let opts = [string_of_syntax case.syntax] in
+    let opts = [ string_of_syntax case.syntax ] in
     let opts =
       match case.theme_uri with
       | Some _ -> "custom_theme" :: opts
-      | None -> opts in
+      | None -> opts
+    in
     let opts = String.concat "," (List.sort compare opts) in
     Env.package ^ "+" ^ opts
 
-  let cmi_file case  = Env.path `scratch // (case.name ^ ".cmi")
+  let cmi_file case = Env.path `scratch // (case.name ^ ".cmi")
+
   let cmti_file case = Env.path `scratch // (case.name ^ ".cmti")
+
   let cmo_file case = Env.path `scratch // (case.name ^ ".cmo")
+
   let cmt_file case = Env.path `scratch // (case.name ^ ".cmt")
 
   let odoc_file case =
@@ -109,30 +110,24 @@ module Case = struct
 
   let source_file case =
     match case.kind with
-    | `mli -> Env.path `cases // case.name ^ ".mli"
-    | `mld -> Env.path `cases // case.name ^ ".mld"
-    | `ml -> Env.path `cases // case.name ^ ".ml"
+    | `mli -> (Env.path `cases // case.name) ^ ".mli"
+    | `mld -> (Env.path `cases // case.name) ^ ".mld"
+    | `ml -> (Env.path `cases // case.name) ^ ".ml"
 
-  let outputs case =
-    List.map (fun o -> package case // o) case.outputs
+  let outputs case = List.map (fun o -> package case // o) case.outputs
 end
-
 
 let pretty_print_html_in_place html_file =
   let temporary_pretty_printed_file = html_file ^ ".pretty" in
   let html_stream, close_html_file = Markup.file html_file in
 
-  html_stream
-  |> Markup.parse_html
-  |> Markup.signals
-  |> Markup.pretty_print
+  html_stream |> Markup.parse_html |> Markup.signals |> Markup.pretty_print
   |> Markup.write_html
   |> Markup.to_file temporary_pretty_printed_file;
 
   close_html_file ();
 
   Sys.rename temporary_pretty_printed_file html_file
-
 
 let generate_html case =
   let theme_uri_option =
@@ -142,85 +137,83 @@ let generate_html case =
   in
   match Case.kind case with
   | `mli ->
-    command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
-      (Case.cmi_file case) (Case.source_file case);
+      command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
+        (Case.cmi_file case) (Case.source_file case);
 
-    command "odoc compile" "%s compile --package=%s %s"
-      Env.odoc (Case.package case) (Case.cmti_file case);
+      command "odoc compile" "%s compile --package=%s %s" Env.odoc
+        (Case.package case) (Case.cmti_file case);
 
-    command "odoc html" "%s html %s --syntax=%s --output-dir=%s %s"
-      Env.odoc theme_uri_option (Case.string_of_syntax case.syntax)
-      (Env.path `scratch) (Case.odoc_file case)
-
+      command "odoc html" "%s html %s --syntax=%s --output-dir=%s %s" Env.odoc
+        theme_uri_option
+        (Case.string_of_syntax case.syntax)
+        (Env.path `scratch)
+        (Case.odoc_file case)
   | `mld ->
-    command "odoc compile" "%s compile --package=%s -o %s %s"
-      Env.odoc
-      (Case.package case) (Case.odoc_file case) (Case.source_file case);
+      command "odoc compile" "%s compile --package=%s -o %s %s" Env.odoc
+        (Case.package case) (Case.odoc_file case) (Case.source_file case);
 
-    command "odoc html" "%s html %s --output-dir=%s %s"
-      Env.odoc theme_uri_option (Env.path `scratch) (Case.odoc_file case)
-
+      command "odoc html" "%s html %s --output-dir=%s %s" Env.odoc
+        theme_uri_option
+        (Env.path `scratch)
+        (Case.odoc_file case)
   | `ml ->
-    command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
-      (Case.cmo_file case) (Case.source_file case);
+      command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
+        (Case.cmo_file case) (Case.source_file case);
 
-    command "odoc compile" "%s compile --package=%s %s"
-      Env.odoc (Case.package case) (Case.cmt_file case);
+      command "odoc compile" "%s compile --package=%s %s" Env.odoc
+        (Case.package case) (Case.cmt_file case);
 
-    command "odoc html" "%s html %s --syntax=%s --output-dir=%s %s"
-      Env.odoc theme_uri_option (Case.string_of_syntax case.syntax)
-      (Env.path `scratch) (Case.odoc_file case)
+      command "odoc html" "%s html %s --syntax=%s --output-dir=%s %s" Env.odoc
+        theme_uri_option
+        (Case.string_of_syntax case.syntax)
+        (Env.path `scratch)
+        (Case.odoc_file case)
 
 let diff =
   (* Alcotest will run all tests. We need to know when something fails for the
      first time to stop diffing and generating promotion files. *)
   let already_failed = ref false in
   fun output ->
-    let actual_file   = Env.path `scratch // output in
-    let expected_file = Env.path `expect  // output in
+    let actual_file = Env.path `scratch // output in
+    let expected_file = Env.path `expect // output in
     let cmd = sprintf "diff -u -b %s %s" expected_file actual_file in
     match Sys.command cmd with
     | 0 -> ()
-
     | 1 when !already_failed ->
-      (* Don't run diff for other failing tests as only one at time is shown. *)
-      Alcotest.fail "generated HTML should match expected"
-
+        (* Don't run diff for other failing tests as only one at time is shown. *)
+        Alcotest.fail "generated HTML should match expected"
     | 1 ->
-      (* If the diff command exits with 1, the two HTML files are different.
-         diff has already written its output to STDOUT.
+        (* If the diff command exits with 1, the two HTML files are different.
+           diff has already written its output to STDOUT.
 
-         Also provide the command for overwriting the expected output with the
-         actual output, in case it is the actual output that is correct.
-         The paths are defined relative to the project's root. *)
-      let root_actual_file   = Env.path `scratch ~from_root:true // output in
-      let root_expected_file = Env.path `expect  ~from_root:true // output in
-      let write_file filename data =
-        Markup.string data |> Markup.to_file filename in
-      write_file Env.(path `scratch // "actual") root_actual_file;
-      write_file Env.(path `scratch // "expected") root_expected_file;
+           Also provide the command for overwriting the expected output with the
+           actual output, in case it is the actual output that is correct.
+           The paths are defined relative to the project's root. *)
+        let root_actual_file = Env.path `scratch ~from_root:true // output in
+        let root_expected_file = Env.path `expect ~from_root:true // output in
+        let write_file filename data =
+          Markup.string data |> Markup.to_file filename
+        in
+        write_file Env.(path `scratch // "actual") root_actual_file;
+        write_file Env.(path `scratch // "expected") root_expected_file;
 
-      prerr_endline "\nTo promote the actual output to expected, run:";
-      Printf.eprintf "cp `cat %s` `cat %s` && make test\n\n"
-        Env.(path ~from_root:true `scratch // "actual")
-        Env.(path ~from_root:true `scratch // "expected");
+        prerr_endline "\nTo promote the actual output to expected, run:";
+        Printf.eprintf "cp `cat %s` `cat %s` && make test\n\n"
+          Env.(path ~from_root:true `scratch // "actual")
+          Env.(path ~from_root:true `scratch // "expected");
 
-      already_failed := true;
-      Alcotest.fail "generated HTML should match expected"
-
-    | exit_code ->
-      Alcotest.failf "'diff' exited with %i" exit_code
-
+        already_failed := true;
+        Alcotest.fail "generated HTML should match expected"
+    | exit_code -> Alcotest.failf "'diff' exited with %i" exit_code
 
 (* Actual Tests *)
 
 let output_support_files =
   let run () =
-    command "odoc support-files" "%s support-files --output-dir %s"
-      Env.odoc (Env.path `scratch)
+    command "odoc support-files" "%s support-files --output-dir %s" Env.odoc
+      (Env.path `scratch)
   in
-  "support-files", `Slow, run
-
+  ("support-files", `Slow, run)
 
 let make_test_case ?theme_uri ?syntax case =
   let case = Case.make ?theme_uri ?syntax case in
@@ -228,98 +221,107 @@ let make_test_case ?theme_uri ?syntax case =
     (* Compile the source file and generate HTML. *)
     generate_html case;
 
-    List.iter begin fun output ->
-      let actual_file = Env.path `scratch // output in
+    List.iter
+      (fun output ->
+        let actual_file = Env.path `scratch // output in
 
-      (* Pretty-print output HTML for better diffing. *)
-      pretty_print_html_in_place actual_file;
+        (* Pretty-print output HTML for better diffing. *)
+        pretty_print_html_in_place actual_file;
 
-      (* Run HTML validation on output files. *)
-      if Tidy.is_present_in_path then begin
-        let issues = Tidy.validate actual_file in
-        if issues <> [] then begin
-          List.iter prerr_endline issues;
-          Alcotest.fail "Tidy validation error"
-        end
-      end;
+        (* Run HTML validation on output files. *)
+        ( if Tidy.is_present_in_path then
+          let issues = Tidy.validate actual_file in
+          if issues <> [] then (
+            List.iter prerr_endline issues;
+            Alcotest.fail "Tidy validation error" ) );
 
-      (* Diff the actual outputs with the expected outputs. *)
-      diff output
-    end
+        (* Diff the actual outputs with the expected outputs. *)
+        diff output)
       (Case.outputs case)
   in
-  Case.name case, `Slow, run
+  (Case.name case, `Slow, run)
 
-let source_files_all = [
-  ("val.mli", ["Val/index.html"]);
-  ("markup.mli", ["Markup/index.html"]);
-  ("section.mli", ["Section/index.html"]);
-  ("module.mli", ["Module/index.html"]);
-  ("interlude.mli", ["Interlude/index.html"]);
-  ("include.mli", ["Include/index.html"]);
-  ("include2.ml", ["Include2/index.html"]);
-  ("include_sections.mli", [
-      "Include_sections/index.html";
-      "Include_sections/module-type-Something/index.html";
-    ]);
-  ("mld.mld", ["mld.html"]);
-  ("nested.mli", [
-      "Nested/index.html";
-      "Nested/F/index.html";
-      "Nested/F/argument-1-Arg1/index.html";
-      "Nested/F/argument-2-Arg2/index.html";
-      "Nested/X/index.html";
-      "Nested/class-z/index.html";
-      "Nested/class-inherits/index.html";
-      "Nested/module-type-Y/index.html";
-    ]);
-  ("ocamlary.mli", ["Ocamlary/index.html"]);
-  ("type.mli", ["Type/index.html"]);
-  ("external.mli", ["External/index.html"]);
-  ("functor.mli", ["Functor/index.html"]);
-  ("class.mli", ["Class/index.html"]);
-  ("stop.mli", ["Stop/index.html"]);
-  ("bugs.ml", ["Bugs/index.html"]);
-  ("alias.ml", [
-      "Alias/index.html";
-      "Alias/X/index.html";
-    ]);
-]
-
-let source_files_post406 =
-  [ ("bugs_post_406.mli", ["Bugs_post_406/index.html"]) ]
-
-let source_files_post408 =
-  [ ("recent.mli", ["Recent/index.html"; "Recent/X/index.html"])
-  ; ("recent_impl.ml", ["Recent_impl/index.html"])
-  ; ("labels.mli", ["Labels/index.html"])
+let source_files_all =
+  [
+    ("val.mli", [ "Val/index.html" ]);
+    ("markup.mli", [ "Markup/index.html" ]);
+    ("section.mli", [ "Section/index.html" ]);
+    ("module.mli", [ "Module/index.html" ]);
+    ("interlude.mli", [ "Interlude/index.html" ]);
+    ("include.mli", [ "Include/index.html" ]);
+    ("include2.ml", [ "Include2/index.html" ]);
+    ( "include_sections.mli",
+      [
+        "Include_sections/index.html";
+        "Include_sections/module-type-Something/index.html";
+      ] );
+    ("mld.mld", [ "mld.html" ]);
+    ( "nested.mli",
+      [
+        "Nested/index.html";
+        "Nested/F/index.html";
+        "Nested/F/argument-1-Arg1/index.html";
+        "Nested/F/argument-2-Arg2/index.html";
+        "Nested/X/index.html";
+        "Nested/class-z/index.html";
+        "Nested/class-inherits/index.html";
+        "Nested/module-type-Y/index.html";
+      ] );
+    ("ocamlary.mli", [ "Ocamlary/index.html" ]);
+    ("type.mli", [ "Type/index.html" ]);
+    ("external.mli", [ "External/index.html" ]);
+    ("functor.mli", [ "Functor/index.html" ]);
+    ("class.mli", [ "Class/index.html" ]);
+    ("stop.mli", [ "Stop/index.html" ]);
+    ("bugs.ml", [ "Bugs/index.html" ]);
+    ("alias.ml", [ "Alias/index.html"; "Alias/X/index.html" ]);
   ]
 
-let source_files_pre410 =
-  [ ("bugs_pre_410.ml", ["Bugs_pre_410/index.html"]) ]
+let source_files_post406 =
+  [ ("bugs_post_406.mli", [ "Bugs_post_406/index.html" ]) ]
+
+let source_files_post408 =
+  [
+    ("recent.mli", [ "Recent/index.html"; "Recent/X/index.html" ]);
+    ("recent_impl.ml", [ "Recent_impl/index.html" ]);
+    ("labels.mli", [ "Labels/index.html" ]);
+  ]
+
+let source_files_pre410 = [ ("bugs_pre_410.ml", [ "Bugs_pre_410/index.html" ]) ]
 
 let source_files =
-  let cur = Astring.String.cuts ~sep:"." (Sys.ocaml_version) |> List.map (fun i -> try Some (int_of_string i) with _ -> None) in
+  let cur =
+    Astring.String.cuts ~sep:"." Sys.ocaml_version
+    |> List.map (fun i -> try Some (int_of_string i) with _ -> None)
+  in
   match cur with
   | Some major :: Some minor :: _ ->
-    List.concat
-      [ (if major=4 && minor<10 then source_files_pre410 else [])
-      ; (if major=4 && minor>8 then source_files_post408 else [])
-      ; (if major=4 && minor>=6 then source_files_post406 else [])
-      ; source_files_all ]
+      List.concat
+        [
+          (if major = 4 && minor < 10 then source_files_pre410 else []);
+          (if major = 4 && minor > 8 then source_files_post408 else []);
+          (if major = 4 && minor >= 6 then source_files_post406 else []);
+          source_files_all;
+        ]
   | _ -> source_files_all
 
 let () =
   Env.init ();
 
-  Alcotest.run "html" [
-    "support_files", [output_support_files];
-    "html_ml", List.map (make_test_case ~syntax:`ml) source_files;
-    "html_re", List.map (make_test_case ~syntax:`re) source_files;
-    "custom_theme", [
-      make_test_case ~theme_uri:"/a/b/c" ("module.mli", ["Module/index.html"]);
-      make_test_case ~theme_uri:"https://foo.com/a/b/c/" ("val.mli", ["Val/index.html"]);
-      make_test_case ~theme_uri:"../b/c" ("include.mli", ["Include/index.html"]);
-      make_test_case ~theme_uri:"b/c" ("section.mli", ["Section/index.html"]);
-    ];
-  ]
+  Alcotest.run "html"
+    [
+      ("support_files", [ output_support_files ]);
+      ("html_ml", List.map (make_test_case ~syntax:`ml) source_files);
+      ("html_re", List.map (make_test_case ~syntax:`re) source_files);
+      ( "custom_theme",
+        [
+          make_test_case ~theme_uri:"/a/b/c"
+            ("module.mli", [ "Module/index.html" ]);
+          make_test_case ~theme_uri:"https://foo.com/a/b/c/"
+            ("val.mli", [ "Val/index.html" ]);
+          make_test_case ~theme_uri:"../b/c"
+            ("include.mli", [ "Include/index.html" ]);
+          make_test_case ~theme_uri:"b/c"
+            ("section.mli", [ "Section/index.html" ]);
+        ] );
+    ]

--- a/test/html/tidy.ml
+++ b/test/html/tidy.ml
@@ -1,38 +1,37 @@
-
-let muted_warnings = [
-  (* NOTE: see https://github.com/ocaml/odoc/issues/188 *)
-  "NESTED_EMPHASIS";
-
-  (* NOTE: see https://github.com/ocaml/odoc/pull/185#discussion_r217906131 *)
-  "MISSING_STARTTAG";
-  "DISCARDING_UNEXPECTED";
-
-  (* NOTE: see https://github.com/ocaml/odoc/issues/186 *)
-  "ANCHOR_NOT_UNIQUE";
-
-  "TRIM_EMPTY_ELEMENT";
-]
-
+let muted_warnings =
+  [
+    (* NOTE: see https://github.com/ocaml/odoc/issues/188 *)
+    "NESTED_EMPHASIS";
+    (* NOTE: see https://github.com/ocaml/odoc/pull/185#discussion_r217906131 *)
+    "MISSING_STARTTAG";
+    "DISCARDING_UNEXPECTED";
+    (* NOTE: see https://github.com/ocaml/odoc/issues/186 *)
+    "ANCHOR_NOT_UNIQUE";
+    "TRIM_EMPTY_ELEMENT";
+  ]
 
 let is_present_in_path =
-  Sys.command "which tidy > /dev/null" = 0 && Sys.command "tidy -show-config < /dev/null | grep '^mute' > /dev/null" = 0
-
+  Sys.command "which tidy > /dev/null" = 0
+  && Sys.command "tidy -show-config < /dev/null | grep '^mute' > /dev/null" = 0
 
 (* Returns a list of errors and warnings. *)
 let validate file =
   if not (Sys.file_exists file) then
     invalid_arg ("tidy: file `" ^ file ^ "` does not exist");
   let muted_warnings = String.concat "," muted_warnings in
-  let options = String.concat " " [
-      "-quiet";
-      "--mute " ^ muted_warnings;
-      "--mute-id yes";
-      "--show-errors 200";
-      "-errors";
-      "-ashtml"
-    ] in
+  let options =
+    String.concat " "
+      [
+        "-quiet";
+        "--mute " ^ muted_warnings;
+        "--mute-id yes";
+        "--show-errors 200";
+        "-errors";
+        "-ashtml";
+      ]
+  in
   let cmd = Printf.sprintf "tidy %s %s" options file in
-  let (_, _, stderr) as proc = Unix.open_process_full cmd [||]  in
+  let ((_, _, stderr) as proc) = Unix.open_process_full cmd [||] in
 
   let errors_and_warnings =
     let rec loop acc =
@@ -46,14 +45,11 @@ let validate file =
   match Unix.close_process_full proc with
   (* All input files were processed successfully. *)
   | WEXITED 0 -> []
-
   (* There were warnings. *)
   | WEXITED 1
-
   (* There were errors. *)
   | WEXITED 2 ->
-    errors_and_warnings
-
+      errors_and_warnings
   | _ ->
-    let msg = "Unexpected process termination while running: " ^ cmd in
-    raise (Failure msg)
+      let msg = "Unexpected process termination while running: " ^ cmd in
+      raise (Failure msg)

--- a/test/inactive/.ocamlformat
+++ b/test/inactive/.ocamlformat
@@ -1,0 +1,1 @@
+disable = true

--- a/test/latex/dune
+++ b/test/latex/dune
@@ -4,7 +4,8 @@
 
 (rule
  (alias runtest)
- (action (run %{exe:test.exe}))
+ (action
+  (run %{exe:test.exe}))
  (deps
   test.exe
   %{workspace_root}/src/odoc/bin/main.exe

--- a/test/latex/test.ml
+++ b/test/latex/test.ml
@@ -3,13 +3,13 @@ open Printf
 
 (* Utils *)
 
-let (//) = Filename.concat
+let ( // ) = Filename.concat
 
 let command label =
   Printf.ksprintf (fun s ->
-    let exit_code = Sys.command s in
-    if exit_code <> 0 then
-      Alcotest.failf "'%s' exited with %i" label exit_code)
+      let exit_code = Sys.command s in
+      if exit_code <> 0 then
+        Alcotest.failf "'%s' exited with %i" label exit_code)
 
 (* Filename.extension is only available on 4.04. *)
 module Filename = struct
@@ -20,11 +20,11 @@ module Filename = struct
     String.sub filename dot_index (String.length filename - dot_index)
 end
 
-
 (* Testing environment *)
 
 module Env = struct
   let package = "test_package"
+
   let odoc = "../../src/odoc/bin/main.exe"
 
   let path ?(from_root = false) = function
@@ -35,11 +35,8 @@ module Env = struct
     | `cases when from_root -> "test/cases"
     | `cases -> "../cases"
 
-  let init () = begin
-    Unix.mkdir (path `scratch) 0o755
-  end
+  let init () = Unix.mkdir (path `scratch) 0o755
 end
-
 
 (* Test case type and helpers *)
 
@@ -50,10 +47,10 @@ end
    All paths defined in this module are relative to the build directory. *)
 module Case = struct
   type t = {
-    name: string;
-    kind: [ `mli | `mld | `ml ];
-    syntax: [ `ml | `re ];
-    outputs: string list;
+    name : string;
+    kind : [ `mli | `mld | `ml ];
+    syntax : [ `ml | `re ];
+    outputs : string list;
   }
 
   let make ?(syntax = `ml) (input, outputs) =
@@ -64,26 +61,28 @@ module Case = struct
       | ".mld" -> `mld
       | ".ml" -> `ml
       | _ ->
-        invalid_arg (sprintf "Expected mli, mld, or ml files, got %s" input)
+          invalid_arg (sprintf "Expected mli, mld, or ml files, got %s" input)
     in
     { name; kind; syntax; outputs }
 
   let name case = case.name
+
   let kind case = case.kind
-  
-  let string_of_syntax = function
-    | `re -> "re"
-    | `ml -> "ml"
+
+  let string_of_syntax = function `re -> "re" | `ml -> "ml"
 
   (* The package name is enriched with test case options. *)
   let package case =
-    let opts = [string_of_syntax case.syntax] in
+    let opts = [ string_of_syntax case.syntax ] in
     let opts = String.concat "," (List.sort compare opts) in
     Env.package ^ "+" ^ opts
 
-  let cmi_file case  = Env.path `scratch // (case.name ^ ".cmi")
+  let cmi_file case = Env.path `scratch // (case.name ^ ".cmi")
+
   let cmti_file case = Env.path `scratch // (case.name ^ ".cmti")
+
   let cmo_file case = Env.path `scratch // (case.name ^ ".cmo")
+
   let cmt_file case = Env.path `scratch // (case.name ^ ".cmt")
 
   let odoc_file case =
@@ -93,89 +92,83 @@ module Case = struct
 
   let source_file case =
     match case.kind with
-    | `mli -> Env.path `cases // case.name ^ ".mli"
-    | `mld -> Env.path `cases // case.name ^ ".mld"
-    | `ml -> Env.path `cases // case.name ^ ".ml"
+    | `mli -> (Env.path `cases // case.name) ^ ".mli"
+    | `mld -> (Env.path `cases // case.name) ^ ".mld"
+    | `ml -> (Env.path `cases // case.name) ^ ".ml"
 
-  let outputs case =
-    List.map (fun o -> package case // o) case.outputs
+  let outputs case = List.map (fun o -> package case // o) case.outputs
 end
 
 let generate_latex case =
   match Case.kind case with
   | `mli ->
-    command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
-      (Case.cmi_file case) (Case.source_file case);
+      command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
+        (Case.cmi_file case) (Case.source_file case);
 
-    command "odoc compile" "%s compile --package=%s %s"
-      Env.odoc (Case.package case) (Case.cmti_file case);
+      command "odoc compile" "%s compile --package=%s %s" Env.odoc
+        (Case.package case) (Case.cmti_file case);
 
-    command "odoc latex" "%s latex --syntax=%s --output-dir=%s %s"
-      Env.odoc (Case.string_of_syntax case.syntax)
-      (Env.path `scratch) (Case.odoc_file case)
-
+      command "odoc latex" "%s latex --syntax=%s --output-dir=%s %s" Env.odoc
+        (Case.string_of_syntax case.syntax)
+        (Env.path `scratch)
+        (Case.odoc_file case)
   | `mld ->
-    command "odoc compile" "%s compile --package=%s -o %s %s"
-      Env.odoc
-      (Case.package case) (Case.odoc_file case) (Case.source_file case);
+      command "odoc compile" "%s compile --package=%s -o %s %s" Env.odoc
+        (Case.package case) (Case.odoc_file case) (Case.source_file case);
 
-    command "odoc latex" "%s latex --output-dir=%s %s"
-      Env.odoc (Env.path `scratch) (Case.odoc_file case)
-
+      command "odoc latex" "%s latex --output-dir=%s %s" Env.odoc
+        (Env.path `scratch)
+        (Case.odoc_file case)
   | `ml ->
-    command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
-      (Case.cmo_file case) (Case.source_file case);
+      command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
+        (Case.cmo_file case) (Case.source_file case);
 
-    command "odoc compile" "%s compile --package=%s %s"
-      Env.odoc (Case.package case) (Case.cmt_file case);
+      command "odoc compile" "%s compile --package=%s %s" Env.odoc
+        (Case.package case) (Case.cmt_file case);
 
-    command "odoc latex" "%s latex --syntax=%s --output-dir=%s %s"
-      Env.odoc (Case.string_of_syntax case.syntax)
-      (Env.path `scratch) (Case.odoc_file case)
+      command "odoc latex" "%s latex --syntax=%s --output-dir=%s %s" Env.odoc
+        (Case.string_of_syntax case.syntax)
+        (Env.path `scratch)
+        (Case.odoc_file case)
 
 let diff =
   (* Alcotest will run all tests. We need to know when something fails for the
      first time to stop diffing and generating promotion files. *)
   let already_failed = ref false in
   fun output ->
-    let actual_file   = Env.path `scratch // output in
-    let expected_file = Env.path `expect  // output in
+    let actual_file = Env.path `scratch // output in
+    let expected_file = Env.path `expect // output in
     let cmd = sprintf "diff -N -u -b %s %s" expected_file actual_file in
     match Sys.command cmd with
     | 0 -> ()
-
     | 1 when !already_failed ->
-      (* Don't run diff for other failing tests as only one at time is shown. *)
-      Alcotest.fail "generated latex files should match expected"
-
+        (* Don't run diff for other failing tests as only one at time is shown. *)
+        Alcotest.fail "generated latex files should match expected"
     | 1 ->
-      (* If the diff command exits with 1, the two MAN files are different.
-         diff has already written its output to STDOUT.
+        (* If the diff command exits with 1, the two MAN files are different.
+           diff has already written its output to STDOUT.
 
-         Also provide the command for overwriting the expected output with the
-         actual output, in case it is the actual output that is correct.
-         The paths are defined relative to the project's root. *)
-      let root_actual_file   = Env.path `scratch ~from_root:true // output in
-      let root_expected_file = Env.path `expect  ~from_root:true // output in
-      let write_file filename data =
-        let oc = open_out filename in
-        output_string oc data;
-        close_out oc
-      in
-      write_file Env.(path `scratch // "actual") root_actual_file;
-      write_file Env.(path `scratch // "expected") root_expected_file;
+           Also provide the command for overwriting the expected output with the
+           actual output, in case it is the actual output that is correct.
+           The paths are defined relative to the project's root. *)
+        let root_actual_file = Env.path `scratch ~from_root:true // output in
+        let root_expected_file = Env.path `expect ~from_root:true // output in
+        let write_file filename data =
+          let oc = open_out filename in
+          output_string oc data;
+          close_out oc
+        in
+        write_file Env.(path `scratch // "actual") root_actual_file;
+        write_file Env.(path `scratch // "expected") root_expected_file;
 
-      prerr_endline "\nTo promote the actual output to expected, run:";
-      Printf.eprintf "cp `cat %s` `cat %s` && make test\n\n"
-        Env.(path ~from_root:true `scratch // "actual")
-        Env.(path ~from_root:true `scratch // "expected");
+        prerr_endline "\nTo promote the actual output to expected, run:";
+        Printf.eprintf "cp `cat %s` `cat %s` && make test\n\n"
+          Env.(path ~from_root:true `scratch // "actual")
+          Env.(path ~from_root:true `scratch // "expected");
 
-      already_failed := true;
-      Alcotest.fail "generated latex files should match expected"
-
-    | exit_code ->
-      Alcotest.failf "'diff' exited with %i" exit_code
-
+        already_failed := true;
+        Alcotest.fail "generated latex files should match expected"
+    | exit_code -> Alcotest.failf "'diff' exited with %i" exit_code
 
 let make_test_case ?syntax case =
   let case = Case.make ?syntax case in
@@ -185,67 +178,62 @@ let make_test_case ?syntax case =
 
     List.iter diff (Case.outputs case)
   in
-  Case.name case, `Slow, run
+  (Case.name case, `Slow, run)
 
+let source_files_all =
+  [
+    ("val.mli", [ "Val.tex" ]);
+    ("markup.mli", [ "Markup.tex" ]);
+    ("section.mli", [ "Section.tex" ]);
+    ("module.mli", [ "Module.tex" ]);
+    ("interlude.mli", [ "Interlude.tex" ]);
+    ("include.mli", [ "Include.tex" ]);
+    ("include2.ml", [ "Include2.tex" ]);
+    ("include_sections.mli", [ "Include_sections.tex" ]);
+    ("mld.mld", [ "mld.tex" ]);
+    ( "nested.mli",
+      [ "Nested.tex"; "Nested.F.tex"; "Nested.z.tex"; "Nested.inherits.tex" ] );
+    ("type.mli", [ "Type.tex" ]);
+    ("external.mli", [ "External.tex" ]);
+    ( "functor.mli",
+      [
+        "Functor.tex";
+        "Functor.F1.tex";
+        "Functor.F2.tex";
+        "Functor.F3.tex";
+        "Functor.F4.tex";
+      ] );
+    ("class.mli", [ "Class.tex" ]);
+    ("stop.mli", [ "Stop.tex" ]);
+    ("bugs.ml", [ "Bugs.tex" ]);
+    ("alias.ml", [ "Alias.tex"; "Alias.X.tex" ]);
+  ]
 
-let source_files_all = [
-  ("val.mli", ["Val.tex"]);
-  ("markup.mli", ["Markup.tex"]);
-  ("section.mli", ["Section.tex"]);
-  ("module.mli", ["Module.tex"]);
-  ("interlude.mli", ["Interlude.tex"]);
-  ("include.mli", ["Include.tex"]);
-  ("include2.ml", ["Include2.tex"]);
-  ("include_sections.mli", [
-      "Include_sections.tex";
-    ]);
-  ("mld.mld", ["mld.tex"]);
-  ("nested.mli", [
-      "Nested.tex";
-      "Nested.F.tex";
-      "Nested.z.tex";
-      "Nested.inherits.tex";
-    ]);
-  ("type.mli", ["Type.tex"]);
-  ("external.mli", ["External.tex"]);
-  ("functor.mli", [
-      "Functor.tex";
-      "Functor.F1.tex";
-      "Functor.F2.tex";
-      "Functor.F3.tex";
-      "Functor.F4.tex";
-    ]);
-  ("class.mli", ["Class.tex"]);
-  ("stop.mli", ["Stop.tex"]);
-  ("bugs.ml", ["Bugs.tex"]);
-  ("alias.ml", [
-      "Alias.tex";
-      "Alias.X.tex";
-    ]);
-]
+let source_files_post408 =
+  [
+    ("recent.mli", [ "Recent.tex" ]);
+    ("recent_impl.ml", [ "Recent_impl.tex"; "Recent_impl.B.tex" ]);
+  ]
 
-let source_files_post408 = [
-  ("recent.mli", ["Recent.tex"]);
-  ("recent_impl.ml", ["Recent_impl.tex"; "Recent_impl.B.tex" ]);
-]
-
-let source_files_pre410 = [
-  ("bugs_pre_410.ml", ["Bugs_pre_410.tex"]);
-]
+let source_files_pre410 = [ ("bugs_pre_410.ml", [ "Bugs_pre_410.tex" ]) ]
 
 let source_files =
-  let cur = Astring.String.cuts ~sep:"." (Sys.ocaml_version) |> List.map (fun i -> try Some (int_of_string i) with _ -> None) in
+  let cur =
+    Astring.String.cuts ~sep:"." Sys.ocaml_version
+    |> List.map (fun i -> try Some (int_of_string i) with _ -> None)
+  in
   match cur with
   | Some major :: Some minor :: _ ->
-    List.concat
-      [ (if major=4 && minor<10 then source_files_pre410 else [])
-      ; (if major=4 && minor>8 then source_files_post408 else [])
-      ; source_files_all ]
+      List.concat
+        [
+          (if major = 4 && minor < 10 then source_files_pre410 else []);
+          (if major = 4 && minor > 8 then source_files_post408 else []);
+          source_files_all;
+        ]
   | _ -> source_files_all
 
 let () =
   Env.init ();
 
-  Alcotest.run "latex" [
-    "latex_ml", List.map (make_test_case ~syntax:`ml) source_files;
-  ]
+  Alcotest.run "latex"
+    [ ("latex_ml", List.map (make_test_case ~syntax:`ml) source_files) ]

--- a/test/man/dune
+++ b/test/man/dune
@@ -4,7 +4,8 @@
 
 (rule
  (alias runtest)
- (action (run %{exe:test.exe}))
+ (action
+  (run %{exe:test.exe}))
  (deps
   test.exe
   %{workspace_root}/src/odoc/bin/main.exe

--- a/test/man/test.ml
+++ b/test/man/test.ml
@@ -3,13 +3,13 @@ open Printf
 
 (* Utils *)
 
-let (//) = Filename.concat
+let ( // ) = Filename.concat
 
 let command label =
   Printf.ksprintf (fun s ->
-    let exit_code = Sys.command s in
-    if exit_code <> 0 then
-      Alcotest.failf "'%s' exited with %i" label exit_code)
+      let exit_code = Sys.command s in
+      if exit_code <> 0 then
+        Alcotest.failf "'%s' exited with %i" label exit_code)
 
 (* Filename.extension is only available on 4.04. *)
 module Filename = struct
@@ -20,11 +20,11 @@ module Filename = struct
     String.sub filename dot_index (String.length filename - dot_index)
 end
 
-
 (* Testing environment *)
 
 module Env = struct
   let package = "test_package"
+
   let odoc = "../../src/odoc/bin/main.exe"
 
   let path ?(from_root = false) = function
@@ -35,11 +35,8 @@ module Env = struct
     | `cases when from_root -> "test/cases"
     | `cases -> "../cases"
 
-  let init () = begin
-    Unix.mkdir (path `scratch) 0o755
-  end
+  let init () = Unix.mkdir (path `scratch) 0o755
 end
-
 
 (* Test case type and helpers *)
 
@@ -50,10 +47,10 @@ end
    All paths defined in this module are relative to the build directory. *)
 module Case = struct
   type t = {
-    name: string;
-    kind: [ `mli | `mld | `ml ];
-    syntax: [ `ml | `re ];
-    outputs: string list;
+    name : string;
+    kind : [ `mli | `mld | `ml ];
+    syntax : [ `ml | `re ];
+    outputs : string list;
   }
 
   let make ?(syntax = `ml) (input, outputs) =
@@ -64,26 +61,28 @@ module Case = struct
       | ".mld" -> `mld
       | ".ml" -> `ml
       | _ ->
-        invalid_arg (sprintf "Expected mli, mld, or ml files, got %s" input)
+          invalid_arg (sprintf "Expected mli, mld, or ml files, got %s" input)
     in
     { name; kind; syntax; outputs }
 
   let name case = case.name
+
   let kind case = case.kind
-  
-  let string_of_syntax = function
-    | `re -> "re"
-    | `ml -> "ml"
+
+  let string_of_syntax = function `re -> "re" | `ml -> "ml"
 
   (* The package name is enriched with test case options. *)
   let package case =
-    let opts = [string_of_syntax case.syntax] in
+    let opts = [ string_of_syntax case.syntax ] in
     let opts = String.concat "," (List.sort compare opts) in
     Env.package ^ "+" ^ opts
 
-  let cmi_file case  = Env.path `scratch // (case.name ^ ".cmi")
+  let cmi_file case = Env.path `scratch // (case.name ^ ".cmi")
+
   let cmti_file case = Env.path `scratch // (case.name ^ ".cmti")
+
   let cmo_file case = Env.path `scratch // (case.name ^ ".cmo")
+
   let cmt_file case = Env.path `scratch // (case.name ^ ".cmt")
 
   let odoc_file case =
@@ -93,89 +92,83 @@ module Case = struct
 
   let source_file case =
     match case.kind with
-    | `mli -> Env.path `cases // case.name ^ ".mli"
-    | `mld -> Env.path `cases // case.name ^ ".mld"
-    | `ml -> Env.path `cases // case.name ^ ".ml"
+    | `mli -> (Env.path `cases // case.name) ^ ".mli"
+    | `mld -> (Env.path `cases // case.name) ^ ".mld"
+    | `ml -> (Env.path `cases // case.name) ^ ".ml"
 
-  let outputs case =
-    List.map (fun o -> package case // o) case.outputs
+  let outputs case = List.map (fun o -> package case // o) case.outputs
 end
 
 let generate_man case =
   match Case.kind case with
   | `mli ->
-    command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
-      (Case.cmi_file case) (Case.source_file case);
+      command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
+        (Case.cmi_file case) (Case.source_file case);
 
-    command "odoc compile" "%s compile --package=%s %s"
-      Env.odoc (Case.package case) (Case.cmti_file case);
+      command "odoc compile" "%s compile --package=%s %s" Env.odoc
+        (Case.package case) (Case.cmti_file case);
 
-    command "odoc man" "%s man --syntax=%s --output-dir=%s %s"
-      Env.odoc (Case.string_of_syntax case.syntax)
-      (Env.path `scratch) (Case.odoc_file case)
-
+      command "odoc man" "%s man --syntax=%s --output-dir=%s %s" Env.odoc
+        (Case.string_of_syntax case.syntax)
+        (Env.path `scratch)
+        (Case.odoc_file case)
   | `mld ->
-    command "odoc compile" "%s compile --package=%s -o %s %s"
-      Env.odoc
-      (Case.package case) (Case.odoc_file case) (Case.source_file case);
+      command "odoc compile" "%s compile --package=%s -o %s %s" Env.odoc
+        (Case.package case) (Case.odoc_file case) (Case.source_file case);
 
-    command "odoc man" "%s man --output-dir=%s %s"
-      Env.odoc (Env.path `scratch) (Case.odoc_file case)
-
+      command "odoc man" "%s man --output-dir=%s %s" Env.odoc
+        (Env.path `scratch)
+        (Case.odoc_file case)
   | `ml ->
-    command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
-      (Case.cmo_file case) (Case.source_file case);
+      command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
+        (Case.cmo_file case) (Case.source_file case);
 
-    command "odoc compile" "%s compile --package=%s %s"
-      Env.odoc (Case.package case) (Case.cmt_file case);
+      command "odoc compile" "%s compile --package=%s %s" Env.odoc
+        (Case.package case) (Case.cmt_file case);
 
-    command "odoc man" "%s man --syntax=%s --output-dir=%s %s"
-      Env.odoc (Case.string_of_syntax case.syntax)
-      (Env.path `scratch) (Case.odoc_file case)
+      command "odoc man" "%s man --syntax=%s --output-dir=%s %s" Env.odoc
+        (Case.string_of_syntax case.syntax)
+        (Env.path `scratch)
+        (Case.odoc_file case)
 
 let diff =
   (* Alcotest will run all tests. We need to know when something fails for the
      first time to stop diffing and generating promotion files. *)
   let already_failed = ref false in
   fun output ->
-    let actual_file   = Env.path `scratch // output in
-    let expected_file = Env.path `expect  // output in
+    let actual_file = Env.path `scratch // output in
+    let expected_file = Env.path `expect // output in
     let cmd = sprintf "diff -N -u -b %s %s" expected_file actual_file in
     match Sys.command cmd with
     | 0 -> ()
-
     | 1 when !already_failed ->
-      (* Don't run diff for other failing tests as only one at time is shown. *)
-      Alcotest.fail "generated MAN should match expected"
-
+        (* Don't run diff for other failing tests as only one at time is shown. *)
+        Alcotest.fail "generated MAN should match expected"
     | 1 ->
-      (* If the diff command exits with 1, the two MAN files are different.
-         diff has already written its output to STDOUT.
+        (* If the diff command exits with 1, the two MAN files are different.
+           diff has already written its output to STDOUT.
 
-         Also provide the command for overwriting the expected output with the
-         actual output, in case it is the actual output that is correct.
-         The paths are defined relative to the project's root. *)
-      let root_actual_file   = Env.path `scratch ~from_root:true // output in
-      let root_expected_file = Env.path `expect  ~from_root:true // output in
-      let write_file filename data =
-        let oc = open_out filename in
-        output_string oc data;
-        close_out oc
-      in
-      write_file Env.(path `scratch // "actual") root_actual_file;
-      write_file Env.(path `scratch // "expected") root_expected_file;
+           Also provide the command for overwriting the expected output with the
+           actual output, in case it is the actual output that is correct.
+           The paths are defined relative to the project's root. *)
+        let root_actual_file = Env.path `scratch ~from_root:true // output in
+        let root_expected_file = Env.path `expect ~from_root:true // output in
+        let write_file filename data =
+          let oc = open_out filename in
+          output_string oc data;
+          close_out oc
+        in
+        write_file Env.(path `scratch // "actual") root_actual_file;
+        write_file Env.(path `scratch // "expected") root_expected_file;
 
-      prerr_endline "\nTo promote the actual output to expected, run:";
-      Printf.eprintf "cp `cat %s` `cat %s` && make test\n\n"
-        Env.(path ~from_root:true `scratch // "actual")
-        Env.(path ~from_root:true `scratch // "expected");
+        prerr_endline "\nTo promote the actual output to expected, run:";
+        Printf.eprintf "cp `cat %s` `cat %s` && make test\n\n"
+          Env.(path ~from_root:true `scratch // "actual")
+          Env.(path ~from_root:true `scratch // "expected");
 
-      already_failed := true;
-      Alcotest.fail "generated MAN should match expected"
-
-    | exit_code ->
-      Alcotest.failf "'diff' exited with %i" exit_code
-
+        already_failed := true;
+        Alcotest.fail "generated MAN should match expected"
+    | exit_code -> Alcotest.failf "'diff' exited with %i" exit_code
 
 let make_test_case ?syntax case =
   let case = Case.make ?syntax case in
@@ -185,67 +178,68 @@ let make_test_case ?syntax case =
 
     List.iter diff (Case.outputs case)
   in
-  Case.name case, `Slow, run
+  (Case.name case, `Slow, run)
 
-let source_files_all = [
-  ("val.mli", ["Val.3o"]);
-  ("markup.mli", ["Markup.3o"]);
-  ("section.mli", ["Section.3o"]);
-  ("module.mli", ["Module.3o"]);
-  ("interlude.mli", ["Interlude.3o"]);
-  ("include.mli", ["Include.3o"]);
-  ("include2.ml", ["Include2.3o"]);
-  ("include_sections.mli", [
-      "Include_sections.3o";
-    ]);
-  ("mld.mld", ["mld.3o"]);
-  ("nested.mli", [
-      "Nested.3o";
-      "Nested.F.3o";
-      "Nested.X.3o";
-      "Nested.z.3o";
-      "Nested.inherits.3o";
-    ]);
-  ("type.mli", ["Type.3o"]);
-  ("external.mli", ["External.3o"]);
-  ("functor.mli", [
-      "Functor.3o";
-      "Functor.F1.3o";
-      "Functor.F2.3o";
-      "Functor.F3.3o";
-      "Functor.F4.3o";
-    ]);
-  ("class.mli", ["Class.3o"]);
-  ("stop.mli", ["Stop.3o"]);
-  ("bugs.ml", ["Bugs.3o"]);
-  ("alias.ml", [
-      "Alias.3o";
-      "Alias.X.3o";
-    ]);
-]
+let source_files_all =
+  [
+    ("val.mli", [ "Val.3o" ]);
+    ("markup.mli", [ "Markup.3o" ]);
+    ("section.mli", [ "Section.3o" ]);
+    ("module.mli", [ "Module.3o" ]);
+    ("interlude.mli", [ "Interlude.3o" ]);
+    ("include.mli", [ "Include.3o" ]);
+    ("include2.ml", [ "Include2.3o" ]);
+    ("include_sections.mli", [ "Include_sections.3o" ]);
+    ("mld.mld", [ "mld.3o" ]);
+    ( "nested.mli",
+      [
+        "Nested.3o";
+        "Nested.F.3o";
+        "Nested.X.3o";
+        "Nested.z.3o";
+        "Nested.inherits.3o";
+      ] );
+    ("type.mli", [ "Type.3o" ]);
+    ("external.mli", [ "External.3o" ]);
+    ( "functor.mli",
+      [
+        "Functor.3o";
+        "Functor.F1.3o";
+        "Functor.F2.3o";
+        "Functor.F3.3o";
+        "Functor.F4.3o";
+      ] );
+    ("class.mli", [ "Class.3o" ]);
+    ("stop.mli", [ "Stop.3o" ]);
+    ("bugs.ml", [ "Bugs.3o" ]);
+    ("alias.ml", [ "Alias.3o"; "Alias.X.3o" ]);
+  ]
 
-let source_files_post408 = [
-  ("recent.mli", ["Recent.3o"; "Recent.X.3o"]);
-  ("recent_impl.ml", ["Recent_impl.3o"]);
-]
+let source_files_post408 =
+  [
+    ("recent.mli", [ "Recent.3o"; "Recent.X.3o" ]);
+    ("recent_impl.ml", [ "Recent_impl.3o" ]);
+  ]
 
-let source_files_pre410 = [
-  ("bugs_pre_410.ml", ["Bugs_pre_410.3o"]);
-]
+let source_files_pre410 = [ ("bugs_pre_410.ml", [ "Bugs_pre_410.3o" ]) ]
 
 let source_files =
-  let cur = Astring.String.cuts ~sep:"." (Sys.ocaml_version) |> List.map (fun i -> try Some (int_of_string i) with _ -> None) in
+  let cur =
+    Astring.String.cuts ~sep:"." Sys.ocaml_version
+    |> List.map (fun i -> try Some (int_of_string i) with _ -> None)
+  in
   match cur with
   | Some major :: Some minor :: _ ->
-    List.concat
-      [ (if major=4 && minor<10 then source_files_pre410 else [])
-      ; (if major=4 && minor>8 then source_files_post408 else [])
-      ; source_files_all ]
+      List.concat
+        [
+          (if major = 4 && minor < 10 then source_files_pre410 else []);
+          (if major = 4 && minor > 8 then source_files_post408 else []);
+          source_files_all;
+        ]
   | _ -> source_files_all
 
 let () =
   Env.init ();
 
-  Alcotest.run "man" [
-    "man_ml", List.map (make_test_case ~syntax:`ml) source_files;
-  ]
+  Alcotest.run "man"
+    [ ("man_ml", List.map (make_test_case ~syntax:`ml) source_files) ]

--- a/test/odoc_print/type_desc_to_yojson.ml
+++ b/test/odoc_print/type_desc_to_yojson.ml
@@ -13,7 +13,7 @@ let rec to_yojson : type a. a t -> a -> yojson =
   | Variant get -> (
       match get a with
       | C0 name -> `String name
-      | C (name, a', t) -> `Assoc [ name, to_yojson t a' ] )
+      | C (name, a', t) -> `Assoc [ (name, to_yojson t a') ] )
   | Pair (t1, t2) ->
       let a1, a2 = a in
       `List [ to_yojson t1 a1; to_yojson t2 a2 ]
@@ -23,7 +23,7 @@ let rec to_yojson : type a. a t -> a -> yojson =
   | List t -> `List (List.map (to_yojson t) a)
   | Option t -> (
       match a with
-      | Some a' -> `Assoc [ "Some", to_yojson t a' ]
+      | Some a' -> `Assoc [ ("Some", to_yojson t a') ]
       | None -> `String "None" )
   | To_string to_string -> `String (to_string a)
   | Indirect (f, t) -> to_yojson t (f a)

--- a/test/pages/dune
+++ b/test/pages/dune
@@ -1,9 +1,9 @@
 (env
  (_
   (binaries
-   (../odoc_print/odoc_print.exe as odoc_print)
-   )))
+   (../odoc_print/odoc_print.exe as odoc_print))))
 
 (cram
- (enabled_if (>= %{ocaml_version} 4.04.1))
- (deps %{bin:odoc} %{bin:odoc_print} ))
+ (enabled_if
+  (>= %{ocaml_version} 4.04.1))
+ (deps %{bin:odoc} %{bin:odoc_print}))

--- a/test/parser/dune
+++ b/test/parser/dune
@@ -1,10 +1,15 @@
 (executable
  (name test)
- (enabled_if (>= %{ocaml_version} 4.04.1))
+ (enabled_if
+  (>= %{ocaml_version} 4.04.1))
  (libraries alcotest markup odoc_model odoc_parser print))
 
 (rule
  (alias runtest)
- (enabled_if (>= %{ocaml_version} 4.04.1))
- (action (run %{exe:test.exe}))
- (deps test.exe (source_tree expect)))
+ (enabled_if
+  (>= %{ocaml_version} 4.04.1))
+ (action
+  (run %{exe:test.exe}))
+ (deps
+  test.exe
+  (source_tree expect)))

--- a/test/parser/test.ml
+++ b/test/parser/test.ml
@@ -5,1095 +5,1089 @@ type test_case = {
   location : Odoc_model.Location_.point;
 }
 
-let make_test_case
-    ?(sections_allowed = `No_titles)
-    ?(location = {Odoc_model.Location_.line = 1; column = 0})
-    name
+let make_test_case ?(sections_allowed = `No_titles)
+    ?(location = { Odoc_model.Location_.line = 1; column = 0 }) name
     parser_input =
-  {name; parser_input; sections_allowed; location}
+  { name; parser_input; sections_allowed; location }
 
 let t = make_test_case
 
-type test_suite = string * (test_case list)
+type test_suite = string * test_case list
 
-
-
-let tests : test_suite list = [
-  "trivial", [
-    t "empty" "";
-    t "space" " ";
-    t "two-spaces" "  ";
-    t "tab" "\t";
-    t "mixed-space" " \t \t";
-    t "newline" "\n";
-    t "blank-line" "\n\n";
-    t "cr-lf" "\r\n";
-  ];
-
-  "one-paragraph", [
-    t "word" "foo";
-    t "two-words" "foo bar";
-    t "two-spaces" "foo  bar";
-    t "mixed-space" "foo \t \t bar";
-    t "two-lines" "foo\nbar";
-    t "two-lines-cr-lf" "foo\r\nbar";
-    t "leading-space" " foo";
-    t "trailing-space" "foo ";
-    t "leading-space-on-line" "foo\n bar";
-    t "trailing-space-on-line" "foo \nbar";
-    t "leading-tab-on-line" "foo\n\tbar";
-    t "trailing-tab-on-line" "foo\t\nbar";
-    t "email" "foo@bar.com";
-  ];
-
-  "two-paragraphs", [
-    t "basic" "foo\n\nbar";
-    t "trailing-space" "foo \n\nbar";
-    t "leading-space" "foo\n\n bar";
-    t "cr-lf" "foo\r\n\r\nbar";
-    t "mixed-cr-lf" "foo\n\r\nbar";
-  ];
-
-  "plus-minus-words", [
-    t "minus-in-word" "foo-bar";
-    t "minus-as-word" "foo -";
-    t "plus-in-word" "foo+bar";
-    t "plus-as-word" "foo +";
-    t "negative-number" "-3.14 -1337";
-    t "en-em-dash" "-- ---";
-    t "minus-at" "-@";
-    t "at-minus" "-@-";
-    t "option" "--option";
-  ];
-
-  "escape-sequence", [
-    t "left-brace" "\\{";
-    t "left-brace-in-word" "foo\\{bar";
-    t "right-brace" "\\}";
-    t "right-brace-in-word" "foo\\}bar";
-    t "left-bracket" "\\[";
-    t "left-bracket-in-word" "foo\\[bar";
-    t "right-bracket" "\\]";
-    t "right-bracket-in-word" "foo\\]bar";
-    t "at" "\\@";
-    t "not-a-tag" "\\@author";
-    t "at-in-word" "foo\\@bar";
-    t "trailing-backslash" "foo\\";
-    t "non-escape" "foo\\bar";
-    t "backslash-not-escaped" "foo\\\\{bar";
-    t "single-backslash" "\\";
-    t "escape-minus" "\\{- foo";
-    t "escape-plus" "\\{+ foo";
-    t "minus-escape" "-\\{";
-    t "plus-escape" "+\\{";
-    t "escape-at" "\\{@author";
-    t "two" "\\{\\}";
-  ];
-
-  "code-span", [
-    t "basic" "[foo]";
-    t "empty" "[]";
-    t "list" "[[]]";
-    (* TODO The next two error messages are particularly unintuitive. *)
-    t "unbalanced-list" "[[]";
-    t "no-markup" "[{b]";
-    t "few-escapes" "[\\{]";
-    t "escaped-right-bracket" "[\\]]";
-    t "escaped-left-bracket" "[\\[]";
-    t "whitespace-preserved" "[ foo  bar ]";
-    t "no-newlines" "[foo\nbar]";
-    t "cr-lf-preserved" "[foo\r\nbar]";
-    t "no-double-newline" "[foo\n\nbar]";
-    t "no-double-crlf" "[foo\r\n\r\nbar]";
-    t "not-merged" "[foo][bar]";
-    t "explicit-space" "[foo] [bar]";
-    t "unterminated" "[foo";
-  ];
-
-  "bold", [
-    t "basic" "{b foo}";
-    t "extra-leading-whitespace" "{b  \t foo}";
-    t "leading-newline" "{b\nfoo}";
-    t "leading-cr-lf" "{b\r\nfoo}";
-    t "leading-newline-and-whitespace" "{b\n foo}";
-    t "no-leading-whitespace" "{bfoo}";
-    t "trailing-whitespace" "{b foo }";
-    t "trailing-newline" "{b foo\n}";
-    t "trailing-cr-lf" "{b foo\r\n}";
-    t "two-words" "{b foo bar}";
-    t "not-merged" "{b foo}{b bar}";
-    t "nested" "{b foo{b bar}}";
-    t "newline" "{b foo\nbar}";
-    t "cr-lf" "{b foo\r\nbar}";
-    t "minus" "{b -}";
-    t "minus-list-item" "{b foo\n - bar}";
-    t "plus-list-item" "{b foo\n + bar}";
-    t "immediate-minus-list-item" "{b\n- foo}";
-    t "immediate-plus-list-item" "{b\n+ foo}";
-    t "blank-line" "{b foo\n\nbar}";
-    t "immediate-blank-line" "{b\n\n";
-    t "end-of-comment" "{b foo";
-    t "nested-code-block" "{b {[foo]}";
-    t "degenerate" "{b}";
-    t "empty" "{b }";
-  ];
-
-  "italic", [
-    t "basic" "{i foo}";
-    t "extra-leading-whitespace" "{i  \t foo}";
-    t "leading-newline" "{i\nfoo}";
-    t "leading-newline-and-whitespace" "{i\n foo}";
-  ];
-
-  "emphasis", [
-    t "basic" "{e foo}";
-    t "extra-leading-whitespace" "{e  \t foo}";
-    t "leading-newline" "{e\nfoo}";
-    t "leading-newline-and-whitespace" "{e\n foo}";
-  ];
-
-  "superscript", [
-    t "basic" "{^ foo}";
-    t "extra-leading-whitespace" "{^  \t foo}";
-    t "leading-newline" "{^\nfoo}";
-    t "leading-cr-lf" "{^\r\nfoo}";
-    t "leading-newline-and-whitespace" "{^\n foo}";
-    t "no-whitespace" "{^foo}";
-    t "degenerate" "{^}";
-    t "empty" "{^ }";
-  ];
-
-  "subscript", [
-    t "basic" "{_ foo}";
-    t "extra-leading-whitespace" "{_  \t foo}";
-    t "leading-newline" "{_\nfoo}";
-    t "leading-newline-and-whitespace" "{_\n foo}";
-    t "no-whitespace" "{_foo}";
-    t "v-verbose" "{_uv}";
-  ];
-
-  "simple-reference", [
-    t "basic" "{!foo}";
-    t "leading-whitespace" "{! foo}";
-    t "trailing-whitespace" "{!foo }";
-    t "adjacent-word-leading" "bar{!foo}";
-    t "explicit-leading-space" "bar {!foo}";
-    t "adjacent-word-trailing" "{!foo}bar";
-    t "explicit-trailing-space" "{!foo} bar";
-    t "kind" "{!val:foo}";
-    t "empty" "{!}";
-    t "whitespace-only" "{! }";
-    t "internal-whitespace" "{!( * )}";
-    (* TODO Limiting the character combinations allowed will make it easier to
-       catch expressions accidentally written inside references. This can also
-       be caught by a good resolver and resolver error messages. *)
-    (* t "expression" *)
-    t "unterminated" "{!foo";
-    t "empty-kind" "{!:foo}";
-    t "whitespace-kind" "{! :foo}";
-    t "with-kind-but-empty" "{!val:}";
-    t "with-kind-but-whitespace" "{!val: }";
-    t "leading-whitespace-in-kind" "{! val:foo}";
-    t "internal-whitespace-in-kind" "{!va l:foo}";
-    t "internal-whitespace-in-referent" "{!val:( * )}";
-    t "two-colons" "{!val:foo:bar}";
-    t "space-before-colon" "{!val :foo}";
-    t "space-after-colon" "{!val: foo}";
-    t "unterminated-after-kind" "{!val:foo";
-    t "operator" "{!(>>=)}";
-    t "operator-with-dash" "{!(@->)}";
-    t "operator-with-dot" "{!(*.)}";
-    t "operator-with-colon" "{!(>::)}";
-  ];
-
-  "reference-with-text", [
-    t "basic" "{{!foo} bar}";
-    t "degenerate" "{{!foo}}";
-    t "empty" "{{!foo} }";
-    t "nested-markup" "{{!foo} {b bar}}";
-    t "in-markup" "{e {{!foo} bar}}";
-    t "no-separating-space" "{{!foo}bar}";
-    t "kind" "{{!val:foo} bar}";
-    t "nested-reference" "{{!foo} {!bar}}";
-    t "nested-empty" "{{!foo} {{!bar}}}";
-    t "nested-through-emphasis" "{{!foo} {e {{!bar} baz}}}";
-    t "simple-through-emphasis" "{{!foo} {e {!bar}}}";
-    t "empty-target" "{{!} foo}";
-    t "whitespace-only-in-target" "{{! } foo}";
-    t "internal-whitespace" "{{!( * )} baz}";
-    t "unterminated" "{{!foo";
-    t "unterminated-content" "{{!foo} bar";
-  ];
-
-  "link", [
-    t "basic" "{{:foo} bar}";
-    t "nested-markup" "{{:foo} {b bar}}";
-    t "in-markup" "{e {{:foo} bar}}";
-    t "no-separating-space" "{{:foo}bar}";
-    t "nested-link" "{{:foo} {{:bar} baz}}";
-    t "nested-through-emphasis" "{{:foo} {e {{:bar} baz}}}";
-    t "reference-through-emphasis" "{{:foo} {e {!bar}}}";
-    t "nested-in-reference" "{{!foo} {e {{:bar} baz}}}";
-    t "empty-target" "{{:} foo}";
-    t "whitespace-only-in-target" "{{: } foo}";
-    t "empty" "{{:foo}}";
-    t "internal-whitespace" "{{:foo bar} baz}";
-    t "unterminated" "{{:foo";
-    t "single-braces" "{:foo}";
-    t "unterminated-single-braces" "{:foo";
-    t "empty-single-braces" "{:}";
-    t "single-braces-whitespace-only" "{: }";
-  ];
-
-  "raw-markup", [
-    t "html-target" "{%html:foo%}";
-    t "whitespace" "{%html: foo bar %}";
-    t "whitespace-only" "{%html: %}";
-    t "empty" "{%html:%}";
-    t "html-payload" "{%html:<e>foo</e>%}";
-    t "colon" "{%html:foo:bar%}";
-    t "no-target" "{%foo%}";
-    t "empty-target" "{%:foo%}";
-    t "whitespace-target" "{% :foo%}";
-    t "multiline-target" "{%\n:foo%}";
-    t "percent-in-target" "{%%:%}";
-    t "percent-in-payload" "{%html:%%}";
-    t "multiple-percent-in-target" "{%%%foo%%:%}";
-    t "multiple-percent-in-payload" "{%html:%%foo%%%}";
-    t "opener-in-target" "{%{%:foo%}";
-    t "opener-in-payload" "{%html:{%%}";
-    t "right-brace-in-target" "{%}:%}";
-    t "right-brace-in-payload" "{%html:}%}";
-    t "unterminated" "{%";
-    t "unterminated-after-target" "{%html:";
-    t "degenerate" "{%}";
-  ];
-
-  "module-list", [
-    t "basic" "{!modules:Foo}";
-    t "two" "{!modules:Foo Bar}";
-    t "extra-whitespace" "{!modules: Foo  Bar }";
-    t "newline" "{!modules:Foo\nBar}";
-    t "cr-lf" "{!modules:Foo\r\nBar}";
-    t "empty" "{!modules:}";
-    t "whitespace-only" "{!modules: }";
-    t "unterminated" "{!modules:";
-    t "in-paragraph" "foo {!modules:Foo}";
-    t "followed-by-word" "{!modules:Foo} foo";
-    t "in-list" "- {!modules:Foo}";
-  ];
-
-  "code-block", [
-    t "basic" "{[foo]}";
-    t "empty" "{[]}";
-    t "whitespace-only" "{[ ]}";
-    t "blank-line-only" "{[\n  \n]}";
-    t "whitespace" "{[foo bar]}";
-    t "newline" "{[foo\nbar]}";
-    t "cr-lf" "{[foo\r\nbar]}";
-    t "blank-line" "{[foo\n\nbar]}";
-    t "leading-whitespace" "{[ foo]}";
-    t "leading-whitespace-two" "{[ foo\n bar]}";
-    t "leading-whitespace-two-cr-lf" "{[ foo\r\n bar]}";
-    t "leading-whitespace-two-different-indent" "{[ foo\n   bar]}";
-    t "leading-whitespace-two-different-indent-rev" "{[   foo\n bar]}";
-    t ~location:{Odoc_model.Location_.line = 1; column = 3}
-      "leading-whitespace-two-different-indent-reloc" "{[ foo\n      bar]}";
-    t "leading-whitespace-with-empty-line" "{[ foo\n\n bar]}";
-    t "leading-whitespace-with-whitespace-line-short" "{[  foo\n \n  bar]}";
-    t "leading-whitespace-with-whitespace-line-long" "{[ foo\n   \n bar]}";
-    t "leading-whitespace-leading-newline" "{[\n  foo\n  bar\n]}";
-    t "leading-tab" "{[\tfoo]}";
-    t "leading-tab-two" "{[\tfoo\n\tbar]}";
-    t "leading-tab-two-different-indent" "{[\tfoo\n\t\tbar]}";
-    t "leading-newline" "{[\nfoo]}";
-    t "leading-cr-lf" "{[\r\nfoo]}";
-    t "leading-newlines" "{[\n\nfoo]}";
-    t "leading-newline-with-space" "{[\n foo]}";
-    t "leading-newline-with-trash" "{[ \nfoo]}";
-    t "nested-opener" "{[{[]}";
-    t "nested-closer" "{[foo]}]}";
-    t "nested-bracket" "{[]]}";
-    t "two-nested-brackets" "{[]]]}";
-    t "nested-brackets-in-text" "{[foo]]bar]}";
-    t "trailing-whitespace" "{[foo ]}";
-    t "trailing-tab" "{[foo\t]}";
-    t "trailing-newline" "{[foo\n]}";
-    t "trailing-cr-lf" "{[foo\r\n]}";
-    t "trailing-newlines" "{[foo\n\n]}";
-    t "preceded-by-whitespace" " {[foo]}";
-    t "followed-by-whitespace" "{[foo]} ";
-    t "two-on-one-line" "{[foo]} {[bar]}";
-    t "two" "{[foo]}\n{[bar]}";
-    t "two-with-blank-line" "{[foo]}\n\n{[bar]}";
-    t "followed-by-words" "{[foo]} bar";
-    t "preceded-by-words" "foo {[bar]}";
-    t "preceded-by-paragraph" "foo\n{[bar]}";
-    t "followed-by-paragraph" "{[foo]}\nbar";
-    t "unterminated" "{[foo";
-    t "unterminated-bracket" "{[foo]";
-    t "trailing-cr" "{[foo\r]}";
-    t "comment" "{[(* foo *)\nlet bar = ()]}";
-    t "docstring" "{[(** foo *)\nlet bar = ()]}";
-    t "docstring-with-code-block" "{[(** {[foo]} *)\nlet bar = ()]}";
-  ];
-
-  "verbatim", [
-    t "basic" "{v foo v}";
-    t "empty" "{v v}";
-    t "degenerate" "{vv}";
-    t "whitespace-only" "{v  v}";
-    t "blank-line-only" "{v\n  \nv}";
-    t "no-leading-whitespace" "{vfoo v}";
-    t "no-trailing-whitespace" "{v foov}";
-    t "multiple-leading-whitespace" "{v  foo v}";
-    t "multiple-trailing-whitespace" "{v foo  v}";
-    t "leading-tab" "{v\tfoo v}";
-    t "leading-newline" "{v\nfoo v}";
-    t "leading-cr-lf" "{v\r\nfoo v}";
-    t "trailing-tab" "{v foo\tv}";
-    t "trailing-newline" "{v foo\nv}";
-    t "trailing-cr-lf" "{v foo\r\nv}";
-    t "internal-whitespace" "{v foo bar v}";
-    t "newline" "{v foo\nbar v}";
-    t "cr-lf" "{v foo\r\nbar v}";
-    t "blank-line" "{v foo\n\nbar v}";
-    t "leading-newlines" "{v\n\nfoo v}";
-    t "leading-newline-with-space" "{v\n foo v}";
-    t "leading-newline-with-trash" "{v \nfoo v}";
-    t "nested-opener" "{v {v v}";
-    t "nested-closer" "{v foo v} v}";
-    t "nested-closer-with-word" "{v {dev} v}";
-    t "nested-v" "{v v v}";
-    t "two-nested-vs" "{v vv v}";
-    t "nested-v-at-end" "{v vv}";
-    t "two-nested-vs-at-end" "{v vvv}";
-    t "nested-vs-in-text" "{v foovvbar v}";
-    t "trailing-newlines" "{v foo\n\nv}";
-    t "preceded-by-whitespace" " {v foo v}";
-    t "followed-by-whitespace" "{v foo v} ";
-    t "two-on-one-line" "{v foo v} {v bar v}";
-    t "two" "{v foo v}\n{v bar v}";
-    t "two-with-blank-line" "{v foo v}\n\n{v bar v}";
-    t "followed-by-words" "{v foo v} bar";
-    t "preceded-by-words" "foo {v bar v}";
-    t "preceded-by-paragraph" "foo\n{v bar v}";
-    t "followed-by-paragraph" "{v foo v}\nbar";
-    t "unterminated" "{v foo";
-    t "unterminated-v" "{v foo v";
-    t "unterminated-empty" "{v";
-    t "unterminated-whitespace" "{v ";
-    t "unterminated-whitespace-2" "{v  ";
-    t "trailing-cr" "{v foo\rv}";
-  ];
-
-  "shorthand-list", [
-    t "basic" "- foo";
-    t "multiple-items" "- foo\n- bar";
-    t "two-lists" "- foo\n\n- bar";
-    t "ordered" "+ foo";
-    t "leading-whitespace" " - foo";
-    t "trailing-whitespace" "- foo ";
-    t "bullet-in-line" "- foo - bar";
-    t "bullet-in-line-immediately" "- - foo";
-    t "code-block" "- {[foo]}";
-    t "verbatim" "- {v foo v}";
-    t "multiple-blocks" "- foo\n{[bar]}";
-    t "followed-by-code-block" "- foo\n\n{[bar]}";
-    t "different-kinds" "- foo\n+ bar";
-    t "no-content" "-";
-    t "immediate-newline" "-\nfoo";
-    t "immediate-blank-line" "-\n\nfoo";
-    t "immediate-markup" "-{b foo}";
-    t "after-code-block" "{[foo]} - bar";
-  ];
-
-  "explicit-list", [
-    t "basic" "{ul {li foo}}";
-    t "ordered" "{ol {li foo}}";
-    t "two-items" "{ul {li foo} {li bar}}";
-    t "items-on-separate-lines" "{ul {li foo}\n{li bar}}";
-    t "blank-line" "{ul {li foo}\n\n{li bar}}";
-    t "blank-line-in-item" "{ul {li foo\n\nbar}}";
-    t "junk" "{ul foo}";
-    t "junk-with-no-whitespace" "{ulfoo}";
-    t "empty" "{ul}";
-    t "unterminated-list" "{ul";
-    t "no-whitespace" "{ul{li foo}}";
-    t "whitespace-at-end-of-item" "{ul {li foo\n\n\n}}";
-    t "unterminated-{li" "{ul {li foo";
-    t "unterminated-{-" "{ul {- foo";
-    t "empty-{li" "{ul {li }}";
-    t "empty-{-" "{ul {- }}";
-    t "{li-without-whitespace" "{ul {lifoo}}";
-    t "{li-followed-by-newline" "{ul {li\nfoo}}";
-    t "{li-followed-by-cr-lf" "{ul {li\r\nfoo}}";
-    t "{li-followed-by-blank-line" "{ul {li\n\nfoo}}";
-    t "{--without-whitespace" "{ul {-foo}}";
-    t "mixed-list-items" "{ul {li foo} {- bar}}";
-    t "nested" "{ul {li {ul {li foo}}}}";
-    t "shorthand-in-explicit" "{ul {li - foo\n- bar}}";
-    t "explicit-in-shorthand" "- {ul {li foo}}";
-    t "bare-{li" "{li foo}";
-    t "bare-{-" "{- foo";
-    t "after-code-block" "{[foo]} {ul {li bar}}";
-  ];
-
-  "heading", [
-    t "basic" "{2 Foo}";
-    t "subsection" "{3 Foo}";
-    t "subsubsection" "{4 Foo}";
-    t "leading-whitespace" "{2  Foo}";
-    t "no-leading-whitespace" "{2Foo}";
-    t "no-leading-whitespace-h3" "{3Foo}";
-    t "leading-newline" "{2\nFoo}";
-    t "leading-cr-lf" "{2\r\nFoo}";
-    t "leading-blank-line" "{2\n\nFoo}";
-    t "leading-blank-line-h3" "{3\n\nFoo}";
-    t "trailing-whitespace" "{2 Foo }";
-    t "trailing-newline" "{2 Foo\n}";
-    t "trailing-blank-line" "{2 Foo\n\n}";
-    t "nested-markup" "{2 [foo]}";
-    t "nested-code-with-uppercase" "{2 [Foo]}";
-    t "nested-code-with-spaces" "{2 [ foo bar  baz  \t]}";
-    t "nested-code-with-newline" "{2 [foo\nbar\r\nbaz]}";
-    t "nested-style" "{2 {e foo bar}}";
-    t "words" "{2 foo bar}";
-    t "nested-heading" "{2 {2 Foo}}";
-    t "in-list" "- {2 Foo}";
-    t "followed-by-junk" "{2 Foo} bar";
-    t "preceded-by-junk" "foo {2 Bar}";
-    t "followed-by-block" "{2 Foo}\nbar";
-    t "preceded-by-block" "foo\n{2 Bar}";
-    t "label" "{2:foo Bar}";
-    t "whitespace-before-colon" "{2 :foo Bar}";
-    t "whitespace-after-colon" "{2: foo Bar}";
-    t "label-only" "{2:foo}";
-    t "label-only-with-whitespace" "{2:foo }";
-    t "in-list-outside-item" "{ul {2 Foo}}";
-    t "preceded-by-shorthand-list" "- foo\n{2 Bar}";
-    t "nested-in-two-lists" "{ul {li - foo\n{2 Bar}}}";
-    t "bad-level-long-number" "{22 Foo}";
-    t "bad-level-long-number-with-label" "{22:foo Bar}";
-    t "bad-level-leading-zero" "{02 Foo}";
-    t "bad-level-leading-zero-with-label" "{02:foo Bar}";
-    t "bad-level-title" "{0 Foo}";
-    t "bad-level-too-deep" "{6 Foo}";
-    t "link-in-markup" "{2 {{:foo}}}";
-    t "reference-in-markup" "{2 {!foo}}";
-    t "two" "{2 Foo}\n{2 Bar}";
-    t "greater" "{2 Foo}\n{3 Bar}";
-  ];
-
-  "section-contexts", [
-    t "titles-allowed" "{0 Foo}"
-      ~sections_allowed:`All;
-    t "titles-no-high-levels" "{6 Foo}"
-      ~sections_allowed:`All;
-    t "two-titles" "{0 Foo}\n{0 Bar}"
-      ~sections_allowed:`All;
-    t "no-heading" "foo"
-      ~sections_allowed:`All;
-    t "heading-after-paragraph" "foo\n{0 Bar}"
-      ~sections_allowed:`All;
-    t "two-top-level-section-headings" "{1 Foo}\n{1 Bar}"
-      ~sections_allowed:`All;
-    t "two-headings-second-higher" "{1 Foo}\n{0 Bar}"
-      ~sections_allowed:`All;
-    t "three-headings-last-two-higher" "{3 Foo}\n{1 Bar}\n{2 Baz}"
-      ~sections_allowed:`All;
-    t "none" "{1 Foo}"
-      ~sections_allowed:`None;
-    t "title-no-titles-allowed" "{0 Foo}"
-      ~sections_allowed:`No_titles;
-    t "two-titles-none-allowed" "{0 Foo}\n{0 Bar}"
-      ~sections_allowed:`No_titles;
-    t "two-headings-none-allowed" "{1 Foo}\n{1 Bar}"
-      ~sections_allowed:`None;
-    t "multiple-with-bad-section" "{0 Foo}\n{0 Foo}\n{6 Foo}"
-      ~sections_allowed:`All;
-    t "promoted-duplicates" "{6 Foo}\n{6 Bar}"
-      ~sections_allowed:`All;
-    t "section-promoted-to-duplicate" "{5 Foo}\n{6 Bar}"
-      ~sections_allowed:`All;
-  ];
-
-  "author", [
-    t "basic" "@author Foo Bar";
-    t "empty" "@author";
-    t "whitespace-only" "@author ";
-    t "extra-whitespace" "@author  Foo Bar ";
-    t "newline" "@author Foo Bar\n";
-    t "cr-lf" "@author Foo Bar\r\n";
-    t "blank-line" "@author Foo Bar\n\n";
-    t "followed-by-junk" "@author Foo\nbar";
-    t "followed-by-code-span" "@author Foo\n[bar]";
-    t "followed-by-code-block" "@author Foo\n{[bar]}";
-    t "followed-by-verbatim" "@author Foo\n{v bar v}";
-    t "followed-by-modules" "@author foo\n{!modules:Foo}";
-    t "followed-by-list" "@author Foo\n{ul {li bar}}";
-    t "followed-by-shorthand-list" "@author Foo\n- bar";
-    t "followed-by-section-heading" "@author Foo\n{2 Bar}";
-    t "followed-by-author" "@author Foo\n@author Bar";
-    t "followed-by-author-cr-lf" "@author Foo\n@author Bar";
-    t "in-author" "@author Foo @author Bar";
-    t "in-author-at-start" "@author @author Foo";
-    t "preceded-by-paragraph" "foo\n@author Bar";
-    t "no-markup" "@author Foo [Bar]";
-    t "in-paragraph" "foo @author Bar";
-    t "in-code" "[@author Foo]";
-    t "in-style" "{b @author Foo}";
-    t "in-heading" "{2 @author Foo}";
-    t "after-shorthand-list" "- foo\n@author Bar";
-    t "in-shorthand-list" "- foo @author Bar";
-    t "in-shorthand-list-at-start" "- @author Foo";
-    t "in-list-item" "{ul {li foo @author Bar}}";
-    t "in-list-item-at-start" "{ul {li @author Foo}}";
-    t "in-list-item-on-new-line" "{ul {li foo\n@author Bar}}";
-    t "in-list" "{ul @author Foo}";
-    t "in-code-block" "{[@author Foo]}";
-    t "in-verbatim" "{v @author Foo v}";
-    t "after-code-block" "{[foo]} @author Bar";
-    t "after-verbatim" "{v foo v} @author Bar";
-    t "after-heading" "{2 Foo} @author Bar";
-    t "after-list" "{ul {li foo}} @author Bar";
-    t "preceded-by-whitespace" " @author Foo Bar";
-    t "second-preceded-by-whitespace" "@author Foo\n @author Bar";
-    t "prefix" "@authorfoo";
-  ];
-
-  "deprecated", [
-    t "basic" "@deprecated";
-    t "words" "@deprecated foo bar";
-    t "multiline" "@deprecated foo\nbar";
-    t "paragraphs" "@deprecated foo\n\nbar";
-    t "whitespace-only" "@deprecated ";
-    t "immediate-newline" "@deprecated\nfoo";
-    t "immediate-cr-lf" "@deprecated\r\nfoo";
-    t "immediate-blank-line" "@deprecated\n\nfoo";
-    t "extra-whitespace" "@deprecated  foo";
-    t "followed-by-deprecated" "@deprecated foo\n@deprecated bar";
-    t "followed-by-deprecated-cr-lf" "@deprecated foo\r\n@deprecated bar";
-    t "nested-in-self" "@deprecated foo @deprecated bar";
-    t "nested-in-self-at-start" "@deprecated @deprecated foo";
-    t "preceded-by-paragraph" "foo\n@deprecated";
-    t "preceded-by-shorthand-list" "- foo\n@deprecated";
-    t "with-shorthand-list" "@deprecated - foo";
-    t "with-shorthand-list-after-newline" "@deprecated\n- foo";
-    t "prefix" "@deprecatedfoo";
-    t "after-code-block" "{[foo]} @deprecated";
-    t "followed-by-section" "@deprecated foo\n{2 Bar}";
-  ];
-
-  "param", [
-    t "basic" "@param foo";
-    t "bare" "@param";
-    t "bare-with-whitespace" "@param ";
-    t "immediate-newline" "@param\nfoo";
-    t "followed-by-whitespace" "@param foo ";
-    t "extra-whitespace" "@param  foo";
-    t "words" "@param foo bar baz";
-    t "multiline" "@param foo\nbar\nbaz";
-    t "paragraphs" "@param foo bar\n\nbaz";
-    t "two" "@param foo\n@param bar";
-    t "nested" "@param foo @param bar";
-    t "preceded-by-paragraph" "foo\n@param bar";
-    t "prefix" "@paramfoo";
-    t "after-code-block" "{[foo]} @param foo";
-  ];
-
-  "raise", [
-    t "basic" "@raise Foo";
-    t "bare" "@raise";
-    t "words" "@raise foo bar baz";
-    t "prefix" "@raisefoo";
-  ];
-
-  "return", [
-    t "basic" "@return";
-    t "words" "@return foo bar";
-    t "prefix" "@returnfoo";
-  ];
-
-  "see", [
-    t "url" "@see <foo>";
-    t "file" "@see 'foo'";
-    t "document" "@see \"foo\"";
-    t "bare" "@see";
-    t "unterminated-url" "@see <foo";
-    t "unterminated-file" "@see 'foo";
-    t "unterminated-document" "@see \"foo";
-    t "no-space" "@see<foo>";
-    t "words" "@see <foo> bar";
-    t "prefix" "@seefoo";
-    t "after-code-block" "{[foo]} @see <foo>";
-    t "url-attempted-nested-closer" "@see <foo>bar>";
-    t "file-attempted-nested-closer" "@see 'foo'bar'";
-    t "document-attempted-nested-closer" "@see \"foo\"bar\"";
-  ];
-
-  "since", [
-    t "basic" "@since foo";
-    t "bare" "@since";
-    t "prefix" "@sincefoo";
-    t "with-whitespace" "@since foo bar";
-    t "leading-whitespace" "@since  foo";
-    t "trailing-whitespace" "@since foo ";
-    t "whitespace-only" "@since ";
-  ];
-
-  "before", [
-    t "basic" "@before Foo";
-    t "bare" "@before";
-    t "words" "@before foo bar baz";
-    t "prefix" "@beforefoo";
-  ];
-
-  "version", [
-    t "basic" "@version foo";
-    t "bare" "@version";
-    t "prefix" "@versionfoo";
-    t "with-whitespace" "@version foo bar";
-    t "leading-whitespace" "@version  foo";
-    t "trailing-whitespace" "@version foo ";
-    t "whitespace-only" "@version ";
-  ];
-
-  "canonical", [
-    t "basic" "@canonical Foo";
-    t "empty" "@canonical";
-    t "whitespace-only" "@canonical ";
-    t "extra-whitespace" "@canonical  Foo ";
-    t "prefix" "@canonicalfoo";
-    (* TODO This should probably be an error of some kind, as Foo Bar is not a
-       valid module path. *)
-    t "with-whitespace" "@canonical Foo Bar";
-  ];
-
-  "inline", [
-    t "basic" "@inline";
-    t "prefix" "@inlinefoo";
-    t "extra-whitespace" "@inline ";
-    t "followed-by-junk" "@inline foo";
-    t "followed-by-paragraph" "@inline\nfoo";
-    t "followed-by-tag" "@inline\n@deprecated";
-    t "with-list" "@inline - foo";
-  ];
-
-  "open", [
-    t "basic" "@open";
-    t "prefix" "@openfoo";
-    t "extra-whitespace" "@open ";
-    t "followed-by-junk" "@open foo";
-    t "followed-by-paragraph" "@open\nfoo";
-    t "followed-by-tag" "@open\n@deprecated";
-    t "with-list" "@open - foo";
-  ];
-
-  "closed", [
-    t "basic" "@closed";
-    t "prefix" "@closedfoo";
-    t "extra-whitespace" "@closed ";
-    t "followed-by-junk" "@closed foo";
-    t "followed-by-paragraph" "@closed\nfoo";
-    t "followed-by-tag" "@closed\n@deprecated";
-    t "with-list" "@closed - foo";
-  ];
-
-  "reference-component-kind", [
-    t "no-kind" "{!foo}";
-    t "class" "{!class-foo}";
-    t "class-type" "{!class-type-foo}";
-    t "class-type-alt" "{!classtype-foo}";
-    t "constructor" "{!constructor-Foo}";
-    t "constructor-alt" "{!const-Foo}";
-    t "exception" "{!exception-Foo}";
-    t "exception-alt" "{!exn-Foo}";
-    t "extension" "{!extension-Foo}";
-    t "field" "{!field-foo}";
-    t "field-alt" "{!recfield-foo}";
-    t "heading" "{!section-foo}";
-    t "heading-alt" "{!label-foo}";
-    t "instance-variable" "{!instance-variable-foo}";
-    t "method" "{!method-foo}";
-    t "module" "{!module-Foo}";
-    t "module-type" "{!module-type-Foo}";
-    t "module-type-alt" "{!modtype-Foo}";
-    t "page" "{!page-foo}";
-    t "type" "{!type-foo}";
-    t "val" "{!val-foo}";
-    t "val-alt" "{!value-foo}";
-    t "longident" "{!module-Foo.type-bar}";
-    t "hyphenated-kind-longident" "{!module-type-Foo.module-type-Bar.type-baz}";
-    t "empty" "{!}";
-    t "empty-qualifier" "{!-foo}";
-    t "empty-identifier" "{!val-}";
-    t "invalid-qualifier" "{!foo-bar}";
-    t "empty-first-component" "{!.foo}";
-    t "empty-second-component" "{!Foo.}";
-    t "second-component-empty-qualifier" "{!Foo.-bar}";
-    t "second-component-empty-identifier" "{!Foo.val-}";
-    t "first-component-empty-identifier" "{!module-.foo}";
-    t "something-in-invalid" "{!foo-bar.baz}";
-    t "something-in-something" "{!foo.bar}";
-    t "something-in-module" "{!module-Foo.bar}";
-    t "something-in-module-type" "{!module-type-Foo.bar}";
-    t "something-in-type" "{!type-foo.bar}";
-    t "something-in-class" "{!class-foo.bar}";
-    t "something-in-class-type" "{!class-type-foo.bar}";
-    t "something-in-page" "{!page-foo.bar}";
-    t "something-in-constructor" "{!constructor-Foo.bar}";
-    t "something-in-exception" "{!exception-Foo.bar}";
-    t "something-in-extension" "{!extension-Foo.bar}";
-    t "something-in-field" "{!field-foo.bar}";
-    t "something-in-section" "{!section-foo.bar}";
-    t "something-in-instance-variable" "{!instance-variable-foo.bar}";
-    t "something-in-method" "{!method-foo.bar}";
-    t "something-in-val" "{!val-foo.bar}";
-    t "something-in-something-nested" "{!foo.bar.baz}";
-    t "something-in-module-nested" "{!Foo.module-Bar.baz}";
-    t "something-in-module-type-nested" "{!Foo.module-type-Bar.baz}";
-    t "something-in-type-nested" "{!Foo.type-bar.baz}";
-    t "something-in-class-nested" "{!Foo.class-bar.baz}";
-    t "something-in-class-type-nested" "{!foo.class-type-bar.baz}";
-    t "something-in-page-nested" "{!foo.page-bar.baz}";
-    t "something-in-constructor-nested" "{!Foo.constructor-Bar.baz}";
-    t "something-in-exception.nested" "{!Foo.exception-bar.baz}";
-    t "something-in-extension-nested" "{!Foo.extension-bar.baz}";
-    t "something-in-field-nested" "{!foo.field-bar.baz}";
-    t "something-in-section-nested" "{!foo.section-bar.baz}";
-    t "something-in-instance-variable-nested"
-      "{!foo.instance-variable-bar.baz}";
-    t "something-in-method-nested" "{!foo.method-bar.baz}";
-    t "something-in-val-nested" "{!Foo.val-bar.baz}";
-    t "module-in-empty" "{!.module-Foo}";
-    t "module-in-something" "{!Foo.module-Bar}";
-    t "module-in-module" "{!module-Foo.module-Bar}";
-    t "module-in-module-type" "{!module-type-Foo.module-Bar}";
-    t "module-in-class" "{!class-foo.module-Bar}";
-    t "module-in-class-type" "{!class-type-foo.module-Bar}";
-    t "module-in-constructor" "{!constructor-Foo.module-Bar}";
-    t "module-in-exception" "{!exception-Foo.module-Bar}";
-    t "module-in-extension" "{!extension-Foo.module-Bar}";
-    t "module-in-field" "{!field-foo.module-Bar}";
-    t "module-in-section" "{!section-foo.module-Bar}";
-    t "module-in-instance-variable" "{!instance-variable-foo.module-Bar}";
-    t "module-in-method" "{!method-foo.module-Bar}";
-    t "module-in-page" "{!page-foo.module-Bar}";
-    t "module-in-type" "{!type-foo.module-Bar}";
-    t "module-in-val" "{!val-foo.module-Bar}";
-    t "module-in-something-nested" "{!Foo.Bar.module-Baz}";
-    t "module-in-module-nested" "{!Foo.module-Bar.module-Baz}";
-    t "module-in-module-type-nested" "{!Foo.module-type-Bar.module-Baz}";
-    t "module-in-class-nested" "{!Foo.class-bar.module-Baz}";
-    t "module-in-class-type-nested" "{!Foo.class-type-bar.module-Baz}";
-    t "module-in-constructor-nested" "{!Foo.constructor-Bar.module-Baz}";
-    t "module-in-exception-nested" "{!Foo.exception-Bar.module-Baz}";
-    t "module-in-extension-nested" "{!Foo.extension-Bar.module-Baz}";
-    t "module-in-field-nested" "{!foo.field-bar.module-Baz}";
-    t "module-in-section-nested" "{!foo.section-bar.module-Baz}";
-    t "module-in-instance-variable-nested"
-      "{!foo.instance-variable-bar.module-Baz}";
-    t "module-in-method-nested" "{!foo.method-bar.module-Baz}";
-    t "module-in-page-nested" "{!foo.page-bar.module-Baz}";
-    t "module-in-type-nested" "{!Foo.type-bar.module-Baz}";
-    t "module-in-val-nested" "{!Foo.val-bar.module-Baz}";
-    t "module-type-in-something" "{!Foo.module-type-Bar}";
-    t "module-type-in-module" "{!module-Foo.module-type-Bar}";
-    t "module-type-in-module-type" "{!module-type-Foo.module-type-Bar}";
-    t "module-type-in-class" "{!class-foo.module-type-Bar}";
-    t "module-type-in-page" "{!page-foo.module-type-Bar}";
-    t "type-in-something" "{!Foo.type-bar}";
-    t "type-in-module" "{!module-Foo.type-bar}";
-    t "type-in-module-type" "{!module-type-Foo.type-bar}";
-    t "type-in-class" "{!class-foo.type-bar}";
-    t "type-in-page" "{!page-foo.type-bar}";
-    t "constructor-in-empty" "{!.constructor-Foo}";
-    t "constructor-in-something" "{!foo.constructor-Bar}";
-    t "constructor-in-type" "{!type-foo.constructor-Bar}";
-    t "constructor-in-class" "{!class-foo.constructor-Bar}";
-    t "constructor-in-class-type" "{!class-type-foo.constructor-Bar}";
-    t "constructor-in-constructor" "{!constructor-Foo.constructor-Bar}";
-    t "constructor-in-exception" "{!exception-Foo.constructor-Bar}";
-    t "constructor-in-extension" "{!extension-Foo.constructor-Bar}";
-    t "constructor-in-field" "{!field-foo.constructor-Bar}";
-    t "constructor-in-section" "{!section-foo.constructor-Bar}";
-    t "constructor-in-instance-variable"
-      "{!instance-variable-foo.constructor-Bar}";
-    t "constructor-in-method" "{!method-foo.constructor-Bar}";
-    t "constructor-in-module" "{!module-Foo.constructor-Bar}";
-    t "constructor-in-module-type" "{!module-type-Foo.constructor-Bar}";
-    t "constructor-in-page" "{!page-foo.constructor-Bar}";
-    t "constructor-in-val" "{!val-foo.constructor-Bar}";
-    t "constructor-in-something-nested" "{!foo.bar.constructor-Baz}";
-    t "constructor-in-type-nested" "{!foo.type-bar.constructor-Baz}";
-    t "constructor-in-class-nested" "{!Foo.class-bar.constructor-Baz}";
-    t "constructor-in-class-type-nested"
-      "{!Foo.class-type-bar.constructor-Baz}";
-    t "constructor-in-constructor-nested"
-      "{!Foo.constructor-Bar.constructor-Baz}";
-    t "constructor-in-exception-nested" "{!Foo.exception-Bar.constructor-Baz}";
-    t "constructor-in-extension-nested" "{!Foo.extension-Bar.constructor-Baz}";
-    t "constructor-in-field-nested" "{!foo.field-bar.constructor-Baz}";
-    t "constructor-in-section-nested" "{!foo.section-bar.constructor-Baz}";
-    t "constructor-in-instance-variable-nested"
-      "{!foo.instance-variable-bar.constructor-Baz}";
-    t "constructor-in-method-nested" "{!foo.method-bar.constructor-Baz}";
-    t "constructor-in-module-nested" "{!Foo.module-Bar.constructor-Baz}";
-    t "constructor-in-module-type-nested"
-      "{!Foo.module-type-Bar.constructor-Baz}";
-    t "constructor-in-page-nested" "{!foo.page-bar.constructor-Baz}";
-    t "constructor-in-val-nested" "{!Foo.val-bar.constructor-Baz}";
-    t "field-in-empty" "{!.field-foo}";
-    t "field-in-something" "{!foo.field-bar}";
-    t "field-in-module" "{!module-Foo.field-bar}";
-    t "field-in-module-type" "{!module-type-Foo.field-bar}";
-    t "field-in-type" "{!type-foo.field-bar}";
-    t "field-in-class" "{!class-foo.field-bar}";
-    t "field-in-class-type" "{!class-type-foo.field-bar}";
-    t "field-in-constructor" "{!constructor-Foo.field-bar}";
-    t "field-in-exception" "{!exception-Foo.field-bar}";
-    t "field-in-extension" "{!extension-Foo.field-bar}";
-    t "field-in-field" "{!field-foo.field-bar}";
-    t "field-in-section" "{!section-foo.field-bar}";
-    t "field-in-instance-variable" "{!instance-variable-foo.field-bar}";
-    t "field-in-method" "{!method-foo.field-bar}";
-    t "field-in-page" "{!page-foo.field-bar}";
-    t "field-in-val" "{!val-foo.field-bar}";
-    t "field-in-something-nested" "{!foo.bar.field-baz}";
-    t "field-in-module-nested" "{!Foo.module-Bar.field-baz}";
-    t "field-in-module-type-nested" "{!Foo.module-type-Bar.field-baz}";
-    t "field-in-type-nested" "{!Foo.type-bar.field-baz}";
-    t "field-in-class-nested" "{!Foo.class-bar.field-baz}";
-    t "field-in-class-type-nested" "{!Foo.class-type-bar.field-baz}";
-    t "field-in-constructor-nested" "{!Foo.constructor-bar.field-baz}";
-    t "field-in-exception-nested" "{!Foo.exception-Bar.field-baz}";
-    t "field-in-extension-nested" "{!Foo.extension-Bar.field-baz}";
-    t "field-in-field-nested" "{!Foo.field-bar.field-baz}";
-    t "field-in-section-nested" "{!foo.section-bar.field-baz}";
-    t "field-in-instance-variable-nested"
-      "{!foo.instance-variable-bar.field-baz}";
-    t "field-in-method-nested" "{!foo.method-bar.field-baz}";
-    t "field-in-page-nested" "{!foo.page-bar.field-baz}";
-    t "field-in-val-nested" "{!Foo.val-bar.field-baz}";
-    t "exception-in-something" "{!Foo.exception-Bar}";
-    t "exception-in-module" "{!module-Foo.exception-Bar}";
-    t "exception-in-class" "{!class-foo.exception-Bar}";
-    t "exception-in-page" "{!page-foo.exception-Bar}";
-    t "extension-in-something" "{!Foo.extension-Bar}";
-    t "extension-in-module" "{!module-Foo.extension-Bar}";
-    t "extension-in-class" "{!class-foo.extension-Bar}";
-    t "extension-in-page" "{!page-foo.extension-Bar}";
-    t "val-in-something" "{!Foo.val-bar}";
-    t "val-in-module" "{!module-Foo.val-bar}";
-    t "val-in-class" "{!class-foo.val-bar}";
-    t "val-in-page" "{!page-foo.val-bar}";
-    t "class-in-something" "{!Foo.class-bar}";
-    t "class-in-module" "{!module-Foo.class-bar}";
-    t "class-in-class" "{!class-foo.class-bar}";
-    t "class-in-page" "{!page-foo.class-bar}";
-    t "class-type-in-something" "{!Foo.class-type-bar}";
-    t "class-type-in-module" "{!module-Foo.class-type-bar}";
-    t "class-type-in-class" "{!class-foo.class-type-bar}";
-    t "class-type-in-page" "{!page-foo.class-type-bar}";
-    t "method-in-empty" "{!.method-foo}";
-    t "method-in-something" "{!foo.method-bar}";
-    t "method-in-class" "{!class-foo.method-bar}";
-    t "method-in-class-type" "{!class-type-foo.method-bar}";
-    t "method-in-constructor" "{!constructor-Foo.method-bar}";
-    t "method-in-exception" "{!exception-Foo.method-bar}";
-    t "method-in-extension" "{!extension-Foo.method-bar}";
-    t "method-in-field" "{!field-foo.method-bar}";
-    t "method-in-section" "{!section-foo.method-bar}";
-    t "method-in-instance-variable" "{!instance-variable-foo.method-bar}";
-    t "method-in-method" "{!method-foo.method-bar}";
-    t "method-in-module" "{!module-Foo.method-bar}";
-    t "method-in-module-type" "{!module-type-Foo.method-bar}";
-    t "method-in-page" "{!page-foo.method-bar}";
-    t "method-in-type" "{!type-foo.method-bar}";
-    t "method-in-val" "{!val-foo.method-bar}";
-    t "method-in-something-nested" "{!foo.bar.method-baz}";
-    t "method-in-class-nested" "{!Foo.class-bar.method-baz}";
-    t "method-in-class-type-nested" "{!Foo.class-type-bar.method-baz}";
-    t "method-in-constructor-nested" "{!foo.constructor-Bar.method-baz}";
-    t "method-in-exception-nested" "{!Foo.exception-Bar.method-baz}";
-    t "method-in-extension-nested" "{!Foo.extension-Bar.method-baz}";
-    t "method-in-field-nested" "{!foo.field-bar.method-baz}";
-    t "method-in-section-nested" "{!foo.section-bar.method-baz}";
-    t "method-in-instance-variable-nested"
-      "{!foo.instance-variable-bar.method-baz}";
-    t "method-in-method-nested" "{!foo.method-bar.method-baz}";
-    t "method-in-module-nested" "{!Foo.module-Bar.method-baz}";
-    t "method-in-module-type-nested" "{!Foo.module-type-Bar.method-baz}";
-    t "method-in-page-nested" "{!foo.page-bar.method-baz}";
-    t "method-in-type-nested" "{!Foo.type-bar.method-baz}";
-    t "method-in-val-nested" "{!Foo.val-bar.method-baz}";
-    t "instance-variable-in-something" "{!Foo.instance-variable-bar}";
-    t "instance-variable-in-module" "{!module-Foo.instance-variable-bar}";
-    t "instance-variable-in-class" "{!class-foo.instance-variable-bar}";
-    t "instance-variable-in-page" "{!page-foo.instance-variable-bar}";
-    t "section-in-something" "{!Foo.section-bar}";
-    t "section-in-module" "{!module-Foo.section-bar}";
-    t "section-in-class" "{!class-foo.section-bar}";
-    t "section-in-page" "{!page-foo.section-bar}";
-    t "page-in-something" "{!foo.page-bar}";
-    t "inner-parent-something-in-something" "{!foo.bar.field-baz}";
-    t "inner-parent-something-in-module" "{!module-Foo.bar.field-baz}";
-    t "inner-parent-something-in-class" "{!class-foo.bar.field-baz}";
-    t "inner-parent-something-in-page" "{!page-foo.bar.field-baz}";
-    t "inner-parent-module-in-module" "{!module-Foo.module-Bar.field-baz}";
-    t "inner-parent-module-in-class" "{!class-foo.module-Bar.field-baz}";
-    t "inner-parent-module-type-in-module"
-      "{!module-Foo.module-type-Bar.field-baz}";
-    t "inner-parent-module-type-in-class"
-      "{!class-foo.module-type-Bar.field-baz}";
-    t "inner-parent-type-in-module" "{!module-Foo.type-bar.field-baz}";
-    t "inner-parent-type-in-class" "{!class-foo.type-bar.field-baz}";
-    t "inner-parent-class-in-module" "{!module-Foo.class-bar.field-baz}";
-    t "inner-parent-class-in-class" "{!class-foo.class-bar.field-baz}";
-    t "inner-parent-class-type-in-module"
-      "{!module-Foo.class-type-bar.field-baz}";
-    t "inner-parent-class-type-in-class"
-      "{!class-foo.class-type-bar.field-baz}";
-    t "inner-label-parent-something-in-something" "{!foo.bar.baz}";
-    t "inner-label-parent-something-in-page" "{!page-foo.bar.baz}";
-    t "inner-label-parent-module-in-module" "{!module-Foo.module-Bar.baz}";
-    t "inner-label-parent-module-in-class" "{!class-foo.module-Bar.baz}";
-    t "inner-label-parent-module-type-in-module"
-      "{!module-Foo.module-type-Bar.baz}";
-    t "inner-label-parent-module-type-in-class"
-      "{!class-foo.module-type-Bar.baz}";
-    t "inner-label-parent-type-in-module" "{!module-Foo.type-bar.baz}";
-    t "inner-label-parent-type-in-class" "{!class-foo.type-bar.baz}";
-    t "inner-label-parent-class-in-module" "{!module-Foo.class-bar.baz}";
-    t "inner-label-parent-class-in-class" "{!class-foo.class-bar.baz}";
-    t "inner-label-parent-class-type-in-module" "{!module-Foo.class-bar.baz}";
-    t "inner-label-parent-class-type-in-class" "{!class-foo.class-bar.baz}";
-    t "inner-page-in-something" "{!foo.page-bar.baz}";
-    t "inner-class-signature-something-in-something" "{!foo.bar.method-baz}";
-    t "inner-class-signature-something-in-page" "{!page-foo.bar.method-baz}";
-    t "inner-class-signature-class-in-module"
-      "{!module-Foo.class-bar.method-baz}";
-    t "inner-class-signature-class-in-class"
-      "{!class-foo.class-bar.method-baz}";
-    t "inner-class-signature-class-type-in-module"
-      "{!module-Foo.class-type-bar.method-baz}";
-    t "inner-class-signature-class-type-in-class"
-      "{!class-foo.class-type-bar.method-baz}";
-    t "inner-signature-something-in-something" "{!foo.bar.type-baz}";
-    t "inner-signature-something-in-page" "{!page-foo.bar.type-baz}";
-    t "inner-signature-module-in-module" "{!module-Foo.module-Bar.type-baz}";
-    t "inner-signature-module-in-class" "{!class-foo.module-Bar.type-baz}";
-    t "inner-signature-module-type-in-module"
-      "{!module-Foo.module-type-Bar.type-baz}";
-    t "inner-signature-module-type-in-class"
-      "{!class-foo.module-type-Bar.type-baz}";
-    t "inner-datatype-something-in-something" "{!foo.bar.constructor-Baz}";
-    t "inner-datatype-something-in-page" "{!page-foo.bar.constructor-Baz}";
-    t "inner-datatype-type-in-module" "{!module-Foo.type-bar.constructor-Baz}";
-    t "inner-datatype-type-in-class" "{!class-foo.type-bar.constructor-Baz}";
-    t "kind-conflict" "{!val:type-foo}";
-    t "kind-agreement" "{!val:val-foo}";
-    t "kind-agreement-alt" "{!value:val-foo}";
-    t "canonical-something" "@canonical Foo";
-    t "canonical-module" "@canonical module-Foo";
-    t "canonical-path" "@canonical Foo.Bar";
-    t "canonical-val" "@canonical val-foo";
-    t "canonical-bad-parent" "@canonical bar.page-foo";
-    t "canonical-empty-component" "@canonical .Foo";
-    t "canonical-empty-name" "@canonical Foo.";
-    t "internal-whitespace" "{!foo. bar .baz}";
-    t "replacement-text-empty-identifier" "{{!val-} foo}";
-  ];
-
-  "bad-markup", [
-    t "left-brace" "{";
-    t "left-brace-with-letter" "{g";
-    t "left-brace-with-letters" "{gg";
-    t "empty-braces" "{}";
-    t "left-space" "{ foo}";
-    t "left-spaces" "{  foo}";
-    t "left-space-eof" "{ ";
-    t "braces-instead-of-brackets" "{foo}";
-    t "right-brace" "}";
-    t "right-brace-in-paragraph" "foo}";
-    t "multiple-right-brace" "foo } bar } baz";
-    t "right-brace-in-list-item" "- foo}";
-    t "right-brace-in-code-span" "[foo}]";
-    t "right-brace-in-code-block" "{[foo}]}";
-    t "right-brace-in-verbatim-text" "{v foo} v}";
-    t "right-brace-in-author" "@author Foo}";
-    t "right-brace-in-deprecated" "@deprecated }";
-    t "right-bracket" "]";
-    t "right-bracket-in-paragraph" "foo]";
-    t "right-bracket-in-shorthand-list" "- foo]";
-    t "right-bracket-in-code-span" "[]]";
-    t "right-bracket-in-style" "{b]}";
-    t "right-bracket-in-verbatim" "{v ] v}";
-    t "right-bracket-in-list" "{ul ]}";
-    t "right-bracket-in-list-item" "{ul {li ]}}";
-    t "right-bracket-in-heading" "{2 ]}";
-    t "right-bracket-in-author" "@author Foo]";
-    t "at" "@";
-    t "cr" "\r";
-  ];
-
-  "utf-8", [
-    t "lambda" "\xce\xbb";
-    t "words" "\xce\xbb \xce\xbb";
-    t "no-validation" "\xce";
-    t "escapes" "\xce\xbb\\}";
-    t "newline" "\xce\xbb \n \xce\xbb";
-    t "paragraphs" "\xce\xbb \n\n \xce\xbb";
-    t "code-span" "[\xce\xbb]";
-    t "minus" "\xce\xbb-\xce\xbb";
-    t "shorthand-list" "- \xce\xbb";
-    t "styled" "{b \xce\xbb}";
-    t "reference-target" "{!\xce\xbb}";
-    t "code-block" "{[\xce\xbb]}";
-    t "verbatim" "{v \xce\xbb v}";
-    t "label" "{2:\xce\xbb Bar}";
-    t "author" "@author \xce\xbb";
-    t "param" "@param \xce\xbb";
-    t "raise" "@raise \xce\xbb";
-    t "see" "@see <\xce\xbb>";
-    t "since" "@since \xce\xbb";
-    t "before" "@before \xce\xbb";
-    t "version" "@version \xce\xbb";
-    t "right-brace" "\xce\xbb}";
-  ];
-
-  "comment-location", [
-    t "error-on-first-line" "  @foo"
-      ~location:{line = 2; column = 4};
-    t "error-on-second-line" "  \n  @foo"
-      ~location:{line = 2; column = 4};
-  ];
-
-  "unsupported", [
-    (* test "index list"
-      "{!indexlist}"
-      (Ok []); *)
-    t "left-alignment" "{L foo}";
-    t "center-alignment" "{C foo}";
-    t "right-alignment" "{R foo}";
-    t "custom-style" "{c foo}";
-    t "custom-tag" "@custom";
-    t "custom-reference-kind" "{!custom:foo}";
-    t "html-tag" "<b>foo</b>";
-  ];
-]
-
-
+let tests : test_suite list =
+  [
+    ( "trivial",
+      [
+        t "empty" "";
+        t "space" " ";
+        t "two-spaces" "  ";
+        t "tab" "\t";
+        t "mixed-space" " \t \t";
+        t "newline" "\n";
+        t "blank-line" "\n\n";
+        t "cr-lf" "\r\n";
+      ] );
+    ( "one-paragraph",
+      [
+        t "word" "foo";
+        t "two-words" "foo bar";
+        t "two-spaces" "foo  bar";
+        t "mixed-space" "foo \t \t bar";
+        t "two-lines" "foo\nbar";
+        t "two-lines-cr-lf" "foo\r\nbar";
+        t "leading-space" " foo";
+        t "trailing-space" "foo ";
+        t "leading-space-on-line" "foo\n bar";
+        t "trailing-space-on-line" "foo \nbar";
+        t "leading-tab-on-line" "foo\n\tbar";
+        t "trailing-tab-on-line" "foo\t\nbar";
+        t "email" "foo@bar.com";
+      ] );
+    ( "two-paragraphs",
+      [
+        t "basic" "foo\n\nbar";
+        t "trailing-space" "foo \n\nbar";
+        t "leading-space" "foo\n\n bar";
+        t "cr-lf" "foo\r\n\r\nbar";
+        t "mixed-cr-lf" "foo\n\r\nbar";
+      ] );
+    ( "plus-minus-words",
+      [
+        t "minus-in-word" "foo-bar";
+        t "minus-as-word" "foo -";
+        t "plus-in-word" "foo+bar";
+        t "plus-as-word" "foo +";
+        t "negative-number" "-3.14 -1337";
+        t "en-em-dash" "-- ---";
+        t "minus-at" "-@";
+        t "at-minus" "-@-";
+        t "option" "--option";
+      ] );
+    ( "escape-sequence",
+      [
+        t "left-brace" "\\{";
+        t "left-brace-in-word" "foo\\{bar";
+        t "right-brace" "\\}";
+        t "right-brace-in-word" "foo\\}bar";
+        t "left-bracket" "\\[";
+        t "left-bracket-in-word" "foo\\[bar";
+        t "right-bracket" "\\]";
+        t "right-bracket-in-word" "foo\\]bar";
+        t "at" "\\@";
+        t "not-a-tag" "\\@author";
+        t "at-in-word" "foo\\@bar";
+        t "trailing-backslash" "foo\\";
+        t "non-escape" "foo\\bar";
+        t "backslash-not-escaped" "foo\\\\{bar";
+        t "single-backslash" "\\";
+        t "escape-minus" "\\{- foo";
+        t "escape-plus" "\\{+ foo";
+        t "minus-escape" "-\\{";
+        t "plus-escape" "+\\{";
+        t "escape-at" "\\{@author";
+        t "two" "\\{\\}";
+      ] );
+    ( "code-span",
+      [
+        t "basic" "[foo]";
+        t "empty" "[]";
+        t "list" "[[]]";
+        (* TODO The next two error messages are particularly unintuitive. *)
+        t "unbalanced-list" "[[]";
+        t "no-markup" "[{b]";
+        t "few-escapes" "[\\{]";
+        t "escaped-right-bracket" "[\\]]";
+        t "escaped-left-bracket" "[\\[]";
+        t "whitespace-preserved" "[ foo  bar ]";
+        t "no-newlines" "[foo\nbar]";
+        t "cr-lf-preserved" "[foo\r\nbar]";
+        t "no-double-newline" "[foo\n\nbar]";
+        t "no-double-crlf" "[foo\r\n\r\nbar]";
+        t "not-merged" "[foo][bar]";
+        t "explicit-space" "[foo] [bar]";
+        t "unterminated" "[foo";
+      ] );
+    ( "bold",
+      [
+        t "basic" "{b foo}";
+        t "extra-leading-whitespace" "{b  \t foo}";
+        t "leading-newline" "{b\nfoo}";
+        t "leading-cr-lf" "{b\r\nfoo}";
+        t "leading-newline-and-whitespace" "{b\n foo}";
+        t "no-leading-whitespace" "{bfoo}";
+        t "trailing-whitespace" "{b foo }";
+        t "trailing-newline" "{b foo\n}";
+        t "trailing-cr-lf" "{b foo\r\n}";
+        t "two-words" "{b foo bar}";
+        t "not-merged" "{b foo}{b bar}";
+        t "nested" "{b foo{b bar}}";
+        t "newline" "{b foo\nbar}";
+        t "cr-lf" "{b foo\r\nbar}";
+        t "minus" "{b -}";
+        t "minus-list-item" "{b foo\n - bar}";
+        t "plus-list-item" "{b foo\n + bar}";
+        t "immediate-minus-list-item" "{b\n- foo}";
+        t "immediate-plus-list-item" "{b\n+ foo}";
+        t "blank-line" "{b foo\n\nbar}";
+        t "immediate-blank-line" "{b\n\n";
+        t "end-of-comment" "{b foo";
+        t "nested-code-block" "{b {[foo]}";
+        t "degenerate" "{b}";
+        t "empty" "{b }";
+      ] );
+    ( "italic",
+      [
+        t "basic" "{i foo}";
+        t "extra-leading-whitespace" "{i  \t foo}";
+        t "leading-newline" "{i\nfoo}";
+        t "leading-newline-and-whitespace" "{i\n foo}";
+      ] );
+    ( "emphasis",
+      [
+        t "basic" "{e foo}";
+        t "extra-leading-whitespace" "{e  \t foo}";
+        t "leading-newline" "{e\nfoo}";
+        t "leading-newline-and-whitespace" "{e\n foo}";
+      ] );
+    ( "superscript",
+      [
+        t "basic" "{^ foo}";
+        t "extra-leading-whitespace" "{^  \t foo}";
+        t "leading-newline" "{^\nfoo}";
+        t "leading-cr-lf" "{^\r\nfoo}";
+        t "leading-newline-and-whitespace" "{^\n foo}";
+        t "no-whitespace" "{^foo}";
+        t "degenerate" "{^}";
+        t "empty" "{^ }";
+      ] );
+    ( "subscript",
+      [
+        t "basic" "{_ foo}";
+        t "extra-leading-whitespace" "{_  \t foo}";
+        t "leading-newline" "{_\nfoo}";
+        t "leading-newline-and-whitespace" "{_\n foo}";
+        t "no-whitespace" "{_foo}";
+        t "v-verbose" "{_uv}";
+      ] );
+    ( "simple-reference",
+      [
+        t "basic" "{!foo}";
+        t "leading-whitespace" "{! foo}";
+        t "trailing-whitespace" "{!foo }";
+        t "adjacent-word-leading" "bar{!foo}";
+        t "explicit-leading-space" "bar {!foo}";
+        t "adjacent-word-trailing" "{!foo}bar";
+        t "explicit-trailing-space" "{!foo} bar";
+        t "kind" "{!val:foo}";
+        t "empty" "{!}";
+        t "whitespace-only" "{! }";
+        t "internal-whitespace" "{!( * )}";
+        (* TODO Limiting the character combinations allowed will make it easier to
+           catch expressions accidentally written inside references. This can also
+           be caught by a good resolver and resolver error messages. *)
+        (* t "expression" *)
+        t "unterminated" "{!foo";
+        t "empty-kind" "{!:foo}";
+        t "whitespace-kind" "{! :foo}";
+        t "with-kind-but-empty" "{!val:}";
+        t "with-kind-but-whitespace" "{!val: }";
+        t "leading-whitespace-in-kind" "{! val:foo}";
+        t "internal-whitespace-in-kind" "{!va l:foo}";
+        t "internal-whitespace-in-referent" "{!val:( * )}";
+        t "two-colons" "{!val:foo:bar}";
+        t "space-before-colon" "{!val :foo}";
+        t "space-after-colon" "{!val: foo}";
+        t "unterminated-after-kind" "{!val:foo";
+        t "operator" "{!(>>=)}";
+        t "operator-with-dash" "{!(@->)}";
+        t "operator-with-dot" "{!(*.)}";
+        t "operator-with-colon" "{!(>::)}";
+      ] );
+    ( "reference-with-text",
+      [
+        t "basic" "{{!foo} bar}";
+        t "degenerate" "{{!foo}}";
+        t "empty" "{{!foo} }";
+        t "nested-markup" "{{!foo} {b bar}}";
+        t "in-markup" "{e {{!foo} bar}}";
+        t "no-separating-space" "{{!foo}bar}";
+        t "kind" "{{!val:foo} bar}";
+        t "nested-reference" "{{!foo} {!bar}}";
+        t "nested-empty" "{{!foo} {{!bar}}}";
+        t "nested-through-emphasis" "{{!foo} {e {{!bar} baz}}}";
+        t "simple-through-emphasis" "{{!foo} {e {!bar}}}";
+        t "empty-target" "{{!} foo}";
+        t "whitespace-only-in-target" "{{! } foo}";
+        t "internal-whitespace" "{{!( * )} baz}";
+        t "unterminated" "{{!foo";
+        t "unterminated-content" "{{!foo} bar";
+      ] );
+    ( "link",
+      [
+        t "basic" "{{:foo} bar}";
+        t "nested-markup" "{{:foo} {b bar}}";
+        t "in-markup" "{e {{:foo} bar}}";
+        t "no-separating-space" "{{:foo}bar}";
+        t "nested-link" "{{:foo} {{:bar} baz}}";
+        t "nested-through-emphasis" "{{:foo} {e {{:bar} baz}}}";
+        t "reference-through-emphasis" "{{:foo} {e {!bar}}}";
+        t "nested-in-reference" "{{!foo} {e {{:bar} baz}}}";
+        t "empty-target" "{{:} foo}";
+        t "whitespace-only-in-target" "{{: } foo}";
+        t "empty" "{{:foo}}";
+        t "internal-whitespace" "{{:foo bar} baz}";
+        t "unterminated" "{{:foo";
+        t "single-braces" "{:foo}";
+        t "unterminated-single-braces" "{:foo";
+        t "empty-single-braces" "{:}";
+        t "single-braces-whitespace-only" "{: }";
+      ] );
+    ( "raw-markup",
+      [
+        t "html-target" "{%html:foo%}";
+        t "whitespace" "{%html: foo bar %}";
+        t "whitespace-only" "{%html: %}";
+        t "empty" "{%html:%}";
+        t "html-payload" "{%html:<e>foo</e>%}";
+        t "colon" "{%html:foo:bar%}";
+        t "no-target" "{%foo%}";
+        t "empty-target" "{%:foo%}";
+        t "whitespace-target" "{% :foo%}";
+        t "multiline-target" "{%\n:foo%}";
+        t "percent-in-target" "{%%:%}";
+        t "percent-in-payload" "{%html:%%}";
+        t "multiple-percent-in-target" "{%%%foo%%:%}";
+        t "multiple-percent-in-payload" "{%html:%%foo%%%}";
+        t "opener-in-target" "{%{%:foo%}";
+        t "opener-in-payload" "{%html:{%%}";
+        t "right-brace-in-target" "{%}:%}";
+        t "right-brace-in-payload" "{%html:}%}";
+        t "unterminated" "{%";
+        t "unterminated-after-target" "{%html:";
+        t "degenerate" "{%}";
+      ] );
+    ( "module-list",
+      [
+        t "basic" "{!modules:Foo}";
+        t "two" "{!modules:Foo Bar}";
+        t "extra-whitespace" "{!modules: Foo  Bar }";
+        t "newline" "{!modules:Foo\nBar}";
+        t "cr-lf" "{!modules:Foo\r\nBar}";
+        t "empty" "{!modules:}";
+        t "whitespace-only" "{!modules: }";
+        t "unterminated" "{!modules:";
+        t "in-paragraph" "foo {!modules:Foo}";
+        t "followed-by-word" "{!modules:Foo} foo";
+        t "in-list" "- {!modules:Foo}";
+      ] );
+    ( "code-block",
+      [
+        t "basic" "{[foo]}";
+        t "empty" "{[]}";
+        t "whitespace-only" "{[ ]}";
+        t "blank-line-only" "{[\n  \n]}";
+        t "whitespace" "{[foo bar]}";
+        t "newline" "{[foo\nbar]}";
+        t "cr-lf" "{[foo\r\nbar]}";
+        t "blank-line" "{[foo\n\nbar]}";
+        t "leading-whitespace" "{[ foo]}";
+        t "leading-whitespace-two" "{[ foo\n bar]}";
+        t "leading-whitespace-two-cr-lf" "{[ foo\r\n bar]}";
+        t "leading-whitespace-two-different-indent" "{[ foo\n   bar]}";
+        t "leading-whitespace-two-different-indent-rev" "{[   foo\n bar]}";
+        t
+          ~location:{ Odoc_model.Location_.line = 1; column = 3 }
+          "leading-whitespace-two-different-indent-reloc" "{[ foo\n      bar]}";
+        t "leading-whitespace-with-empty-line" "{[ foo\n\n bar]}";
+        t "leading-whitespace-with-whitespace-line-short" "{[  foo\n \n  bar]}";
+        t "leading-whitespace-with-whitespace-line-long" "{[ foo\n   \n bar]}";
+        t "leading-whitespace-leading-newline" "{[\n  foo\n  bar\n]}";
+        t "leading-tab" "{[\tfoo]}";
+        t "leading-tab-two" "{[\tfoo\n\tbar]}";
+        t "leading-tab-two-different-indent" "{[\tfoo\n\t\tbar]}";
+        t "leading-newline" "{[\nfoo]}";
+        t "leading-cr-lf" "{[\r\nfoo]}";
+        t "leading-newlines" "{[\n\nfoo]}";
+        t "leading-newline-with-space" "{[\n foo]}";
+        t "leading-newline-with-trash" "{[ \nfoo]}";
+        t "nested-opener" "{[{[]}";
+        t "nested-closer" "{[foo]}]}";
+        t "nested-bracket" "{[]]}";
+        t "two-nested-brackets" "{[]]]}";
+        t "nested-brackets-in-text" "{[foo]]bar]}";
+        t "trailing-whitespace" "{[foo ]}";
+        t "trailing-tab" "{[foo\t]}";
+        t "trailing-newline" "{[foo\n]}";
+        t "trailing-cr-lf" "{[foo\r\n]}";
+        t "trailing-newlines" "{[foo\n\n]}";
+        t "preceded-by-whitespace" " {[foo]}";
+        t "followed-by-whitespace" "{[foo]} ";
+        t "two-on-one-line" "{[foo]} {[bar]}";
+        t "two" "{[foo]}\n{[bar]}";
+        t "two-with-blank-line" "{[foo]}\n\n{[bar]}";
+        t "followed-by-words" "{[foo]} bar";
+        t "preceded-by-words" "foo {[bar]}";
+        t "preceded-by-paragraph" "foo\n{[bar]}";
+        t "followed-by-paragraph" "{[foo]}\nbar";
+        t "unterminated" "{[foo";
+        t "unterminated-bracket" "{[foo]";
+        t "trailing-cr" "{[foo\r]}";
+        t "comment" "{[(* foo *)\nlet bar = ()]}";
+        t "docstring" "{[(** foo *)\nlet bar = ()]}";
+        t "docstring-with-code-block" "{[(** {[foo]} *)\nlet bar = ()]}";
+      ] );
+    ( "verbatim",
+      [
+        t "basic" "{v foo v}";
+        t "empty" "{v v}";
+        t "degenerate" "{vv}";
+        t "whitespace-only" "{v  v}";
+        t "blank-line-only" "{v\n  \nv}";
+        t "no-leading-whitespace" "{vfoo v}";
+        t "no-trailing-whitespace" "{v foov}";
+        t "multiple-leading-whitespace" "{v  foo v}";
+        t "multiple-trailing-whitespace" "{v foo  v}";
+        t "leading-tab" "{v\tfoo v}";
+        t "leading-newline" "{v\nfoo v}";
+        t "leading-cr-lf" "{v\r\nfoo v}";
+        t "trailing-tab" "{v foo\tv}";
+        t "trailing-newline" "{v foo\nv}";
+        t "trailing-cr-lf" "{v foo\r\nv}";
+        t "internal-whitespace" "{v foo bar v}";
+        t "newline" "{v foo\nbar v}";
+        t "cr-lf" "{v foo\r\nbar v}";
+        t "blank-line" "{v foo\n\nbar v}";
+        t "leading-newlines" "{v\n\nfoo v}";
+        t "leading-newline-with-space" "{v\n foo v}";
+        t "leading-newline-with-trash" "{v \nfoo v}";
+        t "nested-opener" "{v {v v}";
+        t "nested-closer" "{v foo v} v}";
+        t "nested-closer-with-word" "{v {dev} v}";
+        t "nested-v" "{v v v}";
+        t "two-nested-vs" "{v vv v}";
+        t "nested-v-at-end" "{v vv}";
+        t "two-nested-vs-at-end" "{v vvv}";
+        t "nested-vs-in-text" "{v foovvbar v}";
+        t "trailing-newlines" "{v foo\n\nv}";
+        t "preceded-by-whitespace" " {v foo v}";
+        t "followed-by-whitespace" "{v foo v} ";
+        t "two-on-one-line" "{v foo v} {v bar v}";
+        t "two" "{v foo v}\n{v bar v}";
+        t "two-with-blank-line" "{v foo v}\n\n{v bar v}";
+        t "followed-by-words" "{v foo v} bar";
+        t "preceded-by-words" "foo {v bar v}";
+        t "preceded-by-paragraph" "foo\n{v bar v}";
+        t "followed-by-paragraph" "{v foo v}\nbar";
+        t "unterminated" "{v foo";
+        t "unterminated-v" "{v foo v";
+        t "unterminated-empty" "{v";
+        t "unterminated-whitespace" "{v ";
+        t "unterminated-whitespace-2" "{v  ";
+        t "trailing-cr" "{v foo\rv}";
+      ] );
+    ( "shorthand-list",
+      [
+        t "basic" "- foo";
+        t "multiple-items" "- foo\n- bar";
+        t "two-lists" "- foo\n\n- bar";
+        t "ordered" "+ foo";
+        t "leading-whitespace" " - foo";
+        t "trailing-whitespace" "- foo ";
+        t "bullet-in-line" "- foo - bar";
+        t "bullet-in-line-immediately" "- - foo";
+        t "code-block" "- {[foo]}";
+        t "verbatim" "- {v foo v}";
+        t "multiple-blocks" "- foo\n{[bar]}";
+        t "followed-by-code-block" "- foo\n\n{[bar]}";
+        t "different-kinds" "- foo\n+ bar";
+        t "no-content" "-";
+        t "immediate-newline" "-\nfoo";
+        t "immediate-blank-line" "-\n\nfoo";
+        t "immediate-markup" "-{b foo}";
+        t "after-code-block" "{[foo]} - bar";
+      ] );
+    ( "explicit-list",
+      [
+        t "basic" "{ul {li foo}}";
+        t "ordered" "{ol {li foo}}";
+        t "two-items" "{ul {li foo} {li bar}}";
+        t "items-on-separate-lines" "{ul {li foo}\n{li bar}}";
+        t "blank-line" "{ul {li foo}\n\n{li bar}}";
+        t "blank-line-in-item" "{ul {li foo\n\nbar}}";
+        t "junk" "{ul foo}";
+        t "junk-with-no-whitespace" "{ulfoo}";
+        t "empty" "{ul}";
+        t "unterminated-list" "{ul";
+        t "no-whitespace" "{ul{li foo}}";
+        t "whitespace-at-end-of-item" "{ul {li foo\n\n\n}}";
+        t "unterminated-{li" "{ul {li foo";
+        t "unterminated-{-" "{ul {- foo";
+        t "empty-{li" "{ul {li }}";
+        t "empty-{-" "{ul {- }}";
+        t "{li-without-whitespace" "{ul {lifoo}}";
+        t "{li-followed-by-newline" "{ul {li\nfoo}}";
+        t "{li-followed-by-cr-lf" "{ul {li\r\nfoo}}";
+        t "{li-followed-by-blank-line" "{ul {li\n\nfoo}}";
+        t "{--without-whitespace" "{ul {-foo}}";
+        t "mixed-list-items" "{ul {li foo} {- bar}}";
+        t "nested" "{ul {li {ul {li foo}}}}";
+        t "shorthand-in-explicit" "{ul {li - foo\n- bar}}";
+        t "explicit-in-shorthand" "- {ul {li foo}}";
+        t "bare-{li" "{li foo}";
+        t "bare-{-" "{- foo";
+        t "after-code-block" "{[foo]} {ul {li bar}}";
+      ] );
+    ( "heading",
+      [
+        t "basic" "{2 Foo}";
+        t "subsection" "{3 Foo}";
+        t "subsubsection" "{4 Foo}";
+        t "leading-whitespace" "{2  Foo}";
+        t "no-leading-whitespace" "{2Foo}";
+        t "no-leading-whitespace-h3" "{3Foo}";
+        t "leading-newline" "{2\nFoo}";
+        t "leading-cr-lf" "{2\r\nFoo}";
+        t "leading-blank-line" "{2\n\nFoo}";
+        t "leading-blank-line-h3" "{3\n\nFoo}";
+        t "trailing-whitespace" "{2 Foo }";
+        t "trailing-newline" "{2 Foo\n}";
+        t "trailing-blank-line" "{2 Foo\n\n}";
+        t "nested-markup" "{2 [foo]}";
+        t "nested-code-with-uppercase" "{2 [Foo]}";
+        t "nested-code-with-spaces" "{2 [ foo bar  baz  \t]}";
+        t "nested-code-with-newline" "{2 [foo\nbar\r\nbaz]}";
+        t "nested-style" "{2 {e foo bar}}";
+        t "words" "{2 foo bar}";
+        t "nested-heading" "{2 {2 Foo}}";
+        t "in-list" "- {2 Foo}";
+        t "followed-by-junk" "{2 Foo} bar";
+        t "preceded-by-junk" "foo {2 Bar}";
+        t "followed-by-block" "{2 Foo}\nbar";
+        t "preceded-by-block" "foo\n{2 Bar}";
+        t "label" "{2:foo Bar}";
+        t "whitespace-before-colon" "{2 :foo Bar}";
+        t "whitespace-after-colon" "{2: foo Bar}";
+        t "label-only" "{2:foo}";
+        t "label-only-with-whitespace" "{2:foo }";
+        t "in-list-outside-item" "{ul {2 Foo}}";
+        t "preceded-by-shorthand-list" "- foo\n{2 Bar}";
+        t "nested-in-two-lists" "{ul {li - foo\n{2 Bar}}}";
+        t "bad-level-long-number" "{22 Foo}";
+        t "bad-level-long-number-with-label" "{22:foo Bar}";
+        t "bad-level-leading-zero" "{02 Foo}";
+        t "bad-level-leading-zero-with-label" "{02:foo Bar}";
+        t "bad-level-title" "{0 Foo}";
+        t "bad-level-too-deep" "{6 Foo}";
+        t "link-in-markup" "{2 {{:foo}}}";
+        t "reference-in-markup" "{2 {!foo}}";
+        t "two" "{2 Foo}\n{2 Bar}";
+        t "greater" "{2 Foo}\n{3 Bar}";
+      ] );
+    ( "section-contexts",
+      [
+        t "titles-allowed" "{0 Foo}" ~sections_allowed:`All;
+        t "titles-no-high-levels" "{6 Foo}" ~sections_allowed:`All;
+        t "two-titles" "{0 Foo}\n{0 Bar}" ~sections_allowed:`All;
+        t "no-heading" "foo" ~sections_allowed:`All;
+        t "heading-after-paragraph" "foo\n{0 Bar}" ~sections_allowed:`All;
+        t "two-top-level-section-headings" "{1 Foo}\n{1 Bar}"
+          ~sections_allowed:`All;
+        t "two-headings-second-higher" "{1 Foo}\n{0 Bar}" ~sections_allowed:`All;
+        t "three-headings-last-two-higher" "{3 Foo}\n{1 Bar}\n{2 Baz}"
+          ~sections_allowed:`All;
+        t "none" "{1 Foo}" ~sections_allowed:`None;
+        t "title-no-titles-allowed" "{0 Foo}" ~sections_allowed:`No_titles;
+        t "two-titles-none-allowed" "{0 Foo}\n{0 Bar}"
+          ~sections_allowed:`No_titles;
+        t "two-headings-none-allowed" "{1 Foo}\n{1 Bar}" ~sections_allowed:`None;
+        t "multiple-with-bad-section" "{0 Foo}\n{0 Foo}\n{6 Foo}"
+          ~sections_allowed:`All;
+        t "promoted-duplicates" "{6 Foo}\n{6 Bar}" ~sections_allowed:`All;
+        t "section-promoted-to-duplicate" "{5 Foo}\n{6 Bar}"
+          ~sections_allowed:`All;
+      ] );
+    ( "author",
+      [
+        t "basic" "@author Foo Bar";
+        t "empty" "@author";
+        t "whitespace-only" "@author ";
+        t "extra-whitespace" "@author  Foo Bar ";
+        t "newline" "@author Foo Bar\n";
+        t "cr-lf" "@author Foo Bar\r\n";
+        t "blank-line" "@author Foo Bar\n\n";
+        t "followed-by-junk" "@author Foo\nbar";
+        t "followed-by-code-span" "@author Foo\n[bar]";
+        t "followed-by-code-block" "@author Foo\n{[bar]}";
+        t "followed-by-verbatim" "@author Foo\n{v bar v}";
+        t "followed-by-modules" "@author foo\n{!modules:Foo}";
+        t "followed-by-list" "@author Foo\n{ul {li bar}}";
+        t "followed-by-shorthand-list" "@author Foo\n- bar";
+        t "followed-by-section-heading" "@author Foo\n{2 Bar}";
+        t "followed-by-author" "@author Foo\n@author Bar";
+        t "followed-by-author-cr-lf" "@author Foo\n@author Bar";
+        t "in-author" "@author Foo @author Bar";
+        t "in-author-at-start" "@author @author Foo";
+        t "preceded-by-paragraph" "foo\n@author Bar";
+        t "no-markup" "@author Foo [Bar]";
+        t "in-paragraph" "foo @author Bar";
+        t "in-code" "[@author Foo]";
+        t "in-style" "{b @author Foo}";
+        t "in-heading" "{2 @author Foo}";
+        t "after-shorthand-list" "- foo\n@author Bar";
+        t "in-shorthand-list" "- foo @author Bar";
+        t "in-shorthand-list-at-start" "- @author Foo";
+        t "in-list-item" "{ul {li foo @author Bar}}";
+        t "in-list-item-at-start" "{ul {li @author Foo}}";
+        t "in-list-item-on-new-line" "{ul {li foo\n@author Bar}}";
+        t "in-list" "{ul @author Foo}";
+        t "in-code-block" "{[@author Foo]}";
+        t "in-verbatim" "{v @author Foo v}";
+        t "after-code-block" "{[foo]} @author Bar";
+        t "after-verbatim" "{v foo v} @author Bar";
+        t "after-heading" "{2 Foo} @author Bar";
+        t "after-list" "{ul {li foo}} @author Bar";
+        t "preceded-by-whitespace" " @author Foo Bar";
+        t "second-preceded-by-whitespace" "@author Foo\n @author Bar";
+        t "prefix" "@authorfoo";
+      ] );
+    ( "deprecated",
+      [
+        t "basic" "@deprecated";
+        t "words" "@deprecated foo bar";
+        t "multiline" "@deprecated foo\nbar";
+        t "paragraphs" "@deprecated foo\n\nbar";
+        t "whitespace-only" "@deprecated ";
+        t "immediate-newline" "@deprecated\nfoo";
+        t "immediate-cr-lf" "@deprecated\r\nfoo";
+        t "immediate-blank-line" "@deprecated\n\nfoo";
+        t "extra-whitespace" "@deprecated  foo";
+        t "followed-by-deprecated" "@deprecated foo\n@deprecated bar";
+        t "followed-by-deprecated-cr-lf" "@deprecated foo\r\n@deprecated bar";
+        t "nested-in-self" "@deprecated foo @deprecated bar";
+        t "nested-in-self-at-start" "@deprecated @deprecated foo";
+        t "preceded-by-paragraph" "foo\n@deprecated";
+        t "preceded-by-shorthand-list" "- foo\n@deprecated";
+        t "with-shorthand-list" "@deprecated - foo";
+        t "with-shorthand-list-after-newline" "@deprecated\n- foo";
+        t "prefix" "@deprecatedfoo";
+        t "after-code-block" "{[foo]} @deprecated";
+        t "followed-by-section" "@deprecated foo\n{2 Bar}";
+      ] );
+    ( "param",
+      [
+        t "basic" "@param foo";
+        t "bare" "@param";
+        t "bare-with-whitespace" "@param ";
+        t "immediate-newline" "@param\nfoo";
+        t "followed-by-whitespace" "@param foo ";
+        t "extra-whitespace" "@param  foo";
+        t "words" "@param foo bar baz";
+        t "multiline" "@param foo\nbar\nbaz";
+        t "paragraphs" "@param foo bar\n\nbaz";
+        t "two" "@param foo\n@param bar";
+        t "nested" "@param foo @param bar";
+        t "preceded-by-paragraph" "foo\n@param bar";
+        t "prefix" "@paramfoo";
+        t "after-code-block" "{[foo]} @param foo";
+      ] );
+    ( "raise",
+      [
+        t "basic" "@raise Foo";
+        t "bare" "@raise";
+        t "words" "@raise foo bar baz";
+        t "prefix" "@raisefoo";
+      ] );
+    ( "return",
+      [
+        t "basic" "@return";
+        t "words" "@return foo bar";
+        t "prefix" "@returnfoo";
+      ] );
+    ( "see",
+      [
+        t "url" "@see <foo>";
+        t "file" "@see 'foo'";
+        t "document" "@see \"foo\"";
+        t "bare" "@see";
+        t "unterminated-url" "@see <foo";
+        t "unterminated-file" "@see 'foo";
+        t "unterminated-document" "@see \"foo";
+        t "no-space" "@see<foo>";
+        t "words" "@see <foo> bar";
+        t "prefix" "@seefoo";
+        t "after-code-block" "{[foo]} @see <foo>";
+        t "url-attempted-nested-closer" "@see <foo>bar>";
+        t "file-attempted-nested-closer" "@see 'foo'bar'";
+        t "document-attempted-nested-closer" "@see \"foo\"bar\"";
+      ] );
+    ( "since",
+      [
+        t "basic" "@since foo";
+        t "bare" "@since";
+        t "prefix" "@sincefoo";
+        t "with-whitespace" "@since foo bar";
+        t "leading-whitespace" "@since  foo";
+        t "trailing-whitespace" "@since foo ";
+        t "whitespace-only" "@since ";
+      ] );
+    ( "before",
+      [
+        t "basic" "@before Foo";
+        t "bare" "@before";
+        t "words" "@before foo bar baz";
+        t "prefix" "@beforefoo";
+      ] );
+    ( "version",
+      [
+        t "basic" "@version foo";
+        t "bare" "@version";
+        t "prefix" "@versionfoo";
+        t "with-whitespace" "@version foo bar";
+        t "leading-whitespace" "@version  foo";
+        t "trailing-whitespace" "@version foo ";
+        t "whitespace-only" "@version ";
+      ] );
+    ( "canonical",
+      [
+        t "basic" "@canonical Foo";
+        t "empty" "@canonical";
+        t "whitespace-only" "@canonical ";
+        t "extra-whitespace" "@canonical  Foo ";
+        t "prefix" "@canonicalfoo";
+        (* TODO This should probably be an error of some kind, as Foo Bar is not a
+           valid module path. *)
+        t "with-whitespace" "@canonical Foo Bar";
+      ] );
+    ( "inline",
+      [
+        t "basic" "@inline";
+        t "prefix" "@inlinefoo";
+        t "extra-whitespace" "@inline ";
+        t "followed-by-junk" "@inline foo";
+        t "followed-by-paragraph" "@inline\nfoo";
+        t "followed-by-tag" "@inline\n@deprecated";
+        t "with-list" "@inline - foo";
+      ] );
+    ( "open",
+      [
+        t "basic" "@open";
+        t "prefix" "@openfoo";
+        t "extra-whitespace" "@open ";
+        t "followed-by-junk" "@open foo";
+        t "followed-by-paragraph" "@open\nfoo";
+        t "followed-by-tag" "@open\n@deprecated";
+        t "with-list" "@open - foo";
+      ] );
+    ( "closed",
+      [
+        t "basic" "@closed";
+        t "prefix" "@closedfoo";
+        t "extra-whitespace" "@closed ";
+        t "followed-by-junk" "@closed foo";
+        t "followed-by-paragraph" "@closed\nfoo";
+        t "followed-by-tag" "@closed\n@deprecated";
+        t "with-list" "@closed - foo";
+      ] );
+    ( "reference-component-kind",
+      [
+        t "no-kind" "{!foo}";
+        t "class" "{!class-foo}";
+        t "class-type" "{!class-type-foo}";
+        t "class-type-alt" "{!classtype-foo}";
+        t "constructor" "{!constructor-Foo}";
+        t "constructor-alt" "{!const-Foo}";
+        t "exception" "{!exception-Foo}";
+        t "exception-alt" "{!exn-Foo}";
+        t "extension" "{!extension-Foo}";
+        t "field" "{!field-foo}";
+        t "field-alt" "{!recfield-foo}";
+        t "heading" "{!section-foo}";
+        t "heading-alt" "{!label-foo}";
+        t "instance-variable" "{!instance-variable-foo}";
+        t "method" "{!method-foo}";
+        t "module" "{!module-Foo}";
+        t "module-type" "{!module-type-Foo}";
+        t "module-type-alt" "{!modtype-Foo}";
+        t "page" "{!page-foo}";
+        t "type" "{!type-foo}";
+        t "val" "{!val-foo}";
+        t "val-alt" "{!value-foo}";
+        t "longident" "{!module-Foo.type-bar}";
+        t "hyphenated-kind-longident"
+          "{!module-type-Foo.module-type-Bar.type-baz}";
+        t "empty" "{!}";
+        t "empty-qualifier" "{!-foo}";
+        t "empty-identifier" "{!val-}";
+        t "invalid-qualifier" "{!foo-bar}";
+        t "empty-first-component" "{!.foo}";
+        t "empty-second-component" "{!Foo.}";
+        t "second-component-empty-qualifier" "{!Foo.-bar}";
+        t "second-component-empty-identifier" "{!Foo.val-}";
+        t "first-component-empty-identifier" "{!module-.foo}";
+        t "something-in-invalid" "{!foo-bar.baz}";
+        t "something-in-something" "{!foo.bar}";
+        t "something-in-module" "{!module-Foo.bar}";
+        t "something-in-module-type" "{!module-type-Foo.bar}";
+        t "something-in-type" "{!type-foo.bar}";
+        t "something-in-class" "{!class-foo.bar}";
+        t "something-in-class-type" "{!class-type-foo.bar}";
+        t "something-in-page" "{!page-foo.bar}";
+        t "something-in-constructor" "{!constructor-Foo.bar}";
+        t "something-in-exception" "{!exception-Foo.bar}";
+        t "something-in-extension" "{!extension-Foo.bar}";
+        t "something-in-field" "{!field-foo.bar}";
+        t "something-in-section" "{!section-foo.bar}";
+        t "something-in-instance-variable" "{!instance-variable-foo.bar}";
+        t "something-in-method" "{!method-foo.bar}";
+        t "something-in-val" "{!val-foo.bar}";
+        t "something-in-something-nested" "{!foo.bar.baz}";
+        t "something-in-module-nested" "{!Foo.module-Bar.baz}";
+        t "something-in-module-type-nested" "{!Foo.module-type-Bar.baz}";
+        t "something-in-type-nested" "{!Foo.type-bar.baz}";
+        t "something-in-class-nested" "{!Foo.class-bar.baz}";
+        t "something-in-class-type-nested" "{!foo.class-type-bar.baz}";
+        t "something-in-page-nested" "{!foo.page-bar.baz}";
+        t "something-in-constructor-nested" "{!Foo.constructor-Bar.baz}";
+        t "something-in-exception.nested" "{!Foo.exception-bar.baz}";
+        t "something-in-extension-nested" "{!Foo.extension-bar.baz}";
+        t "something-in-field-nested" "{!foo.field-bar.baz}";
+        t "something-in-section-nested" "{!foo.section-bar.baz}";
+        t "something-in-instance-variable-nested"
+          "{!foo.instance-variable-bar.baz}";
+        t "something-in-method-nested" "{!foo.method-bar.baz}";
+        t "something-in-val-nested" "{!Foo.val-bar.baz}";
+        t "module-in-empty" "{!.module-Foo}";
+        t "module-in-something" "{!Foo.module-Bar}";
+        t "module-in-module" "{!module-Foo.module-Bar}";
+        t "module-in-module-type" "{!module-type-Foo.module-Bar}";
+        t "module-in-class" "{!class-foo.module-Bar}";
+        t "module-in-class-type" "{!class-type-foo.module-Bar}";
+        t "module-in-constructor" "{!constructor-Foo.module-Bar}";
+        t "module-in-exception" "{!exception-Foo.module-Bar}";
+        t "module-in-extension" "{!extension-Foo.module-Bar}";
+        t "module-in-field" "{!field-foo.module-Bar}";
+        t "module-in-section" "{!section-foo.module-Bar}";
+        t "module-in-instance-variable" "{!instance-variable-foo.module-Bar}";
+        t "module-in-method" "{!method-foo.module-Bar}";
+        t "module-in-page" "{!page-foo.module-Bar}";
+        t "module-in-type" "{!type-foo.module-Bar}";
+        t "module-in-val" "{!val-foo.module-Bar}";
+        t "module-in-something-nested" "{!Foo.Bar.module-Baz}";
+        t "module-in-module-nested" "{!Foo.module-Bar.module-Baz}";
+        t "module-in-module-type-nested" "{!Foo.module-type-Bar.module-Baz}";
+        t "module-in-class-nested" "{!Foo.class-bar.module-Baz}";
+        t "module-in-class-type-nested" "{!Foo.class-type-bar.module-Baz}";
+        t "module-in-constructor-nested" "{!Foo.constructor-Bar.module-Baz}";
+        t "module-in-exception-nested" "{!Foo.exception-Bar.module-Baz}";
+        t "module-in-extension-nested" "{!Foo.extension-Bar.module-Baz}";
+        t "module-in-field-nested" "{!foo.field-bar.module-Baz}";
+        t "module-in-section-nested" "{!foo.section-bar.module-Baz}";
+        t "module-in-instance-variable-nested"
+          "{!foo.instance-variable-bar.module-Baz}";
+        t "module-in-method-nested" "{!foo.method-bar.module-Baz}";
+        t "module-in-page-nested" "{!foo.page-bar.module-Baz}";
+        t "module-in-type-nested" "{!Foo.type-bar.module-Baz}";
+        t "module-in-val-nested" "{!Foo.val-bar.module-Baz}";
+        t "module-type-in-something" "{!Foo.module-type-Bar}";
+        t "module-type-in-module" "{!module-Foo.module-type-Bar}";
+        t "module-type-in-module-type" "{!module-type-Foo.module-type-Bar}";
+        t "module-type-in-class" "{!class-foo.module-type-Bar}";
+        t "module-type-in-page" "{!page-foo.module-type-Bar}";
+        t "type-in-something" "{!Foo.type-bar}";
+        t "type-in-module" "{!module-Foo.type-bar}";
+        t "type-in-module-type" "{!module-type-Foo.type-bar}";
+        t "type-in-class" "{!class-foo.type-bar}";
+        t "type-in-page" "{!page-foo.type-bar}";
+        t "constructor-in-empty" "{!.constructor-Foo}";
+        t "constructor-in-something" "{!foo.constructor-Bar}";
+        t "constructor-in-type" "{!type-foo.constructor-Bar}";
+        t "constructor-in-class" "{!class-foo.constructor-Bar}";
+        t "constructor-in-class-type" "{!class-type-foo.constructor-Bar}";
+        t "constructor-in-constructor" "{!constructor-Foo.constructor-Bar}";
+        t "constructor-in-exception" "{!exception-Foo.constructor-Bar}";
+        t "constructor-in-extension" "{!extension-Foo.constructor-Bar}";
+        t "constructor-in-field" "{!field-foo.constructor-Bar}";
+        t "constructor-in-section" "{!section-foo.constructor-Bar}";
+        t "constructor-in-instance-variable"
+          "{!instance-variable-foo.constructor-Bar}";
+        t "constructor-in-method" "{!method-foo.constructor-Bar}";
+        t "constructor-in-module" "{!module-Foo.constructor-Bar}";
+        t "constructor-in-module-type" "{!module-type-Foo.constructor-Bar}";
+        t "constructor-in-page" "{!page-foo.constructor-Bar}";
+        t "constructor-in-val" "{!val-foo.constructor-Bar}";
+        t "constructor-in-something-nested" "{!foo.bar.constructor-Baz}";
+        t "constructor-in-type-nested" "{!foo.type-bar.constructor-Baz}";
+        t "constructor-in-class-nested" "{!Foo.class-bar.constructor-Baz}";
+        t "constructor-in-class-type-nested"
+          "{!Foo.class-type-bar.constructor-Baz}";
+        t "constructor-in-constructor-nested"
+          "{!Foo.constructor-Bar.constructor-Baz}";
+        t "constructor-in-exception-nested"
+          "{!Foo.exception-Bar.constructor-Baz}";
+        t "constructor-in-extension-nested"
+          "{!Foo.extension-Bar.constructor-Baz}";
+        t "constructor-in-field-nested" "{!foo.field-bar.constructor-Baz}";
+        t "constructor-in-section-nested" "{!foo.section-bar.constructor-Baz}";
+        t "constructor-in-instance-variable-nested"
+          "{!foo.instance-variable-bar.constructor-Baz}";
+        t "constructor-in-method-nested" "{!foo.method-bar.constructor-Baz}";
+        t "constructor-in-module-nested" "{!Foo.module-Bar.constructor-Baz}";
+        t "constructor-in-module-type-nested"
+          "{!Foo.module-type-Bar.constructor-Baz}";
+        t "constructor-in-page-nested" "{!foo.page-bar.constructor-Baz}";
+        t "constructor-in-val-nested" "{!Foo.val-bar.constructor-Baz}";
+        t "field-in-empty" "{!.field-foo}";
+        t "field-in-something" "{!foo.field-bar}";
+        t "field-in-module" "{!module-Foo.field-bar}";
+        t "field-in-module-type" "{!module-type-Foo.field-bar}";
+        t "field-in-type" "{!type-foo.field-bar}";
+        t "field-in-class" "{!class-foo.field-bar}";
+        t "field-in-class-type" "{!class-type-foo.field-bar}";
+        t "field-in-constructor" "{!constructor-Foo.field-bar}";
+        t "field-in-exception" "{!exception-Foo.field-bar}";
+        t "field-in-extension" "{!extension-Foo.field-bar}";
+        t "field-in-field" "{!field-foo.field-bar}";
+        t "field-in-section" "{!section-foo.field-bar}";
+        t "field-in-instance-variable" "{!instance-variable-foo.field-bar}";
+        t "field-in-method" "{!method-foo.field-bar}";
+        t "field-in-page" "{!page-foo.field-bar}";
+        t "field-in-val" "{!val-foo.field-bar}";
+        t "field-in-something-nested" "{!foo.bar.field-baz}";
+        t "field-in-module-nested" "{!Foo.module-Bar.field-baz}";
+        t "field-in-module-type-nested" "{!Foo.module-type-Bar.field-baz}";
+        t "field-in-type-nested" "{!Foo.type-bar.field-baz}";
+        t "field-in-class-nested" "{!Foo.class-bar.field-baz}";
+        t "field-in-class-type-nested" "{!Foo.class-type-bar.field-baz}";
+        t "field-in-constructor-nested" "{!Foo.constructor-bar.field-baz}";
+        t "field-in-exception-nested" "{!Foo.exception-Bar.field-baz}";
+        t "field-in-extension-nested" "{!Foo.extension-Bar.field-baz}";
+        t "field-in-field-nested" "{!Foo.field-bar.field-baz}";
+        t "field-in-section-nested" "{!foo.section-bar.field-baz}";
+        t "field-in-instance-variable-nested"
+          "{!foo.instance-variable-bar.field-baz}";
+        t "field-in-method-nested" "{!foo.method-bar.field-baz}";
+        t "field-in-page-nested" "{!foo.page-bar.field-baz}";
+        t "field-in-val-nested" "{!Foo.val-bar.field-baz}";
+        t "exception-in-something" "{!Foo.exception-Bar}";
+        t "exception-in-module" "{!module-Foo.exception-Bar}";
+        t "exception-in-class" "{!class-foo.exception-Bar}";
+        t "exception-in-page" "{!page-foo.exception-Bar}";
+        t "extension-in-something" "{!Foo.extension-Bar}";
+        t "extension-in-module" "{!module-Foo.extension-Bar}";
+        t "extension-in-class" "{!class-foo.extension-Bar}";
+        t "extension-in-page" "{!page-foo.extension-Bar}";
+        t "val-in-something" "{!Foo.val-bar}";
+        t "val-in-module" "{!module-Foo.val-bar}";
+        t "val-in-class" "{!class-foo.val-bar}";
+        t "val-in-page" "{!page-foo.val-bar}";
+        t "class-in-something" "{!Foo.class-bar}";
+        t "class-in-module" "{!module-Foo.class-bar}";
+        t "class-in-class" "{!class-foo.class-bar}";
+        t "class-in-page" "{!page-foo.class-bar}";
+        t "class-type-in-something" "{!Foo.class-type-bar}";
+        t "class-type-in-module" "{!module-Foo.class-type-bar}";
+        t "class-type-in-class" "{!class-foo.class-type-bar}";
+        t "class-type-in-page" "{!page-foo.class-type-bar}";
+        t "method-in-empty" "{!.method-foo}";
+        t "method-in-something" "{!foo.method-bar}";
+        t "method-in-class" "{!class-foo.method-bar}";
+        t "method-in-class-type" "{!class-type-foo.method-bar}";
+        t "method-in-constructor" "{!constructor-Foo.method-bar}";
+        t "method-in-exception" "{!exception-Foo.method-bar}";
+        t "method-in-extension" "{!extension-Foo.method-bar}";
+        t "method-in-field" "{!field-foo.method-bar}";
+        t "method-in-section" "{!section-foo.method-bar}";
+        t "method-in-instance-variable" "{!instance-variable-foo.method-bar}";
+        t "method-in-method" "{!method-foo.method-bar}";
+        t "method-in-module" "{!module-Foo.method-bar}";
+        t "method-in-module-type" "{!module-type-Foo.method-bar}";
+        t "method-in-page" "{!page-foo.method-bar}";
+        t "method-in-type" "{!type-foo.method-bar}";
+        t "method-in-val" "{!val-foo.method-bar}";
+        t "method-in-something-nested" "{!foo.bar.method-baz}";
+        t "method-in-class-nested" "{!Foo.class-bar.method-baz}";
+        t "method-in-class-type-nested" "{!Foo.class-type-bar.method-baz}";
+        t "method-in-constructor-nested" "{!foo.constructor-Bar.method-baz}";
+        t "method-in-exception-nested" "{!Foo.exception-Bar.method-baz}";
+        t "method-in-extension-nested" "{!Foo.extension-Bar.method-baz}";
+        t "method-in-field-nested" "{!foo.field-bar.method-baz}";
+        t "method-in-section-nested" "{!foo.section-bar.method-baz}";
+        t "method-in-instance-variable-nested"
+          "{!foo.instance-variable-bar.method-baz}";
+        t "method-in-method-nested" "{!foo.method-bar.method-baz}";
+        t "method-in-module-nested" "{!Foo.module-Bar.method-baz}";
+        t "method-in-module-type-nested" "{!Foo.module-type-Bar.method-baz}";
+        t "method-in-page-nested" "{!foo.page-bar.method-baz}";
+        t "method-in-type-nested" "{!Foo.type-bar.method-baz}";
+        t "method-in-val-nested" "{!Foo.val-bar.method-baz}";
+        t "instance-variable-in-something" "{!Foo.instance-variable-bar}";
+        t "instance-variable-in-module" "{!module-Foo.instance-variable-bar}";
+        t "instance-variable-in-class" "{!class-foo.instance-variable-bar}";
+        t "instance-variable-in-page" "{!page-foo.instance-variable-bar}";
+        t "section-in-something" "{!Foo.section-bar}";
+        t "section-in-module" "{!module-Foo.section-bar}";
+        t "section-in-class" "{!class-foo.section-bar}";
+        t "section-in-page" "{!page-foo.section-bar}";
+        t "page-in-something" "{!foo.page-bar}";
+        t "inner-parent-something-in-something" "{!foo.bar.field-baz}";
+        t "inner-parent-something-in-module" "{!module-Foo.bar.field-baz}";
+        t "inner-parent-something-in-class" "{!class-foo.bar.field-baz}";
+        t "inner-parent-something-in-page" "{!page-foo.bar.field-baz}";
+        t "inner-parent-module-in-module" "{!module-Foo.module-Bar.field-baz}";
+        t "inner-parent-module-in-class" "{!class-foo.module-Bar.field-baz}";
+        t "inner-parent-module-type-in-module"
+          "{!module-Foo.module-type-Bar.field-baz}";
+        t "inner-parent-module-type-in-class"
+          "{!class-foo.module-type-Bar.field-baz}";
+        t "inner-parent-type-in-module" "{!module-Foo.type-bar.field-baz}";
+        t "inner-parent-type-in-class" "{!class-foo.type-bar.field-baz}";
+        t "inner-parent-class-in-module" "{!module-Foo.class-bar.field-baz}";
+        t "inner-parent-class-in-class" "{!class-foo.class-bar.field-baz}";
+        t "inner-parent-class-type-in-module"
+          "{!module-Foo.class-type-bar.field-baz}";
+        t "inner-parent-class-type-in-class"
+          "{!class-foo.class-type-bar.field-baz}";
+        t "inner-label-parent-something-in-something" "{!foo.bar.baz}";
+        t "inner-label-parent-something-in-page" "{!page-foo.bar.baz}";
+        t "inner-label-parent-module-in-module" "{!module-Foo.module-Bar.baz}";
+        t "inner-label-parent-module-in-class" "{!class-foo.module-Bar.baz}";
+        t "inner-label-parent-module-type-in-module"
+          "{!module-Foo.module-type-Bar.baz}";
+        t "inner-label-parent-module-type-in-class"
+          "{!class-foo.module-type-Bar.baz}";
+        t "inner-label-parent-type-in-module" "{!module-Foo.type-bar.baz}";
+        t "inner-label-parent-type-in-class" "{!class-foo.type-bar.baz}";
+        t "inner-label-parent-class-in-module" "{!module-Foo.class-bar.baz}";
+        t "inner-label-parent-class-in-class" "{!class-foo.class-bar.baz}";
+        t "inner-label-parent-class-type-in-module"
+          "{!module-Foo.class-bar.baz}";
+        t "inner-label-parent-class-type-in-class" "{!class-foo.class-bar.baz}";
+        t "inner-page-in-something" "{!foo.page-bar.baz}";
+        t "inner-class-signature-something-in-something" "{!foo.bar.method-baz}";
+        t "inner-class-signature-something-in-page" "{!page-foo.bar.method-baz}";
+        t "inner-class-signature-class-in-module"
+          "{!module-Foo.class-bar.method-baz}";
+        t "inner-class-signature-class-in-class"
+          "{!class-foo.class-bar.method-baz}";
+        t "inner-class-signature-class-type-in-module"
+          "{!module-Foo.class-type-bar.method-baz}";
+        t "inner-class-signature-class-type-in-class"
+          "{!class-foo.class-type-bar.method-baz}";
+        t "inner-signature-something-in-something" "{!foo.bar.type-baz}";
+        t "inner-signature-something-in-page" "{!page-foo.bar.type-baz}";
+        t "inner-signature-module-in-module" "{!module-Foo.module-Bar.type-baz}";
+        t "inner-signature-module-in-class" "{!class-foo.module-Bar.type-baz}";
+        t "inner-signature-module-type-in-module"
+          "{!module-Foo.module-type-Bar.type-baz}";
+        t "inner-signature-module-type-in-class"
+          "{!class-foo.module-type-Bar.type-baz}";
+        t "inner-datatype-something-in-something" "{!foo.bar.constructor-Baz}";
+        t "inner-datatype-something-in-page" "{!page-foo.bar.constructor-Baz}";
+        t "inner-datatype-type-in-module"
+          "{!module-Foo.type-bar.constructor-Baz}";
+        t "inner-datatype-type-in-class" "{!class-foo.type-bar.constructor-Baz}";
+        t "kind-conflict" "{!val:type-foo}";
+        t "kind-agreement" "{!val:val-foo}";
+        t "kind-agreement-alt" "{!value:val-foo}";
+        t "canonical-something" "@canonical Foo";
+        t "canonical-module" "@canonical module-Foo";
+        t "canonical-path" "@canonical Foo.Bar";
+        t "canonical-val" "@canonical val-foo";
+        t "canonical-bad-parent" "@canonical bar.page-foo";
+        t "canonical-empty-component" "@canonical .Foo";
+        t "canonical-empty-name" "@canonical Foo.";
+        t "internal-whitespace" "{!foo. bar .baz}";
+        t "replacement-text-empty-identifier" "{{!val-} foo}";
+      ] );
+    ( "bad-markup",
+      [
+        t "left-brace" "{";
+        t "left-brace-with-letter" "{g";
+        t "left-brace-with-letters" "{gg";
+        t "empty-braces" "{}";
+        t "left-space" "{ foo}";
+        t "left-spaces" "{  foo}";
+        t "left-space-eof" "{ ";
+        t "braces-instead-of-brackets" "{foo}";
+        t "right-brace" "}";
+        t "right-brace-in-paragraph" "foo}";
+        t "multiple-right-brace" "foo } bar } baz";
+        t "right-brace-in-list-item" "- foo}";
+        t "right-brace-in-code-span" "[foo}]";
+        t "right-brace-in-code-block" "{[foo}]}";
+        t "right-brace-in-verbatim-text" "{v foo} v}";
+        t "right-brace-in-author" "@author Foo}";
+        t "right-brace-in-deprecated" "@deprecated }";
+        t "right-bracket" "]";
+        t "right-bracket-in-paragraph" "foo]";
+        t "right-bracket-in-shorthand-list" "- foo]";
+        t "right-bracket-in-code-span" "[]]";
+        t "right-bracket-in-style" "{b]}";
+        t "right-bracket-in-verbatim" "{v ] v}";
+        t "right-bracket-in-list" "{ul ]}";
+        t "right-bracket-in-list-item" "{ul {li ]}}";
+        t "right-bracket-in-heading" "{2 ]}";
+        t "right-bracket-in-author" "@author Foo]";
+        t "at" "@";
+        t "cr" "\r";
+      ] );
+    ( "utf-8",
+      [
+        t "lambda" "\xce\xbb";
+        t "words" "\xce\xbb \xce\xbb";
+        t "no-validation" "\xce";
+        t "escapes" "\xce\xbb\\}";
+        t "newline" "\xce\xbb \n \xce\xbb";
+        t "paragraphs" "\xce\xbb \n\n \xce\xbb";
+        t "code-span" "[\xce\xbb]";
+        t "minus" "\xce\xbb-\xce\xbb";
+        t "shorthand-list" "- \xce\xbb";
+        t "styled" "{b \xce\xbb}";
+        t "reference-target" "{!\xce\xbb}";
+        t "code-block" "{[\xce\xbb]}";
+        t "verbatim" "{v \xce\xbb v}";
+        t "label" "{2:\xce\xbb Bar}";
+        t "author" "@author \xce\xbb";
+        t "param" "@param \xce\xbb";
+        t "raise" "@raise \xce\xbb";
+        t "see" "@see <\xce\xbb>";
+        t "since" "@since \xce\xbb";
+        t "before" "@before \xce\xbb";
+        t "version" "@version \xce\xbb";
+        t "right-brace" "\xce\xbb}";
+      ] );
+    ( "comment-location",
+      [
+        t "error-on-first-line" "  @foo" ~location:{ line = 2; column = 4 };
+        t "error-on-second-line" "  \n  @foo" ~location:{ line = 2; column = 4 };
+      ] );
+    ( "unsupported",
+      [
+        (* test "index list"
+           "{!indexlist}"
+           (Ok []); *)
+        t "left-alignment" "{L foo}";
+        t "center-alignment" "{C foo}";
+        t "right-alignment" "{R foo}";
+        t "custom-style" "{c foo}";
+        t "custom-tag" "@custom";
+        t "custom-reference-kind" "{!custom:foo}";
+        t "html-tag" "<b>foo</b>";
+      ] );
+  ]
 
 let expect_directory = "expect"
+
 let actual_root_directory = "_actual"
+
 let test_root = "test/parser"
+
 let promote_script = "promote.sh"
 
-let (//) = Filename.concat
+let ( // ) = Filename.concat
 
 let read_file filename = Markup.file filename |> fst |> Markup.to_string
+
 let write_file filename data = Markup.string data |> Markup.to_file filename
 
 let mkdir directory =
@@ -1105,22 +1099,17 @@ let suggest_commands script_directory commands =
 
   let script_file = script_directory // promote_script in
 
-  if not (Sys.file_exists script_file) then
-    write_file script_file commands;
+  if not (Sys.file_exists script_file) then write_file script_file commands;
 
   Printf.eprintf "\nbash %s\n\n"
     ("_build/default" // test_root // script_directory // promote_script)
 
 let () =
   mkdir actual_root_directory;
-  begin
-    try Unix.unlink (actual_root_directory // promote_script);
-    with _ -> ()
-  end;
+  (try Unix.unlink (actual_root_directory // promote_script) with _ -> ());
 
   let make_parser_test : string -> test_case -> unit Alcotest.test_case =
-      fun suite case ->
-
+   fun suite case ->
     let run_test_case () =
       let file_title = case.name in
       let expect_suite_directory = expect_directory // suite in
@@ -1129,7 +1118,7 @@ let () =
       let actual_file = actual_suite_directory // (file_title ^ ".txt") in
 
       let actual =
-        let {sections_allowed; location; parser_input; _} = case in
+        let { sections_allowed; location; parser_input; _ } = case in
 
         let dummy_filename = "f.ml" in
 
@@ -1142,20 +1131,16 @@ let () =
             Lexing.pos_fname = dummy_filename;
             pos_lnum = location.line;
             pos_bol = 0;
-            pos_cnum = location.column
+            pos_cnum = location.column;
           }
         in
 
-        Odoc_parser.parse_comment
-          ~sections_allowed
-          ~containing_definition:dummy_page
-          ~location
-          ~text:parser_input
+        Odoc_parser.parse_comment ~sections_allowed
+          ~containing_definition:dummy_page ~location ~text:parser_input
         |> fun parser_output ->
-          let buffer = Buffer.create 1024 in
-          Print.parser_output
-            (Format.formatter_of_buffer buffer) parser_output;
-          Buffer.contents buffer
+        let buffer = Buffer.create 1024 in
+        Print.parser_output (Format.formatter_of_buffer buffer) parser_output;
+        Buffer.contents buffer
       in
 
       let expected =
@@ -1173,18 +1158,17 @@ let () =
           prerr_endline "\nThe expected output file does not exist.";
           prerr_endline "\nTo create it, run";
           [
-            Printf.sprintf "mkdir -p %s"
-              (test_root // expect_suite_directory);
+            Printf.sprintf "mkdir -p %s" (test_root // expect_suite_directory);
             Printf.sprintf "cp %s %s"
               ("_build/default" // test_root // actual_file)
               (test_root // expect_file);
           ]
           |> suggest_commands actual_root_directory;
 
-          Alcotest.fail "expected output file does not exist";
+          Alcotest.fail "expected output file does not exist"
       in
 
-      if actual <> expected then begin
+      if actual <> expected then (
         mkdir actual_suite_directory;
         write_file actual_file actual;
 
@@ -1193,8 +1177,7 @@ let () =
         prerr_newline ();
 
         Printf.sprintf "diff -u %s %s" expect_file actual_file
-        |> Sys.command
-        |> ignore;
+        |> Sys.command |> ignore;
 
         prerr_endline "\nTo replace expected output with actual, run";
         [
@@ -1204,51 +1187,53 @@ let () =
         ]
         |> suggest_commands actual_root_directory;
 
-        Alcotest.fail "document tree incorrect";
-      end
+        Alcotest.fail "document tree incorrect" )
     in
 
-    case.name, `Quick, run_test_case
+    (case.name, `Quick, run_test_case)
   in
 
   let scan_for_stale_tests () =
     let directories = Sys.readdir expect_directory in
-    directories |> Array.iter begin fun directory ->
-      let source_directory = test_root // expect_directory // directory in
+    directories
+    |> Array.iter (fun directory ->
+           let source_directory = test_root // expect_directory // directory in
 
-      let (_, tests) =
-        try List.find (fun (suite_name, _) -> suite_name = directory) tests
-        with Not_found ->
-          Printf.eprintf
-            "\n\nDirectory '%s' does not correspond to a test suite.\n"
-            source_directory;
-          prerr_endline "To remove it, run";
-          suggest_commands actual_root_directory
-            [Printf.sprintf "rm -r %s" source_directory];
-          exit 1
-      in
+           let _, tests =
+             try List.find (fun (suite_name, _) -> suite_name = directory) tests
+             with Not_found ->
+               Printf.eprintf
+                 "\n\nDirectory '%s' does not correspond to a test suite.\n"
+                 source_directory;
+               prerr_endline "To remove it, run";
+               suggest_commands actual_root_directory
+                 [ Printf.sprintf "rm -r %s" source_directory ];
+               exit 1
+           in
 
-      let files = Sys.readdir (expect_directory // directory) in
-      files |> Array.iter begin fun file ->
-        let source_file = source_directory // file in
-        let title = String.sub file 0 (String.length file - 4) in
+           let files = Sys.readdir (expect_directory // directory) in
+           files
+           |> Array.iter (fun file ->
+                  let source_file = source_directory // file in
+                  let title = String.sub file 0 (String.length file - 4) in
 
-        try List.find (fun {name; _} -> name = title) tests |> ignore
-        with Not_found ->
-          Printf.eprintf
-            "\n\nExpect file '%s' does not correspond to a test.\n" source_file;
-          prerr_endline "To remove it, run";
-          suggest_commands actual_root_directory
-            [Printf.sprintf "rm %s" source_file];
-          exit 1
-      end
-    end
+                  try
+                    List.find (fun { name; _ } -> name = title) tests |> ignore
+                  with Not_found ->
+                    Printf.eprintf
+                      "\n\nExpect file '%s' does not correspond to a test.\n"
+                      source_file;
+                    prerr_endline "To remove it, run";
+                    suggest_commands actual_root_directory
+                      [ Printf.sprintf "rm %s" source_file ];
+                    exit 1))
   in
   scan_for_stale_tests ();
 
-  let tests : (unit Alcotest.test) list =
-    tests |> List.map (fun (suite_name, test_cases) ->
-      suite_name, List.map (make_parser_test suite_name) test_cases)
+  let tests : unit Alcotest.test list =
+    tests
+    |> List.map (fun (suite_name, test_cases) ->
+           (suite_name, List.map (make_parser_test suite_name) test_cases))
   in
 
   Alcotest.run "parser" tests

--- a/test/print/dune
+++ b/test/print/dune
@@ -1,4 +1,6 @@
 (library
  (name print)
- (enabled_if (>= %{ocaml_version} 4.04.1)) ; Due to sexplib0 dependency
+ (enabled_if
+  (>= %{ocaml_version} 4.04.1))
+ ; Due to sexplib0 dependency
  (libraries odoc_model sexplib0))

--- a/test/print/print.ml
+++ b/test/print/print.ml
@@ -1,122 +1,187 @@
 open Odoc_model.Names
-type sexp = Sexplib0.Sexp.t =
-  | Atom of string
-  | List of sexp list
 
-module Identifier_to_sexp =
-struct
+type sexp = Sexplib0.Sexp.t = Atom of string | List of sexp list
+
+module Identifier_to_sexp = struct
   module Identifier = Odoc_model.Paths.Identifier
 
   let identifier : Identifier.t -> sexp =
     let rec traverse : sexp list -> Identifier.t -> sexp =
-        fun acc -> function
-      | `Root (_, s) ->
-        List ((List [Atom (ModuleName.to_string s)])::acc)
-      | `RootPage s ->
-        List ((List [Atom (PageName.to_string s)])::acc)
-      | `Page (_, s) ->
-        List ((List [Atom (PageName.to_string s)])::acc)
-      | `LeafPage (_, s) ->
-        List ((List [Atom (PageName.to_string s)])::acc)
+     fun acc -> function
+      | `Root (_, s) -> List (List [ Atom (ModuleName.to_string s) ] :: acc)
+      | `RootPage s -> List (List [ Atom (PageName.to_string s) ] :: acc)
+      | `Page (_, s) -> List (List [ Atom (PageName.to_string s) ] :: acc)
+      | `LeafPage (_, s) -> List (List [ Atom (PageName.to_string s) ] :: acc)
       | `Module (parent, s) ->
-        traverse ((List [Atom "module"; Atom (ModuleName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "module"; Atom (ModuleName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
       | `Parameter (parent, s) ->
-        traverse
-          ((List [Atom "parameter"; Atom (ParameterName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "parameter"; Atom (ParameterName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
       | `Result parent ->
-        traverse
-          ((List [Atom "parent"])::acc) (parent :> Identifier.t)
+          traverse (List [ Atom "parent" ] :: acc) (parent :> Identifier.t)
       | `ModuleType (parent, s) ->
-        traverse ((List [Atom "module_type"; Atom (ModuleTypeName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            ( List [ Atom "module_type"; Atom (ModuleTypeName.to_string s) ]
+            :: acc )
+            (parent :> Identifier.t)
       | `Type (parent, s) ->
-        traverse ((List [Atom "type"; Atom (TypeName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "type"; Atom (TypeName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
       | `CoreType s ->
-        List ((List [Atom "core_type"; Atom (TypeName.to_string s)])::acc)
+          List (List [ Atom "core_type"; Atom (TypeName.to_string s) ] :: acc)
       | `Constructor (parent, s) ->
-        traverse ((List [Atom "constructor"; Atom (ConstructorName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            ( List [ Atom "constructor"; Atom (ConstructorName.to_string s) ]
+            :: acc )
+            (parent :> Identifier.t)
       | `Field (parent, s) ->
-        traverse ((List [Atom "field"; Atom (FieldName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "field"; Atom (FieldName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
       | `Extension (parent, s) ->
-        traverse ((List [Atom "extension"; Atom (ExtensionName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "extension"; Atom (ExtensionName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
       | `Exception (parent, s) ->
-        traverse ((List [Atom "exception"; Atom (ExceptionName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "exception"; Atom (ExceptionName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
       | `CoreException s ->
-        List ((List [Atom "core_exception"; Atom (ExceptionName.to_string s)])::acc)
+          List
+            ( List [ Atom "core_exception"; Atom (ExceptionName.to_string s) ]
+            :: acc )
       | `Value (parent, s) ->
-        traverse ((List [Atom "value"; Atom (ValueName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "value"; Atom (ValueName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
       | `Class (parent, s) ->
-        traverse ((List [Atom "class"; Atom (ClassName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "class"; Atom (ClassName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
       | `ClassType (parent, s) ->
-        traverse ((List [Atom "class_type"; Atom (ClassTypeName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "class_type"; Atom (ClassTypeName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
       | `Method (parent, s) ->
-        traverse ((List [Atom "method"; Atom (MethodName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "method"; Atom (MethodName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
       | `InstanceVariable (parent, s) ->
-        traverse ((List [Atom "instance_variable"; Atom (InstanceVariableName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            ( List
+                [
+                  Atom "instance_variable";
+                  Atom (InstanceVariableName.to_string s);
+                ]
+            :: acc )
+            (parent :> Identifier.t)
       | `Label (parent, s) ->
-        traverse ((List [Atom "label"; Atom (LabelName.to_string s)])::acc) (parent :> Identifier.t)
+          traverse
+            (List [ Atom "label"; Atom (LabelName.to_string s) ] :: acc)
+            (parent :> Identifier.t)
     in
-    fun path ->
-      traverse [] path
+    fun path -> traverse [] path
 end
 
-
-
-module Path_to_sexp =
-struct
+module Path_to_sexp = struct
   module Path = Odoc_model.Paths.Path
   module Resolved = Odoc_model.Paths.Path.Resolved
 
   let rec path : Path.t -> sexp = function
-    | `Resolved parent ->
-      List [Atom "resolved"; resolved parent]
-    | `Root s ->
-      List [Atom "root"; Atom s]
-    | `Forward s ->
-      List [Atom "forward"; Atom s]
-    | `Dot (parent, s) ->
-      List [Atom "dot"; Atom s; path (parent :> Path.t)]
+    | `Resolved parent -> List [ Atom "resolved"; resolved parent ]
+    | `Root s -> List [ Atom "root"; Atom s ]
+    | `Forward s -> List [ Atom "forward"; Atom s ]
+    | `Dot (parent, s) -> List [ Atom "dot"; Atom s; path (parent :> Path.t) ]
     | `Identifier (i, b) ->
-      List [Atom "identifier"; Identifier_to_sexp.identifier (i :> Odoc_model.Paths.Identifier.t); Atom (string_of_bool b)]
+        List
+          [
+            Atom "identifier";
+            Identifier_to_sexp.identifier (i :> Odoc_model.Paths.Identifier.t);
+            Atom (string_of_bool b);
+          ]
     | `Apply (m, m') ->
-      List [Atom "apply"; path (m :> Path.t); path (m' :> Path.t)]
+        List [ Atom "apply"; path (m :> Path.t); path (m' :> Path.t) ]
 
   and resolved : Resolved.t -> sexp = function
-    |`Identifier i ->
-      List [Atom "identifier"; Identifier_to_sexp.identifier i]
-    |`Subst (mt, m) ->
-      List [Atom "subst"; resolved (mt :> Resolved.t); resolved (m :> Resolved.t)]
-    |`SubstAlias (m, m') ->
-      List [Atom "subst_alias"; resolved (m :> Resolved.t); resolved (m' :> Resolved.t)]
-    |`Hidden m ->
-      List [Atom "hidden"; resolved (m :> Resolved.t)]
-    |`Module (m, s) ->
-      List [Atom "module"; Atom (ModuleName.to_string s); resolved (m :> Resolved.t)]
-    |`Canonical (m, p) ->
-      List [Atom "canonical"; resolved (m :> Resolved.t); path (p :> Path.t)]
-    |`Apply (m, p) ->
-      List [Atom "apply"; resolved (m :> Resolved.t); resolved (p :> Resolved.t)]
-    |`ModuleType (m, s) ->
-      List [Atom "module_type"; Atom (ModuleTypeName.to_string s); resolved (m :> Resolved.t)]
-    |`Type (m, s) ->
-      List [Atom "type"; Atom (TypeName.to_string s); resolved (m :> Resolved.t)]
-    |`Class (m, s) ->
-      List [Atom "class"; Atom (ClassName.to_string s); resolved (m :> Resolved.t)]
-    |`ClassType (m, s) ->
-      List [Atom "class_type"; Atom (ClassTypeName.to_string s); resolved (m :> Resolved.t)]
-    |`Alias (m, m') ->
-      List [Atom "alias"; resolved (m :> Resolved.t); resolved (m' :> Resolved.t)]
-    |`SubstT (m, m') ->
-      List [Atom "substt"; resolved (m :> Resolved.t); resolved (m' :> Resolved.t)]
-    |`OpaqueModule m ->
-      List [Atom "opaquemodule"; resolved (m :> Resolved.t)]
-    |`OpaqueModuleType m ->
-      List [Atom "opaquemoduletype"; resolved (m :> Resolved.t)]
-    end
+    | `Identifier i ->
+        List [ Atom "identifier"; Identifier_to_sexp.identifier i ]
+    | `Subst (mt, m) ->
+        List
+          [
+            Atom "subst"; resolved (mt :> Resolved.t); resolved (m :> Resolved.t);
+          ]
+    | `SubstAlias (m, m') ->
+        List
+          [
+            Atom "subst_alias";
+            resolved (m :> Resolved.t);
+            resolved (m' :> Resolved.t);
+          ]
+    | `Hidden m -> List [ Atom "hidden"; resolved (m :> Resolved.t) ]
+    | `Module (m, s) ->
+        List
+          [
+            Atom "module";
+            Atom (ModuleName.to_string s);
+            resolved (m :> Resolved.t);
+          ]
+    | `Canonical (m, p) ->
+        List
+          [ Atom "canonical"; resolved (m :> Resolved.t); path (p :> Path.t) ]
+    | `Apply (m, p) ->
+        List
+          [
+            Atom "apply"; resolved (m :> Resolved.t); resolved (p :> Resolved.t);
+          ]
+    | `ModuleType (m, s) ->
+        List
+          [
+            Atom "module_type";
+            Atom (ModuleTypeName.to_string s);
+            resolved (m :> Resolved.t);
+          ]
+    | `Type (m, s) ->
+        List
+          [
+            Atom "type"; Atom (TypeName.to_string s); resolved (m :> Resolved.t);
+          ]
+    | `Class (m, s) ->
+        List
+          [
+            Atom "class";
+            Atom (ClassName.to_string s);
+            resolved (m :> Resolved.t);
+          ]
+    | `ClassType (m, s) ->
+        List
+          [
+            Atom "class_type";
+            Atom (ClassTypeName.to_string s);
+            resolved (m :> Resolved.t);
+          ]
+    | `Alias (m, m') ->
+        List
+          [
+            Atom "alias"; resolved (m :> Resolved.t); resolved (m' :> Resolved.t);
+          ]
+    | `SubstT (m, m') ->
+        List
+          [
+            Atom "substt";
+            resolved (m :> Resolved.t);
+            resolved (m' :> Resolved.t);
+          ]
+    | `OpaqueModule m ->
+        List [ Atom "opaquemodule"; resolved (m :> Resolved.t) ]
+    | `OpaqueModuleType m ->
+        List [ Atom "opaquemoduletype"; resolved (m :> Resolved.t) ]
+end
 
-
-
-module Reference_to_sexp =
-struct
+module Reference_to_sexp = struct
   module Reference = Odoc_model.Paths.Reference
   module Resolved = Odoc_model.Paths.Reference.Resolved
 
@@ -141,97 +206,230 @@ struct
 
   let rec reference : Reference.t -> sexp = function
     | `Resolved parent ->
-      List [Atom "resolved"; resolved (parent :> Reference.Resolved.t)]
-    | `Root (s, k) ->
-      List [Atom "root"; Atom s; tag k]
+        List [ Atom "resolved"; resolved (parent :> Reference.Resolved.t) ]
+    | `Root (s, k) -> List [ Atom "root"; Atom s; tag k ]
     | `Dot (parent, s) ->
-      List [Atom "dot"; Atom (s); reference (parent :> Reference.t)]
+        List [ Atom "dot"; Atom s; reference (parent :> Reference.t) ]
     | `Module (parent, s) ->
-      List [Atom "module"; Atom (ModuleName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "module";
+            Atom (ModuleName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `ModuleType (parent, s) ->
-      List [Atom "module_type"; Atom (ModuleTypeName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "module_type";
+            Atom (ModuleTypeName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `Type (parent, s) ->
-      List [Atom "type"; Atom (TypeName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "type";
+            Atom (TypeName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `Constructor (parent, s) ->
-      List [Atom "constructor"; Atom (ConstructorName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "constructor";
+            Atom (ConstructorName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `Field (parent, s) ->
-      List [Atom "field"; Atom (FieldName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "field";
+            Atom (FieldName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `Extension (parent, s) ->
-      List [Atom "extension"; Atom (ExtensionName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "extension";
+            Atom (ExtensionName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `Exception (parent, s) ->
-      List [Atom "exception"; Atom (ExceptionName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "exception";
+            Atom (ExceptionName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `Value (parent, s) ->
-      List [Atom "value"; Atom (ValueName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "value";
+            Atom (ValueName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `Class (parent, s) ->
-      List [Atom "class"; Atom (ClassName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "class";
+            Atom (ClassName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `ClassType (parent, s) ->
-      List [Atom "class_type"; Atom (ClassTypeName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "class_type";
+            Atom (ClassTypeName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `Method (parent, s) ->
-      List [Atom "method"; Atom (MethodName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "method";
+            Atom (MethodName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `InstanceVariable (parent, s) ->
-      List [Atom "instance_variable"; Atom (InstanceVariableName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "instance_variable";
+            Atom (InstanceVariableName.to_string s);
+            reference (parent :> Reference.t);
+          ]
     | `Label (parent, s) ->
-      List [Atom "label"; Atom (LabelName.to_string s); reference (parent :> Reference.t)]
+        List
+          [
+            Atom "label";
+            Atom (LabelName.to_string s);
+            reference (parent :> Reference.t);
+          ]
 
   and resolved : Resolved.t -> sexp = function
     | `Identifier parent ->
-      List [Atom "identifier"; Identifier_to_sexp.identifier parent]
+        List [ Atom "identifier"; Identifier_to_sexp.identifier parent ]
     | `SubstAlias (m, m') ->
-      List [Atom "subst_alias"; Path_to_sexp.resolved (m :> Odoc_model.Paths.Path.Resolved.t); resolved (m' :> Resolved.t)]
+        List
+          [
+            Atom "subst_alias";
+            Path_to_sexp.resolved (m :> Odoc_model.Paths.Path.Resolved.t);
+            resolved (m' :> Resolved.t);
+          ]
     | `Module (parent, s) ->
-      List [Atom "module"; Atom (ModuleName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "module";
+            Atom (ModuleName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `Canonical (m, m') ->
-      List [Atom "canonical"; resolved (m :> Resolved.t); reference (m' :> Reference.t)]
+        List
+          [
+            Atom "canonical";
+            resolved (m :> Resolved.t);
+            reference (m' :> Reference.t);
+          ]
     | `ModuleType (parent, s) ->
-      List [Atom "module_type"; Atom (ModuleTypeName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "module_type";
+            Atom (ModuleTypeName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `Type (parent, s) ->
-      List [Atom "type"; Atom (TypeName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "type";
+            Atom (TypeName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `Constructor (parent, s) ->
-      List [Atom "constructor"; Atom (ConstructorName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "constructor";
+            Atom (ConstructorName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `Field (parent, s) ->
-      List [Atom "field"; Atom (FieldName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "field";
+            Atom (FieldName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `Extension (parent, s) ->
-      List [Atom "extension"; Atom (ExtensionName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "extension";
+            Atom (ExtensionName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `Exception (parent, s) ->
-      List [Atom "exception"; Atom (ExceptionName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "exception";
+            Atom (ExceptionName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `Value (parent, s) ->
-      List [Atom "value"; Atom (ValueName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "value";
+            Atom (ValueName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `Class (parent, s) ->
-      List [Atom "class"; Atom (ClassName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "class";
+            Atom (ClassName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `ClassType (parent, s) ->
-      List [Atom "class_type"; Atom (ClassTypeName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "class_type";
+            Atom (ClassTypeName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `Method (parent, s) ->
-      List [Atom "method"; Atom (MethodName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "method";
+            Atom (MethodName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `InstanceVariable (parent, s) ->
-      List [Atom "instance_variable"; Atom (InstanceVariableName.to_string s); resolved (parent :> Resolved.t)]
+        List
+          [
+            Atom "instance_variable";
+            Atom (InstanceVariableName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
     | `Label (parent, s) ->
-      List [Atom "label"; Atom (LabelName.to_string s); resolved (parent :> Resolved.t)]
-    | `Hidden s ->
-      List [Atom "hidden"; resolved (s :> Resolved.t)]
+        List
+          [
+            Atom "label";
+            Atom (LabelName.to_string s);
+            resolved (parent :> Resolved.t);
+          ]
+    | `Hidden s -> List [ Atom "hidden"; resolved (s :> Resolved.t) ]
 end
 
-
-
-module Location_to_sexp =
-struct
+module Location_to_sexp = struct
   module Location_ = Odoc_model.Location_
 
-  let point : Location_.point -> sexp = fun {line; column} ->
-    List [Atom (string_of_int line); Atom (string_of_int column)]
+  let point : Location_.point -> sexp =
+   fun { line; column } ->
+    List [ Atom (string_of_int line); Atom (string_of_int column) ]
 
-  let span : Location_.span -> sexp = fun {file; start; end_} ->
-    List [Atom file; point start; point end_]
+  let span : Location_.span -> sexp =
+   fun { file; start; end_ } -> List [ Atom file; point start; point end_ ]
 
   let at : ('a -> sexp) -> 'a Location_.with_location -> sexp =
-      fun f {location; value} ->
-    List [span location; f value]
+   fun f { location; value } -> List [ span location; f value ]
 end
 
-
-
-module Comment_to_sexp =
-struct
+module Comment_to_sexp = struct
   module Comment = Odoc_model.Comment
+
   let at = Location_to_sexp.at
 
   let style : Comment.style -> sexp = function
@@ -241,136 +439,137 @@ struct
     | `Superscript -> Atom "superscript"
     | `Subscript -> Atom "subscript"
 
-  let leaf_inline_element : Comment.leaf_inline_element -> sexp =
-    function
+  let leaf_inline_element : Comment.leaf_inline_element -> sexp = function
     | `Space -> Atom "space"
-    | `Word w -> List [Atom "word"; Atom w]
-    | `Code_span c -> List [Atom "code_span"; Atom c]
-    | `Raw_markup (target, s) -> List [Atom "raw_markup"; Atom target; Atom s]
-
+    | `Word w -> List [ Atom "word"; Atom w ]
+    | `Code_span c -> List [ Atom "code_span"; Atom c ]
+    | `Raw_markup (target, s) -> List [ Atom "raw_markup"; Atom target; Atom s ]
 
   let rec non_link_inline_element : Comment.non_link_inline_element -> sexp =
     function
-    | #Comment.leaf_inline_element as e ->
-      leaf_inline_element e
+    | #Comment.leaf_inline_element as e -> leaf_inline_element e
     | `Styled (s, es) ->
-      List [style s; List (List.map (at non_link_inline_element) es)]
+        List [ style s; List (List.map (at non_link_inline_element) es) ]
 
   let rec inline_element : Comment.inline_element -> sexp = function
-    | #Comment.leaf_inline_element as e ->
-      leaf_inline_element e
+    | #Comment.leaf_inline_element as e -> leaf_inline_element e
     | `Styled (s, es) ->
-      List [style s; List (List.map (at inline_element) es)]
+        List [ style s; List (List.map (at inline_element) es) ]
     | `Reference (r, es) ->
-      List [
-        Atom "reference";
-        Reference_to_sexp.reference r;
-        List (List.map (at non_link_inline_element) es)
-      ]
+        List
+          [
+            Atom "reference";
+            Reference_to_sexp.reference r;
+            List (List.map (at non_link_inline_element) es);
+          ]
     | `Link (u, es) ->
-      List [
-        Atom "link";
-        Atom u;
-        List (List.map (at non_link_inline_element) es)
-      ]
+        List
+          [
+            Atom "link"; Atom u; List (List.map (at non_link_inline_element) es);
+          ]
 
-  let rec nestable_block_element
-      : Comment.nestable_block_element -> sexp =
+  let rec nestable_block_element : Comment.nestable_block_element -> sexp =
     function
     | `Paragraph es ->
-      List [Atom "paragraph"; List (List.map (at inline_element) es)]
-    | `Code_block c -> List [Atom "code_block"; Atom c]
-    | `Verbatim t -> List [Atom "verbatim"; Atom t]
+        List [ Atom "paragraph"; List (List.map (at inline_element) es) ]
+    | `Code_block c -> List [ Atom "code_block"; Atom c ]
+    | `Verbatim t -> List [ Atom "verbatim"; Atom t ]
     | `Modules ps ->
-      List [Atom "modules"; List (List.map Reference_to_sexp.reference (ps :> Odoc_model.Paths.Reference.t list))]
+        List
+          [
+            Atom "modules";
+            List
+              (List.map Reference_to_sexp.reference
+                 (ps :> Odoc_model.Paths.Reference.t list));
+          ]
     | `List (kind, items) ->
-      let kind =
-        match kind with
-        | `Unordered -> "unordered"
-        | `Ordered -> "ordered"
-      in
-      let items =
-        items
-        |> List.map (fun item ->
-          List (List.map (at nestable_block_element) item))
-        |> fun items -> List items
-      in
-      List [Atom kind; items]
+        let kind =
+          match kind with `Unordered -> "unordered" | `Ordered -> "ordered"
+        in
+        let items =
+          items
+          |> List.map (fun item ->
+                 List (List.map (at nestable_block_element) item))
+          |> fun items -> List items
+        in
+        List [ Atom kind; items ]
 
   let tag : Comment.tag -> sexp = function
-    | `Author s ->
-      List [Atom "@author"; Atom s]
+    | `Author s -> List [ Atom "@author"; Atom s ]
     | `Deprecated es ->
-      List ((Atom "@deprecated")::(List.map (at nestable_block_element) es))
+        List (Atom "@deprecated" :: List.map (at nestable_block_element) es)
     | `Param (s, es) ->
-      List ([Atom "@param"; Atom s] @ (List.map (at nestable_block_element) es))
+        List
+          ([ Atom "@param"; Atom s ] @ List.map (at nestable_block_element) es)
     | `Raise (s, es) ->
-      List ([Atom "@raise"; Atom s] @ (List.map (at nestable_block_element) es))
+        List
+          ([ Atom "@raise"; Atom s ] @ List.map (at nestable_block_element) es)
     | `Return es ->
-      List ((Atom "@return")::(List.map (at nestable_block_element) es))
+        List (Atom "@return" :: List.map (at nestable_block_element) es)
     | `See (kind, s, es) ->
-      let kind =
-        match kind with
-        | `Url -> "url"
-        | `File -> "file"
-        | `Document -> "document"
-      in
-      List
-        ([Atom "@see"; Atom kind; Atom s] @
-          (List.map (at nestable_block_element) es))
-    | `Since s -> List [Atom "@since"; Atom s]
+        let kind =
+          match kind with
+          | `Url -> "url"
+          | `File -> "file"
+          | `Document -> "document"
+        in
+        List
+          ( [ Atom "@see"; Atom kind; Atom s ]
+          @ List.map (at nestable_block_element) es )
+    | `Since s -> List [ Atom "@since"; Atom s ]
     | `Before (s, es) ->
-      List ([Atom "@before"; Atom s] @
-        (List.map (at nestable_block_element) es))
-    | `Version s -> List [Atom "@version"; Atom s]
+        List
+          ([ Atom "@before"; Atom s ] @ List.map (at nestable_block_element) es)
+    | `Version s -> List [ Atom "@version"; Atom s ]
     | `Canonical (p, r) ->
-      List
-        [Atom "@canonical"; Path_to_sexp.path (p :> Odoc_model.Paths.Path.t); Reference_to_sexp.reference (r :> Odoc_model.Paths.Reference.t)]
-    | `Inline ->
-      Atom "@inline"
-    | `Open ->
-      Atom "@open"
-    | `Closed ->
-      Atom "@closed"
+        List
+          [
+            Atom "@canonical";
+            Path_to_sexp.path (p :> Odoc_model.Paths.Path.t);
+            Reference_to_sexp.reference (r :> Odoc_model.Paths.Reference.t);
+          ]
+    | `Inline -> Atom "@inline"
+    | `Open -> Atom "@open"
+    | `Closed -> Atom "@closed"
 
   let block_element : Comment.block_element -> sexp = function
     | #Comment.nestable_block_element as e -> nestable_block_element e
     | `Heading (level, label, es) ->
-      let label = List [Atom "label"; Identifier_to_sexp.identifier (label :> Odoc_model.Paths.Identifier.t)] in
-      let level =
-        match level with
-        | `Title -> "0"
-        | `Section -> "1"
-        | `Subsection -> "2"
-        | `Subsubsection -> "3"
-        | `Paragraph -> "4"
-        | `Subparagraph -> "5"
-      in
-      List [Atom level; label; List (List.map (at non_link_inline_element) es)]
+        let label =
+          List
+            [
+              Atom "label";
+              Identifier_to_sexp.identifier
+                (label :> Odoc_model.Paths.Identifier.t);
+            ]
+        in
+        let level =
+          match level with
+          | `Title -> "0"
+          | `Section -> "1"
+          | `Subsection -> "2"
+          | `Subsubsection -> "3"
+          | `Paragraph -> "4"
+          | `Subparagraph -> "5"
+        in
+        List
+          [ Atom level; label; List (List.map (at non_link_inline_element) es) ]
     | `Tag t -> tag t
 
-  let comment : Comment.docs -> sexp = fun comment ->
-    List (List.map (at block_element) comment)
+  let comment : Comment.docs -> sexp =
+   fun comment -> List (List.map (at block_element) comment)
 end
 
-
-
-module Error_to_sexp =
-struct
-  let error : Odoc_model.Error.t -> sexp = fun error ->
-    Atom (Odoc_model.Error.to_string error)
+module Error_to_sexp = struct
+  let error : Odoc_model.Error.t -> sexp =
+   fun error -> Atom (Odoc_model.Error.to_string error)
 end
 
-
-
-let parser_output formatter {Odoc_model.Error.value; warnings} =
+let parser_output formatter { Odoc_model.Error.value; warnings } =
   let value = Comment_to_sexp.comment value in
   let warnings = List (List.map Error_to_sexp.error warnings) in
   let output =
-    List [
-      List [Atom "output"; value];
-      List [Atom "warnings"; warnings];
-    ]
+    List [ List [ Atom "output"; value ]; List [ Atom "warnings"; warnings ] ]
   in
   Sexplib0.Sexp.pp_hum formatter output;
   Format.pp_print_newline formatter ();

--- a/test/print/print.mli
+++ b/test/print/print.mli
@@ -1,2 +1,4 @@
 val parser_output :
-  Format.formatter -> Odoc_model.Comment.docs Odoc_model.Error.with_warnings -> unit
+  Format.formatter ->
+  Odoc_model.Comment.docs Odoc_model.Error.with_warnings ->
+  unit

--- a/test/xref2/refs/dune
+++ b/test/xref2/refs/dune
@@ -1,13 +1,16 @@
 (rule
  (targets refs.output)
- (enabled_if (>= %{ocaml_version} 4.08))
+ (enabled_if
+  (>= %{ocaml_version} 4.08))
  (deps
   (package odoc))
  (action
-  (run ocaml-mdx-test --prelude=%{dep:../lib/prelude.ml} -o %{targets} %{dep:refs.md})))
+  (run ocaml-mdx-test --prelude=%{dep:../lib/prelude.ml} -o %{targets}
+    %{dep:refs.md})))
 
 (rule
  (alias runtest)
- (enabled_if (>= %{ocaml_version} 4.08))
+ (enabled_if
+  (>= %{ocaml_version} 4.08))
  (action
   (diff refs.md refs.output)))

--- a/test/xref2/resolve/dune
+++ b/test/xref2/resolve/dune
@@ -3,10 +3,12 @@
  (deps
   (package odoc))
  (action
-  (run ocaml-mdx-test --prelude=%{dep:../lib/prelude.ml} -o %{targets} %{dep:test.md})))
+  (run ocaml-mdx-test --prelude=%{dep:../lib/prelude.ml} -o %{targets}
+    %{dep:test.md})))
 
 (rule
  (alias runtest)
- (enabled_if (>= %{ocaml_version} 4.03))
+ (enabled_if
+  (>= %{ocaml_version} 4.03))
  (action
   (diff test.md test.output)))

--- a/test/xref2/strengthen/dune
+++ b/test/xref2/strengthen/dune
@@ -1,8 +1,10 @@
 (rule
  (targets test.output)
- (deps (package odoc))
+ (deps
+  (package odoc))
  (action
-   (run ocaml-mdx-test --prelude=%{dep:../lib/prelude.ml} -o %{targets} %{dep:test.md})))
+  (run ocaml-mdx-test --prelude=%{dep:../lib/prelude.ml} -o %{targets}
+    %{dep:test.md})))
 
 (rule
  (alias runtest)

--- a/test/xref2/subst/dune
+++ b/test/xref2/subst/dune
@@ -8,6 +8,7 @@
 
 (rule
  (alias runtest)
- (enabled_if (>= %{ocaml_version} 4.06))
+ (enabled_if
+  (>= %{ocaml_version} 4.06))
  (action
   (diff test.md test.output)))


### PR DESCRIPTION
To reproduce this PR:

```bash
git checkout -b $RANDOM master
git cherry-pick 8c5f4b527f5ccafe8bd24984617480f1554b810d # Some setup
until dune build @fmt; do dune promote; done
git commit -a -m format
git diff @ ocamlformat # 'ocamlformat' is this PR
```

Fixing `git blame`:

I added a `.git-blame-ignore-revs` file that specifies which commits need to be ignored by `git blame`.
This doesn't work out of the box, it must be passed to `git`:
```sh
git blame --ignore-revs-file .git-blame-ignore-revs
```

It is also possible to add a permanent option but I don't recommend it because git will complain if this file is not present (eg. when checked out to before it was added).

Thanks to https://akrabat.com/ignoring-revisions-with-git-blame/
