### PR TITLE
Fix `html-targets` when operating on odoc files

### DIFF
--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -338,13 +338,19 @@ end = struct
   let generate = Generate.(cmd, info)
 
   module Targets = struct
-    let list_targets output_dir _ extra odoc_file =
+    let list_targets output_dir directories extra odoc_file =
       let odoc_file = Fs.File.of_string odoc_file in
-      Rendering.targets_odoc ~renderer:R.renderer ~output:output_dir ~extra
-        odoc_file
+      let env =
+        Env.create ~important_digests:false ~directories ~open_modules:[]
+      in
+      Rendering.targets_odoc ~env ~warn_error:false ~syntax:OCaml
+        ~renderer:R.renderer ~output:output_dir ~extra odoc_file
 
     let back_compat =
-      let doc = "For backwards compatibility. Ignored." in
+      let doc =
+        "For backwards compatibility when processing odoc rather than odocl \
+         files."
+      in
       Arg.(
         value
         & opt_all (convert_directory ()) []

--- a/src/odoc/rendering.ml
+++ b/src/odoc/rendering.ml
@@ -71,8 +71,14 @@ let render_odoc ~env ~warn_error ~syntax ~renderer ~output extra file =
 let generate_odoc ~syntax ~renderer ~output extra file =
   document_of_odocl ~syntax file >>= render_document renderer ~output ~extra
 
-let targets_odoc ~renderer ~output:root_dir ~extra odoctree =
-  document_of_odocl ~syntax:OCaml odoctree >>= fun odoctree ->
+let targets_odoc ~env ~warn_error ~syntax ~renderer ~output:root_dir ~extra
+    odoctree =
+  let doc =
+    if Fpath.get_ext odoctree = ".odoc" then
+      document_of_input ~env ~warn_error ~syntax odoctree
+    else document_of_odocl ~syntax:OCaml odoctree
+  in
+  doc >>= fun odoctree ->
   let pages = renderer.Renderer.render extra odoctree in
   Renderer.traverse pages ~f:(fun filename _content ->
       let filename = Fpath.normalize @@ Fs.File.append root_dir filename in

--- a/src/odoc/rendering.mli
+++ b/src/odoc/rendering.mli
@@ -20,6 +20,9 @@ val generate_odoc :
   (unit, [> msg ]) result
 
 val targets_odoc :
+  env:Env.builder ->
+  warn_error:bool ->
+  syntax:Renderer.syntax ->
   renderer:'a Renderer.t ->
   output:Fs.directory ->
   extra:'a ->


### PR DESCRIPTION
For backward compatibility, `odoc html-targets` can work on odoc files
as well as odocl files. When working on odoc files, it does the link
step (without writing the odocl file) then proceeds as usual on the
result. This is obviously inefficient, but the result is accurate.

Signed-off-by: Jon Ludlam <jon@recoil.org>