### PR TITLE
Add classes to the odoc HTML page structure.

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -350,7 +350,7 @@ module Toc = struct
     in
     match toc with
     | [] -> []
-    | _ -> [ Html.nav ~a:[ Html.a_class [ "toc" ] ] [ sections toc ] ]
+    | _ -> [ Html.nav ~a:[ Html.a_class [ "odoc-toc" ] ] [ sections toc ] ]
 
   let on_sub : Subpage.status -> bool = function
     | `Closed | `Open | `Default -> false

--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -104,15 +104,16 @@ let page_creator ?(theme_uri = Relative "./") ~url name header toc content =
                else [ [ Html.txt lbl ] ])
         |> List.flatten
       in
-      [ Html.nav l ]
+      [ Html.nav ~a:[ Html.a_class [ "odoc-nav" ] ] l ]
     else []
   in
 
   let body =
-    breadcrumbs @ [ Html.header header ] @ toc
-    @ [ Html.div ~a:[ Html.a_class [ "content" ] ] content ]
+    breadcrumbs @ [ Html.header ~a:[ Html.a_class [ "odoc-preamble" ] ] header ]
+    @ toc
+    @ [ Html.div ~a:[ Html.a_class [ "odoc-content" ] ] content ]
   in
-  Html.html head (Html.body body)
+  Html.html head (Html.body ~a:[ Html.a_class [ "odoc" ] ] body)
 
 let make ?theme_uri ~indent ~url ~header ~toc title content children =
   let filename = Link.Path.as_filename url in

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -689,7 +689,7 @@ h1+.modules, h1+.sel {
 
 /* Sidebar and TOC */
 
-.toc:before {
+.odoc-toc:before {
   display: block;
   content: "Contents";
   text-transform: uppercase;
@@ -701,7 +701,7 @@ h1+.modules, h1+.sel {
   line-height: 1.2;
 }
 
-.toc {
+.odoc-toc {
   position: fixed;
   top: 0px;
   bottom: 0px;
@@ -718,7 +718,7 @@ h1+.modules, h1+.sel {
   padding-right: 2ex;
 }
 
-.toc ul li a {
+.odoc-toc ul li a {
   font-family: "Fira Sans", sans-serif;
   font-size: 0.95em;
   color: #333;
@@ -728,33 +728,33 @@ h1+.modules, h1+.sel {
   display: block;
 }
 
-.toc ul li a:hover {
+.odoc-toc ul li a:hover {
   box-shadow: none;
   text-decoration: underline;
 }
 
 /* First level titles */
 
-.toc>ul>li>a {
+.odoc-toc>ul>li>a {
   font-weight: 500;
 }
 
-.toc li ul {
+.odoc-toc li ul {
   margin: 0px;
 }
 
-.toc ul {
+.odoc-toc ul {
   list-style-type: none;
 }
 
-.toc ul li {
+.odoc-toc ul li {
   margin: 0;
 }
-.toc>ul>li {
+.odoc-toc>ul>li {
   margin-bottom: 0.3em;
 }
 
-.toc ul li li {
+.odoc-toc ul li li {
   border-left: 1px solid #ccc;
   border-left: 1px solid var(--toc-list-border);
   margin-left: 5px;
@@ -764,11 +764,11 @@ h1+.modules, h1+.sel {
 /* Mobile adjustements. */
 
 @media only screen and (max-width: 95ex) {
-  .content {
+  .odoc-content {
     margin: auto;
     padding: 2em;
   }
-  .toc {
+  .odoc-toc {
     position: static;
     width: auto;
     min-width: unset;

--- a/test/html/expect/test_package+custom_theme,ml/Include/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Include/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Include
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Include</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module-type" id="module-type-Not_inlined">
     <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Module
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Module</code>
    </h1>
@@ -25,7 +25,7 @@
     Foo.
    </p>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>

--- a/test/html/expect/test_package+custom_theme,ml/Section/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Section/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Section
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Section</code>
    </h1>
@@ -25,7 +25,7 @@
     This is the module comment. Eventually, sections won't be allowed in it.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#empty-section">Empty section</a>
@@ -55,7 +55,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
    </h2>

--- a/test/html/expect/test_package+custom_theme,ml/Val/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Val/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+custom_theme,ml</a> » Val
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Val</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span class="keyword">val</span> documented : unit</code>

--- a/test/html/expect/test_package+ml/Alias/X/index.html
+++ b/test/html/expect/test_package+ml/Alias/X/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Alias</a> » X
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Alias.X</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = int</code>

--- a/test/html/expect/test_package+ml/Alias/index.html
+++ b/test/html/expect/test_package+ml/Alias/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Alias
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Alias</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module" id="module-Foo__X">
     <a href="#module-Foo__X" class="anchor"></a><code><span class="keyword">module</span> <a href="Foo__X/index.html">Foo__X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Bugs
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Bugs</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec type" id="type-opt">
     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt</span> = <span><span class="type-var">'a</span> option</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Bugs_post_406/index.html
+++ b/test/html/expect/test_package+ml/Bugs_post_406/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Bugs_post_406
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Bugs_post_406</code>
    </h1>
@@ -25,7 +25,7 @@
     Let-open in class types, https://github.com/ocaml/odoc/issues/543 This was added to the language in 4.06
    </p>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec class-type" id="class-type-let_open">
     <a href="#class-type-let_open" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-let_open/index.html">let_open</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Bugs_pre_410/index.html
+++ b/test/html/expect/test_package+ml/Bugs_pre_410/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Bugs_pre_410
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Bugs_pre_410</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec type" id="type-opt'">
     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> <span>'a opt'</span> = <span>int option</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Class
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Class</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec class-type" id="class-type-empty">
     <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a> = <span class="keyword">object</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/External/index.html
+++ b/test/html/expect/test_package+ml/External/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » External
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>External</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec external" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit <span>-&gt;</span> unit</code>

--- a/test/html/expect/test_package+ml/Functor/index.html
+++ b/test/html/expect/test_package+ml/Functor/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Functor
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Functor</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Include/index.html
+++ b/test/html/expect/test_package+ml/Include/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Include
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Include</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module-type" id="module-type-Not_inlined">
     <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Include2/index.html
+++ b/test/html/expect/test_package+ml/Include2/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Include2
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Include2</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>

--- a/test/html/expect/test_package+ml/Include_sections/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Include_sections
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Include_sections</code>
    </h1>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#something-1">Something 1</a>
@@ -69,7 +69,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec module-type" id="module-type-Something">
      <a href="#module-type-Something" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Something/index.html">Something</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>

--- a/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Include_sections</a> » Something
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module type <code>Include_sections.Something</code>
    </h1>
@@ -25,7 +25,7 @@
     A module type.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#something-1">Something 1</a>
@@ -40,7 +40,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec value" id="val-something">
     <a href="#val-something" class="anchor"></a><code><span class="keyword">val</span> something : unit</code>
    </div>

--- a/test/html/expect/test_package+ml/Interlude/index.html
+++ b/test/html/expect/test_package+ml/Interlude/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Interlude
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Interlude</code>
    </h1>
@@ -25,7 +25,7 @@
     This is the comment associated to the module.
    </p>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <aside>
     <p>
      Some separate stray text at the top of the module.

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Labels
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Labels</code>
    </h1>
@@ -25,14 +25,14 @@
     <a href="#L1" class="anchor"></a>Attached to unit
    </h2>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#L2">Attached to nothing</a>
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="L2">
     <a href="#L2" class="anchor"></a>Attached to nothing
    </h2>

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Markup
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Markup</code>
    </h1>
@@ -25,7 +25,7 @@
     Here, we test the rendering of comment markup.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#sections">Sections</a>
@@ -79,7 +79,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="sections">
     <a href="#sections" class="anchor"></a>Sections
    </h2>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Module
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Module</code>
    </h1>
@@ -25,7 +25,7 @@
     Foo.
    </p>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : unit</code>

--- a/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+ml</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 1-Arg1
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Parameter <code>F.1-Arg1</code>
    </h1>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#type">Type</a>
@@ -32,7 +32,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
@@ -13,23 +13,23 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+ml</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 2-Arg2
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Parameter <code>F.2-Arg2</code>
    </h1>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#type">Type</a>
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » F
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Nested.F</code>
    </h1>
@@ -28,7 +28,7 @@
     Some additional comments.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#parameters">Parameters</a>
@@ -41,7 +41,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="parameters">
     <a href="#parameters" class="anchor"></a>Parameters
    </h2>

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » X
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Nested.X</code>
    </h1>
@@ -28,7 +28,7 @@
     Some additional comments.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#type">Type</a>
@@ -38,7 +38,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-inherits/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » inherits
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Class <code>Nested.inherits</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec inherit">
     <code><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></code>
    </div>

--- a/test/html/expect/test_package+ml/Nested/class-z/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-z/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » z
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Class <code>Nested.z</code>
    </h1>
@@ -28,14 +28,14 @@
     Some additional comments.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#methods">Methods</a>
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec instance-variable" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y : int</code>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Nested
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Nested</code>
    </h1>
@@ -25,7 +25,7 @@
     This comment needs to be here before #235 is fixed.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#module">Module</a>
@@ -41,7 +41,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="module">
     <a href="#module" class="anchor"></a>Module
    </h2>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Nested</a> » Y
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module type <code>Nested.Y</code>
    </h1>
@@ -28,7 +28,7 @@
     Some additional comments.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#type">Type</a>
@@ -38,7 +38,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Ocamlary
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Ocamlary</code>
    </h1>
@@ -86,7 +86,7 @@
     </dd>
    </dl>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#level-1">Level 1</a>
@@ -154,7 +154,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <aside>
     <p>
      You may find more information about this HTML documentation renderer at <a href="https://github.com/dsheets/ocamlary">github.com/dsheets/ocamlary</a>.

--- a/test/html/expect/test_package+ml/Recent/X/index.html
+++ b/test/html/expect/test_package+ml/Recent/X/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Recent</a> » X
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Recent.X</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module-substitution" id="module-L">
     <a href="#module-L" class="anchor"></a><code><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></code>
    </div>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Recent
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Recent</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Recent_impl/index.html
+++ b/test/html/expect/test_package+ml/Recent_impl/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Recent_impl
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Recent_impl</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module" id="module-Foo">
     <a href="#module-Foo" class="anchor"></a><code><span class="keyword">module</span> <a href="Foo/index.html">Foo</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span></code>
    </div>

--- a/test/html/expect/test_package+ml/Section/index.html
+++ b/test/html/expect/test_package+ml/Section/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Section
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Section</code>
    </h1>
@@ -25,7 +25,7 @@
     This is the module comment. Eventually, sections won't be allowed in it.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#empty-section">Empty section</a>
@@ -55,7 +55,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
    </h2>

--- a/test/html/expect/test_package+ml/Stop/index.html
+++ b/test/html/expect/test_package+ml/Stop/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Stop
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Stop</code>
    </h1>
@@ -25,7 +25,7 @@
     This test cases exercises stop comments.
    </p>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">val</span> foo : int</code>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Type
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Type</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec type" id="type-abstract">
      <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type</span> abstract</code>

--- a/test/html/expect/test_package+ml/Val/index.html
+++ b/test/html/expect/test_package+ml/Val/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Val
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Val</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span class="keyword">val</span> documented : unit</code>

--- a/test/html/expect/test_package+ml/mld.html
+++ b/test/html/expect/test_package+ml/mld.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="index.html">Up</a> – <a href="index.html">test_package+ml</a> » mld
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1 id="mld-page">
     <a href="#mld-page" class="anchor"></a>Mld Page
    </h1>
@@ -28,7 +28,7 @@
     It will have a TOC generated from section headings.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#section">Section</a>
@@ -46,7 +46,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="section">
     <a href="#section" class="anchor"></a>Section
    </h2>

--- a/test/html/expect/test_package+re/Alias/X/index.html
+++ b/test/html/expect/test_package+re/Alias/X/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Alias</a> » X
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Alias.X</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span class="keyword">type</span> t = int;</code>

--- a/test/html/expect/test_package+re/Alias/index.html
+++ b/test/html/expect/test_package+re/Alias/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Alias
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Alias</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module" id="module-Foo__X">
     <a href="#module-Foo__X" class="anchor"></a><code><span class="keyword">module</span> <a href="Foo__X/index.html">Foo__X</a>: { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Bugs/index.html
+++ b/test/html/expect/test_package+re/Bugs/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Bugs
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Bugs</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec type" id="type-opt">
     <a href="#type-opt" class="anchor"></a><code><span class="keyword">type</span> opt('a) = option(<span class="type-var">'a</span>);</code>
    </div>

--- a/test/html/expect/test_package+re/Bugs_post_406/index.html
+++ b/test/html/expect/test_package+re/Bugs_post_406/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Bugs_post_406
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Bugs_post_406</code>
    </h1>
@@ -25,7 +25,7 @@
     Let-open in class types, https://github.com/ocaml/odoc/issues/543 This was added to the language in 4.06
    </p>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec class-type" id="class-type-let_open">
     <a href="#class-type-let_open" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-let_open/index.html">let_open</a> = { ... }</code>
    </div>

--- a/test/html/expect/test_package+re/Bugs_pre_410/index.html
+++ b/test/html/expect/test_package+re/Bugs_pre_410/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Bugs_pre_410
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Bugs_pre_410</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec type" id="type-opt'">
     <a href="#type-opt'" class="anchor"></a><code><span class="keyword">type</span> opt'('a) = option(int);</code>
    </div>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Class
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Class</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec class-type" id="class-type-empty">
     <a href="#class-type-empty" class="anchor"></a><code><span class="keyword">class</span> <span class="keyword">type</span>  <a href="class-type-empty/index.html">empty</a> = { ... }</code>
    </div>

--- a/test/html/expect/test_package+re/External/index.html
+++ b/test/html/expect/test_package+re/External/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » External
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>External</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec external" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit <span>=&gt;</span> unit;</code>

--- a/test/html/expect/test_package+re/Functor/index.html
+++ b/test/html/expect/test_package+re/Functor/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Functor
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Functor</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Include/index.html
+++ b/test/html/expect/test_package+re/Include/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Include
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Include</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module-type" id="module-type-Not_inlined">
     <a href="#module-type-Not_inlined" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a> = { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Include2/index.html
+++ b/test/html/expect/test_package+re/Include2/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Include2
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Include2</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span class="keyword">module</span> <a href="X/index.html">X</a>: { ... };</code>

--- a/test/html/expect/test_package+re/Include_sections/index.html
+++ b/test/html/expect/test_package+re/Include_sections/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Include_sections
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Include_sections</code>
    </h1>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#something-1">Something 1</a>
@@ -69,7 +69,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec module-type" id="module-type-Something">
      <a href="#module-type-Something" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-Something/index.html">Something</a> = { ... };</code>

--- a/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Include_sections</a> » Something
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module type <code>Include_sections.Something</code>
    </h1>
@@ -25,7 +25,7 @@
     A module type.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#something-1">Something 1</a>
@@ -40,7 +40,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec value" id="val-something">
     <a href="#val-something" class="anchor"></a><code><span class="keyword">let</span> something: unit;</code>
    </div>

--- a/test/html/expect/test_package+re/Interlude/index.html
+++ b/test/html/expect/test_package+re/Interlude/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Interlude
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Interlude</code>
    </h1>
@@ -25,7 +25,7 @@
     This is the comment associated to the module.
    </p>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <aside>
     <p>
      Some separate stray text at the top of the module.

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Labels
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Labels</code>
    </h1>
@@ -25,14 +25,14 @@
     <a href="#L1" class="anchor"></a>Attached to unit
    </h2>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#L2">Attached to nothing</a>
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="L2">
     <a href="#L2" class="anchor"></a>Attached to nothing
    </h2>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Markup
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Markup</code>
    </h1>
@@ -25,7 +25,7 @@
     Here, we test the rendering of comment markup.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#sections">Sections</a>
@@ -79,7 +79,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="sections">
     <a href="#sections" class="anchor"></a>Sections
    </h2>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Module
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Module</code>
    </h1>
@@ -25,7 +25,7 @@
     Foo.
    </p>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: unit;</code>

--- a/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+re</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 1-Arg1
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Parameter <code>F.1-Arg1</code>
    </h1>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#type">Type</a>
@@ -32,7 +32,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
@@ -13,23 +13,23 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../../index.html">test_package+re</a> » <a href="../../index.html">Nested</a> » <a href="../index.html">F</a> » 2-Arg2
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Parameter <code>F.2-Arg2</code>
    </h1>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#type">Type</a>
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » F
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Nested.F</code>
    </h1>
@@ -28,7 +28,7 @@
     Some additional comments.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#parameters">Parameters</a>
@@ -41,7 +41,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="parameters">
     <a href="#parameters" class="anchor"></a>Parameters
    </h2>

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » X
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Nested.X</code>
    </h1>
@@ -28,7 +28,7 @@
     Some additional comments.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#type">Type</a>
@@ -38,7 +38,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+re/Nested/class-inherits/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » inherits
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Class <code>Nested.inherits</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec inherit">
     <code><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></code>
    </div>

--- a/test/html/expect/test_package+re/Nested/class-z/index.html
+++ b/test/html/expect/test_package+re/Nested/class-z/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » z
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Class <code>Nested.z</code>
    </h1>
@@ -28,14 +28,14 @@
     Some additional comments.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#methods">Methods</a>
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec instance-variable" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span class="keyword">val</span> y: int</code>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Nested
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Nested</code>
    </h1>
@@ -25,7 +25,7 @@
     This comment needs to be here before #235 is fixed.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#module">Module</a>
@@ -41,7 +41,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="module">
     <a href="#module" class="anchor"></a>Module
    </h2>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Nested</a> » Y
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module type <code>Nested.Y</code>
    </h1>
@@ -28,7 +28,7 @@
     Some additional comments.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#type">Type</a>
@@ -38,7 +38,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Ocamlary
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Ocamlary</code>
    </h1>
@@ -86,7 +86,7 @@
     </dd>
    </dl>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#level-1">Level 1</a>
@@ -154,7 +154,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <aside>
     <p>
      You may find more information about this HTML documentation renderer at <a href="https://github.com/dsheets/ocamlary">github.com/dsheets/ocamlary</a>.

--- a/test/html/expect/test_package+re/Recent/X/index.html
+++ b/test/html/expect/test_package+re/Recent/X/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Recent</a> » X
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Recent.X</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module-substitution" id="module-L">
     <a href="#module-L" class="anchor"></a><code><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></code>
    </div>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Recent
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Recent</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module-type" id="module-type-S">
     <a href="#module-type-S" class="anchor"></a><code><span class="keyword">module</span> <span class="keyword">type</span> <a href="module-type-S/index.html">S</a> = { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Recent_impl/index.html
+++ b/test/html/expect/test_package+re/Recent_impl/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Recent_impl
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Recent_impl</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div class="spec module" id="module-Foo">
     <a href="#module-Foo" class="anchor"></a><code><span class="keyword">module</span> <a href="Foo/index.html">Foo</a>: { ... };</code>
    </div>

--- a/test/html/expect/test_package+re/Section/index.html
+++ b/test/html/expect/test_package+re/Section/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Section
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Section</code>
    </h1>
@@ -25,7 +25,7 @@
     This is the module comment. Eventually, sections won't be allowed in it.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#empty-section">Empty section</a>
@@ -55,7 +55,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
    </h2>

--- a/test/html/expect/test_package+re/Stop/index.html
+++ b/test/html/expect/test_package+re/Stop/index.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Stop
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Stop</code>
    </h1>
@@ -25,7 +25,7 @@
     This test cases exercises stop comments.
    </p>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span class="keyword">let</span> foo: int;</code>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Type
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Type</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec type" id="type-abstract">
      <a href="#type-abstract" class="anchor"></a><code><span class="keyword">type</span> abstract;</code>

--- a/test/html/expect/test_package+re/Val/index.html
+++ b/test/html/expect/test_package+re/Val/index.html
@@ -13,16 +13,16 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Val
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1>
     Module <code>Val</code>
    </h1>
   </header>
-  <div class="content">
+  <div class="odoc-content">
    <div>
     <div class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span class="keyword">let</span> documented: unit;</code>

--- a/test/html/expect/test_package+re/mld.html
+++ b/test/html/expect/test_package+re/mld.html
@@ -13,11 +13,11 @@
    hljs.initHighlightingOnLoad();
   </script>
  </head>
- <body>
-  <nav>
+ <body class="odoc">
+  <nav class="odoc-nav">
    <a href="index.html">Up</a> – <a href="index.html">test_package+re</a> » mld
   </nav>
-  <header>
+  <header class="odoc-preamble">
    <h1 id="mld-page">
     <a href="#mld-page" class="anchor"></a>Mld Page
    </h1>
@@ -28,7 +28,7 @@
     It will have a TOC generated from section headings.
    </p>
   </header>
-  <nav class="toc">
+  <nav class="odoc-toc">
    <ul>
     <li>
      <a href="#section">Section</a>
@@ -46,7 +46,7 @@
     </li>
    </ul>
   </nav>
-  <div class="content">
+  <div class="odoc-content">
    <h2 id="section">
     <a href="#section" class="anchor"></a>Section
    </h2>


### PR DESCRIPTION
/cc @drup I'm being told by @jonludlam

1. Classify the root odoc tree (currently `body`) as `odoc`. This closes #298 and will help stylesheet management/composition if #374 ever becomes a reality.
2. Classify toplevel `nav` as `odoc-nav` (new class)
3. Classify module preamble `header` as `odoc-preamble` (new class)
4. Reclassify the toc `nav` from `toc` to `odoc-toc`.
5. Reclassify the content `div` rom `.content` to `.odoc-content`.

Altogether this allows to replace complicated CSS selectors like:

```
body > nav:first-child { /* toplevel nav */ }
```
By: 
```
.odoc-nav { /* toplevel-nav */ }
```

Besides 1. allows to specify `odoc` page geometry without having to refer to the root tree kind o element (currently `body` which you won't control if you get embedded).

# Pro-tip

To deal with the utterly user-friendly expect test system when you change the markup you want:

```
CMD=$(make test 2>&1 | grep 'cp '); \
while [ -n "$CMD" ]; do CMD=$(sh -c "$CMD" 2>&1 | grep 'cp '); done
```

It's slow but at least you don't have to c&p a cli invocation 50 times. Someone ought to fix that madness (I tried various forms of `--auto-promote`, `dune promote` without any success).
