### PR TITLE
Fix unresolved references from the first comment of a file

### DIFF
--- a/src/model_desc/comment_desc.ml
+++ b/src/model_desc/comment_desc.ml
@@ -3,13 +3,7 @@ open Odoc_model
 open Comment
 open Paths_desc
 
-let location =
-  let open Location_ in
-  let point () p = Printf.sprintf "%d:%d" p.line p.column in
-  To_string
-    (fun s -> Printf.sprintf "%s %a %a" s.file point s.start point s.end_)
-
-let loc_to_pair x = (x.Location_.location, x.value)
+let ignore_loc x = x.Location_.value
 
 type general_inline_element =
   [ `Space
@@ -71,7 +65,7 @@ let rec inline_element : general_inline_element t =
     | `Link (x1, x2) -> C ("`Link", (x1, x2), Pair (string, link_content)))
 
 and link_content : general_link_content t =
-  List (Indirect (loc_to_pair, Pair (location, inline_element)))
+  List (Indirect (ignore_loc, inline_element))
 
 let rec block_element : general_block_element t =
   let heading_level =
@@ -126,8 +120,7 @@ and tag : general_tag t =
     | `Open -> C0 "`Open"
     | `Closed -> C0 "`Closed")
 
-and docs : general_docs t =
-  List (Indirect (loc_to_pair, Pair (location, block_element)))
+and docs : general_docs t = List (Indirect (ignore_loc, block_element))
 
 let docs = Indirect ((fun n -> ((n :> docs) :> general_docs)), docs)
 

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -721,10 +721,6 @@ let rec open_signature : Odoc_model.Lang.Signature.t -> t -> t =
         | Odoc_model.Lang.Signature.Open o -> open_signature o.expansion env)
       e s.items
 
-let open_unit : Odoc_model.Lang.Compilation_unit.t -> t -> t =
- fun unit env ->
-  match unit.content with Module s -> open_signature s env | Pack _ -> env
-
 let initial_env :
     Odoc_model.Lang.Compilation_unit.t ->
     resolver ->

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -189,8 +189,6 @@ val open_class_signature : Odoc_model.Lang.ClassSignature.t -> t -> t
 
 val open_signature : Odoc_model.Lang.Signature.t -> t -> t
 
-val open_unit : Odoc_model.Lang.Compilation_unit.t -> t -> t
-
 val initial_env :
   Odoc_model.Lang.Compilation_unit.t ->
   resolver ->

--- a/test/pages/resolution.t/run.t
+++ b/test/pages/resolution.t/run.t
@@ -27,7 +27,7 @@ If everything has worked to plan, we'll have resolved references for all of the 
 references should be to the correct identifiers - so top1 should be a RootPage, sub1 is a Page, sub2 is a LeafPage, and m1 is a Root.
 
 This is the '{!childpage-sub1}' reference
-  $ odoc_print page-top1.odocl | jq '.content[1][1]["`Paragraph"][0][1]["`Reference"][0]'
+  $ odoc_print page-top1.odocl | jq '.content[1]["`Paragraph"][0]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {
@@ -42,7 +42,7 @@ This is the '{!childpage-sub1}' reference
   }
 
 This is the '{!childpage:sub2}' reference
-  $ odoc_print page-top1.odocl | jq '.content[1][1]["`Paragraph"][2][1]["`Reference"][0]'
+  $ odoc_print page-top1.odocl | jq '.content[1]["`Paragraph"][2]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {
@@ -57,7 +57,7 @@ This is the '{!childpage:sub2}' reference
   }
 
 This is the '{!childmodule:M1}' reference
-  $ odoc_print page-sub1.odocl | jq '.content[1][1]["`Paragraph"][0][1]["`Reference"][0]'
+  $ odoc_print page-sub1.odocl | jq '.content[1]["`Paragraph"][0]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {

--- a/test/xref2/cross_references.t/run.t
+++ b/test/xref2/cross_references.t/run.t
@@ -11,53 +11,47 @@ Two modules that reference each other:
 
 Check that references are resolved:
 
-  $ odoc_print a.odocl | jq '.content.Module.items[0].Type[1].doc[0][1]'
+  $ odoc_print a.odocl | jq '.content.Module.items[0].Type[1].doc[0]'
   {
     "`Paragraph": [
-      [
-        "a.mli 2:4 2:8",
-        {
-          "`Reference": [
-            {
-              "`Resolved": {
-                "`Identifier": {
-                  "`Root": [
-                    {
-                      "`RootPage": "test"
-                    },
-                    "B"
-                  ]
-                }
+      {
+        "`Reference": [
+          {
+            "`Resolved": {
+              "`Identifier": {
+                "`Root": [
+                  {
+                    "`RootPage": "test"
+                  },
+                  "B"
+                ]
               }
-            },
-            []
-          ]
-        }
-      ]
+            }
+          },
+          []
+        ]
+      }
     ]
   }
-  $ odoc_print b.odocl | jq '.content.Module.items[0].Type[1].doc[0][1]'
+  $ odoc_print b.odocl | jq '.content.Module.items[0].Type[1].doc[0]'
   {
     "`Paragraph": [
-      [
-        "b.mli 2:4 2:8",
-        {
-          "`Reference": [
-            {
-              "`Resolved": {
-                "`Identifier": {
-                  "`Root": [
-                    {
-                      "`RootPage": "test"
-                    },
-                    "A"
-                  ]
-                }
+      {
+        "`Reference": [
+          {
+            "`Resolved": {
+              "`Identifier": {
+                "`Root": [
+                  {
+                    "`RootPage": "test"
+                  },
+                  "A"
+                ]
               }
-            },
-            []
-          ]
-        }
-      ]
+            }
+          },
+          []
+        ]
+      }
     ]
   }

--- a/test/xref2/references_scope.t/a.mli
+++ b/test/xref2/references_scope.t/a.mli
@@ -1,0 +1,19 @@
+(** Text attached to references are written as single words to have a more
+    readable output.
+    References from the first comment (which is the doc of the entire module):
+    {{!B.C}Doc-relative}
+    {{!A.B.C}Doc-absolute} *)
+
+(** References from inside the module's signature:
+    {{!B.C}Defined-below}
+    {{!A.B.C}Defined-below-but-absolute} *)
+
+module B : sig
+  module C : sig end
+end
+
+module D : sig
+  open B
+
+  (** {{!C}Through-open} *)
+end

--- a/test/xref2/references_scope.t/run.t
+++ b/test/xref2/references_scope.t/run.t
@@ -1,0 +1,14 @@
+# Testing the scope of references
+
+  $ compile a.mli
+
+  $ jq_scan_references() { jq -c '.. | .["`Reference"]? | select(.)'; }
+
+The references from a.mli, see the attached text to recognize them:
+
+  $ odoc_print a.odocl | jq_scan_references
+  [{"`Dot":[{"`Root":["B","`TUnknown"]},"C"]},[{"`Word":"Doc-relative"}]]
+  [{"`Resolved":{"`Module":[{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"A"]}},"B"]},"C"]}},[{"`Word":"Doc-absolute"}]]
+  [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"A"]},"B"]}},"C"]}},[{"`Word":"Defined-below"}]]
+  [{"`Resolved":{"`Module":[{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"A"]}},"B"]},"C"]}},[{"`Word":"Defined-below-but-absolute"}]]
+  [{"`Root":["C","`TUnknown"]},[{"`Word":"Through-open"}]]

--- a/test/xref2/references_scope.t/run.t
+++ b/test/xref2/references_scope.t/run.t
@@ -7,7 +7,7 @@
 The references from a.mli, see the attached text to recognize them:
 
   $ odoc_print a.odocl | jq_scan_references
-  [{"`Dot":[{"`Root":["B","`TUnknown"]},"C"]},[{"`Word":"Doc-relative"}]]
+  [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"A"]},"B"]}},"C"]}},[{"`Word":"Doc-relative"}]]
   [{"`Resolved":{"`Module":[{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"A"]}},"B"]},"C"]}},[{"`Word":"Doc-absolute"}]]
   [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"A"]},"B"]}},"C"]}},[{"`Word":"Defined-below"}]]
   [{"`Resolved":{"`Module":[{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"A"]}},"B"]},"C"]}},[{"`Word":"Defined-below-but-absolute"}]]


### PR DESCRIPTION
This fixes https://github.com/ocaml/odoc/issues/585 but doesn't fix the issue reported by this comment https://github.com/ocaml/odoc/issues/585#issuecomment-777599121

Resolution failed because doc comment of a file was resolved before the rest of the module is added to the environment.
The first commit is unrelated, it removes the location from `odoc_print`'s output to make the output more readable.

The second issue seems to be in the loader, I'm still investigating.