### PR TITLE
Don't remove the doc of inline includes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,3 +159,9 @@ uutf/dune-project : uutf
 .PHONY : distclean
 distclean :
 	rm -rf $(DUNIVERSE_DEPS) dune-local
+
+.PHONY : promote-html
+promote-html:
+	EXPECTED=`cat _build/default/test/html/_scratch/expected`; \
+	ACTUAL=`cat _build/default/test/html/_scratch/actual`; \
+	mkdir -p "`dirname "$$EXPECTED"`" && cp "$$ACTUAL" "$$EXPECTED"

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -308,11 +308,6 @@ and module_type : Env.t -> ModuleType.t -> ModuleType.t =
 and include_ : Env.t -> Include.t -> Include.t =
  fun env i ->
   let open Include in
-  let remove_top_doc_from_signature s =
-    let open Signature in
-    let items = match s.items with Comment (`Docs _) :: xs -> xs | xs -> xs in
-    { s with items }
-  in
   let decl = Component.Of_Lang.(include_decl empty i.decl) in
   let get_expansion () =
     match
@@ -339,8 +334,7 @@ and include_ : Env.t -> Include.t -> Include.t =
         in
         {
           shadowed = i.expansion.shadowed;
-          content =
-            remove_top_doc_from_signature (signature env i.parent expansion_sg);
+          content = signature env i.parent expansion_sg;
         }
   in
   let expansion =

--- a/test/cases/toplevel_comments.mli
+++ b/test/cases/toplevel_comments.mli
@@ -1,0 +1,37 @@
+(** A doc comment at the beginning of a module is considered to be that
+    module's doc. *)
+
+(** Doc of [T], part 1. *)
+module type T = sig
+  (** Doc of [T], part 2. *)
+
+  type t
+end
+
+module Include_inline : sig
+  include T
+  (** @inline *)
+end
+
+(** Doc of [Include_inline], part 1. *)
+module Include_inline' : sig
+  (** Doc of [Include_inline], part 2. *)
+
+  include T
+  (** part 3
+      @inline *)
+end
+
+module type Include_inline_T = sig
+  include T
+  (** @inline *)
+end
+
+(** Doc of [Include_inline_T'], part 1. *)
+module type Include_inline_T' = sig
+  (** Doc of [Include_inline_T'], part 2. *)
+
+  include T
+  (** part 3
+      @inline *)
+end

--- a/test/html/expect/test_package+ml/Toplevel_comments/Include_inline'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Include_inline'/index.html
@@ -35,6 +35,9 @@
       <p>
        part 3
       </p>
+      <p>
+       Doc of <code>T</code>, part 2.
+      </p>
       <div class="odoc-spec">
        <div class="spec type" id="type-t">
         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Toplevel_comments/Include_inline'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Include_inline'/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include_inline' (test_package+ml.Toplevel_comments.Include_inline')
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » Include_inline'
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.Include_inline'</span></code>
+   </h1>
+   <p>
+    Doc of <code>Include_inline</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>Include_inline</code>, part 2.
+   </p>
+   <div class="odoc-include">
+    <div class="spec include">
+     <div class="doc">
+      <p>
+       part 3
+      </p>
+      <div class="odoc-spec">
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/Include_inline/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Include_inline/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include_inline (test_package+ml.Toplevel_comments.Include_inline)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » Include_inline
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.Include_inline</span></code>
+   </h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-include">
+    <div class="spec include">
+     <div class="doc">
+      <div class="odoc-spec">
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/Include_inline/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Include_inline/index.html
@@ -26,6 +26,9 @@
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
+      <p>
+       Doc of <code>T</code>, part 2.
+      </p>
       <div class="odoc-spec">
        <div class="spec type" id="type-t">
         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Toplevel_comments/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Toplevel_comments (test_package+ml.Toplevel_comments)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+ml</a> » Toplevel_comments
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments</span></code>
+   </h1>
+   <p>
+    A doc comment at the beginning of a module is considered to be that module's doc.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-T">
+     <a href="#module-type-T" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-T/index.html">T</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>T</code>, part 1.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Include_inline">
+     <a href="#module-Include_inline" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Include_inline/index.html">Include_inline</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Include_inline'">
+     <a href="#module-Include_inline'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Include_inline'/index.html">Include_inline'</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>Include_inline</code>, part 1.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Include_inline_T">
+     <a href="#module-type-Include_inline_T" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Include_inline_T/index.html">Include_inline_T</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Include_inline_T'">
+     <a href="#module-type-Include_inline_T'" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Include_inline_T'/index.html">Include_inline_T'</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>Include_inline_T'</code>, part 1.
+     </p>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T'/index.html
@@ -35,6 +35,9 @@
       <p>
        part 3
       </p>
+      <p>
+       Doc of <code>T</code>, part 2.
+      </p>
       <div class="odoc-spec">
        <div class="spec type" id="type-t">
         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T'/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include_inline_T' (test_package+ml.Toplevel_comments.Include_inline_T')
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » Include_inline_T'
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module type <code><span>Toplevel_comments.Include_inline_T'</span></code>
+   </h1>
+   <p>
+    Doc of <code>Include_inline_T'</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>Include_inline_T'</code>, part 2.
+   </p>
+   <div class="odoc-include">
+    <div class="spec include">
+     <div class="doc">
+      <p>
+       part 3
+      </p>
+      <div class="odoc-spec">
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include_inline_T (test_package+ml.Toplevel_comments.Include_inline_T)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » Include_inline_T
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module type <code><span>Toplevel_comments.Include_inline_T</span></code>
+   </h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-include">
+    <div class="spec include">
+     <div class="doc">
+      <div class="odoc-spec">
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T/index.html
@@ -26,6 +26,9 @@
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
+      <p>
+       Doc of <code>T</code>, part 2.
+      </p>
       <div class="odoc-spec">
        <div class="spec type" id="type-t">
         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-T/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-T/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   T (test_package+ml.Toplevel_comments.T)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » T
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module type <code><span>Toplevel_comments.T</span></code>
+   </h1>
+   <p>
+    Doc of <code>T</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>T</code>, part 2.
+   </p>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/Include_inline'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Include_inline'/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include_inline' (test_package+re.Toplevel_comments.Include_inline')
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » Include_inline'
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.Include_inline'</span></code>
+   </h1>
+   <p>
+    Doc of <code>Include_inline</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>Include_inline</code>, part 2.
+   </p>
+   <div class="odoc-include">
+    <div class="spec include">
+     <div class="doc">
+      <p>
+       part 3
+      </p>
+      <div class="odoc-spec">
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/Include_inline'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Include_inline'/index.html
@@ -35,6 +35,9 @@
       <p>
        part 3
       </p>
+      <p>
+       Doc of <code>T</code>, part 2.
+      </p>
       <div class="odoc-spec">
        <div class="spec type" id="type-t">
         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Toplevel_comments/Include_inline/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Include_inline/index.html
@@ -26,6 +26,9 @@
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
+      <p>
+       Doc of <code>T</code>, part 2.
+      </p>
       <div class="odoc-spec">
        <div class="spec type" id="type-t">
         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Toplevel_comments/Include_inline/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Include_inline/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include_inline (test_package+re.Toplevel_comments.Include_inline)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » Include_inline
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.Include_inline</span></code>
+   </h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-include">
+    <div class="spec include">
+     <div class="doc">
+      <div class="odoc-spec">
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Toplevel_comments (test_package+re.Toplevel_comments)
+  </title>
+  <link rel="stylesheet" href="../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../index.html">test_package+re</a> » Toplevel_comments
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments</span></code>
+   </h1>
+   <p>
+    A doc comment at the beginning of a module is considered to be that module's doc.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-T">
+     <a href="#module-type-T" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-T/index.html">T</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>T</code>, part 1.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Include_inline">
+     <a href="#module-Include_inline" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Include_inline/index.html">Include_inline</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Include_inline'">
+     <a href="#module-Include_inline'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Include_inline'/index.html">Include_inline'</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>Include_inline</code>, part 1.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Include_inline_T">
+     <a href="#module-type-Include_inline_T" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Include_inline_T/index.html">Include_inline_T</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Include_inline_T'">
+     <a href="#module-type-Include_inline_T'" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Include_inline_T'/index.html">Include_inline_T'</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>Include_inline_T'</code>, part 1.
+     </p>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T'/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include_inline_T' (test_package+re.Toplevel_comments.Include_inline_T')
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » Include_inline_T'
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module type <code><span>Toplevel_comments.Include_inline_T'</span></code>
+   </h1>
+   <p>
+    Doc of <code>Include_inline_T'</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>Include_inline_T'</code>, part 2.
+   </p>
+   <div class="odoc-include">
+    <div class="spec include">
+     <div class="doc">
+      <p>
+       part 3
+      </p>
+      <div class="odoc-spec">
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T'/index.html
@@ -35,6 +35,9 @@
       <p>
        part 3
       </p>
+      <p>
+       Doc of <code>T</code>, part 2.
+      </p>
       <div class="odoc-spec">
        <div class="spec type" id="type-t">
         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T/index.html
@@ -26,6 +26,9 @@
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
+      <p>
+       Doc of <code>T</code>, part 2.
+      </p>
       <div class="odoc-spec">
        <div class="spec type" id="type-t">
         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Include_inline_T (test_package+re.Toplevel_comments.Include_inline_T)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » Include_inline_T
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module type <code><span>Toplevel_comments.Include_inline_T</span></code>
+   </h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-include">
+    <div class="spec include">
+     <div class="doc">
+      <div class="odoc-spec">
+       <div class="spec type" id="type-t">
+        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
+       </div>
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-T/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-T/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   T (test_package+re.Toplevel_comments.T)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » T
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module type <code><span>Toplevel_comments.T</span></code>
+   </h1>
+   <p>
+    Doc of <code>T</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>T</code>, part 2.
+   </p>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -176,7 +176,7 @@ let diff =
   fun output ->
     let actual_file = Env.path `scratch // output in
     let expected_file = Env.path `expect // output in
-    let cmd = sprintf "diff -N -u -b %s %s" expected_file actual_file in
+    let cmd = sprintf "diff -N -u -b %S %S" expected_file actual_file in
     match Sys.command cmd with
     | 0 -> ()
     | 1 when !already_failed ->

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -240,6 +240,11 @@ let make_test_case ?theme_uri ?syntax case =
   in
   (Case.name case, `Slow, run)
 
+let make_input file sub_modules =
+  let base = String.capitalize_ascii (Filename.chop_extension file) in
+  let index p = String.concat Filename.dir_sep (p @ [ "index.html" ]) in
+  (file, index [ base ] :: List.map (fun m -> index [ base; m ]) sub_modules)
+
 let source_files_all =
   [
     ("val.mli", [ "Val/index.html" ]);
@@ -274,6 +279,14 @@ let source_files_all =
     ("stop.mli", [ "Stop/index.html" ]);
     ("bugs.ml", [ "Bugs/index.html" ]);
     ("alias.ml", [ "Alias/index.html"; "Alias/X/index.html" ]);
+    make_input "toplevel_comments.mli"
+      [
+        "module-type-T";
+        "Include_inline";
+        "Include_inline'";
+        "module-type-Include_inline_T";
+        "module-type-Include_inline_T'";
+      ];
   ]
 
 let source_files_post406 =

--- a/test/html/tidy.ml
+++ b/test/html/tidy.ml
@@ -30,7 +30,7 @@ let validate file =
         "-ashtml";
       ]
   in
-  let cmd = Printf.sprintf "tidy %s %s" options file in
+  let cmd = Printf.sprintf "tidy %s %S" options file in
   let ((_, _, stderr) as proc) = Unix.open_process_full cmd [||] in
 
   let errors_and_warnings =


### PR DESCRIPTION
Fixes the initial issue of https://github.com/ocaml/odoc/issues/478 but doesn't implement @lpw25's suggestion.

The first doc-comment of the expansion of an include was always removed. This PR avoids this for `@inline` includes.

The first two commits are unrelated.