### PR TITLE
Render modules synopsis for `{!modules:...}`

### DIFF
--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -213,7 +213,11 @@ let module_references ms =
         (m.module_reference :> Odoc_model.Paths.Reference.t)
     and synopsis =
       match m.module_synopsis with
-      | Some synopsis -> [ block @@ Paragraph (inline_element_list synopsis) ]
+      | Some synopsis ->
+          [
+            block ~attr:[ "synopsis" ]
+            @@ Paragraph (inline_element_list synopsis);
+          ]
       | None -> []
     in
     (reference, synopsis)

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -206,6 +206,18 @@ and inline_element_list elements =
        (fun elt -> inline_element elt.Odoc_model.Location_.value)
        elements
 
+let module_references (ms : Comment.module_reference list) =
+  let module_reference m =
+    [
+      block
+      @@ Inline
+           (Reference.to_ir ~stop_before:false
+              (m.Comment.module_reference :> Odoc_model.Paths.Reference.t));
+    ]
+  in
+  let items = List.map module_reference ms in
+  block ~attr:[ "modules" ] @@ Block.List (Unordered, items)
+
 let rec nestable_block_element : Comment.nestable_block_element -> Block.one =
  fun content ->
   match content with
@@ -214,13 +226,7 @@ let rec nestable_block_element : Comment.nestable_block_element -> Block.one =
   | `Paragraph content -> block @@ Block.Paragraph (inline_element_list content)
   | `Code_block code -> block @@ Source (source_of_code code)
   | `Verbatim s -> block @@ Verbatim s
-  | `Modules ms ->
-      let items =
-        List.map
-          (fun r -> [ block @@ Inline (Reference.to_ir ~stop_before:false r) ])
-          (ms :> Odoc_model.Paths.Reference.t list)
-      in
-      block ~attr:[ "modules" ] @@ Block.List (Unordered, items)
+  | `Modules ms -> module_references ms
   | `List (kind, items) ->
       let kind =
         match kind with

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -206,17 +206,20 @@ and inline_element_list elements =
        (fun elt -> inline_element elt.Odoc_model.Location_.value)
        elements
 
-let module_references (ms : Comment.module_reference list) =
-  let module_reference m =
-    [
-      block
-      @@ Inline
-           (Reference.to_ir ~stop_before:false
-              (m.Comment.module_reference :> Odoc_model.Paths.Reference.t));
-    ]
+let module_references ms =
+  let module_reference (m : Comment.module_reference) =
+    let reference =
+      Reference.to_ir ~stop_before:false
+        (m.module_reference :> Odoc_model.Paths.Reference.t)
+    and synopsis =
+      match m.module_synopsis with
+      | Some synopsis -> [ block @@ Paragraph (inline_element_list synopsis) ]
+      | None -> []
+    in
+    (reference, synopsis)
   in
   let items = List.map module_reference ms in
-  block ~attr:[ "modules" ] @@ Block.List (Unordered, items)
+  block ~attr:[ "modules" ] @@ Description items
 
 let rec nestable_block_element : Comment.nestable_block_element -> Block.one =
  fun content ->

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -29,11 +29,20 @@ type inline_element =
   | `Reference of Reference.t * link_content
   | `Link of string * link_content ]
 
+type paragraph = inline_element with_location list
+
+type module_reference = {
+  module_reference : Reference.Module.t;
+  module_synopsis : paragraph option;
+}
+(** The [{!modules: ...}] markup. [module_synopsis] is initially [None], it is
+    resolved during linking. *)
+
 type nestable_block_element =
-  [ `Paragraph of inline_element with_location list
+  [ `Paragraph of paragraph
   | `Code_block of string
   | `Verbatim of string
-  | `Modules of Reference.Module.t list
+  | `Modules of module_reference list
   | `List of
     [ `Unordered | `Ordered ] * nestable_block_element with_location list list
   ]

--- a/src/model_desc/comment_desc.ml
+++ b/src/model_desc/comment_desc.ml
@@ -20,7 +20,7 @@ type general_block_element =
   [ `Paragraph of general_link_content
   | `Code_block of string
   | `Verbatim of string
-  | `Modules of Paths.Reference.t list
+  | `Modules of Comment.module_reference list
   | `List of
     [ `Unordered | `Ordered ] * general_block_element with_location list list
   | `Heading of heading_level * Paths.Identifier.Label.t * general_link_content
@@ -67,6 +67,13 @@ let rec inline_element : general_inline_element t =
 and link_content : general_link_content t =
   List (Indirect (ignore_loc, inline_element))
 
+let module_reference =
+  let simplify m =
+    ( (m.module_reference :> Paths.Reference.t),
+      (m.module_synopsis :> general_link_content option) )
+  in
+  Indirect (simplify, Pair (reference, Option link_content))
+
 let rec block_element : general_block_element t =
   let heading_level =
     Variant
@@ -87,7 +94,7 @@ let rec block_element : general_block_element t =
     | `Paragraph x -> C ("`Paragraph", x, link_content)
     | `Code_block x -> C ("`Code_block", x, string)
     | `Verbatim x -> C ("`Verbatim", x, string)
-    | `Modules x -> C ("`Modules", x, List reference)
+    | `Modules x -> C ("`Modules", x, List module_reference)
     | `List (x1, x2) ->
         C ("`List", (x1, (x2 :> general_docs list)), Pair (list_kind, List docs))
     | `Heading (x1, x2, x3) ->

--- a/src/parser/semantics.ml
+++ b/src/parser/semantics.ml
@@ -126,7 +126,8 @@ let rec nestable_block_element :
             match
               Reference.read_mod_longident status.warnings location value
             with
-            | Result.Ok r -> r :: acc
+            | Result.Ok r ->
+                { Comment.module_reference = r; module_synopsis = None } :: acc
             | Result.Error error ->
                 Error.warning status.warnings error;
                 acc)

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -175,9 +175,14 @@ and comment_nestable_block_element env (x : Comment.nestable_block_element) =
   | `Modules refs ->
       let refs =
         List.map
-          (fun r ->
-            match Ref_tools.resolve_module_reference env r with
-            | Some (r, _, _) -> `Resolved r
+          (fun (r : Comment.module_reference) ->
+            match Ref_tools.resolve_module_reference env r.module_reference with
+            | Some (r, _, m) ->
+                ignore m.doc;
+                {
+                  Comment.module_reference = `Resolved r;
+                  module_synopsis = None;
+                }
             | None -> r)
           refs
       in

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -11,31 +11,19 @@ module Opt = struct
   let map f = function Some x -> Some (f x) | None -> None
 end
 
-let string_ends_with_char suffix s =
-  let len = String.length s in
-  len > 0 && s.[len - 1] = suffix
-
 let rec list_find_map f = function
   | hd :: tl -> (
       match f hd with Some _ as x -> x | None -> list_find_map f tl )
   | [] -> None
 
-(** The synopsis is the first sentence of the first paragraph of a comment.
-    Headings, tags and other {!Comment.block_element} that are not [`Paragraph]
-    or [`List] are skipped. *)
+(** The synopsis is the first paragraph of a comment. Headings, tags and other
+    {!Comment.block_element} that are not [`Paragraph] or [`List] are skipped.
+    *)
 let synopsis_from_comment docs =
   let open Location_ in
-  let rec from_paragraph = function
-    | [] -> []
-    | ({ value = `Word w; _ } as hd) :: ({ value = `Space; _ } :: _ | [])
-      when string_ends_with_char '.' w ->
-        (* Stop at the first word ending with '.' that is followed by a space *)
-        [ hd ]
-    | hd :: tl -> hd :: from_paragraph tl
-  in
   let rec from_element elem =
     match elem.value with
-    | `Paragraph p -> Some (from_paragraph p)
+    | `Paragraph p -> Some p
     | `List (_, items) -> list_find_map (list_find_map from_element) items
     | _ -> None
   in

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -286,23 +286,27 @@ let bar =
     <a href="#modules" class="anchor"></a>Modules
    </h2>
    <aside>
-    <ul class="modules"></ul>
-    <ul class="modules">
-     <li>
+    <dl class="modules"></dl>
+    <dl class="modules">
+     <dt>
       <code>X</code>
-     </li>
-    </ul>
-    <ul class="modules">
-     <li>
+     </dt>
+     <dd></dd>
+    </dl>
+    <dl class="modules">
+     <dt>
       <code>X</code>
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <code>Y</code>
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <code>Z</code>
-     </li>
-    </ul>
+     </dt>
+     <dd></dd>
+    </dl>
    </aside>
    <h2 id="tags">
     <a href="#tags" class="anchor"></a>Tags

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -1705,7 +1705,7 @@
      </dt>
      <dd>
       <p class="synopsis">
-       This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features.
+       This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features. <code>C This text is centered. </code> <code>L This text is left-aligned. </code> <code>R This text is right-aligned. </code> This documentation demonstrates:
       </p>
      </dd>
     </dl>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -173,14 +173,24 @@
     <p>
      Here is an index table of <code>Empty</code> modules:
     </p>
-    <ul class="modules">
-     <li>
+    <dl class="modules">
+     <dt>
       <a href="Empty/index.html"><code>Empty</code></a>
-     </li>
-     <li>
+     </dt>
+     <dd>
+      <p>
+       A plain, empty module
+      </p>
+     </dd>
+     <dt>
       <a href="Empty/index.html"><code>EmptyAlias</code></a>
-     </li>
-    </ul>
+     </dt>
+     <dd>
+      <p>
+       A plain module alias of <code>Empty</code>
+      </p>
+     </dd>
+    </dl>
     <p>
      Here is a table of links to indexes: <code>indexlist</code>
     </p>
@@ -1677,36 +1687,47 @@
     <p>
      With odoc, everything should be resolved (and linked) but only toplevel units will be documented.
     </p>
-    <ul class="modules">
-     <li>
+    <dl class="modules">
+     <dt>
       <a href="Dep1/X/index.html"><code>Dep1.X</code></a>
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <code>DocOckTypes</code>
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <a href="IncludeInclude1/index.html"><code>Ocamlary.IncludeInclude1</code></a>
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <a href="#"><code>Ocamlary</code></a>
-     </li>
-    </ul>
+     </dt>
+     <dd>
+      <p>
+       This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features.
+      </p>
+     </dd>
+    </dl>
    </aside>
    <h4 id="weirder-usages-involving-module-types">
     <a href="#weirder-usages-involving-module-types" class="anchor"></a>Weirder usages involving module types
    </h4>
    <aside>
-    <ul class="modules">
-     <li>
+    <dl class="modules">
+     <dt>
       <code>IncludeInclude1</code>.IncludeInclude2
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <code>Dep4</code>.T
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <a href="module-type-A/Q/index.html"><code>A.Q</code></a>
-     </li>
-    </ul>
+     </dt>
+     <dd></dd>
+    </dl>
    </aside>
    <h2 id="playing-with-@canonical-paths">
     <a href="#playing-with-@canonical-paths" class="anchor"></a>Playing with @canonical paths

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -178,7 +178,7 @@
       <a href="Empty/index.html"><code>Empty</code></a>
      </dt>
      <dd>
-      <p>
+      <p class="synopsis">
        A plain, empty module
       </p>
      </dd>
@@ -186,7 +186,7 @@
       <a href="Empty/index.html"><code>EmptyAlias</code></a>
      </dt>
      <dd>
-      <p>
+      <p class="synopsis">
        A plain module alias of <code>Empty</code>
       </p>
      </dd>
@@ -1704,7 +1704,7 @@
       <a href="#"><code>Ocamlary</code></a>
      </dt>
      <dd>
-      <p>
+      <p class="synopsis">
        This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features.
       </p>
      </dd>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -286,23 +286,27 @@ let bar =
     <a href="#modules" class="anchor"></a>Modules
    </h2>
    <aside>
-    <ul class="modules"></ul>
-    <ul class="modules">
-     <li>
+    <dl class="modules"></dl>
+    <dl class="modules">
+     <dt>
       <code>X</code>
-     </li>
-    </ul>
-    <ul class="modules">
-     <li>
+     </dt>
+     <dd></dd>
+    </dl>
+    <dl class="modules">
+     <dt>
       <code>X</code>
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <code>Y</code>
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <code>Z</code>
-     </li>
-    </ul>
+     </dt>
+     <dd></dd>
+    </dl>
    </aside>
    <h2 id="tags">
     <a href="#tags" class="anchor"></a>Tags

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -178,7 +178,7 @@
       <a href="Empty/index.html"><code>Empty</code></a>
      </dt>
      <dd>
-      <p>
+      <p class="synopsis">
        A plain, empty module
       </p>
      </dd>
@@ -186,7 +186,7 @@
       <a href="Empty/index.html"><code>EmptyAlias</code></a>
      </dt>
      <dd>
-      <p>
+      <p class="synopsis">
        A plain module alias of <code>Empty</code>
       </p>
      </dd>
@@ -1721,7 +1721,7 @@
       <a href="#"><code>Ocamlary</code></a>
      </dt>
      <dd>
-      <p>
+      <p class="synopsis">
        This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features.
       </p>
      </dd>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -1722,7 +1722,7 @@
      </dt>
      <dd>
       <p class="synopsis">
-       This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features.
+       This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features. <code>C This text is centered. </code> <code>L This text is left-aligned. </code> <code>R This text is right-aligned. </code> This documentation demonstrates:
       </p>
      </dd>
     </dl>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -173,14 +173,24 @@
     <p>
      Here is an index table of <code>Empty</code> modules:
     </p>
-    <ul class="modules">
-     <li>
+    <dl class="modules">
+     <dt>
       <a href="Empty/index.html"><code>Empty</code></a>
-     </li>
-     <li>
+     </dt>
+     <dd>
+      <p>
+       A plain, empty module
+      </p>
+     </dd>
+     <dt>
       <a href="Empty/index.html"><code>EmptyAlias</code></a>
-     </li>
-    </ul>
+     </dt>
+     <dd>
+      <p>
+       A plain module alias of <code>Empty</code>
+      </p>
+     </dd>
+    </dl>
     <p>
      Here is a table of links to indexes: <code>indexlist</code>
     </p>
@@ -1694,36 +1704,47 @@
     <p>
      With odoc, everything should be resolved (and linked) but only toplevel units will be documented.
     </p>
-    <ul class="modules">
-     <li>
+    <dl class="modules">
+     <dt>
       <a href="Dep1/X/index.html"><code>Dep1.X</code></a>
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <code>DocOckTypes</code>
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <a href="IncludeInclude1/index.html"><code>Ocamlary.IncludeInclude1</code></a>
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <a href="#"><code>Ocamlary</code></a>
-     </li>
-    </ul>
+     </dt>
+     <dd>
+      <p>
+       This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features.
+      </p>
+     </dd>
+    </dl>
    </aside>
    <h4 id="weirder-usages-involving-module-types">
     <a href="#weirder-usages-involving-module-types" class="anchor"></a>Weirder usages involving module types
    </h4>
    <aside>
-    <ul class="modules">
-     <li>
+    <dl class="modules">
+     <dt>
       <code>IncludeInclude1</code>.IncludeInclude2
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <code>Dep4</code>.T
-     </li>
-     <li>
+     </dt>
+     <dd></dd>
+     <dt>
       <a href="module-type-A/Q/index.html"><code>A.Q</code></a>
-     </li>
-    </ul>
+     </dt>
+     <dd></dd>
+    </dl>
    </aside>
    <h2 id="playing-with-@canonical-paths">
     <a href="#playing-with-@canonical-paths" class="anchor"></a>Playing with @canonical paths

--- a/test/latex/expect/test_package+ml/Markup.tex
+++ b/test/latex/expect/test_package+ml/Markup.tex
@@ -83,10 +83,17 @@ The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
 Raw HTML can be  as inline elements into sentences.
 
 \subsection{Modules\label{modules}}%
-\begin{itemize}\item{\ocamlinlinecode{X}}\end{itemize}%
-\begin{itemize}\item{\ocamlinlinecode{X}}%
-\item{\ocamlinlinecode{Y}}%
-\item{\ocamlinlinecode{Z}}\end{itemize}%
+\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\end{description}%
+\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[\ocamlinlinecode{X}]{}\end{description}%
+\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[\ocamlinlinecode{X}]{}%
+\item[\ocamlinlinecode{Y}]{}%
+\item[\ocamlinlinecode{Z}]{}\end{description}%
 \subsection{Tags\label{tags}}%
 Each comment can end with zero or more tags. Here are some examples:
 

--- a/test/man/expect/test_package+ml/Markup.3o
+++ b/test/man/expect/test_package+ml/Markup.3o
@@ -227,14 +227,13 @@ Raw HTML can be  as inline elements into sentences\.
 .in 
 .sp 
 .fi 
-.sp 
-\(bu X
-.sp 
-\(bu X
+@X: 
 .br 
-\(bu Y
+@X: 
 .br 
-\(bu Z
+@Y: 
+.br 
+@Z: 
 .nf 
 .sp 
 .in 3

--- a/test/print/print.ml
+++ b/test/print/print.ml
@@ -479,8 +479,11 @@ module Comment_to_sexp = struct
           [
             Atom "modules";
             List
-              (List.map Reference_to_sexp.reference
-                 (ps :> Odoc_model.Paths.Reference.t list));
+              (List.map
+                 (fun m ->
+                   Reference_to_sexp.reference
+                     (m.Comment.module_reference :> Odoc_model.Paths.Reference.t))
+                 ps);
           ]
     | `List (kind, items) ->
         let kind =

--- a/test/xref2/module_list.t/external.mli
+++ b/test/xref2/module_list.t/external.mli
@@ -1,0 +1,4 @@
+(** Doc for [External]. *)
+
+(** Doc for [X]. *)
+module X : sig end

--- a/test/xref2/module_list.t/main.mli
+++ b/test/xref2/module_list.t/main.mli
@@ -1,0 +1,10 @@
+(** {!modules: External External.X Main Internal Internal.Y} *)
+
+(** Doc for [Internal].
+
+    An other paragraph*)
+module Internal : sig
+
+  (** Doc for Internal.[X]. An other sentence. *)
+  module Y : sig end
+end

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -5,11 +5,11 @@
 Everything should resolve:
 
   $ odoc_print main.odocl | jq -c '.. | .["`Modules"]? | select(.) | .[]'
-  [{"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}}},"None"]
-  [{"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]}},"None"]
+  [{"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"External"},{"`Word":"."}]}]
+  [{"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"X"},{"`Word":"."}]}]
   [{"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Main"]}}},"None"]
-  [{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}}},"None"]
-  [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"Y"]}},"None"]
+  [{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"Internal"},{"`Word":"."}]}]
+  [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"Y"]}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Word":"Internal."},{"`Code_span":"X"},{"`Word":"."}]}]
 
 As HTML, should render as a description list.
 

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -32,14 +32,14 @@ As HTML, should render as a description list.
     <header><h1>Module <code>Main</code></h1>
      <dl class="modules">
       <dt><a href="../External/index.html"><code>External</code></a></dt>
-      <dd><p>Doc for <code>External</code>.</p></dd>
+      <dd><p class="synopsis">Doc for <code>External</code>.</p></dd>
       <dt><a href="../External/X/index.html"><code>External.X</code></a></dt>
-      <dd><p>Doc for <code>X</code>.</p></dd>
+      <dd><p class="synopsis">Doc for <code>X</code>.</p></dd>
       <dt><a href="#"><code>Main</code></a></dt><dd></dd>
       <dt><a href="Internal/index.html"><code>Internal</code></a></dt>
-      <dd><p>Doc for <code>Internal</code>.</p></dd>
+      <dd><p class="synopsis">Doc for <code>Internal</code>.</p></dd>
       <dt><a href="Internal/Y/index.html"><code>Internal.Y</code></a></dt>
-      <dd><p>Doc for Internal.<code>X</code>.</p></dd>
+      <dd><p class="synopsis">Doc for Internal.<code>X</code>.</p></dd>
      </dl>
     </header>
     <div class="content">

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -5,11 +5,11 @@
 Everything should resolve:
 
   $ odoc_print main.odocl | jq -c '.. | .["`Modules"]? | select(.) | .[]'
-  {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}}}
-  {"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]}}
-  {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Main"]}}}
-  {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}}}
-  {"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"Y"]}}
+  [{"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}}},"None"]
+  [{"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]}},"None"]
+  [{"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Main"]}}},"None"]
+  [{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}}},"None"]
+  [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"Y"]}},"None"]
 
 As HTML, should render as a description list.
 

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -9,7 +9,7 @@ Everything should resolve:
   [{"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"X"},{"`Word":"."}]}]
   [{"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Main"]}}},"None"]
   [{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"Internal"},{"`Word":"."}]}]
-  [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"Y"]}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Word":"Internal."},{"`Code_span":"X"},{"`Word":"."}]}]
+  [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"Y"]}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Word":"Internal."},{"`Code_span":"X"},{"`Word":"."},"`Space",{"`Word":"An"},"`Space",{"`Word":"other"},"`Space",{"`Word":"sentence."}]}]
 
 As HTML, should render as a description list.
 
@@ -39,7 +39,10 @@ As HTML, should render as a description list.
       <dt><a href="Internal/index.html"><code>Internal</code></a></dt>
       <dd><p class="synopsis">Doc for <code>Internal</code>.</p></dd>
       <dt><a href="Internal/Y/index.html"><code>Internal.Y</code></a></dt>
-      <dd><p class="synopsis">Doc for Internal.<code>X</code>.</p></dd>
+      <dd>
+       <p class="synopsis">Doc for Internal.<code>X</code>. An other sentence.
+       </p>
+      </dd>
      </dl>
     </header>
     <div class="content">

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -30,13 +30,17 @@ As HTML, should render as a description list.
       &#x00BB; Main
     </nav>
     <header><h1>Module <code>Main</code></h1>
-     <ul class="modules">
-      <li><a href="../External/index.html"><code>External</code></a></li>
-      <li><a href="../External/X/index.html"><code>External.X</code></a></li>
-      <li><a href="#"><code>Main</code></a></li>
-      <li><a href="Internal/index.html"><code>Internal</code></a></li>
-      <li><a href="Internal/Y/index.html"><code>Internal.Y</code></a></li>
-     </ul>
+     <dl class="modules">
+      <dt><a href="../External/index.html"><code>External</code></a></dt>
+      <dd><p>Doc for <code>External</code>.</p></dd>
+      <dt><a href="../External/X/index.html"><code>External.X</code></a></dt>
+      <dd><p>Doc for <code>X</code>.</p></dd>
+      <dt><a href="#"><code>Main</code></a></dt><dd></dd>
+      <dt><a href="Internal/index.html"><code>Internal</code></a></dt>
+      <dd><p>Doc for <code>Internal</code>.</p></dd>
+      <dt><a href="Internal/Y/index.html"><code>Internal.Y</code></a></dt>
+      <dd><p>Doc for Internal.<code>X</code>.</p></dd>
+     </dl>
     </header>
     <div class="content">
      <div>

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -1,0 +1,53 @@
+# Testing {!modules:...} lists
+
+  $ compile external.mli main.mli
+
+Everything should resolve:
+
+  $ odoc_print main.odocl | jq -c '.. | .["`Modules"]? | select(.) | .[]'
+  {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}}}
+  {"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]}}
+  {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Main"]}}}
+  {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}}}
+  {"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"Y"]}}
+
+As HTML, should render as a description list.
+
+  $ odoc html-generate --indent -o html main.odocl
+
+  $ cat html/test/Main/index.html
+  <!DOCTYPE html>
+  <html xmlns="http://www.w3.org/1999/xhtml">
+   <head><title>Main (test.Main)</title>
+    <link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/>
+    <meta name="generator" content="odoc %%VERSION%%"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+    <script src="../../highlight.pack.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+   </head>
+   <body>
+    <nav><a href="../index.html">Up</a> – <a href="../index.html">test</a>
+      &#x00BB; Main
+    </nav>
+    <header><h1>Module <code>Main</code></h1>
+     <ul class="modules">
+      <li><a href="../External/index.html"><code>External</code></a></li>
+      <li><a href="../External/X/index.html"><code>External.X</code></a></li>
+      <li><a href="#"><code>Main</code></a></li>
+      <li><a href="Internal/index.html"><code>Internal</code></a></li>
+      <li><a href="Internal/Y/index.html"><code>Internal.Y</code></a></li>
+     </ul>
+    </header>
+    <div class="content">
+     <div>
+      <div class="spec module" id="module-Internal" class="anchored">
+       <a href="#module-Internal" class="anchor"></a>
+       <code><span class="keyword">module</span> 
+        <a href="Internal/index.html">Internal</a> : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+        </code>
+      </div><div><p>Doc for <code>Internal</code>.</p></div>
+     </div>
+    </div>
+   </body>
+  </html>


### PR DESCRIPTION
Fixes https://github.com/ocaml/odoc/issues/297

Resolve and render the synopsis of modules referenced with the `{!modules:A B C}` markup.

The first sentence of the first paragraph of the modules' documentation is taken. Headings, tags and other elements that are not paragraphs and lists are skipped, I think that's what ocamldoc does: https://caml.inria.fr/pub/docs/manual-ocaml/ocamldoc.html#sss:ocamldoc-preamble