### PR TITLE
Add the 'linked' flag to compilation units

### DIFF
--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -80,7 +80,7 @@ let read_cmti ~make_root ~parent ~filename () =
         in
         let content = Odoc_model.Lang.Compilation_unit.Module items in
         {Odoc_model.Lang.Compilation_unit.id; root; doc; digest; imports; source;
-         interface; hidden; content; expansion = None}
+         interface; hidden; content; expansion = None; linked = false}
       end
     | _ -> not_an_interface filename
 
@@ -138,7 +138,7 @@ let read_cmt ~make_root ~parent ~filename () =
       let source = None in
       let content = Odoc_model.Lang.Compilation_unit.Pack items in
       {Odoc_model.Lang.Compilation_unit.id; root; doc; digest; imports;
-          source; interface; hidden; content; expansion = None}
+          source; interface; hidden; content; expansion = None; linked = false}
 
     | Implementation impl ->
       let name = cmt_info.cmt_modname in
@@ -173,7 +173,7 @@ let read_cmt ~make_root ~parent ~filename () =
       in
       let content = Odoc_model.Lang.Compilation_unit.Module items in
       {Odoc_model.Lang.Compilation_unit.id; root; doc; digest; imports;
-       source; interface; hidden; content; expansion = None}
+       source; interface; hidden; content; expansion = None; linked = false}
 
     | _ -> not_an_implementation filename
 
@@ -203,7 +203,7 @@ let read_cmi ~make_root ~parent ~filename () =
       let source = None in
       let content = Odoc_model.Lang.Compilation_unit.Module items in
       {Odoc_model.Lang.Compilation_unit.id; root; doc; digest; imports;
-       source; interface; hidden; content; expansion = None}
+       source; interface; hidden; content; expansion = None; linked = false}
 
     | _ -> corrupted filename
 

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -441,6 +441,7 @@ module rec Compilation_unit : sig
     hidden : bool;
     content : content;
     expansion : Signature.t option;
+    linked : bool;  (** Whether this unit has been linked. *)
   }
 end =
   Compilation_unit
@@ -452,6 +453,7 @@ module rec Page : sig
     content : Comment.docs;
     children : Reference.t list;
     digest : Digest.t;
+    linked : bool;
   }
 end =
   Page

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -164,7 +164,10 @@ let mld ~parent_spec ~output ~children ~warn_error input =
     }
   in
   let resolve content =
-    let page = Odoc_model.Lang.Page.{ name; root; children; content; digest } in
+    let page =
+      Odoc_model.Lang.Page.
+        { name; root; children; content; digest; linked = false }
+    in
     Page.save output page;
     Ok ()
   in

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -13,7 +13,8 @@ let from_mld ~xref_base_uri ~env ~output ~warn_error input =
   let to_html content =
     (* This is a mess. *)
     let page =
-      Odoc_model.Lang.Page.{ name = id; root; content; children = []; digest }
+      Odoc_model.Lang.Page.
+        { name = id; root; content; children = []; digest; linked = false }
     in
     let resolve_env = Env.build env (`Page page) in
     Odoc_xref2.Link.resolve_page resolve_env page

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -118,7 +118,7 @@ let rec unit (resolver : Env.resolver) t =
     | Pack _ as p -> (p, env)
   in
   let doc = comment_docs env t.doc in
-  { t with content; doc; imports }
+  { t with content; doc; imports; linked = true }
 
 and value_ env parent t =
   let open Value in
@@ -844,7 +844,9 @@ let build_resolver :
  fun ?equal:_ ?hash:_ lookup_unit resolve_unit lookup_page resolve_page ->
   { Env.lookup_unit; resolve_unit; lookup_page; resolve_page }
 *)
-let link x y = Lookup_failures.catch_failures (fun () -> unit x y)
+let link x y =
+  Lookup_failures.catch_failures (fun () ->
+      if y.Lang.Compilation_unit.linked then y else unit x y)
 
 let page env page =
   let env = Env.set_resolver Env.empty env in
@@ -863,6 +865,9 @@ let page env page =
     Page.content =
       List.map (with_location comment_block_element env) page.Page.content;
     children;
+    linked = true;
   }
 
-let resolve_page env p = Lookup_failures.catch_failures (fun () -> page env p)
+let resolve_page env p =
+  Lookup_failures.catch_failures (fun () ->
+      if p.Lang.Page.linked then p else page env p)

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -604,6 +604,7 @@ let my_compilation_unit id docs s =
     ; hidden = false
     ; content = Module s
     ; expansion = None
+    ; linked = false
 }
 
 let mkenv () =


### PR DESCRIPTION
To ensures that linking is not done twice. This can happen when inadvertently using the `html` command instead of
`html-generate`.

Some elements can't be linked twice and will cause an exception. For example when linking `{!modules:...}`.