### PR TITLE
Unnest unattached

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -323,7 +323,9 @@ and items ~resolve l : item Html.elt list =
         let elts =
           let doc = match doc with
           | [] -> []
-          | docs -> [ div (flow_to_item @@ block ~resolve docs) ]
+          | docs ->
+            let a = [ Html.a_class [ "spec-doc" ] ] in
+            [ div ~a (flow_to_item @@ block ~resolve docs) ]
           in
           [ div (div ~a content :: doc) ]
         in

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -201,14 +201,6 @@ let div : ([< Html_types.div_attrib ], [< item ], [> Html_types.div ]) Html.star
     =
   Html.Unsafe.node "div"
 
-let rec is_only_text l =
-  let is_text : Item.t -> _ = function
-    | Heading _ | Text _ -> true
-    | Declaration _ -> false
-    | Include { content = { content; _ }; _ } -> is_only_text content
-  in
-  List.for_all is_text l
-
 let class_of_kind kind =
   match kind with Some spec -> class_ [ "spec"; spec ] | None -> []
 
@@ -263,9 +255,9 @@ and subpage ~resolve (subp : Subpage.t) : item Html.elt list =
   items ~resolve subp.content.items
 
 and items ~resolve l : item Html.elt list =
-  let rec walk_items ~only_text acc (t : Item.t list) : item Html.elt list =
+  let rec walk_items acc (t : Item.t list) : item Html.elt list =
     let continue_with rest elts =
-      (walk_items [@tailcall]) ~only_text (List.rev_append elts acc) rest
+      (walk_items [@tailcall]) (List.rev_append elts acc) rest
     in
     match t with
     | [] -> List.rev acc
@@ -326,7 +318,7 @@ and items ~resolve l : item Html.elt list =
           [ div ~a: [ Html.a_class [ "odoc-spec" ]] (div ~a content :: doc) ]
         in
         (continue_with [@tailcall]) rest elts
-  and items l = walk_items ~only_text:(is_only_text l) [] l in
+  and items l = walk_items [] l in
   items l
 
 module Toc = struct

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -321,13 +321,11 @@ and items ~resolve l : item Html.elt list =
         let a = class_of_kind kind @ anchor_attrib in
         let content = anchor_link @ documentedSrc ~resolve content in
         let elts =
-          let content = div ~a content in
-          match doc with
-          | [] -> [ content ]
-          | docs ->
-              [
-                Html.div [ content; div (flow_to_item @@ block ~resolve docs) ];
-              ]
+          let doc = match doc with
+          | [] -> []
+          | docs -> [ div (flow_to_item @@ block ~resolve docs) ]
+          in
+          [ div (div ~a content :: doc) ]
         in
         (continue_with [@tailcall]) rest elts
   and items l = walk_items ~only_text:(is_only_text l) [] l in

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -296,7 +296,8 @@ and items ~resolve l : item Html.elt list =
         let a = class_of_kind kind @ anchor_attrib in
         (* TODO : Why double div ??? *)
         [
-          Html.div ~a:[ Html.a_class [ "odoc-include" ] ]
+          Html.div
+            ~a:[ Html.a_class [ "odoc-include" ] ]
             [
               Html.div ~a
                 ( anchor_link
@@ -309,13 +310,14 @@ and items ~resolve l : item Html.elt list =
         let a = class_of_kind kind @ anchor_attrib in
         let content = anchor_link @ documentedSrc ~resolve content in
         let elts =
-          let doc = match doc with
-          | [] -> []
-          | docs ->
-            let a = [ Html.a_class [ "spec-doc" ] ] in
-            [ div ~a (flow_to_item @@ block ~resolve docs) ]
+          let doc =
+            match doc with
+            | [] -> []
+            | docs ->
+                let a = [ Html.a_class [ "spec-doc" ] ] in
+                [ div ~a (flow_to_item @@ block ~resolve docs) ]
           in
-          [ div ~a: [ Html.a_class [ "odoc-spec" ]] (div ~a content :: doc) ]
+          [ div ~a:[ Html.a_class [ "odoc-spec" ] ] (div ~a content :: doc) ]
         in
         (continue_with [@tailcall]) rest elts
   and items l = walk_items [] l in

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -278,7 +278,9 @@ and items ~resolve l : item Html.elt list =
         let content = flow_to_item @@ block ~resolve text in
         let elts =
           if only_text then content
-          else [ Html.aside (content :> any Html.elt list) ]
+          else
+            let a = [ Html.a_class [ "odoc-unattached" ] ] in
+            [ Html.aside ~a (content :> any Html.elt list) ]
         in
         elts |> (continue_with [@tailcall]) rest
     | Heading h :: rest ->
@@ -308,7 +310,7 @@ and items ~resolve l : item Html.elt list =
         let a = class_of_kind kind @ anchor_attrib in
         (* TODO : Why double div ??? *)
         [
-          Html.div
+          Html.div ~a:[ Html.a_class [ "odoc-include" ] ]
             [
               Html.div ~a
                 ( anchor_link
@@ -327,7 +329,7 @@ and items ~resolve l : item Html.elt list =
             let a = [ Html.a_class [ "spec-doc" ] ] in
             [ div ~a (flow_to_item @@ block ~resolve docs) ]
           in
-          [ div (div ~a content :: doc) ]
+          [ div ~a: [ Html.a_class [ "odoc-spec" ]] (div ~a content :: doc) ]
         in
         (continue_with [@tailcall]) rest elts
   and items l = walk_items ~only_text:(is_only_text l) [] l in

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -276,13 +276,7 @@ and items ~resolve l : item Html.elt list =
             | _ -> Stop_and_keep)
         in
         let content = flow_to_item @@ block ~resolve text in
-        let elts =
-          if only_text then content
-          else
-            let a = [ Html.a_class [ "odoc-unattached" ] ] in
-            [ Html.aside ~a (content :> any Html.elt list) ]
-        in
-        elts |> (continue_with [@tailcall]) rest
+        content |> (continue_with [@tailcall]) rest
     | Heading h :: rest ->
         [ heading ~resolve h ] |> (continue_with [@tailcall]) rest
     | Include { kind; anchor; doc; content = { summary; status; content } }

--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -109,7 +109,8 @@ let page_creator ?(theme_uri = Relative "./") ~url name header toc content =
   in
 
   let body =
-    breadcrumbs @ [ Html.header ~a:[ Html.a_class [ "odoc-preamble" ] ] header ]
+    breadcrumbs
+    @ [ Html.header ~a:[ Html.a_class [ "odoc-preamble" ] ] header ]
     @ toc
     @ [ Html.div ~a:[ Html.a_class [ "odoc-content" ] ] content ]
   in

--- a/test/html/expect/test_package+custom_theme,ml/Include/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Include/index.html
@@ -23,112 +23,138 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module-type" id="module-type-Not_inlined">
-    <a href="#module-type-Not_inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined/index.html">Not_inlined</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Not_inlined">
+     <a href="#module-type-Not_inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined/index.html">Not_inlined</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a></span></code></span>
        </summary>
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-t">
+         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Inlined">
-    <a href="#module-type-Inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inlined/index.html">Inlined</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Inlined">
+     <a href="#module-type-Inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inlined/index.html">Inlined</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <div class="spec type" id="type-u">
-       <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
+      <div class="odoc-spec">
+       <div class="spec type" id="type-u">
+        <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
+       </div>
       </div>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Not_inlined_and_closed">
-    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Not_inlined_and_closed">
+     <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details>
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span></code></span>
        </summary>
-       <div class="spec type" id="type-v">
-        <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-v">
+         <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Not_inlined_and_opened">
-    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Not_inlined_and_opened">
+     <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span></code></span>
        </summary>
-       <div class="spec type" id="type-w">
-        <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-w">
+         <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Inherent_Module">
-    <a href="#module-type-Inherent_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Inherent_Module">
+     <a href="#module-type-Inherent_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code></span>
        </summary>
-       <div class="spec value" id="val-a">
-        <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
+       <div class="odoc-spec">
+        <div class="spec value" id="val-a">
+         <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Dorminant_Module">
-    <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Dorminant_Module">
+     <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span></code></span>
        </summary>
-       <div>
+       <div class="odoc-include">
         <div class="spec include">
          <div class="doc">
           <details open="open">
            <summary>
             <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code></span>
            </summary>
-           <div class="spec value" id="val-a">
-            <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
+           <div class="odoc-spec">
+            <div class="spec value" id="val-a">
+             <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
+            </div>
            </div>
           </details>
          </div>
         </div>
        </div>
-       <div class="spec value" id="val-a">
-        <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-u">u</a></span></code>
+       <div class="odoc-spec">
+        <div class="spec value" id="val-a">
+         <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-u">u</a></span></code>
+        </div>
        </div>
       </details>
      </div>

--- a/test/html/expect/test_package+custom_theme,ml/Module/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Module/index.html
@@ -26,57 +26,85 @@
    </p>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.
      </p>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span>S1</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S1">
+     <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span>S1</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S2">
-    <a href="#module-type-S2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S2/index.html">S2</a></span><span> = <a href="module-type-S/index.html">S</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S2">
+     <a href="#module-type-S2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S2/index.html">S2</a></span><span> = <a href="module-type-S/index.html">S</a></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S3">
-    <a href="#module-type-S3" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S3/index.html">S3</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = int</span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-u">u</a> = string</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S3">
+     <a href="#module-type-S3" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S3/index.html">S3</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = int</span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-u">u</a> = string</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S4">
-    <a href="#module-type-S4" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S4/index.html">S4</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> := int</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S4">
+     <a href="#module-type-S4" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S4/index.html">S4</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> := int</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S5/index.html">S5</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <span>'a <a href="module-type-S/index.html#type-v">v</a></span> := <span><span class="type-var">'a</span> list</span></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S5">
+     <a href="#module-type-S5" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S5/index.html">S5</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <span>'a <a href="module-type-S/index.html#type-v">v</a></span> := <span><span class="type-var">'a</span> list</span></span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-result">
-    <a href="#type-result" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) result</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-result">
+     <a href="#type-result" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) result</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S6/index.html">S6</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <span>('a, 'b) <a href="module-type-S/index.html#type-w">w</a></span> := <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="#type-result">result</a></span></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S6">
+     <a href="#module-type-S6" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S6/index.html">S6</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <span>('a, 'b) <a href="module-type-S/index.html#type-w">w</a></span> := <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="#type-result">result</a></span></span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-M'">
-    <a href="#module-M'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M'/index.html">M'</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M'">
+     <a href="#module-M'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M'/index.html">M'</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S7">
-    <a href="#module-type-S7" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S7/index.html">S7</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> = <a href="M'/index.html">M'</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S7">
+     <a href="#module-type-S7" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S7/index.html">S7</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> = <a href="M'/index.html">M'</a></span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S8">
-    <a href="#module-type-S8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S8/index.html">S8</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> := <a href="M'/index.html">M'</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S8">
+     <a href="#module-type-S8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S8/index.html">S8</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> := <a href="M'/index.html">M'</a></span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S9">
-    <a href="#module-type-S9" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S9/index.html">S9</a></span><span> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="M'/index.html">M'</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S9">
+     <a href="#module-type-S9" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S9/index.html">S9</a></span><span> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="M'/index.html">M'</a></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Mutually">
-    <a href="#module-Mutually" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Mutually/index.html">Mutually</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Mutually">
+     <a href="#module-Mutually" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Mutually/index.html">Mutually</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Recursive">
-    <a href="#module-Recursive" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recursive/index.html">Recursive</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Recursive">
+     <a href="#module-Recursive" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recursive/index.html">Recursive</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+custom_theme,ml/Section/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Section/index.html
@@ -62,19 +62,15 @@
    <h2 id="text-only">
     <a href="#text-only" class="anchor"></a>Text only
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Foo bar.
-    </p>
-   </aside>
+   <p>
+    Foo bar.
+   </p>
    <h2 id="aside-only">
     <a href="#aside-only" class="anchor"></a>Aside only
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Foo bar.
-    </p>
-   </aside>
+   <p>
+    Foo bar.
+   </p>
    <h2 id="value-only">
     <a href="#value-only" class="anchor"></a>Value only
    </h2>
@@ -95,11 +91,9 @@
    <h2 id="this-section-title-has-markup">
     <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
-    </p>
-   </aside>
+   <p>
+    But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+   </p>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+custom_theme,ml/Section/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Section/index.html
@@ -62,7 +62,7 @@
    <h2 id="text-only">
     <a href="#text-only" class="anchor"></a>Text only
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Foo bar.
     </p>
@@ -70,7 +70,7 @@
    <h2 id="aside-only">
     <a href="#aside-only" class="anchor"></a>Aside only
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Foo bar.
     </p>
@@ -78,8 +78,10 @@
    <h2 id="value-only">
     <a href="#value-only" class="anchor"></a>Value only
    </h2>
-   <div class="spec value" id="val-foo">
-    <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+    </div>
    </div>
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
@@ -93,7 +95,7 @@
    <h2 id="this-section-title-has-markup">
     <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
     </p>

--- a/test/html/expect/test_package+custom_theme,ml/Val/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Val/index.html
@@ -23,24 +23,26 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span><span class="keyword">val</span> documented : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Foo.
      </p>
     </div>
    </div>
-   <div class="spec value" id="val-undocumented">
-    <a href="#val-undocumented" class="anchor"></a><code><span><span class="keyword">val</span> undocumented : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-undocumented">
+     <a href="#val-undocumented" class="anchor"></a><code><span><span class="keyword">val</span> undocumented : unit</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-documented_above">
      <a href="#val-documented_above" class="anchor"></a><code><span><span class="keyword">val</span> documented_above : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Bar.
      </p>

--- a/test/html/expect/test_package+ml/Alias/X/index.html
+++ b/test/html/expect/test_package+ml/Alias/X/index.html
@@ -23,11 +23,11 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Module Foo__X documentation. This should appear in the documentation for the alias to this module 'X'
      </p>

--- a/test/html/expect/test_package+ml/Alias/index.html
+++ b/test/html/expect/test_package+ml/Alias/index.html
@@ -23,11 +23,15 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module" id="module-Foo__X">
-    <a href="#module-Foo__X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Foo__X/index.html">Foo__X</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Foo__X">
+     <a href="#module-Foo__X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Foo__X/index.html">Foo__X</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-X">
-    <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-X">
+     <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Bugs/index.html
+++ b/test/html/expect/test_package+ml/Bugs/index.html
@@ -23,14 +23,16 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec type" id="type-opt">
-    <a href="#type-opt" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a opt</span></span><span> = <span><span class="type-var">'a</span> option</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-opt">
+     <a href="#type-opt" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a opt</span></span><span> = <span><span class="type-var">'a</span> option</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : <span>?⁠bar:<span class="type-var">'a</span> <span>-&gt;</span></span> <span>unit <span>-&gt;</span></span> unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Triggers an assertion failure when <a href="https://github.com/ocaml/odoc/issues/101">https://github.com/ocaml/odoc/issues/101</a> is not fixed.
      </p>

--- a/test/html/expect/test_package+ml/Bugs_post_406/index.html
+++ b/test/html/expect/test_package+ml/Bugs_post_406/index.html
@@ -26,11 +26,15 @@
    </p>
   </header>
   <div class="odoc-content">
-   <div class="spec class-type" id="class-type-let_open">
-    <a href="#class-type-let_open" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-let_open/index.html">let_open</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-let_open">
+     <a href="#class-type-let_open" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-let_open/index.html">let_open</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-let_open'">
-    <a href="#class-let_open'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-let_open'/index.html">let_open'</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-let_open'">
+     <a href="#class-let_open'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-let_open'/index.html">let_open'</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Bugs_pre_410/index.html
+++ b/test/html/expect/test_package+ml/Bugs_pre_410/index.html
@@ -23,14 +23,16 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec type" id="type-opt'">
-    <a href="#type-opt'" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a opt'</span></span><span> = <span>int option</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-opt'">
+     <a href="#type-opt'" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a opt'</span></span><span> = <span>int option</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo'">
      <a href="#val-foo'" class="anchor"></a><code><span><span class="keyword">val</span> foo' : <span>?⁠bar:<span class="type-var">'a</span> <span>-&gt;</span></span> <span>unit <span>-&gt;</span></span> unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Similar to <code>Bugs</code>, but the printed type of <code>~bar</code> should be <code>int</code>, not <code>'a</code>. This probably requires fixing in the compiler. See <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">https://github.com/ocaml/odoc/pull/230#issuecomment-433226807</a>.
      </p>

--- a/test/html/expect/test_package+ml/Class/index.html
+++ b/test/html/expect/test_package+ml/Class/index.html
@@ -23,32 +23,50 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec class-type" id="class-type-empty">
-    <a href="#class-type-empty" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-empty/index.html">empty</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-empty">
+     <a href="#class-type-empty" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-empty/index.html">empty</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class-type" id="class-type-mutually">
-    <a href="#class-type-mutually" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-mutually/index.html">mutually</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-mutually">
+     <a href="#class-type-mutually" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-mutually/index.html">mutually</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class-type" id="class-type-recursive">
-    <a href="#class-type-recursive" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-recursive/index.html">recursive</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-recursive">
+     <a href="#class-type-recursive" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-recursive/index.html">recursive</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-mutually'">
-    <a href="#class-mutually'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-mutually'/index.html">mutually'</a></span><span> : <a href="class-type-mutually/index.html">mutually</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-mutually'">
+     <a href="#class-mutually'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-mutually'/index.html">mutually'</a></span><span> : <a href="class-type-mutually/index.html">mutually</a></span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-recursive'">
-    <a href="#class-recursive'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-recursive'/index.html">recursive'</a></span><span> : <a href="class-type-recursive/index.html">recursive</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-recursive'">
+     <a href="#class-recursive'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-recursive'/index.html">recursive'</a></span><span> : <a href="class-type-recursive/index.html">recursive</a></span></code>
+    </div>
    </div>
-   <div class="spec class-type" id="class-type-empty_virtual">
-    <a href="#class-type-empty_virtual" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  </span><span><a href="class-type-empty_virtual/index.html">empty_virtual</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-empty_virtual">
+     <a href="#class-type-empty_virtual" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  </span><span><a href="class-type-empty_virtual/index.html">empty_virtual</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-empty_virtual'">
-    <a href="#class-empty_virtual'" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">virtual</span>  </span><span><a href="class-empty_virtual'/index.html">empty_virtual'</a></span><span> : <a href="class-type-empty/index.html">empty</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-empty_virtual'">
+     <a href="#class-empty_virtual'" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">virtual</span>  </span><span><a href="class-empty_virtual'/index.html">empty_virtual'</a></span><span> : <a href="class-type-empty/index.html">empty</a></span></code>
+    </div>
    </div>
-   <div class="spec class-type" id="class-type-polymorphic">
-    <a href="#class-type-polymorphic" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span> 'a </span><span><a href="class-type-polymorphic/index.html">polymorphic</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-polymorphic">
+     <a href="#class-type-polymorphic" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span> 'a </span><span><a href="class-type-polymorphic/index.html">polymorphic</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-polymorphic'">
-    <a href="#class-polymorphic'" class="anchor"></a><code><span><span class="keyword">class</span> 'a </span><span><a href="class-polymorphic'/index.html">polymorphic'</a></span><span> : <span><span class="type-var">'a</span> <a href="class-type-polymorphic/index.html">polymorphic</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-polymorphic'">
+     <a href="#class-polymorphic'" class="anchor"></a><code><span><span class="keyword">class</span> 'a </span><span><a href="class-polymorphic'/index.html">polymorphic'</a></span><span> : <span><span class="type-var">'a</span> <a href="class-type-polymorphic/index.html">polymorphic</a></span></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/External/index.html
+++ b/test/html/expect/test_package+ml/External/index.html
@@ -23,11 +23,11 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec external" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : <span>unit <span>-&gt;</span></span> unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Foo <em>bar</em>.
      </p>

--- a/test/html/expect/test_package+ml/Functor/index.html
+++ b/test/html/expect/test_package+ml/Functor/index.html
@@ -23,26 +23,40 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S1/index.html">S1</a></span><span> = <span class="keyword">functor</span><span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="module-type-S/index.html">S</a>) <span>-&gt;</span></span> <a href="module-type-S/index.html">S</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S1">
+     <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S1/index.html">S1</a></span><span> = <span class="keyword">functor</span><span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="module-type-S/index.html">S</a>) <span>-&gt;</span></span> <a href="module-type-S/index.html">S</a></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-F1">
-    <a href="#module-F1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F1/index.html">F1</a></span><span> (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <a href="module-type-S/index.html">S</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-F1">
+     <a href="#module-F1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F1/index.html">F1</a></span><span> (<a href="F1/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <a href="module-type-S/index.html">S</a></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-F2">
-    <a href="#module-F2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F2/index.html">F2</a></span><span> (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = <a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-F2">
+     <a href="#module-F2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F2/index.html">F2</a></span><span> (<a href="F2/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = <a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-F3">
-    <a href="#module-F3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F3/index.html">F3</a></span><span> (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-F3">
+     <a href="#module-F3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F3/index.html">F3</a></span><span> (<a href="F3/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-F4">
-    <a href="#module-F4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F4/index.html">F4</a></span><span> (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <a href="module-type-S/index.html">S</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-F4">
+     <a href="#module-F4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F4/index.html">F4</a></span><span> (<a href="F4/argument-1-Arg/index.html">Arg</a> : <a href="module-type-S/index.html">S</a>) : <a href="module-type-S/index.html">S</a></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-F5">
-    <a href="#module-F5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F5/index.html">F5</a></span><span> () : <a href="module-type-S/index.html">S</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-F5">
+     <a href="#module-F5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F5/index.html">F5</a></span><span> () : <a href="module-type-S/index.html">S</a></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Include/index.html
+++ b/test/html/expect/test_package+ml/Include/index.html
@@ -23,112 +23,138 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module-type" id="module-type-Not_inlined">
-    <a href="#module-type-Not_inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined/index.html">Not_inlined</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Not_inlined">
+     <a href="#module-type-Not_inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined/index.html">Not_inlined</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a></span></code></span>
        </summary>
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-t">
+         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Inlined">
-    <a href="#module-type-Inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inlined/index.html">Inlined</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Inlined">
+     <a href="#module-type-Inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inlined/index.html">Inlined</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <div class="spec type" id="type-u">
-       <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
+      <div class="odoc-spec">
+       <div class="spec type" id="type-u">
+        <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
+       </div>
       </div>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Not_inlined_and_closed">
-    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Not_inlined_and_closed">
+     <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details>
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span></code></span>
        </summary>
-       <div class="spec type" id="type-v">
-        <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-v">
+         <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Not_inlined_and_opened">
-    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Not_inlined_and_opened">
+     <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span></code></span>
        </summary>
-       <div class="spec type" id="type-w">
-        <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-w">
+         <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Inherent_Module">
-    <a href="#module-type-Inherent_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Inherent_Module">
+     <a href="#module-type-Inherent_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code></span>
        </summary>
-       <div class="spec value" id="val-a">
-        <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
+       <div class="odoc-spec">
+        <div class="spec value" id="val-a">
+         <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Dorminant_Module">
-    <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Dorminant_Module">
+     <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span></code></span>
        </summary>
-       <div>
+       <div class="odoc-include">
         <div class="spec include">
          <div class="doc">
           <details open="open">
            <summary>
             <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code></span>
            </summary>
-           <div class="spec value" id="val-a">
-            <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
+           <div class="odoc-spec">
+            <div class="spec value" id="val-a">
+             <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
+            </div>
            </div>
           </details>
          </div>
         </div>
        </div>
-       <div class="spec value" id="val-a">
-        <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-u">u</a></span></code>
+       <div class="odoc-spec">
+        <div class="spec value" id="val-a">
+         <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-u">u</a></span></code>
+        </div>
        </div>
       </details>
      </div>

--- a/test/html/expect/test_package+ml/Include2/index.html
+++ b/test/html/expect/test_package+ml/Include2/index.html
@@ -23,25 +23,27 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Comment about X that should not appear when including X below.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <span class="keyword">struct</span> <span class="keyword">include</span> <a href="X/index.html">X</a> <span class="keyword">end</span></span></code></span>
        </summary>
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-t">
+         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span></code>
+        </div>
        </div>
       </details>
      </div>

--- a/test/html/expect/test_package+ml/Include_sections/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/index.html
@@ -70,46 +70,50 @@
    </ul>
   </nav>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Something">
      <a href="#module-type-Something" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Something/index.html">Something</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A module type.
      </p>
     </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Let's include <a href="module-type-Something/index.html"><code>Something</code></a> once
     </p>
    </aside>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <div class="spec value" id="val-something">
-       <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+       </div>
       </div>
       <h2 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h2>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         foo
        </p>
       </aside>
-      <div class="spec value" id="val-foo">
-       <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+       </div>
       </div>
       <h3 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h3>
-      <div>
+      <div class="odoc-spec">
        <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
        </div>
-       <div>
+       <div class="spec-doc">
         <p>
          foo bar
         </p>
@@ -118,7 +122,7 @@
       <h2 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h2>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         Some text.
        </p>
@@ -129,36 +133,40 @@
    <h2 id="second-include">
     <a href="#second-include" class="anchor"></a>Second include
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
     </p>
    </aside>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <div class="spec value" id="val-something">
-       <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+       </div>
       </div>
       <h3 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h3>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         foo
        </p>
       </aside>
-      <div class="spec value" id="val-foo">
-       <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+       </div>
       </div>
       <h4 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h4>
-      <div>
+      <div class="odoc-spec">
        <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
        </div>
-       <div>
+       <div class="spec-doc">
         <p>
          foo bar
         </p>
@@ -167,7 +175,7 @@
       <h3 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h3>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         Some text.
        </p>
@@ -178,36 +186,40 @@
    <h3 id="third-include">
     <a href="#third-include" class="anchor"></a>Third include
    </h3>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Shifted some more.
     </p>
    </aside>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <div class="spec value" id="val-something">
-       <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+       </div>
       </div>
       <h4 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h4>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         foo
        </p>
       </aside>
-      <div class="spec value" id="val-foo">
-       <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+       </div>
       </div>
       <h5 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h5>
-      <div>
+      <div class="odoc-spec">
        <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
        </div>
-       <div>
+       <div class="spec-doc">
         <p>
          foo bar
         </p>
@@ -216,7 +228,7 @@
       <h4 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h4>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         Some text.
        </p>
@@ -224,40 +236,44 @@
      </div>
     </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      And let's include it again, but without inlining it this time: the ToC shouldn't grow.
     </p>
    </aside>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Something/index.html">Something</a></span></code></span>
        </summary>
-       <div class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+       <div class="odoc-spec">
+        <div class="spec value" id="val-something">
+         <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+        </div>
        </div>
        <h2 id="something-1">
         <a href="#something-1" class="anchor"></a>Something 1
        </h2>
-       <aside>
+       <aside class="odoc-unattached">
         <p>
          foo
         </p>
        </aside>
-       <div class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+       <div class="odoc-spec">
+        <div class="spec value" id="val-foo">
+         <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+        </div>
        </div>
        <h3 id="something-2">
         <a href="#something-2" class="anchor"></a>Something 2
        </h3>
-       <div>
+       <div class="odoc-spec">
         <div class="spec value" id="val-bar">
          <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
         </div>
-        <div>
+        <div class="spec-doc">
          <p>
           foo bar
          </p>
@@ -266,7 +282,7 @@
        <h2 id="something-1-bis">
         <a href="#something-1-bis" class="anchor"></a>Something 1-bis
        </h2>
-       <aside>
+       <aside class="odoc-unattached">
         <p>
          Some text.
         </p>

--- a/test/html/expect/test_package+ml/Include_sections/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/index.html
@@ -80,11 +80,9 @@
      </p>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Let's include <a href="module-type-Something/index.html"><code>Something</code></a> once
-    </p>
-   </aside>
+   <p>
+    Let's include <a href="module-type-Something/index.html"><code>Something</code></a> once
+   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
@@ -96,11 +94,9 @@
       <h2 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h2>
-      <aside class="odoc-unattached">
-       <p>
-        foo
-       </p>
-      </aside>
+      <p>
+       foo
+      </p>
       <div class="odoc-spec">
        <div class="spec value" id="val-foo">
         <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
@@ -122,22 +118,18 @@
       <h2 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h2>
-      <aside class="odoc-unattached">
-       <p>
-        Some text.
-       </p>
-      </aside>
+      <p>
+       Some text.
+      </p>
      </div>
     </div>
    </div>
    <h2 id="second-include">
     <a href="#second-include" class="anchor"></a>Second include
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
-    </p>
-   </aside>
+   <p>
+    Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
+   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
@@ -149,11 +141,9 @@
       <h3 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h3>
-      <aside class="odoc-unattached">
-       <p>
-        foo
-       </p>
-      </aside>
+      <p>
+       foo
+      </p>
       <div class="odoc-spec">
        <div class="spec value" id="val-foo">
         <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
@@ -175,22 +165,18 @@
       <h3 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h3>
-      <aside class="odoc-unattached">
-       <p>
-        Some text.
-       </p>
-      </aside>
+      <p>
+       Some text.
+      </p>
      </div>
     </div>
    </div>
    <h3 id="third-include">
     <a href="#third-include" class="anchor"></a>Third include
    </h3>
-   <aside class="odoc-unattached">
-    <p>
-     Shifted some more.
-    </p>
-   </aside>
+   <p>
+    Shifted some more.
+   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
@@ -202,11 +188,9 @@
       <h4 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h4>
-      <aside class="odoc-unattached">
-       <p>
-        foo
-       </p>
-      </aside>
+      <p>
+       foo
+      </p>
       <div class="odoc-spec">
        <div class="spec value" id="val-foo">
         <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
@@ -228,19 +212,15 @@
       <h4 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h4>
-      <aside class="odoc-unattached">
-       <p>
-        Some text.
-       </p>
-      </aside>
+      <p>
+       Some text.
+      </p>
      </div>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     And let's include it again, but without inlining it this time: the ToC shouldn't grow.
-    </p>
-   </aside>
+   <p>
+    And let's include it again, but without inlining it this time: the ToC shouldn't grow.
+   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
@@ -256,11 +236,9 @@
        <h2 id="something-1">
         <a href="#something-1" class="anchor"></a>Something 1
        </h2>
-       <aside class="odoc-unattached">
-        <p>
-         foo
-        </p>
-       </aside>
+       <p>
+        foo
+       </p>
        <div class="odoc-spec">
         <div class="spec value" id="val-foo">
          <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
@@ -282,11 +260,9 @@
        <h2 id="something-1-bis">
         <a href="#something-1-bis" class="anchor"></a>Something 1-bis
        </h2>
-       <aside class="odoc-unattached">
-        <p>
-         Some text.
-        </p>
-       </aside>
+       <p>
+        Some text.
+       </p>
       </details>
      </div>
     </div>

--- a/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
@@ -49,11 +49,9 @@
    <h2 id="something-1">
     <a href="#something-1" class="anchor"></a>Something 1
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     foo
-    </p>
-   </aside>
+   <p>
+    foo
+   </p>
    <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
@@ -75,11 +73,9 @@
    <h2 id="something-1-bis">
     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Some text.
-    </p>
-   </aside>
+   <p>
+    Some text.
+   </p>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
@@ -41,28 +41,32 @@
    </ul>
   </nav>
   <div class="odoc-content">
-   <div class="spec value" id="val-something">
-    <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-something">
+     <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+    </div>
    </div>
    <h2 id="something-1">
     <a href="#something-1" class="anchor"></a>Something 1
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      foo
     </p>
    </aside>
-   <div class="spec value" id="val-foo">
-    <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+    </div>
    </div>
    <h3 id="something-2">
     <a href="#something-2" class="anchor"></a>Something 2
    </h3>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-bar">
      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       foo bar
      </p>
@@ -71,7 +75,7 @@
    <h2 id="something-1-bis">
     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Some text.
     </p>

--- a/test/html/expect/test_package+ml/Interlude/index.html
+++ b/test/html/expect/test_package+ml/Interlude/index.html
@@ -26,11 +26,9 @@
    </p>
   </header>
   <div class="odoc-content">
-   <aside class="odoc-unattached">
-    <p>
-     Some separate stray text at the top of the module.
-    </p>
-   </aside>
+   <p>
+    Some separate stray text at the top of the module.
+   </p>
    <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
@@ -41,17 +39,15 @@
      </p>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Some stray text that is not associated with any signature item.
-    </p>
-    <p>
-     It has multiple paragraphs.
-    </p>
-    <p>
-     A separate block of stray text, adjacent to the preceding one.
-    </p>
-   </aside>
+   <p>
+    Some stray text that is not associated with any signature item.
+   </p>
+   <p>
+    It has multiple paragraphs.
+   </p>
+   <p>
+    A separate block of stray text, adjacent to the preceding one.
+   </p>
    <div class="odoc-spec">
     <div class="spec value" id="val-bar">
      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
@@ -77,11 +73,9 @@
      <a href="#val-items" class="anchor"></a><code><span><span class="keyword">val</span> items : unit</span></code>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Stray text at the bottom of the module.
-    </p>
-   </aside>
+   <p>
+    Stray text at the bottom of the module.
+   </p>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Interlude/index.html
+++ b/test/html/expect/test_package+ml/Interlude/index.html
@@ -26,22 +26,22 @@
    </p>
   </header>
   <div class="odoc-content">
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Some separate stray text at the top of the module.
     </p>
    </aside>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Foo.
      </p>
     </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Some stray text that is not associated with any signature item.
     </p>
@@ -52,26 +52,32 @@
      A separate block of stray text, adjacent to the preceding one.
     </p>
    </aside>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-bar">
      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Bar.
      </p>
     </div>
    </div>
-   <div class="spec value" id="val-multiple">
-    <a href="#val-multiple" class="anchor"></a><code><span><span class="keyword">val</span> multiple : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-multiple">
+     <a href="#val-multiple" class="anchor"></a><code><span><span class="keyword">val</span> multiple : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-signature">
-    <a href="#val-signature" class="anchor"></a><code><span><span class="keyword">val</span> signature : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-signature">
+     <a href="#val-signature" class="anchor"></a><code><span><span class="keyword">val</span> signature : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-items">
-    <a href="#val-items" class="anchor"></a><code><span><span class="keyword">val</span> items : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-items">
+     <a href="#val-items" class="anchor"></a><code><span><span class="keyword">val</span> items : unit</span></code>
+    </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Stray text at the bottom of the module.
     </p>

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -36,62 +36,72 @@
    <h2 id="L2">
     <a href="#L2" class="anchor"></a>Attached to nothing
    </h2>
-   <div class="spec module" id="module-A">
-    <a href="#module-A" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="A/index.html">A</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-A">
+     <a href="#module-A" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="A/index.html">A</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to type
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-f">
      <a href="#val-f" class="anchor"></a><code><span><span class="keyword">val</span> f : <a href="#type-t">t</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to value
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec external" id="val-e">
      <a href="#val-e" class="anchor"></a><code><span><span class="keyword">val</span> e : <span>unit <span>-&gt;</span></span> <a href="#type-t">t</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to external
      </p>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-c">
-    <a href="#class-c" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-c/index.html">c</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-c">
+     <a href="#class-c" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-c/index.html">c</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class-type" id="class-type-cs">
-    <a href="#class-type-cs" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-cs/index.html">cs</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-cs">
+     <a href="#class-type-cs" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-cs/index.html">cs</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-E">
      <a href="#exception-E" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">E</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to exception
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-x">
-    <a href="#type-x" class="anchor"></a><code><span><span class="keyword">type</span> x</span><span> = </span><span>..</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-x">
+     <a href="#type-x" class="anchor"></a><code><span><span class="keyword">type</span> x</span><span> = </span><span>..</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec extension">
      <code><span><span class="keyword">type</span> <a href="#type-x">x</a> += </span></code>
      <table>
@@ -104,68 +114,72 @@
       </tbody>
      </table>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to extension
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-substitution" id="module-S">
      <a href="#module-S" class="anchor"></a><code><span><span class="keyword">module</span> S := <a href="A/index.html">A</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to module subst
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type-subst" id="type-s">
      <a href="#type-s" class="anchor"></a><code><span><span class="keyword">type</span> s</span><span> := <a href="#type-t">t</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to type subst
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-u">
-    <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-u.A'" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-u.A'" class="anchor"></a><code><span>| </span><span><span class="constructor">A'</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         Attached to constructor
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-u">
+     <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-u.A'" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-u.A'" class="anchor"></a><code><span>| </span><span><span class="constructor">A'</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          Attached to constructor
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec type" id="type-v">
-    <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-v.f" class="anchored">
-       <td class="def record field">
-        <a href="#type-v.f" class="anchor"></a><code><span>f : <a href="#type-t">t</a>;</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         Attached to field
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-v">
+     <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-v.f" class="anchored">
+        <td class="def record field">
+         <a href="#type-v.f" class="anchor"></a><code><span>f : <a href="#type-t">t</a>;</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          Attached to field
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span></code>
+    </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Testing that labels can be referenced
     </p>

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -179,52 +179,50 @@
      <code><span>}</span></code>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Testing that labels can be referenced
-    </p>
-    <ul>
-     <li>
-      <a href="#L1">Attached to unit</a>
-     </li>
-     <li>
-      <a href="#L2">Attached to nothing</a>
-     </li>
-     <li>
-      <a href="#L3">Attached to module</a>
-     </li>
-     <li>
-      <a href="#L4">Attached to type</a>
-     </li>
-     <li>
-      <a href="#L5">Attached to value</a>
-     </li>
-     <li>
-      <a href="#L6">Attached to class</a>
-     </li>
-     <li>
-      <a href="#L7">Attached to class type</a>
-     </li>
-     <li>
-      <a href="#L8">Attached to exception</a>
-     </li>
-     <li>
-      <a href="#L9">Attached to extension</a>
-     </li>
-     <li>
-      <a href="#L10">Attached to module subst</a>
-     </li>
-     <li>
-      <a href="#L11">Attached to type subst</a>
-     </li>
-     <li>
-      <a href="#L12">Attached to constructor</a>
-     </li>
-     <li>
-      <a href="#L13">Attached to field</a>
-     </li>
-    </ul>
-   </aside>
+   <p>
+    Testing that labels can be referenced
+   </p>
+   <ul>
+    <li>
+     <a href="#L1">Attached to unit</a>
+    </li>
+    <li>
+     <a href="#L2">Attached to nothing</a>
+    </li>
+    <li>
+     <a href="#L3">Attached to module</a>
+    </li>
+    <li>
+     <a href="#L4">Attached to type</a>
+    </li>
+    <li>
+     <a href="#L5">Attached to value</a>
+    </li>
+    <li>
+     <a href="#L6">Attached to class</a>
+    </li>
+    <li>
+     <a href="#L7">Attached to class type</a>
+    </li>
+    <li>
+     <a href="#L8">Attached to exception</a>
+    </li>
+    <li>
+     <a href="#L9">Attached to extension</a>
+    </li>
+    <li>
+     <a href="#L10">Attached to module subst</a>
+    </li>
+    <li>
+     <a href="#L11">Attached to type subst</a>
+    </li>
+    <li>
+     <a href="#L12">Attached to constructor</a>
+    </li>
+    <li>
+     <a href="#L13">Attached to field</a>
+    </li>
+   </ul>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -83,339 +83,311 @@
    <h2 id="sections">
     <a href="#sections" class="anchor"></a>Sections
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Let's get these done first, because sections will be used to break up the rest of this test.
-    </p>
-    <p>
-     Besides the section heading above, there are also
-    </p>
-   </aside>
+   <p>
+    Let's get these done first, because sections will be used to break up the rest of this test.
+   </p>
+   <p>
+    Besides the section heading above, there are also
+   </p>
    <h3 id="subsection-headings">
     <a href="#subsection-headings" class="anchor"></a>Subsection headings
    </h3>
-   <aside class="odoc-unattached">
-    <p>
-     and
-    </p>
-   </aside>
+   <p>
+    and
+   </p>
    <h4 id="sub-subsection-headings">
     <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings
    </h4>
-   <aside class="odoc-unattached">
-    <p>
-     but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
-    </p>
-   </aside>
+   <p>
+    but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
+   </p>
    <h4 id="anchors">
     <a href="#anchors" class="anchor"></a>Anchors
    </h4>
-   <aside class="odoc-unattached">
-    <p>
-     Sections can have attached <a href="#anchors">Anchors</a>, and it is possible to <a href="#anchors">link</a> to them. Links to section headers should not be set in source code style.
-    </p>
-   </aside>
+   <p>
+    Sections can have attached <a href="#anchors">Anchors</a>, and it is possible to <a href="#anchors">link</a> to them. Links to section headers should not be set in source code style.
+   </p>
    <h5 id="paragraph">
     <a href="#paragraph" class="anchor"></a>Paragraph
    </h5>
-   <aside class="odoc-unattached">
-    <p>
-     Individual paragraphs can have a heading.
-    </p>
-   </aside>
+   <p>
+    Individual paragraphs can have a heading.
+   </p>
    <h6 id="subparagraph">
     <a href="#subparagraph" class="anchor"></a>Subparagraph
    </h6>
-   <aside class="odoc-unattached">
-    <p>
-     Parts of a longer paragraph that can be considered alone can also have headings.
-    </p>
-   </aside>
+   <p>
+    Parts of a longer paragraph that can be considered alone can also have headings.
+   </p>
    <h2 id="styling">
     <a href="#styling" class="anchor"></a>Styling
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
-    </p>
-    <p>
-     Note: <i>In italics <em>emphasis</em> is rendered as normal text while <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in italics.</i> <i>It also work the same in <a href="#">links in italics with <em>emphasis <em class="odd">in</em> emphasis</em>.</a></i>
-    </p>
-    <p>
-     <code>code</code> is a different kind of markup that doesn't allow nested markup.
-    </p>
-    <p>
-     It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.
-    </p>
-    <p>
-     This is also true between <em>non-</em><code>code</code> markup <em>and</em> <code>code</code>.
-    </p>
-    <p>
-     Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.
-    </p>
-   </aside>
+   <p>
+    This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
+   </p>
+   <p>
+    Note: <i>In italics <em>emphasis</em> is rendered as normal text while <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in italics.</i> <i>It also work the same in <a href="#">links in italics with <em>emphasis <em class="odd">in</em> emphasis</em>.</a></i>
+   </p>
+   <p>
+    <code>code</code> is a different kind of markup that doesn't allow nested markup.
+   </p>
+   <p>
+    It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.
+   </p>
+   <p>
+    This is also true between <em>non-</em><code>code</code> markup <em>and</em> <code>code</code>.
+   </p>
+   <p>
+    Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.
+   </p>
    <h2 id="links-and-references">
     <a href="#links-and-references" class="anchor"></a>Links and references
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
-    </p>
-    <p>
-     This is a reference to <a href="#val-foo"><code>foo</code></a>. References can have replacement text: <a href="#val-foo">the value foo</a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="#val-foo"><b>bold</b></a>, <a href="#val-foo"><i>italic</i></a>, <a href="#val-foo"><em>emphasis</em></a>, <a href="#val-foo">super<sup>script</sup></a>, <a href="#val-foo">sub<sub>script</sub></a>, and <a href="#val-foo"><code>code</code></a>. It's also possible to surround a reference in a style: <b><a href="#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.
-    </p>
-   </aside>
+   <p>
+    This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
+   </p>
+   <p>
+    This is a reference to <a href="#val-foo"><code>foo</code></a>. References can have replacement text: <a href="#val-foo">the value foo</a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="#val-foo"><b>bold</b></a>, <a href="#val-foo"><i>italic</i></a>, <a href="#val-foo"><em>emphasis</em></a>, <a href="#val-foo">super<sup>script</sup></a>, <a href="#val-foo">sub<sub>script</sub></a>, and <a href="#val-foo"><code>code</code></a>. It's also possible to surround a reference in a style: <b><a href="#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.
+   </p>
    <h2 id="preformatted-text">
     <a href="#preformatted-text" class="anchor"></a>Preformatted text
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     This is a code block:
-    </p>
-    <pre><code>let foo = ()
+   <p>
+    This is a code block:
+   </p>
+   <pre><code>let foo = ()
 (** There are some nested comments in here, but an unpaired comment
     terminator would terminate the whole doc surrounding comment. It's
     best to keep code blocks no wider than 72 characters. *)
 
 let bar =
   ignore foo</code></pre>
-    <p>
-     There are also verbatim blocks:
-    </p>
-    <pre>The main difference is these don't get syntax highlighting.</pre>
-   </aside>
+   <p>
+    There are also verbatim blocks:
+   </p>
+   <pre>The main difference is these don't get syntax highlighting.</pre>
    <h2 id="lists">
     <a href="#lists" class="anchor"></a>Lists
    </h2>
-   <aside class="odoc-unattached">
-    <ul>
-     <li>
-      This is a
-     </li>
-     <li>
-      shorthand bulleted list,
-     </li>
-     <li>
-      and the paragraphs in each list item support <em>styling</em>.
-     </li>
-    </ul>
-    <ol>
-     <li>
-      This is a
-     </li>
-     <li>
-      shorthand numbered list.
-     </li>
-    </ol>
-    <ul>
-     <li>
-      Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
-     </li>
-    </ul>
-    <p>
-     just creates a paragraph outside the list.
-    </p>
-    <ul>
-     <li>
-      Similarly, inserting a blank line between two list items
-     </li>
-    </ul>
-    <ul>
-     <li>
-      creates two separate lists.
-     </li>
-    </ul>
-    <ul>
-     <li>
-      <p>
-       To get around this limitation, one
-      </p>
-      <p>
-       can use explicitly-delimited lists.
-      </p>
-     </li>
-     <li>
-      This one is bulleted,
-     </li>
-    </ul>
-    <ol>
-     <li>
-      but there is also the numbered variant.
-     </li>
-    </ol>
-    <ul>
-     <li>
-      <ul>
-       <li>
-        lists
-       </li>
-       <li>
-        can be nested
-       </li>
-       <li>
-        and can include references
-       </li>
-       <li>
-        <a href="#val-foo"><code>foo</code></a>
-       </li>
-      </ul>
-     </li>
-    </ul>
-   </aside>
+   <ul>
+    <li>
+     This is a
+    </li>
+    <li>
+     shorthand bulleted list,
+    </li>
+    <li>
+     and the paragraphs in each list item support <em>styling</em>.
+    </li>
+   </ul>
+   <ol>
+    <li>
+     This is a
+    </li>
+    <li>
+     shorthand numbered list.
+    </li>
+   </ol>
+   <ul>
+    <li>
+     Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
+    </li>
+   </ul>
+   <p>
+    just creates a paragraph outside the list.
+   </p>
+   <ul>
+    <li>
+     Similarly, inserting a blank line between two list items
+    </li>
+   </ul>
+   <ul>
+    <li>
+     creates two separate lists.
+    </li>
+   </ul>
+   <ul>
+    <li>
+     <p>
+      To get around this limitation, one
+     </p>
+     <p>
+      can use explicitly-delimited lists.
+     </p>
+    </li>
+    <li>
+     This one is bulleted,
+    </li>
+   </ul>
+   <ol>
+    <li>
+     but there is also the numbered variant.
+    </li>
+   </ol>
+   <ul>
+    <li>
+     <ul>
+      <li>
+       lists
+      </li>
+      <li>
+       can be nested
+      </li>
+      <li>
+       and can include references
+      </li>
+      <li>
+       <a href="#val-foo"><code>foo</code></a>
+      </li>
+     </ul>
+    </li>
+   </ul>
    <h2 id="unicode">
     <a href="#unicode" class="anchor"></a>Unicode
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
-    </p>
-   </aside>
+   <p>
+    The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
+   </p>
    <h2 id="raw-html">
     <a href="#raw-html" class="anchor"></a>Raw HTML
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
-    </p>
-    <blockquote>
-     If the raw HTML is the only thing in a paragraph, it is treated as a block
+   <p>
+    Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
+   </p>
+   <blockquote>
+    If the raw HTML is the only thing in a paragraph, it is treated as a block
       element, and won't be wrapped in paragraph tags by the HTML generator.
-    </blockquote>
-   </aside>
+   </blockquote>
    <h2 id="modules">
     <a href="#modules" class="anchor"></a>Modules
    </h2>
-   <aside class="odoc-unattached">
-    <ul class="modules"></ul>
-    <ul class="modules">
-     <li>
-      <code>X</code>
-     </li>
-    </ul>
-    <ul class="modules">
-     <li>
-      <code>X</code>
-     </li>
-     <li>
-      <code>Y</code>
-     </li>
-     <li>
-      <code>Z</code>
-     </li>
-    </ul>
-   </aside>
+   <ul class="modules"></ul>
+   <ul class="modules">
+    <li>
+     <code>X</code>
+    </li>
+   </ul>
+   <ul class="modules">
+    <li>
+     <code>X</code>
+    </li>
+    <li>
+     <code>Y</code>
+    </li>
+    <li>
+     <code>Z</code>
+    </li>
+   </ul>
    <h2 id="tags">
     <a href="#tags" class="anchor"></a>Tags
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Each comment can end with zero or more tags. Here are some examples:
-    </p>
-    <dl>
-     <dt>
-      author
-     </dt>
-     <dd>
-      antron
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      deprecated
-     </dt>
-     <dd>
-      <p>
-       a <em>long</em> time ago
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      parameter foo
-     </dt>
-     <dd>
-      <p>
-       unused
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      raises Failure
-     </dt>
-     <dd>
-      <p>
-       always
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      returns
-     </dt>
-     <dd>
-      <p>
-       never
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      see <a href="#">#</a>
-     </dt>
-     <dd>
-      <p>
-       this url
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      see <code>foo.ml</code>
-     </dt>
-     <dd>
-      <p>
-       this file
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      see Foo
-     </dt>
-     <dd>
-      <p>
-       this document
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      since
-     </dt>
-     <dd>
-      0
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      before 1.0
-     </dt>
-     <dd>
-      <p>
-       it was in b<sup>e</sup>t<sub>a</sub>
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      version
-     </dt>
-     <dd>
-      -1
-     </dd>
-    </dl>
-   </aside>
+   <p>
+    Each comment can end with zero or more tags. Here are some examples:
+   </p>
+   <dl>
+    <dt>
+     author
+    </dt>
+    <dd>
+     antron
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     deprecated
+    </dt>
+    <dd>
+     <p>
+      a <em>long</em> time ago
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     parameter foo
+    </dt>
+    <dd>
+     <p>
+      unused
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     raises Failure
+    </dt>
+    <dd>
+     <p>
+      always
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     returns
+    </dt>
+    <dd>
+     <p>
+      never
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     see <a href="#">#</a>
+    </dt>
+    <dd>
+     <p>
+      this url
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     see <code>foo.ml</code>
+    </dt>
+    <dd>
+     <p>
+      this file
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     see Foo
+    </dt>
+    <dd>
+     <p>
+      this document
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     since
+    </dt>
+    <dd>
+     0
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     before 1.0
+    </dt>
+    <dd>
+     <p>
+      it was in b<sup>e</sup>t<sub>a</sub>
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     version
+    </dt>
+    <dd>
+     -1
+    </dd>
+   </dl>
    <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -83,7 +83,7 @@
    <h2 id="sections">
     <a href="#sections" class="anchor"></a>Sections
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Let's get these done first, because sections will be used to break up the rest of this test.
     </p>
@@ -94,7 +94,7 @@
    <h3 id="subsection-headings">
     <a href="#subsection-headings" class="anchor"></a>Subsection headings
    </h3>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      and
     </p>
@@ -102,7 +102,7 @@
    <h4 id="sub-subsection-headings">
     <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings
    </h4>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
     </p>
@@ -110,7 +110,7 @@
    <h4 id="anchors">
     <a href="#anchors" class="anchor"></a>Anchors
    </h4>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Sections can have attached <a href="#anchors">Anchors</a>, and it is possible to <a href="#anchors">link</a> to them. Links to section headers should not be set in source code style.
     </p>
@@ -118,7 +118,7 @@
    <h5 id="paragraph">
     <a href="#paragraph" class="anchor"></a>Paragraph
    </h5>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Individual paragraphs can have a heading.
     </p>
@@ -126,7 +126,7 @@
    <h6 id="subparagraph">
     <a href="#subparagraph" class="anchor"></a>Subparagraph
    </h6>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Parts of a longer paragraph that can be considered alone can also have headings.
     </p>
@@ -134,7 +134,7 @@
    <h2 id="styling">
     <a href="#styling" class="anchor"></a>Styling
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
     </p>
@@ -157,7 +157,7 @@
    <h2 id="links-and-references">
     <a href="#links-and-references" class="anchor"></a>Links and references
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
     </p>
@@ -168,7 +168,7 @@
    <h2 id="preformatted-text">
     <a href="#preformatted-text" class="anchor"></a>Preformatted text
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      This is a code block:
     </p>
@@ -187,7 +187,7 @@ let bar =
    <h2 id="lists">
     <a href="#lists" class="anchor"></a>Lists
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <ul>
      <li>
       This is a
@@ -265,7 +265,7 @@ let bar =
    <h2 id="unicode">
     <a href="#unicode" class="anchor"></a>Unicode
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
     </p>
@@ -273,7 +273,7 @@ let bar =
    <h2 id="raw-html">
     <a href="#raw-html" class="anchor"></a>Raw HTML
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
     </p>
@@ -285,7 +285,7 @@ let bar =
    <h2 id="modules">
     <a href="#modules" class="anchor"></a>Modules
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <ul class="modules"></ul>
     <ul class="modules">
      <li>
@@ -307,7 +307,7 @@ let bar =
    <h2 id="tags">
     <a href="#tags" class="anchor"></a>Tags
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Each comment can end with zero or more tags. Here are some examples:
     </p>
@@ -416,11 +416,11 @@ let bar =
      </dd>
     </dl>
    </aside>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.
      </p>

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -26,57 +26,85 @@
    </p>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.
      </p>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span>S1</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S1">
+     <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span>S1</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S2">
-    <a href="#module-type-S2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S2/index.html">S2</a></span><span> = <a href="module-type-S/index.html">S</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S2">
+     <a href="#module-type-S2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S2/index.html">S2</a></span><span> = <a href="module-type-S/index.html">S</a></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S3">
-    <a href="#module-type-S3" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S3/index.html">S3</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = int</span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-u">u</a> = string</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S3">
+     <a href="#module-type-S3" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S3/index.html">S3</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = int</span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-u">u</a> = string</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S4">
-    <a href="#module-type-S4" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S4/index.html">S4</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> := int</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S4">
+     <a href="#module-type-S4" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S4/index.html">S4</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> := int</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S5/index.html">S5</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <span>'a <a href="module-type-S/index.html#type-v">v</a></span> := <span><span class="type-var">'a</span> list</span></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S5">
+     <a href="#module-type-S5" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S5/index.html">S5</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <span>'a <a href="module-type-S/index.html#type-v">v</a></span> := <span><span class="type-var">'a</span> list</span></span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-result">
-    <a href="#type-result" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) result</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-result">
+     <a href="#type-result" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) result</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S6/index.html">S6</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <span>('a, 'b) <a href="module-type-S/index.html#type-w">w</a></span> := <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="#type-result">result</a></span></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S6">
+     <a href="#module-type-S6" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S6/index.html">S6</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <span>('a, 'b) <a href="module-type-S/index.html#type-w">w</a></span> := <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="#type-result">result</a></span></span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-M'">
-    <a href="#module-M'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M'/index.html">M'</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M'">
+     <a href="#module-M'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M'/index.html">M'</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S7">
-    <a href="#module-type-S7" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S7/index.html">S7</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> = <a href="M'/index.html">M'</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S7">
+     <a href="#module-type-S7" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S7/index.html">S7</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> = <a href="M'/index.html">M'</a></span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S8">
-    <a href="#module-type-S8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S8/index.html">S8</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> := <a href="M'/index.html">M'</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S8">
+     <a href="#module-type-S8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S8/index.html">S8</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> := <a href="M'/index.html">M'</a></span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S9">
-    <a href="#module-type-S9" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S9/index.html">S9</a></span><span> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="M'/index.html">M'</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S9">
+     <a href="#module-type-S9" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S9/index.html">S9</a></span><span> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="M'/index.html">M'</a></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Mutually">
-    <a href="#module-Mutually" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Mutually/index.html">Mutually</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Mutually">
+     <a href="#module-Mutually" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Mutually/index.html">Mutually</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Recursive">
-    <a href="#module-Recursive" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recursive/index.html">Recursive</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Recursive">
+     <a href="#module-Recursive" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recursive/index.html">Recursive</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
@@ -36,11 +36,11 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some type.
      </p>
@@ -49,11 +49,11 @@
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span><span class="keyword">val</span> y : <a href="#type-t">t</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       The value of y.
      </p>

--- a/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
@@ -33,11 +33,11 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some type.
      </p>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -45,11 +45,15 @@
    <h2 id="parameters">
     <a href="#parameters" class="anchor"></a>Parameters
    </h2>
-   <div class="spec parameter" id="argument-1-Arg1">
-    <a href="#argument-1-Arg1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="argument-1-Arg1/index.html">Arg1</a></span><span> : <a href="../module-type-Y/index.html">Y</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec parameter" id="argument-1-Arg1">
+     <a href="#argument-1-Arg1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="argument-1-Arg1/index.html">Arg1</a></span><span> : <a href="../module-type-Y/index.html">Y</a></span></code>
+    </div>
    </div>
-   <div class="spec parameter" id="argument-2-Arg2">
-    <a href="#argument-2-Arg2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="argument-2-Arg2/index.html">Arg2</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec parameter" id="argument-2-Arg2">
+     <a href="#argument-2-Arg2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="argument-2-Arg2/index.html">Arg2</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
    <h2 id="signature">
     <a href="#signature" class="anchor"></a>Signature
@@ -57,11 +61,11 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = <a href="argument-1-Arg1/index.html#type-t">Arg1.t</a> * <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some type.
      </p>

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -42,11 +42,11 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some type.
      </p>
@@ -55,11 +55,11 @@
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-x">
      <a href="#val-x" class="anchor"></a><code><span><span class="keyword">val</span> x : <a href="#type-t">t</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       The value of x.
      </p>

--- a/test/html/expect/test_package+ml/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-inherits/index.html
@@ -23,8 +23,10 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec inherit">
-    <code><span><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec inherit">
+     <code><span><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Nested/class-z/index.html
+++ b/test/html/expect/test_package+ml/Nested/class-z/index.html
@@ -36,34 +36,38 @@
    </ul>
   </nav>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec instance-variable" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span><span class="keyword">val</span> y : int</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some value.
      </p>
     </div>
    </div>
-   <div class="spec instance-variable" id="val-y'">
-    <a href="#val-y'" class="anchor"></a><code><span><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y' : int</span></code>
+   <div class="odoc-spec">
+    <div class="spec instance-variable" id="val-y'">
+     <a href="#val-y'" class="anchor"></a><code><span><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y' : int</span></code>
+    </div>
    </div>
    <h2 id="methods">
     <a href="#methods" class="anchor"></a>Methods
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec method" id="method-z">
      <a href="#method-z" class="anchor"></a><code><span><span class="keyword">method</span> z : int</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some method.
      </p>
     </div>
    </div>
-   <div class="spec method" id="method-z'">
-    <a href="#method-z'" class="anchor"></a><code><span><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z' : int</span></code>
+   <div class="odoc-spec">
+    <div class="spec method" id="method-z'">
+     <a href="#method-z'" class="anchor"></a><code><span><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z' : int</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Nested/index.html
+++ b/test/html/expect/test_package+ml/Nested/index.html
@@ -45,11 +45,11 @@
    <h2 id="module">
     <a href="#module" class="anchor"></a>Module
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is module X.
      </p>
@@ -58,11 +58,11 @@
    <h2 id="module-type">
     <a href="#module-type" class="anchor"></a>Module type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Y">
      <a href="#module-type-Y" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Y/index.html">Y</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is module type Y.
      </p>
@@ -71,11 +71,11 @@
    <h2 id="functor">
     <a href="#functor" class="anchor"></a>Functor
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-F">
      <a href="#module-F" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F/index.html">F</a></span><span> (<a href="F/argument-1-Arg1/index.html">Arg1</a> : <a href="module-type-Y/index.html">Y</a>) (<a href="F/argument-2-Arg2/index.html">Arg2</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is a functor F.
      </p>
@@ -84,18 +84,20 @@
    <h2 id="class">
     <a href="#class" class="anchor"></a>Class
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec class" id="class-z">
      <a href="#class-z" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">virtual</span>  </span><span><a href="class-z/index.html">z</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is class z.
      </p>
     </div>
    </div>
-   <div class="spec class" id="class-inherits">
-    <a href="#class-inherits" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">virtual</span>  </span><span><a href="class-inherits/index.html">inherits</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-inherits">
+     <a href="#class-inherits" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">virtual</span>  </span><span><a href="class-inherits/index.html">inherits</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -42,11 +42,11 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some type.
      </p>
@@ -55,11 +55,11 @@
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span><span class="keyword">val</span> y : <a href="#type-t">t</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       The value of y.
      </p>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -155,51 +155,49 @@
    </ul>
   </nav>
   <div class="odoc-content">
-   <aside class="odoc-unattached">
-    <p>
-     You may find more information about this HTML documentation renderer at <a href="https://github.com/dsheets/ocamlary">github.com/dsheets/ocamlary</a>.
-    </p>
-    <p>
-     This is some verbatim text:
-    </p>
-    <pre>verbatim</pre>
-    <p>
-     This is some verbatim text:
-    </p>
-    <pre>[][df[]]}}</pre>
-    <p>
-     Here is some raw LaTeX: <code> $e^{i\pi} = -1$ </code>
-    </p>
-    <p>
-     Here is an index table of <code>Empty</code> modules:
-    </p>
-    <ul class="modules">
-     <li>
-      <a href="Empty/index.html"><code>Empty</code></a>
-     </li>
-     <li>
-      <a href="Empty/index.html"><code>EmptyAlias</code></a>
-     </li>
-    </ul>
-    <p>
-     Here is a table of links to indexes: <code>indexlist</code>
-    </p>
-    <p>
-     Here is some superscript: x<sup>2</sup>
-    </p>
-    <p>
-     Here is some subscript: x<sub>0</sub>
-    </p>
-    <p>
-     Here are some escaped brackets: { [ @ ] }
-    </p>
-    <p>
-     Here is some <em>emphasis</em> <code>followed by code</code>.
-    </p>
-    <p>
-     An unassociated comment
-    </p>
-   </aside>
+   <p>
+    You may find more information about this HTML documentation renderer at <a href="https://github.com/dsheets/ocamlary">github.com/dsheets/ocamlary</a>.
+   </p>
+   <p>
+    This is some verbatim text:
+   </p>
+   <pre>verbatim</pre>
+   <p>
+    This is some verbatim text:
+   </p>
+   <pre>[][df[]]}}</pre>
+   <p>
+    Here is some raw LaTeX: <code> $e^{i\pi} = -1$ </code>
+   </p>
+   <p>
+    Here is an index table of <code>Empty</code> modules:
+   </p>
+   <ul class="modules">
+    <li>
+     <a href="Empty/index.html"><code>Empty</code></a>
+    </li>
+    <li>
+     <a href="Empty/index.html"><code>EmptyAlias</code></a>
+    </li>
+   </ul>
+   <p>
+    Here is a table of links to indexes: <code>indexlist</code>
+   </p>
+   <p>
+    Here is some superscript: x<sup>2</sup>
+   </p>
+   <p>
+    Here is some subscript: x<sub>0</sub>
+   </p>
+   <p>
+    Here are some escaped brackets: { [ @ ] }
+   </p>
+   <p>
+    Here is some <em>emphasis</em> <code>followed by code</code>.
+   </p>
+   <p>
+    An unassociated comment
+   </p>
    <h2 id="level-1">
     <a href="#level-1" class="anchor"></a>Level 1
    </h2>
@@ -321,11 +319,9 @@
      <a href="#module-type-SuperSig" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-SuperSig/index.html">SuperSig</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     For a good time, see <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a> or <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigB:subSig</code></a> or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="#s9000">Level 9000</a> is also interesting. <a href="#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
-    </p>
-   </aside>
+   <p>
+    For a good time, see <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a> or <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigB:subSig</code></a> or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="#s9000">Level 9000</a> is also interesting. <a href="#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
+   </p>
    <div class="odoc-spec">
     <div class="spec module" id="module-Buffer">
      <a href="#module-Buffer" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Buffer/index.html">Buffer</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
@@ -336,19 +332,15 @@
      </p>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Some text before exception title.
-    </p>
-   </aside>
+   <p>
+    Some text before exception title.
+   </p>
    <h4 id="basic-exception-stuff">
     <a href="#basic-exception-stuff" class="anchor"></a>Basic exception stuff
    </h4>
-   <aside class="odoc-unattached">
-    <p>
-     After exception title.
-    </p>
-   </aside>
+   <p>
+    After exception title.
+   </p>
    <div class="odoc-spec">
     <div class="spec exception" id="exception-Kaboom">
      <a href="#exception-Kaboom" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Kaboom</span> <span class="keyword">of</span> unit</span></code>
@@ -1872,44 +1864,40 @@
    <h2 id="indexmodules">
     <a href="#indexmodules" class="anchor"></a>Trying the {!modules: ...} command.
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     With ocamldoc, toplevel units will be linked and documented, while submodules will behave as simple references.
-    </p>
-    <p>
-     With odoc, everything should be resolved (and linked) but only toplevel units will be documented.
-    </p>
-    <ul class="modules">
-     <li>
-      <a href="Dep1/X/index.html"><code>Dep1.X</code></a>
-     </li>
-     <li>
-      <code>DocOckTypes</code>
-     </li>
-     <li>
-      <a href="IncludeInclude1/index.html"><code>Ocamlary.IncludeInclude1</code></a>
-     </li>
-     <li>
-      <a href="#"><code>Ocamlary</code></a>
-     </li>
-    </ul>
-   </aside>
+   <p>
+    With ocamldoc, toplevel units will be linked and documented, while submodules will behave as simple references.
+   </p>
+   <p>
+    With odoc, everything should be resolved (and linked) but only toplevel units will be documented.
+   </p>
+   <ul class="modules">
+    <li>
+     <a href="Dep1/X/index.html"><code>Dep1.X</code></a>
+    </li>
+    <li>
+     <code>DocOckTypes</code>
+    </li>
+    <li>
+     <a href="IncludeInclude1/index.html"><code>Ocamlary.IncludeInclude1</code></a>
+    </li>
+    <li>
+     <a href="#"><code>Ocamlary</code></a>
+    </li>
+   </ul>
    <h4 id="weirder-usages-involving-module-types">
     <a href="#weirder-usages-involving-module-types" class="anchor"></a>Weirder usages involving module types
    </h4>
-   <aside class="odoc-unattached">
-    <ul class="modules">
-     <li>
-      <code>IncludeInclude1</code>.IncludeInclude2
-     </li>
-     <li>
-      <code>Dep4</code>.T
-     </li>
-     <li>
-      <a href="module-type-A/Q/index.html"><code>A.Q</code></a>
-     </li>
-    </ul>
-   </aside>
+   <ul class="modules">
+    <li>
+     <code>IncludeInclude1</code>.IncludeInclude2
+    </li>
+    <li>
+     <code>Dep4</code>.T
+    </li>
+    <li>
+     <a href="module-type-A/Q/index.html"><code>A.Q</code></a>
+    </li>
+   </ul>
    <h2 id="playing-with-@canonical-paths">
     <a href="#playing-with-@canonical-paths" class="anchor"></a>Playing with @canonical paths
    </h2>
@@ -1939,47 +1927,45 @@
    <h2 id="section-title-splicing">
     <a href="#section-title-splicing" class="anchor"></a>Section title splicing
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     I can refer to
-    </p>
-    <ul>
-     <li>
-      <code>{!section:indexmodules}</code> : <a href="#indexmodules">Trying the {!modules: ...} command.</a>
-     </li>
-     <li>
-      <code>{!aliases}</code> : <a href="#aliases">Aliases again</a>
-     </li>
-    </ul>
-    <p>
-     But also to things in submodules:
-    </p>
-    <ul>
-     <li>
-      <code>{!section:SuperSig.SubSigA.subSig}</code> : <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a>
-     </li>
-     <li>
-      <code>{!Aliases.incl}</code> : <a href="#incl"><code>Aliases:incl</code></a>
-     </li>
-    </ul>
-    <p>
-     And just to make sure we do not mess up:
-    </p>
-    <ul>
-     <li>
-      <code>{{!section:indexmodules}A}</code> : <a href="#indexmodules">A</a>
-     </li>
-     <li>
-      <code>{{!aliases}B}</code> : <a href="#aliases">B</a>
-     </li>
-     <li>
-      <code>{{!section:SuperSig.SubSigA.subSig}C}</code> : <a href="module-type-SuperSig/index.html#subSig">C</a>
-     </li>
-     <li>
-      <code>{{!Aliases.incl}D}</code> : <a href="#incl">D</a>
-     </li>
-    </ul>
-   </aside>
+   <p>
+    I can refer to
+   </p>
+   <ul>
+    <li>
+     <code>{!section:indexmodules}</code> : <a href="#indexmodules">Trying the {!modules: ...} command.</a>
+    </li>
+    <li>
+     <code>{!aliases}</code> : <a href="#aliases">Aliases again</a>
+    </li>
+   </ul>
+   <p>
+    But also to things in submodules:
+   </p>
+   <ul>
+    <li>
+     <code>{!section:SuperSig.SubSigA.subSig}</code> : <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a>
+    </li>
+    <li>
+     <code>{!Aliases.incl}</code> : <a href="#incl"><code>Aliases:incl</code></a>
+    </li>
+   </ul>
+   <p>
+    And just to make sure we do not mess up:
+   </p>
+   <ul>
+    <li>
+     <code>{{!section:indexmodules}A}</code> : <a href="#indexmodules">A</a>
+    </li>
+    <li>
+     <code>{{!aliases}B}</code> : <a href="#aliases">B</a>
+    </li>
+    <li>
+     <code>{{!section:SuperSig.SubSigA.subSig}C}</code> : <a href="module-type-SuperSig/index.html#subSig">C</a>
+    </li>
+    <li>
+     <code>{{!Aliases.incl}D}</code> : <a href="#incl">D</a>
+    </li>
+   </ul>
    <h2 id="new-reference-syntax">
     <a href="#new-reference-syntax" class="anchor"></a>New reference syntax
    </h2>
@@ -1993,43 +1979,39 @@
      <a href="#module-M" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M/index.html">M</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Here goes:
-    </p>
-    <ul>
-     <li>
-      <code>{!M.t}</code> : <a href="M/index.html#type-t"><code>M.t</code></a>
-     </li>
-     <li>
-      <code>{!module-M.t}</code> : <a href="M/index.html#type-t"><code>M.t</code></a>
-     </li>
-     <li>
-      <code>{!module-type-M.t}</code> : <a href="module-type-M/index.html#type-t"><code>M.t</code></a>
-     </li>
-    </ul>
-   </aside>
+   <p>
+    Here goes:
+   </p>
+   <ul>
+    <li>
+     <code>{!M.t}</code> : <a href="M/index.html#type-t"><code>M.t</code></a>
+    </li>
+    <li>
+     <code>{!module-M.t}</code> : <a href="M/index.html#type-t"><code>M.t</code></a>
+    </li>
+    <li>
+     <code>{!module-type-M.t}</code> : <a href="module-type-M/index.html#type-t"><code>M.t</code></a>
+    </li>
+   </ul>
    <div class="odoc-spec">
     <div class="spec module" id="module-Only_a_module">
      <a href="#module-Only_a_module" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Only_a_module/index.html">Only_a_module</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Some here should fail:
-    </p>
-    <ul>
-     <li>
-      <code>{!Only_a_module.t}</code> : <a href="Only_a_module/index.html#type-t"><code>Only_a_module.t</code></a>
-     </li>
-     <li>
-      <code>{!module-Only_a_module.t}</code> : <a href="Only_a_module/index.html#type-t"><code>Only_a_module.t</code></a>
-     </li>
-     <li>
-      <code>{!module-type-Only_a_module.t}</code> : <code>Only_a_module</code>.t : <span class="xref-unresolved">test</span>
-     </li>
-    </ul>
-   </aside>
+   <p>
+    Some here should fail:
+   </p>
+   <ul>
+    <li>
+     <code>{!Only_a_module.t}</code> : <a href="Only_a_module/index.html#type-t"><code>Only_a_module.t</code></a>
+    </li>
+    <li>
+     <code>{!module-Only_a_module.t}</code> : <a href="Only_a_module/index.html#type-t"><code>Only_a_module.t</code></a>
+    </li>
+    <li>
+     <code>{!module-type-Only_a_module.t}</code> : <code>Only_a_module</code>.t : <span class="xref-unresolved">test</span>
+    </li>
+   </ul>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-TypeExt">
      <a href="#module-type-TypeExt" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-TypeExt/index.html">TypeExt</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -155,7 +155,7 @@
    </ul>
   </nav>
   <div class="odoc-content">
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      You may find more information about this HTML documentation renderer at <a href="https://github.com/dsheets/ocamlary">github.com/dsheets/ocamlary</a>.
     </p>
@@ -215,31 +215,31 @@
    <h4 id="basic-module-stuff">
     <a href="#basic-module-stuff" class="anchor"></a>Basic module stuff
    </h4>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-Empty">
      <a href="#module-Empty" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Empty/index.html">Empty</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain, empty module
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Empty">
      <a href="#module-type-Empty" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Empty/index.html">Empty</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       An ambiguous, misnamed module type
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-MissingComment">
      <a href="#module-type-MissingComment" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-MissingComment/index.html">MissingComment</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       An ambiguous, misnamed module type
      </p>
@@ -248,11 +248,11 @@
    <h6 id="s9000">
     <a href="#s9000" class="anchor"></a>Level 9000
    </h6>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-EmptyAlias">
      <a href="#module-EmptyAlias" class="anchor"></a><code><span><span class="keyword">module</span> </span><span>EmptyAlias</span><span> = <a href="Empty/index.html">Empty</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain module alias of <code>Empty</code>
      </p>
@@ -261,78 +261,82 @@
    <h4 id="emptySig">
     <a href="#emptySig" class="anchor"></a>EmptySig
    </h4>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-EmptySig">
      <a href="#module-type-EmptySig" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-EmptySig/index.html">EmptySig</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain, empty module signature
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-EmptySigAlias">
      <a href="#module-type-EmptySigAlias" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-EmptySigAlias/index.html">EmptySigAlias</a></span><span> = <a href="module-type-EmptySig/index.html">EmptySig</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain, empty module signature alias of
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-ModuleWithSignature">
      <a href="#module-ModuleWithSignature" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="ModuleWithSignature/index.html">ModuleWithSignature</a></span><span> : <a href="module-type-EmptySig/index.html">EmptySig</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain module of a signature of <a href="#exception-EmptySig"><code>EmptySig</code></a> (reference)
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-ModuleWithSignatureAlias">
      <a href="#module-ModuleWithSignatureAlias" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="ModuleWithSignatureAlias/index.html">ModuleWithSignatureAlias</a></span><span> : <a href="module-type-EmptySigAlias/index.html">EmptySigAlias</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain module with an alias signature
      </p>
     </div>
    </div>
-   <div class="spec module" id="module-One">
-    <a href="#module-One" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="One/index.html">One</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-One">
+     <a href="#module-One" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="One/index.html">One</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-SigForMod">
      <a href="#module-type-SigForMod" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-SigForMod/index.html">SigForMod</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       There's a signature in a module in this signature.
      </p>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-SuperSig">
-    <a href="#module-type-SuperSig" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-SuperSig/index.html">SuperSig</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-SuperSig">
+     <a href="#module-type-SuperSig" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-SuperSig/index.html">SuperSig</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      For a good time, see <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a> or <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigB:subSig</code></a> or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="#s9000">Level 9000</a> is also interesting. <a href="#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
     </p>
    </aside>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-Buffer">
      <a href="#module-Buffer" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Buffer/index.html">Buffer</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       <code>Buffer</code>.t
      </p>
     </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Some text before exception title.
     </p>
@@ -340,56 +344,56 @@
    <h4 id="basic-exception-stuff">
     <a href="#basic-exception-stuff" class="anchor"></a>Basic exception stuff
    </h4>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      After exception title.
     </p>
    </aside>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-Kaboom">
      <a href="#exception-Kaboom" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Kaboom</span> <span class="keyword">of</span> unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Unary exception constructor
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-Kablam">
      <a href="#exception-Kablam" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Kablam</span> <span class="keyword">of</span> unit * unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Binary exception constructor
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-Kapow">
      <a href="#exception-Kapow" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Kapow</span> <span class="keyword">of</span> unit * unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Unary exception constructor over binary tuple
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-EmptySig">
      <a href="#exception-EmptySig" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">EmptySig</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       <a href="#exception-EmptySig"><code>EmptySig</code></a> is general but <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is a module and <a href="#exception-EmptySig"><code>EmptySig</code></a> is this exception.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-EmptySigAlias">
      <a href="#exception-EmptySigAlias" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">EmptySigAlias</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       <a href="#exception-EmptySigAlias"><code>EmptySigAlias</code></a> is this exception.
      </p>
@@ -398,21 +402,21 @@
    <h4 id="basic-type-and-value-stuff-with-advanced-doc-comments">
     <a href="#basic-type-and-value-stuff-with-advanced-doc-comments" class="anchor"></a>Basic type and value stuff with advanced doc comments
    </h4>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-a_function">
      <a href="#type-a_function" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) a_function</span></span><span> = <span><span class="type-var">'a</span> <span>-&gt;</span></span> <span class="type-var">'b</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       <a href="#val-a_function"><code>a_function</code></a> is general but <a href="#type-a_function"><code>a_function</code></a> is this type and <a href="#val-a_function"><code>a_function</code></a> is the value below.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-a_function">
      <a href="#val-a_function" class="anchor"></a><code><span><span class="keyword">val</span> a_function : <span>x:int <span>-&gt;</span></span> int</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is <code>a_function</code> with param and return type.
      </p>
@@ -438,17 +442,21 @@
      </dl>
     </div>
    </div>
-   <div class="spec value" id="val-fun_fun_fun">
-    <a href="#val-fun_fun_fun" class="anchor"></a><code><span><span class="keyword">val</span> fun_fun_fun : <span><span>(<span><span>(int,&nbsp;int)</span> <a href="#type-a_function">a_function</a></span>,&nbsp;<span><span>(unit,&nbsp;unit)</span> <a href="#type-a_function">a_function</a></span>)</span> <a href="#type-a_function">a_function</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-fun_fun_fun">
+     <a href="#val-fun_fun_fun" class="anchor"></a><code><span><span class="keyword">val</span> fun_fun_fun : <span><span>(<span><span>(int,&nbsp;int)</span> <a href="#type-a_function">a_function</a></span>,&nbsp;<span><span>(unit,&nbsp;unit)</span> <a href="#type-a_function">a_function</a></span>)</span> <a href="#type-a_function">a_function</a></span></span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-fun_maybe">
-    <a href="#val-fun_maybe" class="anchor"></a><code><span><span class="keyword">val</span> fun_maybe : <span>?⁠yes:unit <span>-&gt;</span></span> <span>unit <span>-&gt;</span></span> int</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-fun_maybe">
+     <a href="#val-fun_maybe" class="anchor"></a><code><span><span class="keyword">val</span> fun_maybe : <span>?⁠yes:unit <span>-&gt;</span></span> <span>unit <span>-&gt;</span></span> int</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-not_found">
      <a href="#val-not_found" class="anchor"></a><code><span><span class="keyword">val</span> not_found : <span>unit <span>-&gt;</span></span> unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <dl>
       <dt>
        raises Not_found
@@ -461,11 +469,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-ocaml_org">
      <a href="#val-ocaml_org" class="anchor"></a><code><span><span class="keyword">val</span> ocaml_org : string</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <dl>
       <dt>
        see <a href="http://ocaml.org/">http://ocaml.org/</a>
@@ -478,11 +486,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-some_file">
      <a href="#val-some_file" class="anchor"></a><code><span><span class="keyword">val</span> some_file : string</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <dl>
       <dt>
        see <code>some_file</code>
@@ -495,11 +503,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-some_doc">
      <a href="#val-some_doc" class="anchor"></a><code><span><span class="keyword">val</span> some_doc : string</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <dl>
       <dt>
        see some_doc
@@ -512,11 +520,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-since_mesozoic">
      <a href="#val-since_mesozoic" class="anchor"></a><code><span><span class="keyword">val</span> since_mesozoic : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This value was introduced in the Mesozoic era.
      </p>
@@ -530,11 +538,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-changing">
      <a href="#val-changing" class="anchor"></a><code><span><span class="keyword">val</span> changing : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This value has had changes in 1.0.0, 1.1.0, and 1.2.0.
      </p>
@@ -568,11 +576,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-with_foo">
      <a href="#val-with_foo" class="anchor"></a><code><span><span class="keyword">val</span> with_foo : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This value has a custom tag <code>foo</code>. @foo the body of the custom <code>foo</code> tag
      </p>
@@ -581,134 +589,180 @@
    <h4 id="some-operators">
     <a href="#some-operators" class="anchor"></a>Some Operators
    </h4>
-   <div class="spec value" id="val-(~-)">
-    <a href="#val-(~-)" class="anchor"></a><code><span><span class="keyword">val</span> (~-) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(~-)">
+     <a href="#val-(~-)" class="anchor"></a><code><span><span class="keyword">val</span> (~-) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(!)">
-    <a href="#val-(!)" class="anchor"></a><code><span><span class="keyword">val</span> (!) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(!)">
+     <a href="#val-(!)" class="anchor"></a><code><span><span class="keyword">val</span> (!) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(@)">
-    <a href="#val-(@)" class="anchor"></a><code><span><span class="keyword">val</span> (@) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(@)">
+     <a href="#val-(@)" class="anchor"></a><code><span><span class="keyword">val</span> (@) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-($)">
-    <a href="#val-($)" class="anchor"></a><code><span><span class="keyword">val</span> ($) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-($)">
+     <a href="#val-($)" class="anchor"></a><code><span><span class="keyword">val</span> ($) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(%)">
-    <a href="#val-(%)" class="anchor"></a><code><span><span class="keyword">val</span> (%) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(%)">
+     <a href="#val-(%)" class="anchor"></a><code><span><span class="keyword">val</span> (%) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(&amp;)">
-    <a href="#val-(&amp;)" class="anchor"></a><code><span><span class="keyword">val</span> (&amp;) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(&amp;)">
+     <a href="#val-(&amp;)" class="anchor"></a><code><span><span class="keyword">val</span> (&amp;) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(*)">
-    <a href="#val-(*)" class="anchor"></a><code><span><span class="keyword">val</span> (*) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(*)">
+     <a href="#val-(*)" class="anchor"></a><code><span><span class="keyword">val</span> (*) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(-)">
-    <a href="#val-(-)" class="anchor"></a><code><span><span class="keyword">val</span> (-) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(-)">
+     <a href="#val-(-)" class="anchor"></a><code><span><span class="keyword">val</span> (-) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(+)">
-    <a href="#val-(+)" class="anchor"></a><code><span><span class="keyword">val</span> (+) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(+)">
+     <a href="#val-(+)" class="anchor"></a><code><span><span class="keyword">val</span> (+) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(-?)">
-    <a href="#val-(-?)" class="anchor"></a><code><span><span class="keyword">val</span> (-?) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(-?)">
+     <a href="#val-(-?)" class="anchor"></a><code><span><span class="keyword">val</span> (-?) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(/)">
-    <a href="#val-(/)" class="anchor"></a><code><span><span class="keyword">val</span> (/) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(/)">
+     <a href="#val-(/)" class="anchor"></a><code><span><span class="keyword">val</span> (/) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(:=)">
-    <a href="#val-(:=)" class="anchor"></a><code><span><span class="keyword">val</span> (:=) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(:=)">
+     <a href="#val-(:=)" class="anchor"></a><code><span><span class="keyword">val</span> (:=) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(=)">
-    <a href="#val-(=)" class="anchor"></a><code><span><span class="keyword">val</span> (=) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(=)">
+     <a href="#val-(=)" class="anchor"></a><code><span><span class="keyword">val</span> (=) : unit</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(land)">
-    <a href="#val-(land)" class="anchor"></a><code><span><span class="keyword">val</span> (land) : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(land)">
+     <a href="#val-(land)" class="anchor"></a><code><span><span class="keyword">val</span> (land) : unit</span></code>
+    </div>
    </div>
    <h4 id="advanced-module-stuff">
     <a href="#advanced-module-stuff" class="anchor"></a>Advanced Module Stuff
    </h4>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-CollectionModule">
      <a href="#module-CollectionModule" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="CollectionModule/index.html">CollectionModule</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>CollectionModule</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-COLLECTION">
      <a href="#module-type-COLLECTION" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-COLLECTION/index.html">COLLECTION</a></span><span> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="CollectionModule/index.html">CollectionModule</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       module type of
      </p>
     </div>
    </div>
-   <div class="spec module" id="module-Recollection">
-    <a href="#module-Recollection" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recollection/index.html">Recollection</a></span><span> (<a href="Recollection/argument-1-C/index.html">C</a> : <a href="module-type-COLLECTION/index.html">COLLECTION</a>) : <a href="module-type-COLLECTION/index.html">COLLECTION</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-collection">collection</a> = <span><a href="Recollection/argument-1-C/index.html#type-element">C.element</a> list</span></span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-element">element</a> = <a href="Recollection/argument-1-C/index.html#type-collection">C.collection</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Recollection">
+     <a href="#module-Recollection" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recollection/index.html">Recollection</a></span><span> (<a href="Recollection/argument-1-C/index.html">C</a> : <a href="module-type-COLLECTION/index.html">COLLECTION</a>) : <a href="module-type-COLLECTION/index.html">COLLECTION</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-collection">collection</a> = <span><a href="Recollection/argument-1-C/index.html#type-element">C.element</a> list</span></span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-element">element</a> = <a href="Recollection/argument-1-C/index.html#type-collection">C.collection</a></span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-MMM">
-    <a href="#module-type-MMM" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-MMM/index.html">MMM</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-MMM">
+     <a href="#module-type-MMM" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-MMM/index.html">MMM</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-RECOLLECTION">
-    <a href="#module-type-RECOLLECTION" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-RECOLLECTION/index.html">RECOLLECTION</a></span><span> = <a href="module-type-MMM/index.html">MMM</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-MMM/C/index.html">C</a> = <a href="Recollection/index.html">Recollection(CollectionModule)</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-RECOLLECTION">
+     <a href="#module-type-RECOLLECTION" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-RECOLLECTION/index.html">RECOLLECTION</a></span><span> = <a href="module-type-MMM/index.html">MMM</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-MMM/C/index.html">C</a> = <a href="Recollection/index.html">Recollection(CollectionModule)</a></span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-RecollectionModule">
-    <a href="#module-type-RecollectionModule" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-RecollectionModule/index.html">RecollectionModule</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-RecollectionModule">
+     <a href="#module-type-RecollectionModule" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-RecollectionModule/index.html">RecollectionModule</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-A">
-    <a href="#module-type-A" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-A/index.html">A</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-A">
+     <a href="#module-type-A" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-A/index.html">A</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-B">
-    <a href="#module-type-B" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-B/index.html">B</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-B">
+     <a href="#module-type-B" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-B/index.html">B</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-C">
      <a href="#module-type-C" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-C/index.html">C</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This module type includes two signatures.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-FunctorTypeOf">
      <a href="#module-FunctorTypeOf" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="FunctorTypeOf/index.html">FunctorTypeOf</a></span><span> (<a href="FunctorTypeOf/argument-1-Collection/index.html">Collection</a> : <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="CollectionModule/index.html">CollectionModule</a>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>FunctorTypeOf</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-IncludeModuleType">
      <a href="#module-type-IncludeModuleType" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludeModuleType/index.html">IncludeModuleType</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>IncludeModuleType</code>.
      </p>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-ToInclude">
-    <a href="#module-type-ToInclude" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-ToInclude/index.html">ToInclude</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-ToInclude">
+     <a href="#module-type-ToInclude" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-ToInclude/index.html">ToInclude</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-ToInclude/index.html">ToInclude</a></span></code></span>
        </summary>
-       <div class="spec module" id="module-IncludedA">
-        <a href="#module-IncludedA" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludedA/index.html">IncludedA</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+       <div class="odoc-spec">
+        <div class="spec module" id="module-IncludedA">
+         <a href="#module-IncludedA" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludedA/index.html">IncludedA</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+        </div>
        </div>
-       <div class="spec module-type" id="module-type-IncludedB">
-        <a href="#module-type-IncludedB" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludedB/index.html">IncludedB</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+       <div class="odoc-spec">
+        <div class="spec module-type" id="module-type-IncludedB">
+         <a href="#module-type-IncludedB" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludedB/index.html">IncludedB</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+        </div>
        </div>
       </details>
      </div>
@@ -717,7 +771,7 @@
    <h4 id="advanced-type-stuff">
     <a href="#advanced-type-stuff" class="anchor"></a>Advanced Type Stuff
    </h4>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-record">
      <a href="#type-record" class="anchor"></a><code><span><span class="keyword">type</span> record</span><span> = </span><span>{</span></code>
      <table>
@@ -746,7 +800,7 @@
      </table>
      <code><span>}</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>record</code>.
      </p>
@@ -755,58 +809,62 @@
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-mutable_record">
-    <a href="#type-mutable_record" class="anchor"></a><code><span><span class="keyword">type</span> mutable_record</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-mutable_record.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-mutable_record.a" class="anchor"></a><code><span><span class="keyword">mutable</span> a : int;</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <code>a</code> is first and mutable
-        </p>
-       </td>
-      </tr>
-      <tr id="type-mutable_record.b" class="anchored">
-       <td class="def record field">
-        <a href="#type-mutable_record.b" class="anchor"></a><code><span>b : unit;</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <code>b</code> is second and immutable
-        </p>
-       </td>
-      </tr>
-      <tr id="type-mutable_record.c" class="anchored">
-       <td class="def record field">
-        <a href="#type-mutable_record.c" class="anchor"></a><code><span><span class="keyword">mutable</span> c : int;</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <code>c</code> is third and mutable
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-mutable_record">
+     <a href="#type-mutable_record" class="anchor"></a><code><span><span class="keyword">type</span> mutable_record</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-mutable_record.a" class="anchored">
+        <td class="def record field">
+         <a href="#type-mutable_record.a" class="anchor"></a><code><span><span class="keyword">mutable</span> a : int;</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <code>a</code> is first and mutable
+         </p>
+        </td>
+       </tr>
+       <tr id="type-mutable_record.b" class="anchored">
+        <td class="def record field">
+         <a href="#type-mutable_record.b" class="anchor"></a><code><span>b : unit;</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <code>b</code> is second and immutable
+         </p>
+        </td>
+       </tr>
+       <tr id="type-mutable_record.c" class="anchored">
+        <td class="def record field">
+         <a href="#type-mutable_record.c" class="anchor"></a><code><span><span class="keyword">mutable</span> c : int;</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <code>c</code> is third and mutable
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-universe_record">
-    <a href="#type-universe_record" class="anchor"></a><code><span><span class="keyword">type</span> universe_record</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-universe_record.nihilate" class="anchored">
-       <td class="def record field">
-        <a href="#type-universe_record.nihilate" class="anchor"></a><code><span>nihilate : a. <span><span class="type-var">'a</span> <span>-&gt;</span></span> unit;</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-universe_record">
+     <a href="#type-universe_record" class="anchor"></a><code><span><span class="keyword">type</span> universe_record</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-universe_record.nihilate" class="anchored">
+        <td class="def record field">
+         <a href="#type-universe_record.nihilate" class="anchor"></a><code><span>nihilate : a. <span><span class="type-var">'a</span> <span>-&gt;</span></span> unit;</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-variant">
      <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
      <table>
@@ -854,7 +912,7 @@
       </tbody>
      </table>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>variant</code>.
      </p>
@@ -863,7 +921,7 @@
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-poly_variant">
      <a href="#type-poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> poly_variant</span><span> = </span><span>[ </span></code>
      <table>
@@ -882,7 +940,7 @@
      </table>
      <code><span> ]</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>poly_variant</code>.
      </p>
@@ -891,7 +949,7 @@
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-full_gadt">
      <a href="#type-full_gadt" class="anchor"></a><code><span><span class="keyword">type</span> <span>(_, _) full_gadt</span></span><span> = </span></code>
      <table>
@@ -919,7 +977,7 @@
       </tbody>
      </table>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>full_gadt</code>.
      </p>
@@ -928,7 +986,7 @@
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-partial_gadt">
      <a href="#type-partial_gadt" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a partial_gadt</span></span><span> = </span></code>
      <table>
@@ -951,7 +1009,7 @@
       </tbody>
      </table>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>partial_gadt</code>.
      </p>
@@ -960,27 +1018,27 @@
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-alias">
      <a href="#type-alias" class="anchor"></a><code><span><span class="keyword">type</span> alias</span><span> = <a href="#type-variant">variant</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>alias</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-tuple">
      <a href="#type-tuple" class="anchor"></a><code><span><span class="keyword">type</span> tuple</span><span> = <span>(<a href="#type-alias">alias</a> * <a href="#type-alias">alias</a>)</span> * <a href="#type-alias">alias</a> * <span>(<a href="#type-alias">alias</a> * <a href="#type-alias">alias</a>)</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>tuple</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-variant_alias">
      <a href="#type-variant_alias" class="anchor"></a><code><span><span class="keyword">type</span> variant_alias</span><span> = <a href="#type-variant">variant</a></span><span> = </span></code>
      <table>
@@ -1008,13 +1066,13 @@
       </tbody>
      </table>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>variant_alias</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-record_alias">
      <a href="#type-record_alias" class="anchor"></a><code><span><span class="keyword">type</span> record_alias</span><span> = <a href="#type-record">record</a></span><span> = </span><span>{</span></code>
      <table>
@@ -1033,13 +1091,13 @@
      </table>
      <code><span>}</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>record_alias</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-poly_variant_union">
      <a href="#type-poly_variant_union" class="anchor"></a><code><span><span class="keyword">type</span> poly_variant_union</span><span> = </span><span>[ </span></code>
      <table>
@@ -1058,93 +1116,113 @@
      </table>
      <code><span> ]</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>poly_variant_union</code>.
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-poly_poly_variant">
-    <a href="#type-poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a poly_poly_variant</span></span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-poly_poly_variant.TagA" class="anchored">
-       <td class="def constructor">
-        <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-poly_poly_variant">
+     <a href="#type-poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a poly_poly_variant</span></span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-poly_poly_variant.TagA" class="anchored">
+        <td class="def constructor">
+         <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-bin_poly_poly_variant">
-    <a href="#type-bin_poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) bin_poly_poly_variant</span></span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
-       <td class="def constructor">
-        <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></span></code>
-       </td>
-      </tr>
-      <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
-       <td class="def constructor">
-        <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB <span class="keyword">of</span> <span class="type-var">'b</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-bin_poly_poly_variant">
+     <a href="#type-bin_poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) bin_poly_poly_variant</span></span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
+        <td class="def constructor">
+         <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></span></code>
+        </td>
+       </tr>
+       <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
+        <td class="def constructor">
+         <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB <span class="keyword">of</span> <span class="type-var">'b</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-open_poly_variant">
-    <a href="#type-open_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a open_poly_variant</span></span><span> = <span>[&gt; `TagA ]</span> <span class="keyword">as</span> 'a</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-open_poly_variant">
+     <a href="#type-open_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a open_poly_variant</span></span><span> = <span>[&gt; `TagA ]</span> <span class="keyword">as</span> 'a</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-open_poly_variant2">
-    <a href="#type-open_poly_variant2" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a open_poly_variant2</span></span><span> = <span>[&gt; <span>`ConstrB of int</span> ]</span> <span class="keyword">as</span> 'a</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-open_poly_variant2">
+     <a href="#type-open_poly_variant2" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a open_poly_variant2</span></span><span> = <span>[&gt; <span>`ConstrB of int</span> ]</span> <span class="keyword">as</span> 'a</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-open_poly_variant_alias">
-    <a href="#type-open_poly_variant_alias" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a open_poly_variant_alias</span></span><span> = <span><span><span class="type-var">'a</span> <a href="#type-open_poly_variant">open_poly_variant</a></span> <a href="#type-open_poly_variant2">open_poly_variant2</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-open_poly_variant_alias">
+     <a href="#type-open_poly_variant_alias" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a open_poly_variant_alias</span></span><span> = <span><span><span class="type-var">'a</span> <a href="#type-open_poly_variant">open_poly_variant</a></span> <a href="#type-open_poly_variant2">open_poly_variant2</a></span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-poly_fun">
-    <a href="#type-poly_fun" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a poly_fun</span></span><span> = <span><span>[&gt; <span>`ConstrB of int</span> ]</span> <span class="keyword">as</span> 'a <span>-&gt;</span></span> <span class="type-var">'a</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-poly_fun">
+     <a href="#type-poly_fun" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a poly_fun</span></span><span> = <span><span>[&gt; <span>`ConstrB of int</span> ]</span> <span class="keyword">as</span> 'a <span>-&gt;</span></span> <span class="type-var">'a</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-poly_fun_constraint">
-    <a href="#type-poly_fun_constraint" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a poly_fun_constraint</span></span><span> = <span><span class="type-var">'a</span> <span>-&gt;</span></span> <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `TagA ]</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-poly_fun_constraint">
+     <a href="#type-poly_fun_constraint" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a poly_fun_constraint</span></span><span> = <span><span class="type-var">'a</span> <span>-&gt;</span></span> <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `TagA ]</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-closed_poly_variant">
-    <a href="#type-closed_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a closed_poly_variant</span></span><span> = <span>[&lt; `One <span>| `Two</span> ]</span> <span class="keyword">as</span> 'a</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-closed_poly_variant">
+     <a href="#type-closed_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a closed_poly_variant</span></span><span> = <span>[&lt; `One <span>| `Two</span> ]</span> <span class="keyword">as</span> 'a</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-clopen_poly_variant">
-    <a href="#type-clopen_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a clopen_poly_variant</span></span><span> = <span>[&lt; `One <span><span>| `Two</span> of int</span> <span>| `Three</span> Two Three ]</span> <span class="keyword">as</span> 'a</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-clopen_poly_variant">
+     <a href="#type-clopen_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a clopen_poly_variant</span></span><span> = <span>[&lt; `One <span><span>| `Two</span> of int</span> <span>| `Three</span> Two Three ]</span> <span class="keyword">as</span> 'a</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-nested_poly_variant">
-    <a href="#type-nested_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_poly_variant</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-nested_poly_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-       </td>
-      </tr>
-      <tr id="type-nested_poly_variant.B" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> <span>[ `B1 <span>| `B2</span> ]</span></span></code>
-       </td>
-      </tr>
-      <tr id="type-nested_poly_variant.C" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
-       </td>
-      </tr>
-      <tr id="type-nested_poly_variant.D" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D <span class="keyword">of</span> <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-nested_poly_variant">
+     <a href="#type-nested_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_poly_variant</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-nested_poly_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_poly_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+        </td>
+       </tr>
+       <tr id="type-nested_poly_variant.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_poly_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> <span>[ `B1 <span>| `B2</span> ]</span></span></code>
+        </td>
+       </tr>
+       <tr id="type-nested_poly_variant.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_poly_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
+        </td>
+       </tr>
+       <tr id="type-nested_poly_variant.D" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_poly_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D <span class="keyword">of</span> <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-full_gadt_alias">
      <a href="#type-full_gadt_alias" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) full_gadt_alias</span></span><span> = <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="#type-full_gadt">full_gadt</a></span></span><span> = </span></code>
      <table>
@@ -1172,13 +1250,13 @@
       </tbody>
      </table>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>full_gadt_alias</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-partial_gadt_alias">
      <a href="#type-partial_gadt_alias" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a partial_gadt_alias</span></span><span> = <span><span class="type-var">'a</span> <a href="#type-partial_gadt">partial_gadt</a></span></span><span> = </span></code>
      <table>
@@ -1201,23 +1279,23 @@
       </tbody>
      </table>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>partial_gadt_alias</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-Exn_arrow">
      <a href="#exception-Exn_arrow" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Exn_arrow</span> : unit <span>-&gt;</span> exn</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <a href="#exception-Exn_arrow"><code>Exn_arrow</code></a>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-mutual_constr_a">
      <a href="#type-mutual_constr_a" class="anchor"></a><code><span><span class="keyword">type</span> mutual_constr_a</span><span> = </span></code>
      <table>
@@ -1240,13 +1318,13 @@
       </tbody>
      </table>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a> then <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-mutual_constr_b">
      <a href="#type-mutual_constr_b" class="anchor"></a><code><span><span class="keyword">and</span> mutual_constr_b</span><span> = </span></code>
      <table>
@@ -1269,399 +1347,523 @@
       </tbody>
      </table>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a> then <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a>.
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-rec_obj">
-    <a href="#type-rec_obj" class="anchor"></a><code><span><span class="keyword">type</span> rec_obj</span><span> = <span>&lt; f : int; g : <span>unit <span>-&gt;</span></span> unit; h : <a href="#type-rec_obj">rec_obj</a>; &gt;</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-rec_obj">
+     <a href="#type-rec_obj" class="anchor"></a><code><span><span class="keyword">type</span> rec_obj</span><span> = <span>&lt; f : int; g : <span>unit <span>-&gt;</span></span> unit; h : <a href="#type-rec_obj">rec_obj</a>; &gt;</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-open_obj">
-    <a href="#type-open_obj" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a open_obj</span></span><span> = <span>&lt; f : int; g : <span>unit <span>-&gt;</span></span> unit; .. &gt;</span> <span class="keyword">as</span> 'a</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-open_obj">
+     <a href="#type-open_obj" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a open_obj</span></span><span> = <span>&lt; f : int; g : <span>unit <span>-&gt;</span></span> unit; .. &gt;</span> <span class="keyword">as</span> 'a</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-oof">
-    <a href="#type-oof" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a oof</span></span><span> = <span><span>&lt; a : unit; .. &gt;</span> <span class="keyword">as</span> 'a <span>-&gt;</span></span> <span class="type-var">'a</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-oof">
+     <a href="#type-oof" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a oof</span></span><span> = <span><span>&lt; a : unit; .. &gt;</span> <span class="keyword">as</span> 'a <span>-&gt;</span></span> <span class="type-var">'a</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-any_obj">
-    <a href="#type-any_obj" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a any_obj</span></span><span> = <span>&lt; .. &gt;</span> <span class="keyword">as</span> 'a</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-any_obj">
+     <a href="#type-any_obj" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a any_obj</span></span><span> = <span>&lt; .. &gt;</span> <span class="keyword">as</span> 'a</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-empty_obj">
-    <a href="#type-empty_obj" class="anchor"></a><code><span><span class="keyword">type</span> empty_obj</span><span> = <span>&lt; &gt;</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-empty_obj">
+     <a href="#type-empty_obj" class="anchor"></a><code><span><span class="keyword">type</span> empty_obj</span><span> = <span>&lt; &gt;</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-one_meth">
-    <a href="#type-one_meth" class="anchor"></a><code><span><span class="keyword">type</span> one_meth</span><span> = <span>&lt; meth : unit; &gt;</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-one_meth">
+     <a href="#type-one_meth" class="anchor"></a><code><span><span class="keyword">type</span> one_meth</span><span> = <span>&lt; meth : unit; &gt;</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-ext">
      <a href="#type-ext" class="anchor"></a><code><span><span class="keyword">type</span> ext</span><span> = </span><span>..</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A mystery wrapped in an ellipsis
      </p>
     </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ExtA" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtA" class="anchor"></a><code><span>| </span><span><span class="extension">ExtA</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ExtA" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtA" class="anchor"></a><code><span>| </span><span><span class="extension">ExtA</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ExtB" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtB" class="anchor"></a><code><span>| </span><span><span class="extension">ExtB</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ExtB" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtB" class="anchor"></a><code><span>| </span><span><span class="extension">ExtB</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ExtC" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtC" class="anchor"></a><code><span>| </span><span><span class="extension">ExtC</span> <span class="keyword">of</span> unit</span></code>
-       </td>
-      </tr>
-      <tr id="extension-ExtD" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtD" class="anchor"></a><code><span>| </span><span><span class="extension">ExtD</span> <span class="keyword">of</span> <a href="#type-ext">ext</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ExtC" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtC" class="anchor"></a><code><span>| </span><span><span class="extension">ExtC</span> <span class="keyword">of</span> unit</span></code>
+        </td>
+       </tr>
+       <tr id="extension-ExtD" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtD" class="anchor"></a><code><span>| </span><span><span class="extension">ExtD</span> <span class="keyword">of</span> <a href="#type-ext">ext</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ExtE" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtE" class="anchor"></a><code><span>| </span><span><span class="extension">ExtE</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ExtE" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtE" class="anchor"></a><code><span>| </span><span><span class="extension">ExtE</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ExtF" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtF" class="anchor"></a><code><span>| </span><span><span class="extension">ExtF</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ExtF" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtF" class="anchor"></a><code><span>| </span><span><span class="extension">ExtF</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-poly_ext">
      <a href="#type-poly_ext" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a poly_ext</span></span><span> = </span><span>..</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       'a poly_ext
      </p>
     </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-Foo" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Foo" class="anchor"></a><code><span>| </span><span><span class="extension">Foo</span> <span class="keyword">of</span> <span class="type-var">'b</span></span></code>
-       </td>
-      </tr>
-      <tr id="extension-Bar" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Bar" class="anchor"></a><code><span>| </span><span><span class="extension">Bar</span> <span class="keyword">of</span> <span class="type-var">'b</span> * <span class="type-var">'b</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         'b poly_ext
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-Foo" class="anchored">
+        <td class="def extension">
+         <a href="#extension-Foo" class="anchor"></a><code><span>| </span><span><span class="extension">Foo</span> <span class="keyword">of</span> <span class="type-var">'b</span></span></code>
+        </td>
+       </tr>
+       <tr id="extension-Bar" class="anchored">
+        <td class="def extension">
+         <a href="#extension-Bar" class="anchor"></a><code><span>| </span><span><span class="extension">Bar</span> <span class="keyword">of</span> <span class="type-var">'b</span> * <span class="type-var">'b</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          'b poly_ext
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-Quux" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Quux" class="anchor"></a><code><span>| </span><span><span class="extension">Quux</span> <span class="keyword">of</span> <span class="type-var">'c</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         'c poly_ext
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-Quux" class="anchored">
+        <td class="def extension">
+         <a href="#extension-Quux" class="anchor"></a><code><span>| </span><span><span class="extension">Quux</span> <span class="keyword">of</span> <span class="type-var">'c</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          'c poly_ext
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec module" id="module-ExtMod">
-    <a href="#module-ExtMod" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="ExtMod/index.html">ExtMod</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-ExtMod">
+     <a href="#module-ExtMod" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="ExtMod/index.html">ExtMod</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ZzzTop0" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ZzzTop0" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop0</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         It's got the rock
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ZzzTop0" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ZzzTop0" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop0</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          It's got the rock
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ZzzTop" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ZzzTop" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop</span> <span class="keyword">of</span> unit</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         and it packs a unit.
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ZzzTop" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ZzzTop" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop</span> <span class="keyword">of</span> unit</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          and it packs a unit.
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec external" id="val-launch_missiles">
      <a href="#val-launch_missiles" class="anchor"></a><code><span><span class="keyword">val</span> launch_missiles : <span>unit <span>-&gt;</span></span> unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Rotate keys on my mark...
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-my_mod">
      <a href="#type-my_mod" class="anchor"></a><code><span><span class="keyword">type</span> my_mod</span><span> = <span>(<span class="keyword">module</span> <a href="module-type-COLLECTION/index.html">COLLECTION</a>)</span></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A brown paper package tied up with string
      </p>
     </div>
    </div>
-   <div class="spec class" id="class-empty_class">
-    <a href="#class-empty_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-empty_class/index.html">empty_class</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-empty_class">
+     <a href="#class-empty_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-empty_class/index.html">empty_class</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-one_method_class">
-    <a href="#class-one_method_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-one_method_class/index.html">one_method_class</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-one_method_class">
+     <a href="#class-one_method_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-one_method_class/index.html">one_method_class</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-two_method_class">
-    <a href="#class-two_method_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-two_method_class/index.html">two_method_class</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-two_method_class">
+     <a href="#class-two_method_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-two_method_class/index.html">two_method_class</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-param_class">
-    <a href="#class-param_class" class="anchor"></a><code><span><span class="keyword">class</span> 'a </span><span><a href="class-param_class/index.html">param_class</a></span><span> : <span><span class="type-var">'a</span> <span>-&gt;</span></span> <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-param_class">
+     <a href="#class-param_class" class="anchor"></a><code><span><span class="keyword">class</span> 'a </span><span><a href="class-param_class/index.html">param_class</a></span><span> : <span><span class="type-var">'a</span> <span>-&gt;</span></span> <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-my_unit_object">
-    <a href="#type-my_unit_object" class="anchor"></a><code><span><span class="keyword">type</span> my_unit_object</span><span> = <span>unit <a href="class-param_class/index.html">param_class</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-my_unit_object">
+     <a href="#type-my_unit_object" class="anchor"></a><code><span><span class="keyword">type</span> my_unit_object</span><span> = <span>unit <a href="class-param_class/index.html">param_class</a></span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-my_unit_class">
-    <a href="#type-my_unit_class" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a my_unit_class</span></span><span> = <span>unit <span class="xref-unresolved">param_class</span></span> <span class="keyword">as</span> 'a</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-my_unit_class">
+     <a href="#type-my_unit_class" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a my_unit_class</span></span><span> = <span>unit <span class="xref-unresolved">param_class</span></span> <span class="keyword">as</span> 'a</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep1">
-    <a href="#module-Dep1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep1/index.html">Dep1</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep1">
+     <a href="#module-Dep1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep1/index.html">Dep1</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep2">
-    <a href="#module-Dep2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep2/index.html">Dep2</a></span><span> (<a href="Dep2/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep2">
+     <a href="#module-Dep2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep2/index.html">Dep2</a></span><span> (<a href="Dep2/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-dep1">
-    <a href="#type-dep1" class="anchor"></a><code><span><span class="keyword">type</span> dep1</span><span> = <a href="Dep1/module-type-S/class-c/index.html">Dep2(Dep1).B.c</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-dep1">
+     <a href="#type-dep1" class="anchor"></a><code><span><span class="keyword">type</span> dep1</span><span> = <a href="Dep1/module-type-S/class-c/index.html">Dep2(Dep1).B.c</a></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep3">
-    <a href="#module-Dep3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep3/index.html">Dep3</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep3">
+     <a href="#module-Dep3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep3/index.html">Dep3</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep4">
-    <a href="#module-Dep4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep4/index.html">Dep4</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep4">
+     <a href="#module-Dep4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep4/index.html">Dep4</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep5">
-    <a href="#module-Dep5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep5/index.html">Dep5</a></span><span> (<a href="Dep5/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep5">
+     <a href="#module-Dep5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep5/index.html">Dep5</a></span><span> (<a href="Dep5/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-dep2">
-    <a href="#type-dep2" class="anchor"></a><code><span><span class="keyword">type</span> dep2</span><span> = <a href="Dep4/module-type-T/index.html#type-b">Dep5(Dep4).Z.X.b</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-dep2">
+     <a href="#type-dep2" class="anchor"></a><code><span><span class="keyword">type</span> dep2</span><span> = <a href="Dep4/module-type-T/index.html#type-b">Dep5(Dep4).Z.X.b</a></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-dep3">
-    <a href="#type-dep3" class="anchor"></a><code><span><span class="keyword">type</span> dep3</span><span> = <a href="Dep3/index.html#type-a">Dep5(Dep4).Z.Y.a</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-dep3">
+     <a href="#type-dep3" class="anchor"></a><code><span><span class="keyword">type</span> dep3</span><span> = <a href="Dep3/index.html#type-a">Dep5(Dep4).Z.Y.a</a></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep6">
-    <a href="#module-Dep6" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep6/index.html">Dep6</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep6">
+     <a href="#module-Dep6" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep6/index.html">Dep6</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep7">
-    <a href="#module-Dep7" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep7/index.html">Dep7</a></span><span> (<a href="Dep7/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep7">
+     <a href="#module-Dep7" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep7/index.html">Dep7</a></span><span> (<a href="Dep7/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-dep4">
-    <a href="#type-dep4" class="anchor"></a><code><span><span class="keyword">type</span> dep4</span><span> = <a href="Dep6/module-type-T/Y/index.html#type-d">Dep7(Dep6).M.Y.d</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-dep4">
+     <a href="#type-dep4" class="anchor"></a><code><span><span class="keyword">type</span> dep4</span><span> = <a href="Dep6/module-type-T/Y/index.html#type-d">Dep7(Dep6).M.Y.d</a></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep8">
-    <a href="#module-Dep8" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep8/index.html">Dep8</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep8">
+     <a href="#module-Dep8" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep8/index.html">Dep8</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep9">
-    <a href="#module-Dep9" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep9/index.html">Dep9</a></span><span> (<a href="Dep9/argument-1-X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep9">
+     <a href="#module-Dep9" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep9/index.html">Dep9</a></span><span> (<a href="Dep9/argument-1-X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-Dep10">
-    <a href="#module-type-Dep10" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dep10/index.html">Dep10</a></span><span> = <a href="Dep8/module-type-T/index.html">Dep9(Dep8).T</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="Dep8/module-type-T/index.html#type-t">t</a> = int</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Dep10">
+     <a href="#module-type-Dep10" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dep10/index.html">Dep10</a></span><span> = <a href="Dep8/module-type-T/index.html">Dep9(Dep8).T</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="Dep8/module-type-T/index.html#type-t">t</a> = int</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep11">
-    <a href="#module-Dep11" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep11/index.html">Dep11</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep11">
+     <a href="#module-Dep11" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep11/index.html">Dep11</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep12">
-    <a href="#module-Dep12" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep12/index.html">Dep12</a></span><span> (<a href="Dep12/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep12">
+     <a href="#module-Dep12" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep12/index.html">Dep12</a></span><span> (<a href="Dep12/argument-1-Arg/index.html">Arg</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep13">
-    <a href="#module-Dep13" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep13/index.html">Dep13</a></span><span> : <a href="Dep11/module-type-S/index.html">Dep12(Dep11).T</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep13">
+     <a href="#module-Dep13" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep13/index.html">Dep13</a></span><span> : <a href="Dep11/module-type-S/index.html">Dep12(Dep11).T</a></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-dep5">
-    <a href="#type-dep5" class="anchor"></a><code><span><span class="keyword">type</span> dep5</span><span> = <a href="Dep13/class-c/index.html">Dep13.c</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-dep5">
+     <a href="#type-dep5" class="anchor"></a><code><span><span class="keyword">type</span> dep5</span><span> = <a href="Dep13/class-c/index.html">Dep13.c</a></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-With1">
-    <a href="#module-type-With1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With1/index.html">With1</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-With1">
+     <a href="#module-type-With1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With1/index.html">With1</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With2">
-    <a href="#module-With2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With2/index.html">With2</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With2">
+     <a href="#module-With2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With2/index.html">With2</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With3">
-    <a href="#module-With3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With3/index.html">With3</a></span><span> : <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> = <a href="With2/index.html">With2</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With3">
+     <a href="#module-With3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With3/index.html">With3</a></span><span> : <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> = <a href="With2/index.html">With2</a></span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-with1">
-    <a href="#type-with1" class="anchor"></a><code><span><span class="keyword">type</span> with1</span><span> = <a href="With3/N/index.html#type-t">With3.N.t</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-with1">
+     <a href="#type-with1" class="anchor"></a><code><span><span class="keyword">type</span> with1</span><span> = <a href="With3/N/index.html#type-t">With3.N.t</a></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With4">
-    <a href="#module-With4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With4/index.html">With4</a></span><span> : <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> := <a href="With2/index.html">With2</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With4">
+     <a href="#module-With4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With4/index.html">With4</a></span><span> : <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> := <a href="With2/index.html">With2</a></span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-with2">
-    <a href="#type-with2" class="anchor"></a><code><span><span class="keyword">type</span> with2</span><span> = <a href="With4/N/index.html#type-t">With4.N.t</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-with2">
+     <a href="#type-with2" class="anchor"></a><code><span><span class="keyword">type</span> with2</span><span> = <a href="With4/N/index.html#type-t">With4.N.t</a></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With5">
-    <a href="#module-With5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With5/index.html">With5</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With5">
+     <a href="#module-With5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With5/index.html">With5</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With6">
-    <a href="#module-With6" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With6/index.html">With6</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With6">
+     <a href="#module-With6" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With6/index.html">With6</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With7">
-    <a href="#module-With7" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With7/index.html">With7</a></span><span> (<a href="With7/argument-1-X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With7">
+     <a href="#module-With7" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With7/index.html">With7</a></span><span> (<a href="With7/argument-1-X/index.html">X</a> : <span class="keyword">sig</span> ... <span class="keyword">end</span>) : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-With8">
-    <a href="#module-type-With8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With8/index.html">With8</a></span><span> = <a href="With6/module-type-T/index.html">With7(With6).T</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="With6/module-type-T/M/index.html">M</a> = <a href="With5/index.html">With5</a></span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="With5/N/index.html#type-t">M.N.t</a> = <a href="With5/N/index.html#type-t">With5.N.t</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-With8">
+     <a href="#module-type-With8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With8/index.html">With8</a></span><span> = <a href="With6/module-type-T/index.html">With7(With6).T</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="With6/module-type-T/M/index.html">M</a> = <a href="With5/index.html">With5</a></span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="With5/N/index.html#type-t">M.N.t</a> = <a href="With5/N/index.html#type-t">With5.N.t</a></span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With9">
-    <a href="#module-With9" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With9/index.html">With9</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With9">
+     <a href="#module-With9" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With9/index.html">With9</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With10">
-    <a href="#module-With10" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With10/index.html">With10</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With10">
+     <a href="#module-With10" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With10/index.html">With10</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-With11">
-    <a href="#module-type-With11" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With11/index.html">With11</a></span><span> = <a href="With10/module-type-T/index.html">With7(With10).T</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="With10/module-type-T/M/index.html">M</a> = <a href="With9/index.html">With9</a></span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="With9/module-type-S/index.html#type-t">N.t</a> = int</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-With11">
+     <a href="#module-type-With11" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With11/index.html">With11</a></span><span> = <a href="With10/module-type-T/index.html">With7(With10).T</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="With10/module-type-T/M/index.html">M</a> = <a href="With9/index.html">With9</a></span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="With9/module-type-S/index.html#type-t">N.t</a> = int</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-NestedInclude1">
-    <a href="#module-type-NestedInclude1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude1/index.html">NestedInclude1</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-NestedInclude1">
+     <a href="#module-type-NestedInclude1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude1/index.html">NestedInclude1</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-NestedInclude1/index.html">NestedInclude1</a></span></code></span>
        </summary>
-       <div class="spec module-type" id="module-type-NestedInclude2">
-        <a href="#module-type-NestedInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude2/index.html">NestedInclude2</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+       <div class="odoc-spec">
+        <div class="spec module-type" id="module-type-NestedInclude2">
+         <a href="#module-type-NestedInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude2/index.html">NestedInclude2</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-NestedInclude2/index.html">NestedInclude2</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-NestedInclude2/index.html#type-nested_include">nested_include</a> = int</span></span></code></span>
        </summary>
-       <div class="spec type" id="type-nested_include">
-        <a href="#type-nested_include" class="anchor"></a><code><span><span class="keyword">type</span> nested_include</span><span> = int</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-nested_include">
+         <a href="#type-nested_include" class="anchor"></a><code><span><span class="keyword">type</span> nested_include</span><span> = int</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module" id="module-DoubleInclude1">
-    <a href="#module-DoubleInclude1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="DoubleInclude1/index.html">DoubleInclude1</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-DoubleInclude1">
+     <a href="#module-DoubleInclude1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="DoubleInclude1/index.html">DoubleInclude1</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-DoubleInclude3">
-    <a href="#module-DoubleInclude3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="DoubleInclude3/index.html">DoubleInclude3</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-DoubleInclude3">
+     <a href="#module-DoubleInclude3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="DoubleInclude3/index.html">DoubleInclude3</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="DoubleInclude3/DoubleInclude2/index.html">DoubleInclude3.DoubleInclude2</a></span></code></span>
        </summary>
-       <div class="spec type" id="type-double_include">
-        <a href="#type-double_include" class="anchor"></a><code><span><span class="keyword">type</span> double_include</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-double_include">
+         <a href="#type-double_include" class="anchor"></a><code><span><span class="keyword">type</span> double_include</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module" id="module-IncludeInclude1">
-    <a href="#module-IncludeInclude1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludeInclude1/index.html">IncludeInclude1</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-IncludeInclude1">
+     <a href="#module-IncludeInclude1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludeInclude1/index.html">IncludeInclude1</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="IncludeInclude1/index.html">IncludeInclude1</a></span></code></span>
        </summary>
-       <div class="spec module-type" id="module-type-IncludeInclude2">
-        <a href="#module-type-IncludeInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+       <div class="odoc-spec">
+        <div class="spec module-type" id="module-type-IncludeInclude2">
+         <a href="#module-type-IncludeInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span></code></span>
        </summary>
-       <div class="spec type" id="type-include_include">
-        <a href="#type-include_include" class="anchor"></a><code><span><span class="keyword">type</span> include_include</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-include_include">
+         <a href="#type-include_include" class="anchor"></a><code><span><span class="keyword">type</span> include_include</span></code>
+        </div>
        </div>
       </details>
      </div>
@@ -1670,7 +1872,7 @@
    <h2 id="indexmodules">
     <a href="#indexmodules" class="anchor"></a>Trying the {!modules: ...} command.
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      With ocamldoc, toplevel units will be linked and documented, while submodules will behave as simple references.
     </p>
@@ -1695,7 +1897,7 @@
    <h4 id="weirder-usages-involving-module-types">
     <a href="#weirder-usages-involving-module-types" class="anchor"></a>Weirder usages involving module types
    </h4>
-   <aside>
+   <aside class="odoc-unattached">
     <ul class="modules">
      <li>
       <code>IncludeInclude1</code>.IncludeInclude2
@@ -1711,14 +1913,16 @@
    <h2 id="playing-with-@canonical-paths">
     <a href="#playing-with-@canonical-paths" class="anchor"></a>Playing with @canonical paths
    </h2>
-   <div class="spec module" id="module-CanonicalTest">
-    <a href="#module-CanonicalTest" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="CanonicalTest/index.html">CanonicalTest</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-CanonicalTest">
+     <a href="#module-CanonicalTest" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="CanonicalTest/index.html">CanonicalTest</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-test">
      <a href="#val-test" class="anchor"></a><code><span><span class="keyword">val</span> test : <span><span><span class="type-var">'a</span> <a href="CanonicalTest/Base/List/index.html#type-t">CanonicalTest.Base.List.t</a></span> <span>-&gt;</span></span> unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some ref to <a href="CanonicalTest/Base__Tests/C/index.html#type-t"><code>CanonicalTest.Base__Tests.C.t</code></a> and <a href="CanonicalTest/Base/List/index.html#val-id"><code>CanonicalTest.Base__Tests.L.id</code></a>. But also to <a href="CanonicalTest/Base__/List/index.html"><code>CanonicalTest.Base__.List</code></a> and <a href="CanonicalTest/Base__/List/index.html#type-t"><code>CanonicalTest.Base__.List.t</code></a>
      </p>
@@ -1727,13 +1931,15 @@
    <h2 id="aliases">
     <a href="#aliases" class="anchor"></a>Aliases again
    </h2>
-   <div class="spec module" id="module-Aliases">
-    <a href="#module-Aliases" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Aliases/index.html">Aliases</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Aliases">
+     <a href="#module-Aliases" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Aliases/index.html">Aliases</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
    <h2 id="section-title-splicing">
     <a href="#section-title-splicing" class="anchor"></a>Section title splicing
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      I can refer to
     </p>
@@ -1777,13 +1983,17 @@
    <h2 id="new-reference-syntax">
     <a href="#new-reference-syntax" class="anchor"></a>New reference syntax
    </h2>
-   <div class="spec module-type" id="module-type-M">
-    <a href="#module-type-M" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-M/index.html">M</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-M">
+     <a href="#module-type-M" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-M/index.html">M</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-M">
-    <a href="#module-M" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M/index.html">M</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M">
+     <a href="#module-M" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M/index.html">M</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Here goes:
     </p>
@@ -1799,10 +2009,12 @@
      </li>
     </ul>
    </aside>
-   <div class="spec module" id="module-Only_a_module">
-    <a href="#module-Only_a_module" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Only_a_module/index.html">Only_a_module</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Only_a_module">
+     <a href="#module-Only_a_module" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Only_a_module/index.html">Only_a_module</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Some here should fail:
     </p>
@@ -1818,26 +2030,34 @@
      </li>
     </ul>
    </aside>
-   <div class="spec module-type" id="module-type-TypeExt">
-    <a href="#module-type-TypeExt" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-TypeExt/index.html">TypeExt</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-TypeExt">
+     <a href="#module-type-TypeExt" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-TypeExt/index.html">TypeExt</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-new_t">
-    <a href="#type-new_t" class="anchor"></a><code><span><span class="keyword">type</span> new_t</span><span> = </span><span>..</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-new_t">
+     <a href="#type-new_t" class="anchor"></a><code><span><span class="keyword">type</span> new_t</span><span> = </span><span>..</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-new_t">new_t</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-C" class="anchored">
-       <td class="def extension">
-        <a href="#extension-C" class="anchor"></a><code><span>| </span><span><span class="extension">C</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-new_t">new_t</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-C" class="anchored">
+        <td class="def extension">
+         <a href="#extension-C" class="anchor"></a><code><span>| </span><span><span class="extension">C</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-TypeExtPruned">
-    <a href="#module-type-TypeExtPruned" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-TypeExtPruned/index.html">TypeExtPruned</a></span><span> = <a href="module-type-TypeExt/index.html">TypeExt</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-TypeExt/index.html#type-t">t</a> := <a href="#type-new_t">new_t</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-TypeExtPruned">
+     <a href="#module-type-TypeExtPruned" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-TypeExtPruned/index.html">TypeExtPruned</a></span><span> = <a href="module-type-TypeExt/index.html">TypeExt</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-TypeExt/index.html#type-t">t</a> := <a href="#type-new_t">new_t</a></span></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Recent/X/index.html
+++ b/test/html/expect/test_package+ml/Recent/X/index.html
@@ -23,17 +23,25 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module-substitution" id="module-L">
-    <a href="#module-L" class="anchor"></a><code><span><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-substitution" id="module-L">
+     <a href="#module-L" class="anchor"></a><code><span><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-t">
-    <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = <span>int <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = <span>int <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a></span></span></code>
+    </div>
    </div>
-   <div class="spec type-subst" id="type-u">
-    <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> := int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type-subst" id="type-u">
+     <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> := int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-v">
-    <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = <span><a href="#type-u">u</a> <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-v">
+     <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = <span><a href="#type-u">u</a> <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a></span></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -23,183 +23,211 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S1/index.html">S1</a></span><span> = <span class="keyword">functor</span><span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="module-type-S/index.html">S</a>) <span>-&gt;</span></span> <a href="module-type-S/index.html">S</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S1">
+     <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S1/index.html">S1</a></span><span> = <span class="keyword">functor</span><span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="module-type-S/index.html">S</a>) <span>-&gt;</span></span> <a href="module-type-S/index.html">S</a></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-variant">
-    <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-variant.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-       </td>
-      </tr>
-      <tr id="type-variant.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> int</span></code>
-       </td>
-      </tr>
-      <tr id="type-variant.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         foo
-        </p>
-       </td>
-      </tr>
-      <tr id="type-variant.D" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <em>bar</em>
-        </p>
-       </td>
-      </tr>
-      <tr id="type-variant.E" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> </span><span>{</span></code>
-        <table>
-         <tbody>
-          <tr id="type-variant.a" class="anchored">
-           <td class="def record field">
-            <a href="#type-variant.a" class="anchor"></a><code><span>a : int;</span></code>
-           </td>
-          </tr>
-         </tbody>
-        </table>
-        <code><span>}</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-variant">
+     <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-variant.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+        </td>
+       </tr>
+       <tr id="type-variant.B" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> int</span></code>
+        </td>
+       </tr>
+       <tr id="type-variant.C" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.D" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <em>bar</em>
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.E" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> </span><span>{</span></code>
+         <table>
+          <tbody>
+           <tr id="type-variant.a" class="anchored">
+            <td class="def record field">
+             <a href="#type-variant.a" class="anchor"></a><code><span>a : int;</span></code>
+            </td>
+           </tr>
+          </tbody>
+         </table>
+         <code><span>}</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec type" id="type-gadt">
-    <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> <span>_ gadt</span></span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-gadt.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <span>int <a href="#type-gadt">gadt</a></span></span></code>
-       </td>
-      </tr>
-      <tr id="type-gadt.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> : int <span>-&gt;</span> <span>string <a href="#type-gadt">gadt</a></span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         foo
-        </p>
-       </td>
-      </tr>
-      <tr id="type-gadt.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span> : </span><span>{</span></code>
-        <table>
-         <tbody>
-          <tr id="type-gadt.a" class="anchored">
-           <td class="def record field">
-            <a href="#type-gadt.a" class="anchor"></a><code><span>a : int;</span></code>
-           </td>
-          </tr>
-         </tbody>
-        </table>
-        <code><span>}</span><span> <span>-&gt;</span> <span>unit <a href="#type-gadt">gadt</a></span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-gadt">
+     <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> <span>_ gadt</span></span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-gadt.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <span>int <a href="#type-gadt">gadt</a></span></span></code>
+        </td>
+       </tr>
+       <tr id="type-gadt.B" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> : int <span>-&gt;</span> <span>string <a href="#type-gadt">gadt</a></span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-gadt.C" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span> : </span><span>{</span></code>
+         <table>
+          <tbody>
+           <tr id="type-gadt.a" class="anchored">
+            <td class="def record field">
+             <a href="#type-gadt.a" class="anchor"></a><code><span>a : int;</span></code>
+            </td>
+           </tr>
+          </tbody>
+         </table>
+         <code><span>}</span><span> <span>-&gt;</span> <span>unit <a href="#type-gadt">gadt</a></span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec type" id="type-polymorphic_variant">
-    <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-polymorphic_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.B" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> int</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.C" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         foo
-        </p>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.D" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         bar
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-polymorphic_variant">
+     <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-polymorphic_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> int</span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.D" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          bar
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-empty_variant">
-    <a href="#type-empty_variant" class="anchor"></a><code><span><span class="keyword">type</span> empty_variant</span><span> = </span><span>|</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-empty_variant">
+     <a href="#type-empty_variant" class="anchor"></a><code><span><span class="keyword">type</span> empty_variant</span><span> = </span><span>|</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-nonrec_">
-    <a href="#type-nonrec_" class="anchor"></a><code><span><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_</span><span> = int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-nonrec_">
+     <a href="#type-nonrec_" class="anchor"></a><code><span><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_</span><span> = int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-empty_conj">
-    <a href="#type-empty_conj" class="anchor"></a><code><span><span class="keyword">type</span> empty_conj</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-empty_conj.X" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-empty_conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span> : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span> <span>-&gt;</span> <a href="#type-empty_conj">empty_conj</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-empty_conj">
+     <a href="#type-empty_conj" class="anchor"></a><code><span><span class="keyword">type</span> empty_conj</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-empty_conj.X" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-empty_conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span> : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span> <span>-&gt;</span> <a href="#type-empty_conj">empty_conj</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec type" id="type-conj">
-    <a href="#type-conj" class="anchor"></a><code><span><span class="keyword">type</span> conj</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-conj.X" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span> : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span> <span>-&gt;</span> <a href="#type-conj">conj</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-conj">
+     <a href="#type-conj" class="anchor"></a><code><span><span class="keyword">type</span> conj</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-conj.X" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span> : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span> <span>-&gt;</span> <a href="#type-conj">conj</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec value" id="val-empty_conj">
-    <a href="#val-empty_conj" class="anchor"></a><code><span><span class="keyword">val</span> empty_conj : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-empty_conj">
+     <a href="#val-empty_conj" class="anchor"></a><code><span><span class="keyword">val</span> empty_conj : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span></span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-conj">
-    <a href="#val-conj" class="anchor"></a><code><span><span class="keyword">val</span> conj : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-conj">
+     <a href="#val-conj" class="anchor"></a><code><span><span class="keyword">val</span> conj : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Z">
-    <a href="#module-Z" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Z/index.html">Z</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Z">
+     <a href="#module-Z" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Z/index.html">Z</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-X">
-    <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-X">
+     <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-PolyS">
-    <a href="#module-type-PolyS" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-PolyS/index.html">PolyS</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-PolyS">
+     <a href="#module-type-PolyS" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-PolyS/index.html">PolyS</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Recent_impl/index.html
+++ b/test/html/expect/test_package+ml/Recent_impl/index.html
@@ -23,20 +23,30 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module" id="module-Foo">
-    <a href="#module-Foo" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Foo/index.html">Foo</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Foo">
+     <a href="#module-Foo" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Foo/index.html">Foo</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-B">
-    <a href="#module-B" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="B/index.html">B</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-B">
+     <a href="#module-B" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="B/index.html">B</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-u">
-    <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-u">
+     <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-B'">
-    <a href="#module-B'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span>B'</span><span> = <a href="Foo/B/index.html">Foo.B</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-B'">
+     <a href="#module-B'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span>B'</span><span> = <a href="Foo/B/index.html">Foo.B</a></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Section/index.html
+++ b/test/html/expect/test_package+ml/Section/index.html
@@ -62,19 +62,15 @@
    <h2 id="text-only">
     <a href="#text-only" class="anchor"></a>Text only
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Foo bar.
-    </p>
-   </aside>
+   <p>
+    Foo bar.
+   </p>
    <h2 id="aside-only">
     <a href="#aside-only" class="anchor"></a>Aside only
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Foo bar.
-    </p>
-   </aside>
+   <p>
+    Foo bar.
+   </p>
    <h2 id="value-only">
     <a href="#value-only" class="anchor"></a>Value only
    </h2>
@@ -95,11 +91,9 @@
    <h2 id="this-section-title-has-markup">
     <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
-    </p>
-   </aside>
+   <p>
+    But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+   </p>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Section/index.html
+++ b/test/html/expect/test_package+ml/Section/index.html
@@ -62,7 +62,7 @@
    <h2 id="text-only">
     <a href="#text-only" class="anchor"></a>Text only
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Foo bar.
     </p>
@@ -70,7 +70,7 @@
    <h2 id="aside-only">
     <a href="#aside-only" class="anchor"></a>Aside only
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Foo bar.
     </p>
@@ -78,8 +78,10 @@
    <h2 id="value-only">
     <a href="#value-only" class="anchor"></a>Value only
    </h2>
-   <div class="spec value" id="val-foo">
-    <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+    </div>
    </div>
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
@@ -93,7 +95,7 @@
    <h2 id="this-section-title-has-markup">
     <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
     </p>

--- a/test/html/expect/test_package+ml/Stop/index.html
+++ b/test/html/expect/test_package+ml/Stop/index.html
@@ -36,17 +36,15 @@
      </p>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
-    </p>
-    <p>
-     Documentation is on again.
-    </p>
-    <p>
-     Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
-    </p>
-   </aside>
+   <p>
+    The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
+   </p>
+   <p>
+    Documentation is on again.
+   </p>
+   <p>
+    Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
+   </p>
    <div class="odoc-spec">
     <div class="spec module" id="module-N">
      <a href="#module-N" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="N/index.html">N</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>

--- a/test/html/expect/test_package+ml/Stop/index.html
+++ b/test/html/expect/test_package+ml/Stop/index.html
@@ -26,17 +26,17 @@
    </p>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : int</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is normal commented text.
      </p>
     </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
     </p>
@@ -47,11 +47,15 @@
      Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
     </p>
    </aside>
-   <div class="spec module" id="module-N">
-    <a href="#module-N" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="N/index.html">N</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-N">
+     <a href="#module-N" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="N/index.html">N</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-lol">
-    <a href="#val-lol" class="anchor"></a><code><span><span class="keyword">val</span> lol : int</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-lol">
+     <a href="#val-lol" class="anchor"></a><code><span><span class="keyword">val</span> lol : int</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -23,409 +23,513 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-abstract">
      <a href="#type-abstract" class="anchor"></a><code><span><span class="keyword">type</span> abstract</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some <em>documentation</em>.
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-alias">
-    <a href="#type-alias" class="anchor"></a><code><span><span class="keyword">type</span> alias</span><span> = int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-alias">
+     <a href="#type-alias" class="anchor"></a><code><span><span class="keyword">type</span> alias</span><span> = int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-private_">
-    <a href="#type-private_" class="anchor"></a><code><span><span class="keyword">type</span> private_</span><span> = <span class="keyword">private</span> int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-private_">
+     <a href="#type-private_" class="anchor"></a><code><span><span class="keyword">type</span> private_</span><span> = <span class="keyword">private</span> int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-constructor">
-    <a href="#type-constructor" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a constructor</span></span><span> = <span class="type-var">'a</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-constructor">
+     <a href="#type-constructor" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a constructor</span></span><span> = <span class="type-var">'a</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-arrow">
-    <a href="#type-arrow" class="anchor"></a><code><span><span class="keyword">type</span> arrow</span><span> = <span>int <span>-&gt;</span></span> int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-arrow">
+     <a href="#type-arrow" class="anchor"></a><code><span><span class="keyword">type</span> arrow</span><span> = <span>int <span>-&gt;</span></span> int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-higher_order">
-    <a href="#type-higher_order" class="anchor"></a><code><span><span class="keyword">type</span> higher_order</span><span> = <span><span>(<span>int <span>-&gt;</span></span> int)</span> <span>-&gt;</span></span> int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-higher_order">
+     <a href="#type-higher_order" class="anchor"></a><code><span><span class="keyword">type</span> higher_order</span><span> = <span><span>(<span>int <span>-&gt;</span></span> int)</span> <span>-&gt;</span></span> int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-labeled">
-    <a href="#type-labeled" class="anchor"></a><code><span><span class="keyword">type</span> labeled</span><span> = <span>l:int <span>-&gt;</span></span> int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-labeled">
+     <a href="#type-labeled" class="anchor"></a><code><span><span class="keyword">type</span> labeled</span><span> = <span>l:int <span>-&gt;</span></span> int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-optional">
-    <a href="#type-optional" class="anchor"></a><code><span><span class="keyword">type</span> optional</span><span> = <span>?⁠l:int <span>-&gt;</span></span> int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-optional">
+     <a href="#type-optional" class="anchor"></a><code><span><span class="keyword">type</span> optional</span><span> = <span>?⁠l:int <span>-&gt;</span></span> int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-labeled_higher_order">
-    <a href="#type-labeled_higher_order" class="anchor"></a><code><span><span class="keyword">type</span> labeled_higher_order</span><span> = <span><span>(<span>l:int <span>-&gt;</span></span> int)</span> <span>-&gt;</span></span> <span><span>(<span>?⁠l:int <span>-&gt;</span></span> int)</span> <span>-&gt;</span></span> int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-labeled_higher_order">
+     <a href="#type-labeled_higher_order" class="anchor"></a><code><span><span class="keyword">type</span> labeled_higher_order</span><span> = <span><span>(<span>l:int <span>-&gt;</span></span> int)</span> <span>-&gt;</span></span> <span><span>(<span>?⁠l:int <span>-&gt;</span></span> int)</span> <span>-&gt;</span></span> int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-pair">
-    <a href="#type-pair" class="anchor"></a><code><span><span class="keyword">type</span> pair</span><span> = int * int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-pair">
+     <a href="#type-pair" class="anchor"></a><code><span><span class="keyword">type</span> pair</span><span> = int * int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-parens_dropped">
-    <a href="#type-parens_dropped" class="anchor"></a><code><span><span class="keyword">type</span> parens_dropped</span><span> = int * int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-parens_dropped">
+     <a href="#type-parens_dropped" class="anchor"></a><code><span><span class="keyword">type</span> parens_dropped</span><span> = int * int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-triple">
-    <a href="#type-triple" class="anchor"></a><code><span><span class="keyword">type</span> triple</span><span> = int * int * int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-triple">
+     <a href="#type-triple" class="anchor"></a><code><span><span class="keyword">type</span> triple</span><span> = int * int * int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-nested_pair">
-    <a href="#type-nested_pair" class="anchor"></a><code><span><span class="keyword">type</span> nested_pair</span><span> = <span>(int * int)</span> * int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-nested_pair">
+     <a href="#type-nested_pair" class="anchor"></a><code><span><span class="keyword">type</span> nested_pair</span><span> = <span>(int * int)</span> * int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-instance">
-    <a href="#type-instance" class="anchor"></a><code><span><span class="keyword">type</span> instance</span><span> = <span>int <a href="#type-constructor">constructor</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-instance">
+     <a href="#type-instance" class="anchor"></a><code><span><span class="keyword">type</span> instance</span><span> = <span>int <a href="#type-constructor">constructor</a></span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-long">
-    <a href="#type-long" class="anchor"></a><code><span><span class="keyword">type</span> long</span><span> = <span><a href="#type-labeled_higher_order">labeled_higher_order</a> <span>-&gt;</span></span> <span><span>[ `Bar <span><span>| `Baz</span> of <a href="#type-triple">triple</a></span> ]</span> <span>-&gt;</span></span> <span><a href="#type-pair">pair</a> <span>-&gt;</span></span> <span><a href="#type-labeled">labeled</a> <span>-&gt;</span></span> <span><a href="#type-higher_order">higher_order</a> <span>-&gt;</span></span> <span><span>(<span>string <span>-&gt;</span></span> int)</span> <span>-&gt;</span></span> <span><span><span>(int,&nbsp;float,&nbsp;char,&nbsp;string,&nbsp;char,&nbsp;unit)</span> <span class="xref-unresolved">CamlinternalFormatBasics</span>.fmtty</span> <span>-&gt;</span></span> <span><a href="#type-nested_pair">nested_pair</a> <span>-&gt;</span></span> <span><a href="#type-arrow">arrow</a> <span>-&gt;</span></span> <span>string <span>-&gt;</span></span> <span><a href="#type-nested_pair">nested_pair</a> array</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-long">
+     <a href="#type-long" class="anchor"></a><code><span><span class="keyword">type</span> long</span><span> = <span><a href="#type-labeled_higher_order">labeled_higher_order</a> <span>-&gt;</span></span> <span><span>[ `Bar <span><span>| `Baz</span> of <a href="#type-triple">triple</a></span> ]</span> <span>-&gt;</span></span> <span><a href="#type-pair">pair</a> <span>-&gt;</span></span> <span><a href="#type-labeled">labeled</a> <span>-&gt;</span></span> <span><a href="#type-higher_order">higher_order</a> <span>-&gt;</span></span> <span><span>(<span>string <span>-&gt;</span></span> int)</span> <span>-&gt;</span></span> <span><span><span>(int,&nbsp;float,&nbsp;char,&nbsp;string,&nbsp;char,&nbsp;unit)</span> <span class="xref-unresolved">CamlinternalFormatBasics</span>.fmtty</span> <span>-&gt;</span></span> <span><a href="#type-nested_pair">nested_pair</a> <span>-&gt;</span></span> <span><a href="#type-arrow">arrow</a> <span>-&gt;</span></span> <span>string <span>-&gt;</span></span> <span><a href="#type-nested_pair">nested_pair</a> array</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-variant_e">
-    <a href="#type-variant_e" class="anchor"></a><code><span><span class="keyword">type</span> variant_e</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-variant_e.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-variant_e.a" class="anchor"></a><code><span>a : int;</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-variant_e">
+     <a href="#type-variant_e" class="anchor"></a><code><span><span class="keyword">type</span> variant_e</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-variant_e.a" class="anchored">
+        <td class="def record field">
+         <a href="#type-variant_e.a" class="anchor"></a><code><span>a : int;</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-variant">
-    <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-variant.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-       </td>
-      </tr>
-      <tr id="type-variant.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> int</span></code>
-       </td>
-      </tr>
-      <tr id="type-variant.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         foo
-        </p>
-       </td>
-      </tr>
-      <tr id="type-variant.D" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <em>bar</em>
-        </p>
-       </td>
-      </tr>
-      <tr id="type-variant.E" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> <a href="#type-variant_e">variant_e</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-variant">
+     <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-variant.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+        </td>
+       </tr>
+       <tr id="type-variant.B" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> int</span></code>
+        </td>
+       </tr>
+       <tr id="type-variant.C" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.D" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <em>bar</em>
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.E" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> <a href="#type-variant_e">variant_e</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec type" id="type-variant_c">
-    <a href="#type-variant_c" class="anchor"></a><code><span><span class="keyword">type</span> variant_c</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-variant_c.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-variant_c.a" class="anchor"></a><code><span>a : int;</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-variant_c">
+     <a href="#type-variant_c" class="anchor"></a><code><span><span class="keyword">type</span> variant_c</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-variant_c.a" class="anchored">
+        <td class="def record field">
+         <a href="#type-variant_c.a" class="anchor"></a><code><span>a : int;</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-gadt">
-    <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> <span>_ gadt</span></span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-gadt.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <span>int <a href="#type-gadt">gadt</a></span></span></code>
-       </td>
-      </tr>
-      <tr id="type-gadt.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> : int <span>-&gt;</span> <span>string <a href="#type-gadt">gadt</a></span></span></code>
-       </td>
-      </tr>
-      <tr id="type-gadt.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span> : <a href="#type-variant_c">variant_c</a> <span>-&gt;</span> <span>unit <a href="#type-gadt">gadt</a></span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-gadt">
+     <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> <span>_ gadt</span></span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-gadt.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <span>int <a href="#type-gadt">gadt</a></span></span></code>
+        </td>
+       </tr>
+       <tr id="type-gadt.B" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> : int <span>-&gt;</span> <span>string <a href="#type-gadt">gadt</a></span></span></code>
+        </td>
+       </tr>
+       <tr id="type-gadt.C" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span> : <a href="#type-variant_c">variant_c</a> <span>-&gt;</span> <span>unit <a href="#type-gadt">gadt</a></span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec type" id="type-degenerate_gadt">
-    <a href="#type-degenerate_gadt" class="anchor"></a><code><span><span class="keyword">type</span> degenerate_gadt</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-degenerate_gadt.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-degenerate_gadt">degenerate_gadt</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-degenerate_gadt">
+     <a href="#type-degenerate_gadt" class="anchor"></a><code><span><span class="keyword">type</span> degenerate_gadt</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-degenerate_gadt.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-degenerate_gadt">degenerate_gadt</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec type" id="type-private_variant">
-    <a href="#type-private_variant" class="anchor"></a><code><span><span class="keyword">type</span> private_variant</span><span> = <span class="keyword">private</span> </span></code>
-    <table>
-     <tbody>
-      <tr id="type-private_variant.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-private_variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-private_variant">
+     <a href="#type-private_variant" class="anchor"></a><code><span><span class="keyword">type</span> private_variant</span><span> = <span class="keyword">private</span> </span></code>
+     <table>
+      <tbody>
+       <tr id="type-private_variant.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-private_variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec type" id="type-record">
-    <a href="#type-record" class="anchor"></a><code><span><span class="keyword">type</span> record</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-record.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.a" class="anchor"></a><code><span>a : int;</span></code>
-       </td>
-      </tr>
-      <tr id="type-record.b" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.b" class="anchor"></a><code><span><span class="keyword">mutable</span> b : int;</span></code>
-       </td>
-      </tr>
-      <tr id="type-record.c" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.c" class="anchor"></a><code><span>c : int;</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         foo
-        </p>
-       </td>
-      </tr>
-      <tr id="type-record.d" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.d" class="anchor"></a><code><span>d : int;</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <em>bar</em>
-        </p>
-       </td>
-      </tr>
-      <tr id="type-record.e" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.e" class="anchor"></a><code><span>e : a. <span class="type-var">'a</span>;</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-record">
+     <a href="#type-record" class="anchor"></a><code><span><span class="keyword">type</span> record</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-record.a" class="anchored">
+        <td class="def record field">
+         <a href="#type-record.a" class="anchor"></a><code><span>a : int;</span></code>
+        </td>
+       </tr>
+       <tr id="type-record.b" class="anchored">
+        <td class="def record field">
+         <a href="#type-record.b" class="anchor"></a><code><span><span class="keyword">mutable</span> b : int;</span></code>
+        </td>
+       </tr>
+       <tr id="type-record.c" class="anchored">
+        <td class="def record field">
+         <a href="#type-record.c" class="anchor"></a><code><span>c : int;</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-record.d" class="anchored">
+        <td class="def record field">
+         <a href="#type-record.d" class="anchor"></a><code><span>d : int;</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <em>bar</em>
+         </p>
+        </td>
+       </tr>
+       <tr id="type-record.e" class="anchored">
+        <td class="def record field">
+         <a href="#type-record.e" class="anchor"></a><code><span>e : a. <span class="type-var">'a</span>;</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-polymorphic_variant">
-    <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-polymorphic_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.B" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> int</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.C" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C <span class="keyword">of</span> int * unit</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.D" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-polymorphic_variant">
+     <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-polymorphic_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> int</span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C <span class="keyword">of</span> int * unit</span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.D" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-polymorphic_variant_extension">
-    <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant_extension</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
-       <td class="def type">
-        <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant_extension.E" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span>| </span></code><code><span>`E</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-polymorphic_variant_extension">
+     <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant_extension</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
+        <td class="def type">
+         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant_extension.E" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span>| </span></code><code><span>`E</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-nested_polymorphic_variant">
-    <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_polymorphic_variant</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-nested_polymorphic_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A <span class="keyword">of</span> <span>[ `B <span>| `C</span> ]</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-nested_polymorphic_variant">
+     <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_polymorphic_variant</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-nested_polymorphic_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A <span class="keyword">of</span> <span>[ `B <span>| `C</span> ]</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-private_extenion#row">
-    <a href="#type-private_extenion#row" class="anchor"></a><code><span><span class="keyword">type</span> private_extenion#row</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-private_extenion#row">
+     <a href="#type-private_extenion#row" class="anchor"></a><code><span><span class="keyword">type</span> private_extenion#row</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-private_extenion">
-    <a href="#type-private_extenion" class="anchor"></a><code><span><span class="keyword">and</span> private_extenion</span><span> = <span class="keyword">private</span> </span><span>[&gt; </span></code>
-    <table>
-     <tbody>
-      <tr id="type-private_extenion.polymorphic_variant" class="anchored">
-       <td class="def type">
-        <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-private_extenion">
+     <a href="#type-private_extenion" class="anchor"></a><code><span><span class="keyword">and</span> private_extenion</span><span> = <span class="keyword">private</span> </span><span>[&gt; </span></code>
+     <table>
+      <tbody>
+       <tr id="type-private_extenion.polymorphic_variant" class="anchored">
+        <td class="def type">
+         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-object_">
-    <a href="#type-object_" class="anchor"></a><code><span><span class="keyword">type</span> object_</span><span> = <span>&lt; a : int; b : int; c : int; &gt;</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-object_">
+     <a href="#type-object_" class="anchor"></a><code><span><span class="keyword">type</span> object_</span><span> = <span>&lt; a : int; b : int; c : int; &gt;</span></span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-X">
-    <a href="#module-type-X" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-X/index.html">X</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-X">
+     <a href="#module-type-X" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-X/index.html">X</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-module_">
-    <a href="#type-module_" class="anchor"></a><code><span><span class="keyword">type</span> module_</span><span> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-module_">
+     <a href="#type-module_" class="anchor"></a><code><span><span class="keyword">type</span> module_</span><span> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-module_substitution">
-    <a href="#type-module_substitution" class="anchor"></a><code><span><span class="keyword">type</span> module_substitution</span><span> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-module_substitution">
+     <a href="#type-module_substitution" class="anchor"></a><code><span><span class="keyword">type</span> module_substitution</span><span> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-covariant">
-    <a href="#type-covariant" class="anchor"></a><code><span><span class="keyword">type</span> <span>+'a covariant</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-covariant">
+     <a href="#type-covariant" class="anchor"></a><code><span><span class="keyword">type</span> <span>+'a covariant</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-contravariant">
-    <a href="#type-contravariant" class="anchor"></a><code><span><span class="keyword">type</span> <span>-'a contravariant</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-contravariant">
+     <a href="#type-contravariant" class="anchor"></a><code><span><span class="keyword">type</span> <span>-'a contravariant</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-bivariant">
-    <a href="#type-bivariant" class="anchor"></a><code><span><span class="keyword">type</span> <span>_ bivariant</span></span><span> = int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-bivariant">
+     <a href="#type-bivariant" class="anchor"></a><code><span><span class="keyword">type</span> <span>_ bivariant</span></span><span> = int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-binary">
-    <a href="#type-binary" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) binary</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-binary">
+     <a href="#type-binary" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) binary</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-using_binary">
-    <a href="#type-using_binary" class="anchor"></a><code><span><span class="keyword">type</span> using_binary</span><span> = <span><span>(int,&nbsp;int)</span> <a href="#type-binary">binary</a></span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-using_binary">
+     <a href="#type-using_binary" class="anchor"></a><code><span><span class="keyword">type</span> using_binary</span><span> = <span><span>(int,&nbsp;int)</span> <a href="#type-binary">binary</a></span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-name">
-    <a href="#type-name" class="anchor"></a><code><span><span class="keyword">type</span> <span>'custom name</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-name">
+     <a href="#type-name" class="anchor"></a><code><span><span class="keyword">type</span> <span>'custom name</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-constrained">
-    <a href="#type-constrained" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a constrained</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-constrained">
+     <a href="#type-constrained" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a constrained</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-exact_variant">
-    <a href="#type-exact_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a exact_variant</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[ `A <span><span>| `B</span> of int</span> ]</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-exact_variant">
+     <a href="#type-exact_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a exact_variant</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[ `A <span><span>| `B</span> of int</span> ]</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-lower_variant">
-    <a href="#type-lower_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a lower_variant</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `A <span><span>| `B</span> of int</span> ]</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-lower_variant">
+     <a href="#type-lower_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a lower_variant</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `A <span><span>| `B</span> of int</span> ]</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-any_variant">
-    <a href="#type-any_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a any_variant</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt;  ]</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-any_variant">
+     <a href="#type-any_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a any_variant</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt;  ]</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-upper_variant">
-    <a href="#type-upper_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a upper_variant</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; `A <span><span>| `B</span> of int</span> ]</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-upper_variant">
+     <a href="#type-upper_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a upper_variant</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; `A <span><span>| `B</span> of int</span> ]</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-named_variant">
-    <a href="#type-named_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a named_variant</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; <a href="#type-polymorphic_variant">polymorphic_variant</a> ]</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-named_variant">
+     <a href="#type-named_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a named_variant</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; <a href="#type-polymorphic_variant">polymorphic_variant</a> ]</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-exact_object">
-    <a href="#type-exact_object" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a exact_object</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>&lt; a : int; b : int; &gt;</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-exact_object">
+     <a href="#type-exact_object" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a exact_object</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>&lt; a : int; b : int; &gt;</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-lower_object">
-    <a href="#type-lower_object" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a lower_object</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>&lt; a : int; b : int; .. &gt;</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-lower_object">
+     <a href="#type-lower_object" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a lower_object</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>&lt; a : int; b : int; .. &gt;</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-poly_object">
-    <a href="#type-poly_object" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a poly_object</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>&lt; a : a. <span class="type-var">'a</span>; &gt;</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-poly_object">
+     <a href="#type-poly_object" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a poly_object</span></span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>&lt; a : a. <span class="type-var">'a</span>; &gt;</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-double_constrained">
-    <a href="#type-double_constrained" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) double_constrained</span></span><span> = <span class="type-var">'a</span> * <span class="type-var">'b</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-double_constrained">
+     <a href="#type-double_constrained" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) double_constrained</span></span><span> = <span class="type-var">'a</span> * <span class="type-var">'b</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-as_">
-    <a href="#type-as_" class="anchor"></a><code><span><span class="keyword">type</span> as_</span><span> = int <span class="keyword">as</span> 'a * <span class="type-var">'a</span></span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-as_">
+     <a href="#type-as_" class="anchor"></a><code><span><span class="keyword">type</span> as_</span><span> = int <span class="keyword">as</span> 'a * <span class="type-var">'a</span></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-extensible">
-    <a href="#type-extensible" class="anchor"></a><code><span><span class="keyword">type</span> extensible</span><span> = </span><span>..</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-extensible">
+     <a href="#type-extensible" class="anchor"></a><code><span><span class="keyword">type</span> extensible</span><span> = </span><span>..</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-extensible">extensible</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-Extension" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Extension" class="anchor"></a><code><span>| </span><span><span class="extension">Extension</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         Documentation for <a href="#extension-Extension"><code>Extension</code></a>.
-        </p>
-       </td>
-      </tr>
-      <tr id="extension-Another_extension" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Another_extension" class="anchor"></a><code><span>| </span><span><span class="extension">Another_extension</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         Documentation for <a href="#extension-Another_extension"><code>Another_extension</code></a>.
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-extensible">extensible</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-Extension" class="anchored">
+        <td class="def extension">
+         <a href="#extension-Extension" class="anchor"></a><code><span>| </span><span><span class="extension">Extension</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          Documentation for <a href="#extension-Extension"><code>Extension</code></a>.
+         </p>
+        </td>
+       </tr>
+       <tr id="extension-Another_extension" class="anchored">
+        <td class="def extension">
+         <a href="#extension-Another_extension" class="anchor"></a><code><span>| </span><span><span class="extension">Another_extension</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          Documentation for <a href="#extension-Another_extension"><code>Another_extension</code></a>.
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec type" id="type-mutually">
-    <a href="#type-mutually" class="anchor"></a><code><span><span class="keyword">type</span> mutually</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-mutually.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-mutually.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> <span class="keyword">of</span> <a href="#type-recursive">recursive</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-mutually">
+     <a href="#type-mutually" class="anchor"></a><code><span><span class="keyword">type</span> mutually</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-mutually.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-mutually.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> <span class="keyword">of</span> <a href="#type-recursive">recursive</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec type" id="type-recursive">
-    <a href="#type-recursive" class="anchor"></a><code><span><span class="keyword">and</span> recursive</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-recursive.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-recursive.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> <a href="#type-mutually">mutually</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-recursive">
+     <a href="#type-recursive" class="anchor"></a><code><span><span class="keyword">and</span> recursive</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-recursive.B" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-recursive.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> <a href="#type-mutually">mutually</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+    </div>
    </div>
-   <div class="spec exception" id="exception-Foo">
-    <a href="#exception-Foo" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Foo</span> <span class="keyword">of</span> int * int</span></code>
+   <div class="odoc-spec">
+    <div class="spec exception" id="exception-Foo">
+     <a href="#exception-Foo" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Foo</span> <span class="keyword">of</span> int * int</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Val/index.html
+++ b/test/html/expect/test_package+ml/Val/index.html
@@ -23,24 +23,26 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span><span class="keyword">val</span> documented : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Foo.
      </p>
     </div>
    </div>
-   <div class="spec value" id="val-undocumented">
-    <a href="#val-undocumented" class="anchor"></a><code><span><span class="keyword">val</span> undocumented : unit</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-undocumented">
+     <a href="#val-undocumented" class="anchor"></a><code><span><span class="keyword">val</span> undocumented : unit</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-documented_above">
      <a href="#val-documented_above" class="anchor"></a><code><span><span class="keyword">val</span> documented_above : unit</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Bar.
      </p>

--- a/test/html/expect/test_package+re/Alias/X/index.html
+++ b/test/html/expect/test_package+re/Alias/X/index.html
@@ -23,11 +23,11 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Module Foo__X documentation. This should appear in the documentation for the alias to this module 'X'
      </p>

--- a/test/html/expect/test_package+re/Alias/index.html
+++ b/test/html/expect/test_package+re/Alias/index.html
@@ -23,11 +23,15 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module" id="module-Foo__X">
-    <a href="#module-Foo__X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Foo__X/index.html">Foo__X</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Foo__X">
+     <a href="#module-Foo__X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Foo__X/index.html">Foo__X</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-X">
-    <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-X">
+     <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Bugs/index.html
+++ b/test/html/expect/test_package+re/Bugs/index.html
@@ -23,14 +23,16 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec type" id="type-opt">
-    <a href="#type-opt" class="anchor"></a><code><span><span class="keyword">type</span> opt('a)</span><span> = option(<span class="type-var">'a</span>)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-opt">
+     <a href="#type-opt" class="anchor"></a><code><span><span class="keyword">type</span> opt('a)</span><span> = option(<span class="type-var">'a</span>)</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: <span>?⁠bar:<span class="type-var">'a</span> <span>=&gt;</span></span> <span>unit <span>=&gt;</span></span> unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Triggers an assertion failure when <a href="https://github.com/ocaml/odoc/issues/101">https://github.com/ocaml/odoc/issues/101</a> is not fixed.
      </p>

--- a/test/html/expect/test_package+re/Bugs_post_406/index.html
+++ b/test/html/expect/test_package+re/Bugs_post_406/index.html
@@ -26,11 +26,15 @@
    </p>
   </header>
   <div class="odoc-content">
-   <div class="spec class-type" id="class-type-let_open">
-    <a href="#class-type-let_open" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-let_open/index.html">let_open</a></span><span> = { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-let_open">
+     <a href="#class-type-let_open" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-let_open/index.html">let_open</a></span><span> = { ... }</span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-let_open'">
-    <a href="#class-let_open'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-let_open'/index.html">let_open'</a></span><span>: { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-let_open'">
+     <a href="#class-let_open'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-let_open'/index.html">let_open'</a></span><span>: { ... }</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Bugs_pre_410/index.html
+++ b/test/html/expect/test_package+re/Bugs_pre_410/index.html
@@ -23,14 +23,16 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec type" id="type-opt'">
-    <a href="#type-opt'" class="anchor"></a><code><span><span class="keyword">type</span> opt'('a)</span><span> = option(int)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-opt'">
+     <a href="#type-opt'" class="anchor"></a><code><span><span class="keyword">type</span> opt'('a)</span><span> = option(int)</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo'">
      <a href="#val-foo'" class="anchor"></a><code><span><span class="keyword">let</span> foo': <span>?⁠bar:<span class="type-var">'a</span> <span>=&gt;</span></span> <span>unit <span>=&gt;</span></span> unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Similar to <code>Bugs</code>, but the printed type of <code>~bar</code> should be <code>int</code>, not <code>'a</code>. This probably requires fixing in the compiler. See <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">https://github.com/ocaml/odoc/pull/230#issuecomment-433226807</a>.
      </p>

--- a/test/html/expect/test_package+re/Class/index.html
+++ b/test/html/expect/test_package+re/Class/index.html
@@ -23,32 +23,50 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec class-type" id="class-type-empty">
-    <a href="#class-type-empty" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-empty/index.html">empty</a></span><span> = { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-empty">
+     <a href="#class-type-empty" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-empty/index.html">empty</a></span><span> = { ... }</span></code>
+    </div>
    </div>
-   <div class="spec class-type" id="class-type-mutually">
-    <a href="#class-type-mutually" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-mutually/index.html">mutually</a></span><span> = { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-mutually">
+     <a href="#class-type-mutually" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-mutually/index.html">mutually</a></span><span> = { ... }</span></code>
+    </div>
    </div>
-   <div class="spec class-type" id="class-type-recursive">
-    <a href="#class-type-recursive" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-recursive/index.html">recursive</a></span><span> = { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-recursive">
+     <a href="#class-type-recursive" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-recursive/index.html">recursive</a></span><span> = { ... }</span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-mutually'">
-    <a href="#class-mutually'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-mutually'/index.html">mutually'</a></span><span>: <a href="class-type-mutually/index.html">mutually</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-mutually'">
+     <a href="#class-mutually'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-mutually'/index.html">mutually'</a></span><span>: <a href="class-type-mutually/index.html">mutually</a></span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-recursive'">
-    <a href="#class-recursive'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-recursive'/index.html">recursive'</a></span><span>: <a href="class-type-recursive/index.html">recursive</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-recursive'">
+     <a href="#class-recursive'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-recursive'/index.html">recursive'</a></span><span>: <a href="class-type-recursive/index.html">recursive</a></span></code>
+    </div>
    </div>
-   <div class="spec class-type" id="class-type-empty_virtual">
-    <a href="#class-type-empty_virtual" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  </span><span><a href="class-type-empty_virtual/index.html">empty_virtual</a></span><span> = { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-empty_virtual">
+     <a href="#class-type-empty_virtual" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span> <span class="keyword">virtual</span>  </span><span><a href="class-type-empty_virtual/index.html">empty_virtual</a></span><span> = { ... }</span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-empty_virtual'">
-    <a href="#class-empty_virtual'" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">virtual</span>  </span><span><a href="class-empty_virtual'/index.html">empty_virtual'</a></span><span>: <a href="class-type-empty/index.html">empty</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-empty_virtual'">
+     <a href="#class-empty_virtual'" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">virtual</span>  </span><span><a href="class-empty_virtual'/index.html">empty_virtual'</a></span><span>: <a href="class-type-empty/index.html">empty</a></span></code>
+    </div>
    </div>
-   <div class="spec class-type" id="class-type-polymorphic">
-    <a href="#class-type-polymorphic" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span> ('a) </span><span><a href="class-type-polymorphic/index.html">polymorphic</a></span><span> = { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-polymorphic">
+     <a href="#class-type-polymorphic" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span> ('a) </span><span><a href="class-type-polymorphic/index.html">polymorphic</a></span><span> = { ... }</span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-polymorphic'">
-    <a href="#class-polymorphic'" class="anchor"></a><code><span><span class="keyword">class</span> ('a) </span><span><a href="class-polymorphic'/index.html">polymorphic'</a></span><span>: <a href="class-type-polymorphic/index.html">polymorphic</a>(<span class="type-var">'a</span>)</span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-polymorphic'">
+     <a href="#class-polymorphic'" class="anchor"></a><code><span><span class="keyword">class</span> ('a) </span><span><a href="class-polymorphic'/index.html">polymorphic'</a></span><span>: <a href="class-type-polymorphic/index.html">polymorphic</a>(<span class="type-var">'a</span>)</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/External/index.html
+++ b/test/html/expect/test_package+re/External/index.html
@@ -23,11 +23,11 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec external" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: <span>unit <span>=&gt;</span></span> unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Foo <em>bar</em>.
      </p>

--- a/test/html/expect/test_package+re/Functor/index.html
+++ b/test/html/expect/test_package+re/Functor/index.html
@@ -23,26 +23,40 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S1/index.html">S1</a></span><span> = <span> (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S1">
+     <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S1/index.html">S1</a></span><span> = <span> (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-F1">
-    <a href="#module-F1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F1/index.html">F1</a></span><span>: <span> (<a href="F1/argument-1-Arg/index.html">Arg</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-F1">
+     <a href="#module-F1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F1/index.html">F1</a></span><span>: <span> (<a href="F1/argument-1-Arg/index.html">Arg</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-F2">
-    <a href="#module-F2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F2/index.html">F2</a></span><span>: <span> (<a href="F2/argument-1-Arg/index.html">Arg</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = <a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-F2">
+     <a href="#module-F2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F2/index.html">F2</a></span><span>: <span> (<a href="F2/argument-1-Arg/index.html">Arg</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = <a href="F2/argument-1-Arg/index.html#type-t">Arg.t</a></span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-F3">
-    <a href="#module-F3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F3/index.html">F3</a></span><span>: <span> (<a href="F3/argument-1-Arg/index.html">Arg</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-F3">
+     <a href="#module-F3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F3/index.html">F3</a></span><span>: <span> (<a href="F3/argument-1-Arg/index.html">Arg</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-F4">
-    <a href="#module-F4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F4/index.html">F4</a></span><span>: <span> (<a href="F4/argument-1-Arg/index.html">Arg</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-F4">
+     <a href="#module-F4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F4/index.html">F4</a></span><span>: <span> (<a href="F4/argument-1-Arg/index.html">Arg</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-F5">
-    <a href="#module-F5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F5/index.html">F5</a></span><span>: <span> () <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-F5">
+     <a href="#module-F5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F5/index.html">F5</a></span><span>: <span> () <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Include/index.html
+++ b/test/html/expect/test_package+re/Include/index.html
@@ -23,112 +23,138 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module-type" id="module-type-Not_inlined">
-    <a href="#module-type-Not_inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined/index.html">Not_inlined</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Not_inlined">
+     <a href="#module-type-Not_inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined/index.html">Not_inlined</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-t">
+         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Inlined">
-    <a href="#module-type-Inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inlined/index.html">Inlined</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Inlined">
+     <a href="#module-type-Inlined" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inlined/index.html">Inlined</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <div class="spec type" id="type-u">
-       <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span>;</span></code>
+      <div class="odoc-spec">
+       <div class="spec type" id="type-u">
+        <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span>;</span></code>
+       </div>
       </div>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Not_inlined_and_closed">
-    <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Not_inlined_and_closed">
+     <a href="#module-type-Not_inlined_and_closed" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details>
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec type" id="type-v">
-        <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-v">
+         <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span>;</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Not_inlined_and_opened">
-    <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Not_inlined_and_opened">
+     <a href="#module-type-Not_inlined_and_opened" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec type" id="type-w">
-        <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-w">
+         <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span><span>;</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Inherent_Module">
-    <a href="#module-type-Inherent_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Inherent_Module">
+     <a href="#module-type-Inherent_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec value" id="val-a">
-        <a href="#val-a" class="anchor"></a><code><span><span class="keyword">let</span> a: <a href="#type-t">t</a>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec value" id="val-a">
+         <a href="#val-a" class="anchor"></a><code><span><span class="keyword">let</span> a: <a href="#type-t">t</a>;</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-Dorminant_Module">
-    <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Dorminant_Module">
+     <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div>
+       <div class="odoc-include">
         <div class="spec include">
          <div class="doc">
           <details open="open">
            <summary>
             <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a><span class="keyword">;</span></span></code></span>
            </summary>
-           <div class="spec value" id="val-a">
-            <a href="#val-a" class="anchor"></a><code><span><span class="keyword">let</span> a: <a href="#type-t">t</a>;</span></code>
+           <div class="odoc-spec">
+            <div class="spec value" id="val-a">
+             <a href="#val-a" class="anchor"></a><code><span><span class="keyword">let</span> a: <a href="#type-t">t</a>;</span></code>
+            </div>
            </div>
           </details>
          </div>
         </div>
        </div>
-       <div class="spec value" id="val-a">
-        <a href="#val-a" class="anchor"></a><code><span><span class="keyword">let</span> a: <a href="#type-u">u</a>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec value" id="val-a">
+         <a href="#val-a" class="anchor"></a><code><span><span class="keyword">let</span> a: <a href="#type-u">u</a>;</span></code>
+        </div>
        </div>
       </details>
      </div>

--- a/test/html/expect/test_package+re/Include2/index.html
+++ b/test/html/expect/test_package+re/Include2/index.html
@@ -23,25 +23,27 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span>: { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Comment about X that should not appear when including X below.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <span class="keyword">struct</span> <span class="keyword">include</span> <a href="X/index.html">X</a> <span class="keyword">end</span><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-t">
+         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span><span>;</span></code>
+        </div>
        </div>
       </details>
      </div>

--- a/test/html/expect/test_package+re/Include_sections/index.html
+++ b/test/html/expect/test_package+re/Include_sections/index.html
@@ -70,46 +70,50 @@
    </ul>
   </nav>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Something">
      <a href="#module-type-Something" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Something/index.html">Something</a></span><span> = { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A module type.
      </p>
     </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Let's include <a href="module-type-Something/index.html"><code>Something</code></a> once
     </p>
    </aside>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <div class="spec value" id="val-something">
-       <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+       </div>
       </div>
       <h2 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h2>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         foo
        </p>
       </aside>
-      <div class="spec value" id="val-foo">
-       <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+       </div>
       </div>
       <h3 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h3>
-      <div>
+      <div class="odoc-spec">
        <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
        </div>
-       <div>
+       <div class="spec-doc">
         <p>
          foo bar
         </p>
@@ -118,7 +122,7 @@
       <h2 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h2>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         Some text.
        </p>
@@ -129,36 +133,40 @@
    <h2 id="second-include">
     <a href="#second-include" class="anchor"></a>Second include
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
     </p>
    </aside>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <div class="spec value" id="val-something">
-       <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+       </div>
       </div>
       <h3 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h3>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         foo
        </p>
       </aside>
-      <div class="spec value" id="val-foo">
-       <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+       </div>
       </div>
       <h4 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h4>
-      <div>
+      <div class="odoc-spec">
        <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
        </div>
-       <div>
+       <div class="spec-doc">
         <p>
          foo bar
         </p>
@@ -167,7 +175,7 @@
       <h3 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h3>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         Some text.
        </p>
@@ -178,36 +186,40 @@
    <h3 id="third-include">
     <a href="#third-include" class="anchor"></a>Third include
    </h3>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Shifted some more.
     </p>
    </aside>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <div class="spec value" id="val-something">
-       <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-something">
+        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+       </div>
       </div>
       <h4 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h4>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         foo
        </p>
       </aside>
-      <div class="spec value" id="val-foo">
-       <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+      <div class="odoc-spec">
+       <div class="spec value" id="val-foo">
+        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+       </div>
       </div>
       <h5 id="something-2">
        <a href="#something-2" class="anchor"></a>Something 2
       </h5>
-      <div>
+      <div class="odoc-spec">
        <div class="spec value" id="val-bar">
         <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
        </div>
-       <div>
+       <div class="spec-doc">
         <p>
          foo bar
         </p>
@@ -216,7 +228,7 @@
       <h4 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h4>
-      <aside>
+      <aside class="odoc-unattached">
        <p>
         Some text.
        </p>
@@ -224,40 +236,44 @@
      </div>
     </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      And let's include it again, but without inlining it this time: the ToC shouldn't grow.
     </p>
    </aside>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Something/index.html">Something</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+       <div class="odoc-spec">
+        <div class="spec value" id="val-something">
+         <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+        </div>
        </div>
        <h2 id="something-1">
         <a href="#something-1" class="anchor"></a>Something 1
        </h2>
-       <aside>
+       <aside class="odoc-unattached">
         <p>
          foo
         </p>
        </aside>
-       <div class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+       <div class="odoc-spec">
+        <div class="spec value" id="val-foo">
+         <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+        </div>
        </div>
        <h3 id="something-2">
         <a href="#something-2" class="anchor"></a>Something 2
        </h3>
-       <div>
+       <div class="odoc-spec">
         <div class="spec value" id="val-bar">
          <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
         </div>
-        <div>
+        <div class="spec-doc">
          <p>
           foo bar
          </p>
@@ -266,7 +282,7 @@
        <h2 id="something-1-bis">
         <a href="#something-1-bis" class="anchor"></a>Something 1-bis
        </h2>
-       <aside>
+       <aside class="odoc-unattached">
         <p>
          Some text.
         </p>

--- a/test/html/expect/test_package+re/Include_sections/index.html
+++ b/test/html/expect/test_package+re/Include_sections/index.html
@@ -80,11 +80,9 @@
      </p>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Let's include <a href="module-type-Something/index.html"><code>Something</code></a> once
-    </p>
-   </aside>
+   <p>
+    Let's include <a href="module-type-Something/index.html"><code>Something</code></a> once
+   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
@@ -96,11 +94,9 @@
       <h2 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h2>
-      <aside class="odoc-unattached">
-       <p>
-        foo
-       </p>
-      </aside>
+      <p>
+       foo
+      </p>
       <div class="odoc-spec">
        <div class="spec value" id="val-foo">
         <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
@@ -122,22 +118,18 @@
       <h2 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h2>
-      <aside class="odoc-unattached">
-       <p>
-        Some text.
-       </p>
-      </aside>
+      <p>
+       Some text.
+      </p>
      </div>
     </div>
    </div>
    <h2 id="second-include">
     <a href="#second-include" class="anchor"></a>Second include
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
-    </p>
-   </aside>
+   <p>
+    Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
+   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
@@ -149,11 +141,9 @@
       <h3 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h3>
-      <aside class="odoc-unattached">
-       <p>
-        foo
-       </p>
-      </aside>
+      <p>
+       foo
+      </p>
       <div class="odoc-spec">
        <div class="spec value" id="val-foo">
         <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
@@ -175,22 +165,18 @@
       <h3 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h3>
-      <aside class="odoc-unattached">
-       <p>
-        Some text.
-       </p>
-      </aside>
+      <p>
+       Some text.
+      </p>
      </div>
     </div>
    </div>
    <h3 id="third-include">
     <a href="#third-include" class="anchor"></a>Third include
    </h3>
-   <aside class="odoc-unattached">
-    <p>
-     Shifted some more.
-    </p>
-   </aside>
+   <p>
+    Shifted some more.
+   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
@@ -202,11 +188,9 @@
       <h4 id="something-1">
        <a href="#something-1" class="anchor"></a>Something 1
       </h4>
-      <aside class="odoc-unattached">
-       <p>
-        foo
-       </p>
-      </aside>
+      <p>
+       foo
+      </p>
       <div class="odoc-spec">
        <div class="spec value" id="val-foo">
         <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
@@ -228,19 +212,15 @@
       <h4 id="something-1-bis">
        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
       </h4>
-      <aside class="odoc-unattached">
-       <p>
-        Some text.
-       </p>
-      </aside>
+      <p>
+       Some text.
+      </p>
      </div>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     And let's include it again, but without inlining it this time: the ToC shouldn't grow.
-    </p>
-   </aside>
+   <p>
+    And let's include it again, but without inlining it this time: the ToC shouldn't grow.
+   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
@@ -256,11 +236,9 @@
        <h2 id="something-1">
         <a href="#something-1" class="anchor"></a>Something 1
        </h2>
-       <aside class="odoc-unattached">
-        <p>
-         foo
-        </p>
-       </aside>
+       <p>
+        foo
+       </p>
        <div class="odoc-spec">
         <div class="spec value" id="val-foo">
          <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
@@ -282,11 +260,9 @@
        <h2 id="something-1-bis">
         <a href="#something-1-bis" class="anchor"></a>Something 1-bis
        </h2>
-       <aside class="odoc-unattached">
-        <p>
-         Some text.
-        </p>
-       </aside>
+       <p>
+        Some text.
+       </p>
       </details>
      </div>
     </div>

--- a/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
@@ -41,28 +41,32 @@
    </ul>
   </nav>
   <div class="odoc-content">
-   <div class="spec value" id="val-something">
-    <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-something">
+     <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+    </div>
    </div>
    <h2 id="something-1">
     <a href="#something-1" class="anchor"></a>Something 1
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      foo
     </p>
    </aside>
-   <div class="spec value" id="val-foo">
-    <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+    </div>
    </div>
    <h3 id="something-2">
     <a href="#something-2" class="anchor"></a>Something 2
    </h3>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-bar">
      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       foo bar
      </p>
@@ -71,7 +75,7 @@
    <h2 id="something-1-bis">
     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Some text.
     </p>

--- a/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
@@ -49,11 +49,9 @@
    <h2 id="something-1">
     <a href="#something-1" class="anchor"></a>Something 1
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     foo
-    </p>
-   </aside>
+   <p>
+    foo
+   </p>
    <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
@@ -75,11 +73,9 @@
    <h2 id="something-1-bis">
     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Some text.
-    </p>
-   </aside>
+   <p>
+    Some text.
+   </p>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Interlude/index.html
+++ b/test/html/expect/test_package+re/Interlude/index.html
@@ -26,22 +26,22 @@
    </p>
   </header>
   <div class="odoc-content">
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Some separate stray text at the top of the module.
     </p>
    </aside>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Foo.
      </p>
     </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Some stray text that is not associated with any signature item.
     </p>
@@ -52,26 +52,32 @@
      A separate block of stray text, adjacent to the preceding one.
     </p>
    </aside>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-bar">
      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Bar.
      </p>
     </div>
    </div>
-   <div class="spec value" id="val-multiple">
-    <a href="#val-multiple" class="anchor"></a><code><span><span class="keyword">let</span> multiple: unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-multiple">
+     <a href="#val-multiple" class="anchor"></a><code><span><span class="keyword">let</span> multiple: unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-signature">
-    <a href="#val-signature" class="anchor"></a><code><span><span class="keyword">let</span> signature: unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-signature">
+     <a href="#val-signature" class="anchor"></a><code><span><span class="keyword">let</span> signature: unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-items">
-    <a href="#val-items" class="anchor"></a><code><span><span class="keyword">let</span> items: unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-items">
+     <a href="#val-items" class="anchor"></a><code><span><span class="keyword">let</span> items: unit;</span></code>
+    </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Stray text at the bottom of the module.
     </p>

--- a/test/html/expect/test_package+re/Interlude/index.html
+++ b/test/html/expect/test_package+re/Interlude/index.html
@@ -26,11 +26,9 @@
    </p>
   </header>
   <div class="odoc-content">
-   <aside class="odoc-unattached">
-    <p>
-     Some separate stray text at the top of the module.
-    </p>
-   </aside>
+   <p>
+    Some separate stray text at the top of the module.
+   </p>
    <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
@@ -41,17 +39,15 @@
      </p>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Some stray text that is not associated with any signature item.
-    </p>
-    <p>
-     It has multiple paragraphs.
-    </p>
-    <p>
-     A separate block of stray text, adjacent to the preceding one.
-    </p>
-   </aside>
+   <p>
+    Some stray text that is not associated with any signature item.
+   </p>
+   <p>
+    It has multiple paragraphs.
+   </p>
+   <p>
+    A separate block of stray text, adjacent to the preceding one.
+   </p>
    <div class="odoc-spec">
     <div class="spec value" id="val-bar">
      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
@@ -77,11 +73,9 @@
      <a href="#val-items" class="anchor"></a><code><span><span class="keyword">let</span> items: unit;</span></code>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Stray text at the bottom of the module.
-    </p>
-   </aside>
+   <p>
+    Stray text at the bottom of the module.
+   </p>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -36,62 +36,72 @@
    <h2 id="L2">
     <a href="#L2" class="anchor"></a>Attached to nothing
    </h2>
-   <div class="spec module" id="module-A">
-    <a href="#module-A" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="A/index.html">A</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-A">
+     <a href="#module-A" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="A/index.html">A</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to type
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-f">
      <a href="#val-f" class="anchor"></a><code><span><span class="keyword">let</span> f: <a href="#type-t">t</a>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to value
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec external" id="val-e">
      <a href="#val-e" class="anchor"></a><code><span><span class="keyword">let</span> e: <span>unit <span>=&gt;</span></span> <a href="#type-t">t</a>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to external
      </p>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-c">
-    <a href="#class-c" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-c/index.html">c</a></span><span>: { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-c">
+     <a href="#class-c" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-c/index.html">c</a></span><span>: { ... }</span></code>
+    </div>
    </div>
-   <div class="spec class-type" id="class-type-cs">
-    <a href="#class-type-cs" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-cs/index.html">cs</a></span><span> = { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-cs">
+     <a href="#class-type-cs" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-cs/index.html">cs</a></span><span> = { ... }</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-E">
      <a href="#exception-E" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">E</span></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to exception
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-x">
-    <a href="#type-x" class="anchor"></a><code><span><span class="keyword">type</span> x</span><span> = </span><span>..</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-x">
+     <a href="#type-x" class="anchor"></a><code><span><span class="keyword">type</span> x</span><span> = </span><span>..</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec extension">
      <code><span><span class="keyword">type</span> <a href="#type-x">x</a> += </span></code>
      <table>
@@ -105,69 +115,73 @@
      </table>
      <code><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to extension
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-substitution" id="module-S">
      <a href="#module-S" class="anchor"></a><code><span><span class="keyword">module</span> S := <a href="A/index.html">A</a></span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to module subst
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type-subst" id="type-s">
      <a href="#type-s" class="anchor"></a><code><span><span class="keyword">type</span> s</span><span> := <a href="#type-t">t</a></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Attached to type subst
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-u">
-    <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-u.A'" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-u.A'" class="anchor"></a><code><span>| </span><span><span class="constructor">A'</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         Attached to constructor
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-u">
+     <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-u.A'" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-u.A'" class="anchor"></a><code><span>| </span><span><span class="constructor">A'</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          Attached to constructor
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-v">
-    <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-v.f" class="anchored">
-       <td class="def record field">
-        <a href="#type-v.f" class="anchor"></a><code><span>f: <a href="#type-t">t</a>,</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         Attached to field
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-v">
+     <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-v.f" class="anchored">
+        <td class="def record field">
+         <a href="#type-v.f" class="anchor"></a><code><span>f: <a href="#type-t">t</a>,</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          Attached to field
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span><span>;</span></code>
+    </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Testing that labels can be referenced
     </p>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -181,52 +181,50 @@
      <code><span>}</span><span>;</span></code>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Testing that labels can be referenced
-    </p>
-    <ul>
-     <li>
-      <a href="#L1">Attached to unit</a>
-     </li>
-     <li>
-      <a href="#L2">Attached to nothing</a>
-     </li>
-     <li>
-      <a href="#L3">Attached to module</a>
-     </li>
-     <li>
-      <a href="#L4">Attached to type</a>
-     </li>
-     <li>
-      <a href="#L5">Attached to value</a>
-     </li>
-     <li>
-      <a href="#L6">Attached to class</a>
-     </li>
-     <li>
-      <a href="#L7">Attached to class type</a>
-     </li>
-     <li>
-      <a href="#L8">Attached to exception</a>
-     </li>
-     <li>
-      <a href="#L9">Attached to extension</a>
-     </li>
-     <li>
-      <a href="#L10">Attached to module subst</a>
-     </li>
-     <li>
-      <a href="#L11">Attached to type subst</a>
-     </li>
-     <li>
-      <a href="#L12">Attached to constructor</a>
-     </li>
-     <li>
-      <a href="#L13">Attached to field</a>
-     </li>
-    </ul>
-   </aside>
+   <p>
+    Testing that labels can be referenced
+   </p>
+   <ul>
+    <li>
+     <a href="#L1">Attached to unit</a>
+    </li>
+    <li>
+     <a href="#L2">Attached to nothing</a>
+    </li>
+    <li>
+     <a href="#L3">Attached to module</a>
+    </li>
+    <li>
+     <a href="#L4">Attached to type</a>
+    </li>
+    <li>
+     <a href="#L5">Attached to value</a>
+    </li>
+    <li>
+     <a href="#L6">Attached to class</a>
+    </li>
+    <li>
+     <a href="#L7">Attached to class type</a>
+    </li>
+    <li>
+     <a href="#L8">Attached to exception</a>
+    </li>
+    <li>
+     <a href="#L9">Attached to extension</a>
+    </li>
+    <li>
+     <a href="#L10">Attached to module subst</a>
+    </li>
+    <li>
+     <a href="#L11">Attached to type subst</a>
+    </li>
+    <li>
+     <a href="#L12">Attached to constructor</a>
+    </li>
+    <li>
+     <a href="#L13">Attached to field</a>
+    </li>
+   </ul>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -83,7 +83,7 @@
    <h2 id="sections">
     <a href="#sections" class="anchor"></a>Sections
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Let's get these done first, because sections will be used to break up the rest of this test.
     </p>
@@ -94,7 +94,7 @@
    <h3 id="subsection-headings">
     <a href="#subsection-headings" class="anchor"></a>Subsection headings
    </h3>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      and
     </p>
@@ -102,7 +102,7 @@
    <h4 id="sub-subsection-headings">
     <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings
    </h4>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
     </p>
@@ -110,7 +110,7 @@
    <h4 id="anchors">
     <a href="#anchors" class="anchor"></a>Anchors
    </h4>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Sections can have attached <a href="#anchors">Anchors</a>, and it is possible to <a href="#anchors">link</a> to them. Links to section headers should not be set in source code style.
     </p>
@@ -118,7 +118,7 @@
    <h5 id="paragraph">
     <a href="#paragraph" class="anchor"></a>Paragraph
    </h5>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Individual paragraphs can have a heading.
     </p>
@@ -126,7 +126,7 @@
    <h6 id="subparagraph">
     <a href="#subparagraph" class="anchor"></a>Subparagraph
    </h6>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Parts of a longer paragraph that can be considered alone can also have headings.
     </p>
@@ -134,7 +134,7 @@
    <h2 id="styling">
     <a href="#styling" class="anchor"></a>Styling
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
     </p>
@@ -157,7 +157,7 @@
    <h2 id="links-and-references">
     <a href="#links-and-references" class="anchor"></a>Links and references
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
     </p>
@@ -168,7 +168,7 @@
    <h2 id="preformatted-text">
     <a href="#preformatted-text" class="anchor"></a>Preformatted text
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      This is a code block:
     </p>
@@ -187,7 +187,7 @@ let bar =
    <h2 id="lists">
     <a href="#lists" class="anchor"></a>Lists
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <ul>
      <li>
       This is a
@@ -265,7 +265,7 @@ let bar =
    <h2 id="unicode">
     <a href="#unicode" class="anchor"></a>Unicode
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
     </p>
@@ -273,7 +273,7 @@ let bar =
    <h2 id="raw-html">
     <a href="#raw-html" class="anchor"></a>Raw HTML
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
     </p>
@@ -285,7 +285,7 @@ let bar =
    <h2 id="modules">
     <a href="#modules" class="anchor"></a>Modules
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <ul class="modules"></ul>
     <ul class="modules">
      <li>
@@ -307,7 +307,7 @@ let bar =
    <h2 id="tags">
     <a href="#tags" class="anchor"></a>Tags
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Each comment can end with zero or more tags. Here are some examples:
     </p>
@@ -416,11 +416,11 @@ let bar =
      </dd>
     </dl>
    </aside>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Comments in structure items <b>support</b> <em>markup</em>, t<sup>o</sup><sub>o</sub>.
      </p>

--- a/test/html/expect/test_package+re/Markup/index.html
+++ b/test/html/expect/test_package+re/Markup/index.html
@@ -83,339 +83,311 @@
    <h2 id="sections">
     <a href="#sections" class="anchor"></a>Sections
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Let's get these done first, because sections will be used to break up the rest of this test.
-    </p>
-    <p>
-     Besides the section heading above, there are also
-    </p>
-   </aside>
+   <p>
+    Let's get these done first, because sections will be used to break up the rest of this test.
+   </p>
+   <p>
+    Besides the section heading above, there are also
+   </p>
    <h3 id="subsection-headings">
     <a href="#subsection-headings" class="anchor"></a>Subsection headings
    </h3>
-   <aside class="odoc-unattached">
-    <p>
-     and
-    </p>
-   </aside>
+   <p>
+    and
+   </p>
    <h4 id="sub-subsection-headings">
     <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection headings
    </h4>
-   <aside class="odoc-unattached">
-    <p>
-     but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
-    </p>
-   </aside>
+   <p>
+    but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
+   </p>
    <h4 id="anchors">
     <a href="#anchors" class="anchor"></a>Anchors
    </h4>
-   <aside class="odoc-unattached">
-    <p>
-     Sections can have attached <a href="#anchors">Anchors</a>, and it is possible to <a href="#anchors">link</a> to them. Links to section headers should not be set in source code style.
-    </p>
-   </aside>
+   <p>
+    Sections can have attached <a href="#anchors">Anchors</a>, and it is possible to <a href="#anchors">link</a> to them. Links to section headers should not be set in source code style.
+   </p>
    <h5 id="paragraph">
     <a href="#paragraph" class="anchor"></a>Paragraph
    </h5>
-   <aside class="odoc-unattached">
-    <p>
-     Individual paragraphs can have a heading.
-    </p>
-   </aside>
+   <p>
+    Individual paragraphs can have a heading.
+   </p>
    <h6 id="subparagraph">
     <a href="#subparagraph" class="anchor"></a>Subparagraph
    </h6>
-   <aside class="odoc-unattached">
-    <p>
-     Parts of a longer paragraph that can be considered alone can also have headings.
-    </p>
-   </aside>
+   <p>
+    Parts of a longer paragraph that can be considered alone can also have headings.
+   </p>
    <h2 id="styling">
     <a href="#styling" class="anchor"></a>Styling
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
-    </p>
-    <p>
-     Note: <i>In italics <em>emphasis</em> is rendered as normal text while <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in italics.</i> <i>It also work the same in <a href="#">links in italics with <em>emphasis <em class="odd">in</em> emphasis</em>.</a></i>
-    </p>
-    <p>
-     <code>code</code> is a different kind of markup that doesn't allow nested markup.
-    </p>
-    <p>
-     It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.
-    </p>
-    <p>
-     This is also true between <em>non-</em><code>code</code> markup <em>and</em> <code>code</code>.
-    </p>
-    <p>
-     Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.
-    </p>
-   </aside>
+   <p>
+    This paragraph has some styled elements: <b>bold</b> and <i>italic</i>, <b><i>bold italic</i></b>, <em>emphasis</em>, <em><em class="odd">emphasis</em> within emphasis</em>, <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>. The line spacing should be enough for superscripts and subscripts not to look odd.
+   </p>
+   <p>
+    Note: <i>In italics <em>emphasis</em> is rendered as normal text while <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in italics.</i> <i>It also work the same in <a href="#">links in italics with <em>emphasis <em class="odd">in</em> emphasis</em>.</a></i>
+   </p>
+   <p>
+    <code>code</code> is a different kind of markup that doesn't allow nested markup.
+   </p>
+   <p>
+    It's possible for two markup elements to appear <b>next</b> <i>to</i> each other and have a space, and appear <b>next</b><i>to</i> each other with no space. It doesn't matter <b>how</b> <i>much</i> space it was in the source: in this sentence, it was two space characters. And in this one, there is <b>a</b> <i>newline</i>.
+   </p>
+   <p>
+    This is also true between <em>non-</em><code>code</code> markup <em>and</em> <code>code</code>.
+   </p>
+   <p>
+    Code can appear <b>inside <code>other</code> markup</b>. Its display shouldn't be affected.
+   </p>
    <h2 id="links-and-references">
     <a href="#links-and-references" class="anchor"></a>Links and references
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
-    </p>
-    <p>
-     This is a reference to <a href="#val-foo"><code>foo</code></a>. References can have replacement text: <a href="#val-foo">the value foo</a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="#val-foo"><b>bold</b></a>, <a href="#val-foo"><i>italic</i></a>, <a href="#val-foo"><em>emphasis</em></a>, <a href="#val-foo">super<sup>script</sup></a>, <a href="#val-foo">sub<sub>script</sub></a>, and <a href="#val-foo"><code>code</code></a>. It's also possible to surround a reference in a style: <b><a href="#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.
-    </p>
-   </aside>
+   <p>
+    This is a <a href="#">link</a>. It sends you to the top of this page. Links can have markup inside them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>, <a href="#">super<sup>script</sup></a>, <a href="#">sub<sub>script</sub></a>, and <a href="#"><code>code</code></a>. Links can also be nested <em><a href="#">inside</a></em> markup. Links cannot be nested inside each other. This link has no replacement text: <a href="#">#</a>. The text is filled in by odoc. This is a shorthand link: <a href="#">#</a>. The text is also filled in by odoc in this case.
+   </p>
+   <p>
+    This is a reference to <a href="#val-foo"><code>foo</code></a>. References can have replacement text: <a href="#val-foo">the value foo</a>. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: <a href="#val-foo"><b>bold</b></a>, <a href="#val-foo"><i>italic</i></a>, <a href="#val-foo"><em>emphasis</em></a>, <a href="#val-foo">super<sup>script</sup></a>, <a href="#val-foo">sub<sub>script</sub></a>, and <a href="#val-foo"><code>code</code></a>. It's also possible to surround a reference in a style: <b><a href="#val-foo"><code>foo</code></a></b>. References can't be nested inside references, and links and references can't be nested inside each other.
+   </p>
    <h2 id="preformatted-text">
     <a href="#preformatted-text" class="anchor"></a>Preformatted text
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     This is a code block:
-    </p>
-    <pre><code>let foo = ()
+   <p>
+    This is a code block:
+   </p>
+   <pre><code>let foo = ()
 (** There are some nested comments in here, but an unpaired comment
     terminator would terminate the whole doc surrounding comment. It's
     best to keep code blocks no wider than 72 characters. *)
 
 let bar =
   ignore foo</code></pre>
-    <p>
-     There are also verbatim blocks:
-    </p>
-    <pre>The main difference is these don't get syntax highlighting.</pre>
-   </aside>
+   <p>
+    There are also verbatim blocks:
+   </p>
+   <pre>The main difference is these don't get syntax highlighting.</pre>
    <h2 id="lists">
     <a href="#lists" class="anchor"></a>Lists
    </h2>
-   <aside class="odoc-unattached">
-    <ul>
-     <li>
-      This is a
-     </li>
-     <li>
-      shorthand bulleted list,
-     </li>
-     <li>
-      and the paragraphs in each list item support <em>styling</em>.
-     </li>
-    </ul>
-    <ol>
-     <li>
-      This is a
-     </li>
-     <li>
-      shorthand numbered list.
-     </li>
-    </ol>
-    <ul>
-     <li>
-      Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
-     </li>
-    </ul>
-    <p>
-     just creates a paragraph outside the list.
-    </p>
-    <ul>
-     <li>
-      Similarly, inserting a blank line between two list items
-     </li>
-    </ul>
-    <ul>
-     <li>
-      creates two separate lists.
-     </li>
-    </ul>
-    <ul>
-     <li>
-      <p>
-       To get around this limitation, one
-      </p>
-      <p>
-       can use explicitly-delimited lists.
-      </p>
-     </li>
-     <li>
-      This one is bulleted,
-     </li>
-    </ul>
-    <ol>
-     <li>
-      but there is also the numbered variant.
-     </li>
-    </ol>
-    <ul>
-     <li>
-      <ul>
-       <li>
-        lists
-       </li>
-       <li>
-        can be nested
-       </li>
-       <li>
-        and can include references
-       </li>
-       <li>
-        <a href="#val-foo"><code>foo</code></a>
-       </li>
-      </ul>
-     </li>
-    </ul>
-   </aside>
+   <ul>
+    <li>
+     This is a
+    </li>
+    <li>
+     shorthand bulleted list,
+    </li>
+    <li>
+     and the paragraphs in each list item support <em>styling</em>.
+    </li>
+   </ul>
+   <ol>
+    <li>
+     This is a
+    </li>
+    <li>
+     shorthand numbered list.
+    </li>
+   </ol>
+   <ul>
+    <li>
+     Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
+    </li>
+   </ul>
+   <p>
+    just creates a paragraph outside the list.
+   </p>
+   <ul>
+    <li>
+     Similarly, inserting a blank line between two list items
+    </li>
+   </ul>
+   <ul>
+    <li>
+     creates two separate lists.
+    </li>
+   </ul>
+   <ul>
+    <li>
+     <p>
+      To get around this limitation, one
+     </p>
+     <p>
+      can use explicitly-delimited lists.
+     </p>
+    </li>
+    <li>
+     This one is bulleted,
+    </li>
+   </ul>
+   <ol>
+    <li>
+     but there is also the numbered variant.
+    </li>
+   </ol>
+   <ul>
+    <li>
+     <ul>
+      <li>
+       lists
+      </li>
+      <li>
+       can be nested
+      </li>
+      <li>
+       and can include references
+      </li>
+      <li>
+       <a href="#val-foo"><code>foo</code></a>
+      </li>
+     </ul>
+    </li>
+   </ul>
    <h2 id="unicode">
     <a href="#unicode" class="anchor"></a>Unicode
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
-    </p>
-   </aside>
+   <p>
+    The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
+   </p>
    <h2 id="raw-html">
     <a href="#raw-html" class="anchor"></a>Raw HTML
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
-    </p>
-    <blockquote>
-     If the raw HTML is the only thing in a paragraph, it is treated as a block
+   <p>
+    Raw HTML can be <input type="text" placeholder="inserted"> as inline elements into sentences.
+   </p>
+   <blockquote>
+    If the raw HTML is the only thing in a paragraph, it is treated as a block
       element, and won't be wrapped in paragraph tags by the HTML generator.
-    </blockquote>
-   </aside>
+   </blockquote>
    <h2 id="modules">
     <a href="#modules" class="anchor"></a>Modules
    </h2>
-   <aside class="odoc-unattached">
-    <ul class="modules"></ul>
-    <ul class="modules">
-     <li>
-      <code>X</code>
-     </li>
-    </ul>
-    <ul class="modules">
-     <li>
-      <code>X</code>
-     </li>
-     <li>
-      <code>Y</code>
-     </li>
-     <li>
-      <code>Z</code>
-     </li>
-    </ul>
-   </aside>
+   <ul class="modules"></ul>
+   <ul class="modules">
+    <li>
+     <code>X</code>
+    </li>
+   </ul>
+   <ul class="modules">
+    <li>
+     <code>X</code>
+    </li>
+    <li>
+     <code>Y</code>
+    </li>
+    <li>
+     <code>Z</code>
+    </li>
+   </ul>
    <h2 id="tags">
     <a href="#tags" class="anchor"></a>Tags
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Each comment can end with zero or more tags. Here are some examples:
-    </p>
-    <dl>
-     <dt>
-      author
-     </dt>
-     <dd>
-      antron
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      deprecated
-     </dt>
-     <dd>
-      <p>
-       a <em>long</em> time ago
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      parameter foo
-     </dt>
-     <dd>
-      <p>
-       unused
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      raises Failure
-     </dt>
-     <dd>
-      <p>
-       always
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      returns
-     </dt>
-     <dd>
-      <p>
-       never
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      see <a href="#">#</a>
-     </dt>
-     <dd>
-      <p>
-       this url
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      see <code>foo.ml</code>
-     </dt>
-     <dd>
-      <p>
-       this file
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      see Foo
-     </dt>
-     <dd>
-      <p>
-       this document
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      since
-     </dt>
-     <dd>
-      0
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      before 1.0
-     </dt>
-     <dd>
-      <p>
-       it was in b<sup>e</sup>t<sub>a</sub>
-      </p>
-     </dd>
-    </dl>
-    <dl>
-     <dt>
-      version
-     </dt>
-     <dd>
-      -1
-     </dd>
-    </dl>
-   </aside>
+   <p>
+    Each comment can end with zero or more tags. Here are some examples:
+   </p>
+   <dl>
+    <dt>
+     author
+    </dt>
+    <dd>
+     antron
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     deprecated
+    </dt>
+    <dd>
+     <p>
+      a <em>long</em> time ago
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     parameter foo
+    </dt>
+    <dd>
+     <p>
+      unused
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     raises Failure
+    </dt>
+    <dd>
+     <p>
+      always
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     returns
+    </dt>
+    <dd>
+     <p>
+      never
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     see <a href="#">#</a>
+    </dt>
+    <dd>
+     <p>
+      this url
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     see <code>foo.ml</code>
+    </dt>
+    <dd>
+     <p>
+      this file
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     see Foo
+    </dt>
+    <dd>
+     <p>
+      this document
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     since
+    </dt>
+    <dd>
+     0
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     before 1.0
+    </dt>
+    <dd>
+     <p>
+      it was in b<sup>e</sup>t<sub>a</sub>
+     </p>
+    </dd>
+   </dl>
+   <dl>
+    <dt>
+     version
+    </dt>
+    <dd>
+     -1
+    </dd>
+   </dl>
    <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>

--- a/test/html/expect/test_package+re/Module/index.html
+++ b/test/html/expect/test_package+re/Module/index.html
@@ -26,57 +26,85 @@
    </p>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See <a href="https://caml.inria.fr/mantis/view.php?id=7701">https://caml.inria.fr/mantis/view.php?id=7701</a>.
      </p>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span>S1</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S1">
+     <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span>S1</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S2">
-    <a href="#module-type-S2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S2/index.html">S2</a></span><span> = <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S2">
+     <a href="#module-type-S2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S2/index.html">S2</a></span><span> = <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S3">
-    <a href="#module-type-S3" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S3/index.html">S3</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = int</span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-u">u</a> = string</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S3">
+     <a href="#module-type-S3" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S3/index.html">S3</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = int</span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-u">u</a> = string</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S4">
-    <a href="#module-type-S4" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S4/index.html">S4</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> := int</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S4">
+     <a href="#module-type-S4" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S4/index.html">S4</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> := int</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S5">
-    <a href="#module-type-S5" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S5/index.html">S5</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>)</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S5">
+     <a href="#module-type-S5" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S5/index.html">S5</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-v">v</a>('a) := list(<span class="type-var">'a</span>)</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-result">
-    <a href="#type-result" class="anchor"></a><code><span><span class="keyword">type</span> result('a, 'b)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-result">
+     <a href="#type-result" class="anchor"></a><code><span><span class="keyword">type</span> result('a, 'b)</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S6">
-    <a href="#module-type-S6" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S6/index.html">S6</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-w">w</a>('a, 'b) := <a href="#type-result">result</a><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span></span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S6">
+     <a href="#module-type-S6" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S6/index.html">S6</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-w">w</a>('a, 'b) := <a href="#type-result">result</a><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span></span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-M'">
-    <a href="#module-M'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M'/index.html">M'</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M'">
+     <a href="#module-M'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M'/index.html">M'</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S7">
-    <a href="#module-type-S7" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S7/index.html">S7</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> = <a href="M'/index.html">M'</a></span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S7">
+     <a href="#module-type-S7" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S7/index.html">S7</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> = <a href="M'/index.html">M'</a></span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S8">
-    <a href="#module-type-S8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S8/index.html">S8</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> := <a href="M'/index.html">M'</a></span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S8">
+     <a href="#module-type-S8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S8/index.html">S8</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> := <a href="M'/index.html">M'</a></span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S9">
-    <a href="#module-type-S9" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S9/index.html">S9</a></span><span> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="M'/index.html">M'</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S9">
+     <a href="#module-type-S9" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S9/index.html">S9</a></span><span> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="M'/index.html">M'</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Mutually">
-    <a href="#module-Mutually" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Mutually/index.html">Mutually</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Mutually">
+     <a href="#module-Mutually" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Mutually/index.html">Mutually</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Recursive">
-    <a href="#module-Recursive" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recursive/index.html">Recursive</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Recursive">
+     <a href="#module-Recursive" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recursive/index.html">Recursive</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
@@ -36,11 +36,11 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some type.
      </p>
@@ -49,11 +49,11 @@
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span><span class="keyword">let</span> y: <a href="#type-t">t</a>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       The value of y.
      </p>

--- a/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
@@ -33,11 +33,11 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some type.
      </p>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -45,11 +45,15 @@
    <h2 id="parameters">
     <a href="#parameters" class="anchor"></a>Parameters
    </h2>
-   <div class="spec parameter" id="argument-1-Arg1">
-    <a href="#argument-1-Arg1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="argument-1-Arg1/index.html">Arg1</a></span><span>: <a href="../module-type-Y/index.html">Y</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec parameter" id="argument-1-Arg1">
+     <a href="#argument-1-Arg1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="argument-1-Arg1/index.html">Arg1</a></span><span>: <a href="../module-type-Y/index.html">Y</a></span></code>
+    </div>
    </div>
-   <div class="spec parameter" id="argument-2-Arg2">
-    <a href="#argument-2-Arg2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="argument-2-Arg2/index.html">Arg2</a></span><span>: { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec parameter" id="argument-2-Arg2">
+     <a href="#argument-2-Arg2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="argument-2-Arg2/index.html">Arg2</a></span><span>: { ... }</span></code>
+    </div>
    </div>
    <h2 id="signature">
     <a href="#signature" class="anchor"></a>Signature
@@ -57,11 +61,11 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = <span>(<a href="argument-1-Arg1/index.html#type-t">Arg1.t</a>, <a href="argument-2-Arg2/index.html#type-t">Arg2.t</a>)</span></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some type.
      </p>

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -42,11 +42,11 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some type.
      </p>
@@ -55,11 +55,11 @@
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-x">
      <a href="#val-x" class="anchor"></a><code><span><span class="keyword">let</span> x: <a href="#type-t">t</a>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       The value of x.
      </p>

--- a/test/html/expect/test_package+re/Nested/class-inherits/index.html
+++ b/test/html/expect/test_package+re/Nested/class-inherits/index.html
@@ -23,8 +23,10 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec inherit">
-    <code><span><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec inherit">
+     <code><span><span class="keyword">inherit</span> <a href="../class-z/index.html">z</a></span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Nested/class-z/index.html
+++ b/test/html/expect/test_package+re/Nested/class-z/index.html
@@ -36,34 +36,38 @@
    </ul>
   </nav>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec instance-variable" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span><span class="keyword">val</span> y: int</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some value.
      </p>
     </div>
    </div>
-   <div class="spec instance-variable" id="val-y'">
-    <a href="#val-y'" class="anchor"></a><code><span><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y': int</span></code>
+   <div class="odoc-spec">
+    <div class="spec instance-variable" id="val-y'">
+     <a href="#val-y'" class="anchor"></a><code><span><span class="keyword">val</span> <span class="keyword">mutable</span> <span class="keyword">virtual</span> y': int</span></code>
+    </div>
    </div>
    <h2 id="methods">
     <a href="#methods" class="anchor"></a>Methods
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec method" id="method-z">
      <a href="#method-z" class="anchor"></a><code><span><span class="keyword">method</span> z: int</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some method.
      </p>
     </div>
    </div>
-   <div class="spec method" id="method-z'">
-    <a href="#method-z'" class="anchor"></a><code><span><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z': int</span></code>
+   <div class="odoc-spec">
+    <div class="spec method" id="method-z'">
+     <a href="#method-z'" class="anchor"></a><code><span><span class="keyword">method</span> <span class="keyword">private</span> <span class="keyword">virtual</span> z': int</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Nested/index.html
+++ b/test/html/expect/test_package+re/Nested/index.html
@@ -45,11 +45,11 @@
    <h2 id="module">
     <a href="#module" class="anchor"></a>Module
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span>: { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is module X.
      </p>
@@ -58,11 +58,11 @@
    <h2 id="module-type">
     <a href="#module-type" class="anchor"></a>Module type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Y">
      <a href="#module-type-Y" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Y/index.html">Y</a></span><span> = { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is module type Y.
      </p>
@@ -71,11 +71,11 @@
    <h2 id="functor">
     <a href="#functor" class="anchor"></a>Functor
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-F">
      <a href="#module-F" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="F/index.html">F</a></span><span>: <span> (<a href="F/argument-1-Arg1/index.html">Arg1</a>: <a href="module-type-Y/index.html">Y</a>) <span>=&gt;</span></span> <span> (<a href="F/argument-2-Arg2/index.html">Arg2</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is a functor F.
      </p>
@@ -84,18 +84,20 @@
    <h2 id="class">
     <a href="#class" class="anchor"></a>Class
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec class" id="class-z">
      <a href="#class-z" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">virtual</span>  </span><span><a href="class-z/index.html">z</a></span><span>: { ... }</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is class z.
      </p>
     </div>
    </div>
-   <div class="spec class" id="class-inherits">
-    <a href="#class-inherits" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">virtual</span>  </span><span><a href="class-inherits/index.html">inherits</a></span><span>: { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-inherits">
+     <a href="#class-inherits" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">virtual</span>  </span><span><a href="class-inherits/index.html">inherits</a></span><span>: { ... }</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -42,11 +42,11 @@
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some type.
      </p>
@@ -55,11 +55,11 @@
    <h2 id="values">
     <a href="#values" class="anchor"></a>Values
    </h2>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-y">
      <a href="#val-y" class="anchor"></a><code><span><span class="keyword">let</span> y: <a href="#type-t">t</a>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       The value of y.
      </p>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -155,7 +155,7 @@
    </ul>
   </nav>
   <div class="odoc-content">
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      You may find more information about this HTML documentation renderer at <a href="https://github.com/dsheets/ocamlary">github.com/dsheets/ocamlary</a>.
     </p>
@@ -215,31 +215,31 @@
    <h4 id="basic-module-stuff">
     <a href="#basic-module-stuff" class="anchor"></a>Basic module stuff
    </h4>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-Empty">
      <a href="#module-Empty" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Empty/index.html">Empty</a></span><span>: { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain, empty module
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Empty">
      <a href="#module-type-Empty" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Empty/index.html">Empty</a></span><span> = { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       An ambiguous, misnamed module type
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-MissingComment">
      <a href="#module-type-MissingComment" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-MissingComment/index.html">MissingComment</a></span><span> = { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       An ambiguous, misnamed module type
      </p>
@@ -248,11 +248,11 @@
    <h6 id="s9000">
     <a href="#s9000" class="anchor"></a>Level 9000
    </h6>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-EmptyAlias">
      <a href="#module-EmptyAlias" class="anchor"></a><code><span><span class="keyword">module</span> </span><span>EmptyAlias</span><span> = <a href="Empty/index.html">Empty</a></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain module alias of <code>Empty</code>
      </p>
@@ -261,78 +261,82 @@
    <h4 id="emptySig">
     <a href="#emptySig" class="anchor"></a>EmptySig
    </h4>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-EmptySig">
      <a href="#module-type-EmptySig" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-EmptySig/index.html">EmptySig</a></span><span> = { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain, empty module signature
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-EmptySigAlias">
      <a href="#module-type-EmptySigAlias" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-EmptySigAlias/index.html">EmptySigAlias</a></span><span> = <a href="module-type-EmptySig/index.html">EmptySig</a></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain, empty module signature alias of
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-ModuleWithSignature">
      <a href="#module-ModuleWithSignature" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="ModuleWithSignature/index.html">ModuleWithSignature</a></span><span>: <a href="module-type-EmptySig/index.html">EmptySig</a></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain module of a signature of <a href="#exception-EmptySig"><code>EmptySig</code></a> (reference)
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-ModuleWithSignatureAlias">
      <a href="#module-ModuleWithSignatureAlias" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="ModuleWithSignatureAlias/index.html">ModuleWithSignatureAlias</a></span><span>: <a href="module-type-EmptySigAlias/index.html">EmptySigAlias</a></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A plain module with an alias signature
      </p>
     </div>
    </div>
-   <div class="spec module" id="module-One">
-    <a href="#module-One" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="One/index.html">One</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-One">
+     <a href="#module-One" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="One/index.html">One</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-SigForMod">
      <a href="#module-type-SigForMod" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-SigForMod/index.html">SigForMod</a></span><span> = { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       There's a signature in a module in this signature.
      </p>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-SuperSig">
-    <a href="#module-type-SuperSig" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-SuperSig/index.html">SuperSig</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-SuperSig">
+     <a href="#module-type-SuperSig" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-SuperSig/index.html">SuperSig</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      For a good time, see <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a> or <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigB:subSig</code></a> or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="#s9000">Level 9000</a> is also interesting. <a href="#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
     </p>
    </aside>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-Buffer">
      <a href="#module-Buffer" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Buffer/index.html">Buffer</a></span><span>: { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       <code>Buffer</code>.t
      </p>
     </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Some text before exception title.
     </p>
@@ -340,56 +344,56 @@
    <h4 id="basic-exception-stuff">
     <a href="#basic-exception-stuff" class="anchor"></a>Basic exception stuff
    </h4>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      After exception title.
     </p>
    </aside>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-Kaboom">
      <a href="#exception-Kaboom" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Kaboom</span>(unit)</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Unary exception constructor
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-Kablam">
      <a href="#exception-Kablam" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Kablam</span>(unit, unit)</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Binary exception constructor
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-Kapow">
      <a href="#exception-Kapow" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Kapow</span>(<span>(unit, unit)</span>)</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Unary exception constructor over binary tuple
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-EmptySig">
      <a href="#exception-EmptySig" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">EmptySig</span></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       <a href="#exception-EmptySig"><code>EmptySig</code></a> is general but <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is a module and <a href="#exception-EmptySig"><code>EmptySig</code></a> is this exception.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-EmptySigAlias">
      <a href="#exception-EmptySigAlias" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">EmptySigAlias</span></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       <a href="#exception-EmptySigAlias"><code>EmptySigAlias</code></a> is this exception.
      </p>
@@ -398,21 +402,21 @@
    <h4 id="basic-type-and-value-stuff-with-advanced-doc-comments">
     <a href="#basic-type-and-value-stuff-with-advanced-doc-comments" class="anchor"></a>Basic type and value stuff with advanced doc comments
    </h4>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-a_function">
      <a href="#type-a_function" class="anchor"></a><code><span><span class="keyword">type</span> a_function('a, 'b)</span><span> = <span><span class="type-var">'a</span> <span>=&gt;</span></span> <span class="type-var">'b</span></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       <a href="#val-a_function"><code>a_function</code></a> is general but <a href="#type-a_function"><code>a_function</code></a> is this type and <a href="#val-a_function"><code>a_function</code></a> is the value below.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-a_function">
      <a href="#val-a_function" class="anchor"></a><code><span><span class="keyword">let</span> a_function: <span>x:int <span>=&gt;</span></span> int;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is <code>a_function</code> with param and return type.
      </p>
@@ -438,17 +442,21 @@
      </dl>
     </div>
    </div>
-   <div class="spec value" id="val-fun_fun_fun">
-    <a href="#val-fun_fun_fun" class="anchor"></a><code><span><span class="keyword">let</span> fun_fun_fun: <a href="#type-a_function">a_function</a><span>(<a href="#type-a_function">a_function</a><span>(int,&nbsp;int)</span>,&nbsp;<a href="#type-a_function">a_function</a><span>(unit,&nbsp;unit)</span>)</span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-fun_fun_fun">
+     <a href="#val-fun_fun_fun" class="anchor"></a><code><span><span class="keyword">let</span> fun_fun_fun: <a href="#type-a_function">a_function</a><span>(<a href="#type-a_function">a_function</a><span>(int,&nbsp;int)</span>,&nbsp;<a href="#type-a_function">a_function</a><span>(unit,&nbsp;unit)</span>)</span>;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-fun_maybe">
-    <a href="#val-fun_maybe" class="anchor"></a><code><span><span class="keyword">let</span> fun_maybe: <span>?⁠yes:unit <span>=&gt;</span></span> <span>unit <span>=&gt;</span></span> int;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-fun_maybe">
+     <a href="#val-fun_maybe" class="anchor"></a><code><span><span class="keyword">let</span> fun_maybe: <span>?⁠yes:unit <span>=&gt;</span></span> <span>unit <span>=&gt;</span></span> int;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-not_found">
      <a href="#val-not_found" class="anchor"></a><code><span><span class="keyword">let</span> not_found: <span>unit <span>=&gt;</span></span> unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <dl>
       <dt>
        raises Not_found
@@ -461,11 +469,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-ocaml_org">
      <a href="#val-ocaml_org" class="anchor"></a><code><span><span class="keyword">let</span> ocaml_org: string;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <dl>
       <dt>
        see <a href="http://ocaml.org/">http://ocaml.org/</a>
@@ -478,11 +486,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-some_file">
      <a href="#val-some_file" class="anchor"></a><code><span><span class="keyword">let</span> some_file: string;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <dl>
       <dt>
        see <code>some_file</code>
@@ -495,11 +503,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-some_doc">
      <a href="#val-some_doc" class="anchor"></a><code><span><span class="keyword">let</span> some_doc: string;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <dl>
       <dt>
        see some_doc
@@ -512,11 +520,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-since_mesozoic">
      <a href="#val-since_mesozoic" class="anchor"></a><code><span><span class="keyword">let</span> since_mesozoic: unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This value was introduced in the Mesozoic era.
      </p>
@@ -530,11 +538,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-changing">
      <a href="#val-changing" class="anchor"></a><code><span><span class="keyword">let</span> changing: unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This value has had changes in 1.0.0, 1.1.0, and 1.2.0.
      </p>
@@ -568,11 +576,11 @@
      </dl>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-with_foo">
      <a href="#val-with_foo" class="anchor"></a><code><span><span class="keyword">let</span> with_foo: unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This value has a custom tag <code>foo</code>. @foo the body of the custom <code>foo</code> tag
      </p>
@@ -581,134 +589,180 @@
    <h4 id="some-operators">
     <a href="#some-operators" class="anchor"></a>Some Operators
    </h4>
-   <div class="spec value" id="val-(~-)">
-    <a href="#val-(~-)" class="anchor"></a><code><span><span class="keyword">let</span> (~-): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(~-)">
+     <a href="#val-(~-)" class="anchor"></a><code><span><span class="keyword">let</span> (~-): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(!)">
-    <a href="#val-(!)" class="anchor"></a><code><span><span class="keyword">let</span> (!): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(!)">
+     <a href="#val-(!)" class="anchor"></a><code><span><span class="keyword">let</span> (!): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(@)">
-    <a href="#val-(@)" class="anchor"></a><code><span><span class="keyword">let</span> (@): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(@)">
+     <a href="#val-(@)" class="anchor"></a><code><span><span class="keyword">let</span> (@): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-($)">
-    <a href="#val-($)" class="anchor"></a><code><span><span class="keyword">let</span> ($): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-($)">
+     <a href="#val-($)" class="anchor"></a><code><span><span class="keyword">let</span> ($): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(%)">
-    <a href="#val-(%)" class="anchor"></a><code><span><span class="keyword">let</span> (%): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(%)">
+     <a href="#val-(%)" class="anchor"></a><code><span><span class="keyword">let</span> (%): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(&amp;)">
-    <a href="#val-(&amp;)" class="anchor"></a><code><span><span class="keyword">let</span> (&amp;): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(&amp;)">
+     <a href="#val-(&amp;)" class="anchor"></a><code><span><span class="keyword">let</span> (&amp;): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(*)">
-    <a href="#val-(*)" class="anchor"></a><code><span><span class="keyword">let</span> (*): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(*)">
+     <a href="#val-(*)" class="anchor"></a><code><span><span class="keyword">let</span> (*): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(-)">
-    <a href="#val-(-)" class="anchor"></a><code><span><span class="keyword">let</span> (-): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(-)">
+     <a href="#val-(-)" class="anchor"></a><code><span><span class="keyword">let</span> (-): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(+)">
-    <a href="#val-(+)" class="anchor"></a><code><span><span class="keyword">let</span> (+): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(+)">
+     <a href="#val-(+)" class="anchor"></a><code><span><span class="keyword">let</span> (+): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(-?)">
-    <a href="#val-(-?)" class="anchor"></a><code><span><span class="keyword">let</span> (-?): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(-?)">
+     <a href="#val-(-?)" class="anchor"></a><code><span><span class="keyword">let</span> (-?): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(/)">
-    <a href="#val-(/)" class="anchor"></a><code><span><span class="keyword">let</span> (/): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(/)">
+     <a href="#val-(/)" class="anchor"></a><code><span><span class="keyword">let</span> (/): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(:=)">
-    <a href="#val-(:=)" class="anchor"></a><code><span><span class="keyword">let</span> (:=): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(:=)">
+     <a href="#val-(:=)" class="anchor"></a><code><span><span class="keyword">let</span> (:=): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(=)">
-    <a href="#val-(=)" class="anchor"></a><code><span><span class="keyword">let</span> (=): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(=)">
+     <a href="#val-(=)" class="anchor"></a><code><span><span class="keyword">let</span> (=): unit;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-(land)">
-    <a href="#val-(land)" class="anchor"></a><code><span><span class="keyword">let</span> (land): unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-(land)">
+     <a href="#val-(land)" class="anchor"></a><code><span><span class="keyword">let</span> (land): unit;</span></code>
+    </div>
    </div>
    <h4 id="advanced-module-stuff">
     <a href="#advanced-module-stuff" class="anchor"></a>Advanced Module Stuff
    </h4>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-CollectionModule">
      <a href="#module-CollectionModule" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="CollectionModule/index.html">CollectionModule</a></span><span>: { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>CollectionModule</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-COLLECTION">
      <a href="#module-type-COLLECTION" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-COLLECTION/index.html">COLLECTION</a></span><span> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="CollectionModule/index.html">CollectionModule</a></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       module type of
      </p>
     </div>
    </div>
-   <div class="spec module" id="module-Recollection">
-    <a href="#module-Recollection" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recollection/index.html">Recollection</a></span><span>: <span> (<a href="Recollection/argument-1-C/index.html">C</a>: <a href="module-type-COLLECTION/index.html">COLLECTION</a>) <span>=&gt;</span></span> <a href="module-type-COLLECTION/index.html">COLLECTION</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-collection">collection</a> = list(<a href="Recollection/argument-1-C/index.html#type-element">C.element</a>)</span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-element">element</a> = <a href="Recollection/argument-1-C/index.html#type-collection">C.collection</a></span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Recollection">
+     <a href="#module-Recollection" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recollection/index.html">Recollection</a></span><span>: <span> (<a href="Recollection/argument-1-C/index.html">C</a>: <a href="module-type-COLLECTION/index.html">COLLECTION</a>) <span>=&gt;</span></span> <a href="module-type-COLLECTION/index.html">COLLECTION</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-collection">collection</a> = list(<a href="Recollection/argument-1-C/index.html#type-element">C.element</a>)</span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-COLLECTION/index.html#type-element">element</a> = <a href="Recollection/argument-1-C/index.html#type-collection">C.collection</a></span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-MMM">
-    <a href="#module-type-MMM" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-MMM/index.html">MMM</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-MMM">
+     <a href="#module-type-MMM" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-MMM/index.html">MMM</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-RECOLLECTION">
-    <a href="#module-type-RECOLLECTION" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-RECOLLECTION/index.html">RECOLLECTION</a></span><span> = <a href="module-type-MMM/index.html">MMM</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-MMM/C/index.html">C</a> = <a href="Recollection/index.html">Recollection(CollectionModule)</a></span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-RECOLLECTION">
+     <a href="#module-type-RECOLLECTION" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-RECOLLECTION/index.html">RECOLLECTION</a></span><span> = <a href="module-type-MMM/index.html">MMM</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-MMM/C/index.html">C</a> = <a href="Recollection/index.html">Recollection(CollectionModule)</a></span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-RecollectionModule">
-    <a href="#module-type-RecollectionModule" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-RecollectionModule/index.html">RecollectionModule</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-RecollectionModule">
+     <a href="#module-type-RecollectionModule" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-RecollectionModule/index.html">RecollectionModule</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-A">
-    <a href="#module-type-A" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-A/index.html">A</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-A">
+     <a href="#module-type-A" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-A/index.html">A</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-B">
-    <a href="#module-type-B" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-B/index.html">B</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-B">
+     <a href="#module-type-B" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-B/index.html">B</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-C">
      <a href="#module-type-C" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-C/index.html">C</a></span><span> = { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This module type includes two signatures.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module" id="module-FunctorTypeOf">
      <a href="#module-FunctorTypeOf" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="FunctorTypeOf/index.html">FunctorTypeOf</a></span><span>: <span> (<a href="FunctorTypeOf/argument-1-Collection/index.html">Collection</a>: <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="CollectionModule/index.html">CollectionModule</a>) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>FunctorTypeOf</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec module-type" id="module-type-IncludeModuleType">
      <a href="#module-type-IncludeModuleType" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludeModuleType/index.html">IncludeModuleType</a></span><span> = { ... }</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>IncludeModuleType</code>.
      </p>
     </div>
    </div>
-   <div class="spec module-type" id="module-type-ToInclude">
-    <a href="#module-type-ToInclude" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-ToInclude/index.html">ToInclude</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-ToInclude">
+     <a href="#module-type-ToInclude" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-ToInclude/index.html">ToInclude</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-ToInclude/index.html">ToInclude</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec module" id="module-IncludedA">
-        <a href="#module-IncludedA" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludedA/index.html">IncludedA</a></span><span>: { ... }</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec module" id="module-IncludedA">
+         <a href="#module-IncludedA" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludedA/index.html">IncludedA</a></span><span>: { ... }</span><span>;</span></code>
+        </div>
        </div>
-       <div class="spec module-type" id="module-type-IncludedB">
-        <a href="#module-type-IncludedB" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludedB/index.html">IncludedB</a></span><span> = { ... }</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec module-type" id="module-type-IncludedB">
+         <a href="#module-type-IncludedB" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludedB/index.html">IncludedB</a></span><span> = { ... }</span><span>;</span></code>
+        </div>
        </div>
       </details>
      </div>
@@ -717,7 +771,7 @@
    <h4 id="advanced-type-stuff">
     <a href="#advanced-type-stuff" class="anchor"></a>Advanced Type Stuff
    </h4>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-record">
      <a href="#type-record" class="anchor"></a><code><span><span class="keyword">type</span> record</span><span> = </span><span>{</span></code>
      <table>
@@ -746,7 +800,7 @@
      </table>
      <code><span>}</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>record</code>.
      </p>
@@ -755,58 +809,62 @@
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-mutable_record">
-    <a href="#type-mutable_record" class="anchor"></a><code><span><span class="keyword">type</span> mutable_record</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-mutable_record.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-mutable_record.a" class="anchor"></a><code><span><span class="keyword">mutable</span> a: int,</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <code>a</code> is first and mutable
-        </p>
-       </td>
-      </tr>
-      <tr id="type-mutable_record.b" class="anchored">
-       <td class="def record field">
-        <a href="#type-mutable_record.b" class="anchor"></a><code><span>b: unit,</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <code>b</code> is second and immutable
-        </p>
-       </td>
-      </tr>
-      <tr id="type-mutable_record.c" class="anchored">
-       <td class="def record field">
-        <a href="#type-mutable_record.c" class="anchor"></a><code><span><span class="keyword">mutable</span> c: int,</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <code>c</code> is third and mutable
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-mutable_record">
+     <a href="#type-mutable_record" class="anchor"></a><code><span><span class="keyword">type</span> mutable_record</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-mutable_record.a" class="anchored">
+        <td class="def record field">
+         <a href="#type-mutable_record.a" class="anchor"></a><code><span><span class="keyword">mutable</span> a: int,</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <code>a</code> is first and mutable
+         </p>
+        </td>
+       </tr>
+       <tr id="type-mutable_record.b" class="anchored">
+        <td class="def record field">
+         <a href="#type-mutable_record.b" class="anchor"></a><code><span>b: unit,</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <code>b</code> is second and immutable
+         </p>
+        </td>
+       </tr>
+       <tr id="type-mutable_record.c" class="anchored">
+        <td class="def record field">
+         <a href="#type-mutable_record.c" class="anchor"></a><code><span><span class="keyword">mutable</span> c: int,</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <code>c</code> is third and mutable
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-universe_record">
-    <a href="#type-universe_record" class="anchor"></a><code><span><span class="keyword">type</span> universe_record</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-universe_record.nihilate" class="anchored">
-       <td class="def record field">
-        <a href="#type-universe_record.nihilate" class="anchor"></a><code><span>nihilate: a. <span><span class="type-var">'a</span> <span>=&gt;</span></span> unit,</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-universe_record">
+     <a href="#type-universe_record" class="anchor"></a><code><span><span class="keyword">type</span> universe_record</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-universe_record.nihilate" class="anchored">
+        <td class="def record field">
+         <a href="#type-universe_record.nihilate" class="anchor"></a><code><span>nihilate: a. <span><span class="type-var">'a</span> <span>=&gt;</span></span> unit,</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-variant">
      <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
      <table>
@@ -855,7 +913,7 @@
      </table>
      <code><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>variant</code>.
      </p>
@@ -864,7 +922,7 @@
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-poly_variant">
      <a href="#type-poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> poly_variant</span><span> = </span><span>[ </span></code>
      <table>
@@ -883,7 +941,7 @@
      </table>
      <code><span> ]</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>poly_variant</code>.
      </p>
@@ -892,7 +950,7 @@
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-full_gadt">
      <a href="#type-full_gadt" class="anchor"></a><code><span><span class="keyword">type</span> full_gadt(_, _)</span><span> = </span></code>
      <table>
@@ -921,7 +979,7 @@
      </table>
      <code><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>full_gadt</code>.
      </p>
@@ -930,7 +988,7 @@
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-partial_gadt">
      <a href="#type-partial_gadt" class="anchor"></a><code><span><span class="keyword">type</span> partial_gadt('a)</span><span> = </span></code>
      <table>
@@ -954,7 +1012,7 @@
      </table>
      <code><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>partial_gadt</code>.
      </p>
@@ -963,27 +1021,27 @@
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-alias">
      <a href="#type-alias" class="anchor"></a><code><span><span class="keyword">type</span> alias</span><span> = <a href="#type-variant">variant</a></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>alias</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-tuple">
      <a href="#type-tuple" class="anchor"></a><code><span><span class="keyword">type</span> tuple</span><span> = <span>(<span>(<a href="#type-alias">alias</a>, <a href="#type-alias">alias</a>)</span>, <a href="#type-alias">alias</a>, <span>(<a href="#type-alias">alias</a>, <a href="#type-alias">alias</a>)</span>)</span></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>tuple</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-variant_alias">
      <a href="#type-variant_alias" class="anchor"></a><code><span><span class="keyword">type</span> variant_alias</span><span> = <a href="#type-variant">variant</a></span><span> = </span></code>
      <table>
@@ -1012,13 +1070,13 @@
      </table>
      <code><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>variant_alias</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-record_alias">
      <a href="#type-record_alias" class="anchor"></a><code><span><span class="keyword">type</span> record_alias</span><span> = <a href="#type-record">record</a></span><span> = </span><span>{</span></code>
      <table>
@@ -1037,13 +1095,13 @@
      </table>
      <code><span>}</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>record_alias</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-poly_variant_union">
      <a href="#type-poly_variant_union" class="anchor"></a><code><span><span class="keyword">type</span> poly_variant_union</span><span> = </span><span>[ </span></code>
      <table>
@@ -1062,93 +1120,113 @@
      </table>
      <code><span> ]</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>poly_variant_union</code>.
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-poly_poly_variant">
-    <a href="#type-poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> poly_poly_variant('a)</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-poly_poly_variant.TagA" class="anchored">
-       <td class="def constructor">
-        <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA(<span class="type-var">'a</span>)</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-poly_poly_variant">
+     <a href="#type-poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> poly_poly_variant('a)</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-poly_poly_variant.TagA" class="anchored">
+        <td class="def constructor">
+         <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA(<span class="type-var">'a</span>)</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-bin_poly_poly_variant">
-    <a href="#type-bin_poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> bin_poly_poly_variant('a, 'b)</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
-       <td class="def constructor">
-        <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA(<span class="type-var">'a</span>)</span></code>
-       </td>
-      </tr>
-      <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
-       <td class="def constructor">
-        <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB(<span class="type-var">'b</span>)</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-bin_poly_poly_variant">
+     <a href="#type-bin_poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> bin_poly_poly_variant('a, 'b)</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
+        <td class="def constructor">
+         <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA(<span class="type-var">'a</span>)</span></code>
+        </td>
+       </tr>
+       <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
+        <td class="def constructor">
+         <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB(<span class="type-var">'b</span>)</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-open_poly_variant">
-    <a href="#type-open_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> open_poly_variant('a)</span><span> = <span>[&gt; `TagA ]</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-open_poly_variant">
+     <a href="#type-open_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> open_poly_variant('a)</span><span> = <span>[&gt; `TagA ]</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-open_poly_variant2">
-    <a href="#type-open_poly_variant2" class="anchor"></a><code><span><span class="keyword">type</span> open_poly_variant2('a)</span><span> = <span>[&gt; <span>`ConstrB<span>(int)</span></span> ]</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-open_poly_variant2">
+     <a href="#type-open_poly_variant2" class="anchor"></a><code><span><span class="keyword">type</span> open_poly_variant2('a)</span><span> = <span>[&gt; <span>`ConstrB<span>(int)</span></span> ]</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-open_poly_variant_alias">
-    <a href="#type-open_poly_variant_alias" class="anchor"></a><code><span><span class="keyword">type</span> open_poly_variant_alias('a)</span><span> = <a href="#type-open_poly_variant2">open_poly_variant2</a>(<a href="#type-open_poly_variant">open_poly_variant</a>(<span class="type-var">'a</span>))</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-open_poly_variant_alias">
+     <a href="#type-open_poly_variant_alias" class="anchor"></a><code><span><span class="keyword">type</span> open_poly_variant_alias('a)</span><span> = <a href="#type-open_poly_variant2">open_poly_variant2</a>(<a href="#type-open_poly_variant">open_poly_variant</a>(<span class="type-var">'a</span>))</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-poly_fun">
-    <a href="#type-poly_fun" class="anchor"></a><code><span><span class="keyword">type</span> poly_fun('a)</span><span> = <span><span>[&gt; <span>`ConstrB<span>(int)</span></span> ]</span> <span class="keyword">as</span> 'a <span>=&gt;</span></span> <span class="type-var">'a</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-poly_fun">
+     <a href="#type-poly_fun" class="anchor"></a><code><span><span class="keyword">type</span> poly_fun('a)</span><span> = <span><span>[&gt; <span>`ConstrB<span>(int)</span></span> ]</span> <span class="keyword">as</span> 'a <span>=&gt;</span></span> <span class="type-var">'a</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-poly_fun_constraint">
-    <a href="#type-poly_fun_constraint" class="anchor"></a><code><span><span class="keyword">type</span> poly_fun_constraint('a)</span><span> = <span><span class="type-var">'a</span> <span>=&gt;</span></span> <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `TagA ]</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-poly_fun_constraint">
+     <a href="#type-poly_fun_constraint" class="anchor"></a><code><span><span class="keyword">type</span> poly_fun_constraint('a)</span><span> = <span><span class="type-var">'a</span> <span>=&gt;</span></span> <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `TagA ]</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-closed_poly_variant">
-    <a href="#type-closed_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> closed_poly_variant('a)</span><span> = <span>[&lt; `One <span>| `Two</span> ]</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-closed_poly_variant">
+     <a href="#type-closed_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> closed_poly_variant('a)</span><span> = <span>[&lt; `One <span>| `Two</span> ]</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-clopen_poly_variant">
-    <a href="#type-clopen_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> clopen_poly_variant('a)</span><span> = <span>[&lt; `One <span><span>| `Two</span><span>(int)</span></span> <span>| `Three</span> Two Three ]</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-clopen_poly_variant">
+     <a href="#type-clopen_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> clopen_poly_variant('a)</span><span> = <span>[&lt; `One <span><span>| `Two</span><span>(int)</span></span> <span>| `Three</span> Two Three ]</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-nested_poly_variant">
-    <a href="#type-nested_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_poly_variant</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-nested_poly_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-       </td>
-      </tr>
-      <tr id="type-nested_poly_variant.B" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(<span>[ `B1 <span>| `B2</span> ]</span>)</span></code>
-       </td>
-      </tr>
-      <tr id="type-nested_poly_variant.C" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
-       </td>
-      </tr>
-      <tr id="type-nested_poly_variant.D" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D(<span>[ <span>`D1<span>(<span>[ `D1a ]</span>)</span></span> ]</span>)</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-nested_poly_variant">
+     <a href="#type-nested_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_poly_variant</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-nested_poly_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_poly_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+        </td>
+       </tr>
+       <tr id="type-nested_poly_variant.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_poly_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(<span>[ `B1 <span>| `B2</span> ]</span>)</span></code>
+        </td>
+       </tr>
+       <tr id="type-nested_poly_variant.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_poly_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
+        </td>
+       </tr>
+       <tr id="type-nested_poly_variant.D" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_poly_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D(<span>[ <span>`D1<span>(<span>[ `D1a ]</span>)</span></span> ]</span>)</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-full_gadt_alias">
      <a href="#type-full_gadt_alias" class="anchor"></a><code><span><span class="keyword">type</span> full_gadt_alias('a, 'b)</span><span> = <a href="#type-full_gadt">full_gadt</a><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span></span><span> = </span></code>
      <table>
@@ -1177,13 +1255,13 @@
      </table>
      <code><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>full_gadt_alias</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-partial_gadt_alias">
      <a href="#type-partial_gadt_alias" class="anchor"></a><code><span><span class="keyword">type</span> partial_gadt_alias('a)</span><span> = <a href="#type-partial_gadt">partial_gadt</a>(<span class="type-var">'a</span>)</span><span> = </span></code>
      <table>
@@ -1207,23 +1285,23 @@
      </table>
      <code><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <code>partial_gadt_alias</code>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec exception" id="exception-Exn_arrow">
      <a href="#exception-Exn_arrow" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Exn_arrow</span>(unit) : exn</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <a href="#exception-Exn_arrow"><code>Exn_arrow</code></a>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-mutual_constr_a">
      <a href="#type-mutual_constr_a" class="anchor"></a><code><span><span class="keyword">type</span> mutual_constr_a</span><span> = </span></code>
      <table>
@@ -1247,13 +1325,13 @@
      </table>
      <code><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a> then <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>.
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-mutual_constr_b">
      <a href="#type-mutual_constr_b" class="anchor"></a><code><span><span class="keyword">and</span> mutual_constr_b</span><span> = </span></code>
      <table>
@@ -1277,408 +1355,532 @@
      </table>
      <code><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This comment is for <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a> then <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a>.
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-rec_obj">
-    <a href="#type-rec_obj" class="anchor"></a><code><span><span class="keyword">type</span> rec_obj</span><span> = <span>{. f: int, g: <span>unit <span>=&gt;</span></span> unit, h: <a href="#type-rec_obj">rec_obj</a>, }</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-rec_obj">
+     <a href="#type-rec_obj" class="anchor"></a><code><span><span class="keyword">type</span> rec_obj</span><span> = <span>{. f: int, g: <span>unit <span>=&gt;</span></span> unit, h: <a href="#type-rec_obj">rec_obj</a>, }</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-open_obj">
-    <a href="#type-open_obj" class="anchor"></a><code><span><span class="keyword">type</span> open_obj('a)</span><span> = <span>{.. f: int, g: <span>unit <span>=&gt;</span></span> unit, }</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-open_obj">
+     <a href="#type-open_obj" class="anchor"></a><code><span><span class="keyword">type</span> open_obj('a)</span><span> = <span>{.. f: int, g: <span>unit <span>=&gt;</span></span> unit, }</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-oof">
-    <a href="#type-oof" class="anchor"></a><code><span><span class="keyword">type</span> oof('a)</span><span> = <span><span>{.. a: unit, }</span> <span class="keyword">as</span> 'a <span>=&gt;</span></span> <span class="type-var">'a</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-oof">
+     <a href="#type-oof" class="anchor"></a><code><span><span class="keyword">type</span> oof('a)</span><span> = <span><span>{.. a: unit, }</span> <span class="keyword">as</span> 'a <span>=&gt;</span></span> <span class="type-var">'a</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-any_obj">
-    <a href="#type-any_obj" class="anchor"></a><code><span><span class="keyword">type</span> any_obj('a)</span><span> = <span>{.. }</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-any_obj">
+     <a href="#type-any_obj" class="anchor"></a><code><span><span class="keyword">type</span> any_obj('a)</span><span> = <span>{.. }</span> <span class="keyword">as</span> 'a</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-empty_obj">
-    <a href="#type-empty_obj" class="anchor"></a><code><span><span class="keyword">type</span> empty_obj</span><span> = <span>{. }</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-empty_obj">
+     <a href="#type-empty_obj" class="anchor"></a><code><span><span class="keyword">type</span> empty_obj</span><span> = <span>{. }</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-one_meth">
-    <a href="#type-one_meth" class="anchor"></a><code><span><span class="keyword">type</span> one_meth</span><span> = <span>{. meth: unit, }</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-one_meth">
+     <a href="#type-one_meth" class="anchor"></a><code><span><span class="keyword">type</span> one_meth</span><span> = <span>{. meth: unit, }</span></span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-ext">
      <a href="#type-ext" class="anchor"></a><code><span><span class="keyword">type</span> ext</span><span> = </span><span>..</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A mystery wrapped in an ellipsis
      </p>
     </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ExtA" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtA" class="anchor"></a><code><span>| </span><span><span class="extension">ExtA</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ExtA" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtA" class="anchor"></a><code><span>| </span><span><span class="extension">ExtA</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ExtB" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtB" class="anchor"></a><code><span>| </span><span><span class="extension">ExtB</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ExtB" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtB" class="anchor"></a><code><span>| </span><span><span class="extension">ExtB</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ExtC" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtC" class="anchor"></a><code><span>| </span><span><span class="extension">ExtC</span>(unit)</span></code>
-       </td>
-      </tr>
-      <tr id="extension-ExtD" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtD" class="anchor"></a><code><span>| </span><span><span class="extension">ExtD</span>(<a href="#type-ext">ext</a>)</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ExtC" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtC" class="anchor"></a><code><span>| </span><span><span class="extension">ExtC</span>(unit)</span></code>
+        </td>
+       </tr>
+       <tr id="extension-ExtD" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtD" class="anchor"></a><code><span>| </span><span><span class="extension">ExtD</span>(<a href="#type-ext">ext</a>)</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ExtE" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtE" class="anchor"></a><code><span>| </span><span><span class="extension">ExtE</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ExtE" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtE" class="anchor"></a><code><span>| </span><span><span class="extension">ExtE</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ExtF" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtF" class="anchor"></a><code><span>| </span><span><span class="extension">ExtF</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ExtF" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ExtF" class="anchor"></a><code><span>| </span><span><span class="extension">ExtF</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-poly_ext">
      <a href="#type-poly_ext" class="anchor"></a><code><span><span class="keyword">type</span> poly_ext('a)</span><span> = </span><span>..</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       'a poly_ext
      </p>
     </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-Foo" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Foo" class="anchor"></a><code><span>| </span><span><span class="extension">Foo</span>(<span class="type-var">'b</span>)</span></code>
-       </td>
-      </tr>
-      <tr id="extension-Bar" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Bar" class="anchor"></a><code><span>| </span><span><span class="extension">Bar</span>(<span class="type-var">'b</span>, <span class="type-var">'b</span>)</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         'b poly_ext
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-Foo" class="anchored">
+        <td class="def extension">
+         <a href="#extension-Foo" class="anchor"></a><code><span>| </span><span><span class="extension">Foo</span>(<span class="type-var">'b</span>)</span></code>
+        </td>
+       </tr>
+       <tr id="extension-Bar" class="anchored">
+        <td class="def extension">
+         <a href="#extension-Bar" class="anchor"></a><code><span>| </span><span><span class="extension">Bar</span>(<span class="type-var">'b</span>, <span class="type-var">'b</span>)</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          'b poly_ext
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-Quux" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Quux" class="anchor"></a><code><span>| </span><span><span class="extension">Quux</span>(<span class="type-var">'c</span>)</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         'c poly_ext
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-Quux" class="anchored">
+        <td class="def extension">
+         <a href="#extension-Quux" class="anchor"></a><code><span>| </span><span><span class="extension">Quux</span>(<span class="type-var">'c</span>)</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          'c poly_ext
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-ExtMod">
-    <a href="#module-ExtMod" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="ExtMod/index.html">ExtMod</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-ExtMod">
+     <a href="#module-ExtMod" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="ExtMod/index.html">ExtMod</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ZzzTop0" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ZzzTop0" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop0</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         It's got the rock
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ZzzTop0" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ZzzTop0" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop0</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          It's got the rock
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-ZzzTop" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ZzzTop" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop</span>(unit)</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         and it packs a unit.
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-ZzzTop" class="anchored">
+        <td class="def extension">
+         <a href="#extension-ZzzTop" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop</span>(unit)</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          and it packs a unit.
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec external" id="val-launch_missiles">
      <a href="#val-launch_missiles" class="anchor"></a><code><span><span class="keyword">let</span> launch_missiles: <span>unit <span>=&gt;</span></span> unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Rotate keys on my mark...
      </p>
     </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-my_mod">
      <a href="#type-my_mod" class="anchor"></a><code><span><span class="keyword">type</span> my_mod</span><span> = <span>(<span class="keyword">module</span> <a href="module-type-COLLECTION/index.html">COLLECTION</a>)</span></span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       A brown paper package tied up with string
      </p>
     </div>
    </div>
-   <div class="spec class" id="class-empty_class">
-    <a href="#class-empty_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-empty_class/index.html">empty_class</a></span><span>: { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-empty_class">
+     <a href="#class-empty_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-empty_class/index.html">empty_class</a></span><span>: { ... }</span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-one_method_class">
-    <a href="#class-one_method_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-one_method_class/index.html">one_method_class</a></span><span>: { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-one_method_class">
+     <a href="#class-one_method_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-one_method_class/index.html">one_method_class</a></span><span>: { ... }</span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-two_method_class">
-    <a href="#class-two_method_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-two_method_class/index.html">two_method_class</a></span><span>: { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-two_method_class">
+     <a href="#class-two_method_class" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-two_method_class/index.html">two_method_class</a></span><span>: { ... }</span></code>
+    </div>
    </div>
-   <div class="spec class" id="class-param_class">
-    <a href="#class-param_class" class="anchor"></a><code><span><span class="keyword">class</span> ('a) </span><span><a href="class-param_class/index.html">param_class</a></span><span>: <span><span class="type-var">'a</span> <span>=&gt;</span></span> { ... }</span></code>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-param_class">
+     <a href="#class-param_class" class="anchor"></a><code><span><span class="keyword">class</span> ('a) </span><span><a href="class-param_class/index.html">param_class</a></span><span>: <span><span class="type-var">'a</span> <span>=&gt;</span></span> { ... }</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-my_unit_object">
-    <a href="#type-my_unit_object" class="anchor"></a><code><span><span class="keyword">type</span> my_unit_object</span><span> = <a href="class-param_class/index.html">param_class</a>(unit)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-my_unit_object">
+     <a href="#type-my_unit_object" class="anchor"></a><code><span><span class="keyword">type</span> my_unit_object</span><span> = <a href="class-param_class/index.html">param_class</a>(unit)</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-my_unit_class">
-    <a href="#type-my_unit_class" class="anchor"></a><code><span><span class="keyword">type</span> my_unit_class('a)</span><span> = <span class="xref-unresolved">param_class</span>(unit) <span class="keyword">as</span> 'a</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-my_unit_class">
+     <a href="#type-my_unit_class" class="anchor"></a><code><span><span class="keyword">type</span> my_unit_class('a)</span><span> = <span class="xref-unresolved">param_class</span>(unit) <span class="keyword">as</span> 'a</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep1">
-    <a href="#module-Dep1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep1/index.html">Dep1</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep1">
+     <a href="#module-Dep1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep1/index.html">Dep1</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep2">
-    <a href="#module-Dep2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep2/index.html">Dep2</a></span><span>: <span> (<a href="Dep2/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep2">
+     <a href="#module-Dep2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep2/index.html">Dep2</a></span><span>: <span> (<a href="Dep2/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-dep1">
-    <a href="#type-dep1" class="anchor"></a><code><span><span class="keyword">type</span> dep1</span><span> = <a href="Dep1/module-type-S/class-c/index.html">Dep2(Dep1).B.c</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-dep1">
+     <a href="#type-dep1" class="anchor"></a><code><span><span class="keyword">type</span> dep1</span><span> = <a href="Dep1/module-type-S/class-c/index.html">Dep2(Dep1).B.c</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep3">
-    <a href="#module-Dep3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep3/index.html">Dep3</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep3">
+     <a href="#module-Dep3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep3/index.html">Dep3</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep4">
-    <a href="#module-Dep4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep4/index.html">Dep4</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep4">
+     <a href="#module-Dep4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep4/index.html">Dep4</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep5">
-    <a href="#module-Dep5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep5/index.html">Dep5</a></span><span>: <span> (<a href="Dep5/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep5">
+     <a href="#module-Dep5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep5/index.html">Dep5</a></span><span>: <span> (<a href="Dep5/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-dep2">
-    <a href="#type-dep2" class="anchor"></a><code><span><span class="keyword">type</span> dep2</span><span> = <a href="Dep4/module-type-T/index.html#type-b">Dep5(Dep4).Z.X.b</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-dep2">
+     <a href="#type-dep2" class="anchor"></a><code><span><span class="keyword">type</span> dep2</span><span> = <a href="Dep4/module-type-T/index.html#type-b">Dep5(Dep4).Z.X.b</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-dep3">
-    <a href="#type-dep3" class="anchor"></a><code><span><span class="keyword">type</span> dep3</span><span> = <a href="Dep3/index.html#type-a">Dep5(Dep4).Z.Y.a</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-dep3">
+     <a href="#type-dep3" class="anchor"></a><code><span><span class="keyword">type</span> dep3</span><span> = <a href="Dep3/index.html#type-a">Dep5(Dep4).Z.Y.a</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep6">
-    <a href="#module-Dep6" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep6/index.html">Dep6</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep6">
+     <a href="#module-Dep6" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep6/index.html">Dep6</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep7">
-    <a href="#module-Dep7" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep7/index.html">Dep7</a></span><span>: <span> (<a href="Dep7/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep7">
+     <a href="#module-Dep7" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep7/index.html">Dep7</a></span><span>: <span> (<a href="Dep7/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-dep4">
-    <a href="#type-dep4" class="anchor"></a><code><span><span class="keyword">type</span> dep4</span><span> = <a href="Dep6/module-type-T/Y/index.html#type-d">Dep7(Dep6).M.Y.d</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-dep4">
+     <a href="#type-dep4" class="anchor"></a><code><span><span class="keyword">type</span> dep4</span><span> = <a href="Dep6/module-type-T/Y/index.html#type-d">Dep7(Dep6).M.Y.d</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep8">
-    <a href="#module-Dep8" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep8/index.html">Dep8</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep8">
+     <a href="#module-Dep8" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep8/index.html">Dep8</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep9">
-    <a href="#module-Dep9" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep9/index.html">Dep9</a></span><span>: <span> (<a href="Dep9/argument-1-X/index.html">X</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep9">
+     <a href="#module-Dep9" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep9/index.html">Dep9</a></span><span>: <span> (<a href="Dep9/argument-1-X/index.html">X</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-Dep10">
-    <a href="#module-type-Dep10" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dep10/index.html">Dep10</a></span><span> = <a href="Dep8/module-type-T/index.html">Dep9(Dep8).T</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="Dep8/module-type-T/index.html#type-t">t</a> = int</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Dep10">
+     <a href="#module-type-Dep10" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dep10/index.html">Dep10</a></span><span> = <a href="Dep8/module-type-T/index.html">Dep9(Dep8).T</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="Dep8/module-type-T/index.html#type-t">t</a> = int</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep11">
-    <a href="#module-Dep11" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep11/index.html">Dep11</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep11">
+     <a href="#module-Dep11" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep11/index.html">Dep11</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep12">
-    <a href="#module-Dep12" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep12/index.html">Dep12</a></span><span>: <span> (<a href="Dep12/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep12">
+     <a href="#module-Dep12" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep12/index.html">Dep12</a></span><span>: <span> (<a href="Dep12/argument-1-Arg/index.html">Arg</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Dep13">
-    <a href="#module-Dep13" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep13/index.html">Dep13</a></span><span>: <a href="Dep11/module-type-S/index.html">Dep12(Dep11).T</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Dep13">
+     <a href="#module-Dep13" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Dep13/index.html">Dep13</a></span><span>: <a href="Dep11/module-type-S/index.html">Dep12(Dep11).T</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-dep5">
-    <a href="#type-dep5" class="anchor"></a><code><span><span class="keyword">type</span> dep5</span><span> = <a href="Dep13/class-c/index.html">Dep13.c</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-dep5">
+     <a href="#type-dep5" class="anchor"></a><code><span><span class="keyword">type</span> dep5</span><span> = <a href="Dep13/class-c/index.html">Dep13.c</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-With1">
-    <a href="#module-type-With1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With1/index.html">With1</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-With1">
+     <a href="#module-type-With1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With1/index.html">With1</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With2">
-    <a href="#module-With2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With2/index.html">With2</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With2">
+     <a href="#module-With2" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With2/index.html">With2</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With3">
-    <a href="#module-With3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With3/index.html">With3</a></span><span>: <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> = <a href="With2/index.html">With2</a></span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With3">
+     <a href="#module-With3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With3/index.html">With3</a></span><span>: <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> = <a href="With2/index.html">With2</a></span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-with1">
-    <a href="#type-with1" class="anchor"></a><code><span><span class="keyword">type</span> with1</span><span> = <a href="With3/N/index.html#type-t">With3.N.t</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-with1">
+     <a href="#type-with1" class="anchor"></a><code><span><span class="keyword">type</span> with1</span><span> = <a href="With3/N/index.html#type-t">With3.N.t</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With4">
-    <a href="#module-With4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With4/index.html">With4</a></span><span>: <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> := <a href="With2/index.html">With2</a></span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With4">
+     <a href="#module-With4" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With4/index.html">With4</a></span><span>: <a href="module-type-With1/index.html">With1</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-With1/M/index.html">M</a> := <a href="With2/index.html">With2</a></span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-with2">
-    <a href="#type-with2" class="anchor"></a><code><span><span class="keyword">type</span> with2</span><span> = <a href="With4/N/index.html#type-t">With4.N.t</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-with2">
+     <a href="#type-with2" class="anchor"></a><code><span><span class="keyword">type</span> with2</span><span> = <a href="With4/N/index.html#type-t">With4.N.t</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With5">
-    <a href="#module-With5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With5/index.html">With5</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With5">
+     <a href="#module-With5" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With5/index.html">With5</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With6">
-    <a href="#module-With6" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With6/index.html">With6</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With6">
+     <a href="#module-With6" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With6/index.html">With6</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With7">
-    <a href="#module-With7" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With7/index.html">With7</a></span><span>: <span> (<a href="With7/argument-1-X/index.html">X</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With7">
+     <a href="#module-With7" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With7/index.html">With7</a></span><span>: <span> (<a href="With7/argument-1-X/index.html">X</a>: { ... }) <span>=&gt;</span></span> { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-With8">
-    <a href="#module-type-With8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With8/index.html">With8</a></span><span> = <a href="With6/module-type-T/index.html">With7(With6).T</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="With6/module-type-T/M/index.html">M</a> = <a href="With5/index.html">With5</a></span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="With5/N/index.html#type-t">M.N.t</a> = <a href="With5/N/index.html#type-t">With5.N.t</a></span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-With8">
+     <a href="#module-type-With8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With8/index.html">With8</a></span><span> = <a href="With6/module-type-T/index.html">With7(With6).T</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="With6/module-type-T/M/index.html">M</a> = <a href="With5/index.html">With5</a></span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="With5/N/index.html#type-t">M.N.t</a> = <a href="With5/N/index.html#type-t">With5.N.t</a></span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With9">
-    <a href="#module-With9" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With9/index.html">With9</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With9">
+     <a href="#module-With9" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With9/index.html">With9</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-With10">
-    <a href="#module-With10" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With10/index.html">With10</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-With10">
+     <a href="#module-With10" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="With10/index.html">With10</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-With11">
-    <a href="#module-type-With11" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With11/index.html">With11</a></span><span> = <a href="With10/module-type-T/index.html">With7(With10).T</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="With10/module-type-T/M/index.html">M</a> = <a href="With9/index.html">With9</a></span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="With9/module-type-S/index.html#type-t">N.t</a> = int</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-With11">
+     <a href="#module-type-With11" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-With11/index.html">With11</a></span><span> = <a href="With10/module-type-T/index.html">With7(With10).T</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="With10/module-type-T/M/index.html">M</a> = <a href="With9/index.html">With9</a></span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="With9/module-type-S/index.html#type-t">N.t</a> = int</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-NestedInclude1">
-    <a href="#module-type-NestedInclude1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude1/index.html">NestedInclude1</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-NestedInclude1">
+     <a href="#module-type-NestedInclude1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude1/index.html">NestedInclude1</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-NestedInclude1/index.html">NestedInclude1</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec module-type" id="module-type-NestedInclude2">
-        <a href="#module-type-NestedInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude2/index.html">NestedInclude2</a></span><span> = { ... }</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec module-type" id="module-type-NestedInclude2">
+         <a href="#module-type-NestedInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude2/index.html">NestedInclude2</a></span><span> = { ... }</span><span>;</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-NestedInclude2/index.html">NestedInclude2</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-NestedInclude2/index.html#type-nested_include">nested_include</a> = int</span><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec type" id="type-nested_include">
-        <a href="#type-nested_include" class="anchor"></a><code><span><span class="keyword">type</span> nested_include</span><span> = int</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-nested_include">
+         <a href="#type-nested_include" class="anchor"></a><code><span><span class="keyword">type</span> nested_include</span><span> = int</span><span>;</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module" id="module-DoubleInclude1">
-    <a href="#module-DoubleInclude1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="DoubleInclude1/index.html">DoubleInclude1</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-DoubleInclude1">
+     <a href="#module-DoubleInclude1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="DoubleInclude1/index.html">DoubleInclude1</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-DoubleInclude3">
-    <a href="#module-DoubleInclude3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="DoubleInclude3/index.html">DoubleInclude3</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-DoubleInclude3">
+     <a href="#module-DoubleInclude3" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="DoubleInclude3/index.html">DoubleInclude3</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="DoubleInclude3/DoubleInclude2/index.html">DoubleInclude3.DoubleInclude2</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec type" id="type-double_include">
-        <a href="#type-double_include" class="anchor"></a><code><span><span class="keyword">type</span> double_include</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-double_include">
+         <a href="#type-double_include" class="anchor"></a><code><span><span class="keyword">type</span> double_include</span><span>;</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div class="spec module" id="module-IncludeInclude1">
-    <a href="#module-IncludeInclude1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludeInclude1/index.html">IncludeInclude1</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-IncludeInclude1">
+     <a href="#module-IncludeInclude1" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludeInclude1/index.html">IncludeInclude1</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="IncludeInclude1/index.html">IncludeInclude1</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec module-type" id="module-type-IncludeInclude2">
-        <a href="#module-type-IncludeInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span><span> = { ... }</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec module-type" id="module-type-IncludeInclude2">
+         <a href="#module-type-IncludeInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span><span> = { ... }</span><span>;</span></code>
+        </div>
        </div>
       </details>
      </div>
     </div>
    </div>
-   <div>
+   <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
       <details open="open">
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a><span class="keyword">;</span></span></code></span>
        </summary>
-       <div class="spec type" id="type-include_include">
-        <a href="#type-include_include" class="anchor"></a><code><span><span class="keyword">type</span> include_include</span><span>;</span></code>
+       <div class="odoc-spec">
+        <div class="spec type" id="type-include_include">
+         <a href="#type-include_include" class="anchor"></a><code><span><span class="keyword">type</span> include_include</span><span>;</span></code>
+        </div>
        </div>
       </details>
      </div>
@@ -1687,7 +1889,7 @@
    <h2 id="indexmodules">
     <a href="#indexmodules" class="anchor"></a>Trying the {!modules: ...} command.
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      With ocamldoc, toplevel units will be linked and documented, while submodules will behave as simple references.
     </p>
@@ -1712,7 +1914,7 @@
    <h4 id="weirder-usages-involving-module-types">
     <a href="#weirder-usages-involving-module-types" class="anchor"></a>Weirder usages involving module types
    </h4>
-   <aside>
+   <aside class="odoc-unattached">
     <ul class="modules">
      <li>
       <code>IncludeInclude1</code>.IncludeInclude2
@@ -1728,14 +1930,16 @@
    <h2 id="playing-with-@canonical-paths">
     <a href="#playing-with-@canonical-paths" class="anchor"></a>Playing with @canonical paths
    </h2>
-   <div class="spec module" id="module-CanonicalTest">
-    <a href="#module-CanonicalTest" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="CanonicalTest/index.html">CanonicalTest</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-CanonicalTest">
+     <a href="#module-CanonicalTest" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="CanonicalTest/index.html">CanonicalTest</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-test">
      <a href="#val-test" class="anchor"></a><code><span><span class="keyword">let</span> test: <span><a href="CanonicalTest/Base/List/index.html#type-t">CanonicalTest.Base.List.t</a>(<span class="type-var">'a</span>) <span>=&gt;</span></span> unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some ref to <a href="CanonicalTest/Base__Tests/C/index.html#type-t"><code>CanonicalTest.Base__Tests.C.t</code></a> and <a href="CanonicalTest/Base/List/index.html#val-id"><code>CanonicalTest.Base__Tests.L.id</code></a>. But also to <a href="CanonicalTest/Base__/List/index.html"><code>CanonicalTest.Base__.List</code></a> and <a href="CanonicalTest/Base__/List/index.html#type-t"><code>CanonicalTest.Base__.List.t</code></a>
      </p>
@@ -1744,13 +1948,15 @@
    <h2 id="aliases">
     <a href="#aliases" class="anchor"></a>Aliases again
    </h2>
-   <div class="spec module" id="module-Aliases">
-    <a href="#module-Aliases" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Aliases/index.html">Aliases</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Aliases">
+     <a href="#module-Aliases" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Aliases/index.html">Aliases</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
    <h2 id="section-title-splicing">
     <a href="#section-title-splicing" class="anchor"></a>Section title splicing
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      I can refer to
     </p>
@@ -1794,13 +2000,17 @@
    <h2 id="new-reference-syntax">
     <a href="#new-reference-syntax" class="anchor"></a>New reference syntax
    </h2>
-   <div class="spec module-type" id="module-type-M">
-    <a href="#module-type-M" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-M/index.html">M</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-M">
+     <a href="#module-type-M" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-M/index.html">M</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-M">
-    <a href="#module-M" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M/index.html">M</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M">
+     <a href="#module-M" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M/index.html">M</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Here goes:
     </p>
@@ -1816,10 +2026,12 @@
      </li>
     </ul>
    </aside>
-   <div class="spec module" id="module-Only_a_module">
-    <a href="#module-Only_a_module" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Only_a_module/index.html">Only_a_module</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Only_a_module">
+     <a href="#module-Only_a_module" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Only_a_module/index.html">Only_a_module</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Some here should fail:
     </p>
@@ -1835,27 +2047,35 @@
      </li>
     </ul>
    </aside>
-   <div class="spec module-type" id="module-type-TypeExt">
-    <a href="#module-type-TypeExt" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-TypeExt/index.html">TypeExt</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-TypeExt">
+     <a href="#module-type-TypeExt" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-TypeExt/index.html">TypeExt</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-new_t">
-    <a href="#type-new_t" class="anchor"></a><code><span><span class="keyword">type</span> new_t</span><span> = </span><span>..</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-new_t">
+     <a href="#type-new_t" class="anchor"></a><code><span><span class="keyword">type</span> new_t</span><span> = </span><span>..</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-new_t">new_t</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-C" class="anchored">
-       <td class="def extension">
-        <a href="#extension-C" class="anchor"></a><code><span>| </span><span><span class="extension">C</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-new_t">new_t</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-C" class="anchored">
+        <td class="def extension">
+         <a href="#extension-C" class="anchor"></a><code><span>| </span><span><span class="extension">C</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-TypeExtPruned">
-    <a href="#module-type-TypeExtPruned" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-TypeExtPruned/index.html">TypeExtPruned</a></span><span> = <a href="module-type-TypeExt/index.html">TypeExt</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-TypeExt/index.html#type-t">t</a> := <a href="#type-new_t">new_t</a></span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-TypeExtPruned">
+     <a href="#module-type-TypeExtPruned" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-TypeExtPruned/index.html">TypeExtPruned</a></span><span> = <a href="module-type-TypeExt/index.html">TypeExt</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-TypeExt/index.html#type-t">t</a> := <a href="#type-new_t">new_t</a></span></span><span>;</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -155,51 +155,49 @@
    </ul>
   </nav>
   <div class="odoc-content">
-   <aside class="odoc-unattached">
-    <p>
-     You may find more information about this HTML documentation renderer at <a href="https://github.com/dsheets/ocamlary">github.com/dsheets/ocamlary</a>.
-    </p>
-    <p>
-     This is some verbatim text:
-    </p>
-    <pre>verbatim</pre>
-    <p>
-     This is some verbatim text:
-    </p>
-    <pre>[][df[]]}}</pre>
-    <p>
-     Here is some raw LaTeX: <code> $e^{i\pi} = -1$ </code>
-    </p>
-    <p>
-     Here is an index table of <code>Empty</code> modules:
-    </p>
-    <ul class="modules">
-     <li>
-      <a href="Empty/index.html"><code>Empty</code></a>
-     </li>
-     <li>
-      <a href="Empty/index.html"><code>EmptyAlias</code></a>
-     </li>
-    </ul>
-    <p>
-     Here is a table of links to indexes: <code>indexlist</code>
-    </p>
-    <p>
-     Here is some superscript: x<sup>2</sup>
-    </p>
-    <p>
-     Here is some subscript: x<sub>0</sub>
-    </p>
-    <p>
-     Here are some escaped brackets: { [ @ ] }
-    </p>
-    <p>
-     Here is some <em>emphasis</em> <code>followed by code</code>.
-    </p>
-    <p>
-     An unassociated comment
-    </p>
-   </aside>
+   <p>
+    You may find more information about this HTML documentation renderer at <a href="https://github.com/dsheets/ocamlary">github.com/dsheets/ocamlary</a>.
+   </p>
+   <p>
+    This is some verbatim text:
+   </p>
+   <pre>verbatim</pre>
+   <p>
+    This is some verbatim text:
+   </p>
+   <pre>[][df[]]}}</pre>
+   <p>
+    Here is some raw LaTeX: <code> $e^{i\pi} = -1$ </code>
+   </p>
+   <p>
+    Here is an index table of <code>Empty</code> modules:
+   </p>
+   <ul class="modules">
+    <li>
+     <a href="Empty/index.html"><code>Empty</code></a>
+    </li>
+    <li>
+     <a href="Empty/index.html"><code>EmptyAlias</code></a>
+    </li>
+   </ul>
+   <p>
+    Here is a table of links to indexes: <code>indexlist</code>
+   </p>
+   <p>
+    Here is some superscript: x<sup>2</sup>
+   </p>
+   <p>
+    Here is some subscript: x<sub>0</sub>
+   </p>
+   <p>
+    Here are some escaped brackets: { [ @ ] }
+   </p>
+   <p>
+    Here is some <em>emphasis</em> <code>followed by code</code>.
+   </p>
+   <p>
+    An unassociated comment
+   </p>
    <h2 id="level-1">
     <a href="#level-1" class="anchor"></a>Level 1
    </h2>
@@ -321,11 +319,9 @@
      <a href="#module-type-SuperSig" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-SuperSig/index.html">SuperSig</a></span><span> = { ... }</span><span>;</span></code>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     For a good time, see <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a> or <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigB:subSig</code></a> or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="#s9000">Level 9000</a> is also interesting. <a href="#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
-    </p>
-   </aside>
+   <p>
+    For a good time, see <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a> or <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigB:subSig</code></a> or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="#s9000">Level 9000</a> is also interesting. <a href="#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
+   </p>
    <div class="odoc-spec">
     <div class="spec module" id="module-Buffer">
      <a href="#module-Buffer" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Buffer/index.html">Buffer</a></span><span>: { ... }</span><span>;</span></code>
@@ -336,19 +332,15 @@
      </p>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Some text before exception title.
-    </p>
-   </aside>
+   <p>
+    Some text before exception title.
+   </p>
    <h4 id="basic-exception-stuff">
     <a href="#basic-exception-stuff" class="anchor"></a>Basic exception stuff
    </h4>
-   <aside class="odoc-unattached">
-    <p>
-     After exception title.
-    </p>
-   </aside>
+   <p>
+    After exception title.
+   </p>
    <div class="odoc-spec">
     <div class="spec exception" id="exception-Kaboom">
      <a href="#exception-Kaboom" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Kaboom</span>(unit)</span><span>;</span></code>
@@ -1889,44 +1881,40 @@
    <h2 id="indexmodules">
     <a href="#indexmodules" class="anchor"></a>Trying the {!modules: ...} command.
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     With ocamldoc, toplevel units will be linked and documented, while submodules will behave as simple references.
-    </p>
-    <p>
-     With odoc, everything should be resolved (and linked) but only toplevel units will be documented.
-    </p>
-    <ul class="modules">
-     <li>
-      <a href="Dep1/X/index.html"><code>Dep1.X</code></a>
-     </li>
-     <li>
-      <code>DocOckTypes</code>
-     </li>
-     <li>
-      <a href="IncludeInclude1/index.html"><code>Ocamlary.IncludeInclude1</code></a>
-     </li>
-     <li>
-      <a href="#"><code>Ocamlary</code></a>
-     </li>
-    </ul>
-   </aside>
+   <p>
+    With ocamldoc, toplevel units will be linked and documented, while submodules will behave as simple references.
+   </p>
+   <p>
+    With odoc, everything should be resolved (and linked) but only toplevel units will be documented.
+   </p>
+   <ul class="modules">
+    <li>
+     <a href="Dep1/X/index.html"><code>Dep1.X</code></a>
+    </li>
+    <li>
+     <code>DocOckTypes</code>
+    </li>
+    <li>
+     <a href="IncludeInclude1/index.html"><code>Ocamlary.IncludeInclude1</code></a>
+    </li>
+    <li>
+     <a href="#"><code>Ocamlary</code></a>
+    </li>
+   </ul>
    <h4 id="weirder-usages-involving-module-types">
     <a href="#weirder-usages-involving-module-types" class="anchor"></a>Weirder usages involving module types
    </h4>
-   <aside class="odoc-unattached">
-    <ul class="modules">
-     <li>
-      <code>IncludeInclude1</code>.IncludeInclude2
-     </li>
-     <li>
-      <code>Dep4</code>.T
-     </li>
-     <li>
-      <a href="module-type-A/Q/index.html"><code>A.Q</code></a>
-     </li>
-    </ul>
-   </aside>
+   <ul class="modules">
+    <li>
+     <code>IncludeInclude1</code>.IncludeInclude2
+    </li>
+    <li>
+     <code>Dep4</code>.T
+    </li>
+    <li>
+     <a href="module-type-A/Q/index.html"><code>A.Q</code></a>
+    </li>
+   </ul>
    <h2 id="playing-with-@canonical-paths">
     <a href="#playing-with-@canonical-paths" class="anchor"></a>Playing with @canonical paths
    </h2>
@@ -1956,47 +1944,45 @@
    <h2 id="section-title-splicing">
     <a href="#section-title-splicing" class="anchor"></a>Section title splicing
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     I can refer to
-    </p>
-    <ul>
-     <li>
-      <code>{!section:indexmodules}</code> : <a href="#indexmodules">Trying the {!modules: ...} command.</a>
-     </li>
-     <li>
-      <code>{!aliases}</code> : <a href="#aliases">Aliases again</a>
-     </li>
-    </ul>
-    <p>
-     But also to things in submodules:
-    </p>
-    <ul>
-     <li>
-      <code>{!section:SuperSig.SubSigA.subSig}</code> : <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a>
-     </li>
-     <li>
-      <code>{!Aliases.incl}</code> : <a href="#incl"><code>Aliases:incl</code></a>
-     </li>
-    </ul>
-    <p>
-     And just to make sure we do not mess up:
-    </p>
-    <ul>
-     <li>
-      <code>{{!section:indexmodules}A}</code> : <a href="#indexmodules">A</a>
-     </li>
-     <li>
-      <code>{{!aliases}B}</code> : <a href="#aliases">B</a>
-     </li>
-     <li>
-      <code>{{!section:SuperSig.SubSigA.subSig}C}</code> : <a href="module-type-SuperSig/index.html#subSig">C</a>
-     </li>
-     <li>
-      <code>{{!Aliases.incl}D}</code> : <a href="#incl">D</a>
-     </li>
-    </ul>
-   </aside>
+   <p>
+    I can refer to
+   </p>
+   <ul>
+    <li>
+     <code>{!section:indexmodules}</code> : <a href="#indexmodules">Trying the {!modules: ...} command.</a>
+    </li>
+    <li>
+     <code>{!aliases}</code> : <a href="#aliases">Aliases again</a>
+    </li>
+   </ul>
+   <p>
+    But also to things in submodules:
+   </p>
+   <ul>
+    <li>
+     <code>{!section:SuperSig.SubSigA.subSig}</code> : <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a>
+    </li>
+    <li>
+     <code>{!Aliases.incl}</code> : <a href="#incl"><code>Aliases:incl</code></a>
+    </li>
+   </ul>
+   <p>
+    And just to make sure we do not mess up:
+   </p>
+   <ul>
+    <li>
+     <code>{{!section:indexmodules}A}</code> : <a href="#indexmodules">A</a>
+    </li>
+    <li>
+     <code>{{!aliases}B}</code> : <a href="#aliases">B</a>
+    </li>
+    <li>
+     <code>{{!section:SuperSig.SubSigA.subSig}C}</code> : <a href="module-type-SuperSig/index.html#subSig">C</a>
+    </li>
+    <li>
+     <code>{{!Aliases.incl}D}</code> : <a href="#incl">D</a>
+    </li>
+   </ul>
    <h2 id="new-reference-syntax">
     <a href="#new-reference-syntax" class="anchor"></a>New reference syntax
    </h2>
@@ -2010,43 +1996,39 @@
      <a href="#module-M" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M/index.html">M</a></span><span>: { ... }</span><span>;</span></code>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Here goes:
-    </p>
-    <ul>
-     <li>
-      <code>{!M.t}</code> : <a href="M/index.html#type-t"><code>M.t</code></a>
-     </li>
-     <li>
-      <code>{!module-M.t}</code> : <a href="M/index.html#type-t"><code>M.t</code></a>
-     </li>
-     <li>
-      <code>{!module-type-M.t}</code> : <a href="module-type-M/index.html#type-t"><code>M.t</code></a>
-     </li>
-    </ul>
-   </aside>
+   <p>
+    Here goes:
+   </p>
+   <ul>
+    <li>
+     <code>{!M.t}</code> : <a href="M/index.html#type-t"><code>M.t</code></a>
+    </li>
+    <li>
+     <code>{!module-M.t}</code> : <a href="M/index.html#type-t"><code>M.t</code></a>
+    </li>
+    <li>
+     <code>{!module-type-M.t}</code> : <a href="module-type-M/index.html#type-t"><code>M.t</code></a>
+    </li>
+   </ul>
    <div class="odoc-spec">
     <div class="spec module" id="module-Only_a_module">
      <a href="#module-Only_a_module" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Only_a_module/index.html">Only_a_module</a></span><span>: { ... }</span><span>;</span></code>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     Some here should fail:
-    </p>
-    <ul>
-     <li>
-      <code>{!Only_a_module.t}</code> : <a href="Only_a_module/index.html#type-t"><code>Only_a_module.t</code></a>
-     </li>
-     <li>
-      <code>{!module-Only_a_module.t}</code> : <a href="Only_a_module/index.html#type-t"><code>Only_a_module.t</code></a>
-     </li>
-     <li>
-      <code>{!module-type-Only_a_module.t}</code> : <code>Only_a_module</code>.t : <span class="xref-unresolved">test</span>
-     </li>
-    </ul>
-   </aside>
+   <p>
+    Some here should fail:
+   </p>
+   <ul>
+    <li>
+     <code>{!Only_a_module.t}</code> : <a href="Only_a_module/index.html#type-t"><code>Only_a_module.t</code></a>
+    </li>
+    <li>
+     <code>{!module-Only_a_module.t}</code> : <a href="Only_a_module/index.html#type-t"><code>Only_a_module.t</code></a>
+    </li>
+    <li>
+     <code>{!module-type-Only_a_module.t}</code> : <code>Only_a_module</code>.t : <span class="xref-unresolved">test</span>
+    </li>
+   </ul>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-TypeExt">
      <a href="#module-type-TypeExt" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-TypeExt/index.html">TypeExt</a></span><span> = { ... }</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Recent/X/index.html
+++ b/test/html/expect/test_package+re/Recent/X/index.html
@@ -23,17 +23,25 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module-substitution" id="module-L">
-    <a href="#module-L" class="anchor"></a><code><span><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></span></code>
+   <div class="odoc-spec">
+    <div class="spec module-substitution" id="module-L">
+     <a href="#module-L" class="anchor"></a><code><span><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-t">
-    <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a>(int)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a>(int)</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type-subst" id="type-u">
-    <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> := int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type-subst" id="type-u">
+     <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> := int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-v">
-    <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a>(<a href="#type-u">u</a>)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-v">
+     <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a>(<a href="#type-u">u</a>)</span><span>;</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -23,187 +23,215 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S1">
-    <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S1/index.html">S1</a></span><span> = <span> (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S1">
+     <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S1/index.html">S1</a></span><span> = <span> (<a href="module-type-S1/argument-1-_/index.html">_</a>: <a href="module-type-S/index.html">S</a>) <span>=&gt;</span></span> <a href="module-type-S/index.html">S</a></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-variant">
-    <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-variant.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-       </td>
-      </tr>
-      <tr id="type-variant.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int)</span></code>
-       </td>
-      </tr>
-      <tr id="type-variant.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         foo
-        </p>
-       </td>
-      </tr>
-      <tr id="type-variant.D" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <em>bar</em>
-        </p>
-       </td>
-      </tr>
-      <tr id="type-variant.E" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> </span><span>{</span></code>
-        <table>
-         <tbody>
-          <tr id="type-variant.a" class="anchored">
-           <td class="def record field">
-            <a href="#type-variant.a" class="anchor"></a><code><span>a: int,</span></code>
-           </td>
-          </tr>
-         </tbody>
-        </table>
-        <code><span>}</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-variant">
+     <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-variant.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+        </td>
+       </tr>
+       <tr id="type-variant.B" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int)</span></code>
+        </td>
+       </tr>
+       <tr id="type-variant.C" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.D" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <em>bar</em>
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.E" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> </span><span>{</span></code>
+         <table>
+          <tbody>
+           <tr id="type-variant.a" class="anchored">
+            <td class="def record field">
+             <a href="#type-variant.a" class="anchor"></a><code><span>a: int,</span></code>
+            </td>
+           </tr>
+          </tbody>
+         </table>
+         <code><span>}</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-gadt">
-    <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> gadt(_)</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-gadt.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-gadt">gadt</a>(int)</span></code>
-       </td>
-      </tr>
-      <tr id="type-gadt.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int) : <a href="#type-gadt">gadt</a>(string)</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         foo
-        </p>
-       </td>
-      </tr>
-      <tr id="type-gadt.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span>: </span><span>{</span></code>
-        <table>
-         <tbody>
-          <tr id="type-gadt.a" class="anchored">
-           <td class="def record field">
-            <a href="#type-gadt.a" class="anchor"></a><code><span>a: int,</span></code>
-           </td>
-          </tr>
-         </tbody>
-        </table>
-        <code><span>}</span><span> : <a href="#type-gadt">gadt</a>(unit)</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-gadt">
+     <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> gadt(_)</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-gadt.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-gadt">gadt</a>(int)</span></code>
+        </td>
+       </tr>
+       <tr id="type-gadt.B" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int) : <a href="#type-gadt">gadt</a>(string)</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-gadt.C" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span>: </span><span>{</span></code>
+         <table>
+          <tbody>
+           <tr id="type-gadt.a" class="anchored">
+            <td class="def record field">
+             <a href="#type-gadt.a" class="anchor"></a><code><span>a: int,</span></code>
+            </td>
+           </tr>
+          </tbody>
+         </table>
+         <code><span>}</span><span> : <a href="#type-gadt">gadt</a>(unit)</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-polymorphic_variant">
-    <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-polymorphic_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.B" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(int)</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.C" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         foo
-        </p>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.D" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         bar
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-polymorphic_variant">
+     <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-polymorphic_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(int)</span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.D" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          bar
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-empty_variant">
-    <a href="#type-empty_variant" class="anchor"></a><code><span><span class="keyword">type</span> empty_variant</span><span> = </span><span>|</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-empty_variant">
+     <a href="#type-empty_variant" class="anchor"></a><code><span><span class="keyword">type</span> empty_variant</span><span> = </span><span>|</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-nonrec_">
-    <a href="#type-nonrec_" class="anchor"></a><code><span><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_</span><span> = int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-nonrec_">
+     <a href="#type-nonrec_" class="anchor"></a><code><span><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_</span><span> = int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-empty_conj">
-    <a href="#type-empty_conj" class="anchor"></a><code><span><span class="keyword">type</span> empty_conj</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-empty_conj.X" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-empty_conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span>(<span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>) : <a href="#type-empty_conj">empty_conj</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-empty_conj">
+     <a href="#type-empty_conj" class="anchor"></a><code><span><span class="keyword">type</span> empty_conj</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-empty_conj.X" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-empty_conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span>(<span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>) : <a href="#type-empty_conj">empty_conj</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-conj">
-    <a href="#type-conj" class="anchor"></a><code><span><span class="keyword">type</span> conj</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-conj.X" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span>(<span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>) : <a href="#type-conj">conj</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-conj">
+     <a href="#type-conj" class="anchor"></a><code><span><span class="keyword">type</span> conj</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-conj.X" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span>(<span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>) : <a href="#type-conj">conj</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-empty_conj">
-    <a href="#val-empty_conj" class="anchor"></a><code><span><span class="keyword">let</span> empty_conj: <span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-empty_conj">
+     <a href="#val-empty_conj" class="anchor"></a><code><span><span class="keyword">let</span> empty_conj: <span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-conj">
-    <a href="#val-conj" class="anchor"></a><code><span><span class="keyword">let</span> conj: <span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-conj">
+     <a href="#val-conj" class="anchor"></a><code><span><span class="keyword">let</span> conj: <span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-Z">
-    <a href="#module-Z" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Z/index.html">Z</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Z">
+     <a href="#module-Z" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Z/index.html">Z</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-X">
-    <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-X">
+     <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-PolyS">
-    <a href="#module-type-PolyS" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-PolyS/index.html">PolyS</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-PolyS">
+     <a href="#module-type-PolyS" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-PolyS/index.html">PolyS</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Recent_impl/index.html
+++ b/test/html/expect/test_package+re/Recent_impl/index.html
@@ -23,20 +23,30 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div class="spec module" id="module-Foo">
-    <a href="#module-Foo" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Foo/index.html">Foo</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Foo">
+     <a href="#module-Foo" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Foo/index.html">Foo</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-B">
-    <a href="#module-B" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="B/index.html">B</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-B">
+     <a href="#module-B" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="B/index.html">B</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-u">
-    <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-u">
+     <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-S">
-    <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-S">
+     <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module" id="module-B'">
-    <a href="#module-B'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span>B'</span><span> = <a href="Foo/B/index.html">Foo.B</a></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-B'">
+     <a href="#module-B'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span>B'</span><span> = <a href="Foo/B/index.html">Foo.B</a></span><span>;</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Section/index.html
+++ b/test/html/expect/test_package+re/Section/index.html
@@ -62,7 +62,7 @@
    <h2 id="text-only">
     <a href="#text-only" class="anchor"></a>Text only
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Foo bar.
     </p>
@@ -70,7 +70,7 @@
    <h2 id="aside-only">
     <a href="#aside-only" class="anchor"></a>Aside only
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      Foo bar.
     </p>
@@ -78,8 +78,10 @@
    <h2 id="value-only">
     <a href="#value-only" class="anchor"></a>Value only
    </h2>
-   <div class="spec value" id="val-foo">
-    <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-foo">
+     <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+    </div>
    </div>
    <h2 id="empty-section">
     <a href="#empty-section" class="anchor"></a>Empty section
@@ -93,7 +95,7 @@
    <h2 id="this-section-title-has-markup">
     <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
    </h2>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
     </p>

--- a/test/html/expect/test_package+re/Section/index.html
+++ b/test/html/expect/test_package+re/Section/index.html
@@ -62,19 +62,15 @@
    <h2 id="text-only">
     <a href="#text-only" class="anchor"></a>Text only
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Foo bar.
-    </p>
-   </aside>
+   <p>
+    Foo bar.
+   </p>
    <h2 id="aside-only">
     <a href="#aside-only" class="anchor"></a>Aside only
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     Foo bar.
-    </p>
-   </aside>
+   <p>
+    Foo bar.
+   </p>
    <h2 id="value-only">
     <a href="#value-only" class="anchor"></a>Value only
    </h2>
@@ -95,11 +91,9 @@
    <h2 id="this-section-title-has-markup">
     <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em> <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
    </h2>
-   <aside class="odoc-unattached">
-    <p>
-     But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
-    </p>
-   </aside>
+   <p>
+    But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+   </p>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Stop/index.html
+++ b/test/html/expect/test_package+re/Stop/index.html
@@ -26,17 +26,17 @@
    </p>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: int;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       This is normal commented text.
      </p>
     </div>
    </div>
-   <aside>
+   <aside class="odoc-unattached">
     <p>
      The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
     </p>
@@ -47,11 +47,15 @@
      Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
     </p>
    </aside>
-   <div class="spec module" id="module-N">
-    <a href="#module-N" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="N/index.html">N</a></span><span>: { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-N">
+     <a href="#module-N" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="N/index.html">N</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec value" id="val-lol">
-    <a href="#val-lol" class="anchor"></a><code><span><span class="keyword">let</span> lol: int;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-lol">
+     <a href="#val-lol" class="anchor"></a><code><span><span class="keyword">let</span> lol: int;</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Stop/index.html
+++ b/test/html/expect/test_package+re/Stop/index.html
@@ -36,17 +36,15 @@
      </p>
     </div>
    </div>
-   <aside class="odoc-unattached">
-    <p>
-     The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
-    </p>
-    <p>
-     Documentation is on again.
-    </p>
-    <p>
-     Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
-    </p>
-   </aside>
+   <p>
+    The next value is <code>bar</code>, and it should be missing from the documentation. There is also an entire module, <code>M</code>, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
+   </p>
+   <p>
+    Documentation is on again.
+   </p>
+   <p>
+    Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
+   </p>
    <div class="odoc-spec">
     <div class="spec module" id="module-N">
      <a href="#module-N" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="N/index.html">N</a></span><span>: { ... }</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -23,416 +23,520 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec type" id="type-abstract">
      <a href="#type-abstract" class="anchor"></a><code><span><span class="keyword">type</span> abstract</span><span>;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Some <em>documentation</em>.
      </p>
     </div>
    </div>
-   <div class="spec type" id="type-alias">
-    <a href="#type-alias" class="anchor"></a><code><span><span class="keyword">type</span> alias</span><span> = int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-alias">
+     <a href="#type-alias" class="anchor"></a><code><span><span class="keyword">type</span> alias</span><span> = int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-private_">
-    <a href="#type-private_" class="anchor"></a><code><span><span class="keyword">type</span> private_</span><span> = <span class="keyword">pri</span> int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-private_">
+     <a href="#type-private_" class="anchor"></a><code><span><span class="keyword">type</span> private_</span><span> = <span class="keyword">pri</span> int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-constructor">
-    <a href="#type-constructor" class="anchor"></a><code><span><span class="keyword">type</span> constructor('a)</span><span> = <span class="type-var">'a</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-constructor">
+     <a href="#type-constructor" class="anchor"></a><code><span><span class="keyword">type</span> constructor('a)</span><span> = <span class="type-var">'a</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-arrow">
-    <a href="#type-arrow" class="anchor"></a><code><span><span class="keyword">type</span> arrow</span><span> = <span>int <span>=&gt;</span></span> int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-arrow">
+     <a href="#type-arrow" class="anchor"></a><code><span><span class="keyword">type</span> arrow</span><span> = <span>int <span>=&gt;</span></span> int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-higher_order">
-    <a href="#type-higher_order" class="anchor"></a><code><span><span class="keyword">type</span> higher_order</span><span> = <span><span>(<span>int <span>=&gt;</span></span> int)</span> <span>=&gt;</span></span> int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-higher_order">
+     <a href="#type-higher_order" class="anchor"></a><code><span><span class="keyword">type</span> higher_order</span><span> = <span><span>(<span>int <span>=&gt;</span></span> int)</span> <span>=&gt;</span></span> int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-labeled">
-    <a href="#type-labeled" class="anchor"></a><code><span><span class="keyword">type</span> labeled</span><span> = <span>l:int <span>=&gt;</span></span> int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-labeled">
+     <a href="#type-labeled" class="anchor"></a><code><span><span class="keyword">type</span> labeled</span><span> = <span>l:int <span>=&gt;</span></span> int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-optional">
-    <a href="#type-optional" class="anchor"></a><code><span><span class="keyword">type</span> optional</span><span> = <span>?⁠l:int <span>=&gt;</span></span> int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-optional">
+     <a href="#type-optional" class="anchor"></a><code><span><span class="keyword">type</span> optional</span><span> = <span>?⁠l:int <span>=&gt;</span></span> int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-labeled_higher_order">
-    <a href="#type-labeled_higher_order" class="anchor"></a><code><span><span class="keyword">type</span> labeled_higher_order</span><span> = <span><span>(<span>l:int <span>=&gt;</span></span> int)</span> <span>=&gt;</span></span> <span><span>(<span>?⁠l:int <span>=&gt;</span></span> int)</span> <span>=&gt;</span></span> int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-labeled_higher_order">
+     <a href="#type-labeled_higher_order" class="anchor"></a><code><span><span class="keyword">type</span> labeled_higher_order</span><span> = <span><span>(<span>l:int <span>=&gt;</span></span> int)</span> <span>=&gt;</span></span> <span><span>(<span>?⁠l:int <span>=&gt;</span></span> int)</span> <span>=&gt;</span></span> int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-pair">
-    <a href="#type-pair" class="anchor"></a><code><span><span class="keyword">type</span> pair</span><span> = <span>(int, int)</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-pair">
+     <a href="#type-pair" class="anchor"></a><code><span><span class="keyword">type</span> pair</span><span> = <span>(int, int)</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-parens_dropped">
-    <a href="#type-parens_dropped" class="anchor"></a><code><span><span class="keyword">type</span> parens_dropped</span><span> = <span>(int, int)</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-parens_dropped">
+     <a href="#type-parens_dropped" class="anchor"></a><code><span><span class="keyword">type</span> parens_dropped</span><span> = <span>(int, int)</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-triple">
-    <a href="#type-triple" class="anchor"></a><code><span><span class="keyword">type</span> triple</span><span> = <span>(int, int, int)</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-triple">
+     <a href="#type-triple" class="anchor"></a><code><span><span class="keyword">type</span> triple</span><span> = <span>(int, int, int)</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-nested_pair">
-    <a href="#type-nested_pair" class="anchor"></a><code><span><span class="keyword">type</span> nested_pair</span><span> = <span>(<span>(int, int)</span>, int)</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-nested_pair">
+     <a href="#type-nested_pair" class="anchor"></a><code><span><span class="keyword">type</span> nested_pair</span><span> = <span>(<span>(int, int)</span>, int)</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-instance">
-    <a href="#type-instance" class="anchor"></a><code><span><span class="keyword">type</span> instance</span><span> = <a href="#type-constructor">constructor</a>(int)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-instance">
+     <a href="#type-instance" class="anchor"></a><code><span><span class="keyword">type</span> instance</span><span> = <a href="#type-constructor">constructor</a>(int)</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-long">
-    <a href="#type-long" class="anchor"></a><code><span><span class="keyword">type</span> long</span><span> = <span><a href="#type-labeled_higher_order">labeled_higher_order</a> <span>=&gt;</span></span> <span><span>[ `Bar <span><span>| `Baz</span><span>(<a href="#type-triple">triple</a>)</span></span> ]</span> <span>=&gt;</span></span> <span><a href="#type-pair">pair</a> <span>=&gt;</span></span> <span><a href="#type-labeled">labeled</a> <span>=&gt;</span></span> <span><a href="#type-higher_order">higher_order</a> <span>=&gt;</span></span> <span><span>(<span>string <span>=&gt;</span></span> int)</span> <span>=&gt;</span></span> <span><span class="xref-unresolved">CamlinternalFormatBasics</span>.fmtty<span>(int,&nbsp;float,&nbsp;char,&nbsp;string,&nbsp;char,&nbsp;unit)</span> <span>=&gt;</span></span> <span><a href="#type-nested_pair">nested_pair</a> <span>=&gt;</span></span> <span><a href="#type-arrow">arrow</a> <span>=&gt;</span></span> <span>string <span>=&gt;</span></span> array(<a href="#type-nested_pair">nested_pair</a>)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-long">
+     <a href="#type-long" class="anchor"></a><code><span><span class="keyword">type</span> long</span><span> = <span><a href="#type-labeled_higher_order">labeled_higher_order</a> <span>=&gt;</span></span> <span><span>[ `Bar <span><span>| `Baz</span><span>(<a href="#type-triple">triple</a>)</span></span> ]</span> <span>=&gt;</span></span> <span><a href="#type-pair">pair</a> <span>=&gt;</span></span> <span><a href="#type-labeled">labeled</a> <span>=&gt;</span></span> <span><a href="#type-higher_order">higher_order</a> <span>=&gt;</span></span> <span><span>(<span>string <span>=&gt;</span></span> int)</span> <span>=&gt;</span></span> <span><span class="xref-unresolved">CamlinternalFormatBasics</span>.fmtty<span>(int,&nbsp;float,&nbsp;char,&nbsp;string,&nbsp;char,&nbsp;unit)</span> <span>=&gt;</span></span> <span><a href="#type-nested_pair">nested_pair</a> <span>=&gt;</span></span> <span><a href="#type-arrow">arrow</a> <span>=&gt;</span></span> <span>string <span>=&gt;</span></span> array(<a href="#type-nested_pair">nested_pair</a>)</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-variant_e">
-    <a href="#type-variant_e" class="anchor"></a><code><span><span class="keyword">type</span> variant_e</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-variant_e.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-variant_e.a" class="anchor"></a><code><span>a: int,</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-variant_e">
+     <a href="#type-variant_e" class="anchor"></a><code><span><span class="keyword">type</span> variant_e</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-variant_e.a" class="anchored">
+        <td class="def record field">
+         <a href="#type-variant_e.a" class="anchor"></a><code><span>a: int,</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-variant">
-    <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-variant.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-       </td>
-      </tr>
-      <tr id="type-variant.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int)</span></code>
-       </td>
-      </tr>
-      <tr id="type-variant.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         foo
-        </p>
-       </td>
-      </tr>
-      <tr id="type-variant.D" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <em>bar</em>
-        </p>
-       </td>
-      </tr>
-      <tr id="type-variant.E" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span>(<a href="#type-variant_e">variant_e</a>)</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-variant">
+     <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-variant.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+        </td>
+       </tr>
+       <tr id="type-variant.B" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int)</span></code>
+        </td>
+       </tr>
+       <tr id="type-variant.C" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.D" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <em>bar</em>
+         </p>
+        </td>
+       </tr>
+       <tr id="type-variant.E" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span>(<a href="#type-variant_e">variant_e</a>)</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-variant_c">
-    <a href="#type-variant_c" class="anchor"></a><code><span><span class="keyword">type</span> variant_c</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-variant_c.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-variant_c.a" class="anchor"></a><code><span>a: int,</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-variant_c">
+     <a href="#type-variant_c" class="anchor"></a><code><span><span class="keyword">type</span> variant_c</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-variant_c.a" class="anchored">
+        <td class="def record field">
+         <a href="#type-variant_c.a" class="anchor"></a><code><span>a: int,</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-gadt">
-    <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> gadt(_)</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-gadt.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-gadt">gadt</a>(int)</span></code>
-       </td>
-      </tr>
-      <tr id="type-gadt.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int) : <a href="#type-gadt">gadt</a>(string)</span></code>
-       </td>
-      </tr>
-      <tr id="type-gadt.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span>(<a href="#type-variant_c">variant_c</a>) : <a href="#type-gadt">gadt</a>(unit)</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-gadt">
+     <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> gadt(_)</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-gadt.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-gadt">gadt</a>(int)</span></code>
+        </td>
+       </tr>
+       <tr id="type-gadt.B" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int) : <a href="#type-gadt">gadt</a>(string)</span></code>
+        </td>
+       </tr>
+       <tr id="type-gadt.C" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span>(<a href="#type-variant_c">variant_c</a>) : <a href="#type-gadt">gadt</a>(unit)</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-degenerate_gadt">
-    <a href="#type-degenerate_gadt" class="anchor"></a><code><span><span class="keyword">type</span> degenerate_gadt</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-degenerate_gadt.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-degenerate_gadt">degenerate_gadt</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-degenerate_gadt">
+     <a href="#type-degenerate_gadt" class="anchor"></a><code><span><span class="keyword">type</span> degenerate_gadt</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-degenerate_gadt.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-degenerate_gadt">degenerate_gadt</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-private_variant">
-    <a href="#type-private_variant" class="anchor"></a><code><span><span class="keyword">type</span> private_variant</span><span> = <span class="keyword">pri</span> </span></code>
-    <table>
-     <tbody>
-      <tr id="type-private_variant.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-private_variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-private_variant">
+     <a href="#type-private_variant" class="anchor"></a><code><span><span class="keyword">type</span> private_variant</span><span> = <span class="keyword">pri</span> </span></code>
+     <table>
+      <tbody>
+       <tr id="type-private_variant.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-private_variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-record">
-    <a href="#type-record" class="anchor"></a><code><span><span class="keyword">type</span> record</span><span> = </span><span>{</span></code>
-    <table>
-     <tbody>
-      <tr id="type-record.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.a" class="anchor"></a><code><span>a: int,</span></code>
-       </td>
-      </tr>
-      <tr id="type-record.b" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.b" class="anchor"></a><code><span><span class="keyword">mutable</span> b: int,</span></code>
-       </td>
-      </tr>
-      <tr id="type-record.c" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.c" class="anchor"></a><code><span>c: int,</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         foo
-        </p>
-       </td>
-      </tr>
-      <tr id="type-record.d" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.d" class="anchor"></a><code><span>d: int,</span></code>
-       </td>
-       <td class="doc">
-        <p>
-         <em>bar</em>
-        </p>
-       </td>
-      </tr>
-      <tr id="type-record.e" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.e" class="anchor"></a><code><span>e: a. <span class="type-var">'a</span>,</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>}</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-record">
+     <a href="#type-record" class="anchor"></a><code><span><span class="keyword">type</span> record</span><span> = </span><span>{</span></code>
+     <table>
+      <tbody>
+       <tr id="type-record.a" class="anchored">
+        <td class="def record field">
+         <a href="#type-record.a" class="anchor"></a><code><span>a: int,</span></code>
+        </td>
+       </tr>
+       <tr id="type-record.b" class="anchored">
+        <td class="def record field">
+         <a href="#type-record.b" class="anchor"></a><code><span><span class="keyword">mutable</span> b: int,</span></code>
+        </td>
+       </tr>
+       <tr id="type-record.c" class="anchored">
+        <td class="def record field">
+         <a href="#type-record.c" class="anchor"></a><code><span>c: int,</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          foo
+         </p>
+        </td>
+       </tr>
+       <tr id="type-record.d" class="anchored">
+        <td class="def record field">
+         <a href="#type-record.d" class="anchor"></a><code><span>d: int,</span></code>
+        </td>
+        <td class="doc">
+         <p>
+          <em>bar</em>
+         </p>
+        </td>
+       </tr>
+       <tr id="type-record.e" class="anchored">
+        <td class="def record field">
+         <a href="#type-record.e" class="anchor"></a><code><span>e: a. <span class="type-var">'a</span>,</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>}</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-polymorphic_variant">
-    <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-polymorphic_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.B" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(int)</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.C" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C(<span>(int, unit)</span>)</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.D" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-polymorphic_variant">
+     <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-polymorphic_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.B" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(int)</span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.C" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C(<span>(int, unit)</span>)</span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant.D" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-polymorphic_variant_extension">
-    <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant_extension</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
-       <td class="def type">
-        <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant_extension.E" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span>| </span></code><code><span>`E</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-polymorphic_variant_extension">
+     <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant_extension</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
+        <td class="def type">
+         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
+        </td>
+       </tr>
+       <tr id="type-polymorphic_variant_extension.E" class="anchored">
+        <td class="def constructor">
+         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span>| </span></code><code><span>`E</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-nested_polymorphic_variant">
-    <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_polymorphic_variant</span><span> = </span><span>[ </span></code>
-    <table>
-     <tbody>
-      <tr id="type-nested_polymorphic_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A(<span>[ `B <span>| `C</span> ]</span>)</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-nested_polymorphic_variant">
+     <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_polymorphic_variant</span><span> = </span><span>[ </span></code>
+     <table>
+      <tbody>
+       <tr id="type-nested_polymorphic_variant.A" class="anchored">
+        <td class="def constructor">
+         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A(<span>[ `B <span>| `C</span> ]</span>)</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-private_extenion#row">
-    <a href="#type-private_extenion#row" class="anchor"></a><code><span><span class="keyword">type</span> private_extenion#row</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-private_extenion#row">
+     <a href="#type-private_extenion#row" class="anchor"></a><code><span><span class="keyword">type</span> private_extenion#row</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-private_extenion">
-    <a href="#type-private_extenion" class="anchor"></a><code><span><span class="keyword">and</span> private_extenion</span><span> = <span class="keyword">pri</span> </span><span>[&gt; </span></code>
-    <table>
-     <tbody>
-      <tr id="type-private_extenion.polymorphic_variant" class="anchored">
-       <td class="def type">
-        <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span> ]</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-private_extenion">
+     <a href="#type-private_extenion" class="anchor"></a><code><span><span class="keyword">and</span> private_extenion</span><span> = <span class="keyword">pri</span> </span><span>[&gt; </span></code>
+     <table>
+      <tbody>
+       <tr id="type-private_extenion.polymorphic_variant" class="anchored">
+        <td class="def type">
+         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span> ]</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-object_">
-    <a href="#type-object_" class="anchor"></a><code><span><span class="keyword">type</span> object_</span><span> = <span>{. a: int, b: int, c: int, }</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-object_">
+     <a href="#type-object_" class="anchor"></a><code><span><span class="keyword">type</span> object_</span><span> = <span>{. a: int, b: int, c: int, }</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec module-type" id="module-type-X">
-    <a href="#module-type-X" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-X/index.html">X</a></span><span> = { ... }</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-X">
+     <a href="#module-type-X" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-X/index.html">X</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-module_">
-    <a href="#type-module_" class="anchor"></a><code><span><span class="keyword">type</span> module_</span><span> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-module_">
+     <a href="#type-module_" class="anchor"></a><code><span><span class="keyword">type</span> module_</span><span> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a>)</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-module_substitution">
-    <a href="#type-module_substitution" class="anchor"></a><code><span><span class="keyword">type</span> module_substitution</span><span> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-module_substitution">
+     <a href="#type-module_substitution" class="anchor"></a><code><span><span class="keyword">type</span> module_substitution</span><span> = <span>(<span class="keyword">module</span> <a href="module-type-X/index.html">X</a> <span class="keyword">with</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-t">t</a> = int <span class="keyword">and</span> <span class="keyword">type</span> <a href="module-type-X/index.html#type-u">u</a> = unit)</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-covariant">
-    <a href="#type-covariant" class="anchor"></a><code><span><span class="keyword">type</span> covariant(+'a)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-covariant">
+     <a href="#type-covariant" class="anchor"></a><code><span><span class="keyword">type</span> covariant(+'a)</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-contravariant">
-    <a href="#type-contravariant" class="anchor"></a><code><span><span class="keyword">type</span> contravariant(-'a)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-contravariant">
+     <a href="#type-contravariant" class="anchor"></a><code><span><span class="keyword">type</span> contravariant(-'a)</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-bivariant">
-    <a href="#type-bivariant" class="anchor"></a><code><span><span class="keyword">type</span> bivariant(_)</span><span> = int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-bivariant">
+     <a href="#type-bivariant" class="anchor"></a><code><span><span class="keyword">type</span> bivariant(_)</span><span> = int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-binary">
-    <a href="#type-binary" class="anchor"></a><code><span><span class="keyword">type</span> binary('a, 'b)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-binary">
+     <a href="#type-binary" class="anchor"></a><code><span><span class="keyword">type</span> binary('a, 'b)</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-using_binary">
-    <a href="#type-using_binary" class="anchor"></a><code><span><span class="keyword">type</span> using_binary</span><span> = <a href="#type-binary">binary</a><span>(int,&nbsp;int)</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-using_binary">
+     <a href="#type-using_binary" class="anchor"></a><code><span><span class="keyword">type</span> using_binary</span><span> = <a href="#type-binary">binary</a><span>(int,&nbsp;int)</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-name">
-    <a href="#type-name" class="anchor"></a><code><span><span class="keyword">type</span> name('custom)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-name">
+     <a href="#type-name" class="anchor"></a><code><span><span class="keyword">type</span> name('custom)</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-constrained">
-    <a href="#type-constrained" class="anchor"></a><code><span><span class="keyword">type</span> constrained('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-constrained">
+     <a href="#type-constrained" class="anchor"></a><code><span><span class="keyword">type</span> constrained('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-exact_variant">
-    <a href="#type-exact_variant" class="anchor"></a><code><span><span class="keyword">type</span> exact_variant('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[ `A <span><span>| `B</span><span>(int)</span></span> ]</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-exact_variant">
+     <a href="#type-exact_variant" class="anchor"></a><code><span><span class="keyword">type</span> exact_variant('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[ `A <span><span>| `B</span><span>(int)</span></span> ]</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-lower_variant">
-    <a href="#type-lower_variant" class="anchor"></a><code><span><span class="keyword">type</span> lower_variant('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `A <span><span>| `B</span><span>(int)</span></span> ]</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-lower_variant">
+     <a href="#type-lower_variant" class="anchor"></a><code><span><span class="keyword">type</span> lower_variant('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt; `A <span><span>| `B</span><span>(int)</span></span> ]</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-any_variant">
-    <a href="#type-any_variant" class="anchor"></a><code><span><span class="keyword">type</span> any_variant('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt;  ]</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-any_variant">
+     <a href="#type-any_variant" class="anchor"></a><code><span><span class="keyword">type</span> any_variant('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&gt;  ]</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-upper_variant">
-    <a href="#type-upper_variant" class="anchor"></a><code><span><span class="keyword">type</span> upper_variant('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; `A <span><span>| `B</span><span>(int)</span></span> ]</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-upper_variant">
+     <a href="#type-upper_variant" class="anchor"></a><code><span><span class="keyword">type</span> upper_variant('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; `A <span><span>| `B</span><span>(int)</span></span> ]</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-named_variant">
-    <a href="#type-named_variant" class="anchor"></a><code><span><span class="keyword">type</span> named_variant('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; <a href="#type-polymorphic_variant">polymorphic_variant</a> ]</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-named_variant">
+     <a href="#type-named_variant" class="anchor"></a><code><span><span class="keyword">type</span> named_variant('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>[&lt; <a href="#type-polymorphic_variant">polymorphic_variant</a> ]</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-exact_object">
-    <a href="#type-exact_object" class="anchor"></a><code><span><span class="keyword">type</span> exact_object('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>{. a: int, b: int, }</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-exact_object">
+     <a href="#type-exact_object" class="anchor"></a><code><span><span class="keyword">type</span> exact_object('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>{. a: int, b: int, }</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-lower_object">
-    <a href="#type-lower_object" class="anchor"></a><code><span><span class="keyword">type</span> lower_object('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>{.. a: int, b: int, }</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-lower_object">
+     <a href="#type-lower_object" class="anchor"></a><code><span><span class="keyword">type</span> lower_object('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>{.. a: int, b: int, }</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-poly_object">
-    <a href="#type-poly_object" class="anchor"></a><code><span><span class="keyword">type</span> poly_object('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>{. a: a. <span class="type-var">'a</span>, }</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-poly_object">
+     <a href="#type-poly_object" class="anchor"></a><code><span><span class="keyword">type</span> poly_object('a)</span><span> = <span class="type-var">'a</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = <span>{. a: a. <span class="type-var">'a</span>, }</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-double_constrained">
-    <a href="#type-double_constrained" class="anchor"></a><code><span><span class="keyword">type</span> double_constrained('a, 'b)</span><span> = <span>(<span class="type-var">'a</span>, <span class="type-var">'b</span>)</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-double_constrained">
+     <a href="#type-double_constrained" class="anchor"></a><code><span><span class="keyword">type</span> double_constrained('a, 'b)</span><span> = <span>(<span class="type-var">'a</span>, <span class="type-var">'b</span>)</span></span><span> <span class="keyword">constraint</span> <span class="type-var">'a</span> = int <span class="keyword">constraint</span> <span class="type-var">'b</span> = unit</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-as_">
-    <a href="#type-as_" class="anchor"></a><code><span><span class="keyword">type</span> as_</span><span> = <span>(int <span class="keyword">as</span> 'a, <span class="type-var">'a</span>)</span></span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-as_">
+     <a href="#type-as_" class="anchor"></a><code><span><span class="keyword">type</span> as_</span><span> = <span>(int <span class="keyword">as</span> 'a, <span class="type-var">'a</span>)</span></span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-extensible">
-    <a href="#type-extensible" class="anchor"></a><code><span><span class="keyword">type</span> extensible</span><span> = </span><span>..</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-extensible">
+     <a href="#type-extensible" class="anchor"></a><code><span><span class="keyword">type</span> extensible</span><span> = </span><span>..</span><span>;</span></code>
+    </div>
    </div>
-   <div class="spec extension">
-    <code><span><span class="keyword">type</span> <a href="#type-extensible">extensible</a> += </span></code>
-    <table>
-     <tbody>
-      <tr id="extension-Extension" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Extension" class="anchor"></a><code><span>| </span><span><span class="extension">Extension</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         Documentation for <a href="#extension-Extension"><code>Extension</code></a>.
-        </p>
-       </td>
-      </tr>
-      <tr id="extension-Another_extension" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Another_extension" class="anchor"></a><code><span>| </span><span><span class="extension">Another_extension</span></span></code>
-       </td>
-       <td class="doc">
-        <p>
-         Documentation for <a href="#extension-Another_extension"><code>Another_extension</code></a>.
-        </p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec extension">
+     <code><span><span class="keyword">type</span> <a href="#type-extensible">extensible</a> += </span></code>
+     <table>
+      <tbody>
+       <tr id="extension-Extension" class="anchored">
+        <td class="def extension">
+         <a href="#extension-Extension" class="anchor"></a><code><span>| </span><span><span class="extension">Extension</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          Documentation for <a href="#extension-Extension"><code>Extension</code></a>.
+         </p>
+        </td>
+       </tr>
+       <tr id="extension-Another_extension" class="anchored">
+        <td class="def extension">
+         <a href="#extension-Another_extension" class="anchor"></a><code><span>| </span><span><span class="extension">Another_extension</span></span></code>
+        </td>
+        <td class="doc">
+         <p>
+          Documentation for <a href="#extension-Another_extension"><code>Another_extension</code></a>.
+         </p>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-mutually">
-    <a href="#type-mutually" class="anchor"></a><code><span><span class="keyword">type</span> mutually</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-mutually.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-mutually.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span>(<a href="#type-recursive">recursive</a>)</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-mutually">
+     <a href="#type-mutually" class="anchor"></a><code><span><span class="keyword">type</span> mutually</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-mutually.A" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-mutually.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span>(<a href="#type-recursive">recursive</a>)</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec type" id="type-recursive">
-    <a href="#type-recursive" class="anchor"></a><code><span><span class="keyword">and</span> recursive</span><span> = </span></code>
-    <table>
-     <tbody>
-      <tr id="type-recursive.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-recursive.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(<a href="#type-mutually">mutually</a>)</span></code>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    <code><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-recursive">
+     <a href="#type-recursive" class="anchor"></a><code><span><span class="keyword">and</span> recursive</span><span> = </span></code>
+     <table>
+      <tbody>
+       <tr id="type-recursive.B" class="anchored">
+        <td class="def variant constructor">
+         <a href="#type-recursive.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(<a href="#type-mutually">mutually</a>)</span></code>
+        </td>
+       </tr>
+      </tbody>
+     </table>
+     <code><span>;</span></code>
+    </div>
    </div>
-   <div class="spec exception" id="exception-Foo">
-    <a href="#exception-Foo" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Foo</span>(int, int)</span><span>;</span></code>
+   <div class="odoc-spec">
+    <div class="spec exception" id="exception-Foo">
+     <a href="#exception-Foo" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">Foo</span>(int, int)</span><span>;</span></code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Val/index.html
+++ b/test/html/expect/test_package+re/Val/index.html
@@ -23,24 +23,26 @@
    </h1>
   </header>
   <div class="odoc-content">
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span><span class="keyword">let</span> documented: unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Foo.
      </p>
     </div>
    </div>
-   <div class="spec value" id="val-undocumented">
-    <a href="#val-undocumented" class="anchor"></a><code><span><span class="keyword">let</span> undocumented: unit;</span></code>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-undocumented">
+     <a href="#val-undocumented" class="anchor"></a><code><span><span class="keyword">let</span> undocumented: unit;</span></code>
+    </div>
    </div>
-   <div>
+   <div class="odoc-spec">
     <div class="spec value" id="val-documented_above">
      <a href="#val-documented_above" class="anchor"></a><code><span><span class="keyword">let</span> documented_above: unit;</span></code>
     </div>
-    <div>
+    <div class="spec-doc">
      <p>
       Bar.
      </p>


### PR DESCRIPTION
This PR is built on top of #589 and #593. The relevant commits are the three last ones. 

It does the unnesting mentioned in [that comment](https://github.com/ocaml/odoc/pull/593#issue-575508300). This unifies the markup structure for .mld and module pages and drops the `.odoc-unattached` class added in #589. 

