### PR TITLE
latex backend: harden description environment

### DIFF
--- a/src/latex/raw.ml
+++ b/src/latex/raw.ml
@@ -143,7 +143,9 @@ let href x pp ppf y =
 let item ?options = create "item" ?options
 
 let description pp ppf x =
-  let elt ppf (d, elt) = item ~options:[ bind pp d ] pp ppf elt in
+  (* printing description inside a group make them more robust *)
+  let group_printer d ppf = Fmt.pf ppf "{%a}" pp d in
+  let elt ppf (d, elt) = item ~options:[ group_printer d ] pp ppf elt in
   let all ppf x =
     Fmt.pf ppf
       {|\kern-\topsep
@@ -151,7 +153,9 @@ let description pp ppf x =
 |};
     Fmt.list ~sep:(fun ppf () -> break ppf Aesthetic) elt ppf x
   in
-  raw_description all ppf x
+  match x with
+  | [] -> () (* empty description are not supported *)
+  | _ :: _ -> raw_description all ppf x
 
 let url ppf s =
   create "url" Fmt.string ppf (Escape.text ~code_hyphenation:false s)

--- a/test/latex/expect/test_package+ml/Markup.tex
+++ b/test/latex/expect/test_package+ml/Markup.tex
@@ -85,67 +85,64 @@ Raw HTML can be  as inline elements into sentences.
 \subsection{Modules\label{modules}}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\end{description}%
+\item[{\ocamlinlinecode{X}}]{}\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[\ocamlinlinecode{X}]{}\end{description}%
-\begin{description}\kern-\topsep
-\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[\ocamlinlinecode{X}]{}%
-\item[\ocamlinlinecode{Y}]{}%
-\item[\ocamlinlinecode{Z}]{}\end{description}%
+\item[{\ocamlinlinecode{X}}]{}%
+\item[{\ocamlinlinecode{Y}}]{}%
+\item[{\ocamlinlinecode{Z}}]{}\end{description}%
 \subsection{Tags\label{tags}}%
 Each comment can end with zero or more tags. Here are some examples:
 
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[author]{antron}\end{description}%
+\item[{author}]{antron}\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[deprecated]{a \emph{long} time ago
+\item[{deprecated}]{a \emph{long} time ago
 
 }\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[parameter foo]{unused
+\item[{parameter foo}]{unused
 
 }\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[raises Failure]{always
+\item[{raises Failure}]{always
 
 }\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[returns]{never
+\item[{returns}]{never
 
 }\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[see \href{\#}{\#}\footnote{\url{\#}}]{this url
+\item[{see \href{\#}{\#}\footnote{\url{\#}}}]{this url
 
 }\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[see \ocamlinlinecode{foo.\allowbreak{}ml}]{this file
+\item[{see \ocamlinlinecode{foo.\allowbreak{}ml}}]{this file
 
 }\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[see Foo]{this document
+\item[{see Foo}]{this document
 
 }\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[since]{0}\end{description}%
+\item[{since}]{0}\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[before 1.0]{it was in b\textsuperscript{e}t\textsubscript{a}
+\item[{before 1.0}]{it was in b\textsuperscript{e}t\textsubscript{a}
 
 }\end{description}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
-\item[version]{-1}\end{description}%
+\item[{version}]{-1}\end{description}%
 \label{container-page-test+u+package+++ml-module-Markup-val-foo}\ocamlcodefragment{\ocamltag{keyword}{val} foo : unit}\begin{ocamlindent}Comments in structure items \bold{support} \emph{markup}, t\textsuperscript{o}\textsubscript{o}.\end{ocamlindent}%
 \medbreak
 


### PR DESCRIPTION
The addition of synopsis to module list generated by `{!modules}` broke the latex manual by putting complex elements (inlined code block with links) in the label part of description items. The compilation of odoc latex text was also broken, due to an empty `{!modules:}`.
This PR fixes boths issue by hardening the description environment:

- empty descriptions are no longer printed
-  the label of description items are rendered inside a latex group (`{}`)