### PR TITLE
Refine includes

### DIFF
--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -20,6 +20,12 @@
   --target-background: rgba(187, 239, 253, 0.3);
   --target-shadow: rgba(187, 239, 253, 0.8);
   --pre-border-color: #eee;
+  --code-background: #f6f8fa;
+  --spec-summary-border-color: #5c9cf5;
+  --spec-summary-background: var(--code-background);
+  --spec-summary-hover-background: #ebeff2;
+  --spec-details-after-background: rgba(0, 4, 15, 0.05);
+  --spec-details-after-shadow: rgba(204, 204, 204, 0.53);
 }
 
 .dark:root {
@@ -84,9 +90,7 @@
     --toc-color: #777;
     --toc-background: #252525;
     --toc-list-border: #ccc;
-    --spec-summary-background: var(--code-background);
     --spec-summary-hover-background: #ebeff2;
-    --spec-summary-border-color: #5c9cf5;
     --spec-details-after-background: rgba(0, 4, 15, 0.05);
     --spec-details-after-shadow: rgba(204, 204, 204, 0.53);
 
@@ -393,17 +397,14 @@ pre code {
 /* Module member specification */
 
 .spec {
-  background-color: #f6f8fa;
   background-color: var(--spec-summary-background);
   border-radius: 3px;
-  border-left: 4px solid #5c9cf5;
   border-left: 4px solid var(--spec-summary-border-color);
   border-right: 5px solid transparent;
   padding: 0.35em 0.5em;
 }
 
 .odoc-include details summary:hover {
-  background-color: #ebeff2;
   background-color: var(--spec-summary-hover-background);
 }
 

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -392,7 +392,7 @@ pre code {
 
 /* Module member specification */
 
-.spec:not(.include), .spec.include details summary {
+.spec {
   background-color: #f6f8fa;
   background-color: var(--spec-summary-background);
   border-radius: 3px;
@@ -402,7 +402,7 @@ pre code {
   padding: 0.35em 0.5em;
 }
 
-.spec.include details summary:hover {
+.odoc-include details summary:hover {
   background-color: #ebeff2;
   background-color: var(--spec-summary-hover-background);
 }
@@ -443,11 +443,11 @@ div.doc>*:first-child {
 
 /* Collapsible inlined include and module */
 
-.spec.include details {
+.odoc-include details {
   position: relative;
 }
 
-.spec.include details:after {
+.odoc-include details:after {
   z-index: -100;
   display: block;
   content: " ";
@@ -463,7 +463,7 @@ div.doc>*:first-child {
   box-shadow: 0 0px 0 1px var(--spec-details-after-shadow);
 }
 
-.spec.include details summary {
+.odoc-include details summary {
   position: relative;
   margin-bottom: 20px;
   cursor: pointer;
@@ -471,7 +471,7 @@ div.doc>*:first-child {
 }
 
 /* FIXME: Does not work in Firefox. */
-details summary::-webkit-details-marker {
+.odoc-include details summary::-webkit-details-marker {
   color: #888;
   transform: scaleX(-1);
   position: absolute;

--- a/test/html/expect/test_package+custom_theme,ml/Include/index.html
+++ b/test/html/expect/test_package+custom_theme,ml/Include/index.html
@@ -29,20 +29,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-t">
+       <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Inlined">
@@ -50,13 +46,9 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <div class="odoc-spec">
-       <div class="spec type" id="type-u">
-        <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
-       </div>
-      </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-u">
+      <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
      </div>
     </div>
    </div>
@@ -66,20 +58,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details>
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-v">
-         <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span></code>
-        </div>
-       </div>
-      </details>
+    <details>
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-v">
+       <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Not_inlined_and_opened">
@@ -87,20 +75,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-w">
-         <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-w">
+       <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Inherent_Module">
@@ -108,11 +92,31 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-a">
+       <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
+      </div>
+     </div>
+    </details>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Dorminant_Module">
+     <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
+   </div>
+   <div class="odoc-include">
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span></code>
+     </summary>
+     <div class="odoc-include">
       <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code></span>
+       <summary class="spec include">
+        <code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code>
        </summary>
        <div class="odoc-spec">
         <div class="spec value" id="val-a">
@@ -121,44 +125,12 @@
        </div>
       </details>
      </div>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Dorminant_Module">
-     <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
-    </div>
-   </div>
-   <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span></code></span>
-       </summary>
-       <div class="odoc-include">
-        <div class="spec include">
-         <div class="doc">
-          <details open="open">
-           <summary>
-            <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code></span>
-           </summary>
-           <div class="odoc-spec">
-            <div class="spec value" id="val-a">
-             <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
-            </div>
-           </div>
-          </details>
-         </div>
-        </div>
-       </div>
-       <div class="odoc-spec">
-        <div class="spec value" id="val-a">
-         <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-u">u</a></span></code>
-        </div>
-       </div>
-      </details>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-a">
+       <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-u">u</a></span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Include/index.html
+++ b/test/html/expect/test_package+ml/Include/index.html
@@ -29,20 +29,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-t">
+       <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Inlined">
@@ -50,13 +46,9 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <div class="odoc-spec">
-       <div class="spec type" id="type-u">
-        <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
-       </div>
-      </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-u">
+      <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
      </div>
     </div>
    </div>
@@ -66,20 +58,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details>
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-v">
-         <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span></code>
-        </div>
-       </div>
-      </details>
+    <details>
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-v">
+       <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Not_inlined_and_opened">
@@ -87,20 +75,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-w">
-         <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-w">
+       <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Inherent_Module">
@@ -108,11 +92,31 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-a">
+       <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
+      </div>
+     </div>
+    </details>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Dorminant_Module">
+     <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
+   </div>
+   <div class="odoc-include">
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span></code>
+     </summary>
+     <div class="odoc-include">
       <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code></span>
+       <summary class="spec include">
+        <code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code>
        </summary>
        <div class="odoc-spec">
         <div class="spec value" id="val-a">
@@ -121,44 +125,12 @@
        </div>
       </details>
      </div>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Dorminant_Module">
-     <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
-    </div>
-   </div>
-   <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span></code></span>
-       </summary>
-       <div class="odoc-include">
-        <div class="spec include">
-         <div class="doc">
-          <details open="open">
-           <summary>
-            <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a></span></code></span>
-           </summary>
-           <div class="odoc-spec">
-            <div class="spec value" id="val-a">
-             <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-t">t</a></span></code>
-            </div>
-           </div>
-          </details>
-         </div>
-        </div>
-       </div>
-       <div class="odoc-spec">
-        <div class="spec value" id="val-a">
-         <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-u">u</a></span></code>
-        </div>
-       </div>
-      </details>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-a">
+       <a href="#val-a" class="anchor"></a><code><span><span class="keyword">val</span> a : <a href="#type-u">u</a></span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Include2/index.html
+++ b/test/html/expect/test_package+ml/Include2/index.html
@@ -34,23 +34,19 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <span class="keyword">struct</span> <span class="keyword">include</span> <a href="X/index.html">X</a> <span class="keyword">end</span></span></code></span>
-       </summary>
-       <p>
-        Comment about X that should not appear when including X below.
-       </p>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <span class="keyword">struct</span> <span class="keyword">include</span> <a href="X/index.html">X</a> <span class="keyword">end</span></span></code>
+     </summary>
+     <p>
+      Comment about X that should not appear when including X below.
+     </p>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-t">
+       <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Include_sections/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/index.html
@@ -84,45 +84,41 @@
     Let's include <a href="module-type-Something/index.html"><code>Something</code></a> once
    </p>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <div class="odoc-spec">
-       <div class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
-       </div>
-      </div>
-      <h2 id="something-1">
-       <a href="#something-1" class="anchor"></a>Something 1
-      </h2>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-something">
+      <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+     </div>
+    </div>
+    <h2 id="something-1">
+     <a href="#something-1" class="anchor"></a>Something 1
+    </h2>
+    <p>
+     foo
+    </p>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+     </div>
+    </div>
+    <h3 id="something-2">
+     <a href="#something-2" class="anchor"></a>Something 2
+    </h3>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-bar">
+      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
+     </div>
+     <div class="spec-doc">
       <p>
-       foo
-      </p>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
-       </div>
-      </div>
-      <h3 id="something-2">
-       <a href="#something-2" class="anchor"></a>Something 2
-      </h3>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-bar">
-        <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
-       </div>
-       <div class="spec-doc">
-        <p>
-         foo bar
-        </p>
-       </div>
-      </div>
-      <h2 id="something-1-bis">
-       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-      </h2>
-      <p>
-       Some text.
+       foo bar
       </p>
      </div>
     </div>
+    <h2 id="something-1-bis">
+     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+    </h2>
+    <p>
+     Some text.
+    </p>
    </div>
    <h2 id="second-include">
     <a href="#second-include" class="anchor"></a>Second include
@@ -131,45 +127,41 @@
     Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
    </p>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <div class="odoc-spec">
-       <div class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
-       </div>
-      </div>
-      <h3 id="something-1">
-       <a href="#something-1" class="anchor"></a>Something 1
-      </h3>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-something">
+      <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+     </div>
+    </div>
+    <h3 id="something-1">
+     <a href="#something-1" class="anchor"></a>Something 1
+    </h3>
+    <p>
+     foo
+    </p>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+     </div>
+    </div>
+    <h4 id="something-2">
+     <a href="#something-2" class="anchor"></a>Something 2
+    </h4>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-bar">
+      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
+     </div>
+     <div class="spec-doc">
       <p>
-       foo
-      </p>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
-       </div>
-      </div>
-      <h4 id="something-2">
-       <a href="#something-2" class="anchor"></a>Something 2
-      </h4>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-bar">
-        <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
-       </div>
-       <div class="spec-doc">
-        <p>
-         foo bar
-        </p>
-       </div>
-      </div>
-      <h3 id="something-1-bis">
-       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-      </h3>
-      <p>
-       Some text.
+       foo bar
       </p>
      </div>
     </div>
+    <h3 id="something-1-bis">
+     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+    </h3>
+    <p>
+     Some text.
+    </p>
    </div>
    <h3 id="third-include">
     <a href="#third-include" class="anchor"></a>Third include
@@ -178,94 +170,86 @@
     Shifted some more.
    </p>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <div class="odoc-spec">
-       <div class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
-       </div>
-      </div>
-      <h4 id="something-1">
-       <a href="#something-1" class="anchor"></a>Something 1
-      </h4>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-something">
+      <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+     </div>
+    </div>
+    <h4 id="something-1">
+     <a href="#something-1" class="anchor"></a>Something 1
+    </h4>
+    <p>
+     foo
+    </p>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+     </div>
+    </div>
+    <h5 id="something-2">
+     <a href="#something-2" class="anchor"></a>Something 2
+    </h5>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-bar">
+      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
+     </div>
+     <div class="spec-doc">
       <p>
-       foo
-      </p>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
-       </div>
-      </div>
-      <h5 id="something-2">
-       <a href="#something-2" class="anchor"></a>Something 2
-      </h5>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-bar">
-        <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
-       </div>
-       <div class="spec-doc">
-        <p>
-         foo bar
-        </p>
-       </div>
-      </div>
-      <h4 id="something-1-bis">
-       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-      </h4>
-      <p>
-       Some text.
+       foo bar
       </p>
      </div>
     </div>
+    <h4 id="something-1-bis">
+     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+    </h4>
+    <p>
+     Some text.
+    </p>
    </div>
    <p>
     And let's include it again, but without inlining it this time: the ToC shouldn't grow.
    </p>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Something/index.html">Something</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec value" id="val-something">
-         <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
-        </div>
-       </div>
-       <h2 id="something-1">
-        <a href="#something-1" class="anchor"></a>Something 1
-       </h2>
-       <p>
-        foo
-       </p>
-       <div class="odoc-spec">
-        <div class="spec value" id="val-foo">
-         <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
-        </div>
-       </div>
-       <h3 id="something-2">
-        <a href="#something-2" class="anchor"></a>Something 2
-       </h3>
-       <div class="odoc-spec">
-        <div class="spec value" id="val-bar">
-         <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
-        </div>
-        <div class="spec-doc">
-         <p>
-          foo bar
-         </p>
-        </div>
-       </div>
-       <h2 id="something-1-bis">
-        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-       </h2>
-       <p>
-        Some text.
-       </p>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Something/index.html">Something</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-something">
+       <a href="#val-something" class="anchor"></a><code><span><span class="keyword">val</span> something : unit</span></code>
+      </div>
      </div>
-    </div>
+     <h2 id="something-1">
+      <a href="#something-1" class="anchor"></a>Something 1
+     </h2>
+     <p>
+      foo
+     </p>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-foo">
+       <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
+      </div>
+     </div>
+     <h3 id="something-2">
+      <a href="#something-2" class="anchor"></a>Something 2
+     </h3>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-bar">
+       <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">val</span> bar : unit</span></code>
+      </div>
+      <div class="spec-doc">
+       <p>
+        foo bar
+       </p>
+      </div>
+     </div>
+     <h2 id="something-1-bis">
+      <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+     </h2>
+     <p>
+      Some text.
+     </p>
+    </details>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -727,25 +727,21 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-ToInclude/index.html">ToInclude</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec module" id="module-IncludedA">
-         <a href="#module-IncludedA" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludedA/index.html">IncludedA</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
-        </div>
-       </div>
-       <div class="odoc-spec">
-        <div class="spec module-type" id="module-type-IncludedB">
-         <a href="#module-type-IncludedB" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludedB/index.html">IncludedB</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-ToInclude/index.html">ToInclude</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec module" id="module-IncludedA">
+       <a href="#module-IncludedA" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludedA/index.html">IncludedA</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+      </div>
      </div>
-    </div>
+     <div class="odoc-spec">
+      <div class="spec module-type" id="module-type-IncludedB">
+       <a href="#module-type-IncludedB" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludedB/index.html">IncludedB</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+      </div>
+     </div>
+    </details>
    </div>
    <h4 id="advanced-type-stuff">
     <a href="#advanced-type-stuff" class="anchor"></a>Advanced Type Stuff
@@ -1754,36 +1750,28 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-NestedInclude1/index.html">NestedInclude1</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec module-type" id="module-type-NestedInclude2">
-         <a href="#module-type-NestedInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude2/index.html">NestedInclude2</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-NestedInclude1/index.html">NestedInclude1</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec module-type" id="module-type-NestedInclude2">
+       <a href="#module-type-NestedInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude2/index.html">NestedInclude2</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-NestedInclude2/index.html">NestedInclude2</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-NestedInclude2/index.html#type-nested_include">nested_include</a> = int</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-nested_include">
-         <a href="#type-nested_include" class="anchor"></a><code><span><span class="keyword">type</span> nested_include</span><span> = int</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-NestedInclude2/index.html">NestedInclude2</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-NestedInclude2/index.html#type-nested_include">nested_include</a> = int</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-nested_include">
+       <a href="#type-nested_include" class="anchor"></a><code><span><span class="keyword">type</span> nested_include</span><span> = int</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module" id="module-DoubleInclude1">
@@ -1796,20 +1784,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="DoubleInclude3/DoubleInclude2/index.html">DoubleInclude3.DoubleInclude2</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-double_include">
-         <a href="#type-double_include" class="anchor"></a><code><span><span class="keyword">type</span> double_include</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="DoubleInclude3/DoubleInclude2/index.html">DoubleInclude3.DoubleInclude2</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-double_include">
+       <a href="#type-double_include" class="anchor"></a><code><span><span class="keyword">type</span> double_include</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module" id="module-IncludeInclude1">
@@ -1817,36 +1801,28 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="IncludeInclude1/index.html">IncludeInclude1</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec module-type" id="module-type-IncludeInclude2">
-         <a href="#module-type-IncludeInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="IncludeInclude1/index.html">IncludeInclude1</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec module-type" id="module-type-IncludeInclude2">
+       <a href="#module-type-IncludeInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-include_include">
-         <a href="#type-include_include" class="anchor"></a><code><span><span class="keyword">type</span> include_include</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-include_include">
+       <a href="#type-include_include" class="anchor"></a><code><span><span class="keyword">type</span> include_include</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <h2 id="indexmodules">
     <a href="#indexmodules" class="anchor"></a>Trying the {!modules: ...} command.

--- a/test/html/expect/test_package+ml/Toplevel_comments/Include_inline'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Include_inline'/index.html
@@ -30,16 +30,14 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <p>
-       Doc of <code>T</code>, part 2.
-      </p>
-      <div class="odoc-spec">
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
-       </div>
-      </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>T</code>, part 2.
+     </p>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
      </div>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Toplevel_comments/Include_inline/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Include_inline/index.html
@@ -24,16 +24,14 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <p>
-       Doc of <code>T</code>, part 2.
-      </p>
-      <div class="odoc-spec">
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
-       </div>
-      </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>T</code>, part 2.
+     </p>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
      </div>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T'/index.html
@@ -30,16 +30,14 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <p>
-       Doc of <code>T</code>, part 2.
-      </p>
-      <div class="odoc-spec">
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
-       </div>
-      </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>T</code>, part 2.
+     </p>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
      </div>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T/index.html
@@ -24,16 +24,14 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <p>
-       Doc of <code>T</code>, part 2.
-      </p>
-      <div class="odoc-spec">
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
-       </div>
-      </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>T</code>, part 2.
+     </p>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
      </div>
     </div>
    </div>

--- a/test/html/expect/test_package+re/Include/index.html
+++ b/test/html/expect/test_package+re/Include/index.html
@@ -29,20 +29,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Not_inlined/index.html">Not_inlined</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-t">
+       <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Inlined">
@@ -50,13 +46,9 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <div class="odoc-spec">
-       <div class="spec type" id="type-u">
-        <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span>;</span></code>
-       </div>
-      </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-u">
+      <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span>;</span></code>
      </div>
     </div>
    </div>
@@ -66,20 +58,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details>
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-v">
-         <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span>;</span></code>
-        </div>
-       </div>
-      </details>
+    <details>
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_closed/index.html">Not_inlined_and_closed</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-v">
+       <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span>;</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Not_inlined_and_opened">
@@ -87,20 +75,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-w">
-         <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span><span>;</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Not_inlined_and_opened/index.html">Not_inlined_and_opened</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-w">
+       <a href="#type-w" class="anchor"></a><code><span><span class="keyword">type</span> w</span><span>;</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module-type" id="module-type-Inherent_Module">
@@ -108,11 +92,31 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-a">
+       <a href="#val-a" class="anchor"></a><code><span><span class="keyword">let</span> a: <a href="#type-t">t</a>;</span></code>
+      </div>
+     </div>
+    </details>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module-type" id="module-type-Dorminant_Module">
+     <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = { ... }</span><span>;</span></code>
+    </div>
+   </div>
+   <div class="odoc-include">
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-include">
       <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a><span class="keyword">;</span></span></code></span>
+       <summary class="spec include">
+        <code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a><span class="keyword">;</span></span></code>
        </summary>
        <div class="odoc-spec">
         <div class="spec value" id="val-a">
@@ -121,44 +125,12 @@
        </div>
       </details>
      </div>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Dorminant_Module">
-     <a href="#module-type-Dorminant_Module" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a></span><span> = { ... }</span><span>;</span></code>
-    </div>
-   </div>
-   <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Dorminant_Module/index.html">Dorminant_Module</a><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-include">
-        <div class="spec include">
-         <div class="doc">
-          <details open="open">
-           <summary>
-            <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Inherent_Module/index.html">Inherent_Module</a><span class="keyword">;</span></span></code></span>
-           </summary>
-           <div class="odoc-spec">
-            <div class="spec value" id="val-a">
-             <a href="#val-a" class="anchor"></a><code><span><span class="keyword">let</span> a: <a href="#type-t">t</a>;</span></code>
-            </div>
-           </div>
-          </details>
-         </div>
-        </div>
-       </div>
-       <div class="odoc-spec">
-        <div class="spec value" id="val-a">
-         <a href="#val-a" class="anchor"></a><code><span><span class="keyword">let</span> a: <a href="#type-u">u</a>;</span></code>
-        </div>
-       </div>
-      </details>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-a">
+       <a href="#val-a" class="anchor"></a><code><span><span class="keyword">let</span> a: <a href="#type-u">u</a>;</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Include2/index.html
+++ b/test/html/expect/test_package+re/Include2/index.html
@@ -34,23 +34,19 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <span class="keyword">struct</span> <span class="keyword">include</span> <a href="X/index.html">X</a> <span class="keyword">end</span><span class="keyword">;</span></span></code></span>
-       </summary>
-       <p>
-        Comment about X that should not appear when including X below.
-       </p>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-t">
-         <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span><span>;</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <span class="keyword">struct</span> <span class="keyword">include</span> <a href="X/index.html">X</a> <span class="keyword">end</span><span class="keyword">;</span></span></code>
+     </summary>
+     <p>
+      Comment about X that should not appear when including X below.
+     </p>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-t">
+       <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span><span>;</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Include_sections/index.html
+++ b/test/html/expect/test_package+re/Include_sections/index.html
@@ -84,45 +84,41 @@
     Let's include <a href="module-type-Something/index.html"><code>Something</code></a> once
    </p>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <div class="odoc-spec">
-       <div class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
-       </div>
-      </div>
-      <h2 id="something-1">
-       <a href="#something-1" class="anchor"></a>Something 1
-      </h2>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-something">
+      <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+     </div>
+    </div>
+    <h2 id="something-1">
+     <a href="#something-1" class="anchor"></a>Something 1
+    </h2>
+    <p>
+     foo
+    </p>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+     </div>
+    </div>
+    <h3 id="something-2">
+     <a href="#something-2" class="anchor"></a>Something 2
+    </h3>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-bar">
+      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
+     </div>
+     <div class="spec-doc">
       <p>
-       foo
-      </p>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
-       </div>
-      </div>
-      <h3 id="something-2">
-       <a href="#something-2" class="anchor"></a>Something 2
-      </h3>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-bar">
-        <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
-       </div>
-       <div class="spec-doc">
-        <p>
-         foo bar
-        </p>
-       </div>
-      </div>
-      <h2 id="something-1-bis">
-       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-      </h2>
-      <p>
-       Some text.
+       foo bar
       </p>
      </div>
     </div>
+    <h2 id="something-1-bis">
+     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+    </h2>
+    <p>
+     Some text.
+    </p>
    </div>
    <h2 id="second-include">
     <a href="#second-include" class="anchor"></a>Second include
@@ -131,45 +127,41 @@
     Let's include <a href="module-type-Something/index.html"><code>Something</code></a> a second time: the heading level should be shift here.
    </p>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <div class="odoc-spec">
-       <div class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
-       </div>
-      </div>
-      <h3 id="something-1">
-       <a href="#something-1" class="anchor"></a>Something 1
-      </h3>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-something">
+      <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+     </div>
+    </div>
+    <h3 id="something-1">
+     <a href="#something-1" class="anchor"></a>Something 1
+    </h3>
+    <p>
+     foo
+    </p>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+     </div>
+    </div>
+    <h4 id="something-2">
+     <a href="#something-2" class="anchor"></a>Something 2
+    </h4>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-bar">
+      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
+     </div>
+     <div class="spec-doc">
       <p>
-       foo
-      </p>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
-       </div>
-      </div>
-      <h4 id="something-2">
-       <a href="#something-2" class="anchor"></a>Something 2
-      </h4>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-bar">
-        <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
-       </div>
-       <div class="spec-doc">
-        <p>
-         foo bar
-        </p>
-       </div>
-      </div>
-      <h3 id="something-1-bis">
-       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-      </h3>
-      <p>
-       Some text.
+       foo bar
       </p>
      </div>
     </div>
+    <h3 id="something-1-bis">
+     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+    </h3>
+    <p>
+     Some text.
+    </p>
    </div>
    <h3 id="third-include">
     <a href="#third-include" class="anchor"></a>Third include
@@ -178,94 +170,86 @@
     Shifted some more.
    </p>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <div class="odoc-spec">
-       <div class="spec value" id="val-something">
-        <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
-       </div>
-      </div>
-      <h4 id="something-1">
-       <a href="#something-1" class="anchor"></a>Something 1
-      </h4>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-something">
+      <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+     </div>
+    </div>
+    <h4 id="something-1">
+     <a href="#something-1" class="anchor"></a>Something 1
+    </h4>
+    <p>
+     foo
+    </p>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-foo">
+      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+     </div>
+    </div>
+    <h5 id="something-2">
+     <a href="#something-2" class="anchor"></a>Something 2
+    </h5>
+    <div class="odoc-spec">
+     <div class="spec value" id="val-bar">
+      <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
+     </div>
+     <div class="spec-doc">
       <p>
-       foo
-      </p>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-foo">
-        <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
-       </div>
-      </div>
-      <h5 id="something-2">
-       <a href="#something-2" class="anchor"></a>Something 2
-      </h5>
-      <div class="odoc-spec">
-       <div class="spec value" id="val-bar">
-        <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
-       </div>
-       <div class="spec-doc">
-        <p>
-         foo bar
-        </p>
-       </div>
-      </div>
-      <h4 id="something-1-bis">
-       <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-      </h4>
-      <p>
-       Some text.
+       foo bar
       </p>
      </div>
     </div>
+    <h4 id="something-1-bis">
+     <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+    </h4>
+    <p>
+     Some text.
+    </p>
    </div>
    <p>
     And let's include it again, but without inlining it this time: the ToC shouldn't grow.
    </p>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-Something/index.html">Something</a><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec value" id="val-something">
-         <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
-        </div>
-       </div>
-       <h2 id="something-1">
-        <a href="#something-1" class="anchor"></a>Something 1
-       </h2>
-       <p>
-        foo
-       </p>
-       <div class="odoc-spec">
-        <div class="spec value" id="val-foo">
-         <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
-        </div>
-       </div>
-       <h3 id="something-2">
-        <a href="#something-2" class="anchor"></a>Something 2
-       </h3>
-       <div class="odoc-spec">
-        <div class="spec value" id="val-bar">
-         <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
-        </div>
-        <div class="spec-doc">
-         <p>
-          foo bar
-         </p>
-        </div>
-       </div>
-       <h2 id="something-1-bis">
-        <a href="#something-1-bis" class="anchor"></a>Something 1-bis
-       </h2>
-       <p>
-        Some text.
-       </p>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-Something/index.html">Something</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-something">
+       <a href="#val-something" class="anchor"></a><code><span><span class="keyword">let</span> something: unit;</span></code>
+      </div>
      </div>
-    </div>
+     <h2 id="something-1">
+      <a href="#something-1" class="anchor"></a>Something 1
+     </h2>
+     <p>
+      foo
+     </p>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-foo">
+       <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">let</span> foo: unit;</span></code>
+      </div>
+     </div>
+     <h3 id="something-2">
+      <a href="#something-2" class="anchor"></a>Something 2
+     </h3>
+     <div class="odoc-spec">
+      <div class="spec value" id="val-bar">
+       <a href="#val-bar" class="anchor"></a><code><span><span class="keyword">let</span> bar: unit;</span></code>
+      </div>
+      <div class="spec-doc">
+       <p>
+        foo bar
+       </p>
+      </div>
+     </div>
+     <h2 id="something-1-bis">
+      <a href="#something-1-bis" class="anchor"></a>Something 1-bis
+     </h2>
+     <p>
+      Some text.
+     </p>
+    </details>
    </div>
   </div>
  </body>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -727,25 +727,21 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-ToInclude/index.html">ToInclude</a><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec module" id="module-IncludedA">
-         <a href="#module-IncludedA" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludedA/index.html">IncludedA</a></span><span>: { ... }</span><span>;</span></code>
-        </div>
-       </div>
-       <div class="odoc-spec">
-        <div class="spec module-type" id="module-type-IncludedB">
-         <a href="#module-type-IncludedB" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludedB/index.html">IncludedB</a></span><span> = { ... }</span><span>;</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-ToInclude/index.html">ToInclude</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec module" id="module-IncludedA">
+       <a href="#module-IncludedA" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="IncludedA/index.html">IncludedA</a></span><span>: { ... }</span><span>;</span></code>
+      </div>
      </div>
-    </div>
+     <div class="odoc-spec">
+      <div class="spec module-type" id="module-type-IncludedB">
+       <a href="#module-type-IncludedB" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludedB/index.html">IncludedB</a></span><span> = { ... }</span><span>;</span></code>
+      </div>
+     </div>
+    </details>
    </div>
    <h4 id="advanced-type-stuff">
     <a href="#advanced-type-stuff" class="anchor"></a>Advanced Type Stuff
@@ -1771,36 +1767,28 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-NestedInclude1/index.html">NestedInclude1</a><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec module-type" id="module-type-NestedInclude2">
-         <a href="#module-type-NestedInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude2/index.html">NestedInclude2</a></span><span> = { ... }</span><span>;</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-NestedInclude1/index.html">NestedInclude1</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec module-type" id="module-type-NestedInclude2">
+       <a href="#module-type-NestedInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-NestedInclude2/index.html">NestedInclude2</a></span><span> = { ... }</span><span>;</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-NestedInclude2/index.html">NestedInclude2</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-NestedInclude2/index.html#type-nested_include">nested_include</a> = int</span><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-nested_include">
-         <a href="#type-nested_include" class="anchor"></a><code><span><span class="keyword">type</span> nested_include</span><span> = int</span><span>;</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-NestedInclude2/index.html">NestedInclude2</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-NestedInclude2/index.html#type-nested_include">nested_include</a> = int</span><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-nested_include">
+       <a href="#type-nested_include" class="anchor"></a><code><span><span class="keyword">type</span> nested_include</span><span> = int</span><span>;</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module" id="module-DoubleInclude1">
@@ -1813,20 +1801,16 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="DoubleInclude3/DoubleInclude2/index.html">DoubleInclude3.DoubleInclude2</a><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-double_include">
-         <a href="#type-double_include" class="anchor"></a><code><span><span class="keyword">type</span> double_include</span><span>;</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="DoubleInclude3/DoubleInclude2/index.html">DoubleInclude3.DoubleInclude2</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-double_include">
+       <a href="#type-double_include" class="anchor"></a><code><span><span class="keyword">type</span> double_include</span><span>;</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-spec">
     <div class="spec module" id="module-IncludeInclude1">
@@ -1834,36 +1818,28 @@
     </div>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="IncludeInclude1/index.html">IncludeInclude1</a><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec module-type" id="module-type-IncludeInclude2">
-         <a href="#module-type-IncludeInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span><span> = { ... }</span><span>;</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="IncludeInclude1/index.html">IncludeInclude1</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec module-type" id="module-type-IncludeInclude2">
+       <a href="#module-type-IncludeInclude2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a></span><span> = { ... }</span><span>;</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <details open="open">
-       <summary>
-        <span class="def"><code><span><span class="keyword">include</span> <a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a><span class="keyword">;</span></span></code></span>
-       </summary>
-       <div class="odoc-spec">
-        <div class="spec type" id="type-include_include">
-         <a href="#type-include_include" class="anchor"></a><code><span><span class="keyword">type</span> include_include</span><span>;</span></code>
-        </div>
-       </div>
-      </details>
+    <details open="open">
+     <summary class="spec include">
+      <code><span><span class="keyword">include</span> <a href="module-type-IncludeInclude2/index.html">IncludeInclude2</a><span class="keyword">;</span></span></code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type" id="type-include_include">
+       <a href="#type-include_include" class="anchor"></a><code><span><span class="keyword">type</span> include_include</span><span>;</span></code>
+      </div>
      </div>
-    </div>
+    </details>
    </div>
    <h2 id="indexmodules">
     <a href="#indexmodules" class="anchor"></a>Trying the {!modules: ...} command.

--- a/test/html/expect/test_package+re/Toplevel_comments/Include_inline'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Include_inline'/index.html
@@ -30,16 +30,14 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <p>
-       Doc of <code>T</code>, part 2.
-      </p>
-      <div class="odoc-spec">
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
-       </div>
-      </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>T</code>, part 2.
+     </p>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
      </div>
     </div>
    </div>

--- a/test/html/expect/test_package+re/Toplevel_comments/Include_inline/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Include_inline/index.html
@@ -24,16 +24,14 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <p>
-       Doc of <code>T</code>, part 2.
-      </p>
-      <div class="odoc-spec">
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
-       </div>
-      </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>T</code>, part 2.
+     </p>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
      </div>
     </div>
    </div>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T'/index.html
@@ -30,16 +30,14 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <p>
-       Doc of <code>T</code>, part 2.
-      </p>
-      <div class="odoc-spec">
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
-       </div>
-      </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>T</code>, part 2.
+     </p>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
      </div>
     </div>
    </div>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T/index.html
@@ -24,16 +24,14 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-include">
-    <div class="spec include">
-     <div class="doc">
-      <p>
-       Doc of <code>T</code>, part 2.
-      </p>
-      <div class="odoc-spec">
-       <div class="spec type" id="type-t">
-        <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
-       </div>
-      </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>T</code>, part 2.
+     </p>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type" id="type-t">
+      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
      </div>
     </div>
    </div>


### PR DESCRIPTION
This PR is build on top of #607 the relevant commits are the 4 last ones (sorry for always proceeding that way but changing the markup bit-by-bit in different branches is too unconvenient).

The current structure of includes is quite involved and messy. For one non-inlined include we have:

```
div.odoc-include
  div."spec include"
    div.doc 
      content of doc string (may be multiple paragraphs)
      details 
        summary
          span.def
            code
      include defs
```

This PR proposes to change the structure to 

```
div.odoc-include 
  div.spec-doc
    content of doc string
  details
    summary."spec include"
      code
    include defs
```

Except for the docstring of the include coming *before* the specification (it would have been nice to put in the `summary`, but the content model  disallows it). This more regular with other structure items which have the following markup: 
```
  div.odoc-spec 
    div."spec $(kind)"
      code
    div."spec-doc"
      content of doc string
``` 
In particular structure item doc strings are always in a `spec-doc` div and the `spec` class is always on elements spanning directly the source of structure items.

I have adapted the `odoc.css` and checked that stuff like double includes like [this one work](https://b0-system.github.io/odig/doc@odoc.default/containers/CCArray/index.html#arrays). I took the oportunity to fix #586 along the way. 

