### PR TITLE
Make type definition copy-pastable with hidden comment delimiters.

### DIFF
--- a/src/document/ML.ml
+++ b/src/document/ML.ml
@@ -93,6 +93,10 @@ module ML = Generator.Make (struct
 
     let semicolon = false
   end
+
+  module Comment = struct
+    let markers = ("(*", "*)")
+  end
 end)
 
 include ML

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -409,7 +409,8 @@ module Make (Syntax : SYNTAX) = struct
                let anchor = Some url in
                let rhs = Comment.to_ir fld.doc in
                let doc = if not (Comment.has_doc fld.doc) then [] else rhs in
-               DocumentedSrc.Documented { anchor; attrs; code; doc })
+               let markers = Syntax.Comment.markers in
+               DocumentedSrc.Documented { anchor; attrs; code; doc; markers })
       in
       let content =
         O.documentedSrc (O.txt "{") @ rows @ O.documentedSrc (O.txt "}")
@@ -513,7 +514,8 @@ module Make (Syntax : SYNTAX) = struct
                    let doc =
                      if not (Comment.has_doc cstr.doc) then [] else rhs
                    in
-                   DocumentedSrc.Nested { anchor; attrs; code; doc })
+                   let markers = Syntax.Comment.markers in
+                   DocumentedSrc.Nested { anchor; attrs; code; doc; markers })
           in
           rows
 
@@ -528,7 +530,8 @@ module Make (Syntax : SYNTAX) = struct
             O.documentedSrc (O.txt "| ") @ constructor id t.args t.res
           in
           let doc = Comment.to_ir t.doc in
-          DocumentedSrc.Nested { anchor; attrs; code; doc }
+          let markers = Syntax.Comment.markers in
+          DocumentedSrc.Nested { anchor; attrs; code; doc; markers }
 
     let extension (t : Odoc_model.Lang.Extension.t) =
       let content =
@@ -596,20 +599,21 @@ module Make (Syntax : SYNTAX) = struct
                 ),
                 match doc with [] -> None | _ -> Some (Comment.to_ir doc) ) )
         in
+        let markers = Syntax.Comment.markers in
         try
           let url = Url.Anchor.polymorphic_variant ~type_ident item in
           let attrs = [ "def"; url.kind ] in
           let anchor = Some url in
           let code = O.code (O.txt "| ") @ cstr in
           let doc = match doc with None -> [] | Some doc -> doc in
-          DocumentedSrc.Documented { attrs; anchor; code; doc }
+          DocumentedSrc.Documented { attrs; anchor; code; doc; markers }
         with Failure s ->
           Printf.eprintf "ERROR: %s\n%!" s;
           let code = O.code (O.txt "| ") @ cstr in
           let attrs = [ "def"; kind_approx ] in
           let doc = [] in
           let anchor = None in
-          DocumentedSrc.Documented { attrs; anchor; code; doc }
+          DocumentedSrc.Documented { attrs; anchor; code; doc; markers }
       in
       let variants = List.map row t.elements in
       let intro, ending =

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -95,6 +95,10 @@ module type SYNTAX = sig
 
     val semicolon : bool
   end
+
+  module Comment : sig
+    val markers : string * string
+  end
 end
 
 module type GENERATOR = sig

--- a/src/document/reason.ml
+++ b/src/document/reason.ml
@@ -97,6 +97,10 @@ module Reason = Generator.Make (struct
 
     let semicolon = true
   end
+
+  module Comment = struct
+    let markers = ("/*", "*/")
+  end
 end)
 
 include Reason

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -87,6 +87,7 @@ and DocumentedSrc : sig
     anchor : Url.Anchor.t option;
     code : 'a;
     doc : Block.t;
+    markers : string * string;
   }
 
   type t = one list

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -359,10 +359,28 @@ let rec documentedSrc (t : DocumentedSrc.t) =
     | (Documented _ | Nested _) :: _ ->
         let take_descr l =
           Doctree.Take.until l ~classify:(function
-            | Documented { attrs; anchor; code; doc } ->
-                Accum [ { DocumentedSrc.attrs; anchor; code = `D code; doc } ]
-            | Nested { attrs; anchor; code; doc } ->
-                Accum [ { DocumentedSrc.attrs; anchor; code = `N code; doc } ]
+            | Documented { attrs; anchor; code; doc; markers } ->
+                Accum
+                  [
+                    {
+                      DocumentedSrc.attrs;
+                      anchor;
+                      code = `D code;
+                      doc;
+                      markers;
+                    };
+                  ]
+            | Nested { attrs; anchor; code; doc; markers } ->
+                Accum
+                  [
+                    {
+                      DocumentedSrc.attrs;
+                      anchor;
+                      code = `N code;
+                      doc;
+                      markers;
+                    };
+                  ]
             | _ -> Stop_and_keep)
         in
         let l, _, rest = take_descr t in

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -351,6 +351,22 @@ h4 {
   font-size: 1.12em;
 }
 
+/* Comment delimiters, hidden but accessible to screen readers and 
+   selected for copy/pasting */
+
+/* Taken from bootstrap */
+/* See also https://stackoverflow.com/a/27769435/4220738 */
+.comment-delim {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 
 /* Preformatted and code */
 

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -150,9 +150,11 @@
          <a href="#type-u.A'" class="anchor"></a><code><span>| </span><span><span class="constructor">A'</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           Attached to constructor
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>
@@ -169,9 +171,11 @@
          <a href="#type-v.f" class="anchor"></a><code><span>f : <a href="#type-t">t</a>;</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           Attached to field
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -756,9 +756,11 @@
          <a href="#type-record.field1" class="anchor"></a><code><span>field1 : int;</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           This comment is for <code>field1</code>.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-record.field2" class="anchored">
@@ -766,9 +768,11 @@
          <a href="#type-record.field2" class="anchor"></a><code><span>field2 : int;</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           This comment is for <code>field2</code>.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>
@@ -794,9 +798,11 @@
          <a href="#type-mutable_record.a" class="anchor"></a><code><span><span class="keyword">mutable</span> a : int;</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           <code>a</code> is first and mutable
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-mutable_record.b" class="anchored">
@@ -804,9 +810,11 @@
          <a href="#type-mutable_record.b" class="anchor"></a><code><span>b : unit;</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           <code>b</code> is second and immutable
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-mutable_record.c" class="anchored">
@@ -814,9 +822,11 @@
          <a href="#type-mutable_record.c" class="anchor"></a><code><span><span class="keyword">mutable</span> c : int;</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           <code>c</code> is third and mutable
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>
@@ -849,9 +859,11 @@
          <a href="#type-variant.TagA" class="anchor"></a><code><span>| </span><span><span class="constructor">TagA</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           This comment is for <code>TagA</code>.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-variant.ConstrB" class="anchored">
@@ -859,9 +871,11 @@
          <a href="#type-variant.ConstrB" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrB</span> <span class="keyword">of</span> int</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           This comment is for <code>ConstrB</code>.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-variant.ConstrC" class="anchored">
@@ -869,9 +883,11 @@
          <a href="#type-variant.ConstrC" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrC</span> <span class="keyword">of</span> int * int</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           This comment is for binary <code>ConstrC</code>.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-variant.ConstrD" class="anchored">
@@ -879,9 +895,11 @@
          <a href="#type-variant.ConstrD" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrD</span> <span class="keyword">of</span> int * int</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           This comment is for unary <code>ConstrD</code> of binary tuple.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>
@@ -1285,9 +1303,11 @@
          <a href="#type-mutual_constr_a.B_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">B_ish</span> <span class="keyword">of</span> <a href="#type-mutual_constr_b">mutual_constr_b</a></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           This comment is between <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a> and <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>
@@ -1314,9 +1334,11 @@
          <a href="#type-mutual_constr_b.A_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">A_ish</span> <span class="keyword">of</span> <a href="#type-mutual_constr_a">mutual_constr_a</a></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           This comment must be here for the next to associate correctly.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>
@@ -1468,9 +1490,11 @@
          <a href="#extension-Bar" class="anchor"></a><code><span>| </span><span><span class="extension">Bar</span> <span class="keyword">of</span> <span class="type-var">'b</span> * <span class="type-var">'b</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           'b poly_ext
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>
@@ -1487,9 +1511,11 @@
          <a href="#extension-Quux" class="anchor"></a><code><span>| </span><span><span class="extension">Quux</span> <span class="keyword">of</span> <span class="type-var">'c</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           'c poly_ext
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>
@@ -1511,9 +1537,11 @@
          <a href="#extension-ZzzTop0" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop0</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           It's got the rock
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>
@@ -1530,9 +1558,11 @@
          <a href="#extension-ZzzTop" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop</span> <span class="keyword">of</span> unit</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           and it packs a unit.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -53,9 +53,11 @@
          <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           foo
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-variant.D" class="anchored">
@@ -63,9 +65,11 @@
          <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           <em>bar</em>
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-variant.E" class="anchored">
@@ -102,9 +106,11 @@
          <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> : int <span class="arrow">-&gt;</span> <span>string <a href="#type-gadt">gadt</a></span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           foo
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-gadt.C" class="anchored">
@@ -146,9 +152,11 @@
          <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           foo
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.D" class="anchored">
@@ -156,9 +164,11 @@
          <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           bar
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -138,9 +138,11 @@
          <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           foo
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-variant.D" class="anchored">
@@ -148,9 +150,11 @@
          <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           <em>bar</em>
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-variant.E" class="anchored">
@@ -249,9 +253,11 @@
          <a href="#type-record.c" class="anchor"></a><code><span>c : int;</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           foo
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-record.d" class="anchored">
@@ -259,9 +265,11 @@
          <a href="#type-record.d" class="anchor"></a><code><span>d : int;</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           <em>bar</em>
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="type-record.e" class="anchored">
@@ -479,9 +487,11 @@
          <a href="#extension-Extension" class="anchor"></a><code><span>| </span><span><span class="extension">Extension</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           Documentation for <a href="#extension-Extension"><code>Extension</code></a>.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
        <tr id="extension-Another_extension" class="anchored">
@@ -489,9 +499,11 @@
          <a href="#extension-Another_extension" class="anchor"></a><code><span>| </span><span><span class="extension">Another_extension</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">(*</span>
          <p>
           Documentation for <a href="#extension-Another_extension"><code>Another_extension</code></a>.
          </p>
+         <span class="comment-delim">*)</span>
         </td>
        </tr>
       </tbody>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -151,9 +151,11 @@
          <a href="#type-u.A'" class="anchor"></a><code><span>| </span><span><span class="constructor">A'</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           Attached to constructor
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>
@@ -171,9 +173,11 @@
          <a href="#type-v.f" class="anchor"></a><code><span>f: <a href="#type-t">t</a>,</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           Attached to field
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -756,9 +756,11 @@
          <a href="#type-record.field1" class="anchor"></a><code><span>field1: int,</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           This comment is for <code>field1</code>.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-record.field2" class="anchored">
@@ -766,9 +768,11 @@
          <a href="#type-record.field2" class="anchor"></a><code><span>field2: int,</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           This comment is for <code>field2</code>.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>
@@ -794,9 +798,11 @@
          <a href="#type-mutable_record.a" class="anchor"></a><code><span><span class="keyword">mutable</span> a: int,</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           <code>a</code> is first and mutable
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-mutable_record.b" class="anchored">
@@ -804,9 +810,11 @@
          <a href="#type-mutable_record.b" class="anchor"></a><code><span>b: unit,</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           <code>b</code> is second and immutable
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-mutable_record.c" class="anchored">
@@ -814,9 +822,11 @@
          <a href="#type-mutable_record.c" class="anchor"></a><code><span><span class="keyword">mutable</span> c: int,</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           <code>c</code> is third and mutable
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>
@@ -849,9 +859,11 @@
          <a href="#type-variant.TagA" class="anchor"></a><code><span>| </span><span><span class="constructor">TagA</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           This comment is for <code>TagA</code>.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-variant.ConstrB" class="anchored">
@@ -859,9 +871,11 @@
          <a href="#type-variant.ConstrB" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrB</span>(int)</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           This comment is for <code>ConstrB</code>.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-variant.ConstrC" class="anchored">
@@ -869,9 +883,11 @@
          <a href="#type-variant.ConstrC" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrC</span>(int, int)</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           This comment is for binary <code>ConstrC</code>.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-variant.ConstrD" class="anchored">
@@ -879,9 +895,11 @@
          <a href="#type-variant.ConstrD" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrD</span>(<span>(int, int)</span>)</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           This comment is for unary <code>ConstrD</code> of binary tuple.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>
@@ -1291,9 +1309,11 @@
          <a href="#type-mutual_constr_a.B_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">B_ish</span>(<a href="#type-mutual_constr_b">mutual_constr_b</a>)</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           This comment is between <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a> and <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>
@@ -1321,9 +1341,11 @@
          <a href="#type-mutual_constr_b.A_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">A_ish</span>(<a href="#type-mutual_constr_a">mutual_constr_a</a>)</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           This comment must be here for the next to associate correctly.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>
@@ -1481,9 +1503,11 @@
          <a href="#extension-Bar" class="anchor"></a><code><span>| </span><span><span class="extension">Bar</span>(<span class="type-var">'b</span>, <span class="type-var">'b</span>)</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           'b poly_ext
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>
@@ -1501,9 +1525,11 @@
          <a href="#extension-Quux" class="anchor"></a><code><span>| </span><span><span class="extension">Quux</span>(<span class="type-var">'c</span>)</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           'c poly_ext
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>
@@ -1526,9 +1552,11 @@
          <a href="#extension-ZzzTop0" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop0</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           It's got the rock
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>
@@ -1546,9 +1574,11 @@
          <a href="#extension-ZzzTop" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop</span>(unit)</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           and it packs a unit.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -53,9 +53,11 @@
          <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           foo
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-variant.D" class="anchored">
@@ -63,9 +65,11 @@
          <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           <em>bar</em>
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-variant.E" class="anchored">
@@ -103,9 +107,11 @@
          <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int) : <a href="#type-gadt">gadt</a>(string)</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           foo
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-gadt.C" class="anchored">
@@ -148,9 +154,11 @@
          <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           foo
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-polymorphic_variant.D" class="anchored">
@@ -158,9 +166,11 @@
          <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           bar
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -138,9 +138,11 @@
          <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           foo
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-variant.D" class="anchored">
@@ -148,9 +150,11 @@
          <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           <em>bar</em>
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-variant.E" class="anchored">
@@ -253,9 +257,11 @@
          <a href="#type-record.c" class="anchor"></a><code><span>c: int,</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           foo
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-record.d" class="anchored">
@@ -263,9 +269,11 @@
          <a href="#type-record.d" class="anchor"></a><code><span>d: int,</span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           <em>bar</em>
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="type-record.e" class="anchored">
@@ -483,9 +491,11 @@
          <a href="#extension-Extension" class="anchor"></a><code><span>| </span><span><span class="extension">Extension</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           Documentation for <a href="#extension-Extension"><code>Extension</code></a>.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
        <tr id="extension-Another_extension" class="anchored">
@@ -493,9 +503,11 @@
          <a href="#extension-Another_extension" class="anchor"></a><code><span>| </span><span><span class="extension">Another_extension</span></span></code>
         </td>
         <td class="def-doc">
+         <span class="comment-delim">/*</span>
          <p>
           Documentation for <a href="#extension-Another_extension"><code>Another_extension</code></a>.
          </p>
+         <span class="comment-delim">*/</span>
         </td>
        </tr>
       </tbody>


### PR DESCRIPTION
This is an alternative take on the copy paste problem mentioned in https://github.com/ocaml/odoc/issues/296. It inserts comment delimiters (in ocaml, `(*` `*)`) around documentation, but hide them while keeping them in the text selection with some CSS trickery. The trickery in question seems rather standard (it's used in bootstrap as a way to have text only for screen-readers, which is rather consistent with what we want). It also has the advantage that people can style it to keep the delimiters in their own CSS, if they like that.

cc @dbuenzli 