### PR TITLE
Pass documentation along with signatures

### DIFF
--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1069,6 +1069,9 @@ module Make (Syntax : SYNTAX) = struct
       | `Module (_, name) when ModuleName.is_internal name -> true
       | _ -> false
 
+    let doc_of_expansion ~decl_doc ~expansion_doc =
+      Comment.standalone decl_doc @ Comment.standalone expansion_doc
+
     let rec signature (s : Lang.Signature.t) =
       let rec loop l acc_items =
         match l with
@@ -1251,7 +1254,7 @@ module Make (Syntax : SYNTAX) = struct
         match expansion with
         | None -> (O.documentedSrc (O.txt modname), `Default, None)
         | Some (expansion_doc, items) ->
-            let doc = Comment.standalone expansion_doc in
+            let doc = doc_of_expansion ~decl_doc:t.doc ~expansion_doc in
             let status =
               match t.type_ with
               | ModuleType (Signature _) -> `Inline
@@ -1316,7 +1319,7 @@ module Make (Syntax : SYNTAX) = struct
         match expansion with
         | None -> (O.documentedSrc @@ O.txt modname, None)
         | Some (expansion_doc, items) ->
-            let doc = Comment.standalone expansion_doc in
+            let doc = doc_of_expansion ~decl_doc:t.doc ~expansion_doc in
             let url = Url.Path.from_identifier t.id in
             let link = path url [ inline @@ Text modname ] in
             let title = modname in

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1241,18 +1241,15 @@ module Make (Syntax : SYNTAX) = struct
       let modname = Paths.Identifier.name t.id in
       let expansion =
         match t.type_ with
-        | Alias (_, Some e) -> Some (simple_expansion e.a_expansion, e.a_doc)
+        | Alias (_, Some e) -> Some (simple_expansion e)
         | Alias (_, None) -> None
-        | ModuleType e -> (
-            match expansion_of_module_type_expr e with
-            | Some e -> Some (e, t.doc)
-            | None -> None )
+        | ModuleType e -> expansion_of_module_type_expr e
       in
       let modname, status, expansion =
         match expansion with
         | None -> (O.documentedSrc (O.txt modname), `Default, None)
-        | Some (items, expansion_doc) ->
-            let doc = Comment.standalone expansion_doc in
+        | Some items ->
+            let doc = Comment.standalone t.doc in
             let status =
               match t.type_ with
               | ModuleType (Signature _) -> `Inline
@@ -1296,7 +1293,7 @@ module Make (Syntax : SYNTAX) = struct
         ++ Syntax.Mod.open_tag ++ O.txt " ... " ++ Syntax.Mod.close_tag
       in
       match md with
-      | Alias (_, Some se) -> simple_expansion_in_decl base se.a_expansion
+      | Alias (_, Some se) -> simple_expansion_in_decl base se
       | Alias (p, _) when not Paths.Path.(is_hidden (p :> t)) ->
           O.txt " = " ++ mdexpr md
       | Alias _ -> sig_dotdotdot

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1559,7 +1559,7 @@ module Make (Syntax : SYNTAX) = struct
 
     let compilation_unit (t : Odoc_model.Lang.Compilation_unit.t) : Page.t =
       let title = Paths.Identifier.name t.id in
-      let header = format_title `Mod title @ Comment.standalone t.doc in
+      let header = format_title `Mod title in
       let url = Url.Path.from_identifier t.id in
       let items =
         match t.content with

--- a/src/document/targets.ml
+++ b/src/document/targets.ml
@@ -55,7 +55,7 @@ and module_ (t : Odoc_model.Lang.Module.t) =
   let url = Url.Path.from_identifier t.id in
   let subpages =
     match t.type_ with
-    | Alias (_, Some e) -> simple_expansion e.a_expansion
+    | Alias (_, Some e) -> simple_expansion e
     | Alias (_, None) -> []
     | ModuleType expr -> module_type_expr expr
   in

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -755,7 +755,7 @@ let rec read_class_signature env parent params =
         List.map (read_method env parent csig.csig_concr) methods
       in
       let items = constraints @ instance_variables @ methods in
-        Signature {self; items}
+      Signature {self; items; doc = []}
   | Cty_arrow _ -> assert false
 
 let rec read_virtual = function

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -976,7 +976,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_class_type _ :: _
     | Sig_class _ :: _ -> assert false
 
-    | [] -> ({items = List.rev acc; compiled=false}, shadowed)
+    | [] -> ({items = List.rev acc; compiled=false; doc = [] }, shadowed)
   in
     loop ([],{s_modules=[]; s_module_types=[]; s_values=[];s_types=[]; s_classes=[]; s_class_types=[]}) items
 
@@ -986,7 +986,6 @@ and read_signature env parent (items : Odoc_model.Compat.signature) =
 
 
 let read_interface root name intf =
-  let id = `Root(root, Odoc_model.Names.ModuleName.make_std name) in
-  let doc = Doc_attr.empty in
+  let id = `Root (root, Odoc_model.Names.ModuleName.make_std name) in
   let items = read_signature Env.empty id intf in
-    (id, doc, items)
+  (id, items)

--- a/src/loader/cmi.mli
+++ b/src/loader/cmi.mli
@@ -19,10 +19,11 @@
 module Paths = Odoc_model.Paths
 
 
-val read_interface: Odoc_model.Paths.Identifier.ContainerPage.t -> string -> Odoc_model.Compat.signature ->
-  Paths.Identifier.RootModule.t *
-  Odoc_model.Comment.docs *
-  Odoc_model.Lang.Signature.t
+val read_interface :
+  Odoc_model.Paths.Identifier.ContainerPage.t ->
+  string ->
+  Odoc_model.Compat.signature ->
+  Paths.Identifier.RootModule.t * Odoc_model.Lang.Signature.t
 
 val canonical : Odoc_model.Comment.docs -> [ `Dot of Paths.Path.Module.t * string ] option
 

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -176,7 +176,8 @@ and read_class_signature env parent params cltyp =
             [] csig.csig_fields
         in
         let items = constraints @ List.rev items in
-          Signature {self; items}
+        let items, doc = Doc_attr.extract_top_comment_class items in
+        Signature {self; items; doc}
     | Tcty_arrow _ -> assert false
 #if OCAML_MAJOR = 4 && OCAML_MINOR >= 06
     | Tcty_open _ -> assert false
@@ -263,7 +264,8 @@ and read_class_structure env parent params cl =
             [] cstr.cstr_fields
         in
         let items = constraints @ List.rev items in
-          Signature {self; items}
+        let items, doc = Doc_attr.extract_top_comment_class items in
+        Signature {self; items; doc}
     | Tcl_fun _ -> assert false
     | Tcl_let(_, _, _, cl) -> read_class_structure env parent params cl
     | Tcl_constraint(cl, None, _, _, _) -> read_class_structure env parent params cl

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -545,20 +545,16 @@ and read_structure env parent str =
   let items =
     List.fold_left
       (fun items item ->
-         List.rev_append (read_structure_item env parent item) items)
+        List.rev_append (read_structure_item env parent item) items)
       [] str.str_items
+    |> List.rev
   in
-    { items = List.rev items; compiled=false }
+  let items, doc = Doc_attr.extract_top_comment items in
+  { items; compiled = false; doc }
 
 let read_implementation root name impl =
-  let id = `Root(root, Odoc_model.Names.ModuleName.make_std name) in
+  let id = `Root (root, Odoc_model.Names.ModuleName.make_std name) in
   let sg = read_structure Env.empty id impl in
-  let doc, sg =
-    let open Signature in
-    match sg.items with
-    | Comment (`Docs doc) :: items -> doc, {sg with items}
-    | _ -> Doc_attr.empty, sg
-  in
-    (id, doc, sg)
+  (id, sg)
 
 let _ = Cmti.read_module_expr := read_module_expr

--- a/src/loader/cmt.mli
+++ b/src/loader/cmt.mli
@@ -14,7 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-val read_implementation: Odoc_model.Paths.Identifier.ContainerPage.t -> string -> Typedtree.structure ->
-  Odoc_model.Paths.Identifier.RootModule.t *
-  Odoc_model.Comment.docs *
-  Odoc_model.Lang.Signature.t
+val read_implementation :
+  Odoc_model.Paths.Identifier.ContainerPage.t ->
+  string ->
+  Typedtree.structure ->
+  Odoc_model.Paths.Identifier.RootModule.t * Odoc_model.Lang.Signature.t

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -703,24 +703,18 @@ and read_open env parent o =
 #endif
 
 and read_signature env parent sg =
-  let env =
-    Env.add_signature_tree_items parent sg env
-  in
+  let env = Env.add_signature_tree_items parent sg env in
   let items =
     List.fold_left
       (fun items item ->
-         List.rev_append (read_signature_item env parent item) items)
+        List.rev_append (read_signature_item env parent item) items)
       [] sg.sig_items
+    |> List.rev
   in
-    { items = List.rev items; compiled=false }
+  let items, doc = Doc_attr.extract_top_comment items in
+  { items; compiled = false; doc }
 
 let read_interface root name intf =
-  let id = `Root(root, Odoc_model.Names.ModuleName.make_std name) in
+  let id = `Root (root, Odoc_model.Names.ModuleName.make_std name) in
   let sg = read_signature Env.empty id intf in
-  let doc, sg =
-    let open Signature in
-    match sg.items with
-    | Comment (`Docs doc) :: items -> doc, {sg with items}
-    | _ -> Doc_attr.empty, sg
-  in
-    (id, doc, sg)
+  (id, sg)

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -383,7 +383,8 @@ and read_class_signature env parent label_parent cltyp =
             [] csig.csig_fields
         in
         let items = List.rev items in
-          Signature {self; items}
+        let items, doc = Doc_attr.extract_top_comment_class items in
+        Signature {self; items; doc}
     | Tcty_arrow _ -> assert false
 #if OCAML_MAJOR = 4 && OCAML_MINOR >= 06 && OCAML_MINOR < 08
   | Tcty_open (_, _, _, _, cty) -> read_class_signature env parent label_parent cty

--- a/src/loader/cmti.mli
+++ b/src/loader/cmti.mli
@@ -16,14 +16,19 @@
 
 module Paths = Odoc_model.Paths
 
-val read_module_expr : (Ident_env.t -> Paths.Identifier.Signature.t -> Paths.Identifier.LabelParent.t -> Typedtree.module_expr -> Odoc_model.Lang.ModuleType.expr) ref
+val read_module_expr :
+  (Ident_env.t ->
+  Paths.Identifier.Signature.t ->
+  Paths.Identifier.LabelParent.t ->
+  Typedtree.module_expr ->
+  Odoc_model.Lang.ModuleType.expr)
+  ref
+
 val read_interface :
   Odoc_model.Paths.Identifier.ContainerPage.t ->
   string ->
   Typedtree.signature ->
-  Paths.Identifier.RootModule.t
-  * Odoc_model.Comment.docs
-  * Odoc_model.Lang.Signature.t
+  Paths.Identifier.RootModule.t * Odoc_model.Lang.Signature.t
 
 val read_module_type :
   Ident_env.t ->

--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -1,5 +1,3 @@
-open Result
-
 (*
  * Copyright (c) 2014 Leo White <lpw25@cl.cam.ac.uk>
  *
@@ -16,7 +14,8 @@ open Result
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-
+open Result
+open Odoc_model
 
 module Paths = Odoc_model.Paths
 
@@ -128,3 +127,8 @@ let standalone_multiple parent attrs =
       [] attrs
   in
     List.rev coms
+
+let extract_top_comment items =
+  match items with
+  | Lang.Signature.Comment (`Docs doc) :: tl -> (tl, doc)
+  | _ -> (items, empty)

--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -132,3 +132,8 @@ let extract_top_comment items =
   match items with
   | Lang.Signature.Comment (`Docs doc) :: tl -> (tl, doc)
   | _ -> (items, empty)
+
+let extract_top_comment_class items =
+  match items with
+  | Lang.ClassSignature.Comment (`Docs doc) :: tl -> (tl, doc)
+  | _ -> items, empty

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -54,3 +54,7 @@ val standalone_multiple :
 val extract_top_comment :
   Lang.Signature.item list -> Lang.Signature.item list * Comment.docs
 (** Extract the first comment of a signature. Returns the remaining items. *)
+
+val extract_top_comment_class :
+  Lang.ClassSignature.item list -> Lang.ClassSignature.item list * Comment.docs
+(** Extract the first comment of a class signature. Returns the remaining items. *)

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-
+open Odoc_model
 
 module Paths = Odoc_model.Paths
 
@@ -50,3 +50,7 @@ val standalone_multiple :
   Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
     Odoc_model.Comment.docs_or_stop list
+
+val extract_top_comment :
+  Lang.Signature.item list -> Lang.Signature.item list * Comment.docs
+(** Extract the first comment of a signature. Returns the remaining items. *)

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -59,7 +59,7 @@ let read_cmti ~make_root ~parent ~filename () =
           | Ok root -> root
           | Error (`Msg m) -> error_msg filename m
         in
-        let (id, doc, items) = Cmti.read_interface parent name intf in
+        let (id, items) = Cmti.read_interface parent name intf in
         let imports =
           List.filter (fun (name', _) -> name <> name') cmt_info.cmt_imports
         in
@@ -70,6 +70,7 @@ let read_cmti ~make_root ~parent ~filename () =
         in
         let interface = true in
         let hidden = Odoc_model.Root.contains_double_underscore name in
+        let doc = Doc_attr.empty in
         let source =
           match cmt_info.cmt_sourcefile, cmt_info.cmt_source_digest with
           | Some file, Some digest ->
@@ -156,13 +157,14 @@ let read_cmt ~make_root ~parent ~filename () =
         | Ok root -> root
         | Error (`Msg m) -> error_msg filename m
       in
-      let (id, doc, items) = Cmt.read_implementation parent name impl in
+      let (id, items) = Cmt.read_implementation parent name impl in
       let imports =
         List.filter (fun (name', _) -> name <> name') cmt_info.cmt_imports in
       let imports =
         List.map (fun (s, d) ->
           Odoc_model.Lang.Compilation_unit.Import.Unresolved(s, d)) imports
       in
+      let doc = Doc_attr.empty in
       let source =
         match cmt_info.cmt_sourcefile, cmt_info.cmt_source_digest with
         | Some file, Some digest ->
@@ -192,13 +194,14 @@ let read_cmi ~make_root ~parent ~filename () =
         | Ok root -> root
         | Error (`Msg m) -> error_msg filename m
       in
-      let (id, doc, items) = Cmi.read_interface parent name (Odoc_model.Compat.signature cmi_info.cmi_sign) in
+      let (id, items) = Cmi.read_interface parent name (Odoc_model.Compat.signature cmi_info.cmi_sign) in
       let imports =
         List.map (fun (s, d) ->
           Odoc_model.Lang.Compilation_unit.Import.Unresolved(s, d)) imports
       in
       let interface = true in
       let hidden = Odoc_model.Root.contains_double_underscore name in
+      let doc = Doc_attr.empty in
       let source = None in
       let content = Odoc_model.Lang.Compilation_unit.Module items in
       {Odoc_model.Lang.Compilation_unit.id; root; doc; digest; imports;

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -70,7 +70,6 @@ let read_cmti ~make_root ~parent ~filename () =
         in
         let interface = true in
         let hidden = Odoc_model.Root.contains_double_underscore name in
-        let doc = Doc_attr.empty in
         let source =
           match cmt_info.cmt_sourcefile, cmt_info.cmt_source_digest with
           | Some file, Some digest ->
@@ -79,7 +78,7 @@ let read_cmti ~make_root ~parent ~filename () =
           | _, _ -> None
         in
         let content = Odoc_model.Lang.Compilation_unit.Module items in
-        {Odoc_model.Lang.Compilation_unit.id; root; doc; digest; imports; source;
+        {Odoc_model.Lang.Compilation_unit.id; root; digest; imports; source;
          interface; hidden; content; expansion = None; linked = false}
       end
     | _ -> not_an_interface filename
@@ -134,10 +133,9 @@ let read_cmt ~make_root ~parent ~filename () =
         List.map (fun (s, d) ->
           Odoc_model.Lang.Compilation_unit.Import.Unresolved(s, d)) imports
       in
-      let doc = Doc_attr.empty in
       let source = None in
       let content = Odoc_model.Lang.Compilation_unit.Pack items in
-      {Odoc_model.Lang.Compilation_unit.id; root; doc; digest; imports;
+      {Odoc_model.Lang.Compilation_unit.id; root; digest; imports;
           source; interface; hidden; content; expansion = None; linked = false}
 
     | Implementation impl ->
@@ -164,7 +162,6 @@ let read_cmt ~make_root ~parent ~filename () =
         List.map (fun (s, d) ->
           Odoc_model.Lang.Compilation_unit.Import.Unresolved(s, d)) imports
       in
-      let doc = Doc_attr.empty in
       let source =
         match cmt_info.cmt_sourcefile, cmt_info.cmt_source_digest with
         | Some file, Some digest ->
@@ -173,7 +170,7 @@ let read_cmt ~make_root ~parent ~filename () =
         | _, _ -> None
       in
       let content = Odoc_model.Lang.Compilation_unit.Module items in
-      {Odoc_model.Lang.Compilation_unit.id; root; doc; digest; imports;
+      {Odoc_model.Lang.Compilation_unit.id; root; digest; imports;
        source; interface; hidden; content; expansion = None; linked = false}
 
     | _ -> not_an_implementation filename
@@ -201,10 +198,9 @@ let read_cmi ~make_root ~parent ~filename () =
       in
       let interface = true in
       let hidden = Odoc_model.Root.contains_double_underscore name in
-      let doc = Doc_attr.empty in
       let source = None in
       let content = Odoc_model.Lang.Compilation_unit.Module items in
-      {Odoc_model.Lang.Compilation_unit.id; root; doc; digest; imports;
+      {Odoc_model.Lang.Compilation_unit.id; root; digest; imports;
        source; interface; hidden; content; expansion = None; linked = false}
 
     | _ -> corrupted filename

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -141,7 +141,11 @@ and Signature : sig
     | Include of Include.t
     | Comment of Comment.docs_or_stop
 
-  type t = { items : item list; compiled : bool }
+  type t = {
+    items : item list;
+    compiled : bool;
+    doc : Comment.docs;  (** The top comment. *)
+  }
 end =
   Signature
 

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -334,7 +334,7 @@ and ClassSignature : sig
     | Inherit of ClassType.expr
     | Comment of Comment.docs_or_stop
 
-  type t = { self : TypeExpr.t option; items : item list }
+  type t = { self : TypeExpr.t option; items : item list; doc : Comment.docs }
 end =
   ClassSignature
 

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -444,7 +444,6 @@ module rec Compilation_unit : sig
   type t = {
     id : Identifier.RootModule.t;
     root : Root.t;
-    doc : Comment.docs;
     digest : Digest.t;
     imports : Import.t list;
     source : Source.t option;

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -19,13 +19,8 @@ open Paths
 (** {3 Modules} *)
 
 module rec Module : sig
-  type alias_expansion = {
-    a_doc : Comment.docs;
-    a_expansion : ModuleType.simple_expansion;
-  }
-
   type decl =
-    | Alias of (Path.Module.t * alias_expansion option)
+    | Alias of (Path.Module.t * ModuleType.simple_expansion option)
     | ModuleType of ModuleType.expr
 
   type t = {

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -215,6 +215,7 @@ and signature_t : Lang.Signature.t Type_desc.t =
     [
       F ("items", (fun t -> t.items), List signature_item);
       F ("compiled", (fun t -> t.compiled), bool);
+      F ("doc", (fun t -> t.doc), docs);
     ]
 
 (** {3 Open} *)

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -18,16 +18,8 @@ let rec module_decl =
         C
           ( "Alias",
             ((x :> Paths.Path.t), y),
-            Pair (path, Option module_alias_expansion) )
+            Pair (path, Option simple_expansion) )
     | ModuleType x -> C ("ModuleType", x, moduletype_expr))
-
-and module_alias_expansion =
-  let open Lang.Module in
-  Record
-    [
-      F ("a_doc", (fun t -> t.a_doc), docs);
-      F ("a_expansion", (fun t -> t.a_expansion), simple_expansion);
-    ]
 
 and module_t =
   let open Lang.Module in

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -640,7 +640,6 @@ and compilation_unit_t =
     [
       F ("id", (fun t -> t.id), identifier);
       F ("root", (fun t -> t.root), root);
-      F ("doc", (fun t -> t.doc), docs);
       F ("digest", (fun t -> t.digest), Digest.t);
       F ("imports", (fun t -> t.imports), List compilation_unit_import);
       F ("source", (fun t -> t.source), Option compilation_unit_source);

--- a/src/odoc/odoc_link.ml
+++ b/src/odoc/odoc_link.ml
@@ -22,7 +22,7 @@ let from_odoc ~env ~warn_error input output =
             unit with
             content =
               Odoc_model.Lang.Compilation_unit.Module
-                { items = []; compiled = false };
+                { items = []; compiled = false; doc = [] };
             expansion = None;
           }
         else unit

--- a/src/odoc/rendering.ml
+++ b/src/odoc/rendering.ml
@@ -32,7 +32,7 @@ let document_of_input ~env ~warn_error ~syntax input =
             unit with
             content =
               Odoc_model.Lang.Compilation_unit.Module
-                { items = []; compiled = false };
+                { items = []; compiled = false; doc = [] };
             expansion = None;
           }
         else unit

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -319,7 +319,7 @@ and include_ : Env.t -> Include.t -> Include.t =
       match decl with
       | Alias p ->
           Expand_tools.aux_expansion_of_module_alias env ~strengthen:true p
-          >>= fun (expansion, _doc) -> Expand_tools.assert_not_functor expansion
+          >>= Expand_tools.assert_not_functor
       | ModuleType mty ->
           Expand_tools.aux_expansion_of_u_module_type_expr env mty
     with

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -151,6 +151,7 @@ and class_signature env parent c =
     | Comment c -> Comment c
   in
   {
+    c with
     self = Opt.map (type_expression env container) c.self;
     items = List.map map_item c.items;
   }

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -269,9 +269,13 @@ and signature : Env.t -> Id.Signature.t -> Signature.t -> _ =
  fun env id s ->
   if s.compiled then s
   else
-    let env = Env.open_signature s env in
+    let env = Env.open_signature s env |> Env.add_docs s.doc in
     let items = signature_items env id s.items in
-    { items; compiled = true }
+    {
+      items;
+      compiled = true;
+      doc = s.doc (* comments are ignored while compiling *);
+    }
 
 and module_ : Env.t -> Module.t -> Module.t =
  fun env m ->

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -377,7 +377,7 @@ and ClassSignature : sig
     | Inherit of ClassType.expr
     | Comment of CComment.docs_or_stop
 
-  type t = { self : TypeExpr.t option; items : item list }
+  type t = { self : TypeExpr.t option; items : item list; doc : CComment.docs }
 end =
   ClassSignature
 
@@ -2177,7 +2177,11 @@ module Of_Lang = struct
           | Comment c -> Comment (docs_or_stop ident_map c))
         sg.items
     in
-    { ClassSignature.self = Opt.map (type_expression ident_map) sg.self; items }
+    {
+      ClassSignature.self = Opt.map (type_expression ident_map) sg.self;
+      items;
+      doc = docs ident_map sg.doc;
+    }
 
   and method_ ident_map m =
     let open Odoc_model.Lang.Method in

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -312,7 +312,12 @@ and Signature : sig
     | RType of Ident.type_ * TypeExpr.t * TypeDecl.Equation.t
         (** [RType (_, texpr, eq)], [eq.manifest = Some texpr] *)
 
-  type t = { items : item list; compiled : bool; removed : removed_item list }
+  type t = {
+    items : item list;
+    compiled : bool;
+    removed : removed_item list;
+    doc : CComment.docs;
+  }
 end =
   Signature
 
@@ -2291,7 +2296,7 @@ module Of_Lang = struct
         | Include i -> Include (include_ ident_map i))
         sg.items
     in
-    { items; removed = []; compiled = sg.compiled }
+    { items; removed = []; compiled = sg.compiled; doc = docs ident_map sg.doc }
 
   and with_location :
         'a 'b. (map -> 'a -> 'b) -> map -> 'a Location_.with_location ->

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -71,13 +71,8 @@ module Opt = struct
 end
 
 module rec Module : sig
-  type alias_expansion = {
-    a_doc : CComment.docs;
-    a_expansion : ModuleType.simple_expansion;
-  }
-
   type decl =
-    | Alias of Cpath.module_ * alias_expansion option
+    | Alias of Cpath.module_ * ModuleType.simple_expansion option
     | ModuleType of ModuleType.expr
 
   type t = {
@@ -1924,15 +1919,9 @@ module Of_Lang = struct
     match m with
     | Odoc_model.Lang.Module.Alias (p, e) ->
         Module.Alias
-          (module_path ident_map p, option module_alias_expansion ident_map e)
+          (module_path ident_map p, option simple_expansion ident_map e)
     | Odoc_model.Lang.Module.ModuleType s ->
         Module.ModuleType (module_type_expr ident_map s)
-
-  and module_alias_expansion ident_map e =
-    {
-      Module.a_doc = docs ident_map e.a_doc;
-      a_expansion = simple_expansion ident_map e.a_expansion;
-    }
 
   and include_decl ident_map m =
     match m with

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -292,7 +292,12 @@ and Signature : sig
     | RModule of Ident.module_ * Cpath.Resolved.module_
     | RType of Ident.type_ * TypeExpr.t * TypeDecl.Equation.t
 
-  type t = { items : item list; compiled : bool; removed : removed_item list }
+  type t = {
+    items : item list;
+    compiled : bool;
+    removed : removed_item list;
+    doc : CComment.docs;
+  }
 end
 
 and Open : sig

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -351,7 +351,7 @@ and ClassSignature : sig
     | Inherit of ClassType.expr
     | Comment of CComment.docs_or_stop
 
-  type t = { self : TypeExpr.t option; items : item list }
+  type t = { self : TypeExpr.t option; items : item list; doc : CComment.docs }
 end
 
 and Method : sig

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -61,13 +61,8 @@ end
 *)
 
 module rec Module : sig
-  type alias_expansion = {
-    a_doc : CComment.docs;
-    a_expansion : ModuleType.simple_expansion;
-  }
-
   type decl =
-    | Alias of Cpath.module_ * alias_expansion option
+    | Alias of Cpath.module_ * ModuleType.simple_expansion option
     | ModuleType of ModuleType.expr
 
   type t = {

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -338,7 +338,7 @@ let module_of_unit : Odoc_model.Lang.Compilation_unit.t -> Component.Module.t =
         Odoc_model.Lang.Module.
           {
             id = (unit.id :> Odoc_model.Paths.Identifier.Module.t);
-            doc = unit.doc;
+            doc = [];
             type_ = ModuleType (Signature s);
             canonical = None;
             hidden = unit.hidden;
@@ -351,7 +351,7 @@ let module_of_unit : Odoc_model.Lang.Compilation_unit.t -> Component.Module.t =
         Odoc_model.Lang.Module.
           {
             id = (unit.id :> Odoc_model.Paths.Identifier.Module.t);
-            doc = unit.doc;
+            doc = [];
             type_ =
               ModuleType (Signature { items = []; compiled = true; doc = [] });
             canonical = None;

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -352,7 +352,8 @@ let module_of_unit : Odoc_model.Lang.Compilation_unit.t -> Component.Module.t =
           {
             id = (unit.id :> Odoc_model.Paths.Identifier.Module.t);
             doc = unit.doc;
-            type_ = ModuleType (Signature { items = []; compiled = true });
+            type_ =
+              ModuleType (Signature { items = []; compiled = true; doc = [] });
             canonical = None;
             hidden = unit.hidden;
           }

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -497,8 +497,8 @@ and class_signature map parent sg =
         | Comment c ->
             Comment (docs_or_stop (parent :> Identifier.LabelParent.t) c))
       sg.items
-  in
-  { self = Opt.map (type_expr map pparent) sg.self; items }
+  and doc = docs (parent :> Identifier.LabelParent.t) sg.doc in
+  { self = Opt.map (type_expr map pparent) sg.self; items; doc }
 
 and method_ map parent id m =
   let open Component.Method in

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -419,7 +419,11 @@ and signature :
  fun id map sg ->
   let open Component.Signature in
   (* let map = { map with shadowed = empty_shadow } in *)
-  { items = signature_items id map sg.items; compiled = sg.compiled }
+  {
+    items = signature_items id map sg.items;
+    compiled = sg.compiled;
+    doc = docs (id :> Identifier.LabelParent.t) sg.doc;
+  }
 
 and class_ map parent id c =
   let open Component.Class in

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -679,19 +679,8 @@ and module_decl :
   match d with
   | Component.Module.Alias (p, s) ->
       Odoc_model.Lang.Module.Alias
-        (Path.module_ map p, Opt.map (module_alias_expansion map identifier) s)
+        (Path.module_ map p, Opt.map (simple_expansion map identifier) s)
   | ModuleType mty -> ModuleType (module_type_expr map identifier mty)
-
-and module_alias_expansion :
-    maps ->
-    Identifier.Signature.t ->
-    Component.Module.alias_expansion ->
-    Lang.Module.alias_expansion =
- fun map identifier t ->
-  {
-    a_doc = docs (identifier :> Identifier.LabelParent.t) t.a_doc;
-    a_expansion = simple_expansion map identifier t.a_expansion;
-  }
 
 and mty_substitution map identifier = function
   | Component.ModuleType.ModuleEq (frag, decl) ->

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -385,11 +385,9 @@ and module_ : Env.t -> Module.t -> Module.t =
             match
               Expand_tools.expansion_of_module_alias env m.id (`Resolved cp)
             with
-            | Ok (_, _, e, doc) ->
+            | Ok (_, _, e) ->
                 let le = Lang_of.(simple_expansion empty sg_id e) in
-                let a_doc = Lang_of.docs (sg_id :> Id.LabelParent.t) doc
-                and a_expansion = simple_expansion env sg_id le in
-                Alias (`Resolved p, Some { a_doc; a_expansion })
+                Alias (`Resolved p, Some (simple_expansion env sg_id le))
             | Error _ -> type_
           else type_
       | Alias _ | ModuleType _ -> type_
@@ -402,16 +400,7 @@ and module_decl : Env.t -> Id.Signature.t -> Module.decl -> Module.decl =
   match decl with
   | ModuleType expr -> ModuleType (module_type_expr env id expr)
   | Alias (p, e) ->
-      Alias (module_path env p, Opt.map (module_alias_expansion env id) e)
-
-and module_alias_expansion :
-    Env.t -> Id.Signature.t -> Module.alias_expansion -> Module.alias_expansion
-    =
- fun env id e ->
-  {
-    a_doc = comment_docs env e.a_doc;
-    a_expansion = simple_expansion env id e.a_expansion;
-  }
+      Alias (module_path env p, Opt.map (simple_expansion env id) e)
 
 and include_decl : Env.t -> Id.Signature.t -> Include.decl -> Include.decl =
  fun env id decl ->

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -199,10 +199,16 @@ and comment_nestable_block_element env (x : Comment.nestable_block_element) =
           (fun (r : Comment.module_reference) ->
             match Ref_tools.resolve_module_reference env r.module_reference with
             | Some (r, _, m) ->
-                {
-                  Comment.module_reference = `Resolved r;
-                  module_synopsis = synopsis_from_comment m.doc;
-                }
+                let module_synopsis =
+                  match synopsis_from_comment m.doc with
+                  | Some _ as s -> s
+                  | None -> (
+                      (* If there is no doc, look at the expansion. *)
+                      match Tools.signature_of_module env m with
+                      | Ok sg -> synopsis_from_comment sg.doc
+                      | Error _ -> None )
+                in
+                { Comment.module_reference = `Resolved r; module_synopsis }
             | None -> r)
           refs
       in

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -297,6 +297,7 @@ and class_signature env parent c =
   {
     self = Opt.map (type_expression env parent []) c.self;
     items = List.map map_item c.items;
+    doc = comment_docs env c.doc;
   }
 
 and method_ env parent m =

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -139,19 +139,12 @@ and module_path : Env.t -> Paths.Path.Module.t -> Paths.Path.Module.t =
 let rec unit (resolver : Env.resolver) t =
   let open Compilation_unit in
   let imports, env = Env.initial_env t resolver in
-  let env = (* Add doc to env *) Env.add_docs t.doc env in
-  let content, env =
+  let content =
     match t.content with
-    | Module sg ->
-        (* Inline [signature] to keep [env]. *)
-        let env = Env.open_signature sg env |> Env.add_docs sg.doc in
-        let items = signature_items env (t.id :> Id.Signature.t) sg.items
-        and doc = comment_docs env sg.doc in
-        (Module { sg with items; doc }, env)
-    | Pack _ as p -> (p, env)
+    | Module sg -> Module (signature env (t.id :> Id.Signature.t) sg)
+    | Pack _ as p -> p
   in
-  let doc = comment_docs env t.doc in
-  { t with content; doc; imports; linked = true }
+  { t with content; imports; linked = true }
 
 and value_ env parent t =
   let open Value in

--- a/src/xref2/strengthen.ml
+++ b/src/xref2/strengthen.ml
@@ -65,8 +65,7 @@ let rec signature :
       (fun s mid -> Subst.path_invalidate_module (mid :> Ident.path_module) s)
       Subst.identity strengthened_modules
   in
-  Subst.signature substs
-    { items = List.rev items; removed = sg.removed; compiled = sg.compiled }
+  Subst.signature substs { sg with items = List.rev items }
 
 and module_ :
     ?canonical:Cpath.module_ ->

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -653,11 +653,8 @@ and module_type_substitution s sub =
 
 and module_decl s t =
   match t with
-  | Alias (p, e) -> Alias (module_path s p, option_ module_alias_expansion s e)
+  | Alias (p, e) -> Alias (module_path s p, option_ simple_expansion s e)
   | ModuleType t -> ModuleType (module_type_expr s t)
-
-and module_alias_expansion s t =
-  { t with a_expansion = simple_expansion s t.a_expansion }
 
 and include_decl s t =
   match t with

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -769,6 +769,7 @@ and class_signature_item s =
 and class_signature s sg =
   let open Component.ClassSignature in
   {
+    sg with
     self = option_ type_expr s sg.self;
     items = List.map (class_signature_item s) sg.items;
   }

--- a/src/xref2/subst.mli
+++ b/src/xref2/subst.mli
@@ -66,7 +66,8 @@ val signature : t -> Component.Signature.t -> Component.Signature.t
 
 val apply_sig_map :
   t ->
-  Component.Signature.item list ->
-  Component.Signature.removed_item list ->
-  bool ->
-  Component.Signature.t
+  Signature.item list ->
+  Signature.removed_item list ->
+  Signature.item list * Signature.removed_item list * bool
+(** Apply substitutions. The third value is [false] if the corresponding
+    signature needs to be compiled again and [true] otherwise. *)

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -145,7 +145,7 @@ let prefix_signature (path, sg) =
         | Comment c -> Comment c)
       sg.items
   in
-  { items; removed = sg.removed; compiled = sg.compiled }
+  { sg with items }
 
 let simplify_resolved_module_path :
     Env.t -> Cpath.Resolved.module_ -> Cpath.Resolved.module_ =
@@ -1272,7 +1272,12 @@ and fragmap :
                 map_include_decl i.decl sub >>= fun decl ->
                 let expansion_ =
                   Component.Signature.
-                    { items = items'; removed = removed'; compiled = false }
+                    {
+                      expansion_ with
+                      items = items';
+                      removed = removed';
+                      compiled = false;
+                    }
                 in
                 Ok (Component.Signature.Include { i with decl; expansion_ })
               else Ok item
@@ -1378,9 +1383,9 @@ and fragmap :
     in
     (* Need to call `apply_sig_map` directly as we're substituting for an item
        that's declared within the signature *)
-    let sg = Subst.apply_sig_map substituted_sub items [] false in
+    let items, _, _ = Subst.apply_sig_map substituted_sub items [] in
     (* Finished marking substituted stuff *)
-    sg.items
+    items
   in
 
   let items = map_items items in
@@ -1391,6 +1396,7 @@ and fragmap :
         Component.Signature.items;
         removed = removed @ sg.removed;
         compiled = false;
+        doc = sg.doc;
       }
   in
   Ok res

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -1142,8 +1142,7 @@ and signature_of_module_decl :
     (Component.Signature.t, signature_of_module_error) Result.result =
  fun env decl ->
   match decl with
-  | Component.Module.Alias (_, Some e) ->
-      Ok (signature_of_simple_expansion e.a_expansion)
+  | Component.Module.Alias (_, Some e) -> Ok (signature_of_simple_expansion e)
   | Component.Module.Alias (p, _) ->
       signature_of_module_path env ~strengthen:true p
   | Component.Module.ModuleType expr ->

--- a/src/xref2/type_of.ml
+++ b/src/xref2/type_of.ml
@@ -54,8 +54,8 @@ and module_type_expr_typeof env (id : Id.Signature.t) t =
   let cp = Component.Of_Lang.(module_path empty p) in
   let open Expand_tools in
   let open Utils.ResultMonad in
-  aux_expansion_of_module_alias env ~strengthen cp >>= fun (sg, _doc) ->
-  handle_expansion env id sg >>= fun (_env, e) -> Ok e
+  aux_expansion_of_module_alias env ~strengthen cp >>= handle_expansion env id
+  >>= fun (_env, e) -> Ok e
 
 and module_type_expr env (id : Id.Signature.t) expr =
   match expr with

--- a/test/cases/toplevel_comments.mli
+++ b/test/cases/toplevel_comments.mli
@@ -37,6 +37,7 @@ module type Include_inline_T' = sig
 end
 
 module M : sig
+
   (** Doc of [M] *)
 end
 
@@ -45,6 +46,7 @@ module M' : sig end
 
 (** Doc of [M''], part 1. *)
 module M'' : sig
+
   (** Doc of [M''], part 2. *)
 end
 

--- a/test/cases/toplevel_comments.mli
+++ b/test/cases/toplevel_comments.mli
@@ -35,3 +35,18 @@ module type Include_inline_T' = sig
   (** part 3
       @inline *)
 end
+
+module M : sig
+  (** Doc of [M] *)
+end
+
+module M' : sig end
+(** Doc of [M'] from outside *)
+
+(** Doc of [M''], part 1. *)
+module M'' : sig
+  (** Doc of [M''], part 2. *)
+end
+
+module Alias : T
+(** Doc of [Alias]. *)

--- a/test/cases/toplevel_comments.mli
+++ b/test/cases/toplevel_comments.mli
@@ -50,3 +50,21 @@ end
 
 module Alias : T
 (** Doc of [Alias]. *)
+
+(** Doc of [c1], part 1. *)
+class c1 :
+  int
+  -> object
+
+       (** Doc of [c1], part 2. *)
+     end
+
+(** Doc of [ct], part 1. *)
+class type ct =
+  object
+
+    (** Doc of [ct], part 2. *)
+  end
+
+class c2 : ct
+(** Doc of [c2]. *)

--- a/test/html/expect/test_package+ml/Include2/index.html
+++ b/test/html/expect/test_package+ml/Include2/index.html
@@ -40,6 +40,9 @@
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <span class="keyword">struct</span> <span class="keyword">include</span> <a href="X/index.html">X</a> <span class="keyword">end</span></span></code></span>
        </summary>
+       <p>
+        Comment about X that should not appear when including X below.
+       </p>
        <div class="odoc-spec">
         <div class="spec type" id="type-t">
          <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span></code>

--- a/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
@@ -21,6 +21,9 @@
    <h1>
     Module type <code><span>Include_sections.Something</span></code>
    </h1>
+   <p>
+    A module type.
+   </p>
   </header>
   <nav class="odoc-toc">
    <ul>

--- a/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+ml/Include_sections/module-type-Something/index.html
@@ -21,9 +21,6 @@
    <h1>
     Module type <code><span>Include_sections.Something</span></code>
    </h1>
-   <p>
-    A module type.
-   </p>
   </header>
   <nav class="odoc-toc">
    <ul>

--- a/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
@@ -21,21 +21,18 @@
    <h1>
     Parameter <code><span>F.1-Arg1</span></code>
    </h1>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
-    <li>
-     <a href="#type">Type</a>
-    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
@@ -21,18 +21,11 @@
    <h1>
     Parameter <code><span>F.2-Arg2</span></code>
    </h1>
-  </header>
-  <nav class="odoc-toc">
-   <ul>
-    <li>
-     <a href="#type">Type</a>
-    </li>
-   </ul>
-  </nav>
-  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
+  </header>
+  <div class="odoc-content">
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -21,6 +21,12 @@
    <h1>
     Module <code><span>Nested.F</span></code>
    </h1>
+   <p>
+    This is a functor F.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -21,12 +21,9 @@
    <h1>
     Module <code><span>Nested.F</span></code>
    </h1>
-   <p>
-    This is a functor F.
-   </p>
-   <p>
-    Some additional comments.
-   </p>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
@@ -35,9 +32,6 @@
     </li>
     <li>
      <a href="#signature">Signature</a>
-    </li>
-    <li>
-     <a href="#type">Type</a>
     </li>
    </ul>
   </nav>
@@ -57,9 +51,6 @@
    </div>
    <h2 id="signature">
     <a href="#signature" class="anchor"></a>Signature
-   </h2>
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
    </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -21,27 +21,18 @@
    <h1>
     Module <code><span>Nested.X</span></code>
    </h1>
-   <p>
-    This is module X.
-   </p>
-   <p>
-    Some additional comments.
-   </p>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
-    <li>
-     <a href="#type">Type</a>
-    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -21,6 +21,12 @@
    <h1>
     Module <code><span>Nested.X</span></code>
    </h1>
+   <p>
+    This is module X.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -21,6 +21,12 @@
    <h1>
     Module type <code><span>Nested.Y</span></code>
    </h1>
+   <p>
+    This is module type Y.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -21,27 +21,18 @@
    <h1>
     Module type <code><span>Nested.Y</span></code>
    </h1>
-   <p>
-    This is module type Y.
-   </p>
-   <p>
-    Some additional comments.
-   </p>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
-    <li>
-     <a href="#type">Type</a>
-    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -1856,7 +1856,7 @@
      <a href="IncludeInclude1/index.html"><code>Ocamlary.IncludeInclude1</code></a>
     </li>
     <li>
-     <a href="#"><code>Ocamlary</code></a>
+     <a href="#"><code>Ocamlary</code></a> <span class="synopsis">This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features. <code>C This text is centered. </code> <code>L This text is left-aligned. </code> <code>R This text is right-aligned. </code> This documentation demonstrates:</span>
     </li>
    </ul>
    <h4 id="weirder-usages-involving-module-types">

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -317,7 +317,7 @@
     </div>
    </div>
    <p>
-    For a good time, see <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a> or <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigB:subSig</code></a> or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="#s9000">Level 9000</a> is also interesting. <a href="#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
+    For a good time, see <code>SuperSig</code>.SubSigA.subSig or <code>SuperSig</code>.SubSigB.subSig or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="#s9000">Level 9000</a> is also interesting. <a href="#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
    </p>
    <div class="odoc-spec">
     <div class="spec module" id="module-Buffer">
@@ -1856,7 +1856,7 @@
      <a href="IncludeInclude1/index.html"><code>Ocamlary.IncludeInclude1</code></a>
     </li>
     <li>
-     <a href="#"><code>Ocamlary</code></a> <span class="synopsis">This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features. <code>C This text is centered. </code> <code>L This text is left-aligned. </code> <code>R This text is right-aligned. </code> This documentation demonstrates:</span>
+     <a href="#"><code>Ocamlary</code></a>
     </li>
    </ul>
    <h4 id="weirder-usages-involving-module-types">
@@ -1918,7 +1918,7 @@
    </p>
    <ul>
     <li>
-     <code>{!section:SuperSig.SubSigA.subSig}</code> : <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a>
+     <code>{!section:SuperSig.SubSigA.subSig}</code> : <code>SuperSig</code>.SubSigA.subSig
     </li>
     <li>
      <code>{!Aliases.incl}</code> : <a href="#incl"><code>Aliases:incl</code></a>
@@ -1935,7 +1935,7 @@
      <code>{{!aliases}B}</code> : <a href="#aliases">B</a>
     </li>
     <li>
-     <code>{{!section:SuperSig.SubSigA.subSig}C}</code> : <a href="module-type-SuperSig/index.html#subSig">C</a>
+     <code>{{!section:SuperSig.SubSigA.subSig}C}</code> : <span class="xref-unresolved">C</span>
     </li>
     <li>
      <code>{{!Aliases.incl}D}</code> : <a href="#incl">D</a>

--- a/test/html/expect/test_package+ml/Toplevel_comments/Alias/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Alias/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Alias (test_package+ml.Toplevel_comments.Alias)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » Alias
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.Alias</span></code>
+   </h1>
+   <p>
+    Doc of <code>Alias</code>.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>T</code>, part 2.
+   </p>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/Alias/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Alias/index.html
@@ -22,6 +22,9 @@
     Module <code><span>Toplevel_comments.Alias</span></code>
    </h1>
    <p>
+    Doc of <code>Alias</code>.
+   </p>
+   <p>
     Doc of <code>T</code>, part 2.
    </p>
   </header>

--- a/test/html/expect/test_package+ml/Toplevel_comments/Alias/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Alias/index.html
@@ -22,13 +22,10 @@
     Module <code><span>Toplevel_comments.Alias</span></code>
    </h1>
    <p>
-    Doc of <code>Alias</code>.
+    Doc of <code>T</code>, part 2.
    </p>
   </header>
   <div class="odoc-content">
-   <p>
-    Doc of <code>T</code>, part 2.
-   </p>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Toplevel_comments/Include_inline'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Include_inline'/index.html
@@ -22,6 +22,9 @@
     Module <code><span>Toplevel_comments.Include_inline'</span></code>
    </h1>
    <p>
+    Doc of <code>Include_inline</code>, part 1.
+   </p>
+   <p>
     Doc of <code>Include_inline</code>, part 2.
    </p>
   </header>

--- a/test/html/expect/test_package+ml/Toplevel_comments/Include_inline'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/Include_inline'/index.html
@@ -22,19 +22,13 @@
     Module <code><span>Toplevel_comments.Include_inline'</span></code>
    </h1>
    <p>
-    Doc of <code>Include_inline</code>, part 1.
+    Doc of <code>Include_inline</code>, part 2.
    </p>
   </header>
   <div class="odoc-content">
-   <p>
-    Doc of <code>Include_inline</code>, part 2.
-   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <p>
-       part 3
-      </p>
       <p>
        Doc of <code>T</code>, part 2.
       </p>

--- a/test/html/expect/test_package+ml/Toplevel_comments/M''/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/M''/index.html
@@ -22,6 +22,9 @@
     Module <code><span>Toplevel_comments.M''</span></code>
    </h1>
    <p>
+    Doc of <code>M''</code>, part 1.
+   </p>
+   <p>
     Doc of <code>M''</code>, part 2.
    </p>
   </header>

--- a/test/html/expect/test_package+ml/Toplevel_comments/M''/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/M''/index.html
@@ -22,13 +22,9 @@
     Module <code><span>Toplevel_comments.M''</span></code>
    </h1>
    <p>
-    Doc of <code>M''</code>, part 1.
-   </p>
-  </header>
-  <div class="odoc-content">
-   <p>
     Doc of <code>M''</code>, part 2.
    </p>
-  </div>
+  </header>
+  <div class="odoc-content"></div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/M''/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/M''/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   M'' (test_package+ml.Toplevel_comments.M'')
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » M''
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.M''</span></code>
+   </h1>
+   <p>
+    Doc of <code>M''</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>M''</code>, part 2.
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/M'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/M'/index.html
@@ -21,9 +21,6 @@
    <h1>
     Module <code><span>Toplevel_comments.M'</span></code>
    </h1>
-   <p>
-    Doc of <code>M'</code> from outside
-   </p>
   </header>
   <div class="odoc-content"></div>
  </body>

--- a/test/html/expect/test_package+ml/Toplevel_comments/M'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/M'/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   M' (test_package+ml.Toplevel_comments.M')
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » M'
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.M'</span></code>
+   </h1>
+   <p>
+    Doc of <code>M'</code> from outside
+   </p>
+  </header>
+  <div class="odoc-content"></div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/M'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/M'/index.html
@@ -21,6 +21,9 @@
    <h1>
     Module <code><span>Toplevel_comments.M'</span></code>
    </h1>
+   <p>
+    Doc of <code>M'</code> from outside
+   </p>
   </header>
   <div class="odoc-content"></div>
  </body>

--- a/test/html/expect/test_package+ml/Toplevel_comments/M/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/M/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   M (test_package+ml.Toplevel_comments.M)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » M
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.M</span></code>
+   </h1>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>M</code>
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/M/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/M/index.html
@@ -21,11 +21,10 @@
    <h1>
     Module <code><span>Toplevel_comments.M</span></code>
    </h1>
-  </header>
-  <div class="odoc-content">
    <p>
     Doc of <code>M</code>
    </p>
-  </div>
+  </header>
+  <div class="odoc-content"></div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/class-c1/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/class-c1/index.html
@@ -24,11 +24,10 @@
    <p>
     Doc of <code>c1</code>, part 1.
    </p>
-  </header>
-  <div class="odoc-content">
    <p>
     Doc of <code>c1</code>, part 2.
    </p>
-  </div>
+  </header>
+  <div class="odoc-content"></div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/class-c1/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/class-c1/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   c1 (test_package+ml.Toplevel_comments.c1)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » c1
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Class <code><span>Toplevel_comments.c1</span></code>
+   </h1>
+   <p>
+    Doc of <code>c1</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>c1</code>, part 2.
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/class-c2/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/class-c2/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   c2 (test_package+ml.Toplevel_comments.c2)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » c2
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Class <code><span>Toplevel_comments.c2</span></code>
+   </h1>
+   <p>
+    Doc of <code>c2</code>.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>ct</code>, part 2.
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/class-c2/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/class-c2/index.html
@@ -24,11 +24,10 @@
    <p>
     Doc of <code>c2</code>.
    </p>
-  </header>
-  <div class="odoc-content">
    <p>
     Doc of <code>ct</code>, part 2.
    </p>
-  </div>
+  </header>
+  <div class="odoc-content"></div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/class-type-ct/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/class-type-ct/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   ct (test_package+ml.Toplevel_comments.ct)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+ml</a> » <a href="../index.html">Toplevel_comments</a> » ct
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Class type <code><span>Toplevel_comments.ct</span></code>
+   </h1>
+   <p>
+    Doc of <code>ct</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>ct</code>, part 2.
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/class-type-ct/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/class-type-ct/index.html
@@ -24,11 +24,10 @@
    <p>
     Doc of <code>ct</code>, part 1.
    </p>
-  </header>
-  <div class="odoc-content">
    <p>
     Doc of <code>ct</code>, part 2.
    </p>
-  </div>
+  </header>
+  <div class="odoc-content"></div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/index.html
@@ -101,6 +101,36 @@
      </p>
     </div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-c1">
+     <a href="#class-c1" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-c1/index.html">c1</a></span><span> : <span>int <span>-&gt;</span></span> <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>c1</code>, part 1.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-ct">
+     <a href="#class-type-ct" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-ct/index.html">ct</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>ct</code>, part 1.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-c2">
+     <a href="#class-c2" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-c2/index.html">c2</a></span><span> : <a href="class-type-ct/index.html">ct</a></span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>c2</code>.
+     </p>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/index.html
@@ -66,6 +66,41 @@
      </p>
     </div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M">
+     <a href="#module-M" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M/index.html">M</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M'">
+     <a href="#module-M'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M'/index.html">M'</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>M'</code> from outside
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M''">
+     <a href="#module-M''" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M''/index.html">M''</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>M''</code>, part 1.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Alias">
+     <a href="#module-Alias" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Alias/index.html">Alias</a></span><span> : <a href="module-type-T/index.html">T</a></span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>Alias</code>.
+     </p>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T'/index.html
@@ -22,6 +22,9 @@
     Module type <code><span>Toplevel_comments.Include_inline_T'</span></code>
    </h1>
    <p>
+    Doc of <code>Include_inline_T'</code>, part 1.
+   </p>
+   <p>
     Doc of <code>Include_inline_T'</code>, part 2.
    </p>
   </header>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T'/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-Include_inline_T'/index.html
@@ -22,19 +22,13 @@
     Module type <code><span>Toplevel_comments.Include_inline_T'</span></code>
    </h1>
    <p>
-    Doc of <code>Include_inline_T'</code>, part 1.
+    Doc of <code>Include_inline_T'</code>, part 2.
    </p>
   </header>
   <div class="odoc-content">
-   <p>
-    Doc of <code>Include_inline_T'</code>, part 2.
-   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <p>
-       part 3
-      </p>
       <p>
        Doc of <code>T</code>, part 2.
       </p>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-T/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-T/index.html
@@ -22,6 +22,9 @@
     Module type <code><span>Toplevel_comments.T</span></code>
    </h1>
    <p>
+    Doc of <code>T</code>, part 1.
+   </p>
+   <p>
     Doc of <code>T</code>, part 2.
    </p>
   </header>

--- a/test/html/expect/test_package+ml/Toplevel_comments/module-type-T/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/module-type-T/index.html
@@ -22,13 +22,10 @@
     Module type <code><span>Toplevel_comments.T</span></code>
    </h1>
    <p>
-    Doc of <code>T</code>, part 1.
+    Doc of <code>T</code>, part 2.
    </p>
   </header>
   <div class="odoc-content">
-   <p>
-    Doc of <code>T</code>, part 2.
-   </p>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+re/Include2/index.html
+++ b/test/html/expect/test_package+re/Include2/index.html
@@ -40,6 +40,9 @@
        <summary>
         <span class="def"><code><span><span class="keyword">include</span> <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <span class="keyword">struct</span> <span class="keyword">include</span> <a href="X/index.html">X</a> <span class="keyword">end</span><span class="keyword">;</span></span></code></span>
        </summary>
+       <p>
+        Comment about X that should not appear when including X below.
+       </p>
        <div class="odoc-spec">
         <div class="spec type" id="type-t">
          <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = int</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
@@ -21,6 +21,9 @@
    <h1>
     Module type <code><span>Include_sections.Something</span></code>
    </h1>
+   <p>
+    A module type.
+   </p>
   </header>
   <nav class="odoc-toc">
    <ul>

--- a/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
+++ b/test/html/expect/test_package+re/Include_sections/module-type-Something/index.html
@@ -21,9 +21,6 @@
    <h1>
     Module type <code><span>Include_sections.Something</span></code>
    </h1>
-   <p>
-    A module type.
-   </p>
   </header>
   <nav class="odoc-toc">
    <ul>

--- a/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
@@ -21,21 +21,18 @@
    <h1>
     Parameter <code><span>F.1-Arg1</span></code>
    </h1>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
-    <li>
-     <a href="#type">Type</a>
-    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
@@ -21,18 +21,11 @@
    <h1>
     Parameter <code><span>F.2-Arg2</span></code>
    </h1>
-  </header>
-  <nav class="odoc-toc">
-   <ul>
-    <li>
-     <a href="#type">Type</a>
-    </li>
-   </ul>
-  </nav>
-  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
+  </header>
+  <div class="odoc-content">
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -21,6 +21,12 @@
    <h1>
     Module <code><span>Nested.F</span></code>
    </h1>
+   <p>
+    This is a functor F.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -21,12 +21,9 @@
    <h1>
     Module <code><span>Nested.F</span></code>
    </h1>
-   <p>
-    This is a functor F.
-   </p>
-   <p>
-    Some additional comments.
-   </p>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
@@ -35,9 +32,6 @@
     </li>
     <li>
      <a href="#signature">Signature</a>
-    </li>
-    <li>
-     <a href="#type">Type</a>
     </li>
    </ul>
   </nav>
@@ -57,9 +51,6 @@
    </div>
    <h2 id="signature">
     <a href="#signature" class="anchor"></a>Signature
-   </h2>
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
    </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -21,27 +21,18 @@
    <h1>
     Module <code><span>Nested.X</span></code>
    </h1>
-   <p>
-    This is module X.
-   </p>
-   <p>
-    Some additional comments.
-   </p>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
-    <li>
-     <a href="#type">Type</a>
-    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -21,6 +21,12 @@
    <h1>
     Module <code><span>Nested.X</span></code>
    </h1>
+   <p>
+    This is module X.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -21,27 +21,18 @@
    <h1>
     Module type <code><span>Nested.Y</span></code>
    </h1>
-   <p>
-    This is module type Y.
-   </p>
-   <p>
-    Some additional comments.
-   </p>
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
-    <li>
-     <a href="#type">Type</a>
-    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -21,6 +21,12 @@
    <h1>
     Module type <code><span>Nested.Y</span></code>
    </h1>
+   <p>
+    This is module type Y.
+   </p>
+   <p>
+    Some additional comments.
+   </p>
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -1873,7 +1873,7 @@
      <a href="IncludeInclude1/index.html"><code>Ocamlary.IncludeInclude1</code></a>
     </li>
     <li>
-     <a href="#"><code>Ocamlary</code></a>
+     <a href="#"><code>Ocamlary</code></a> <span class="synopsis">This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features. <code>C This text is centered. </code> <code>L This text is left-aligned. </code> <code>R This text is right-aligned. </code> This documentation demonstrates:</span>
     </li>
    </ul>
    <h4 id="weirder-usages-involving-module-types">

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -317,7 +317,7 @@
     </div>
    </div>
    <p>
-    For a good time, see <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a> or <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigB:subSig</code></a> or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="#s9000">Level 9000</a> is also interesting. <a href="#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
+    For a good time, see <code>SuperSig</code>.SubSigA.subSig or <code>SuperSig</code>.SubSigB.subSig or <a href="module-type-SuperSig/module-type-EmptySig/index.html"><code>SuperSig.EmptySig</code></a>. Section <a href="#s9000">Level 9000</a> is also interesting. <a href="#exception-EmptySig"><code>EmptySig</code></a> is a general reference but <a href="#emptySig">EmptySig</a> is the section and <a href="module-type-EmptySig/index.html"><code>EmptySig</code></a> is the module signature.
    </p>
    <div class="odoc-spec">
     <div class="spec module" id="module-Buffer">
@@ -1873,7 +1873,7 @@
      <a href="IncludeInclude1/index.html"><code>Ocamlary.IncludeInclude1</code></a>
     </li>
     <li>
-     <a href="#"><code>Ocamlary</code></a> <span class="synopsis">This is an <i>interface</i> with <b>all</b> of the <em>module system</em> features. <code>C This text is centered. </code> <code>L This text is left-aligned. </code> <code>R This text is right-aligned. </code> This documentation demonstrates:</span>
+     <a href="#"><code>Ocamlary</code></a>
     </li>
    </ul>
    <h4 id="weirder-usages-involving-module-types">
@@ -1935,7 +1935,7 @@
    </p>
    <ul>
     <li>
-     <code>{!section:SuperSig.SubSigA.subSig}</code> : <a href="module-type-SuperSig/index.html#subSig"><code>SuperSig.SubSigA:subSig</code></a>
+     <code>{!section:SuperSig.SubSigA.subSig}</code> : <code>SuperSig</code>.SubSigA.subSig
     </li>
     <li>
      <code>{!Aliases.incl}</code> : <a href="#incl"><code>Aliases:incl</code></a>
@@ -1952,7 +1952,7 @@
      <code>{{!aliases}B}</code> : <a href="#aliases">B</a>
     </li>
     <li>
-     <code>{{!section:SuperSig.SubSigA.subSig}C}</code> : <a href="module-type-SuperSig/index.html#subSig">C</a>
+     <code>{{!section:SuperSig.SubSigA.subSig}C}</code> : <span class="xref-unresolved">C</span>
     </li>
     <li>
      <code>{{!Aliases.incl}D}</code> : <a href="#incl">D</a>

--- a/test/html/expect/test_package+re/Toplevel_comments/Alias/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Alias/index.html
@@ -22,6 +22,9 @@
     Module <code><span>Toplevel_comments.Alias</span></code>
    </h1>
    <p>
+    Doc of <code>Alias</code>.
+   </p>
+   <p>
     Doc of <code>T</code>, part 2.
    </p>
   </header>

--- a/test/html/expect/test_package+re/Toplevel_comments/Alias/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Alias/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   Alias (test_package+re.Toplevel_comments.Alias)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » Alias
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.Alias</span></code>
+   </h1>
+   <p>
+    Doc of <code>Alias</code>.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>T</code>, part 2.
+   </p>
+   <div class="odoc-spec">
+    <div class="spec type" id="type-t">
+     <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/Alias/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Alias/index.html
@@ -22,13 +22,10 @@
     Module <code><span>Toplevel_comments.Alias</span></code>
    </h1>
    <p>
-    Doc of <code>Alias</code>.
+    Doc of <code>T</code>, part 2.
    </p>
   </header>
   <div class="odoc-content">
-   <p>
-    Doc of <code>T</code>, part 2.
-   </p>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Toplevel_comments/Include_inline'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Include_inline'/index.html
@@ -22,6 +22,9 @@
     Module <code><span>Toplevel_comments.Include_inline'</span></code>
    </h1>
    <p>
+    Doc of <code>Include_inline</code>, part 1.
+   </p>
+   <p>
     Doc of <code>Include_inline</code>, part 2.
    </p>
   </header>

--- a/test/html/expect/test_package+re/Toplevel_comments/Include_inline'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/Include_inline'/index.html
@@ -22,19 +22,13 @@
     Module <code><span>Toplevel_comments.Include_inline'</span></code>
    </h1>
    <p>
-    Doc of <code>Include_inline</code>, part 1.
+    Doc of <code>Include_inline</code>, part 2.
    </p>
   </header>
   <div class="odoc-content">
-   <p>
-    Doc of <code>Include_inline</code>, part 2.
-   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <p>
-       part 3
-      </p>
       <p>
        Doc of <code>T</code>, part 2.
       </p>

--- a/test/html/expect/test_package+re/Toplevel_comments/M''/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/M''/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   M'' (test_package+re.Toplevel_comments.M'')
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » M''
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.M''</span></code>
+   </h1>
+   <p>
+    Doc of <code>M''</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>M''</code>, part 2.
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/M''/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/M''/index.html
@@ -22,6 +22,9 @@
     Module <code><span>Toplevel_comments.M''</span></code>
    </h1>
    <p>
+    Doc of <code>M''</code>, part 1.
+   </p>
+   <p>
     Doc of <code>M''</code>, part 2.
    </p>
   </header>

--- a/test/html/expect/test_package+re/Toplevel_comments/M''/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/M''/index.html
@@ -22,13 +22,9 @@
     Module <code><span>Toplevel_comments.M''</span></code>
    </h1>
    <p>
-    Doc of <code>M''</code>, part 1.
-   </p>
-  </header>
-  <div class="odoc-content">
-   <p>
     Doc of <code>M''</code>, part 2.
    </p>
-  </div>
+  </header>
+  <div class="odoc-content"></div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Toplevel_comments/M'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/M'/index.html
@@ -21,9 +21,6 @@
    <h1>
     Module <code><span>Toplevel_comments.M'</span></code>
    </h1>
-   <p>
-    Doc of <code>M'</code> from outside
-   </p>
   </header>
   <div class="odoc-content"></div>
  </body>

--- a/test/html/expect/test_package+re/Toplevel_comments/M'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/M'/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   M' (test_package+re.Toplevel_comments.M')
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » M'
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.M'</span></code>
+   </h1>
+   <p>
+    Doc of <code>M'</code> from outside
+   </p>
+  </header>
+  <div class="odoc-content"></div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/M'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/M'/index.html
@@ -21,6 +21,9 @@
    <h1>
     Module <code><span>Toplevel_comments.M'</span></code>
    </h1>
+   <p>
+    Doc of <code>M'</code> from outside
+   </p>
   </header>
   <div class="odoc-content"></div>
  </body>

--- a/test/html/expect/test_package+re/Toplevel_comments/M/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/M/index.html
@@ -21,11 +21,10 @@
    <h1>
     Module <code><span>Toplevel_comments.M</span></code>
    </h1>
-  </header>
-  <div class="odoc-content">
    <p>
     Doc of <code>M</code>
    </p>
-  </div>
+  </header>
+  <div class="odoc-content"></div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Toplevel_comments/M/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/M/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   M (test_package+re.Toplevel_comments.M)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » M
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Module <code><span>Toplevel_comments.M</span></code>
+   </h1>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>M</code>
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/class-c1/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/class-c1/index.html
@@ -24,11 +24,10 @@
    <p>
     Doc of <code>c1</code>, part 1.
    </p>
-  </header>
-  <div class="odoc-content">
    <p>
     Doc of <code>c1</code>, part 2.
    </p>
-  </div>
+  </header>
+  <div class="odoc-content"></div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Toplevel_comments/class-c1/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/class-c1/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   c1 (test_package+re.Toplevel_comments.c1)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » c1
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Class <code><span>Toplevel_comments.c1</span></code>
+   </h1>
+   <p>
+    Doc of <code>c1</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>c1</code>, part 2.
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/class-c2/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/class-c2/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   c2 (test_package+re.Toplevel_comments.c2)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » c2
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Class <code><span>Toplevel_comments.c2</span></code>
+   </h1>
+   <p>
+    Doc of <code>c2</code>.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>ct</code>, part 2.
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/class-c2/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/class-c2/index.html
@@ -24,11 +24,10 @@
    <p>
     Doc of <code>c2</code>.
    </p>
-  </header>
-  <div class="odoc-content">
    <p>
     Doc of <code>ct</code>, part 2.
    </p>
-  </div>
+  </header>
+  <div class="odoc-content"></div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Toplevel_comments/class-type-ct/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/class-type-ct/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>
+   ct (test_package+re.Toplevel_comments.ct)
+  </title>
+  <link rel="stylesheet" href="../../../odoc.css">
+  <meta charset="utf-8">
+  <meta name="generator" content="odoc %%VERSION%%">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <script src="../../../highlight.pack.js"></script>
+  <script>
+   hljs.initHighlightingOnLoad();
+  </script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav">
+   <a href="../index.html">Up</a> – <a href="../../index.html">test_package+re</a> » <a href="../index.html">Toplevel_comments</a> » ct
+  </nav>
+  <header class="odoc-preamble">
+   <h1>
+    Class type <code><span>Toplevel_comments.ct</span></code>
+   </h1>
+   <p>
+    Doc of <code>ct</code>, part 1.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <p>
+    Doc of <code>ct</code>, part 2.
+   </p>
+  </div>
+ </body>
+</html>

--- a/test/html/expect/test_package+re/Toplevel_comments/class-type-ct/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/class-type-ct/index.html
@@ -24,11 +24,10 @@
    <p>
     Doc of <code>ct</code>, part 1.
    </p>
-  </header>
-  <div class="odoc-content">
    <p>
     Doc of <code>ct</code>, part 2.
    </p>
-  </div>
+  </header>
+  <div class="odoc-content"></div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Toplevel_comments/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/index.html
@@ -66,6 +66,41 @@
      </p>
     </div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M">
+     <a href="#module-M" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M/index.html">M</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M'">
+     <a href="#module-M'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M'/index.html">M'</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>M'</code> from outside
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-M''">
+     <a href="#module-M''" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M''/index.html">M''</a></span><span>: { ... }</span><span>;</span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>M''</code>, part 1.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Alias">
+     <a href="#module-Alias" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Alias/index.html">Alias</a></span><span>: <a href="module-type-T/index.html">T</a></span><span>;</span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>Alias</code>.
+     </p>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Toplevel_comments/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/index.html
@@ -101,6 +101,36 @@
      </p>
     </div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-c1">
+     <a href="#class-c1" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-c1/index.html">c1</a></span><span>: <span>int <span>=&gt;</span></span> { ... }</span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>c1</code>, part 1.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec class-type" id="class-type-ct">
+     <a href="#class-type-ct" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-ct/index.html">ct</a></span><span> = { ... }</span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>ct</code>, part 1.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec class" id="class-c2">
+     <a href="#class-c2" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-c2/index.html">c2</a></span><span>: <a href="class-type-ct/index.html">ct</a></span></code>
+    </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>c2</code>.
+     </p>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T'/index.html
@@ -22,6 +22,9 @@
     Module type <code><span>Toplevel_comments.Include_inline_T'</span></code>
    </h1>
    <p>
+    Doc of <code>Include_inline_T'</code>, part 1.
+   </p>
+   <p>
     Doc of <code>Include_inline_T'</code>, part 2.
    </p>
   </header>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T'/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-Include_inline_T'/index.html
@@ -22,19 +22,13 @@
     Module type <code><span>Toplevel_comments.Include_inline_T'</span></code>
    </h1>
    <p>
-    Doc of <code>Include_inline_T'</code>, part 1.
+    Doc of <code>Include_inline_T'</code>, part 2.
    </p>
   </header>
   <div class="odoc-content">
-   <p>
-    Doc of <code>Include_inline_T'</code>, part 2.
-   </p>
    <div class="odoc-include">
     <div class="spec include">
      <div class="doc">
-      <p>
-       part 3
-      </p>
       <p>
        Doc of <code>T</code>, part 2.
       </p>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-T/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-T/index.html
@@ -22,6 +22,9 @@
     Module type <code><span>Toplevel_comments.T</span></code>
    </h1>
    <p>
+    Doc of <code>T</code>, part 1.
+   </p>
+   <p>
     Doc of <code>T</code>, part 2.
    </p>
   </header>

--- a/test/html/expect/test_package+re/Toplevel_comments/module-type-T/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/module-type-T/index.html
@@ -22,13 +22,10 @@
     Module type <code><span>Toplevel_comments.T</span></code>
    </h1>
    <p>
-    Doc of <code>T</code>, part 1.
+    Doc of <code>T</code>, part 2.
    </p>
   </header>
   <div class="odoc-content">
-   <p>
-    Doc of <code>T</code>, part 2.
-   </p>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -289,6 +289,9 @@ let source_files_all =
         "M'";
         "M''";
         "Alias";
+        "class-c1";
+        "class-type-ct";
+        "class-c2";
       ];
   ]
 

--- a/test/html/test.ml
+++ b/test/html/test.ml
@@ -285,6 +285,10 @@ let source_files_all =
         "Include_inline'";
         "module-type-Include_inline_T";
         "module-type-Include_inline_T'";
+        "M";
+        "M'";
+        "M''";
+        "Alias";
       ];
   ]
 

--- a/test/latex/expect/test_package+ml/Include2.tex
+++ b/test/latex/expect/test_package+ml/Include2.tex
@@ -3,6 +3,8 @@
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Comment about X that should not appear when including X below.\end{ocamlindent}%
 \medbreak
-\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[container-page-test+u+package+++ml-module-Include2-module-X]{\ocamlinlinecode{X}} \ocamltag{keyword}{end}\label{container-page-test+u+package+++ml-module-Include2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = int}\\
+\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[container-page-test+u+package+++ml-module-Include2-module-X]{\ocamlinlinecode{X}} \ocamltag{keyword}{end}Comment about X that should not appear when including X below.
+
+\label{container-page-test+u+package+++ml-module-Include2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = int}\\
 
 

--- a/test/latex/expect/test_package+ml/Nested.F.tex
+++ b/test/latex/expect/test_package+ml/Nested.F.tex
@@ -1,24 +1,18 @@
 \section{Module \ocamlinlinecode{Nested.\allowbreak{}F}}\label{container-page-test+u+package+++ml-module-Nested-module-F}%
-This is a functor F.
-
-Some additional comments.
-
+\subsection{Type\label{type}}%
 \subsection{Parameters\label{parameters}}%
-\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1]{\ocamlinlinecode{Arg1}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
-\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
+\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1]{\ocamlinlinecode{Arg1}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \subsubsection{Values\label{values}}%
 \label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1-val-y}\ocamlcodefragment{\ocamltag{keyword}{val} y : \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1-type-t]{\ocamlinlinecode{t}}}\begin{ocamlindent}The value of y.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2]{\ocamlinlinecode{Arg2}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
-\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
+\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2]{\ocamlinlinecode{Arg2}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \subsection{Signature\label{signature}}%
-\subsection{Type\label{type}}%
 \label{container-page-test+u+package+++ml-module-Nested-module-F-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1-type-t]{\ocamlinlinecode{Arg1.\allowbreak{}t}} * \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2-type-t]{\ocamlinlinecode{Arg2.\allowbreak{}t}}}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 

--- a/test/latex/expect/test_package+ml/Nested.F.tex
+++ b/test/latex/expect/test_package+ml/Nested.F.tex
@@ -1,4 +1,8 @@
 \section{Module \ocamlinlinecode{Nested.\allowbreak{}F}}\label{container-page-test+u+package+++ml-module-Nested-module-F}%
+This is a functor F.
+
+Some additional comments.
+
 \subsection{Type\label{type}}%
 \subsection{Parameters\label{parameters}}%
 \label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1]{\ocamlinlinecode{Arg1}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%

--- a/test/latex/expect/test_package+ml/Nested.tex
+++ b/test/latex/expect/test_package+ml/Nested.tex
@@ -2,8 +2,7 @@
 This comment needs to be here before \#235 is fixed.
 
 \subsection{Module\label{module}}%
-\label{container-page-test+u+package+++ml-module-Nested-module-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
-\label{container-page-test+u+package+++ml-module-Nested-module-X-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
+\label{container-page-test+u+package+++ml-module-Nested-module-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{container-page-test+u+package+++ml-module-Nested-module-X-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \subsubsection{Values\label{values}}%
 \label{container-page-test+u+package+++ml-module-Nested-module-X-val-x}\ocamlcodefragment{\ocamltag{keyword}{val} x : \hyperref[container-page-test+u+package+++ml-module-Nested-module-X-type-t]{\ocamlinlinecode{t}}}\begin{ocamlindent}The value of x.\end{ocamlindent}%
@@ -12,8 +11,7 @@ This comment needs to be here before \#235 is fixed.
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}This is module X.\end{ocamlindent}%
 \medbreak
 \subsection{Module type\label{module-type}}%
-\label{container-page-test+u+package+++ml-module-Nested-module-type-Y}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[container-page-test+u+package+++ml-module-Nested-module-type-Y]{\ocamlinlinecode{Y}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
-\label{container-page-test+u+package+++ml-module-Nested-module-type-Y-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
+\label{container-page-test+u+package+++ml-module-Nested-module-type-Y}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[container-page-test+u+package+++ml-module-Nested-module-type-Y]{\ocamlinlinecode{Y}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{container-page-test+u+package+++ml-module-Nested-module-type-Y-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \subsubsection{Values\label{values}}%
 \label{container-page-test+u+package+++ml-module-Nested-module-type-Y-val-y}\ocamlcodefragment{\ocamltag{keyword}{val} y : \hyperref[container-page-test+u+package+++ml-module-Nested-module-type-Y-type-t]{\ocamlinlinecode{t}}}\begin{ocamlindent}The value of y.\end{ocamlindent}%

--- a/test/man/expect/test_package+ml/Include2.3o
+++ b/test/man/expect/test_package+ml/Include2.3o
@@ -18,4 +18,8 @@ test_package+ml\.Include2
 Comment about X that should not appear when including X below\.
 .nf 
 .sp 
+.fi 
+Comment about X that should not appear when including X below\.
+.nf 
+.sp 
 \f[CB]type\fR t = int

--- a/test/man/expect/test_package+ml/Nested.3o
+++ b/test/man/expect/test_package+ml/Nested.3o
@@ -19,7 +19,7 @@ This comment needs to be here before #235 is fixed\.
 \fB1 Module\fR
 .in 
 .sp 
-\f[CB]module\fR X :  \f[CB]sig\fR \.\.\. \f[CB]end\fR
+\f[CB]module\fR X : \f[CB]sig\fR \.\.\. \f[CB]end\fR
 .fi 
 .br 
 .ti +2
@@ -33,11 +33,6 @@ This is module X\.
 \f[CB]module\fR \f[CB]type\fR Y = \f[CB]sig\fR
 .br 
 .ti +2
-.sp 
-.ti +2
-\fB2\.1\.1 Type\fR
-.sp 
-.ti +2
 \f[CB]type\fR t
 .fi 
 .br 
@@ -46,7 +41,7 @@ Some type\.
 .nf 
 .sp 
 .ti +2
-\fB2\.1\.2 Values\fR
+\fB2\.1\.1 Values\fR
 .sp 
 .ti +2
 \f[CB]val\fR y : t
@@ -68,7 +63,7 @@ This is module type Y\.
 \fB3 Functor\fR
 .in 
 .sp 
-\f[CB]module\fR F (Arg1 : Y) (Arg2 : \f[CB]sig\fR \.\.\. \f[CB]end\fR) :  \f[CB]sig\fR \.\.\. \f[CB]end\fR
+\f[CB]module\fR F (Arg1 : Y) (Arg2 : \f[CB]sig\fR \.\.\. \f[CB]end\fR) : \f[CB]sig\fR \.\.\. \f[CB]end\fR
 .fi 
 .br 
 .ti +2

--- a/test/man/expect/test_package+ml/Nested.F.3o
+++ b/test/man/expect/test_package+ml/Nested.F.3o
@@ -8,6 +8,14 @@ test_package+ml\.Nested\.F
 \fBModule Nested\.F\fR
 .in 
 .sp 
+.fi 
+This is a functor F\.
+.nf 
+.sp 
+.fi 
+Some additional comments\.
+.nf 
+.sp 
 .in 3
 \fB3 Type\fR
 .in 

--- a/test/man/expect/test_package+ml/Nested.F.3o
+++ b/test/man/expect/test_package+ml/Nested.F.3o
@@ -8,13 +8,10 @@ test_package+ml\.Nested\.F
 \fBModule Nested\.F\fR
 .in 
 .sp 
-.fi 
-This is a functor F\.
-.nf 
+.in 3
+\fB3 Type\fR
+.in 
 .sp 
-.fi 
-Some additional comments\.
-.nf 
 .SH Documentation
 .sp 
 .nf 
@@ -26,11 +23,6 @@ Some additional comments\.
 \f[CB]module\fR Arg1 : \f[CB]sig\fR
 .br 
 .ti +2
-.sp 
-.ti +2
-\fB1\.1\.1 Type\fR
-.sp 
-.ti +2
 \f[CB]type\fR t
 .fi 
 .br 
@@ -39,7 +31,7 @@ Some type\.
 .nf 
 .sp 
 .ti +2
-\fB1\.1\.2 Values\fR
+\fB1\.1\.1 Values\fR
 .sp 
 .ti +2
 \f[CB]val\fR y : t
@@ -55,11 +47,6 @@ The value of y\.
 \f[CB]module\fR Arg2 : \f[CB]sig\fR
 .br 
 .ti +2
-.sp 
-.ti +2
-\fB1\.1\.3 Type\fR
-.sp 
-.ti +2
 \f[CB]type\fR t
 .fi 
 .br 
@@ -72,10 +59,6 @@ Some type\.
 .sp 
 .in 3
 \fB2 Signature\fR
-.in 
-.sp 
-.in 3
-\fB3 Type\fR
 .in 
 .sp 
 \f[CB]type\fR t = Arg1\.t * Arg2\.t

--- a/test/man/expect/test_package+ml/Nested.X.3o
+++ b/test/man/expect/test_package+ml/Nested.X.3o
@@ -8,6 +8,14 @@ test_package+ml\.Nested\.X
 \fBModule Nested\.X\fR
 .in 
 .sp 
+.fi 
+This is module X\.
+.nf 
+.sp 
+.fi 
+Some additional comments\.
+.nf 
+.sp 
 .in 3
 \fB2 Type\fR
 .in 

--- a/test/man/expect/test_package+ml/Nested.X.3o
+++ b/test/man/expect/test_package+ml/Nested.X.3o
@@ -8,21 +8,13 @@ test_package+ml\.Nested\.X
 \fBModule Nested\.X\fR
 .in 
 .sp 
-.fi 
-This is module X\.
-.nf 
+.in 3
+\fB2 Type\fR
+.in 
 .sp 
-.fi 
-Some additional comments\.
-.nf 
 .SH Documentation
 .sp 
 .nf 
-.sp 
-.in 3
-\fB1 Type\fR
-.in 
-.sp 
 \f[CB]type\fR t
 .fi 
 .br 
@@ -31,7 +23,7 @@ Some type\.
 .nf 
 .sp 
 .in 3
-\fB2 Values\fR
+\fB1 Values\fR
 .in 
 .sp 
 \f[CB]val\fR x : t

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -598,7 +598,6 @@ let my_compilation_unit id s =
     { Odoc_model.Lang.Compilation_unit.
       id = id
     ; root = root
-    ; doc = []
     ; digest = "nodigest"
     ; imports = []
     ; source = None

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -71,7 +71,7 @@ let model_of_string_impl str =
 
 let signature_of_mli_string str =
     Odoc_xref2.Ident.reset ();
-    let _, _, sg = model_of_string str in
+    let _, sg = model_of_string str in
     sg
 
 let string_of_file f =
@@ -594,11 +594,11 @@ module LangUtils = struct
 
 end
 
-let my_compilation_unit id docs s =
+let my_compilation_unit id s =
     { Odoc_model.Lang.Compilation_unit.
       id = id
     ; root = root
-    ; doc = docs
+    ; doc = []
     ; digest = "nodigest"
     ; imports = []
     ; source = None
@@ -628,6 +628,6 @@ let resolve unit =
 
 
 let resolve_from_string s =
-    let id, docs, sg = model_of_string s in
-    let unit = my_compilation_unit id docs sg in
+    let id, sg = model_of_string s in
+    let unit = my_compilation_unit id sg in
     resolve unit

--- a/test/xref2/module_list.t/main.mli
+++ b/test/xref2/module_list.t/main.mli
@@ -14,22 +14,29 @@ module Internal : sig
       @canonical Main.C1 *)
 
   module C2 : sig
+
     (* Doc for [C2]. *)
   end
   (** @canonical Main.C2 *)
 end
 
 module Z : sig
+
   (** Doc for [Z]. *)
 end
 
 module F () : sig
+
   (** Doc for [F ()]. *)
 end
 
 module Type_of : module type of F ()
 
+(* Without the extra blank lines in sig/struct, OCaml<4.06 doesn't see the doc
+   comments. *)
+
 module Type_of_str : module type of struct
+
   (** Doc of [Type_of_str]. *)
 end
 

--- a/test/xref2/module_list.t/main.mli
+++ b/test/xref2/module_list.t/main.mli
@@ -1,10 +1,51 @@
-(** {!modules: External External.X Main Internal Internal.Y} *)
+(** {!modules:External External.X Main Internal Internal.Y Z F Type_of
+    Type_of_str With_type Alias C1 C2 Inline_include} *)
 
 (** Doc for [Internal].
 
     An other paragraph*)
 module Internal : sig
-
-  (** Doc for Internal.[X]. An other sentence. *)
   module Y : sig end
+  (** Doc for Internal.[X]. An other sentence. *)
+
+  module C1 : sig end
+  (** Doc for [C1].
+
+      @canonical Main.C1 *)
+
+  module C2 : sig
+    (* Doc for [C2]. *)
+  end
+  (** @canonical Main.C2 *)
+end
+
+module Z : sig
+  (** Doc for [Z]. *)
+end
+
+module F () : sig
+  (** Doc for [F ()]. *)
+end
+
+module Type_of : module type of F ()
+
+module Type_of_str : module type of struct
+  (** Doc of [Type_of_str]. *)
+end
+
+module type T = sig
+  (** Doc for [T]. *)
+
+  type t
+end
+
+module With_type : T with type t = int
+
+module Alias = External.X
+module C1 = Internal.C1
+module C2 = Internal.C2
+
+module Inline_include : sig
+  include T
+  (** @inline *)
 end

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -6,7 +6,7 @@ Everything should resolve:
 
   $ odoc_print main.odocl | jq -c '.. | .["`Modules"]? | select(.) | .[] | .[]'
   {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}}}
-  "None"
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"External"},{"`Word":"."}]}
   {"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]}}
   {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"X"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Main"]}}}
@@ -16,15 +16,15 @@ Everything should resolve:
   {"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"Y"]}}
   {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Word":"Internal."},{"`Code_span":"X"},{"`Word":"."},"`Space",{"`Word":"An"},"`Space",{"`Word":"other"},"`Space",{"`Word":"sentence."}]}
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Z"]}}}
-  "None"
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"Z"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"F"]}}}
-  "None"
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"F ()"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Type_of"]}}}
   "None"
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Type_of_str"]}}}
-  "None"
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"of"},"`Space",{"`Code_span":"Type_of_str"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"With_type"]}}}
-  "None"
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"T"},{"`Word":"."}]}
   {"`Resolved":{"`SubstAlias":[{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]},{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Alias"]}}]}}
   "None"
   {"`Resolved":{"`SubstAlias":[{"`Canonical":[{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"C1"]},{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"C1"]}}}]},{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"C1"]}}]}}

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -6,7 +6,7 @@ Everything should resolve:
 
   $ odoc_print main.odocl | jq -c '.. | .["`Modules"]? | select(.) | .[] | .[]'
   {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"External"},{"`Word":"."}]}
+  "None"
   {"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]}}
   {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"X"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Main"]}}}

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -4,62 +4,34 @@
 
 Everything should resolve:
 
-  $ odoc_print main.odocl | jq -c '.. | .["`Modules"]? | select(.) | .[]'
-  [{"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"External"},{"`Word":"."}]}]
-  [{"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"X"},{"`Word":"."}]}]
-  [{"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Main"]}}},"None"]
-  [{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"Internal"},{"`Word":"."}]}]
-  [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"Y"]}},{"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Word":"Internal."},{"`Code_span":"X"},{"`Word":"."},"`Space",{"`Word":"An"},"`Space",{"`Word":"other"},"`Space",{"`Word":"sentence."}]}]
+  $ odoc_print main.odocl | jq -c '.. | .["`Modules"]? | select(.) | .[] | .[]'
+  {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}}}
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"External"},{"`Word":"."}]}
+  {"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]}}
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"X"},{"`Word":"."}]}
+  {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Main"]}}}
+  "None"
+  {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}}}
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"Internal"},{"`Word":"."}]}
+  {"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"Y"]}}
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Word":"Internal."},{"`Code_span":"X"},{"`Word":"."},"`Space",{"`Word":"An"},"`Space",{"`Word":"other"},"`Space",{"`Word":"sentence."}]}
+  {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Z"]}}}
+  "None"
+  {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"F"]}}}
+  "None"
+  {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Type_of"]}}}
+  "None"
+  {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Type_of_str"]}}}
+  "None"
+  {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"With_type"]}}}
+  "None"
+  {"`Resolved":{"`SubstAlias":[{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"External"]}},"X"]},{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Alias"]}}]}}
+  "None"
+  {"`Resolved":{"`SubstAlias":[{"`Canonical":[{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"C1"]},{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"C1"]}}}]},{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"C1"]}}]}}
+  "None"
+  {"`Resolved":{"`SubstAlias":[{"`Canonical":[{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Internal"]}},"C2"]},{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"C2"]}}}]},{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"C2"]}}]}}
+  "None"
+  {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Inline_include"]}}}
+  "None"
 
-As HTML, should render as a description list.
-
-  $ odoc html-generate --indent -o html main.odocl
-
-  $ cat html/test/Main/index.html
-  <!DOCTYPE html>
-  <html xmlns="http://www.w3.org/1999/xhtml">
-   <head><title>Main (test.Main)</title>
-    <link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/>
-    <meta name="generator" content="odoc %%VERSION%%"/>
-    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
-    <script src="../../highlight.pack.js"></script>
-    <script>hljs.initHighlightingOnLoad();</script>
-   </head>
-   <body class="odoc">
-    <nav class="odoc-nav"><a href="../index.html">Up</a> – 
-     <a href="../index.html">test</a> &#x00BB; Main
-    </nav>
-    <header class="odoc-preamble">
-     <h1>Module <code><span>Main</span></code></h1>
-     <ul class="modules">
-      <li><a href="../External/index.html"><code>External</code></a> 
-       <span class="synopsis">Doc for <code>External</code>.</span>
-      </li>
-      <li><a href="../External/X/index.html"><code>External.X</code></a>
-        <span class="synopsis">Doc for <code>X</code>.</span>
-      </li><li><a href="#"><code>Main</code></a> </li>
-      <li><a href="Internal/index.html"><code>Internal</code></a> 
-       <span class="synopsis">Doc for <code>Internal</code>.</span>
-      </li>
-      <li><a href="Internal/Y/index.html"><code>Internal.Y</code></a> 
-       <span class="synopsis">Doc for Internal.<code>X</code>. An other
-         sentence.
-       </span>
-      </li>
-     </ul>
-    </header>
-    <div class="odoc-content">
-     <div class="odoc-spec">
-      <div class="spec module" id="module-Internal" class="anchored">
-       <a href="#module-Internal" class="anchor"></a>
-       <code><span><span class="keyword">module</span> </span>
-        <span><a href="Internal/index.html">Internal</a></span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
-      </div><div class="spec-doc"><p>Doc for <code>Internal</code>.</p></div>
-     </div>
-    </div>
-   </body>
-  </html>
+'Type_of' and 'Alias' don't have a summary. `C1` and `C2` neither, we expect at least `C2` to have one.

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -41,7 +41,6 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
      <a href="../index.html">test</a> &#x00BB; A
     </nav>
     <header class="odoc-preamble"><h1>Module <code><span>A</span></code></h1>
-     <p>Module A.</p>
     </header>
     <div class="odoc-content">
      <div class="odoc-spec">
@@ -77,7 +76,6 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
       &#x00BB; B
     </nav>
     <header class="odoc-preamble"><h1>Module <code><span>A.B</span></code></h1>
-     <p>Module B.</p><p>Some documentation.</p>
     </header>
     <div class="odoc-content">
      <div class="odoc-spec">
@@ -107,8 +105,7 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
      <a href="../index.html">test</a> &#x00BB; A__b
     </nav>
     <header class="odoc-preamble">
-     <h1>Module <code><span>A__b</span></code></h1><p>Module B.</p>
-     <p>Some documentation.</p>
+     <h1>Module <code><span>A__b</span></code></h1>
     </header><div class="odoc-content"></div>
    </body>
   </html>

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -41,6 +41,7 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
      <a href="../index.html">test</a> &#x00BB; A
     </nav>
     <header class="odoc-preamble"><h1>Module <code><span>A</span></code></h1>
+     <p>Module A.</p>
     </header>
     <div class="odoc-content">
      <div class="odoc-spec">
@@ -76,6 +77,7 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
       &#x00BB; B
     </nav>
     <header class="odoc-preamble"><h1>Module <code><span>A.B</span></code></h1>
+     <p>Module B.</p><p>Some documentation.</p>
     </header>
     <div class="odoc-content">
      <div class="odoc-spec">

--- a/test/xref2/references_scope.t/run.t
+++ b/test/xref2/references_scope.t/run.t
@@ -7,8 +7,8 @@
 The references from a.mli, see the attached text to recognize them:
 
   $ odoc_print a.odocl | jq_scan_references
-  [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"A"]},"B"]}},"C"]}},[{"`Word":"Doc-relative"}]]
-  [{"`Resolved":{"`Module":[{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"A"]}},"B"]},"C"]}},[{"`Word":"Doc-absolute"}]]
   [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"A"]},"B"]}},"C"]}},[{"`Word":"Defined-below"}]]
   [{"`Resolved":{"`Module":[{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"A"]}},"B"]},"C"]}},[{"`Word":"Defined-below-but-absolute"}]]
   [{"`Root":["C","`TUnknown"]},[{"`Word":"Through-open"}]]
+  [{"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"A"]},"B"]}},"C"]}},[{"`Word":"Doc-relative"}]]
+  [{"`Resolved":{"`Module":[{"`Module":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"A"]}},"B"]},"C"]}},[{"`Word":"Doc-absolute"}]]

--- a/test/xref2/references_to_pages.t/bad_references.mli
+++ b/test/xref2/references_to_pages.t/bad_references.mli
@@ -1,4 +1,5 @@
-(** *)
+(* Make sure that the next doc comment is not the top-comment. *)
+type t
 
 (** Page not found: {!page-not_found} *)
 


### PR DESCRIPTION
Before this PR, the top-comment of a signature was handled unevenly and sometimes dropped.
This PR improves how the top-comment is passed and implement [@lpw25's suggestion](https://github.com/ocaml/odoc/issues/478#issuecomment-762744498).

An issue remain in <https://github.com/ocaml/odoc/issues/478>, the documentation from an `@inline` include is not in the preamble and is not used for the synopsis due to being handled too late. This will be fixed in a follow-up PR.
