### PR TITLE
Include headings in synopsis

### DIFF
--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -25,13 +25,17 @@ let synopsis_from_comment docs =
     match elem.value with
     | `Paragraph p -> Some p
     | `List (_, items) -> list_find_map (list_find_map from_element) items
-    | _ -> None
+    | `Verbatim _ | `Code_block _ | `Modules _ ->
+        (* Skip some elements *)
+        None
   in
   list_find_map
     (function
       | { value = #Comment.nestable_block_element; _ } as elem ->
           from_element elem
-      | _ -> None)
+      | { value = `Heading (_, _, p); _ } ->
+          Some (p : Comment.link_content :> Comment.paragraph)
+      | { value = `Tag _; _ } -> None)
     docs
 
 exception Loop

--- a/test/xref2/module_list.t/main.mli
+++ b/test/xref2/module_list.t/main.mli
@@ -1,5 +1,5 @@
 (** {!modules:External External.X Main Internal Internal.Y Z F Type_of
-    Type_of_str With_type Alias C1 C2 Inline_include} *)
+    Type_of_str With_type Alias C1 C2 Inline_include Heading} *)
 
 (** Doc for [Internal].
 
@@ -56,3 +56,8 @@ module Inline_include : sig
   include T
   (** @inline *)
 end
+
+module Heading : sig end
+(** {1 Heading}
+
+    The synopsis is the heading's text. *)

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -33,5 +33,7 @@ Everything should resolve:
   "None"
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Inline_include"]}}}
   "None"
+  {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Heading"]}}}
+  {"Some":[{"`Word":"Heading"}]}
 
 'Type_of' and 'Alias' don't have a summary. `C1` and `C2` neither, we expect at least `C2` to have one.


### PR DESCRIPTION
Heading were skipped while computing the synopsis for a module. Now the heading's text is used when it's the first element.

In the examples from https://github.com/ocaml/odoc/issues/235, the `CCArray` module wouldn't have a synopsis in `{!modules:...}` lists. This PR doesn't answer the rest of the discussion.