### PR TITLE
Skip opens when looking up the top-comment

### DIFF
--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -128,9 +128,13 @@ let standalone_multiple parent attrs =
   in
     List.rev coms
 
-let extract_top_comment items =
+let rec extract_top_comment items =
   match items with
   | Lang.Signature.Comment (`Docs doc) :: tl -> (tl, doc)
+  | (Open _ as skipped) :: tl ->
+      (* Skip opens *)
+      let items, doc = extract_top_comment tl in
+      (skipped :: items, doc)
   | _ -> (items, empty)
 
 let extract_top_comment_class items =

--- a/test/xref2/module_list.t/external.mli
+++ b/test/xref2/module_list.t/external.mli
@@ -1,4 +1,4 @@
 (** Doc for [External]. *)
 
 (** Doc for [X]. *)
-module X : sig end
+module X : sig type t end

--- a/test/xref2/module_list.t/main.mli
+++ b/test/xref2/module_list.t/main.mli
@@ -1,5 +1,5 @@
 (** {!modules:External External.X Main Internal Internal.Y Z F Type_of
-    Type_of_str With_type Alias C1 C2 Inline_include} *)
+    Type_of_str With_type Alias C1 C2 Inline_include Starts_with_open} *)
 
 (** Doc for [Internal].
 

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -1,6 +1,6 @@
 # Testing {!modules:...} lists
 
-  $ compile external.mli main.mli
+  $ compile external.mli starts_with_open.mli main.mli
 
 Everything should resolve:
 
@@ -33,5 +33,7 @@ Everything should resolve:
   "None"
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Main"]},"Inline_include"]}}}
   "None"
+  {"`Resolved":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Starts_with_open"]}}}
+  {"Some":[{"`Word":"Synopsis"},"`Space",{"`Word":"of"},"`Space",{"`Code_span":"Starts_with_open"},{"`Word":"."}]}
 
 'Type_of' and 'Alias' don't have a summary. `C1` and `C2` neither, we expect at least `C2` to have one.

--- a/test/xref2/module_list.t/starts_with_open.mli
+++ b/test/xref2/module_list.t/starts_with_open.mli
@@ -1,0 +1,10 @@
+open External
+
+(** Synopsis of [Starts_with_open].
+
+    Opens should be skipped while looking up the first comment. Odoc doesn't
+    render them and sometimes the typechecker remove them too.
+    (eg. when they add only types) *)
+
+(* From [External], otherwise the [open] would be dropped by the compiler *)
+type t = X.t


### PR DESCRIPTION
Finally closes https://github.com/ocaml/odoc/issues/328

Odoc doesn't render `open`s so it makes sense to expect the top-comment to be placed after.