### PR TITLE
Tweak ocp-indent config

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Auto-format the whole project using OCamlformat
 75efc08df487fa1a89fb86e446aadc8f6273b5bb
+# ocamlformat 0.17.0
+b0c03d1b76f7da7d88d40bbc5029accfa9228112

--- a/.ocp-indent
+++ b/.ocp-indent
@@ -1,5 +1,4 @@
 normal
-max_indent = 2
-strict_with = auto
 align_ops = false
 align_params = never
+match_clause = 4


### PR DESCRIPTION
This only fixes the most annoying case: match clauses.
Ocp-indent doesn't offer enough options to fix this problem entirely (and that's fine because we shouldn't think about formatting now because of OCamlformat).
A lot of things are still not right: indentation inside a `(fun ...)`, long type constraints on `let`, etc..
