### PR TITLE
Cut the preamble at the first top-level heading

### DIFF
--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -309,18 +309,18 @@ let block_element : Comment.block_element -> Block.t = function
          TODO: Remove heading in attached documentation in the model *)
       [ block @@ Paragraph (non_link_inline_element_list content) ]
 
+let heading_level = function
+  | `Title -> 0
+  | `Section -> 1
+  | `Subsection -> 2
+  | `Subsubsection -> 3
+  | `Paragraph -> 4
+  | `Subparagraph -> 5
+
 let heading (`Heading (level, `Label (_, label), content)) =
   let label = Odoc_model.Names.LabelName.to_string label in
   let title = non_link_inline_element_list content in
-  let level =
-    match level with
-    | `Title -> 0
-    | `Section -> 1
-    | `Subsection -> 2
-    | `Subsubsection -> 3
-    | `Paragraph -> 4
-    | `Subparagraph -> 5
-  in
+  let level = heading_level level in
   let label = Some label in
   Item.Heading { label; level; title }
 

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -81,16 +81,13 @@ let attach_expansion ?(status = `Default) (eq, o, e) page text =
       DocumentedSrc.
         [ Alternative (Expansion { summary; url; status; expansion }) ]
 
-(** Returns the preamble as an item. Stop the preamble at the first heading of
-    level 2 or more. The rest is inserted into [items]. *)
+(** Returns the preamble as an item. Stop the preamble at the first heading. The
+    rest is inserted into [items]. *)
 let prepare_preamble comment items =
   let preamble, first_comment =
     Utils.split_at
       ~f:(function
-        | { Odoc_model.Location_.value = `Heading (level, _, _); _ }
-          when Comment.heading_level level < 2 ->
-            true
-        | _ -> false)
+        | { Odoc_model.Location_.value = `Heading _; _ } -> true | _ -> false)
       comment
   in
   (Comment.standalone preamble, Comment.standalone first_comment @ items)

--- a/src/document/utils.ml
+++ b/src/document/utils.ml
@@ -11,3 +11,11 @@ let rec flatmap ?sep ~f = function
 let rec skip_until ~p = function
   | [] -> []
   | h :: t -> if p h then t else skip_until ~p t
+
+let split_at ~f lst =
+  let rec loop acc = function
+    | hd :: _ as rest when f hd -> (List.rev acc, rest)
+    | [] -> (List.rev acc, [])
+    | hd :: tl -> loop (hd :: acc) tl
+  in
+  loop [] lst

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -21,18 +21,21 @@
    <h1>
     Module <code><span>Labels</span></code>
    </h1>
-   <h2 id="L1">
-    <a href="#L1" class="anchor"></a>Attached to unit
-   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
+    <li>
+     <a href="#L1">Attached to unit</a>
+    </li>
     <li>
      <a href="#L2">Attached to nothing</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
+   <h2 id="L1">
+    <a href="#L1" class="anchor"></a>Attached to unit
+   </h2>
    <h2 id="L2">
     <a href="#L2" class="anchor"></a>Attached to nothing
    </h2>

--- a/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-1-Arg1/index.html
@@ -21,18 +21,21 @@
    <h1>
     Parameter <code><span>F.1-Arg1</span></code>
    </h1>
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/argument-2-Arg2/index.html
@@ -21,11 +21,18 @@
    <h1>
     Parameter <code><span>F.2-Arg2</span></code>
    </h1>
+  </header>
+  <nav class="odoc-toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+   </ul>
+  </nav>
+  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-  </header>
-  <div class="odoc-content">
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Nested/F/index.html
+++ b/test/html/expect/test_package+ml/Nested/F/index.html
@@ -27,12 +27,12 @@
    <p>
     Some additional comments.
    </p>
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
     <li>
      <a href="#parameters">Parameters</a>
     </li>
@@ -42,6 +42,9 @@
    </ul>
   </nav>
   <div class="odoc-content">
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
    <h2 id="parameters">
     <a href="#parameters" class="anchor"></a>Parameters
    </h2>

--- a/test/html/expect/test_package+ml/Nested/X/index.html
+++ b/test/html/expect/test_package+ml/Nested/X/index.html
@@ -27,18 +27,21 @@
    <p>
     Some additional comments.
    </p>
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+ml/Nested/module-type-Y/index.html
@@ -27,18 +27,21 @@
    <p>
     Some additional comments.
    </p>
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -21,18 +21,21 @@
    <h1>
     Module <code><span>Labels</span></code>
    </h1>
-   <h2 id="L1">
-    <a href="#L1" class="anchor"></a>Attached to unit
-   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
+    <li>
+     <a href="#L1">Attached to unit</a>
+    </li>
     <li>
      <a href="#L2">Attached to nothing</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
+   <h2 id="L1">
+    <a href="#L1" class="anchor"></a>Attached to unit
+   </h2>
    <h2 id="L2">
     <a href="#L2" class="anchor"></a>Attached to nothing
    </h2>

--- a/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-1-Arg1/index.html
@@ -21,18 +21,21 @@
    <h1>
     Parameter <code><span>F.1-Arg1</span></code>
    </h1>
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
+++ b/test/html/expect/test_package+re/Nested/F/argument-2-Arg2/index.html
@@ -21,11 +21,18 @@
    <h1>
     Parameter <code><span>F.2-Arg2</span></code>
    </h1>
+  </header>
+  <nav class="odoc-toc">
+   <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
+   </ul>
+  </nav>
+  <div class="odoc-content">
    <h2 id="type">
     <a href="#type" class="anchor"></a>Type
    </h2>
-  </header>
-  <div class="odoc-content">
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Nested/F/index.html
+++ b/test/html/expect/test_package+re/Nested/F/index.html
@@ -27,12 +27,12 @@
    <p>
     Some additional comments.
    </p>
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
     <li>
      <a href="#parameters">Parameters</a>
     </li>
@@ -42,6 +42,9 @@
    </ul>
   </nav>
   <div class="odoc-content">
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
    <h2 id="parameters">
     <a href="#parameters" class="anchor"></a>Parameters
    </h2>

--- a/test/html/expect/test_package+re/Nested/X/index.html
+++ b/test/html/expect/test_package+re/Nested/X/index.html
@@ -27,18 +27,21 @@
    <p>
     Some additional comments.
    </p>
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/html/expect/test_package+re/Nested/module-type-Y/index.html
+++ b/test/html/expect/test_package+re/Nested/module-type-Y/index.html
@@ -27,18 +27,21 @@
    <p>
     Some additional comments.
    </p>
-   <h2 id="type">
-    <a href="#type" class="anchor"></a>Type
-   </h2>
   </header>
   <nav class="odoc-toc">
    <ul>
+    <li>
+     <a href="#type">Type</a>
+    </li>
     <li>
      <a href="#values">Values</a>
     </li>
    </ul>
   </nav>
   <div class="odoc-content">
+   <h2 id="type">
+    <a href="#type" class="anchor"></a>Type
+   </h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span>;</span></code>

--- a/test/latex/expect/test_package+ml/Nested.F.tex
+++ b/test/latex/expect/test_package+ml/Nested.F.tex
@@ -5,14 +5,16 @@ Some additional comments.
 
 \subsection{Type\label{type}}%
 \subsection{Parameters\label{parameters}}%
-\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1]{\ocamlinlinecode{Arg1}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
+\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1]{\ocamlinlinecode{Arg1}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
+\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \subsubsection{Values\label{values}}%
 \label{container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1-val-y}\ocamlcodefragment{\ocamltag{keyword}{val} y : \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-1-Arg1-type-t]{\ocamlinlinecode{t}}}\begin{ocamlindent}The value of y.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2]{\ocamlinlinecode{Arg2}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
+\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2]{\ocamlinlinecode{Arg2}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
+\label{container-page-test+u+package+++ml-module-Nested-module-F-argument-2-Arg2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\

--- a/test/latex/expect/test_package+ml/Nested.tex
+++ b/test/latex/expect/test_package+ml/Nested.tex
@@ -2,7 +2,8 @@
 This comment needs to be here before \#235 is fixed.
 
 \subsection{Module\label{module}}%
-\label{container-page-test+u+package+++ml-module-Nested-module-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{container-page-test+u+package+++ml-module-Nested-module-X-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
+\label{container-page-test+u+package+++ml-module-Nested-module-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[container-page-test+u+package+++ml-module-Nested-module-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
+\label{container-page-test+u+package+++ml-module-Nested-module-X-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \subsubsection{Values\label{values}}%
 \label{container-page-test+u+package+++ml-module-Nested-module-X-val-x}\ocamlcodefragment{\ocamltag{keyword}{val} x : \hyperref[container-page-test+u+package+++ml-module-Nested-module-X-type-t]{\ocamlinlinecode{t}}}\begin{ocamlindent}The value of x.\end{ocamlindent}%
@@ -11,7 +12,8 @@ This comment needs to be here before \#235 is fixed.
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}This is module X.\end{ocamlindent}%
 \medbreak
 \subsection{Module type\label{module-type}}%
-\label{container-page-test+u+package+++ml-module-Nested-module-type-Y}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[container-page-test+u+package+++ml-module-Nested-module-type-Y]{\ocamlinlinecode{Y}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{container-page-test+u+package+++ml-module-Nested-module-type-Y-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
+\label{container-page-test+u+package+++ml-module-Nested-module-type-Y}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[container-page-test+u+package+++ml-module-Nested-module-type-Y]{\ocamlinlinecode{Y}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
+\label{container-page-test+u+package+++ml-module-Nested-module-type-Y-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \subsubsection{Values\label{values}}%
 \label{container-page-test+u+package+++ml-module-Nested-module-type-Y-val-y}\ocamlcodefragment{\ocamltag{keyword}{val} y : \hyperref[container-page-test+u+package+++ml-module-Nested-module-type-Y-type-t]{\ocamlinlinecode{t}}}\begin{ocamlindent}The value of y.\end{ocamlindent}%

--- a/test/man/expect/test_package+ml/Nested.3o
+++ b/test/man/expect/test_package+ml/Nested.3o
@@ -33,6 +33,11 @@ This is module X\.
 \f[CB]module\fR \f[CB]type\fR Y = \f[CB]sig\fR
 .br 
 .ti +2
+.sp 
+.ti +2
+\fB2\.1\.1 Type\fR
+.sp 
+.ti +2
 \f[CB]type\fR t
 .fi 
 .br 
@@ -41,7 +46,7 @@ Some type\.
 .nf 
 .sp 
 .ti +2
-\fB2\.1\.1 Values\fR
+\fB2\.1\.2 Values\fR
 .sp 
 .ti +2
 \f[CB]val\fR y : t

--- a/test/man/expect/test_package+ml/Nested.F.3o
+++ b/test/man/expect/test_package+ml/Nested.F.3o
@@ -15,21 +15,25 @@ This is a functor F\.
 .fi 
 Some additional comments\.
 .nf 
-.sp 
-.in 3
-\fB3 Type\fR
-.in 
-.sp 
 .SH Documentation
 .sp 
 .nf 
 .sp 
 .in 3
-\fB1 Parameters\fR
+\fB1 Type\fR
+.in 
+.sp 
+.in 3
+\fB2 Parameters\fR
 .in 
 .sp 
 \f[CB]module\fR Arg1 : \f[CB]sig\fR
 .br 
+.ti +2
+.sp 
+.ti +2
+\fB2\.1\.1 Type\fR
+.sp 
 .ti +2
 \f[CB]type\fR t
 .fi 
@@ -39,7 +43,7 @@ Some type\.
 .nf 
 .sp 
 .ti +2
-\fB1\.1\.1 Values\fR
+\fB2\.1\.2 Values\fR
 .sp 
 .ti +2
 \f[CB]val\fR y : t
@@ -55,6 +59,11 @@ The value of y\.
 \f[CB]module\fR Arg2 : \f[CB]sig\fR
 .br 
 .ti +2
+.sp 
+.ti +2
+\fB2\.1\.3 Type\fR
+.sp 
+.ti +2
 \f[CB]type\fR t
 .fi 
 .br 
@@ -66,7 +75,7 @@ Some type\.
 \f[CB]end\fR
 .sp 
 .in 3
-\fB2 Signature\fR
+\fB3 Signature\fR
 .in 
 .sp 
 \f[CB]type\fR t = Arg1\.t * Arg2\.t

--- a/test/man/expect/test_package+ml/Nested.X.3o
+++ b/test/man/expect/test_package+ml/Nested.X.3o
@@ -15,14 +15,14 @@ This is module X\.
 .fi 
 Some additional comments\.
 .nf 
-.sp 
-.in 3
-\fB2 Type\fR
-.in 
-.sp 
 .SH Documentation
 .sp 
 .nf 
+.sp 
+.in 3
+\fB1 Type\fR
+.in 
+.sp 
 \f[CB]type\fR t
 .fi 
 .br 
@@ -31,7 +31,7 @@ Some type\.
 .nf 
 .sp 
 .in 3
-\fB1 Values\fR
+\fB2 Values\fR
 .in 
 .sp 
 \f[CB]val\fR x : t

--- a/test/xref2/module_preamble.t/b.mli
+++ b/test/xref2/module_preamble.t/b.mli
@@ -4,8 +4,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Module B.
+(** Module B. This paragraph is the synopsis.
 
-    Some documentation. *)
+    This paragraph and the previous are part of the preamble.
+
+    {2 An heading}
+
+    This paragraph is not part of the preamble. It'll be rendered in the
+    "content". *)
 
 type t

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -77,9 +77,18 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
       &#x00BB; B
     </nav>
     <header class="odoc-preamble"><h1>Module <code><span>A.B</span></code></h1>
-     <p>Module B.</p><p>Some documentation.</p>
+     <p>Module B. This paragraph is the synopsis.</p>
+     <p>This paragraph and the previous are part of the preamble.</p>
     </header>
+    <nav class="odoc-toc">
+     <ul><li><a href="#an-heading">An heading</a></li></ul>
+    </nav>
     <div class="odoc-content">
+     <h3 id="an-heading"><a href="#an-heading" class="anchor"></a>An heading
+     </h3>
+     <p>This paragraph is not part of the preamble. It'll be rendered in
+       the &quot;content&quot;.
+     </p>
      <div class="odoc-spec">
       <div class="spec type" id="type-t" class="anchored">
        <a href="#type-t" class="anchor"></a>


### PR DESCRIPTION
Closes https://github.com/ocaml/odoc/issues/235 and https://github.com/ocaml/odoc/issues/631

If the preamble contains a level 1 heading, this heading and the rest of the preamble is moved out of the 'header' to the 'content' of the page.
That part of the preamble is rendered after the TOC and appears in it.

Heading of level 2 or higher are kept in the preamble.

cc @Drup, @dbuenzli 