### PR TITLE
Take expansion's doc when computing a declaration's synopsis

### DIFF
--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -335,13 +335,8 @@ let item_element : Comment.block_element -> Item.t list = function
 (** The documentation of the expansion is used if there is no comment attached
     to the declaration. *)
 let synopsis ~decl_doc ~expansion_doc =
-  let expansion_doc = match expansion_doc with Some d -> d | None -> [] in
-  match Comment.synopsis decl_doc with
-  | Some p -> [ paragraph p ]
-  | None -> (
-      match Comment.synopsis expansion_doc with
-      | Some p -> [ paragraph p ]
-      | None -> [])
+  let ([], Some docs | docs, _) = (decl_doc, expansion_doc) in
+  match Comment.synopsis docs with Some p -> [ paragraph p ] | None -> []
 
 let standalone docs =
   Utils.flatmap ~f:item_element

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -994,16 +994,18 @@ module Make (Syntax : SYNTAX) = struct
         if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop
       in
 
-      let cname, expansion =
+      let cname, expansion, expansion_doc =
         match t.expansion with
-        | None -> (O.documentedSrc @@ O.txt name, None)
+        | None -> (O.documentedSrc @@ O.txt name, None, None)
         | Some csig ->
             let expansion_doc, items = class_signature csig in
             let url = Url.Path.from_identifier t.id in
             let page =
               make_expansion_page name `Class url [ t.doc; expansion_doc ] items
             in
-            (O.documentedSrc @@ path url [ inline @@ Text name ], Some page)
+            ( O.documentedSrc @@ path url [ inline @@ Text name ],
+              Some page,
+              Some expansion_doc )
       in
       let summary =
         O.txt Syntax.Type.annotation_separator ++ class_decl t.type_
@@ -1020,7 +1022,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "class" ] in
       let anchor = path_to_id t.id in
-      let doc = Comment.first_to_ir t.doc in
+      let doc = Comment.synopsis ~decl_doc:t.doc ~expansion_doc in
       Item.Declaration { attr; anchor; doc; content }
 
     let class_type (t : Odoc_model.Lang.ClassType.t) =
@@ -1029,16 +1031,18 @@ module Make (Syntax : SYNTAX) = struct
       let virtual_ =
         if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop
       in
-      let cname, expansion =
+      let cname, expansion, expansion_doc =
         match t.expansion with
-        | None -> (O.documentedSrc @@ O.txt name, None)
+        | None -> (O.documentedSrc @@ O.txt name, None, None)
         | Some csig ->
             let url = Url.Path.from_identifier t.id in
             let expansion_doc, items = class_signature csig in
             let page =
               make_expansion_page name `Cty url [ t.doc; expansion_doc ] items
             in
-            (O.documentedSrc @@ path url [ inline @@ Text name ], Some page)
+            ( O.documentedSrc @@ path url [ inline @@ Text name ],
+              Some page,
+              Some expansion_doc )
       in
       let summary = O.txt " = " ++ class_type_expr t.expr in
       let expr = attach_expansion (" = ", "object", "end") expansion summary in
@@ -1050,7 +1054,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "class-type" ] in
       let anchor = path_to_id t.id in
-      let doc = Comment.first_to_ir t.doc in
+      let doc = Comment.synopsis ~decl_doc:t.doc ~expansion_doc in
       Item.Declaration { attr; anchor; doc; content }
   end
 
@@ -1265,9 +1269,9 @@ module Make (Syntax : SYNTAX) = struct
         | Alias (_, None) -> None
         | ModuleType e -> expansion_of_module_type_expr e
       in
-      let modname, status, expansion =
+      let modname, status, expansion, expansion_doc =
         match expansion with
-        | None -> (O.documentedSrc (O.txt modname), `Default, None)
+        | None -> (O.documentedSrc (O.txt modname), `Default, None, None)
         | Some (expansion_doc, items) ->
             let status =
               match t.type_ with
@@ -1280,7 +1284,7 @@ module Make (Syntax : SYNTAX) = struct
               make_expansion_page modname `Mod url [ t.doc; expansion_doc ]
                 items
             in
-            (O.documentedSrc link, status, Some page)
+            (O.documentedSrc link, status, Some page, Some expansion_doc)
       in
       let summary = mdexpr_in_decl t.id t.type_ in
       let modexpr =
@@ -1296,7 +1300,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "module" ] in
       let anchor = path_to_id t.id in
-      let doc = Comment.first_to_ir t.doc in
+      let doc = Comment.synopsis ~decl_doc:t.doc ~expansion_doc in
       Item.Declaration { attr; anchor; doc; content }
 
     and simple_expansion_in_decl (base : Paths.Identifier.Module.t) se =
@@ -1330,9 +1334,9 @@ module Make (Syntax : SYNTAX) = struct
         | None -> None
         | Some e -> expansion_of_module_type_expr e
       in
-      let modname, expansion =
+      let modname, expansion, expansion_doc =
         match expansion with
-        | None -> (O.documentedSrc @@ O.txt modname, None)
+        | None -> (O.documentedSrc @@ O.txt modname, None, None)
         | Some (expansion_doc, items) ->
             let url = Url.Path.from_identifier t.id in
             let link = path url [ inline @@ Text modname ] in
@@ -1340,7 +1344,7 @@ module Make (Syntax : SYNTAX) = struct
               make_expansion_page modname `Mty url [ t.doc; expansion_doc ]
                 items
             in
-            (O.documentedSrc link, Some page)
+            (O.documentedSrc link, Some page, Some expansion_doc)
       in
       let summary =
         match t.expr with
@@ -1357,7 +1361,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "module-type" ] in
       let anchor = path_to_id t.id in
-      let doc = Comment.first_to_ir t.doc in
+      let doc = Comment.synopsis ~decl_doc:t.doc ~expansion_doc in
       Item.Declaration { attr; anchor; doc; content }
 
     and umty_hidden : Odoc_model.Lang.ModuleType.U.expr -> bool = function
@@ -1541,7 +1545,7 @@ module Make (Syntax : SYNTAX) = struct
       let content = { Include.content; status; summary } in
       let attr = [ "include" ] in
       let anchor = None in
-      let doc = Comment.first_to_ir sg_doc in
+      let doc = Comment.synopsis ~decl_doc:[] ~expansion_doc:(Some sg_doc) in
       Item.Include { attr; anchor; doc; content }
   end
 

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -85,3 +85,25 @@ type block_element =
 type docs = block_element with_location list
 
 type docs_or_stop = [ `Docs of docs | `Stop ]
+
+(** The synopsis is the first paragraph of a comment. Headings, tags and other
+    {!Comment.block_element} that are not [`Paragraph] or [`List] are skipped.
+    *)
+let synopsis docs =
+  let rec list_find_map f = function
+    | hd :: tl -> (
+        match f hd with Some _ as x -> x | None -> list_find_map f tl)
+    | [] -> None
+  in
+  let open Location_ in
+  let rec from_element elem =
+    match elem.value with
+    | `Paragraph p -> Some p
+    | `List (_, items) -> list_find_map (list_find_map from_element) items
+    | _ -> None
+  in
+  list_find_map
+    (function
+      | { value = #nestable_block_element; _ } as elem -> from_element elem
+      | _ -> None)
+    docs

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -86,13 +86,8 @@ type docs = block_element with_location list
 
 type docs_or_stop = [ `Docs of docs | `Stop ]
 
-(** The synopsis is the first element of a comment if it is a paragraph or a
-    list. In the case of a list, the first item is considered. Otherwise, there
-    is no synopsis. *)
-let rec synopsis docs =
-  let open Location_ in
-  match docs with
-  | { value = `Paragraph p; _ } :: _ -> Some p
-  | { value = `List (_, first_item :: _); _ } :: _ ->
-      synopsis (first_item :> docs)
+(** The synopsis is the first element of a comment if it is a paragraph.
+    Otherwise, there is no synopsis. *)
+let synopsis = function
+  | { Location_.value = `Paragraph p; _ } :: _ -> Some p
   | _ -> None

--- a/src/odoc/interface.mld
+++ b/src/odoc/interface.mld
@@ -26,8 +26,9 @@ The following describes the changes between what odoc understands and what is in
 - {{:https://caml.inria.fr/pub/docs/manual-ocaml/ocamldoc.html#ss:ocamldoc-formatting}Alignment elements} are not handled ([{C text}], [{L text}] and [{R text}]) ({{:https://github.com/ocaml/odoc/issues/541}github issue})
 - Odoc does not recognise {{:https://caml.inria.fr/pub/docs/manual-ocaml/ocamldoc.html#sss:ocamldoc-html-tags}html tags embedded in comments} ({{:https://github.com/ocaml/odoc/issues/576}github issue})
 - [{!indexlist}] is not supported ({{:https://github.com/ocaml/odoc/issues/577}github issue})
-- When rendering [{!modules:...}] lists, the first paragraph is used instead of
-  the {{:https://caml.inria.fr/pub/docs/manual-ocaml/ocamldoc.html#sss:ocamldoc-preamble}first sentence}.
+- The first paragraph is used for synopses instead of the {{:https://caml.inria.fr/pub/docs/manual-ocaml/ocamldoc.html#sss:ocamldoc-preamble}first sentence}.
+  Synopses are used when rendering declarations (of modules, classes, etc..) and [{!modules:...}] lists.
+  An other difference is that documentation starting with a heading or something that is not a paragraph won't have a synopsis ({{:https://github.com/ocaml/odoc/pull/643}github issue}).
 
 {4 Improvements}
 - Odoc has a better mechanism for disambiguating references in comments. See 'reference syntax' later in this document.

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -1894,6 +1894,11 @@
     <div class="spec module" id="module-Aliases">
      <a href="#module-Aliases" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Aliases/index.html">Aliases</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
+    <div class="spec-doc">
+     <p>
+      Let's imitate jst's layout.
+     </p>
+    </div>
    </div>
    <h2 id="section-title-splicing">
     <a href="#section-title-splicing" class="anchor"></a>Section title splicing

--- a/test/html/expect/test_package+ml/Toplevel_comments/index.html
+++ b/test/html/expect/test_package+ml/Toplevel_comments/index.html
@@ -70,6 +70,11 @@
     <div class="spec module" id="module-M">
      <a href="#module-M" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M/index.html">M</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>M</code>
+     </p>
+    </div>
    </div>
    <div class="odoc-spec">
     <div class="spec module" id="module-M'">

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -1911,6 +1911,11 @@
     <div class="spec module" id="module-Aliases">
      <a href="#module-Aliases" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Aliases/index.html">Aliases</a></span><span>: { ... }</span><span>;</span></code>
     </div>
+    <div class="spec-doc">
+     <p>
+      Let's imitate jst's layout.
+     </p>
+    </div>
    </div>
    <h2 id="section-title-splicing">
     <a href="#section-title-splicing" class="anchor"></a>Section title splicing

--- a/test/html/expect/test_package+re/Toplevel_comments/index.html
+++ b/test/html/expect/test_package+re/Toplevel_comments/index.html
@@ -70,6 +70,11 @@
     <div class="spec module" id="module-M">
      <a href="#module-M" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M/index.html">M</a></span><span>: { ... }</span><span>;</span></code>
     </div>
+    <div class="spec-doc">
+     <p>
+      Doc of <code>M</code>
+     </p>
+    </div>
    </div>
    <div class="odoc-spec">
     <div class="spec module" id="module-M'">

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -53,7 +53,7 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
          <span class="keyword">end</span>
         </span>
        </code>
-      </div><div class="spec-doc"><p>Module B.</p></div>
+      </div>
      </div>
     </div>
    </body>

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -53,7 +53,7 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
          <span class="keyword">end</span>
         </span>
        </code>
-      </div>
+      </div><div class="spec-doc"><p>Module B.</p></div>
      </div>
     </div>
    </body>


### PR DESCRIPTION
Fixes https://github.com/ocaml/odoc/issues/632

Before this patch, no synopsis was attached to declarations like this: (also work on classes, class types and module types)

```ocaml
module M : sig
  (** Expansion doc. *)
end
```

This is consistent with what ocamldoc does.

The first commit refactors the function generating the synopsis for `{!modules:}` lists so it can be shared with the generator. Before that, a simpler rule was used that didn't skip headings and other elements:

```ocaml
(** {1 Heading}

    @canonical M

    This is the synopsis. *)
```

```ocaml
(** - This is the synopsis. *)
```

These are rules I made up in https://github.com/ocaml/odoc/pull/597, it's still time to change them and to document them too.