### PR TITLE
Preview: upgrade to ocamlformat.0.18.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version=0.17.0
+version=0.18.0

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -644,8 +644,10 @@ module Make (Syntax : SYNTAX) = struct
       intro @ variants @ ending
 
     let format_params :
-          'row. ?delim:[ `parens | `brackets ] ->
-          Odoc_model.Lang.TypeDecl.param list -> text =
+          'row.
+          ?delim:[ `parens | `brackets ] ->
+          Odoc_model.Lang.TypeDecl.param list ->
+          text =
      fun ?(delim = `parens) params ->
       let format_param { Odoc_model.Lang.TypeDecl.desc; variance; injectivity }
           =
@@ -679,8 +681,10 @@ module Make (Syntax : SYNTAX) = struct
           ++ O.txt " = " ++ type_expr t2)
 
     let format_manifest :
-          'inner_row 'outer_row. ?is_substitution:bool ->
-          ?compact_variants:bool -> Odoc_model.Lang.TypeDecl.Equation.t ->
+          'inner_row 'outer_row.
+          ?is_substitution:bool ->
+          ?compact_variants:bool ->
+          Odoc_model.Lang.TypeDecl.Equation.t ->
           text * bool =
      fun ?(is_substitution = false) ?(compact_variants = true) equation ->
       let _ = compact_variants in

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -2292,7 +2292,10 @@ module Of_Lang = struct
     { items; removed = []; compiled = sg.compiled; doc = docs ident_map sg.doc }
 
   and with_location :
-        'a 'b. (map -> 'a -> 'b) -> map -> 'a Location_.with_location ->
+        'a 'b.
+        (map -> 'a -> 'b) ->
+        map ->
+        'a Location_.with_location ->
         'b Location_.with_location =
    fun conv ident_map v -> { v with value = conv ident_map v.Location_.value }
 


### PR DESCRIPTION
This is a preview of the not-yet-released ocamlformat.0.18.0, please wait until the package is published in opam to merge this PR.
The diff is composed of:
 -   a break was added between polytype quantification and arrow-type body (spurious spaces are removed), causing the arrow-type to properly break
