### PR TITLE
Handle @canonical tags on compilation unit

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,4 +1,9 @@
 src/compat/*
-src/loader/*
+src/loader/cmi.ml
+src/loader/cmi.mli
+src/loader/cmt.ml
+src/loader/cmti.ml
+src/loader/doc_attr.ml
+src/loader/*.cppo.ml
 src/model/*.cppo.ml
 test/xref2/lib/*

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -15,10 +15,7 @@
  *)
 
 open Odoc_model
-
 module Paths = Odoc_model.Paths
-
-
 
 val empty : Odoc_model.Comment.docs
 
@@ -27,13 +24,13 @@ val parse_attribute : Parsetree.attribute -> (string * Location.t) option
 val attached :
   Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
-    Odoc_model.Comment.docs
+  Odoc_model.Comment.docs
 
 val page :
   Paths.Identifier.LabelParent.t ->
   Location.t ->
   string ->
-    Odoc_model.Comment.docs_or_stop
+  Odoc_model.Comment.docs_or_stop
 (** The parent identifier is used to define labels in the given string (i.e.
     for things like [{1:some_section Some title}]) and the location is used for
     error messages.
@@ -44,12 +41,12 @@ val page :
 val standalone :
   Paths.Identifier.LabelParent.t ->
   Parsetree.attribute ->
-    Odoc_model.Comment.docs_or_stop option
+  Odoc_model.Comment.docs_or_stop option
 
 val standalone_multiple :
   Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
-    Odoc_model.Comment.docs_or_stop list
+  Odoc_model.Comment.docs_or_stop list
 
 val extract_top_comment :
   Lang.Signature.item list -> Lang.Signature.item list * Comment.docs

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -38,7 +38,7 @@ exception Not_an_interface
 exception Make_root_error of string
 
 let make_compilation_unit ~make_root ~imports ~interface ?sourcefile ~name ~id
-    content =
+    ?canonical content =
   let open Odoc_model.Lang.Compilation_unit in
   let interface, digest =
     match interface with
@@ -73,13 +73,17 @@ let make_compilation_unit ~make_root ~imports ~interface ?sourcefile ~name ~id
     content;
     expansion = None;
     linked = false;
+    canonical;
   }
 
 let compilation_unit_of_sig ~make_root ~imports ~interface ?sourcefile ~name ~id
     sg =
   let content = Odoc_model.Lang.Compilation_unit.Module sg in
+  let canonical =
+    (Cmi.canonical sg.doc :> Odoc_model.Paths.Path.Module.t option)
+  in
   make_compilation_unit ~make_root ~imports ~interface ?sourcefile ~name ~id
-    content
+    ?canonical content
 
 let read_cmti ~make_root ~parent ~filename () =
   let cmt_info = Cmt_format.read_cmt filename in

--- a/src/loader/odoc_loader.mli
+++ b/src/loader/odoc_loader.mli
@@ -8,19 +8,28 @@ val read_string :
   (Comment.docs_or_stop, Error.t) result Error.with_warnings
 
 val read_cmti :
-  make_root:(module_name:string -> digest:Digest.t -> (Odoc_model.Root.t, [ `Msg of string ]) result) ->
+  make_root:
+    (module_name:string ->
+    digest:Digest.t ->
+    (Odoc_model.Root.t, [ `Msg of string ]) result) ->
   parent:Odoc_model.Paths.Identifier.ContainerPage.t ->
   filename:string ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_cmt :
-  make_root:(module_name:string -> digest:Digest.t -> (Odoc_model.Root.t, [ `Msg of string ]) result) ->
+  make_root:
+    (module_name:string ->
+    digest:Digest.t ->
+    (Odoc_model.Root.t, [ `Msg of string ]) result) ->
   parent:Odoc_model.Paths.Identifier.ContainerPage.t ->
   filename:string ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_cmi :
-  make_root:(module_name:string -> digest:Digest.t -> (Odoc_model.Root.t, [ `Msg of string ]) result) ->
+  make_root:
+    (module_name:string ->
+    digest:Digest.t ->
+    (Odoc_model.Root.t, [ `Msg of string ]) result) ->
   parent:Odoc_model.Paths.Identifier.ContainerPage.t ->
   filename:string ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -447,6 +447,7 @@ module rec Compilation_unit : sig
     content : content;
     expansion : Signature.t option;
     linked : bool;  (** Whether this unit has been linked. *)
+    canonical : Path.Module.t option;
   }
 end =
   Compilation_unit

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -639,6 +639,10 @@ and compilation_unit_t =
       F ("hidden", (fun t -> t.hidden), bool);
       F ("content", (fun t -> t.content), compilation_unit_content);
       F ("expansion", (fun t -> t.expansion), Option signature_t);
+      F
+        ( "canonical",
+          (fun t -> (t.canonical :> Paths.Path.t option)),
+          Option path );
     ]
 
 (** {3 Page} *)

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -337,7 +337,7 @@ let module_of_unit : Odoc_model.Lang.Compilation_unit.t -> Component.Module.t =
             id = (unit.id :> Odoc_model.Paths.Identifier.Module.t);
             doc = [];
             type_ = ModuleType (Signature s);
-            canonical = None;
+            canonical = unit.canonical;
             hidden = unit.hidden;
           }
       in
@@ -351,7 +351,7 @@ let module_of_unit : Odoc_model.Lang.Compilation_unit.t -> Component.Module.t =
             doc = [];
             type_ =
               ModuleType (Signature { items = []; compiled = true; doc = [] });
-            canonical = None;
+            canonical = unit.canonical;
             hidden = unit.hidden;
           }
       in
@@ -472,7 +472,9 @@ let lookup_by_id (scope : 'a scope) id env : 'a option =
 let lookup_root_module_fallback name t =
   match lookup_root_module name t with
   | Some (Resolved (_, id, m)) ->
-      Some (`Module ((id :> Identifier.Path.Module.t), Component.Delayed.put (fun () -> m)))
+      Some
+        (`Module
+          ((id :> Identifier.Path.Module.t), Component.Delayed.put_val m))
   | Some Forward | None -> None
 
 let s_signature : Component.Element.signature scope =

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -9,10 +9,7 @@ type lookup_unit_result =
 
 type root =
   | Resolved of
-      (Digest.t
-      * Odoc_model.Paths.Identifier.Module.t
-      * bool
-      * Component.Module.t Component.Delayed.t)
+      (Digest.t * Odoc_model.Paths.Identifier.Module.t * Component.Module.t)
   | Forward
 
 type resolver = {

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -190,7 +190,8 @@ module M = struct
     | Some e -> of_element env e
     | None -> (
         match Env.lookup_root_module name env with
-        | Some (Env.Resolved (_, id, _, m)) -> of_element env (`Module (id, m))
+        | Some (Env.Resolved (_, id, m)) ->
+            of_element env (`Module (id, Component.Delayed.put_val m))
         | _ -> None)
 end
 
@@ -730,8 +731,7 @@ let resolve_reference : Env.t -> t -> Resolved.t option =
         | None -> None)
     | `Root (name, `TChildModule) -> (
         match Env.lookup_root_module name env with
-        | Some (Resolved (_, id, _, _)) ->
-            Some (`Identifier (id :> Identifier.t))
+        | Some (Resolved (_, id, _)) -> Some (`Identifier (id :> Identifier.t))
         | Some Forward | None -> None)
     | `Resolved r -> Some r
     | `Root (name, `TModule) -> M.in_env env name >>= resolved

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -712,12 +712,12 @@ and resolve_module :
     | `Root r -> (
         (* Format.fprintf Format.err_formatter "Looking up module %s by name...%!" r; *)
         match Env.lookup_root_module r env with
-        | Some (Env.Resolved (_, p, hidden, m)) ->
+        | Some (Env.Resolved (_, p, m)) ->
             let p =
               `Identifier (p :> Odoc_model.Paths.Identifier.Path.Module.t)
             in
-            let p = if hidden then `Hidden p else p in
-            Ok (p, m)
+            let p = process_module_path env ~add_canonical m p in
+            Ok (p, Component.Delayed.put_val m)
         | Some Env.Forward ->
             Error (`Parent (`Parent_sig `UnresolvedForwardPath))
         | None ->

--- a/test/xref2/canonical_unit.t/run.t
+++ b/test/xref2/canonical_unit.t/run.t
@@ -5,9 +5,14 @@ The module Test__X is expected to be referenced through Test.X.
 
   $ compile test__x.mli test.ml
 
+Test__x has a 'canonical' field:
+
+  $ odoc_print test__x.odocl | jq -c ".canonical"
+  {"Some":{"`Dot":[{"`Root":"Test"},"X"]}}
+
 The alias Test.X should be marked as canonical:
 
   $ odoc_print test.odocl | jq -c ".content.Module.items | .[] | .Module[1].type_.Alias[0] | select(.)"
-  {"`Resolved":{"`Hidden":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Test__x"]}}}}
+  {"`Resolved":{"`Canonical":[{"`Hidden":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Test__x"]}}},{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Test"]},"X"]}}}]}}
   {"`Resolved":{"`Canonical":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Test"]},"Test__y"]}},{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Test"]},"Y"]}}}]}}
   {"`Resolved":{"`Hidden":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Test"]},"Test__z"]}}}}

--- a/test/xref2/canonical_unit.t/run.t
+++ b/test/xref2/canonical_unit.t/run.t
@@ -1,0 +1,13 @@
+Test that @canonical tags work on compilation units when it is placed in the
+top-comment.
+
+The module Test__X is expected to be referenced through Test.X.
+
+  $ compile test__x.mli test.ml
+
+The alias Test.X should be marked as canonical:
+
+  $ odoc_print test.odocl | jq -c ".content.Module.items | .[] | .Module[1].type_.Alias[0] | select(.)"
+  {"`Resolved":{"`Hidden":{"`Identifier":{"`Root":[{"`RootPage":"test"},"Test__x"]}}}}
+  {"`Resolved":{"`Canonical":[{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Test"]},"Test__y"]}},{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Test"]},"Y"]}}}]}}
+  {"`Resolved":{"`Hidden":{"`Identifier":{"`Module":[{"`Root":[{"`RootPage":"test"},"Test"]},"Test__z"]}}}}

--- a/test/xref2/canonical_unit.t/test.ml
+++ b/test/xref2/canonical_unit.t/test.ml
@@ -1,0 +1,20 @@
+(** Main module of this test. *)
+
+module X = Test__x
+
+(** An other example that is not an unit for comparison.
+    @canonical Test.Y *)
+module Test__y = struct
+  type t
+end
+
+module Y = Test__y
+
+(** An example with the tag inside the sig. *)
+module Test__z = struct
+  (** @canonical Test.Z *)
+
+  type t
+end
+
+module Z = Test__z

--- a/test/xref2/canonical_unit.t/test__x.mli
+++ b/test/xref2/canonical_unit.t/test__x.mli
@@ -1,0 +1,4 @@
+(** We expect this module to be referenced through Test.X.
+    @canonical Test.X *)
+
+type t

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -606,6 +606,7 @@ let my_compilation_unit id s =
     ; content = Module s
     ; expansion = None
     ; linked = false
+    ; canonical = None
 }
 
 let mkenv () =


### PR DESCRIPTION
Fix https://github.com/ocaml/odoc/issues/559#event-4382610148

Before this, `@canonical` tags in the top-comments of a file were ignored.