### PR TITLE
Add a plain text output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ test : build
 	$(DUNE) build $(DUNE_ARGS) @test/model/runtest --no-buffer -j 1
 	$(DUNE) build $(DUNE_ARGS) @test/html/runtest --no-buffer -j 1
 	$(DUNE) build $(DUNE_ARGS) @test/man/runtest --no-buffer -j 1
+	$(DUNE) build $(DUNE_ARGS) @test/mlioutput/runtest --no-buffer -j 1
 	$(DUNE) build $(DUNE_ARGS) @test/latex/runtest --no-buffer -j 1
 	$(DUNE) build $(DUNE_ARGS) @test/xref2/runtest --no-buffer -j 1
 

--- a/src/mlioutput/dune
+++ b/src/mlioutput/dune
@@ -1,0 +1,6 @@
+(library
+ (name odoc_mli)
+ (public_name odoc.mli)
+ (instrumentation
+  (backend bisect_ppx))
+ (libraries odoc_model odoc_document))

--- a/src/mlioutput/generator.ml
+++ b/src/mlioutput/generator.ml
@@ -1,0 +1,321 @@
+open Odoc_document
+open Types
+open Doctree
+
+module Markup = struct
+  type t =
+    | Concat of t list
+    | Command of string * t
+    | Env of indent * string * t * string
+    | Space
+    | Break
+    | String of string
+    | Indent of indent * int * t
+
+  and indent = Any | V
+  
+  let noop = Concat []
+
+  let sp = Space
+
+  let break = Break
+
+  let command s t = Command (s,t)
+  let env indent s s' t = Env (indent,s,t,s')
+
+  let append t1 t2 =
+    match (t1, t2) with
+    | Concat l1, Concat l2 -> Concat (l1 @ l2)
+    | Concat l1, e2 -> Concat (l1 @ [ e2 ])
+    | e1, Concat l2 -> Concat (e1 :: l2)
+    | e1, e2 -> Concat [ e1; e2 ]
+
+  let ( ++ ) = append
+
+  let concat = List.fold_left ( ++ ) (Concat [])
+
+  let rec intersperse ~sep = function
+    | [] -> []
+    | [ h ] -> [ h ]
+    | h1 :: (_ :: _ as t) -> h1 :: sep :: intersperse ~sep t
+
+  let list ?(sep = Concat []) l = concat @@ intersperse ~sep l
+
+  let indent indent i content = Indent (indent, i, content)
+
+  let str fmt = Format.ksprintf (fun s -> String s) fmt
+
+  let escaped fmt = Format.ksprintf (fun s -> String s) fmt
+
+  let rec pp ppf t = match t with
+    | Concat l -> pp_many ppf l
+    | String s -> Format.pp_print_string ppf s
+    | Space -> Format.fprintf ppf "@ "
+    | Break -> Format.fprintf ppf "@,"
+    | Command (s, t) ->
+        Format.fprintf ppf "@[{%s%a}@]"
+          s pp t
+    | Env (indent,s, t, s') ->
+        Format.fprintf ppf "@[<v>@[<%s2>%s@ %a@]@,%s@]"
+          (match indent with Any -> "" | V -> "v")
+          s pp t s'
+    | Indent (indent, i, content) ->
+        Format.fprintf ppf "@[<%s%i>%a@]"
+          (match indent with Any -> "" | V -> "v") i
+          pp content
+  and pp_many ppf l = List.iter (pp ppf) l
+end
+
+open Markup
+
+let style (style : style) content =
+  let s = match style with
+    | `Bold -> "b "
+    | `Italic -> "i "    
+    | `Emphasis -> "e "
+    | `Superscript -> "^ "
+    | `Subscript -> "_ "
+  in
+  command s content
+
+(* Striped content should be rendered in one line, without styling *)
+let strip l =
+  let rec loop acc = function
+    | [] -> acc
+    | h :: t -> (
+        match h.Inline.desc with
+        | Text _ | Entity _ | Raw_markup _ -> loop (h :: acc) t
+        | Linebreak -> loop acc t
+        | Styled (sty, content) ->
+            let h =
+              { h with desc = Styled (sty, List.rev @@ loop [] content) }
+            in
+            loop (h :: acc) t
+        | Link (_, content)
+        | InternalLink (Resolved (_, content))
+        | InternalLink (Unresolved content) ->
+            let acc = loop acc content in
+            loop acc t
+        | Source code ->
+            let acc = loop_source acc code in
+            loop acc t)
+  and loop_source acc = function
+    | [] -> acc
+    | Source.Elt content :: t -> loop_source (List.rev_append content acc) t
+    | Source.Tag (_, content) :: t ->
+        let acc = loop_source acc content in
+        loop_source acc t
+  in
+  List.rev @@ loop [] l
+
+(* Partial support for now *)
+let entity e =
+  match e with "#45" -> escaped "-" | "gt" -> str ">" | s -> str "&%s;" s
+
+(* Should hopefully make people notice and report *)
+
+let raw_markup (_ : Raw_markup.t) = noop
+
+let rec source_code (s : Source.t) =
+  match s with
+  | [] -> noop
+  | h :: t -> (
+      match h with
+      | Source.Elt i -> inline (strip i) ++ source_code t
+      | Tag (None, s) -> source_code s ++ source_code t
+      | Tag (Some _, s) -> source_code s ++ source_code t)
+
+and inline (l : Inline.t) =
+  match l with
+  | [] -> noop
+  | i :: rest -> (
+      match i.desc with
+      | Text "" -> inline rest
+      | Text _ ->
+          let l, _, rest =
+            Doctree.Take.until l ~classify:(function
+              | { Inline.desc = Text s; _ } -> Accum [ s ]
+              | _ -> Stop_and_keep)
+          in
+          str {|%s|} (String.concat "" l) ++ inline rest
+      | Entity e ->
+          let x = entity e in
+          x ++ inline rest
+      | Linebreak -> break ++ inline rest
+      | Styled (sty, content) -> style sty (inline content) ++ inline rest
+      | Link (href, content) ->
+          command "" (str "{: %s}" href ++ inline (strip content))
+          ++ inline rest
+      | InternalLink (Resolved (_, content) | Unresolved content) ->
+          command "!" (inline @@ strip content) ++ inline rest
+      | Source content -> source_code content ++ inline rest
+      | Raw_markup t -> raw_markup t ++ inline rest)
+
+let rec block (l : Block.t) =
+  match l with
+  | [] -> noop
+  | b :: rest -> (
+      let continue r = if r = [] then noop else break ++ block r in
+      match b.desc with
+      | Inline i -> inline i ++ continue rest
+      | Paragraph i -> inline i ++ continue rest
+      | List (list_typ, l) ->
+          let f n b =
+            let bullet =
+              match list_typ with
+              | Unordered -> escaped "-"
+              | Ordered -> str "%d)" (n + 1)
+            in
+            indent V 2 (bullet ++ sp ++ block b)
+          in
+          list ~sep:break (List.mapi f l) ++ continue rest
+      | Description _ ->
+          let descrs, _, rest =
+            Take.until l ~classify:(function
+              | { Block.desc = Description l; _ } -> Accum l
+              | _ -> Stop_and_keep)
+          in
+          let f i =
+            let key = inline i.Description.key in
+            let def = block i.Description.definition in
+            indent V 2 (str "@" ++ key ++ str ":" ++ sp ++ def)
+          in
+          list ~sep:break (List.map f descrs) ++ continue rest
+      | Source content ->
+          env Any "{[" "]}"  (source_code content) ++ continue rest
+      | Verbatim content ->
+          env Any "{v" "v}" (str "%s" content) ++ continue rest
+      | Raw_markup t -> raw_markup t ++ continue rest)
+
+let heading { Heading.label; level; title } =
+  let level = string_of_int level in
+  let title = inline title in
+  env Any "(**" "*)" @@ match label with
+  | Some label -> 
+      command level (str ":%s " label ++ title)
+  | None -> 
+      command (level ^ " ") (title)
+
+let expansion_not_inlined url = not (Link.should_inline url)
+
+let take_code l =
+  let c, _, rest =
+    Take.until l ~classify:(function
+      | DocumentedSrc.Code c -> Accum c
+      | DocumentedSrc.Alternative (Expansion e) when expansion_not_inlined e.url
+        ->
+          Accum e.summary
+      | _ -> Stop_and_keep)
+  in
+  (c, rest)
+
+let inline_subpage = function
+  | `Inline | `Open | `Default -> true
+  | `Closed -> false
+
+let rec documentedSrc (l : DocumentedSrc.t) =
+  match l with
+  | [] -> noop
+  | line :: rest -> (
+      let continue r = documentedSrc r in
+      match line with
+      | Code _ ->
+          let c, rest = take_code l in
+          source_code c ++ continue rest
+      | Alternative alt -> (
+          match alt with
+          | Expansion { expansion; url; _ } ->
+              if expansion_not_inlined url then
+                let c, rest = take_code l in
+                source_code c ++ continue rest
+              else documentedSrc expansion)
+      | Subpage p ->
+          subpage p.content ++ continue rest
+      | Documented _ | Nested _ ->
+          let lines, _, rest =
+            Take.until l ~classify:(function
+              | DocumentedSrc.Documented { code; doc; _ } ->
+                  Accum [ (`D code, doc) ]
+              | DocumentedSrc.Nested { code; doc; _ } ->
+                  Accum [ (`N code, doc) ]
+              | _ -> Stop_and_keep)
+          in
+          let f (content, doc) =
+            let doc =
+              match doc with
+              | [] -> noop
+              | doc -> break ++ env V "(**" "*)" (block doc)
+            in
+            let content =
+              match content with
+              | `D code -> inline code
+              | `N l -> documentedSrc l
+            in
+            break ++ content ++ doc
+          in
+          let l = list ~sep:noop (List.map f lines) in
+          l ++ continue rest)
+
+and subpage { title = _; header = _; items; url = _ } =
+  let content = items in
+  let surround body =
+    if content = [] then sp
+    else break ++ break ++ body ++ break
+  in
+  surround @@ item content
+
+and item (l : Item.t list) =
+  match l with
+  | [] -> noop
+  | i :: rest -> (
+      let continue r = if r = [] then noop else break ++ break ++ item r in
+      match i with
+      | Text b ->
+          let d = env Any "(**" "*)" (block b) in
+          d ++ continue rest
+      | Heading h ->
+          heading h ++ continue rest
+      | Declaration { attr = _; anchor = _; content; doc } ->
+          let decl = documentedSrc content in
+          let doc =
+            match doc with
+            | [] -> noop
+            | doc -> env V "(**" "*)" (block doc) ++ break
+          in
+          doc ++ indent V 2 decl ++ continue rest
+      | Include
+          { attr = _; anchor = _; content = { summary; status; content }; doc }
+        ->
+          let d =
+            if inline_subpage status then item content
+            else
+              let s = source_code summary in
+              match doc with
+              | [] -> s
+              | doc -> s ++ break ++ env Any "(**" "*)" (block doc)
+          in
+          d ++ continue rest)
+
+let on_sub subp =
+  match subp with
+  | `Page p -> if Link.should_inline p.Subpage.content.url then Some 1 else None
+  | `Include incl -> if inline_subpage incl.Include.status then Some 0 else None
+
+let page { Page.title = _ ; header; items = i; url = _ } =
+  let header = Shift.compute ~on_sub header in
+  let i = Shift.compute ~on_sub i in
+  indent V 0 (
+    item header
+    ++ break ++ break
+    ++ item i
+  )
+
+let rec subpage subp =
+  let p = subp.Subpage.content in
+  if Link.should_inline p.url then [] else [ render p ]
+
+and render (p : Page.t) =
+  let content ppf = Format.fprintf ppf "%a@." Markup.pp (page p) in
+  let children = Utils.flatmap ~f:subpage @@ Subpages.compute p in
+  let filename = Link.as_filename p.url in
+  { Renderer.filename; content; children }

--- a/src/mlioutput/generator.mli
+++ b/src/mlioutput/generator.mli
@@ -1,0 +1,1 @@
+val render : Odoc_document.Types.Page.t -> Odoc_document.Renderer.page

--- a/src/mlioutput/link.ml
+++ b/src/mlioutput/link.ml
@@ -1,0 +1,43 @@
+open Odoc_document
+
+let to_list url =
+  let rec loop acc { Url.Path.parent; name; kind } =
+    match parent with
+    | None -> (kind, name) :: acc
+    | Some p -> loop ((kind, name) :: acc) p
+  in
+  loop [] url
+
+let for_printing url = List.map snd @@ to_list url
+
+let segment_to_string (kind, name) =
+  if
+    kind = "module" || kind = "container-page" || kind = "page"
+    || kind = "class" || kind = "page"
+  then name
+  else Printf.sprintf "%s-%s" kind name
+
+let as_filename (url : Url.Path.t) =
+  let rec get_components { Url.Path.parent; name; kind } =
+    match parent with
+    | None -> (name, [])
+    | Some p ->
+        let dir, path = get_components p in
+        (dir, segment_to_string (kind, name) :: path)
+  in
+  let dir, path = get_components url in
+  let s = String.concat "." @@ List.rev path in
+  Fpath.((v dir / s) + ".mli")
+
+let rec is_class_or_module_path (url : Url.Path.t) =
+  match url.kind with
+  | "module" | "page" | "container-page" | "class" -> (
+      match url.parent with
+      | None -> true
+      | Some url -> is_class_or_module_path url)
+  | _ -> false
+
+let should_inline x = not @@ is_class_or_module_path x
+
+let files_of_url url =
+  if is_class_or_module_path url then [ as_filename url ] else []

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -482,6 +482,14 @@ module Odoc_manpage = Make_renderer (struct
   let extra_args = Term.const ()
 end)
 
+module Odoc_mli = Make_renderer (struct
+  type args = unit
+
+  let renderer = Mli_output.renderer
+
+  let extra_args = Term.const ()
+end)
+
 module Odoc_latex = Make_renderer (struct
   type args = Latex.args
 
@@ -624,6 +632,9 @@ let () =
       Odoc_manpage.process;
       Odoc_manpage.targets;
       Odoc_manpage.generate;
+      Odoc_mli.process;
+      Odoc_mli.targets;
+      Odoc_mli.generate;
       Odoc_latex.process;
       Odoc_latex.targets;
       Odoc_latex.generate;

--- a/src/odoc/dune
+++ b/src/odoc/dune
@@ -1,7 +1,7 @@
 (library
  (name odoc_odoc)
  (public_name odoc.odoc)
- (libraries compiler-libs.common fpath odoc_html odoc_manpage odoc_latex
+ (libraries compiler-libs.common fpath odoc_html odoc_manpage odoc_mli odoc_latex
    odoc_loader odoc_model odoc_xref2 tyxml unix)
  (instrumentation
   (backend bisect_ppx)))

--- a/src/odoc/mli_output.ml
+++ b/src/odoc/mli_output.ml
@@ -1,0 +1,7 @@
+open Odoc_document
+
+let render _ page = Odoc_mli.Generator.render page
+
+let files_of_url url = Odoc_mli.Link.files_of_url url
+
+let renderer = { Renderer.name = "mli"; render; files_of_url }

--- a/test/mlioutput/dune
+++ b/test/mlioutput/dune
@@ -1,0 +1,13 @@
+(executable
+ (name test)
+ (libraries alcotest))
+
+(rule
+ (alias runtest)
+ (action
+  (run %{exe:test.exe}))
+ (deps
+  test.exe
+  %{workspace_root}/src/odoc/bin/main.exe
+  (source_tree ../cases)
+  (source_tree expect)))

--- a/test/mlioutput/expect/test_package+ml/Alias.X.mli
+++ b/test/mlioutput/expect/test_package+ml/Alias.X.mli
@@ -1,0 +1,7 @@
+(** {0 Module Alias.X}
+*)
+
+(**
+  Module Foo__X documentation. This should appear in the documentation for the alias to this module 'X'
+*)
+type t = int

--- a/test/mlioutput/expect/test_package+ml/Alias.mli
+++ b/test/mlioutput/expect/test_package+ml/Alias.mli
@@ -1,0 +1,6 @@
+(** {0 Module Alias}
+*)
+
+module Foo__X : sig ... end
+
+module X : sig ... end

--- a/test/mlioutput/expect/test_package+ml/Bugs.mli
+++ b/test/mlioutput/expect/test_package+ml/Bugs.mli
@@ -1,0 +1,9 @@
+(** {0 Module Bugs}
+*)
+
+type 'a opt = 'a option
+
+(**
+  Triggers an assertion failure when {{: https://github.com/ocaml/odoc/issues/101}https://github.com/ocaml/odoc/issues/101} is not fixed.
+*)
+val foo : ?bar:'a -> unit -> unit

--- a/test/mlioutput/expect/test_package+ml/Class.mli
+++ b/test/mlioutput/expect/test_package+ml/Class.mli
@@ -1,0 +1,25 @@
+(** {0 Module Class}
+*)
+
+class type  empty = object
+  end
+
+class type  mutually = object
+  end
+
+class type  recursive = object
+  end
+
+class  mutually' : mutually
+
+class  recursive' : recursive
+
+class type virtual  empty_virtual = object
+  end
+
+class virtual  empty_virtual' : empty
+
+class type 'a polymorphic = object
+  end
+
+class 'a polymorphic' : 'a polymorphic

--- a/test/mlioutput/expect/test_package+ml/External.mli
+++ b/test/mlioutput/expect/test_package+ml/External.mli
@@ -1,0 +1,7 @@
+(** {0 Module External}
+*)
+
+(**
+  Foo {e bar}.
+*)
+val foo : unit -> unit

--- a/test/mlioutput/expect/test_package+ml/Functor.F1.mli
+++ b/test/mlioutput/expect/test_package+ml/Functor.F1.mli
@@ -1,0 +1,15 @@
+(** {0 Module Functor.F1}
+*)
+
+(** {1:parameters Parameters}
+*)
+
+module Arg : sig
+  
+  type t
+  end
+
+(** {1:signature Signature}
+*)
+
+type t

--- a/test/mlioutput/expect/test_package+ml/Functor.F2.mli
+++ b/test/mlioutput/expect/test_package+ml/Functor.F2.mli
@@ -1,0 +1,15 @@
+(** {0 Module Functor.F2}
+*)
+
+(** {1:parameters Parameters}
+*)
+
+module Arg : sig
+  
+  type t
+  end
+
+(** {1:signature Signature}
+*)
+
+type t = Arg.t

--- a/test/mlioutput/expect/test_package+ml/Functor.F3.mli
+++ b/test/mlioutput/expect/test_package+ml/Functor.F3.mli
@@ -1,0 +1,15 @@
+(** {0 Module Functor.F3}
+*)
+
+(** {1:parameters Parameters}
+*)
+
+module Arg : sig
+  
+  type t
+  end
+
+(** {1:signature Signature}
+*)
+
+type t = Arg.t

--- a/test/mlioutput/expect/test_package+ml/Functor.F4.mli
+++ b/test/mlioutput/expect/test_package+ml/Functor.F4.mli
@@ -1,0 +1,15 @@
+(** {0 Module Functor.F4}
+*)
+
+(** {1:parameters Parameters}
+*)
+
+module Arg : sig
+  
+  type t
+  end
+
+(** {1:signature Signature}
+*)
+
+type t

--- a/test/mlioutput/expect/test_package+ml/Functor.mli
+++ b/test/mlioutput/expect/test_package+ml/Functor.mli
@@ -1,0 +1,33 @@
+(** {0 Module Functor}
+*)
+
+module type S = sig
+  
+  type t
+  end
+
+module type S1 = sig
+  
+  (** {2:parameters Parameters}
+  *)
+  
+  module _ : sig
+    
+    type t
+    end
+  
+  (** {2:signature Signature}
+  *)
+  
+  type t
+  end
+
+module F1 (Arg : S) : S
+
+module F2 (Arg : S) : S with type t = Arg.t
+
+module F3 (Arg : S) : sig ... end
+
+module F4 (Arg : S) : S
+
+module F5 () : S

--- a/test/mlioutput/expect/test_package+ml/Include.mli
+++ b/test/mlioutput/expect/test_package+ml/Include.mli
@@ -1,0 +1,48 @@
+(** {0 Module Include}
+*)
+
+module type Not_inlined = sig
+  
+  type t
+  end
+
+type t
+
+module type Inlined = sig
+  
+  type u
+  end
+
+type u
+
+module type Not_inlined_and_closed = sig
+  
+  type v
+  end
+
+include Not_inlined_and_closed
+
+module type Not_inlined_and_opened = sig
+  
+  type w
+  end
+
+type w
+
+module type Inherent_Module = sig
+  
+  val a : t
+  end
+
+val a : t
+
+module type Dorminant_Module = sig
+  
+  val a : t
+  
+  val a : u
+  end
+
+val a : t
+
+val a : u

--- a/test/mlioutput/expect/test_package+ml/Include2.mli
+++ b/test/mlioutput/expect/test_package+ml/Include2.mli
@@ -1,0 +1,12 @@
+(** {0 Module Include2}
+*)
+
+(**
+  Comment about X that should not appear when including X below.
+*)
+module X : sig ... end
+
+(** Comment about X that should not appear when including X below.
+*)
+
+type t = int

--- a/test/mlioutput/expect/test_package+ml/Include_sections.mli
+++ b/test/mlioutput/expect/test_package+ml/Include_sections.mli
@@ -1,0 +1,148 @@
+(** {0 Module Include_sections}
+*)
+
+(**
+  A module type.
+*)
+module type Something = sig
+  
+  val something : unit
+  
+  (** {2:something-1 Something 1}
+  *)
+  
+  (** foo
+  *)
+  
+  val foo : unit
+  
+  (** {3:something-2 Something 2}
+  *)
+  
+  (**
+    foo bar
+  *)
+  val bar : unit
+  
+  (** {2:something-1-bis Something 1-bis}
+  *)
+  
+  (** Some text.
+  *)
+  end
+
+(** Let's include {!Something} once
+*)
+
+val something : unit
+
+(** {1:something-1 Something 1}
+*)
+
+(** foo
+*)
+
+val foo : unit
+
+(** {2:something-2 Something 2}
+*)
+
+(**
+  foo bar
+*)
+val bar : unit
+
+(** {1:something-1-bis Something 1-bis}
+*)
+
+(** Some text.
+*)
+
+(** {1:second-include Second include}
+*)
+
+(**
+  Let's include {!Something} a second time: the heading level should be shift here.
+*)
+
+val something : unit
+
+(** {2:something-1 Something 1}
+*)
+
+(** foo
+*)
+
+val foo : unit
+
+(** {3:something-2 Something 2}
+*)
+
+(**
+  foo bar
+*)
+val bar : unit
+
+(** {2:something-1-bis Something 1-bis}
+*)
+
+(** Some text.
+*)
+
+(** {2:third-include Third include}
+*)
+
+(** Shifted some more.
+*)
+
+val something : unit
+
+(** {3:something-1 Something 1}
+*)
+
+(** foo
+*)
+
+val foo : unit
+
+(** {4:something-2 Something 2}
+*)
+
+(**
+  foo bar
+*)
+val bar : unit
+
+(** {3:something-1-bis Something 1-bis}
+*)
+
+(** Some text.
+*)
+
+(**
+  And let's include it again, but without inlining it this time: the ToC shouldn't grow.
+*)
+
+val something : unit
+
+(** {3:something-1 Something 1}
+*)
+
+(** foo
+*)
+
+val foo : unit
+
+(** {4:something-2 Something 2}
+*)
+
+(**
+  foo bar
+*)
+val bar : unit
+
+(** {3:something-1-bis Something 1-bis}
+*)
+
+(** Some text.
+*)

--- a/test/mlioutput/expect/test_package+ml/Interlude.mli
+++ b/test/mlioutput/expect/test_package+ml/Interlude.mli
@@ -1,0 +1,34 @@
+(** {0 Module Interlude}
+*)
+
+(** This is the comment associated to the module.
+*)
+
+(** Some separate stray text at the top of the module.
+*)
+
+(**
+  Foo.
+*)
+val foo : unit
+
+(** Some stray text that is not associated with any signature item.
+  It has multiple paragraphs.
+*)
+
+(** A separate block of stray text, adjacent to the preceding one.
+*)
+
+(**
+  Bar.
+*)
+val bar : unit
+
+val multiple : unit
+
+val signature : unit
+
+val items : unit
+
+(** Stray text at the bottom of the module.
+*)

--- a/test/mlioutput/expect/test_package+ml/Markup.mli
+++ b/test/mlioutput/expect/test_package+ml/Markup.mli
@@ -1,0 +1,195 @@
+(** {0 Module Markup}
+*)
+
+(** Here, we test the rendering of comment markup.
+*)
+
+(** {1:sections Sections}
+*)
+
+(**
+  Let's get these done first, because sections will be used to break up the rest of this test.
+  Besides the section heading above, there are also
+*)
+
+(** {2:subsection-headings Subsection headings}
+*)
+
+(** and
+*)
+
+(** {3:sub-subsection-headings Sub-subsection headings}
+*)
+
+(**
+  but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
+*)
+
+(** {3:anchors Anchors}
+*)
+
+(**
+  Sections can have attached {!Anchors}, and it is possible to {!link} to them. Links to section headers should not be set in source code style.
+*)
+
+(** {4:paragraph Paragraph}
+*)
+
+(** Individual paragraphs can have a heading.
+*)
+
+(** {5:subparagraph Subparagraph}
+*)
+
+(**
+  Parts of a longer paragraph that can be considered alone can also have headings.
+*)
+
+(** {1:styling Styling}
+*)
+
+(**
+  This paragraph has some styled elements: {b bold} and {i italic}, {b 
+                                                                    {i bold italic}}, 
+  {e emphasis}, {e {e emphasis} within emphasis}, {b {i bold italic}}, super
+  {^ script}, sub{_ script}. The line spacing should be enough for superscripts and subscripts not to look odd.
+  Note: {i In italics {e emphasis} is rendered as normal text while {e emphasis 
+                                                                    {e in} emphasis} is rendered in italics.} 
+  {i It also work the same in {{: #}links in italics with {e emphasis 
+                                                          {e in} emphasis}.}}
+  code is a different kind of markup that doesn't allow nested markup.
+  It's possible for two markup elements to appear {b next} {i to} each other and have a space, and appear 
+  {b next}{i to} each other with no space. It doesn't matter {b how} 
+  {i much} space it was in the source: in this sentence, it was two space characters. And in this one, there is 
+  {b a} {i newline}.
+  This is also true between {e non-}code markup {e and} code.
+  Code can appear {b inside other markup}. Its display shouldn't be affected.
+*)
+
+(** {1:links-and-references Links and references}
+*)
+
+(**
+  This is a {{: #}link}. It sends you to the top of this page. Links can have markup inside them: 
+  {{: #}{b bold}}, {{: #}{i italics}}, {{: #}{e emphasis}}, {{: #}super
+                                                            {^ script}}, 
+  {{: #}sub{_ script}}, and {{: #}code}. Links can also be nested {e 
+                                                                  {{: #}inside}} markup. Links cannot be nested inside each other. This link has no replacement text: 
+  {{: #}#}. The text is filled in by odoc. This is a shorthand link: 
+  {{: #}#}. The text is also filled in by odoc in this case.
+  This is a reference to {!foo}. References can have replacement text: 
+  {!the value foo}. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: 
+  {!{b bold}}, {!{i italic}}, {!{e emphasis}}, {!super{^ script}}, {!sub
+                                                                   {_ script}}, and 
+  {!code}. It's also possible to surround a reference in a style: {b {!foo}}. References can't be nested inside references, and links and references can't be nested inside each other.
+*)
+
+(** {1:preformatted-text Preformatted text}
+*)
+
+(** This is a code block:
+  {[
+    let foo = ()
+(** There are some nested comments in here, but an unpaired comment
+    terminator would terminate the whole doc surrounding comment. It's
+    best to keep code blocks no wider than 72 characters. *)
+
+let bar =
+  ignore foo
+  ]}There are also verbatim blocks:
+  {v The main difference is these don't get syntax highlighting.
+  v}
+*)
+
+(** {1:lists Lists}
+*)
+
+(** -
+      This is a
+  -
+    shorthand bulleted list,
+  -
+    and the paragraphs in each list item support {e styling}.
+  1)
+    This is a
+  2)
+    shorthand numbered list.
+  -
+    Shorthand list items can span multiple lines, however trying to put two paragraphs into a shorthand list item using a double line break
+  just creates a paragraph outside the list.
+  -
+    Similarly, inserting a blank line between two list items
+  -
+    creates two separate lists.
+  -
+    To get around this limitation, one
+    can use explicitly-delimited lists.
+  -
+    This one is bulleted,
+  1)
+    but there is also the numbered variant.
+  -
+    -
+      lists
+    -
+      can be nested
+    -
+      and can include references
+    -
+      {!foo}
+*)
+
+(** {1:unicode Unicode}
+*)
+
+(** The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
+*)
+
+(** {1:raw-html Raw HTML}
+*)
+
+(** Raw HTML can be  as inline elements into sentences.
+*)
+
+(** {1:modules Modules}
+*)
+
+(** @X:
+      @X:
+        @Y:
+          @Z:
+            
+*)
+
+(** {1:tags Tags}
+*)
+
+(** Each comment can end with zero or more tags. Here are some examples:
+  @author:
+    antron
+  @deprecated:
+    a {e long} time ago
+  @parameter foo:
+    unused
+  @raises Failure:
+    always
+  @returns:
+    never
+  @see {{: #}#}:
+    this url
+  @see foo.ml:
+    this file
+  @see Foo:
+    this document
+  @since:
+    0
+  @before 1.0:
+    it was in b{^ e}t{_ a}
+  @version:
+    -1
+*)
+
+(**
+  Comments in structure items {b support} {e markup}, t{^ o}{_ o}.
+*)
+val foo : unit

--- a/test/mlioutput/expect/test_package+ml/Module.mli
+++ b/test/mlioutput/expect/test_package+ml/Module.mli
@@ -1,0 +1,126 @@
+(** {0 Module Module}
+*)
+
+(** Foo.
+*)
+
+(**
+  The module needs at least one signature item, otherwise a bug causes the compiler to drop the module comment (above). See 
+  {{: https://caml.inria.fr/mantis/view.php?id=7701}https://caml.inria.fr/mantis/view.php?id=7701}.
+*)
+val foo : unit
+
+module type S = sig
+  
+  type t
+  
+  type u
+  
+  type 'a v
+  
+  type ('a, 'b) w
+  
+  module M : sig
+    end
+  end
+
+module type S1
+
+module type S2 = sig
+  
+  type t
+  
+  type u
+  
+  type 'a v
+  
+  type ('a, 'b) w
+  
+  module M : sig
+    end
+  end
+
+module type S3 = sig
+  
+  type t = int
+  
+  type u = string
+  
+  type 'a v
+  
+  type ('a, 'b) w
+  
+  module M : sig
+    end
+  end
+
+module type S4 = sig
+  
+  type u
+  
+  type 'a v
+  
+  type ('a, 'b) w
+  
+  module M : sig
+    end
+  end
+
+module type S5 = sig
+  
+  type t
+  
+  type u
+  
+  type ('a, 'b) w
+  
+  module M : sig
+    end
+  end
+
+type ('a, 'b) result
+
+module type S6 = sig
+  
+  type t
+  
+  type u
+  
+  type 'a v
+  
+  module M : sig
+    end
+  end
+
+module M' : sig ... end
+
+module type S7 = sig
+  
+  type t
+  
+  type u
+  
+  type 'a v
+  
+  type ('a, 'b) w
+  
+  module M = M'
+  end
+
+module type S8 = sig
+  
+  type t
+  
+  type u
+  
+  type 'a v
+  
+  type ('a, 'b) w
+  end
+
+module type S9 = sig
+  end
+
+module Mutually : sig ... end
+
+module Recursive : sig ... end

--- a/test/mlioutput/expect/test_package+ml/Nested.F.mli
+++ b/test/mlioutput/expect/test_package+ml/Nested.F.mli
@@ -1,0 +1,52 @@
+(** {0 Module Nested.F}
+*)
+
+(** This is a functor F.
+*)
+
+(** Some additional comments.
+*)
+
+(** {1:type Type}
+*)
+
+(** {1:parameters Parameters}
+*)
+
+module Arg1 : sig
+  
+  (** {3:type Type}
+  *)
+  
+  (**
+    Some type.
+  *)
+  type t
+  
+  (** {3:values Values}
+  *)
+  
+  (**
+    The value of y.
+  *)
+  val y : t
+  end
+
+module Arg2 : sig
+  
+  (** {3:type Type}
+  *)
+  
+  (**
+    Some type.
+  *)
+  type t
+  end
+
+(** {1:signature Signature}
+*)
+
+(**
+  Some type.
+*)
+type t = Arg1.t * Arg2.t

--- a/test/mlioutput/expect/test_package+ml/Nested.X.mli
+++ b/test/mlioutput/expect/test_package+ml/Nested.X.mli
@@ -1,0 +1,24 @@
+(** {0 Module Nested.X}
+*)
+
+(** This is module X.
+*)
+
+(** Some additional comments.
+*)
+
+(** {1:type Type}
+*)
+
+(**
+  Some type.
+*)
+type t
+
+(** {1:values Values}
+*)
+
+(**
+  The value of x.
+*)
+val x : t

--- a/test/mlioutput/expect/test_package+ml/Nested.inherits.mli
+++ b/test/mlioutput/expect/test_package+ml/Nested.inherits.mli
@@ -1,0 +1,4 @@
+(** {0 Class Nested.inherits}
+*)
+
+inherit z

--- a/test/mlioutput/expect/test_package+ml/Nested.mli
+++ b/test/mlioutput/expect/test_package+ml/Nested.mli
@@ -1,0 +1,56 @@
+(** {0 Module Nested}
+*)
+
+(** This comment needs to be here before #235 is fixed.
+*)
+
+(** {1:module Module}
+*)
+
+(**
+  This is module X.
+*)
+module X : sig ... end
+
+(** {1:module-type Module type}
+*)
+
+(**
+  This is module type Y.
+*)
+module type Y = sig
+  
+  (** {3:type Type}
+  *)
+  
+  (**
+    Some type.
+  *)
+  type t
+  
+  (** {3:values Values}
+  *)
+  
+  (**
+    The value of y.
+  *)
+  val y : t
+  end
+
+(** {1:functor Functor}
+*)
+
+(**
+  This is a functor F.
+*)
+module F (Arg1 : Y) (Arg2 : sig ... end) : sig ... end
+
+(** {1:class Class}
+*)
+
+(**
+  This is class z.
+*)
+class virtual  z : object ... end
+
+class virtual  inherits : object ... end

--- a/test/mlioutput/expect/test_package+ml/Nested.z.mli
+++ b/test/mlioutput/expect/test_package+ml/Nested.z.mli
@@ -1,0 +1,25 @@
+(** {0 Class Nested.z}
+*)
+
+(** This is class z.
+*)
+
+(** Some additional comments.
+*)
+
+(**
+  Some value.
+*)
+val y : int
+
+val mutable virtual y' : int
+
+(** {1:methods Methods}
+*)
+
+(**
+  Some method.
+*)
+method z : int
+
+method private virtual z' : int

--- a/test/mlioutput/expect/test_package+ml/Ocamlary.mli
+++ b/test/mlioutput/expect/test_package+ml/Ocamlary.mli
@@ -1,0 +1,1265 @@
+(** {0 Module Ocamlary}
+*)
+
+(**
+  This is an {i interface} with {b all} of the {e module system} features. This documentation demonstrates:
+*)
+
+(** -
+      comment formatting
+  -
+    unassociated comments
+  -
+    documentation sections
+  -
+    module system documentation including
+    1)
+      submodules
+    2)
+      module aliases
+    3)
+      module types
+    4)
+      module type aliases
+    5)
+      modules with signatures
+    6)
+      modules with aliased signatures
+*)
+
+(** A numbered list:
+*)
+
+(** 1)
+      32)
+         23)
+            1
+*)
+
+(** David Sheets is the author.
+*)
+
+(** @author:
+      David Sheets
+*)
+
+(**
+  You may find more information about this HTML documentation renderer at 
+  {{: https://github.com/dsheets/ocamlary}github.com/dsheets/ocamlary}.
+*)
+
+(** This is some verbatim text:{v verbatim
+                               v}
+*)
+
+(** This is some verbatim text:{v [][df[]]}}
+                               v}
+*)
+
+(** Here is some raw LaTeX: 
+*)
+
+(** Here is an index table of Empty modules:@{!Empty}:
+                                              A plain, empty module
+  @{!EmptyAlias}:
+    A plain module alias of Empty
+*)
+
+(** Here is a table of links to indexes: indexlist
+*)
+
+(** Here is some superscript: x{^ 2}
+*)
+
+(** Here is some subscript: x{_ 0}
+*)
+
+(** Here are some escaped brackets: { [ @ ] }
+*)
+
+(** Here is some {e emphasis} followed by code.
+*)
+
+(** An unassociated comment
+*)
+
+(** {1:level-1 Level 1}
+*)
+
+(** {2:level-2 Level 2}
+*)
+
+(** {3:level-3 Level 3}
+*)
+
+(** {4:level-4 Level 4}
+*)
+
+(** {3:basic-module-stuff Basic module stuff}
+*)
+
+(**
+  A plain, empty module
+*)
+module Empty : sig ... end
+
+(**
+  An ambiguous, misnamed module type
+*)
+module type Empty = sig
+  
+  type t
+  end
+
+(**
+  An ambiguous, misnamed module type
+*)
+module type MissingComment = sig
+  
+  type t
+  end
+
+(** {1:s9000 Section 9000}
+*)
+
+(**
+  A plain module alias of Empty
+*)
+module EmptyAlias = Empty
+
+(** {3:emptySig EmptySig}
+*)
+
+(**
+  A plain, empty module signature
+*)
+module type EmptySig = sig
+  end
+
+(**
+  A plain, empty module signature alias of
+*)
+module type EmptySigAlias = sig
+  end
+
+(**
+  A plain module of a signature of {!EmptySig} (reference)
+*)
+module ModuleWithSignature : EmptySig
+
+(**
+  A plain module with an alias signature
+*)
+module ModuleWithSignatureAlias : EmptySigAlias
+
+module One : sig ... end
+
+(**
+  There's a signature in a module in this signature.
+*)
+module type SigForMod = sig
+  
+  module Inner : sig
+    
+    module type Empty = sig
+      end
+    end
+  end
+
+module type SuperSig = sig
+  
+  module type SubSigA = sig
+    
+    (** {7:subSig A Labeled Section Header Inside of a Signature}
+    *)
+    
+    type t
+    
+    module SubSigAMod : sig
+      
+      type sub_sig_a_mod
+      end
+    end
+  
+  module type SubSigB = sig
+    
+    (** {7:subSig Another Labeled Section Header Inside of a Signature}
+    *)
+    
+    type t
+    end
+  
+  module type EmptySig = sig
+    
+    type not_actually_empty
+    end
+  
+  module type One = sig
+    
+    type two
+    end
+  
+  module type SuperSig = sig
+    end
+  end
+
+(**
+  For a good time, see SuperSig.SubSigA.subSig or SuperSig.SubSigB.subSig or 
+  {!SuperSig.EmptySig}. Section {!Section 9000} is also interesting. 
+  {!EmptySig} is the section and {!EmptySig} is the module signature.
+*)
+
+(**
+  Buffer.t
+*)
+module Buffer : sig ... end
+
+(** Some text before exception title.
+*)
+
+(** {3:basic-exception-stuff Basic exception stuff}
+*)
+
+(** After exception title.
+*)
+
+(**
+  Unary exception constructor
+*)
+exception Kaboom of unit
+
+(**
+  Binary exception constructor
+*)
+exception Kablam of unit * unit
+
+(**
+  Unary exception constructor over binary tuple
+*)
+exception Kapow of unit * unit
+
+(**
+  {!EmptySig} is a module and {!EmptySig} is this exception.
+*)
+exception EmptySig
+
+(**
+  {!EmptySigAlias} is this exception.
+*)
+exception EmptySigAlias
+
+(**
+  {3:basic-type-and-value-stuff-with-advanced-doc-comments Basic type and value stuff with advanced doc comments}
+*)
+
+(**
+  {!a_function} is this type and {!a_function} is the value below.
+*)
+type ('a, 'b) a_function = 'a -> 'b
+
+(**
+  This is a_function with param and return type.
+  @parameter x:
+    the x coordinate
+  @returns:
+    the y coordinate
+*)
+val a_function : x:int -> int
+
+val fun_fun_fun : ((int, int) a_function, (unit, unit) a_function) a_function
+
+val fun_maybe : ?yes:unit -> unit -> int
+
+(**
+  @raises Not_found:
+    That's all it does
+*)
+val not_found : unit -> unit
+
+(**
+  @see {{: http://ocaml.org/}http://ocaml.org/}:
+    The OCaml Web site
+*)
+val ocaml_org : string
+
+(**
+  @see some_file:
+    The file called some_file
+*)
+val some_file : string
+
+(**
+  @see some_doc:
+    The document called some_doc
+*)
+val some_doc : string
+
+(**
+  This value was introduced in the Mesozoic era.
+  @since:
+    mesozoic
+*)
+val since_mesozoic : unit
+
+(**
+  This value has had changes in 1.0.0, 1.1.0, and 1.2.0.
+  @before 1.0.0:
+    before 1.0.0
+  @before 1.1.0:
+    before 1.1.0
+  @version:
+    1.2.0
+*)
+val changing : unit
+
+(** {3:some-operators Some Operators}
+*)
+
+val (~-) : unit
+
+val (!) : unit
+
+val (@) : unit
+
+val ($) : unit
+
+val (%) : unit
+
+val (&) : unit
+
+val (*) : unit
+
+val (-) : unit
+
+val (+) : unit
+
+val (-?) : unit
+
+val (/) : unit
+
+val (:=) : unit
+
+val (=) : unit
+
+val (land) : unit
+
+(** {3:advanced-module-stuff Advanced Module Stuff}
+*)
+
+(**
+  This comment is for CollectionModule.
+*)
+module CollectionModule : sig ... end
+
+(**
+  module type of
+*)
+module type COLLECTION = sig
+  
+  (** This comment is for CollectionModule.
+  *)
+  
+  (**
+    This comment is for collection.
+  *)
+  type collection
+  
+  type element
+  
+  (**
+    This comment is for InnerModuleA.
+  *)
+  module InnerModuleA : sig
+    
+    (**
+      This comment is for t.
+    *)
+    type t = collection
+    
+    (**
+      This comment is for InnerModuleA'.
+    *)
+    module InnerModuleA' : sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = (unit, unit) a_function
+      end
+    
+    (**
+      This comment is for InnerModuleTypeA'.
+    *)
+    module type InnerModuleTypeA' = sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = InnerModuleA'.t
+      end
+    end
+  
+  (**
+    This comment is for InnerModuleTypeA.
+  *)
+  module type InnerModuleTypeA = sig
+    
+    (**
+      This comment is for t.
+    *)
+    type t = InnerModuleA.InnerModuleA'.t
+    end
+  end
+
+module Recollection (C : COLLECTION) : COLLECTION with type collection = C.element list and type element = C.collection
+
+module type MMM = sig
+  
+  module C : sig
+    
+    (** This comment is for CollectionModule.
+    *)
+    
+    (**
+      This comment is for collection.
+    *)
+    type collection
+    
+    type element
+    
+    (**
+      This comment is for InnerModuleA.
+    *)
+    module InnerModuleA : sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = collection
+      
+      (**
+        This comment is for InnerModuleA'.
+      *)
+      module InnerModuleA' : sig
+        
+        (**
+          This comment is for t.
+        *)
+        type t = (unit, unit) a_function
+        end
+      
+      (**
+        This comment is for InnerModuleTypeA'.
+      *)
+      module type InnerModuleTypeA' = sig
+        
+        (**
+          This comment is for t.
+        *)
+        type t = InnerModuleA'.t
+        end
+      end
+    
+    (**
+      This comment is for InnerModuleTypeA.
+    *)
+    module type InnerModuleTypeA = sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = InnerModuleA.InnerModuleA'.t
+      end
+    end
+  end
+
+module type RECOLLECTION = sig
+  
+  module C = Recollection(CollectionModule)
+  end
+
+module type RecollectionModule = sig
+  
+  type collection = CollectionModule.element list
+  
+  type element = CollectionModule.collection
+  
+  (**
+    This comment is for InnerModuleA.
+  *)
+  module InnerModuleA : sig
+    
+    (**
+      This comment is for t.
+    *)
+    type t = collection
+    
+    (**
+      This comment is for InnerModuleA'.
+    *)
+    module InnerModuleA' : sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = (unit, unit) a_function
+      end
+    
+    (**
+      This comment is for InnerModuleTypeA'.
+    *)
+    module type InnerModuleTypeA' = sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = InnerModuleA'.t
+      end
+    end
+  
+  (**
+    This comment is for InnerModuleTypeA.
+  *)
+  module type InnerModuleTypeA = sig
+    
+    (**
+      This comment is for t.
+    *)
+    type t = InnerModuleA.InnerModuleA'.t
+    end
+  end
+
+module type A = sig
+  
+  type t
+  
+  module Q : sig
+    
+    (** This comment is for CollectionModule.
+    *)
+    
+    (**
+      This comment is for collection.
+    *)
+    type collection
+    
+    type element
+    
+    (**
+      This comment is for InnerModuleA.
+    *)
+    module InnerModuleA : sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = collection
+      
+      (**
+        This comment is for InnerModuleA'.
+      *)
+      module InnerModuleA' : sig
+        
+        (**
+          This comment is for t.
+        *)
+        type t = (unit, unit) a_function
+        end
+      
+      (**
+        This comment is for InnerModuleTypeA'.
+      *)
+      module type InnerModuleTypeA' = sig
+        
+        (**
+          This comment is for t.
+        *)
+        type t = InnerModuleA'.t
+        end
+      end
+    
+    (**
+      This comment is for InnerModuleTypeA.
+    *)
+    module type InnerModuleTypeA = sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = InnerModuleA.InnerModuleA'.t
+      end
+    end
+  end
+
+module type B = sig
+  
+  type t
+  
+  module Q : sig
+    
+    (** This comment is for CollectionModule.
+    *)
+    
+    (**
+      This comment is for collection.
+    *)
+    type collection
+    
+    type element
+    
+    (**
+      This comment is for InnerModuleA.
+    *)
+    module InnerModuleA : sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = collection
+      
+      (**
+        This comment is for InnerModuleA'.
+      *)
+      module InnerModuleA' : sig
+        
+        (**
+          This comment is for t.
+        *)
+        type t = (unit, unit) a_function
+        end
+      
+      (**
+        This comment is for InnerModuleTypeA'.
+      *)
+      module type InnerModuleTypeA' = sig
+        
+        (**
+          This comment is for t.
+        *)
+        type t = InnerModuleA'.t
+        end
+      end
+    
+    (**
+      This comment is for InnerModuleTypeA.
+    *)
+    module type InnerModuleTypeA = sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = InnerModuleA.InnerModuleA'.t
+      end
+    end
+  end
+
+(**
+  This module type includes two signatures.
+*)
+module type C = sig
+  
+  type t
+  
+  module Q : sig
+    
+    (** This comment is for CollectionModule.
+    *)
+    
+    (**
+      This comment is for collection.
+    *)
+    type collection
+    
+    type element
+    
+    (**
+      This comment is for InnerModuleA.
+    *)
+    module InnerModuleA : sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = collection
+      
+      (**
+        This comment is for InnerModuleA'.
+      *)
+      module InnerModuleA' : sig
+        
+        (**
+          This comment is for t.
+        *)
+        type t = (unit, unit) a_function
+        end
+      
+      (**
+        This comment is for InnerModuleTypeA'.
+      *)
+      module type InnerModuleTypeA' = sig
+        
+        (**
+          This comment is for t.
+        *)
+        type t = InnerModuleA'.t
+        end
+      end
+    
+    (**
+      This comment is for InnerModuleTypeA.
+    *)
+    module type InnerModuleTypeA = sig
+      
+      (**
+        This comment is for t.
+      *)
+      type t = InnerModuleA.InnerModuleA'.t
+      end
+    end
+  
+  
+  end
+
+(**
+  This comment is for FunctorTypeOf.
+*)
+module FunctorTypeOf (Collection : module type of CollectionModule) : sig ... end
+
+(**
+  This comment is for IncludeModuleType.
+*)
+module type IncludeModuleType = sig
+  
+  
+  end
+
+module type ToInclude = sig
+  
+  module IncludedA : sig
+    
+    type t
+    end
+  
+  module type IncludedB = sig
+    
+    type s
+    end
+  end
+
+module IncludedA : sig ... end
+
+module type IncludedB = sig
+  
+  type s
+  end
+
+(** {3:advanced-type-stuff Advanced Type Stuff}
+*)
+
+(**
+  This comment is for record.
+  This comment is also for record.
+*)
+type record = {
+  field1 : int;
+  (**
+    This comment is for field1.
+  *)
+  field2 : int;
+  (**
+    This comment is for field2.
+  *)}
+
+type mutable_record = {
+  mutable a : int;
+  (**
+    a is first and mutable
+  *)
+  b : unit;
+  (**
+    b is second and immutable
+  *)
+  mutable c : int;
+  (**
+    c is third and mutable
+  *)}
+
+type universe_record = {
+  nihilate : a. 'a -> unit;}
+
+(**
+  This comment is for variant.
+  This comment is also for variant.
+*)
+type variant = 
+  | TagA
+  (**
+    This comment is for TagA.
+  *)
+  | ConstrB of int
+  (**
+    This comment is for ConstrB.
+  *)
+  | ConstrC of int * int
+  (**
+    This comment is for binary ConstrC.
+  *)
+  | ConstrD of int * int
+  (**
+    This comment is for unary ConstrD of binary tuple.
+  *)
+
+(**
+  This comment is for poly_variant.
+  Wow! It was a polymorphic variant!
+*)
+type poly_variant = [ 
+  | `TagA
+  | `ConstrB of int ]
+
+(**
+  This comment is for full_gadt.
+  Wow! It was a GADT!
+*)
+type (_, _) full_gadt = 
+  | Tag : (unit, unit) full_gadt
+  | First : 'a -> ('a, unit) full_gadt
+  | Second : 'a -> (unit, 'a) full_gadt
+  | Exist : 'a * 'b -> ('b, unit) full_gadt
+
+(**
+  This comment is for partial_gadt.
+  Wow! It was a mixed GADT!
+*)
+type 'a partial_gadt = 
+  | AscribeTag : 'a partial_gadt
+  | OfTag of 'a partial_gadt
+  | ExistGadtTag : ('a -> 'b) -> 'a partial_gadt
+
+(**
+  This comment is for alias.
+*)
+type alias = variant
+
+(**
+  This comment is for tuple.
+*)
+type tuple = (alias * alias) * alias * (alias * alias)
+
+(**
+  This comment is for variant_alias.
+*)
+type variant_alias = variant = 
+  | TagA
+  | ConstrB of int
+  | ConstrC of int * int
+  | ConstrD of int * int
+
+(**
+  This comment is for record_alias.
+*)
+type record_alias = record = {
+  field1 : int;
+  field2 : int;}
+
+(**
+  This comment is for poly_variant_union.
+*)
+type poly_variant_union = [ 
+  | poly_variant
+  | `TagC ]
+
+type 'a poly_poly_variant = [ 
+  | `TagA of 'a ]
+
+type ('a, 'b) bin_poly_poly_variant = [ 
+  | `TagA of 'a
+  | `ConstrB of 'b ]
+
+type 'a open_poly_variant = [> `TagA ] as 'a
+
+type 'a open_poly_variant2 = [> `ConstrB of int ] as 'a
+
+type 'a open_poly_variant_alias = 'a open_poly_variant open_poly_variant2
+
+type 'a poly_fun = [> `ConstrB of int ] as 'a -> 'a
+
+type 'a poly_fun_constraint = 'a -> 'a constraint 'a = [> `TagA ]
+
+type 'a closed_poly_variant = [< `One | `Two ] as 'a
+
+type 'a clopen_poly_variant = [< `One | `Two of int | `Three Two Three ] as 'a
+
+type nested_poly_variant = [ 
+  | `A
+  | `B of [ `B1 | `B2 ]
+  | `C
+  | `D of [ `D1 of [ `D1a ] ] ]
+
+(**
+  This comment is for full_gadt_alias.
+*)
+type ('a, 'b) full_gadt_alias = ('a, 'b) full_gadt = 
+  | Tag : (unit, unit) full_gadt_alias
+  | First : 'a -> ('a, unit) full_gadt_alias
+  | Second : 'a -> (unit, 'a) full_gadt_alias
+  | Exist : 'a * 'b -> ('b, unit) full_gadt_alias
+
+(**
+  This comment is for partial_gadt_alias.
+*)
+type 'a partial_gadt_alias = 'a partial_gadt = 
+  | AscribeTag : 'a partial_gadt_alias
+  | OfTag of 'a partial_gadt_alias
+  | ExistGadtTag : ('a -> 'b) -> 'a partial_gadt_alias
+
+(**
+  This comment is for {!Exn_arrow}.
+*)
+exception Exn_arrow : unit -> exn
+
+(**
+  This comment is for {!mutual_constr_a} then {!mutual_constr_b}.
+*)
+type mutual_constr_a = 
+  | A
+  | B_ish of mutual_constr_b
+  (**
+    This comment is between {!mutual_constr_a} and {!mutual_constr_b}.
+  *)
+
+(**
+  This comment is for {!mutual_constr_b} then {!mutual_constr_a}.
+*)
+and mutual_constr_b = 
+  | B
+  | A_ish of mutual_constr_a
+  (**
+    This comment must be here for the next to associate correctly.
+  *)
+
+type rec_obj = < f : int; g : unit -> unit; h : rec_obj; >
+
+type 'a open_obj = < f : int; g : unit -> unit; .. > as 'a
+
+type 'a oof = < a : unit; .. > as 'a -> 'a
+
+type 'a any_obj = < .. > as 'a
+
+type empty_obj = < >
+
+type one_meth = < meth : unit; >
+
+(**
+  A mystery wrapped in an ellipsis
+*)
+type ext = ..
+
+type ext += 
+  | ExtA
+
+type ext += 
+  | ExtB
+
+type ext += 
+  | ExtC of unit
+  | ExtD of ext
+
+type ext += 
+  | ExtE
+
+type ext += 
+  | ExtF
+
+(**
+  'a poly_ext
+*)
+type 'a poly_ext = ..
+
+type poly_ext += 
+  | Foo of 'b
+  | Bar of 'b * 'b
+  (**
+    'b poly_ext
+  *)
+
+type poly_ext += 
+  | Quux of 'c
+  (**
+    'c poly_ext
+  *)
+
+module ExtMod : sig ... end
+
+type ExtMod.t += 
+  | ZzzTop0
+  (**
+    It's got the rock
+  *)
+
+type ExtMod.t += 
+  | ZzzTop of unit
+  (**
+    and it packs a unit.
+  *)
+
+(**
+  Rotate keys on my mark...
+*)
+val launch_missiles : unit -> unit
+
+(**
+  A brown paper package tied up with string
+*)
+type my_mod = (module COLLECTION)
+
+class  empty_class : object ... end
+
+class  one_method_class : object ... end
+
+class  two_method_class : object ... end
+
+class 'a param_class : 'a -> object ... end
+
+type my_unit_object = unit param_class
+
+type 'a my_unit_class = unit param_class as 'a
+
+module Dep1 : sig ... end
+
+module Dep2 (Arg : sig ... end) : sig ... end
+
+type dep1 = Dep2(Dep1).B.c
+
+module Dep3 : sig ... end
+
+module Dep4 : sig ... end
+
+module Dep5 (Arg : sig ... end) : sig ... end
+
+type dep2 = Dep5(Dep4).Z.X.b
+
+type dep3 = Dep5(Dep4).Z.Y.a
+
+module Dep6 : sig ... end
+
+module Dep7 (Arg : sig ... end) : sig ... end
+
+type dep4 = Dep7(Dep6).M.Y.d
+
+module Dep8 : sig ... end
+
+module Dep9 (X : sig ... end) : sig ... end
+
+module type Dep10 = sig
+  
+  type t = int
+  end
+
+module Dep11 : sig ... end
+
+module Dep12 (Arg : sig ... end) : sig ... end
+
+module Dep13 : Dep12(Dep11).T
+
+type dep5 = Dep13.c
+
+module type With1 = sig
+  
+  module M : sig
+    
+    module type S
+    end
+  
+  module N : M.S
+  end
+
+module With2 : sig ... end
+
+module With3 : With1 with module M = With2
+
+type with1 = With3.N.t
+
+module With4 : With1 with module M := With2
+
+type with2 = With4.N.t
+
+module With5 : sig ... end
+
+module With6 : sig ... end
+
+module With7 (X : sig ... end) : sig ... end
+
+module type With8 = sig
+  
+  module M : sig
+    
+    module type S = sig
+      
+      type t
+      end
+    
+    module N : sig
+      
+      type t = With5.N.t
+      end
+    end
+  end
+
+module With9 : sig ... end
+
+module With10 : sig ... end
+
+module type With11 = sig
+  
+  module M = With9
+  
+  module N : sig
+    
+    type t = int
+    end
+  end
+
+module type NestedInclude1 = sig
+  
+  module type NestedInclude2 = sig
+    
+    type nested_include
+    end
+  end
+
+module type NestedInclude2 = sig
+  
+  type nested_include
+  end
+
+type nested_include = int
+
+module DoubleInclude1 : sig ... end
+
+module DoubleInclude3 : sig ... end
+
+type double_include
+
+module IncludeInclude1 : sig ... end
+
+module type IncludeInclude2 = sig
+  
+  type include_include
+  end
+
+type include_include
+
+(** {1:indexmodules Trying the {!modules: ...} command.}
+*)
+
+(**
+  With ocamldoc, toplevel units will be linked and documented, while submodules will behave as simple references.
+  With odoc, everything should be resolved (and linked) but only toplevel units will be documented.
+  @{!Dep1.X}:
+    @DocOckTypes:
+      @{!Ocamlary.IncludeInclude1}:
+        @{!Ocamlary}:
+          This is an {i interface} with {b all} of the {e module system} features. This documentation demonstrates:
+*)
+
+(**
+  {3:weirder-usages-involving-module-types Weirder usages involving module types}
+*)
+
+(** @IncludeInclude1.IncludeInclude2:
+      @Dep4.T:
+        @{!A.Q}:
+          
+*)
+
+(** {1:playing-with-@canonical-paths Playing with @canonical paths}
+*)
+
+module CanonicalTest : sig ... end
+
+(**
+  Some ref to {!CanonicalTest.Base__Tests.C.t} and {!CanonicalTest.Base__Tests.L.id}. But also to 
+  {!CanonicalTest.Base__.List} and {!CanonicalTest.Base__.List.t}
+*)
+val test : 'a CanonicalTest.Base.List.t -> unit
+
+(** {1:aliases Aliases again}
+*)
+
+(**
+  Let's imitate jst's layout.
+*)
+module Aliases : sig ... end
+
+(** {1:section-title-splicing Section title splicing}
+*)
+
+(** I can refer to
+  -
+    {!section:indexmodules} : {!Trying the {!modules: ...} command.}
+  -
+    {!aliases} : {!Aliases again}
+  But also to things in submodules:
+  -
+    {!section:SuperSig.SubSigA.subSig} : SuperSig.SubSigA.subSig
+  -
+    {!Aliases.incl} : {!Aliases:incl}
+  And just to make sure we do not mess up:-
+                                            {{!section:indexmodules}A} : 
+                                            {!A}
+  -
+    {{!aliases}B} : {!B}
+  -
+    {{!section:SuperSig.SubSigA.subSig}C} : {!C}
+  -
+    {{!Aliases.incl}D} : {!D}
+*)
+
+(** {1:new-reference-syntax New reference syntax}
+*)
+
+module type M = sig
+  
+  type t
+  end
+
+module M : sig ... end
+
+(** Here goes:-
+                {!module-M.t} : {!M.t}-
+                                        {!module-type-M.t} : {!M.t}
+*)
+
+module Only_a_module : sig ... end
+
+(** Some here should fail:-
+                            {!Only_a_module.t} : {!Only_a_module.t}
+  -
+    {!module-Only_a_module.t} : {!Only_a_module.t}
+  -
+    {!module-type-Only_a_module.t} : Only_a_module.t : {!test}
+*)
+
+module type TypeExt = sig
+  
+  type t = ..
+  
+  type t += 
+    | C
+  
+  val f : t -> unit
+  end
+
+type new_t = ..
+
+type new_t += 
+  | C
+
+module type TypeExtPruned = sig
+  
+  type new_t += 
+    | C
+  
+  val f : new_t -> unit
+  end

--- a/test/mlioutput/expect/test_package+ml/Recent.X.mli
+++ b/test/mlioutput/expect/test_package+ml/Recent.X.mli
@@ -1,0 +1,10 @@
+(** {0 Module Recent.X}
+*)
+
+module L := Z.Y
+
+type t = int Z.Y.X.t
+
+type u := int
+
+type v = u Z.Y.X.t

--- a/test/mlioutput/expect/test_package+ml/Recent.mli
+++ b/test/mlioutput/expect/test_package+ml/Recent.mli
@@ -1,0 +1,77 @@
+(** {0 Module Recent}
+*)
+
+module type S = sig
+  end
+
+module type S1 = sig
+  
+  (** {2:parameters Parameters}
+  *)
+  
+  module _ : sig
+    end
+  
+  (** {2:signature Signature}
+  *)
+  end
+
+type variant = 
+  | A
+  | B of int
+  | C
+  (**
+    foo
+  *)
+  | D
+  (**
+    {e bar}
+  *)
+  | E of {
+  a : int;}
+
+type _ gadt = 
+  | A : int gadt
+  | B : int -> string gadt
+  (**
+    foo
+  *)
+  | C : {
+  a : int;} -> unit gadt
+
+type polymorphic_variant = [ 
+  | `A
+  | `B of int
+  | `C
+  (**
+    foo
+  *)
+  | `D
+  (**
+    bar
+  *) ]
+
+type empty_variant = |
+
+type nonrec nonrec_ = int
+
+type empty_conj = 
+  | X : [< `X of & 'a & int * float ] -> empty_conj
+
+type conj = 
+  | X : [< `X of int & [< `B of int & float ] ] -> conj
+
+val empty_conj : [< `X of & 'a & int * float ]
+
+val conj : [< `X of int & [< `B of int & float ] ]
+
+module Z : sig ... end
+
+module X : sig ... end
+
+module type PolyS = sig
+  
+  type t = [ 
+    | `A
+    | `B ]
+  end

--- a/test/mlioutput/expect/test_package+ml/Recent_impl.mli
+++ b/test/mlioutput/expect/test_package+ml/Recent_impl.mli
@@ -1,0 +1,32 @@
+(** {0 Module Recent_impl}
+*)
+
+module Foo : sig ... end
+
+module B : sig ... end
+
+type u
+
+module type S = sig
+  
+  module F : sig
+    
+    (** {2:parameters Parameters}
+    *)
+    
+    module _ : sig
+      end
+    
+    (** {2:signature Signature}
+    *)
+    
+    type t
+    end
+  
+  module X : sig
+    end
+  
+  val f : F(X).t
+  end
+
+module B' = Foo.B

--- a/test/mlioutput/expect/test_package+ml/Section.mli
+++ b/test/mlioutput/expect/test_package+ml/Section.mli
@@ -1,0 +1,43 @@
+(** {0 Module Section}
+*)
+
+(** This is the module comment. Eventually, sections won't be allowed in it.
+*)
+
+(** {1:empty-section Empty section}
+*)
+
+(** {1:text-only Text only}
+*)
+
+(** Foo bar.
+*)
+
+(** {1:aside-only Aside only}
+*)
+
+(** Foo bar.
+*)
+
+(** {1:value-only Value only}
+*)
+
+val foo : unit
+
+(** {1:empty-section Empty section}
+*)
+
+(** {1:within-a-comment within a comment}
+*)
+
+(** {2:and-one-with-a-nested-section and one with a nested section}
+*)
+
+(**
+  {1:this-section-title-has-markup {e This} section {b title} {_ has} 
+  {^ markup}}
+*)
+
+(**
+  But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+*)

--- a/test/mlioutput/expect/test_package+ml/Stop.mli
+++ b/test/mlioutput/expect/test_package+ml/Stop.mli
@@ -1,0 +1,22 @@
+(** {0 Module Stop}
+*)
+
+(** This test cases exercises stop comments.
+*)
+
+(**
+  This is normal commented text.
+*)
+val foo : int
+
+(**
+  The next value is bar, and it should be missing from the documentation. There is also an entire module, M, which should also be hidden. It contains a nested stop comment, but that stop comment should not turn documentation back on in this outer module, because stop comments respect scope.
+*)
+
+(** Documentation is on again.
+  Now, we have a nested module, and it has a stop comment between its two items. We want to see that the first item is displayed, but the second is missing, and the stop comment disables documenation only in that module, and not in this outer module.
+*)
+
+module N : sig ... end
+
+val lol : int

--- a/test/mlioutput/expect/test_package+ml/Type.mli
+++ b/test/mlioutput/expect/test_package+ml/Type.mli
@@ -1,0 +1,163 @@
+(** {0 Module Type}
+*)
+
+(**
+  Some {e documentation}.
+*)
+type abstract
+
+type alias = int
+
+type private_ = private int
+
+type 'a constructor = 'a
+
+type arrow = int -> int
+
+type higher_order = (int -> int) -> int
+
+type labeled = l:int -> int
+
+type optional = ?l:int -> int
+
+type labeled_higher_order = (l:int -> int) -> (?l:int -> int) -> int
+
+type pair = int * int
+
+type parens_dropped = int * int
+
+type triple = int * int * int
+
+type nested_pair = (int * int) * int
+
+type instance = int constructor
+
+type long = labeled_higher_order -> [ `Bar | `Baz of triple ] -> pair -> labeled -> higher_order -> (string -> int) -> (int, float, char, string, char, unit) CamlinternalFormatBasics.fmtty -> nested_pair -> arrow -> string -> nested_pair array
+
+type variant_e = {
+  a : int;}
+
+type variant = 
+  | A
+  | B of int
+  | C
+  (**
+    foo
+  *)
+  | D
+  (**
+    {e bar}
+  *)
+  | E of variant_e
+
+type variant_c = {
+  a : int;}
+
+type _ gadt = 
+  | A : int gadt
+  | B : int -> string gadt
+  | C : variant_c -> unit gadt
+
+type degenerate_gadt = 
+  | A : degenerate_gadt
+
+type private_variant = private 
+  | A
+
+type record = {
+  a : int;
+  mutable b : int;
+  c : int;
+  (**
+    foo
+  *)
+  d : int;
+  (**
+    {e bar}
+  *)
+  e : a. 'a;}
+
+type polymorphic_variant = [ 
+  | `A
+  | `B of int
+  | `C of int * unit
+  | `D ]
+
+type polymorphic_variant_extension = [ 
+  | polymorphic_variant
+  | `E ]
+
+type nested_polymorphic_variant = [ 
+  | `A of [ `B | `C ] ]
+
+type private_extenion#row
+
+and private_extenion = private [> 
+  | polymorphic_variant ]
+
+type object_ = < a : int; b : int; c : int; >
+
+module type X = sig
+  
+  type t
+  
+  type u
+  end
+
+type module_ = (module X)
+
+type module_substitution = (module X with type t = int and type u = unit)
+
+type +'a covariant
+
+type -'a contravariant
+
+type _ bivariant = int
+
+type ('a, 'b) binary
+
+type using_binary = (int, int) binary
+
+type 'custom name
+
+type 'a constrained = 'a constraint 'a = int
+
+type 'a exact_variant = 'a constraint 'a = [ `A | `B of int ]
+
+type 'a lower_variant = 'a constraint 'a = [> `A | `B of int ]
+
+type 'a any_variant = 'a constraint 'a = [>  ]
+
+type 'a upper_variant = 'a constraint 'a = [< `A | `B of int ]
+
+type 'a named_variant = 'a constraint 'a = [< polymorphic_variant ]
+
+type 'a exact_object = 'a constraint 'a = < a : int; b : int; >
+
+type 'a lower_object = 'a constraint 'a = < a : int; b : int; .. >
+
+type 'a poly_object = 'a constraint 'a = < a : a. 'a; >
+
+type ('a, 'b) double_constrained = 'a * 'b constraint 'a = int constraint 'b = unit
+
+type as_ = int as 'a * 'a
+
+type extensible = ..
+
+type extensible += 
+  | Extension
+  (**
+    Documentation for {!Extension}.
+  *)
+  | Another_extension
+  (**
+    Documentation for {!Another_extension}.
+  *)
+
+type mutually = 
+  | A of recursive
+
+and recursive = 
+  | B of mutually
+
+exception Foo of int * int

--- a/test/mlioutput/expect/test_package+ml/Val.mli
+++ b/test/mlioutput/expect/test_package+ml/Val.mli
@@ -1,0 +1,14 @@
+(** {0 Module Val}
+*)
+
+(**
+  Foo.
+*)
+val documented : unit
+
+val undocumented : unit
+
+(**
+  Bar.
+*)
+val documented_above : unit

--- a/test/mlioutput/expect/test_package+ml/mld.mli
+++ b/test/mlioutput/expect/test_package+ml/mld.mli
@@ -1,0 +1,33 @@
+(** {0:mld-page Mld Page}
+*)
+
+(**
+  This is an .mld file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
+  It will have a TOC generated from section headings.
+*)
+
+(** {1:section Section}
+*)
+
+(** This is a section.Another paragraph in section.
+*)
+
+(** {1:another-section Another section}
+*)
+
+(** This is another section.Another paragraph in section 2.
+*)
+
+(** {2:subsection Subsection}
+*)
+
+(** This is a subsection.Another paragraph in subsection.
+  Yet another paragraph in subsection.
+*)
+
+(** {2:another-subsection Another Subsection}
+*)
+
+(** This is another subsection.Another paragraph in subsection 2.
+  Yet another paragraph in subsection 2.
+*)

--- a/test/mlioutput/test.ml
+++ b/test/mlioutput/test.ml
@@ -1,0 +1,245 @@
+open Printf
+
+(* Utils *)
+
+let ( // ) = Filename.concat
+
+let command label =
+  Printf.ksprintf (fun s ->
+      let exit_code = Sys.command s in
+      if exit_code <> 0 then
+        Alcotest.failf "'%s' exited with %i" label exit_code)
+
+(* Filename.extension is only available on 4.04. *)
+module Filename = struct
+  include Filename
+
+  let extension filename =
+    let dot_index = String.rindex filename '.' in
+    String.sub filename dot_index (String.length filename - dot_index)
+end
+
+(* Testing environment *)
+
+module Env = struct
+  let package = "test_package"
+
+  let odoc = "../../src/odoc/bin/main.exe"
+
+  let path ?(from_root = false) = function
+    | `scratch when from_root -> "_build/default/test/mlioutput/_scratch"
+    | `scratch -> "_scratch"
+    | `expect when from_root -> "test/mlioutput/expect"
+    | `expect -> "expect"
+    | `cases when from_root -> "test/cases"
+    | `cases -> "../cases"
+
+  let init () = Unix.mkdir (path `scratch) 0o755
+end
+
+(* Test case type and helpers *)
+
+(* A test case is a description of an input source file with a specific set of
+   options to be tested. Each test case results in a unique generated output to
+   be compared with an actually produced one.
+
+   All paths defined in this module are relative to the build directory. *)
+module Case = struct
+  type t = {
+    name : string;
+    kind : [ `mli | `mld | `ml ];
+    syntax : [ `ml | `re ];
+    outputs : string list;
+  }
+
+  let make ?(syntax = `ml) (input, outputs) =
+    let name = Filename.chop_extension input in
+    let kind =
+      match Filename.extension input with
+      | ".mli" -> `mli
+      | ".mld" -> `mld
+      | ".ml" -> `ml
+      | _ ->
+          invalid_arg (sprintf "Expected mli, mld, or ml files, got %s" input)
+    in
+    { name; kind; syntax; outputs }
+
+  let name case = case.name
+
+  let kind case = case.kind
+
+  let string_of_syntax = function `re -> "re" | `ml -> "ml"
+
+  (* The package name is enriched with test case options. *)
+  let package case =
+    let opts = [ string_of_syntax case.syntax ] in
+    let opts = String.concat "," (List.sort compare opts) in
+    Env.package ^ "+" ^ opts
+
+  let cmi_file case = Env.path `scratch // (case.name ^ ".cmi")
+
+  let cmti_file case = Env.path `scratch // (case.name ^ ".cmti")
+
+  let cmo_file case = Env.path `scratch // (case.name ^ ".cmo")
+
+  let cmt_file case = Env.path `scratch // (case.name ^ ".cmt")
+
+  let odoc_file case =
+    match case.kind with
+    | `mli | `ml -> Env.path `scratch // (case.name ^ ".odoc")
+    | `mld -> Env.path `scratch // ("page-" ^ case.name ^ ".odoc")
+
+  let source_file case =
+    match case.kind with
+    | `mli -> (Env.path `cases // case.name) ^ ".mli"
+    | `mld -> (Env.path `cases // case.name) ^ ".mld"
+    | `ml -> (Env.path `cases // case.name) ^ ".ml"
+
+  let outputs case = List.map (fun o -> package case // o) case.outputs
+end
+
+let generate_mli case =
+  match Case.kind case with
+  | `mli ->
+      command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
+        (Case.cmi_file case) (Case.source_file case);
+
+      command "odoc compile" "%s compile --package=%s %s" Env.odoc
+        (Case.package case) (Case.cmti_file case);
+
+      command "odoc mli" "%s mli --syntax=%s --output-dir=%s %s" Env.odoc
+        (Case.string_of_syntax case.syntax)
+        (Env.path `scratch)
+        (Case.odoc_file case)
+  | `mld ->
+      command "odoc compile" "%s compile --package=%s -o %s %s" Env.odoc
+        (Case.package case) (Case.odoc_file case) (Case.source_file case);
+
+      command "odoc mli" "%s mli --output-dir=%s %s" Env.odoc
+        (Env.path `scratch)
+        (Case.odoc_file case)
+  | `ml ->
+      command "ocamlfind c" "ocamlfind c -bin-annot -o %s -c %s"
+        (Case.cmo_file case) (Case.source_file case);
+
+      command "odoc compile" "%s compile --package=%s %s" Env.odoc
+        (Case.package case) (Case.cmt_file case);
+
+      command "odoc mli" "%s mli --syntax=%s --output-dir=%s %s" Env.odoc
+        (Case.string_of_syntax case.syntax)
+        (Env.path `scratch)
+        (Case.odoc_file case)
+
+let diff =
+  (* Alcotest will run all tests. We need to know when something fails for the
+     first time to stop diffing and generating promotion files. *)
+  let already_failed = ref false in
+  fun output ->
+    let actual_file = Env.path `scratch // output in
+    let expected_file = Env.path `expect // output in
+    let cmd = sprintf "diff -N -u -b %s %s" expected_file actual_file in
+    match Sys.command cmd with
+    | 0 -> ()
+    | 1 when !already_failed ->
+        (* Don't run diff for other failing tests as only one at time is shown. *)
+        Alcotest.fail "generated MLI should match expected"
+    | 1 ->
+        (* If the diff command exits with 1, the two MAN files are different.
+           diff has already written its output to STDOUT.
+
+           Also provide the command for overwriting the expected output with the
+           actual output, in case it is the actual output that is correct.
+           The paths are defined relative to the project's root. *)
+        let root_actual_file = Env.path `scratch ~from_root:true // output in
+        let root_expected_file = Env.path `expect ~from_root:true // output in
+        let write_file filename data =
+          let oc = open_out filename in
+          output_string oc data;
+          close_out oc
+        in
+        write_file Env.(path `scratch // "actual") root_actual_file;
+        write_file Env.(path `scratch // "expected") root_expected_file;
+
+        prerr_endline "\nTo promote the actual output to expected, run:";
+        Printf.eprintf "cp `cat %s` `cat %s` && make test\n\n"
+          Env.(path ~from_root:true `scratch // "actual")
+          Env.(path ~from_root:true `scratch // "expected");
+
+        already_failed := true;
+        Alcotest.fail "generated MLI should match expected"
+    | exit_code -> Alcotest.failf "'diff' exited with %i" exit_code
+
+let make_test_case ?syntax case =
+  let case = Case.make ?syntax case in
+  let run () =
+    (* Compile the source file and generate MAN. *)
+    generate_mli case;
+
+    List.iter diff (Case.outputs case)
+  in
+  (Case.name case, `Slow, run)
+
+let source_files_all =
+  [
+    ("val.mli", [ "Val.mli" ]);
+    ("markup.mli", [ "Markup.mli" ]);
+    ("section.mli", [ "Section.mli" ]);
+    ("module.mli", [ "Module.mli" ]);
+    ("interlude.mli", [ "Interlude.mli" ]);
+    ("include.mli", [ "Include.mli" ]);
+    ("include2.ml", [ "Include2.mli" ]);
+    ("include_sections.mli", [ "Include_sections.mli" ]);
+    ("mld.mld", [ "mld.mli" ]);
+    ("ocamlary.mli", [ "Ocamlary.mli" ]);
+    ( "nested.mli",
+      [
+        "Nested.mli";
+        "Nested.F.mli";
+        "Nested.X.mli";
+        "Nested.z.mli";
+        "Nested.inherits.mli";
+      ] );
+    ("type.mli", [ "Type.mli" ]);
+    ("external.mli", [ "External.mli" ]);
+    ( "functor.mli",
+      [
+        "Functor.mli";
+        "Functor.F1.mli";
+        "Functor.F2.mli";
+        "Functor.F3.mli";
+        "Functor.F4.mli";
+      ] );
+    ("class.mli", [ "Class.mli" ]);
+    ("stop.mli", [ "Stop.mli" ]);
+    ("bugs.ml", [ "Bugs.mli" ]);
+    ("alias.ml", [ "Alias.mli"; "Alias.X.mli" ]);
+  ]
+
+let source_files_post408 =
+  [
+    ("recent.mli", [ "Recent.mli"; "Recent.X.mli" ]);
+    ("recent_impl.ml", [ "Recent_impl.mli" ]);
+  ]
+
+let source_files_pre410 = [ ("bugs_pre_410.ml", [ "Bugs_pre_410.mli" ]) ]
+
+let source_files =
+  let cur =
+    Astring.String.cuts ~sep:"." Sys.ocaml_version
+    |> List.map (fun i -> try Some (int_of_string i) with _ -> None)
+  in
+  match cur with
+  | Some major :: Some minor :: _ ->
+      List.concat
+        [
+          (if major = 4 && minor < 10 then source_files_pre410 else []);
+          (if major = 4 && minor > 8 then source_files_post408 else []);
+          source_files_all;
+        ]
+  | _ -> source_files_all
+
+let () =
+  Env.init ();
+
+  Alcotest.run "mli"
+    [ ("mli_ml", List.map (make_test_case ~syntax:`ml) source_files) ]


### PR DESCRIPTION
@lpw25 has regularly requested a "plain text" output for odoc, which allow to browse the document at a leisure pace, from the comfort of a text editor.

This patch adds a new output (yay), which does exactly that. The format chosen doesn't require any tooling except a text editor. Furthermore, if standard tooling from ocaml is available, such as merlin or ocp-index, jump to-definition should work immediately, along with nice formatting and colouration.

Here is an extract from `ocamlary`:

```ocaml
(** {3:advanced-type-stuff Advanced Type Stuff}
*)

(**
  This comment is for record.
  This comment is also for record.
*)
type record = {
  field1 : int;
  (**
    This comment is for field1.
  *)
  field2 : int;
  (**
    This comment is for field2.
  *)}

(**
  This comment is for variant.
  This comment is also for variant.
*)
type variant = 
  | TagA
  (**
    This comment is for TagA.
  *)
  | ConstrB of int
  (**
    This comment is for ConstrB.
  *)
  | ConstrC of int * int
  (**
    This comment is for binary ConstrC.
  *)
  | ConstrD of int * int
  (**
    This comment is for unary ConstrD of binary tuple.
  *)
```

The behaviour of includes is governed by the attributes, and unfolded by default. Submodules are also unfolded by default.

Since these files can be considered as the simplest representation of ML interfaces, I simply called them `.mli`. 

This output is largely functional, but not yet completely polished. In particular, it occasional produces less-than-ideal indentation. I plan to improve that aspect if people like this new output format. Functors are also a bit problematic, for reasons already mentioned in #616