### PR TITLE
Improve and simplify the layout for datatypes

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -249,29 +249,21 @@ let rec documentedSrc ~resolve (t : DocumentedSrc.t) : item Html.elt list =
             match doc with
             | [] -> []
             | doc ->
-                let opening, closing = markers in
-                [
-                  Html.td
-                    ~a:(class_ [ "def-doc" ])
-                    (Html.span
-                       ~a:(class_ [ "comment-delim" ])
-                       [ Html.txt opening ]
-                     :: block ~resolve doc
-                    @ [
-                        Html.span
-                          ~a:(class_ [ "comment-delim" ])
-                          [ Html.txt closing ];
-                      ]);
-                ]
+              let opening, closing = markers in
+              let delim s =
+                [Html.span ~a:(class_ [ "comment-delim" ]) [Html.txt s]]
+              in
+              [ Html.div ~a:(class_ [ "def-doc" ]) (
+                  delim opening
+                  @ block ~resolve doc
+                  @ delim closing
+                )]
           in
           let a, link = mk_anchor anchor in
-          let content =
-            let c = link @ content in
-            Html.td ~a:(class_ attrs) (c :> any Html.elt list)
-          in
-          Html.tr ~a (content :: doc)
+          let content = (content :> any Html.elt list) in
+          Html.li ~a:(a @ class_ attrs) (link @ content @ doc)
         in
-        Html.table (List.map one l) :: to_html rest
+        Html.ol (List.map one l) :: to_html rest
   in
   to_html t
 

--- a/test/html/expect/test_package+ml/Bugs_post_406/index.html
+++ b/test/html/expect/test_package+ml/Bugs_post_406/index.html
@@ -27,12 +27,12 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec class-type" id="class-type-let_open">
+    <div class="spec class-type anchored" id="class-type-let_open">
      <a href="#class-type-let_open" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-let_open/index.html">let_open</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-let_open'">
+    <div class="spec class anchored" id="class-let_open'">
      <a href="#class-let_open'" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-let_open'/index.html">let_open'</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Labels/index.html
+++ b/test/html/expect/test_package+ml/Labels/index.html
@@ -40,12 +40,12 @@
     <a href="#L2" class="anchor"></a>Attached to nothing
    </h2>
    <div class="odoc-spec">
-    <div class="spec module" id="module-A">
+    <div class="spec module anchored" id="module-A">
      <a href="#module-A" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="A/index.html">A</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span></code>
     </div>
     <div class="spec-doc">
@@ -55,7 +55,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-f">
+    <div class="spec value anchored" id="val-f">
      <a href="#val-f" class="anchor"></a><code><span><span class="keyword">val</span> f : <a href="#type-t">t</a></span></code>
     </div>
     <div class="spec-doc">
@@ -65,7 +65,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value external" id="val-e">
+    <div class="spec value external anchored" id="val-e">
      <a href="#val-e" class="anchor"></a><code><span><span class="keyword">val</span> e : <span>unit <span class="arrow">-&gt;</span></span> <a href="#type-t">t</a></span></code>
     </div>
     <div class="spec-doc">
@@ -75,22 +75,22 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-c">
+    <div class="spec class anchored" id="class-c">
      <a href="#class-c" class="anchor"></a><code><span><span class="keyword">class</span>  </span><span><a href="class-c/index.html">c</a></span><span> : <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class-type" id="class-type-cs">
+    <div class="spec class-type anchored" id="class-type-cs">
      <a href="#class-type-cs" class="anchor"></a><code><span><span class="keyword">class</span> <span class="keyword">type</span>  </span><span><a href="class-type-cs/index.html">cs</a></span><span> = <span class="keyword">object</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec exception" id="exception-E">
+    <div class="spec exception anchored" id="exception-E">
      <a href="#exception-E" class="anchor"></a><code><span><span class="keyword">exception</span> </span><span><span class="exception">E</span></span></code>
     </div>
     <div class="spec-doc">
@@ -100,22 +100,18 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-x">
+    <div class="spec type anchored" id="type-x">
      <a href="#type-x" class="anchor"></a><code><span><span class="keyword">type</span> x</span><span> = </span><span>..</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-x">x</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-X" class="anchored">
-        <td class="def extension">
-         <a href="#extension-X" class="anchor"></a><code><span>| </span><span><span class="extension">X</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-X" class="def extension anchored">
+       <a href="#extension-X" class="anchor"></a><code><span>| </span><span><span class="extension">X</span></span></code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>
@@ -124,7 +120,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-substitution" id="module-S">
+    <div class="spec module-substitution anchored" id="module-S">
      <a href="#module-S" class="anchor"></a><code><span><span class="keyword">module</span> S := <a href="A/index.html">A</a></span></code>
     </div>
     <div class="spec-doc">
@@ -134,7 +130,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type subst" id="type-s">
+    <div class="spec type subst anchored" id="type-s">
      <a href="#type-s" class="anchor"></a><code><span><span class="keyword">type</span> s</span><span> := <a href="#type-t">t</a></span></code>
     </div>
     <div class="spec-doc">
@@ -144,45 +140,23 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-u.A'" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-u.A'" class="anchor"></a><code><span>| </span><span><span class="constructor">A'</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          Attached to constructor
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-u.A'" class="def variant constructor anchored">
+       <a href="#type-u.A'" class="anchor"></a><code><span>| </span><span><span class="constructor">A'</span></span></code><span class="def-doc"><span class="comment-delim">(*</span>Attached to constructor<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-v">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-v.f" class="anchored">
-        <td class="def record field">
-         <a href="#type-v.f" class="anchor"></a><code><span>f : <a href="#type-t">t</a>;</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          Attached to field
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-v.f" class="def record field anchored">
+       <a href="#type-v.f" class="anchor"></a><code><span>f : <a href="#type-t">t</a>;</span></code><span class="def-doc"><span class="comment-delim">(*</span>Attached to field<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
      <code><span>}</span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Markup/index.html
+++ b/test/html/expect/test_package+ml/Markup/index.html
@@ -364,7 +364,7 @@ let bar =
     </li>
    </ul>
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
     <div class="spec-doc">

--- a/test/html/expect/test_package+ml/Module/index.html
+++ b/test/html/expect/test_package+ml/Module/index.html
@@ -27,7 +27,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
     <div class="spec-doc">
@@ -37,72 +37,72 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S1">
+    <div class="spec module-type anchored" id="module-type-S1">
      <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span>S1</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S2">
+    <div class="spec module-type anchored" id="module-type-S2">
      <a href="#module-type-S2" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S2/index.html">S2</a></span><span> = <a href="module-type-S/index.html">S</a></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S3">
+    <div class="spec module-type anchored" id="module-type-S3">
      <a href="#module-type-S3" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S3/index.html">S3</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> = int</span> <span class="keyword">and</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-u">u</a> = string</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S4">
+    <div class="spec module-type anchored" id="module-type-S4">
      <a href="#module-type-S4" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S4/index.html">S4</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <a href="module-type-S/index.html#type-t">t</a> := int</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S5">
+    <div class="spec module-type anchored" id="module-type-S5">
      <a href="#module-type-S5" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S5/index.html">S5</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <span>'a <a href="module-type-S/index.html#type-v">v</a></span> := <span><span class="type-var">'a</span> list</span></span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-result">
+    <div class="spec type anchored" id="type-result">
      <a href="#type-result" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) result</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S6">
+    <div class="spec module-type anchored" id="module-type-S6">
      <a href="#module-type-S6" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S6/index.html">S6</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">type</span> <span>('a, 'b) <a href="module-type-S/index.html#type-w">w</a></span> := <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="#type-result">result</a></span></span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M'">
+    <div class="spec module anchored" id="module-M'">
      <a href="#module-M'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="M'/index.html">M'</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S7">
+    <div class="spec module-type anchored" id="module-type-S7">
      <a href="#module-type-S7" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S7/index.html">S7</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> = <a href="M'/index.html">M'</a></span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S8">
+    <div class="spec module-type anchored" id="module-type-S8">
      <a href="#module-type-S8" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S8/index.html">S8</a></span><span> = <a href="module-type-S/index.html">S</a> <span class="keyword">with</span> <span><span class="keyword">module</span> <a href="module-type-S/M/index.html">M</a> := <a href="M'/index.html">M'</a></span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S9">
+    <div class="spec module-type anchored" id="module-type-S9">
      <a href="#module-type-S9" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S9/index.html">S9</a></span><span> = <span class="keyword">module</span> <span class="keyword">type</span> <span class="keyword">of</span> <a href="M'/index.html">M'</a></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Mutually">
+    <div class="spec module anchored" id="module-Mutually">
      <a href="#module-Mutually" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Mutually/index.html">Mutually</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Recursive">
+    <div class="spec module anchored" id="module-Recursive">
      <a href="#module-Recursive" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Recursive/index.html">Recursive</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Ocamlary/index.html
+++ b/test/html/expect/test_package+ml/Ocamlary/index.html
@@ -727,34 +727,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-record">
      <a href="#type-record" class="anchor"></a><code><span><span class="keyword">type</span> record</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-record.field1" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.field1" class="anchor"></a><code><span>field1 : int;</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          This comment is for <code>field1</code>.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-record.field2" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.field2" class="anchor"></a><code><span>field2 : int;</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          This comment is for <code>field2</code>.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-record.field1" class="anchored">
+       <a href="#type-record.field1" class="anchor"></a><code><span>field1 : int;</span></code><span class="def-doc"><span class="comment-delim">(*</span>This comment is for <code>field1</code>.<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-record.field2" class="anchored">
+       <a href="#type-record.field2" class="anchor"></a><code><span>field2 : int;</span></code><span class="def-doc"><span class="comment-delim">(*</span>This comment is for <code>field2</code>.<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
      <code><span>}</span></code>
     </div>
     <div class="spec-doc">
@@ -769,119 +749,48 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-mutable_record">
      <a href="#type-mutable_record" class="anchor"></a><code><span><span class="keyword">type</span> mutable_record</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-mutable_record.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.a" class="anchor"></a><code><span><span class="keyword">mutable</span> a : int;</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          <code>a</code> is first and mutable
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-mutable_record.b" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.b" class="anchor"></a><code><span>b : unit;</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          <code>b</code> is second and immutable
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-mutable_record.c" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.c" class="anchor"></a><code><span><span class="keyword">mutable</span> c : int;</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          <code>c</code> is third and mutable
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-mutable_record.a" class="anchored">
+       <a href="#type-mutable_record.a" class="anchor"></a><code><span><span class="keyword">mutable</span> a : int;</span></code><span class="def-doc"><span class="comment-delim">(*</span><code>a</code> is first and mutable<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-mutable_record.b" class="anchored">
+       <a href="#type-mutable_record.b" class="anchor"></a><code><span>b : unit;</span></code><span class="def-doc"><span class="comment-delim">(*</span><code>b</code> is second and immutable<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-mutable_record.c" class="anchored">
+       <a href="#type-mutable_record.c" class="anchor"></a><code><span><span class="keyword">mutable</span> c : int;</span></code><span class="def-doc"><span class="comment-delim">(*</span><code>c</code> is third and mutable<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
      <code><span>}</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-universe_record">
      <a href="#type-universe_record" class="anchor"></a><code><span><span class="keyword">type</span> universe_record</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-universe_record.nihilate" class="anchored">
-        <td class="def record field">
-         <a href="#type-universe_record.nihilate" class="anchor"></a><code><span>nihilate : a. <span><span class="type-var">'a</span> <span class="arrow">-&gt;</span></span> unit;</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-universe_record.nihilate" class="anchored">
+       <a href="#type-universe_record.nihilate" class="anchor"></a><code><span>nihilate : a. <span><span class="type-var">'a</span> <span class="arrow">-&gt;</span></span> unit;</span></code>
+      </li>
+     </ol>
      <code><span>}</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-variant">
      <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant.TagA" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.TagA" class="anchor"></a><code><span>| </span><span><span class="constructor">TagA</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          This comment is for <code>TagA</code>.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-variant.ConstrB" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.ConstrB" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrB</span> <span class="keyword">of</span> int</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          This comment is for <code>ConstrB</code>.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-variant.ConstrC" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.ConstrC" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrC</span> <span class="keyword">of</span> int * int</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          This comment is for binary <code>ConstrC</code>.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-variant.ConstrD" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.ConstrD" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrD</span> <span class="keyword">of</span> int * int</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          This comment is for unary <code>ConstrD</code> of binary tuple.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant.TagA" class="anchored">
+       <a href="#type-variant.TagA" class="anchor"></a><code><span>| </span><span><span class="constructor">TagA</span></span></code><span class="def-doc"><span class="comment-delim">(*</span>This comment is for <code>TagA</code>.<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-variant.ConstrB" class="anchored">
+       <a href="#type-variant.ConstrB" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrB</span> <span class="keyword">of</span> int</span></code><span class="def-doc"><span class="comment-delim">(*</span>This comment is for <code>ConstrB</code>.<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-variant.ConstrC" class="anchored">
+       <a href="#type-variant.ConstrC" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrC</span> <span class="keyword">of</span> int * int</span></code><span class="def-doc"><span class="comment-delim">(*</span>This comment is for binary <code>ConstrC</code>.<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-variant.ConstrD" class="anchored">
+       <a href="#type-variant.ConstrD" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrD</span> <span class="keyword">of</span> int * int</span></code><span class="def-doc"><span class="comment-delim">(*</span>This comment is for unary <code>ConstrD</code> of binary tuple.<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>
@@ -895,20 +804,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-poly_variant">
      <a href="#type-poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> poly_variant</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-poly_variant.TagA" class="anchored">
-        <td class="def constructor">
-         <a href="#type-poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA</span></code>
-        </td>
-       </tr>
-       <tr id="type-poly_variant.ConstrB" class="anchored">
-        <td class="def constructor">
-         <a href="#type-poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB <span class="keyword">of</span> int</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-poly_variant.TagA" class="anchored">
+       <a href="#type-poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA</span></code>
+      </li>
+      <li id="type-poly_variant.ConstrB" class="anchored">
+       <a href="#type-poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB <span class="keyword">of</span> int</span></code>
+      </li>
+     </ol>
      <code><span> ]</span></code>
     </div>
     <div class="spec-doc">
@@ -923,30 +826,20 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-full_gadt">
      <a href="#type-full_gadt" class="anchor"></a><code><span><span class="keyword">type</span> <span>(_, _) full_gadt</span></span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-full_gadt.Tag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt.Tag" class="anchor"></a><code><span>| </span><span><span class="constructor">Tag</span> : <span><span>(unit,&nbsp;unit)</span> <a href="#type-full_gadt">full_gadt</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt.First" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt.First" class="anchor"></a><code><span>| </span><span><span class="constructor">First</span> : <span class="type-var">'a</span> <span class="arrow">-&gt;</span> <span><span>(<span class="type-var">'a</span>,&nbsp;unit)</span> <a href="#type-full_gadt">full_gadt</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt.Second" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt.Second" class="anchor"></a><code><span>| </span><span><span class="constructor">Second</span> : <span class="type-var">'a</span> <span class="arrow">-&gt;</span> <span><span>(unit,&nbsp;<span class="type-var">'a</span>)</span> <a href="#type-full_gadt">full_gadt</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt.Exist" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt.Exist" class="anchor"></a><code><span>| </span><span><span class="constructor">Exist</span> : <span class="type-var">'a</span> * <span class="type-var">'b</span> <span class="arrow">-&gt;</span> <span><span>(<span class="type-var">'b</span>,&nbsp;unit)</span> <a href="#type-full_gadt">full_gadt</a></span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-full_gadt.Tag" class="anchored">
+       <a href="#type-full_gadt.Tag" class="anchor"></a><code><span>| </span><span><span class="constructor">Tag</span> : <span><span>(unit,&nbsp;unit)</span> <a href="#type-full_gadt">full_gadt</a></span></span></code>
+      </li>
+      <li id="type-full_gadt.First" class="anchored">
+       <a href="#type-full_gadt.First" class="anchor"></a><code><span>| </span><span><span class="constructor">First</span> : <span class="type-var">'a</span> <span class="arrow">-&gt;</span> <span><span>(<span class="type-var">'a</span>,&nbsp;unit)</span> <a href="#type-full_gadt">full_gadt</a></span></span></code>
+      </li>
+      <li id="type-full_gadt.Second" class="anchored">
+       <a href="#type-full_gadt.Second" class="anchor"></a><code><span>| </span><span><span class="constructor">Second</span> : <span class="type-var">'a</span> <span class="arrow">-&gt;</span> <span><span>(unit,&nbsp;<span class="type-var">'a</span>)</span> <a href="#type-full_gadt">full_gadt</a></span></span></code>
+      </li>
+      <li id="type-full_gadt.Exist" class="anchored">
+       <a href="#type-full_gadt.Exist" class="anchor"></a><code><span>| </span><span><span class="constructor">Exist</span> : <span class="type-var">'a</span> * <span class="type-var">'b</span> <span class="arrow">-&gt;</span> <span><span>(<span class="type-var">'b</span>,&nbsp;unit)</span> <a href="#type-full_gadt">full_gadt</a></span></span></code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>
@@ -960,25 +853,17 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-partial_gadt">
      <a href="#type-partial_gadt" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a partial_gadt</span></span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-partial_gadt.AscribeTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt.AscribeTag" class="anchor"></a><code><span>| </span><span><span class="constructor">AscribeTag</span> : <span><span class="type-var">'a</span> <a href="#type-partial_gadt">partial_gadt</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-partial_gadt.OfTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt.OfTag" class="anchor"></a><code><span>| </span><span><span class="constructor">OfTag</span> <span class="keyword">of</span> <span><span class="type-var">'a</span> <a href="#type-partial_gadt">partial_gadt</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-partial_gadt.ExistGadtTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt.ExistGadtTag" class="anchor"></a><code><span>| </span><span><span class="constructor">ExistGadtTag</span> : <span>(<span><span class="type-var">'a</span> <span class="arrow">-&gt;</span></span> <span class="type-var">'b</span>)</span> <span class="arrow">-&gt;</span> <span><span class="type-var">'a</span> <a href="#type-partial_gadt">partial_gadt</a></span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-partial_gadt.AscribeTag" class="anchored">
+       <a href="#type-partial_gadt.AscribeTag" class="anchor"></a><code><span>| </span><span><span class="constructor">AscribeTag</span> : <span><span class="type-var">'a</span> <a href="#type-partial_gadt">partial_gadt</a></span></span></code>
+      </li>
+      <li id="type-partial_gadt.OfTag" class="anchored">
+       <a href="#type-partial_gadt.OfTag" class="anchor"></a><code><span>| </span><span><span class="constructor">OfTag</span> <span class="keyword">of</span> <span><span class="type-var">'a</span> <a href="#type-partial_gadt">partial_gadt</a></span></span></code>
+      </li>
+      <li id="type-partial_gadt.ExistGadtTag" class="anchored">
+       <a href="#type-partial_gadt.ExistGadtTag" class="anchor"></a><code><span>| </span><span><span class="constructor">ExistGadtTag</span> : <span>(<span><span class="type-var">'a</span> <span class="arrow">-&gt;</span></span> <span class="type-var">'b</span>)</span> <span class="arrow">-&gt;</span> <span><span class="type-var">'a</span> <a href="#type-partial_gadt">partial_gadt</a></span></span></code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>
@@ -1012,30 +897,20 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-variant_alias">
      <a href="#type-variant_alias" class="anchor"></a><code><span><span class="keyword">type</span> variant_alias</span><span> = <a href="#type-variant">variant</a></span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant_alias.TagA" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant_alias.TagA" class="anchor"></a><code><span>| </span><span><span class="constructor">TagA</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-variant_alias.ConstrB" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant_alias.ConstrB" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrB</span> <span class="keyword">of</span> int</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant_alias.ConstrC" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant_alias.ConstrC" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrC</span> <span class="keyword">of</span> int * int</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant_alias.ConstrD" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant_alias.ConstrD" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrD</span> <span class="keyword">of</span> int * int</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant_alias.TagA" class="anchored">
+       <a href="#type-variant_alias.TagA" class="anchor"></a><code><span>| </span><span><span class="constructor">TagA</span></span></code>
+      </li>
+      <li id="type-variant_alias.ConstrB" class="anchored">
+       <a href="#type-variant_alias.ConstrB" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrB</span> <span class="keyword">of</span> int</span></code>
+      </li>
+      <li id="type-variant_alias.ConstrC" class="anchored">
+       <a href="#type-variant_alias.ConstrC" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrC</span> <span class="keyword">of</span> int * int</span></code>
+      </li>
+      <li id="type-variant_alias.ConstrD" class="anchored">
+       <a href="#type-variant_alias.ConstrD" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrD</span> <span class="keyword">of</span> int * int</span></code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>
@@ -1046,20 +921,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-record_alias">
      <a href="#type-record_alias" class="anchor"></a><code><span><span class="keyword">type</span> record_alias</span><span> = <a href="#type-record">record</a></span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-record_alias.field1" class="anchored">
-        <td class="def record field">
-         <a href="#type-record_alias.field1" class="anchor"></a><code><span>field1 : int;</span></code>
-        </td>
-       </tr>
-       <tr id="type-record_alias.field2" class="anchored">
-        <td class="def record field">
-         <a href="#type-record_alias.field2" class="anchor"></a><code><span>field2 : int;</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-record_alias.field1" class="anchored">
+       <a href="#type-record_alias.field1" class="anchor"></a><code><span>field1 : int;</span></code>
+      </li>
+      <li id="type-record_alias.field2" class="anchored">
+       <a href="#type-record_alias.field2" class="anchor"></a><code><span>field2 : int;</span></code>
+      </li>
+     </ol>
      <code><span>}</span></code>
     </div>
     <div class="spec-doc">
@@ -1071,20 +940,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-poly_variant_union">
      <a href="#type-poly_variant_union" class="anchor"></a><code><span><span class="keyword">type</span> poly_variant_union</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-poly_variant_union.poly_variant" class="anchored">
-        <td class="def type">
-         <a href="#type-poly_variant_union.poly_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-poly_variant">poly_variant</a></span></code>
-        </td>
-       </tr>
-       <tr id="type-poly_variant_union.TagC" class="anchored">
-        <td class="def constructor">
-         <a href="#type-poly_variant_union.TagC" class="anchor"></a><code><span>| </span></code><code><span>`TagC</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-poly_variant_union.poly_variant" class="anchored">
+       <a href="#type-poly_variant_union.poly_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-poly_variant">poly_variant</a></span></code>
+      </li>
+      <li id="type-poly_variant_union.TagC" class="anchored">
+       <a href="#type-poly_variant_union.TagC" class="anchor"></a><code><span>| </span></code><code><span>`TagC</span></code>
+      </li>
+     </ol>
      <code><span> ]</span></code>
     </div>
     <div class="spec-doc">
@@ -1096,35 +959,25 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-poly_poly_variant">
      <a href="#type-poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a poly_poly_variant</span></span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-poly_poly_variant.TagA" class="anchored">
-        <td class="def constructor">
-         <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-poly_poly_variant.TagA" class="anchored">
+       <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></span></code>
+      </li>
+     </ol>
      <code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-bin_poly_poly_variant">
      <a href="#type-bin_poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) bin_poly_poly_variant</span></span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
-        <td class="def constructor">
-         <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
-        <td class="def constructor">
-         <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB <span class="keyword">of</span> <span class="type-var">'b</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-bin_poly_poly_variant.TagA" class="anchored">
+       <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA <span class="keyword">of</span> <span class="type-var">'a</span></span></code>
+      </li>
+      <li id="type-bin_poly_poly_variant.ConstrB" class="anchored">
+       <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB <span class="keyword">of</span> <span class="type-var">'b</span></span></code>
+      </li>
+     </ol>
      <code><span> ]</span></code>
     </div>
    </div>
@@ -1166,60 +1019,40 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-nested_poly_variant">
      <a href="#type-nested_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_poly_variant</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-nested_poly_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> <span>[ `B1 <span>| `B2</span> ]</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D <span class="keyword">of</span> <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-nested_poly_variant.A" class="anchored">
+       <a href="#type-nested_poly_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+      </li>
+      <li id="type-nested_poly_variant.B" class="anchored">
+       <a href="#type-nested_poly_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> <span>[ `B1 <span>| `B2</span> ]</span></span></code>
+      </li>
+      <li id="type-nested_poly_variant.C" class="anchored">
+       <a href="#type-nested_poly_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
+      </li>
+      <li id="type-nested_poly_variant.D" class="anchored">
+       <a href="#type-nested_poly_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D <span class="keyword">of</span> <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span></span></code>
+      </li>
+     </ol>
      <code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-full_gadt_alias">
      <a href="#type-full_gadt_alias" class="anchor"></a><code><span><span class="keyword">type</span> <span>('a, 'b) full_gadt_alias</span></span><span> = <span><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span> <a href="#type-full_gadt">full_gadt</a></span></span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-full_gadt_alias.Tag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt_alias.Tag" class="anchor"></a><code><span>| </span><span><span class="constructor">Tag</span> : <span><span>(unit,&nbsp;unit)</span> <a href="#type-full_gadt_alias">full_gadt_alias</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt_alias.First" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt_alias.First" class="anchor"></a><code><span>| </span><span><span class="constructor">First</span> : <span class="type-var">'a</span> <span class="arrow">-&gt;</span> <span><span>(<span class="type-var">'a</span>,&nbsp;unit)</span> <a href="#type-full_gadt_alias">full_gadt_alias</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt_alias.Second" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt_alias.Second" class="anchor"></a><code><span>| </span><span><span class="constructor">Second</span> : <span class="type-var">'a</span> <span class="arrow">-&gt;</span> <span><span>(unit,&nbsp;<span class="type-var">'a</span>)</span> <a href="#type-full_gadt_alias">full_gadt_alias</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt_alias.Exist" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt_alias.Exist" class="anchor"></a><code><span>| </span><span><span class="constructor">Exist</span> : <span class="type-var">'a</span> * <span class="type-var">'b</span> <span class="arrow">-&gt;</span> <span><span>(<span class="type-var">'b</span>,&nbsp;unit)</span> <a href="#type-full_gadt_alias">full_gadt_alias</a></span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-full_gadt_alias.Tag" class="anchored">
+       <a href="#type-full_gadt_alias.Tag" class="anchor"></a><code><span>| </span><span><span class="constructor">Tag</span> : <span><span>(unit,&nbsp;unit)</span> <a href="#type-full_gadt_alias">full_gadt_alias</a></span></span></code>
+      </li>
+      <li id="type-full_gadt_alias.First" class="anchored">
+       <a href="#type-full_gadt_alias.First" class="anchor"></a><code><span>| </span><span><span class="constructor">First</span> : <span class="type-var">'a</span> <span class="arrow">-&gt;</span> <span><span>(<span class="type-var">'a</span>,&nbsp;unit)</span> <a href="#type-full_gadt_alias">full_gadt_alias</a></span></span></code>
+      </li>
+      <li id="type-full_gadt_alias.Second" class="anchored">
+       <a href="#type-full_gadt_alias.Second" class="anchor"></a><code><span>| </span><span><span class="constructor">Second</span> : <span class="type-var">'a</span> <span class="arrow">-&gt;</span> <span><span>(unit,&nbsp;<span class="type-var">'a</span>)</span> <a href="#type-full_gadt_alias">full_gadt_alias</a></span></span></code>
+      </li>
+      <li id="type-full_gadt_alias.Exist" class="anchored">
+       <a href="#type-full_gadt_alias.Exist" class="anchor"></a><code><span>| </span><span><span class="constructor">Exist</span> : <span class="type-var">'a</span> * <span class="type-var">'b</span> <span class="arrow">-&gt;</span> <span><span>(<span class="type-var">'b</span>,&nbsp;unit)</span> <a href="#type-full_gadt_alias">full_gadt_alias</a></span></span></code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>
@@ -1230,25 +1063,17 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-partial_gadt_alias">
      <a href="#type-partial_gadt_alias" class="anchor"></a><code><span><span class="keyword">type</span> <span>'a partial_gadt_alias</span></span><span> = <span><span class="type-var">'a</span> <a href="#type-partial_gadt">partial_gadt</a></span></span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-partial_gadt_alias.AscribeTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt_alias.AscribeTag" class="anchor"></a><code><span>| </span><span><span class="constructor">AscribeTag</span> : <span><span class="type-var">'a</span> <a href="#type-partial_gadt_alias">partial_gadt_alias</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-partial_gadt_alias.OfTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt_alias.OfTag" class="anchor"></a><code><span>| </span><span><span class="constructor">OfTag</span> <span class="keyword">of</span> <span><span class="type-var">'a</span> <a href="#type-partial_gadt_alias">partial_gadt_alias</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-partial_gadt_alias.ExistGadtTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt_alias.ExistGadtTag" class="anchor"></a><code><span>| </span><span><span class="constructor">ExistGadtTag</span> : <span>(<span><span class="type-var">'a</span> <span class="arrow">-&gt;</span></span> <span class="type-var">'b</span>)</span> <span class="arrow">-&gt;</span> <span><span class="type-var">'a</span> <a href="#type-partial_gadt_alias">partial_gadt_alias</a></span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-partial_gadt_alias.AscribeTag" class="anchored">
+       <a href="#type-partial_gadt_alias.AscribeTag" class="anchor"></a><code><span>| </span><span><span class="constructor">AscribeTag</span> : <span><span class="type-var">'a</span> <a href="#type-partial_gadt_alias">partial_gadt_alias</a></span></span></code>
+      </li>
+      <li id="type-partial_gadt_alias.OfTag" class="anchored">
+       <a href="#type-partial_gadt_alias.OfTag" class="anchor"></a><code><span>| </span><span><span class="constructor">OfTag</span> <span class="keyword">of</span> <span><span class="type-var">'a</span> <a href="#type-partial_gadt_alias">partial_gadt_alias</a></span></span></code>
+      </li>
+      <li id="type-partial_gadt_alias.ExistGadtTag" class="anchored">
+       <a href="#type-partial_gadt_alias.ExistGadtTag" class="anchor"></a><code><span>| </span><span><span class="constructor">ExistGadtTag</span> : <span>(<span><span class="type-var">'a</span> <span class="arrow">-&gt;</span></span> <span class="type-var">'b</span>)</span> <span class="arrow">-&gt;</span> <span><span class="type-var">'a</span> <a href="#type-partial_gadt_alias">partial_gadt_alias</a></span></span></code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>
@@ -1269,27 +1094,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-mutual_constr_a">
      <a href="#type-mutual_constr_a" class="anchor"></a><code><span><span class="keyword">type</span> mutual_constr_a</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-mutual_constr_a.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutual_constr_a.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-mutual_constr_a.B_ish" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutual_constr_a.B_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">B_ish</span> <span class="keyword">of</span> <a href="#type-mutual_constr_b">mutual_constr_b</a></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          This comment is between <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a> and <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-mutual_constr_a.A" class="anchored">
+       <a href="#type-mutual_constr_a.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+      </li>
+      <li id="type-mutual_constr_a.B_ish" class="anchored">
+       <a href="#type-mutual_constr_a.B_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">B_ish</span> <span class="keyword">of</span> <a href="#type-mutual_constr_b">mutual_constr_b</a></span></code><span class="def-doc"><span class="comment-delim">(*</span>This comment is between <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a> and <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>.<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>
@@ -1300,27 +1112,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-mutual_constr_b">
      <a href="#type-mutual_constr_b" class="anchor"></a><code><span><span class="keyword">and</span> mutual_constr_b</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-mutual_constr_b.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutual_constr_b.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-mutual_constr_b.A_ish" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutual_constr_b.A_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">A_ish</span> <span class="keyword">of</span> <a href="#type-mutual_constr_a">mutual_constr_a</a></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          This comment must be here for the next to associate correctly.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-mutual_constr_b.B" class="anchored">
+       <a href="#type-mutual_constr_b.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span></span></code>
+      </li>
+      <li id="type-mutual_constr_b.A_ish" class="anchored">
+       <a href="#type-mutual_constr_b.A_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">A_ish</span> <span class="keyword">of</span> <a href="#type-mutual_constr_a">mutual_constr_a</a></span></code><span class="def-doc"><span class="comment-delim">(*</span>This comment must be here for the next to associate correctly.<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>
@@ -1371,76 +1170,54 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ExtA" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtA" class="anchor"></a><code><span>| </span><span><span class="extension">ExtA</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ExtA" class="anchored">
+       <a href="#extension-ExtA" class="anchor"></a><code><span>| </span><span><span class="extension">ExtA</span></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ExtB" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtB" class="anchor"></a><code><span>| </span><span><span class="extension">ExtB</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ExtB" class="anchored">
+       <a href="#extension-ExtB" class="anchor"></a><code><span>| </span><span><span class="extension">ExtB</span></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ExtC" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtC" class="anchor"></a><code><span>| </span><span><span class="extension">ExtC</span> <span class="keyword">of</span> unit</span></code>
-        </td>
-       </tr>
-       <tr id="extension-ExtD" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtD" class="anchor"></a><code><span>| </span><span><span class="extension">ExtD</span> <span class="keyword">of</span> <a href="#type-ext">ext</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ExtC" class="anchored">
+       <a href="#extension-ExtC" class="anchor"></a><code><span>| </span><span><span class="extension">ExtC</span> <span class="keyword">of</span> unit</span></code>
+      </li>
+      <li id="extension-ExtD" class="anchored">
+       <a href="#extension-ExtD" class="anchor"></a><code><span>| </span><span><span class="extension">ExtD</span> <span class="keyword">of</span> <a href="#type-ext">ext</a></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ExtE" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtE" class="anchor"></a><code><span>| </span><span><span class="extension">ExtE</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ExtE" class="anchored">
+       <a href="#extension-ExtE" class="anchor"></a><code><span>| </span><span><span class="extension">ExtE</span></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ExtF" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtF" class="anchor"></a><code><span>| </span><span><span class="extension">ExtF</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ExtF" class="anchored">
+       <a href="#extension-ExtF" class="anchor"></a><code><span>| </span><span><span class="extension">ExtF</span></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
@@ -1456,48 +1233,24 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-Foo" class="anchored">
-        <td class="def extension">
-         <a href="#extension-Foo" class="anchor"></a><code><span>| </span><span><span class="extension">Foo</span> <span class="keyword">of</span> <span class="type-var">'b</span></span></code>
-        </td>
-       </tr>
-       <tr id="extension-Bar" class="anchored">
-        <td class="def extension">
-         <a href="#extension-Bar" class="anchor"></a><code><span>| </span><span><span class="extension">Bar</span> <span class="keyword">of</span> <span class="type-var">'b</span> * <span class="type-var">'b</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          'b poly_ext
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-Foo" class="anchored">
+       <a href="#extension-Foo" class="anchor"></a><code><span>| </span><span><span class="extension">Foo</span> <span class="keyword">of</span> <span class="type-var">'b</span></span></code>
+      </li>
+      <li id="extension-Bar" class="anchored">
+       <a href="#extension-Bar" class="anchor"></a><code><span>| </span><span><span class="extension">Bar</span> <span class="keyword">of</span> <span class="type-var">'b</span> * <span class="type-var">'b</span></span></code><span class="def-doc"><span class="comment-delim">(*</span>'b poly_ext<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-Quux" class="anchored">
-        <td class="def extension">
-         <a href="#extension-Quux" class="anchor"></a><code><span>| </span><span><span class="extension">Quux</span> <span class="keyword">of</span> <span class="type-var">'c</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          'c poly_ext
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-Quux" class="anchored">
+       <a href="#extension-Quux" class="anchor"></a><code><span>| </span><span><span class="extension">Quux</span> <span class="keyword">of</span> <span class="type-var">'c</span></span></code><span class="def-doc"><span class="comment-delim">(*</span>'c poly_ext<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
@@ -1508,43 +1261,21 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ZzzTop0" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ZzzTop0" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop0</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          It's got the rock
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ZzzTop0" class="anchored">
+       <a href="#extension-ZzzTop0" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop0</span></span></code><span class="def-doc"><span class="comment-delim">(*</span>It's got the rock<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ZzzTop" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ZzzTop" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop</span> <span class="keyword">of</span> unit</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          and it packs a unit.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ZzzTop" class="anchored">
+       <a href="#extension-ZzzTop" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop</span> <span class="keyword">of</span> unit</span></code><span class="def-doc"><span class="comment-delim">(*</span>and it packs a unit.<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
@@ -1998,15 +1729,11 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-new_t">new_t</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-C" class="anchored">
-        <td class="def extension">
-         <a href="#extension-C" class="anchor"></a><code><span>| </span><span><span class="extension">C</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-C" class="anchored">
+       <a href="#extension-C" class="anchor"></a><code><span>| </span><span><span class="extension">C</span></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">

--- a/test/html/expect/test_package+ml/Recent/X/index.html
+++ b/test/html/expect/test_package+ml/Recent/X/index.html
@@ -24,22 +24,22 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-substitution" id="module-L">
+    <div class="spec module-substitution anchored" id="module-L">
      <a href="#module-L" class="anchor"></a><code><span><span class="keyword">module</span> L := <a href="../Z/Y/index.html">Z.Y</a></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a><code><span><span class="keyword">type</span> t</span><span> = <span>int <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a></span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type subst" id="type-u">
+    <div class="spec type subst anchored" id="type-u">
      <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> := int</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-v">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = <span><a href="#type-u">u</a> <a href="../Z/Y/X/index.html#type-t">Z.Y.X.t</a></span></span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Recent/index.html
+++ b/test/html/expect/test_package+ml/Recent/index.html
@@ -24,218 +24,137 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S1">
+    <div class="spec module-type anchored" id="module-type-S1">
      <a href="#module-type-S1" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S1/index.html">S1</a></span><span> = <span class="keyword">functor</span><span> (<a href="module-type-S1/argument-1-_/index.html">_</a> : <a href="module-type-S/index.html">S</a>) <span class="arrow">-&gt;</span></span> <a href="module-type-S/index.html">S</a></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-variant">
+    <div class="spec type anchored" id="type-variant">
      <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> int</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          foo
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-variant.D" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          <em>bar</em>
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-variant.E" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> </span><span>{</span></code>
-         <table>
-          <tbody>
-           <tr id="type-variant.a" class="anchored">
-            <td class="def record field">
-             <a href="#type-variant.a" class="anchor"></a><code><span>a : int;</span></code>
-            </td>
-           </tr>
-          </tbody>
-         </table>
-         <code><span>}</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant.A" class="def variant constructor anchored">
+       <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+      </li>
+      <li id="type-variant.B" class="def variant constructor anchored">
+       <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> int</span></code>
+      </li>
+      <li id="type-variant.C" class="def variant constructor anchored">
+       <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code><span class="def-doc"><span class="comment-delim">(*</span>foo<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-variant.D" class="def variant constructor anchored">
+       <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code><span class="def-doc"><span class="comment-delim">(*</span><em>bar</em><span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-variant.E" class="def variant constructor anchored">
+       <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> </span><span>{</span></code>
+       <ol>
+        <li id="type-variant.a" class="def record field anchored">
+         <a href="#type-variant.a" class="anchor"></a><code><span>a : int;</span></code>
+        </li>
+       </ol>
+       <code><span>}</span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-gadt">
+    <div class="spec type anchored" id="type-gadt">
      <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> <span>_ gadt</span></span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <span>int <a href="#type-gadt">gadt</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-gadt.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> : int <span class="arrow">-&gt;</span> <span>string <a href="#type-gadt">gadt</a></span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          foo
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-gadt.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span> : </span><span>{</span></code>
-         <table>
-          <tbody>
-           <tr id="type-gadt.a" class="anchored">
-            <td class="def record field">
-             <a href="#type-gadt.a" class="anchor"></a><code><span>a : int;</span></code>
-            </td>
-           </tr>
-          </tbody>
-         </table>
-         <code><span>}</span><span> <span class="arrow">-&gt;</span> <span>unit <a href="#type-gadt">gadt</a></span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-gadt.A" class="def variant constructor anchored">
+       <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <span>int <a href="#type-gadt">gadt</a></span></span></code>
+      </li>
+      <li id="type-gadt.B" class="def variant constructor anchored">
+       <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> : int <span class="arrow">-&gt;</span> <span>string <a href="#type-gadt">gadt</a></span></span></code><span class="def-doc"><span class="comment-delim">(*</span>foo<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-gadt.C" class="def variant constructor anchored">
+       <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span> : </span><span>{</span></code>
+       <ol>
+        <li id="type-gadt.a" class="def record field anchored">
+         <a href="#type-gadt.a" class="anchor"></a><code><span>a : int;</span></code>
+        </li>
+       </ol>
+       <code><span>}</span><span> <span class="arrow">-&gt;</span> <span>unit <a href="#type-gadt">gadt</a></span></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-polymorphic_variant">
+    <div class="spec type anchored" id="type-polymorphic_variant">
      <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> int</span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          foo
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          bar
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-polymorphic_variant.A" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+      </li>
+      <li id="type-polymorphic_variant.B" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> int</span></code>
+      </li>
+      <li id="type-polymorphic_variant.C" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code><span class="def-doc"><span class="comment-delim">(*</span>foo<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-polymorphic_variant.D" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code><span class="def-doc"><span class="comment-delim">(*</span>bar<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
      <code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-empty_variant">
+    <div class="spec type anchored" id="type-empty_variant">
      <a href="#type-empty_variant" class="anchor"></a><code><span><span class="keyword">type</span> empty_variant</span><span> = </span><span>|</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-nonrec_">
+    <div class="spec type anchored" id="type-nonrec_">
      <a href="#type-nonrec_" class="anchor"></a><code><span><span class="keyword">type</span> <span class="keyword">nonrec</span> nonrec_</span><span> = int</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-empty_conj">
+    <div class="spec type anchored" id="type-empty_conj">
      <a href="#type-empty_conj" class="anchor"></a><code><span><span class="keyword">type</span> empty_conj</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-empty_conj.X" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-empty_conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span> : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span> <span class="arrow">-&gt;</span> <a href="#type-empty_conj">empty_conj</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-empty_conj.X" class="def variant constructor anchored">
+       <a href="#type-empty_conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span> : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span> <span class="arrow">-&gt;</span> <a href="#type-empty_conj">empty_conj</a></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-conj">
+    <div class="spec type anchored" id="type-conj">
      <a href="#type-conj" class="anchor"></a><code><span><span class="keyword">type</span> conj</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-conj.X" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span> : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span> <span class="arrow">-&gt;</span> <a href="#type-conj">conj</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-conj.X" class="def variant constructor anchored">
+       <a href="#type-conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span> : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span> <span class="arrow">-&gt;</span> <a href="#type-conj">conj</a></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-empty_conj">
+    <div class="spec value anchored" id="val-empty_conj">
      <a href="#val-empty_conj" class="anchor"></a><code><span><span class="keyword">val</span> empty_conj : <span>[&lt; <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float</span> ]</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-conj">
+    <div class="spec value anchored" id="val-conj">
      <a href="#val-conj" class="anchor"></a><code><span><span class="keyword">val</span> conj : <span>[&lt; <span>`X of int &amp; <span>[&lt; <span>`B of int &amp; float</span> ]</span></span> ]</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Z">
+    <div class="spec module anchored" id="module-Z">
      <a href="#module-Z" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Z/index.html">Z</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="X/index.html">X</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-PolyS">
+    <div class="spec module-type anchored" id="module-type-PolyS">
      <a href="#module-type-PolyS" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-PolyS/index.html">PolyS</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Recent_impl/index.html
+++ b/test/html/expect/test_package+ml/Recent_impl/index.html
@@ -24,27 +24,27 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Foo">
+    <div class="spec module anchored" id="module-Foo">
      <a href="#module-Foo" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Foo/index.html">Foo</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-B">
+    <div class="spec module anchored" id="module-B">
      <a href="#module-B" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="B/index.html">B</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a><code><span><span class="keyword">module</span> <span class="keyword">type</span> </span><span><a href="module-type-S/index.html">S</a></span><span> = <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-B'">
+    <div class="spec module anchored" id="module-B'">
      <a href="#module-B'" class="anchor"></a><code><span><span class="keyword">module</span> </span><span>B'</span><span> = <a href="Foo/B/index.html">Foo.B</a></span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Section/index.html
+++ b/test/html/expect/test_package+ml/Section/index.html
@@ -75,7 +75,7 @@
     <a href="#value-only" class="anchor"></a>Value only
    </h2>
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a><code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Stop_dead_link_doc/index.html
+++ b/test/html/expect/test_package+ml/Stop_dead_link_doc/index.html
@@ -24,93 +24,73 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Foo">
+    <div class="spec module anchored" id="module-Foo">
      <a href="#module-Foo" class="anchor"></a><code><span><span class="keyword">module</span> </span><span><a href="Foo/index.html">Foo</a></span><span> : <span class="keyword">sig</span> ... <span class="keyword">end</span></span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-foo">
+    <div class="spec type anchored" id="type-foo">
      <a href="#type-foo" class="anchor"></a><code><span><span class="keyword">type</span> foo</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-foo.Bar" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-foo.Bar" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar</span> <span class="keyword">of</span> <a href="Foo/index.html#type-t">Foo.t</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-foo.Bar" class="def variant constructor anchored">
+       <a href="#type-foo.Bar" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar</span> <span class="keyword">of</span> <a href="Foo/index.html#type-t">Foo.t</a></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-bar">
+    <div class="spec type anchored" id="type-bar">
      <a href="#type-bar" class="anchor"></a><code><span><span class="keyword">type</span> bar</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-bar.Bar" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-bar.Bar" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar</span> <span class="keyword">of</span> </span><span>{</span></code>
-         <table>
-          <tbody>
-           <tr id="type-bar.field" class="anchored">
-            <td class="def record field">
-             <a href="#type-bar.field" class="anchor"></a><code><span>field : <a href="Foo/index.html#type-t">Foo.t</a>;</span></code>
-            </td>
-           </tr>
-          </tbody>
-         </table>
-         <code><span>}</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-bar.Bar" class="def variant constructor anchored">
+       <a href="#type-bar.Bar" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar</span> <span class="keyword">of</span> </span><span>{</span></code>
+       <ol>
+        <li id="type-bar.field" class="def record field anchored">
+         <a href="#type-bar.field" class="anchor"></a><code><span>field : <a href="Foo/index.html#type-t">Foo.t</a>;</span></code>
+        </li>
+       </ol>
+       <code><span>}</span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-foo_">
+    <div class="spec type anchored" id="type-foo_">
      <a href="#type-foo_" class="anchor"></a><code><span><span class="keyword">type</span> foo_</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-foo_.Bar_" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-foo_.Bar_" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar_</span> <span class="keyword">of</span> int * <a href="Foo/index.html#type-t">Foo.t</a> * int</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-foo_.Bar_" class="def variant constructor anchored">
+       <a href="#type-foo_.Bar_" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar_</span> <span class="keyword">of</span> int * <a href="Foo/index.html#type-t">Foo.t</a> * int</span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-bar_">
+    <div class="spec type anchored" id="type-bar_">
      <a href="#type-bar_" class="anchor"></a><code><span><span class="keyword">type</span> bar_</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-bar_.Bar__" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-bar_.Bar__" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar__</span> <span class="keyword">of</span> <span><a href="Foo/index.html#type-t">Foo.t</a> option</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-bar_.Bar__" class="def variant constructor anchored">
+       <a href="#type-bar_.Bar__" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar__</span> <span class="keyword">of</span> <span><a href="Foo/index.html#type-t">Foo.t</a> option</span></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-another_foo">
+    <div class="spec type anchored" id="type-another_foo">
      <a href="#type-another_foo" class="anchor"></a><code><span><span class="keyword">type</span> another_foo</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-another_bar">
+    <div class="spec type anchored" id="type-another_bar">
      <a href="#type-another_bar" class="anchor"></a><code><span><span class="keyword">type</span> another_bar</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-another_foo_">
+    <div class="spec type anchored" id="type-another_foo_">
      <a href="#type-another_foo_" class="anchor"></a><code><span><span class="keyword">type</span> another_foo_</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-another_bar_">
+    <div class="spec type anchored" id="type-another_bar_">
      <a href="#type-another_bar_" class="anchor"></a><code><span><span class="keyword">type</span> another_bar_</span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+ml/Type/index.html
+++ b/test/html/expect/test_package+ml/Type/index.html
@@ -106,244 +106,148 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-variant_e">
      <a href="#type-variant_e" class="anchor"></a><code><span><span class="keyword">type</span> variant_e</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant_e.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-variant_e.a" class="anchor"></a><code><span>a : int;</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant_e.a" class="anchored">
+       <a href="#type-variant_e.a" class="anchor"></a><code><span>a : int;</span></code>
+      </li>
+     </ol>
      <code><span>}</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-variant">
      <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> int</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          foo
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-variant.D" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          <em>bar</em>
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-variant.E" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> <a href="#type-variant_e">variant_e</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant.A" class="anchored">
+       <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+      </li>
+      <li id="type-variant.B" class="anchored">
+       <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> int</span></code>
+      </li>
+      <li id="type-variant.C" class="anchored">
+       <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code><span class="def-doc"><span class="comment-delim">(*</span>foo<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-variant.D" class="anchored">
+       <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code><span class="def-doc"><span class="comment-delim">(*</span><em>bar</em><span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-variant.E" class="anchored">
+       <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> <a href="#type-variant_e">variant_e</a></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-variant_c">
      <a href="#type-variant_c" class="anchor"></a><code><span><span class="keyword">type</span> variant_c</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant_c.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-variant_c.a" class="anchor"></a><code><span>a : int;</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant_c.a" class="anchored">
+       <a href="#type-variant_c.a" class="anchor"></a><code><span>a : int;</span></code>
+      </li>
+     </ol>
      <code><span>}</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-gadt">
      <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> <span>_ gadt</span></span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <span>int <a href="#type-gadt">gadt</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-gadt.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> : int <span class="arrow">-&gt;</span> <span>string <a href="#type-gadt">gadt</a></span></span></code>
-        </td>
-       </tr>
-       <tr id="type-gadt.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span> : <a href="#type-variant_c">variant_c</a> <span class="arrow">-&gt;</span> <span>unit <a href="#type-gadt">gadt</a></span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-gadt.A" class="anchored">
+       <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <span>int <a href="#type-gadt">gadt</a></span></span></code>
+      </li>
+      <li id="type-gadt.B" class="anchored">
+       <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> : int <span class="arrow">-&gt;</span> <span>string <a href="#type-gadt">gadt</a></span></span></code>
+      </li>
+      <li id="type-gadt.C" class="anchored">
+       <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span> : <a href="#type-variant_c">variant_c</a> <span class="arrow">-&gt;</span> <span>unit <a href="#type-gadt">gadt</a></span></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-degenerate_gadt">
      <a href="#type-degenerate_gadt" class="anchor"></a><code><span><span class="keyword">type</span> degenerate_gadt</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-degenerate_gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-degenerate_gadt">degenerate_gadt</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-degenerate_gadt.A" class="anchored">
+       <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-degenerate_gadt">degenerate_gadt</a></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-private_variant">
      <a href="#type-private_variant" class="anchor"></a><code><span><span class="keyword">type</span> private_variant</span><span> = <span class="keyword">private</span> </span></code>
-     <table>
-      <tbody>
-       <tr id="type-private_variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-private_variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-private_variant.A" class="anchored">
+       <a href="#type-private_variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-record">
      <a href="#type-record" class="anchor"></a><code><span><span class="keyword">type</span> record</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-record.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.a" class="anchor"></a><code><span>a : int;</span></code>
-        </td>
-       </tr>
-       <tr id="type-record.b" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.b" class="anchor"></a><code><span><span class="keyword">mutable</span> b : int;</span></code>
-        </td>
-       </tr>
-       <tr id="type-record.c" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.c" class="anchor"></a><code><span>c : int;</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          foo
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-record.d" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.d" class="anchor"></a><code><span>d : int;</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          <em>bar</em>
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="type-record.e" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.e" class="anchor"></a><code><span>e : a. <span class="type-var">'a</span>;</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-record.a" class="anchored">
+       <a href="#type-record.a" class="anchor"></a><code><span>a : int;</span></code>
+      </li>
+      <li id="type-record.b" class="anchored">
+       <a href="#type-record.b" class="anchor"></a><code><span><span class="keyword">mutable</span> b : int;</span></code>
+      </li>
+      <li id="type-record.c" class="anchored">
+       <a href="#type-record.c" class="anchor"></a><code><span>c : int;</span></code><span class="def-doc"><span class="comment-delim">(*</span>foo<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-record.d" class="anchored">
+       <a href="#type-record.d" class="anchor"></a><code><span>d : int;</span></code><span class="def-doc"><span class="comment-delim">(*</span><em>bar</em><span class="comment-delim">*)</span></span>
+      </li>
+      <li id="type-record.e" class="anchored">
+       <a href="#type-record.e" class="anchor"></a><code><span>e : a. <span class="type-var">'a</span>;</span></code>
+      </li>
+     </ol>
      <code><span>}</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-polymorphic_variant">
      <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> int</span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C <span class="keyword">of</span> int * unit</span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-polymorphic_variant.A" class="anchored">
+       <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+      </li>
+      <li id="type-polymorphic_variant.B" class="anchored">
+       <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B <span class="keyword">of</span> int</span></code>
+      </li>
+      <li id="type-polymorphic_variant.C" class="anchored">
+       <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C <span class="keyword">of</span> int * unit</span></code>
+      </li>
+      <li id="type-polymorphic_variant.D" class="anchored">
+       <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
+      </li>
+     </ol>
      <code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-polymorphic_variant_extension">
      <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant_extension</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
-        <td class="def type">
-         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant_extension.E" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span>| </span></code><code><span>`E</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
+       <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
+      </li>
+      <li id="type-polymorphic_variant_extension.E" class="anchored">
+       <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span>| </span></code><code><span>`E</span></code>
+      </li>
+     </ol>
      <code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-nested_polymorphic_variant">
      <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_polymorphic_variant</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-nested_polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A <span class="keyword">of</span> <span>[ `B <span>| `C</span> ]</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-nested_polymorphic_variant.A" class="anchored">
+       <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A <span class="keyword">of</span> <span>[ `B <span>| `C</span> ]</span></span></code>
+      </li>
+     </ol>
      <code><span> ]</span></code>
     </div>
    </div>
@@ -355,15 +259,11 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-private_extenion">
      <a href="#type-private_extenion" class="anchor"></a><code><span><span class="keyword">and</span> private_extenion</span><span> = <span class="keyword">private</span> </span><span>[&gt; </span></code>
-     <table>
-      <tbody>
-       <tr id="type-private_extenion.polymorphic_variant" class="anchored">
-        <td class="def type">
-         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-private_extenion.polymorphic_variant" class="anchored">
+       <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
+      </li>
+     </ol>
      <code><span> ]</span></code>
     </div>
    </div>
@@ -480,62 +380,34 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-extensible">extensible</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-Extension" class="anchored">
-        <td class="def extension">
-         <a href="#extension-Extension" class="anchor"></a><code><span>| </span><span><span class="extension">Extension</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          Documentation for <a href="#extension-Extension"><code>Extension</code></a>.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-       <tr id="extension-Another_extension" class="anchored">
-        <td class="def extension">
-         <a href="#extension-Another_extension" class="anchor"></a><code><span>| </span><span><span class="extension">Another_extension</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">(*</span>
-         <p>
-          Documentation for <a href="#extension-Another_extension"><code>Another_extension</code></a>.
-         </p>
-         <span class="comment-delim">*)</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-Extension" class="anchored">
+       <a href="#extension-Extension" class="anchor"></a><code><span>| </span><span><span class="extension">Extension</span></span></code><span class="def-doc"><span class="comment-delim">(*</span>Documentation for <a href="#extension-Extension"><code>Extension</code></a>.<span class="comment-delim">*)</span></span>
+      </li>
+      <li id="extension-Another_extension" class="anchored">
+       <a href="#extension-Another_extension" class="anchor"></a><code><span>| </span><span><span class="extension">Another_extension</span></span></code><span class="def-doc"><span class="comment-delim">(*</span>Documentation for <a href="#extension-Another_extension"><code>Another_extension</code></a>.<span class="comment-delim">*)</span></span>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-mutually">
      <a href="#type-mutually" class="anchor"></a><code><span><span class="keyword">type</span> mutually</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-mutually.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutually.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> <span class="keyword">of</span> <a href="#type-recursive">recursive</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-mutually.A" class="anchored">
+       <a href="#type-mutually.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> <span class="keyword">of</span> <a href="#type-recursive">recursive</a></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-recursive">
      <a href="#type-recursive" class="anchor"></a><code><span><span class="keyword">and</span> recursive</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-recursive.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-recursive.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> <a href="#type-mutually">mutually</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-recursive.B" class="anchored">
+       <a href="#type-recursive.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span> <span class="keyword">of</span> <a href="#type-mutually">mutually</a></span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">

--- a/test/html/expect/test_package+ml/Val/index.html
+++ b/test/html/expect/test_package+ml/Val/index.html
@@ -24,7 +24,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value" id="val-documented">
+    <div class="spec value anchored" id="val-documented">
      <a href="#val-documented" class="anchor"></a><code><span><span class="keyword">val</span> documented : unit</span></code>
     </div>
     <div class="spec-doc">
@@ -34,12 +34,12 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-undocumented">
+    <div class="spec value anchored" id="val-undocumented">
      <a href="#val-undocumented" class="anchor"></a><code><span><span class="keyword">val</span> undocumented : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-documented_above">
+    <div class="spec value anchored" id="val-documented_above">
      <a href="#val-documented_above" class="anchor"></a><code><span><span class="keyword">val</span> documented_above : unit</span></code>
     </div>
     <div class="spec-doc">

--- a/test/html/expect/test_package+re/Labels/index.html
+++ b/test/html/expect/test_package+re/Labels/index.html
@@ -107,15 +107,11 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-x">x</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-X" class="anchored">
-        <td class="def extension">
-         <a href="#extension-X" class="anchor"></a><code><span>| </span><span><span class="extension">X</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-X" class="anchored">
+       <a href="#extension-X" class="anchor"></a><code><span>| </span><span><span class="extension">X</span></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -147,44 +143,22 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-u">
      <a href="#type-u" class="anchor"></a><code><span><span class="keyword">type</span> u</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-u.A'" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-u.A'" class="anchor"></a><code><span>| </span><span><span class="constructor">A'</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          Attached to constructor
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-u.A'" class="anchored">
+       <a href="#type-u.A'" class="anchor"></a><code><span>| </span><span><span class="constructor">A'</span></span></code><span class="def-doc"><span class="comment-delim">/*</span>Attached to constructor<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-v">
      <a href="#type-v" class="anchor"></a><code><span><span class="keyword">type</span> v</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-v.f" class="anchored">
-        <td class="def record field">
-         <a href="#type-v.f" class="anchor"></a><code><span>f: <a href="#type-t">t</a>,</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          Attached to field
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-v.f" class="anchored">
+       <a href="#type-v.f" class="anchor"></a><code><span>f: <a href="#type-t">t</a>,</span></code><span class="def-doc"><span class="comment-delim">/*</span>Attached to field<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>}</span><span>;</span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+re/Ocamlary/index.html
+++ b/test/html/expect/test_package+re/Ocamlary/index.html
@@ -727,34 +727,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-record">
      <a href="#type-record" class="anchor"></a><code><span><span class="keyword">type</span> record</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-record.field1" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.field1" class="anchor"></a><code><span>field1: int,</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          This comment is for <code>field1</code>.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-record.field2" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.field2" class="anchor"></a><code><span>field2: int,</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          This comment is for <code>field2</code>.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-record.field1" class="anchored">
+       <a href="#type-record.field1" class="anchor"></a><code><span>field1: int,</span></code><span class="def-doc"><span class="comment-delim">/*</span>This comment is for <code>field1</code>.<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-record.field2" class="anchored">
+       <a href="#type-record.field2" class="anchor"></a><code><span>field2: int,</span></code><span class="def-doc"><span class="comment-delim">/*</span>This comment is for <code>field2</code>.<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>}</span><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -769,119 +749,48 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-mutable_record">
      <a href="#type-mutable_record" class="anchor"></a><code><span><span class="keyword">type</span> mutable_record</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-mutable_record.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.a" class="anchor"></a><code><span><span class="keyword">mutable</span> a: int,</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          <code>a</code> is first and mutable
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-mutable_record.b" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.b" class="anchor"></a><code><span>b: unit,</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          <code>b</code> is second and immutable
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-mutable_record.c" class="anchored">
-        <td class="def record field">
-         <a href="#type-mutable_record.c" class="anchor"></a><code><span><span class="keyword">mutable</span> c: int,</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          <code>c</code> is third and mutable
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-mutable_record.a" class="anchored">
+       <a href="#type-mutable_record.a" class="anchor"></a><code><span><span class="keyword">mutable</span> a: int,</span></code><span class="def-doc"><span class="comment-delim">/*</span><code>a</code> is first and mutable<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-mutable_record.b" class="anchored">
+       <a href="#type-mutable_record.b" class="anchor"></a><code><span>b: unit,</span></code><span class="def-doc"><span class="comment-delim">/*</span><code>b</code> is second and immutable<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-mutable_record.c" class="anchored">
+       <a href="#type-mutable_record.c" class="anchor"></a><code><span><span class="keyword">mutable</span> c: int,</span></code><span class="def-doc"><span class="comment-delim">/*</span><code>c</code> is third and mutable<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>}</span><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-universe_record">
      <a href="#type-universe_record" class="anchor"></a><code><span><span class="keyword">type</span> universe_record</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-universe_record.nihilate" class="anchored">
-        <td class="def record field">
-         <a href="#type-universe_record.nihilate" class="anchor"></a><code><span>nihilate: a. <span><span class="type-var">'a</span> <span class="arrow">=&gt;</span></span> unit,</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-universe_record.nihilate" class="anchored">
+       <a href="#type-universe_record.nihilate" class="anchor"></a><code><span>nihilate: a. <span><span class="type-var">'a</span> <span class="arrow">=&gt;</span></span> unit,</span></code>
+      </li>
+     </ol>
      <code><span>}</span><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-variant">
      <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant.TagA" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.TagA" class="anchor"></a><code><span>| </span><span><span class="constructor">TagA</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          This comment is for <code>TagA</code>.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-variant.ConstrB" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.ConstrB" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrB</span>(int)</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          This comment is for <code>ConstrB</code>.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-variant.ConstrC" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.ConstrC" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrC</span>(int, int)</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          This comment is for binary <code>ConstrC</code>.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-variant.ConstrD" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.ConstrD" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrD</span>(<span>(int, int)</span>)</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          This comment is for unary <code>ConstrD</code> of binary tuple.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant.TagA" class="anchored">
+       <a href="#type-variant.TagA" class="anchor"></a><code><span>| </span><span><span class="constructor">TagA</span></span></code><span class="def-doc"><span class="comment-delim">/*</span>This comment is for <code>TagA</code>.<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-variant.ConstrB" class="anchored">
+       <a href="#type-variant.ConstrB" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrB</span>(int)</span></code><span class="def-doc"><span class="comment-delim">/*</span>This comment is for <code>ConstrB</code>.<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-variant.ConstrC" class="anchored">
+       <a href="#type-variant.ConstrC" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrC</span>(int, int)</span></code><span class="def-doc"><span class="comment-delim">/*</span>This comment is for binary <code>ConstrC</code>.<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-variant.ConstrD" class="anchored">
+       <a href="#type-variant.ConstrD" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrD</span>(<span>(int, int)</span>)</span></code><span class="def-doc"><span class="comment-delim">/*</span>This comment is for unary <code>ConstrD</code> of binary tuple.<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -896,20 +805,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-poly_variant">
      <a href="#type-poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> poly_variant</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-poly_variant.TagA" class="anchored">
-        <td class="def constructor">
-         <a href="#type-poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA</span></code>
-        </td>
-       </tr>
-       <tr id="type-poly_variant.ConstrB" class="anchored">
-        <td class="def constructor">
-         <a href="#type-poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB(int)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-poly_variant.TagA" class="anchored">
+       <a href="#type-poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA</span></code>
+      </li>
+      <li id="type-poly_variant.ConstrB" class="anchored">
+       <a href="#type-poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB(int)</span></code>
+      </li>
+     </ol>
      <code><span> ]</span><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -924,30 +827,20 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-full_gadt">
      <a href="#type-full_gadt" class="anchor"></a><code><span><span class="keyword">type</span> full_gadt(_, _)</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-full_gadt.Tag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt.Tag" class="anchor"></a><code><span>| </span><span><span class="constructor">Tag</span> : <a href="#type-full_gadt">full_gadt</a><span>(unit,&nbsp;unit)</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt.First" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt.First" class="anchor"></a><code><span>| </span><span><span class="constructor">First</span>(<span class="type-var">'a</span>) : <a href="#type-full_gadt">full_gadt</a><span>(<span class="type-var">'a</span>,&nbsp;unit)</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt.Second" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt.Second" class="anchor"></a><code><span>| </span><span><span class="constructor">Second</span>(<span class="type-var">'a</span>) : <a href="#type-full_gadt">full_gadt</a><span>(unit,&nbsp;<span class="type-var">'a</span>)</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt.Exist" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt.Exist" class="anchor"></a><code><span>| </span><span><span class="constructor">Exist</span>(<span class="type-var">'a</span>, <span class="type-var">'b</span>) : <a href="#type-full_gadt">full_gadt</a><span>(<span class="type-var">'b</span>,&nbsp;unit)</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-full_gadt.Tag" class="anchored">
+       <a href="#type-full_gadt.Tag" class="anchor"></a><code><span>| </span><span><span class="constructor">Tag</span> : <a href="#type-full_gadt">full_gadt</a><span>(unit,&nbsp;unit)</span></span></code>
+      </li>
+      <li id="type-full_gadt.First" class="anchored">
+       <a href="#type-full_gadt.First" class="anchor"></a><code><span>| </span><span><span class="constructor">First</span>(<span class="type-var">'a</span>) : <a href="#type-full_gadt">full_gadt</a><span>(<span class="type-var">'a</span>,&nbsp;unit)</span></span></code>
+      </li>
+      <li id="type-full_gadt.Second" class="anchored">
+       <a href="#type-full_gadt.Second" class="anchor"></a><code><span>| </span><span><span class="constructor">Second</span>(<span class="type-var">'a</span>) : <a href="#type-full_gadt">full_gadt</a><span>(unit,&nbsp;<span class="type-var">'a</span>)</span></span></code>
+      </li>
+      <li id="type-full_gadt.Exist" class="anchored">
+       <a href="#type-full_gadt.Exist" class="anchor"></a><code><span>| </span><span><span class="constructor">Exist</span>(<span class="type-var">'a</span>, <span class="type-var">'b</span>) : <a href="#type-full_gadt">full_gadt</a><span>(<span class="type-var">'b</span>,&nbsp;unit)</span></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -962,25 +855,17 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-partial_gadt">
      <a href="#type-partial_gadt" class="anchor"></a><code><span><span class="keyword">type</span> partial_gadt('a)</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-partial_gadt.AscribeTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt.AscribeTag" class="anchor"></a><code><span>| </span><span><span class="constructor">AscribeTag</span> : <a href="#type-partial_gadt">partial_gadt</a>(<span class="type-var">'a</span>)</span></code>
-        </td>
-       </tr>
-       <tr id="type-partial_gadt.OfTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt.OfTag" class="anchor"></a><code><span>| </span><span><span class="constructor">OfTag</span>(<a href="#type-partial_gadt">partial_gadt</a>(<span class="type-var">'a</span>))</span></code>
-        </td>
-       </tr>
-       <tr id="type-partial_gadt.ExistGadtTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt.ExistGadtTag" class="anchor"></a><code><span>| </span><span><span class="constructor">ExistGadtTag</span>(<span>(<span><span class="type-var">'a</span> <span class="arrow">=&gt;</span></span> <span class="type-var">'b</span>)</span>) : <a href="#type-partial_gadt">partial_gadt</a>(<span class="type-var">'a</span>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-partial_gadt.AscribeTag" class="anchored">
+       <a href="#type-partial_gadt.AscribeTag" class="anchor"></a><code><span>| </span><span><span class="constructor">AscribeTag</span> : <a href="#type-partial_gadt">partial_gadt</a>(<span class="type-var">'a</span>)</span></code>
+      </li>
+      <li id="type-partial_gadt.OfTag" class="anchored">
+       <a href="#type-partial_gadt.OfTag" class="anchor"></a><code><span>| </span><span><span class="constructor">OfTag</span>(<a href="#type-partial_gadt">partial_gadt</a>(<span class="type-var">'a</span>))</span></code>
+      </li>
+      <li id="type-partial_gadt.ExistGadtTag" class="anchored">
+       <a href="#type-partial_gadt.ExistGadtTag" class="anchor"></a><code><span>| </span><span><span class="constructor">ExistGadtTag</span>(<span>(<span><span class="type-var">'a</span> <span class="arrow">=&gt;</span></span> <span class="type-var">'b</span>)</span>) : <a href="#type-partial_gadt">partial_gadt</a>(<span class="type-var">'a</span>)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -1015,30 +900,20 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-variant_alias">
      <a href="#type-variant_alias" class="anchor"></a><code><span><span class="keyword">type</span> variant_alias</span><span> = <a href="#type-variant">variant</a></span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant_alias.TagA" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant_alias.TagA" class="anchor"></a><code><span>| </span><span><span class="constructor">TagA</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-variant_alias.ConstrB" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant_alias.ConstrB" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrB</span>(int)</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant_alias.ConstrC" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant_alias.ConstrC" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrC</span>(int, int)</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant_alias.ConstrD" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant_alias.ConstrD" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrD</span>(<span>(int, int)</span>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant_alias.TagA" class="anchored">
+       <a href="#type-variant_alias.TagA" class="anchor"></a><code><span>| </span><span><span class="constructor">TagA</span></span></code>
+      </li>
+      <li id="type-variant_alias.ConstrB" class="anchored">
+       <a href="#type-variant_alias.ConstrB" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrB</span>(int)</span></code>
+      </li>
+      <li id="type-variant_alias.ConstrC" class="anchored">
+       <a href="#type-variant_alias.ConstrC" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrC</span>(int, int)</span></code>
+      </li>
+      <li id="type-variant_alias.ConstrD" class="anchored">
+       <a href="#type-variant_alias.ConstrD" class="anchor"></a><code><span>| </span><span><span class="constructor">ConstrD</span>(<span>(int, int)</span>)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -1050,20 +925,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-record_alias">
      <a href="#type-record_alias" class="anchor"></a><code><span><span class="keyword">type</span> record_alias</span><span> = <a href="#type-record">record</a></span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-record_alias.field1" class="anchored">
-        <td class="def record field">
-         <a href="#type-record_alias.field1" class="anchor"></a><code><span>field1: int,</span></code>
-        </td>
-       </tr>
-       <tr id="type-record_alias.field2" class="anchored">
-        <td class="def record field">
-         <a href="#type-record_alias.field2" class="anchor"></a><code><span>field2: int,</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-record_alias.field1" class="anchored">
+       <a href="#type-record_alias.field1" class="anchor"></a><code><span>field1: int,</span></code>
+      </li>
+      <li id="type-record_alias.field2" class="anchored">
+       <a href="#type-record_alias.field2" class="anchor"></a><code><span>field2: int,</span></code>
+      </li>
+     </ol>
      <code><span>}</span><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -1075,20 +944,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-poly_variant_union">
      <a href="#type-poly_variant_union" class="anchor"></a><code><span><span class="keyword">type</span> poly_variant_union</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-poly_variant_union.poly_variant" class="anchored">
-        <td class="def type">
-         <a href="#type-poly_variant_union.poly_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-poly_variant">poly_variant</a></span></code>
-        </td>
-       </tr>
-       <tr id="type-poly_variant_union.TagC" class="anchored">
-        <td class="def constructor">
-         <a href="#type-poly_variant_union.TagC" class="anchor"></a><code><span>| </span></code><code><span>`TagC</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-poly_variant_union.poly_variant" class="anchored">
+       <a href="#type-poly_variant_union.poly_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-poly_variant">poly_variant</a></span></code>
+      </li>
+      <li id="type-poly_variant_union.TagC" class="anchored">
+       <a href="#type-poly_variant_union.TagC" class="anchor"></a><code><span>| </span></code><code><span>`TagC</span></code>
+      </li>
+     </ol>
      <code><span> ]</span><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -1100,35 +963,25 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-poly_poly_variant">
      <a href="#type-poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> poly_poly_variant('a)</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-poly_poly_variant.TagA" class="anchored">
-        <td class="def constructor">
-         <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA(<span class="type-var">'a</span>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-poly_poly_variant.TagA" class="anchored">
+       <a href="#type-poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA(<span class="type-var">'a</span>)</span></code>
+      </li>
+     </ol>
      <code><span> ]</span><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-bin_poly_poly_variant">
      <a href="#type-bin_poly_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> bin_poly_poly_variant('a, 'b)</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
-        <td class="def constructor">
-         <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA(<span class="type-var">'a</span>)</span></code>
-        </td>
-       </tr>
-       <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
-        <td class="def constructor">
-         <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB(<span class="type-var">'b</span>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-bin_poly_poly_variant.TagA" class="anchored">
+       <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a><code><span>| </span></code><code><span>`TagA(<span class="type-var">'a</span>)</span></code>
+      </li>
+      <li id="type-bin_poly_poly_variant.ConstrB" class="anchored">
+       <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a><code><span>| </span></code><code><span>`ConstrB(<span class="type-var">'b</span>)</span></code>
+      </li>
+     </ol>
      <code><span> ]</span><span>;</span></code>
     </div>
    </div>
@@ -1170,60 +1023,40 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-nested_poly_variant">
      <a href="#type-nested_poly_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_poly_variant</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-nested_poly_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(<span>[ `B1 <span>| `B2</span> ]</span>)</span></code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
-        </td>
-       </tr>
-       <tr id="type-nested_poly_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_poly_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D(<span>[ <span>`D1<span>(<span>[ `D1a ]</span>)</span></span> ]</span>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-nested_poly_variant.A" class="anchored">
+       <a href="#type-nested_poly_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+      </li>
+      <li id="type-nested_poly_variant.B" class="anchored">
+       <a href="#type-nested_poly_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(<span>[ `B1 <span>| `B2</span> ]</span>)</span></code>
+      </li>
+      <li id="type-nested_poly_variant.C" class="anchored">
+       <a href="#type-nested_poly_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
+      </li>
+      <li id="type-nested_poly_variant.D" class="anchored">
+       <a href="#type-nested_poly_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D(<span>[ <span>`D1<span>(<span>[ `D1a ]</span>)</span></span> ]</span>)</span></code>
+      </li>
+     </ol>
      <code><span> ]</span><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-full_gadt_alias">
      <a href="#type-full_gadt_alias" class="anchor"></a><code><span><span class="keyword">type</span> full_gadt_alias('a, 'b)</span><span> = <a href="#type-full_gadt">full_gadt</a><span>(<span class="type-var">'a</span>,&nbsp;<span class="type-var">'b</span>)</span></span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-full_gadt_alias.Tag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt_alias.Tag" class="anchor"></a><code><span>| </span><span><span class="constructor">Tag</span> : <a href="#type-full_gadt_alias">full_gadt_alias</a><span>(unit,&nbsp;unit)</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt_alias.First" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt_alias.First" class="anchor"></a><code><span>| </span><span><span class="constructor">First</span>(<span class="type-var">'a</span>) : <a href="#type-full_gadt_alias">full_gadt_alias</a><span>(<span class="type-var">'a</span>,&nbsp;unit)</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt_alias.Second" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt_alias.Second" class="anchor"></a><code><span>| </span><span><span class="constructor">Second</span>(<span class="type-var">'a</span>) : <a href="#type-full_gadt_alias">full_gadt_alias</a><span>(unit,&nbsp;<span class="type-var">'a</span>)</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-full_gadt_alias.Exist" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-full_gadt_alias.Exist" class="anchor"></a><code><span>| </span><span><span class="constructor">Exist</span>(<span class="type-var">'a</span>, <span class="type-var">'b</span>) : <a href="#type-full_gadt_alias">full_gadt_alias</a><span>(<span class="type-var">'b</span>,&nbsp;unit)</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-full_gadt_alias.Tag" class="anchored">
+       <a href="#type-full_gadt_alias.Tag" class="anchor"></a><code><span>| </span><span><span class="constructor">Tag</span> : <a href="#type-full_gadt_alias">full_gadt_alias</a><span>(unit,&nbsp;unit)</span></span></code>
+      </li>
+      <li id="type-full_gadt_alias.First" class="anchored">
+       <a href="#type-full_gadt_alias.First" class="anchor"></a><code><span>| </span><span><span class="constructor">First</span>(<span class="type-var">'a</span>) : <a href="#type-full_gadt_alias">full_gadt_alias</a><span>(<span class="type-var">'a</span>,&nbsp;unit)</span></span></code>
+      </li>
+      <li id="type-full_gadt_alias.Second" class="anchored">
+       <a href="#type-full_gadt_alias.Second" class="anchor"></a><code><span>| </span><span><span class="constructor">Second</span>(<span class="type-var">'a</span>) : <a href="#type-full_gadt_alias">full_gadt_alias</a><span>(unit,&nbsp;<span class="type-var">'a</span>)</span></span></code>
+      </li>
+      <li id="type-full_gadt_alias.Exist" class="anchored">
+       <a href="#type-full_gadt_alias.Exist" class="anchor"></a><code><span>| </span><span><span class="constructor">Exist</span>(<span class="type-var">'a</span>, <span class="type-var">'b</span>) : <a href="#type-full_gadt_alias">full_gadt_alias</a><span>(<span class="type-var">'b</span>,&nbsp;unit)</span></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -1235,25 +1068,17 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-partial_gadt_alias">
      <a href="#type-partial_gadt_alias" class="anchor"></a><code><span><span class="keyword">type</span> partial_gadt_alias('a)</span><span> = <a href="#type-partial_gadt">partial_gadt</a>(<span class="type-var">'a</span>)</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-partial_gadt_alias.AscribeTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt_alias.AscribeTag" class="anchor"></a><code><span>| </span><span><span class="constructor">AscribeTag</span> : <a href="#type-partial_gadt_alias">partial_gadt_alias</a>(<span class="type-var">'a</span>)</span></code>
-        </td>
-       </tr>
-       <tr id="type-partial_gadt_alias.OfTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt_alias.OfTag" class="anchor"></a><code><span>| </span><span><span class="constructor">OfTag</span>(<a href="#type-partial_gadt_alias">partial_gadt_alias</a>(<span class="type-var">'a</span>))</span></code>
-        </td>
-       </tr>
-       <tr id="type-partial_gadt_alias.ExistGadtTag" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-partial_gadt_alias.ExistGadtTag" class="anchor"></a><code><span>| </span><span><span class="constructor">ExistGadtTag</span>(<span>(<span><span class="type-var">'a</span> <span class="arrow">=&gt;</span></span> <span class="type-var">'b</span>)</span>) : <a href="#type-partial_gadt_alias">partial_gadt_alias</a>(<span class="type-var">'a</span>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-partial_gadt_alias.AscribeTag" class="anchored">
+       <a href="#type-partial_gadt_alias.AscribeTag" class="anchor"></a><code><span>| </span><span><span class="constructor">AscribeTag</span> : <a href="#type-partial_gadt_alias">partial_gadt_alias</a>(<span class="type-var">'a</span>)</span></code>
+      </li>
+      <li id="type-partial_gadt_alias.OfTag" class="anchored">
+       <a href="#type-partial_gadt_alias.OfTag" class="anchor"></a><code><span>| </span><span><span class="constructor">OfTag</span>(<a href="#type-partial_gadt_alias">partial_gadt_alias</a>(<span class="type-var">'a</span>))</span></code>
+      </li>
+      <li id="type-partial_gadt_alias.ExistGadtTag" class="anchored">
+       <a href="#type-partial_gadt_alias.ExistGadtTag" class="anchor"></a><code><span>| </span><span><span class="constructor">ExistGadtTag</span>(<span>(<span><span class="type-var">'a</span> <span class="arrow">=&gt;</span></span> <span class="type-var">'b</span>)</span>) : <a href="#type-partial_gadt_alias">partial_gadt_alias</a>(<span class="type-var">'a</span>)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -1275,27 +1100,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-mutual_constr_a">
      <a href="#type-mutual_constr_a" class="anchor"></a><code><span><span class="keyword">type</span> mutual_constr_a</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-mutual_constr_a.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutual_constr_a.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-mutual_constr_a.B_ish" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutual_constr_a.B_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">B_ish</span>(<a href="#type-mutual_constr_b">mutual_constr_b</a>)</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          This comment is between <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a> and <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-mutual_constr_a.A" class="anchored">
+       <a href="#type-mutual_constr_a.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+      </li>
+      <li id="type-mutual_constr_a.B_ish" class="anchored">
+       <a href="#type-mutual_constr_a.B_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">B_ish</span>(<a href="#type-mutual_constr_b">mutual_constr_b</a>)</span></code><span class="def-doc"><span class="comment-delim">/*</span>This comment is between <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a> and <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>.<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -1307,27 +1119,14 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-mutual_constr_b">
      <a href="#type-mutual_constr_b" class="anchor"></a><code><span><span class="keyword">and</span> mutual_constr_b</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-mutual_constr_b.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutual_constr_b.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-mutual_constr_b.A_ish" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutual_constr_b.A_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">A_ish</span>(<a href="#type-mutual_constr_a">mutual_constr_a</a>)</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          This comment must be here for the next to associate correctly.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-mutual_constr_b.B" class="anchored">
+       <a href="#type-mutual_constr_b.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span></span></code>
+      </li>
+      <li id="type-mutual_constr_b.A_ish" class="anchored">
+       <a href="#type-mutual_constr_b.A_ish" class="anchor"></a><code><span>| </span><span><span class="constructor">A_ish</span>(<a href="#type-mutual_constr_a">mutual_constr_a</a>)</span></code><span class="def-doc"><span class="comment-delim">/*</span>This comment must be here for the next to associate correctly.<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
     <div class="spec-doc">
@@ -1379,80 +1178,58 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ExtA" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtA" class="anchor"></a><code><span>| </span><span><span class="extension">ExtA</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ExtA" class="anchored">
+       <a href="#extension-ExtA" class="anchor"></a><code><span>| </span><span><span class="extension">ExtA</span></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ExtB" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtB" class="anchor"></a><code><span>| </span><span><span class="extension">ExtB</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ExtB" class="anchored">
+       <a href="#extension-ExtB" class="anchor"></a><code><span>| </span><span><span class="extension">ExtB</span></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ExtC" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtC" class="anchor"></a><code><span>| </span><span><span class="extension">ExtC</span>(unit)</span></code>
-        </td>
-       </tr>
-       <tr id="extension-ExtD" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtD" class="anchor"></a><code><span>| </span><span><span class="extension">ExtD</span>(<a href="#type-ext">ext</a>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ExtC" class="anchored">
+       <a href="#extension-ExtC" class="anchor"></a><code><span>| </span><span><span class="extension">ExtC</span>(unit)</span></code>
+      </li>
+      <li id="extension-ExtD" class="anchored">
+       <a href="#extension-ExtD" class="anchor"></a><code><span>| </span><span><span class="extension">ExtD</span>(<a href="#type-ext">ext</a>)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ExtE" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtE" class="anchor"></a><code><span>| </span><span><span class="extension">ExtE</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ExtE" class="anchored">
+       <a href="#extension-ExtE" class="anchor"></a><code><span>| </span><span><span class="extension">ExtE</span></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-ext">ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ExtF" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ExtF" class="anchor"></a><code><span>| </span><span><span class="extension">ExtF</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ExtF" class="anchored">
+       <a href="#extension-ExtF" class="anchor"></a><code><span>| </span><span><span class="extension">ExtF</span></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
@@ -1469,49 +1246,25 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-Foo" class="anchored">
-        <td class="def extension">
-         <a href="#extension-Foo" class="anchor"></a><code><span>| </span><span><span class="extension">Foo</span>(<span class="type-var">'b</span>)</span></code>
-        </td>
-       </tr>
-       <tr id="extension-Bar" class="anchored">
-        <td class="def extension">
-         <a href="#extension-Bar" class="anchor"></a><code><span>| </span><span><span class="extension">Bar</span>(<span class="type-var">'b</span>, <span class="type-var">'b</span>)</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          'b poly_ext
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-Foo" class="anchored">
+       <a href="#extension-Foo" class="anchor"></a><code><span>| </span><span><span class="extension">Foo</span>(<span class="type-var">'b</span>)</span></code>
+      </li>
+      <li id="extension-Bar" class="anchored">
+       <a href="#extension-Bar" class="anchor"></a><code><span>| </span><span><span class="extension">Bar</span>(<span class="type-var">'b</span>, <span class="type-var">'b</span>)</span></code><span class="def-doc"><span class="comment-delim">/*</span>'b poly_ext<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-poly_ext">poly_ext</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-Quux" class="anchored">
-        <td class="def extension">
-         <a href="#extension-Quux" class="anchor"></a><code><span>| </span><span><span class="extension">Quux</span>(<span class="type-var">'c</span>)</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          'c poly_ext
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-Quux" class="anchored">
+       <a href="#extension-Quux" class="anchor"></a><code><span>| </span><span><span class="extension">Quux</span>(<span class="type-var">'c</span>)</span></code><span class="def-doc"><span class="comment-delim">/*</span>'c poly_ext<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
@@ -1523,44 +1276,22 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ZzzTop0" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ZzzTop0" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop0</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          It's got the rock
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ZzzTop0" class="anchored">
+       <a href="#extension-ZzzTop0" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop0</span></span></code><span class="def-doc"><span class="comment-delim">/*</span>It's got the rock<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="ExtMod/index.html#type-t">ExtMod.t</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-ZzzTop" class="anchored">
-        <td class="def extension">
-         <a href="#extension-ZzzTop" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop</span>(unit)</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          and it packs a unit.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-ZzzTop" class="anchored">
+       <a href="#extension-ZzzTop" class="anchor"></a><code><span>| </span><span><span class="extension">ZzzTop</span>(unit)</span></code><span class="def-doc"><span class="comment-delim">/*</span>and it packs a unit.<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
@@ -2015,15 +1746,11 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-new_t">new_t</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-C" class="anchored">
-        <td class="def extension">
-         <a href="#extension-C" class="anchor"></a><code><span>| </span><span><span class="extension">C</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-C" class="anchored">
+       <a href="#extension-C" class="anchor"></a><code><span>| </span><span><span class="extension">C</span></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+re/Recent/index.html
+++ b/test/html/expect/test_package+re/Recent/index.html
@@ -36,145 +36,72 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-variant">
      <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int)</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          foo
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-variant.D" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          <em>bar</em>
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-variant.E" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> </span><span>{</span></code>
-         <table>
-          <tbody>
-           <tr id="type-variant.a" class="anchored">
-            <td class="def record field">
-             <a href="#type-variant.a" class="anchor"></a><code><span>a: int,</span></code>
-            </td>
-           </tr>
-          </tbody>
-         </table>
-         <code><span>}</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant.A" class="anchored">
+       <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+      </li>
+      <li id="type-variant.B" class="anchored">
+       <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int)</span></code>
+      </li>
+      <li id="type-variant.C" class="anchored">
+       <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code><span class="def-doc"><span class="comment-delim">/*</span>foo<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-variant.D" class="anchored">
+       <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code><span class="def-doc"><span class="comment-delim">/*</span><em>bar</em><span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-variant.E" class="anchored">
+       <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span> <span class="keyword">of</span> </span><span>{</span></code>
+       <ol>
+        <li id="type-variant.a" class="anchored">
+         <a href="#type-variant.a" class="anchor"></a><code><span>a: int,</span></code>
+        </li>
+       </ol>
+       <code><span>}</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-gadt">
      <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> gadt(_)</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-gadt">gadt</a>(int)</span></code>
-        </td>
-       </tr>
-       <tr id="type-gadt.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int) : <a href="#type-gadt">gadt</a>(string)</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          foo
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-gadt.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span>: </span><span>{</span></code>
-         <table>
-          <tbody>
-           <tr id="type-gadt.a" class="anchored">
-            <td class="def record field">
-             <a href="#type-gadt.a" class="anchor"></a><code><span>a: int,</span></code>
-            </td>
-           </tr>
-          </tbody>
-         </table>
-         <code><span>}</span><span> : <a href="#type-gadt">gadt</a>(unit)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-gadt.A" class="anchored">
+       <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-gadt">gadt</a>(int)</span></code>
+      </li>
+      <li id="type-gadt.B" class="anchored">
+       <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int) : <a href="#type-gadt">gadt</a>(string)</span></code><span class="def-doc"><span class="comment-delim">/*</span>foo<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-gadt.C" class="anchored">
+       <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span>: </span><span>{</span></code>
+       <ol>
+        <li id="type-gadt.a" class="anchored">
+         <a href="#type-gadt.a" class="anchor"></a><code><span>a: int,</span></code>
+        </li>
+       </ol>
+       <code><span>}</span><span> : <a href="#type-gadt">gadt</a>(unit)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-polymorphic_variant">
      <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(int)</span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          foo
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          bar
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-polymorphic_variant.A" class="anchored">
+       <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+      </li>
+      <li id="type-polymorphic_variant.B" class="anchored">
+       <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(int)</span></code>
+      </li>
+      <li id="type-polymorphic_variant.C" class="anchored">
+       <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C</span></code><span class="def-doc"><span class="comment-delim">/*</span>foo<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-polymorphic_variant.D" class="anchored">
+       <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code><span class="def-doc"><span class="comment-delim">/*</span>bar<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span> ]</span><span>;</span></code>
     </div>
    </div>
@@ -191,30 +118,22 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-empty_conj">
      <a href="#type-empty_conj" class="anchor"></a><code><span><span class="keyword">type</span> empty_conj</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-empty_conj.X" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-empty_conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span>(<span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>) : <a href="#type-empty_conj">empty_conj</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-empty_conj.X" class="anchored">
+       <a href="#type-empty_conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span>(<span>[&lt; <span>`X&amp; <span>(<span class="type-var">'a</span>)</span> &amp; <span>(<span>(int, float)</span>)</span></span> ]</span>) : <a href="#type-empty_conj">empty_conj</a></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-conj">
      <a href="#type-conj" class="anchor"></a><code><span><span class="keyword">type</span> conj</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-conj.X" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span>(<span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>) : <a href="#type-conj">conj</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-conj.X" class="anchored">
+       <a href="#type-conj.X" class="anchor"></a><code><span>| </span><span><span class="constructor">X</span>(<span>[&lt; <span>`X<span>(int)</span> &amp; <span>(<span>[&lt; <span>`B<span>(int)</span> &amp; <span>(float)</span></span> ]</span>)</span></span> ]</span>) : <a href="#type-conj">conj</a></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+re/Stop_dead_link_doc/index.html
+++ b/test/html/expect/test_package+re/Stop_dead_link_doc/index.html
@@ -31,70 +31,50 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-foo">
      <a href="#type-foo" class="anchor"></a><code><span><span class="keyword">type</span> foo</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-foo.Bar" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-foo.Bar" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar</span>(<a href="Foo/index.html#type-t">Foo.t</a>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-foo.Bar" class="anchored">
+       <a href="#type-foo.Bar" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar</span>(<a href="Foo/index.html#type-t">Foo.t</a>)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-bar">
      <a href="#type-bar" class="anchor"></a><code><span><span class="keyword">type</span> bar</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-bar.Bar" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-bar.Bar" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar</span> <span class="keyword">of</span> </span><span>{</span></code>
-         <table>
-          <tbody>
-           <tr id="type-bar.field" class="anchored">
-            <td class="def record field">
-             <a href="#type-bar.field" class="anchor"></a><code><span>field: <a href="Foo/index.html#type-t">Foo.t</a>,</span></code>
-            </td>
-           </tr>
-          </tbody>
-         </table>
-         <code><span>}</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-bar.Bar" class="anchored">
+       <a href="#type-bar.Bar" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar</span> <span class="keyword">of</span> </span><span>{</span></code>
+       <ol>
+        <li id="type-bar.field" class="anchored">
+         <a href="#type-bar.field" class="anchor"></a><code><span>field: <a href="Foo/index.html#type-t">Foo.t</a>,</span></code>
+        </li>
+       </ol>
+       <code><span>}</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-foo_">
      <a href="#type-foo_" class="anchor"></a><code><span><span class="keyword">type</span> foo_</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-foo_.Bar_" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-foo_.Bar_" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar_</span>(<span>(int, <a href="Foo/index.html#type-t">Foo.t</a>)</span>, int)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-foo_.Bar_" class="anchored">
+       <a href="#type-foo_.Bar_" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar_</span>(<span>(int, <a href="Foo/index.html#type-t">Foo.t</a>)</span>, int)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-bar_">
      <a href="#type-bar_" class="anchor"></a><code><span><span class="keyword">type</span> bar_</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-bar_.Bar__" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-bar_.Bar__" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar__</span>(option(<a href="Foo/index.html#type-t">Foo.t</a>))</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-bar_.Bar__" class="anchored">
+       <a href="#type-bar_.Bar__" class="anchor"></a><code><span>| </span><span><span class="constructor">Bar__</span>(option(<a href="Foo/index.html#type-t">Foo.t</a>))</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>

--- a/test/html/expect/test_package+re/Type/index.html
+++ b/test/html/expect/test_package+re/Type/index.html
@@ -106,248 +106,152 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-variant_e">
      <a href="#type-variant_e" class="anchor"></a><code><span><span class="keyword">type</span> variant_e</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant_e.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-variant_e.a" class="anchor"></a><code><span>a: int,</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant_e.a" class="anchored">
+       <a href="#type-variant_e.a" class="anchor"></a><code><span>a: int,</span></code>
+      </li>
+     </ol>
      <code><span>}</span><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-variant">
      <a href="#type-variant" class="anchor"></a><code><span><span class="keyword">type</span> variant</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int)</span></code>
-        </td>
-       </tr>
-       <tr id="type-variant.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          foo
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-variant.D" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          <em>bar</em>
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-variant.E" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span>(<a href="#type-variant_e">variant_e</a>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant.A" class="anchored">
+       <a href="#type-variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+      </li>
+      <li id="type-variant.B" class="anchored">
+       <a href="#type-variant.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int)</span></code>
+      </li>
+      <li id="type-variant.C" class="anchored">
+       <a href="#type-variant.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span></span></code><span class="def-doc"><span class="comment-delim">/*</span>foo<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-variant.D" class="anchored">
+       <a href="#type-variant.D" class="anchor"></a><code><span>| </span><span><span class="constructor">D</span></span></code><span class="def-doc"><span class="comment-delim">/*</span><em>bar</em><span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-variant.E" class="anchored">
+       <a href="#type-variant.E" class="anchor"></a><code><span>| </span><span><span class="constructor">E</span>(<a href="#type-variant_e">variant_e</a>)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-variant_c">
      <a href="#type-variant_c" class="anchor"></a><code><span><span class="keyword">type</span> variant_c</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-variant_c.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-variant_c.a" class="anchor"></a><code><span>a: int,</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-variant_c.a" class="anchored">
+       <a href="#type-variant_c.a" class="anchor"></a><code><span>a: int,</span></code>
+      </li>
+     </ol>
      <code><span>}</span><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-gadt">
      <a href="#type-gadt" class="anchor"></a><code><span><span class="keyword">type</span> gadt(_)</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-gadt">gadt</a>(int)</span></code>
-        </td>
-       </tr>
-       <tr id="type-gadt.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int) : <a href="#type-gadt">gadt</a>(string)</span></code>
-        </td>
-       </tr>
-       <tr id="type-gadt.C" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span>(<a href="#type-variant_c">variant_c</a>) : <a href="#type-gadt">gadt</a>(unit)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-gadt.A" class="anchored">
+       <a href="#type-gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-gadt">gadt</a>(int)</span></code>
+      </li>
+      <li id="type-gadt.B" class="anchored">
+       <a href="#type-gadt.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(int) : <a href="#type-gadt">gadt</a>(string)</span></code>
+      </li>
+      <li id="type-gadt.C" class="anchored">
+       <a href="#type-gadt.C" class="anchor"></a><code><span>| </span><span><span class="constructor">C</span>(<a href="#type-variant_c">variant_c</a>) : <a href="#type-gadt">gadt</a>(unit)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-degenerate_gadt">
      <a href="#type-degenerate_gadt" class="anchor"></a><code><span><span class="keyword">type</span> degenerate_gadt</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-degenerate_gadt.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-degenerate_gadt">degenerate_gadt</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-degenerate_gadt.A" class="anchored">
+       <a href="#type-degenerate_gadt.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span> : <a href="#type-degenerate_gadt">degenerate_gadt</a></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-private_variant">
      <a href="#type-private_variant" class="anchor"></a><code><span><span class="keyword">type</span> private_variant</span><span> = <span class="keyword">pri</span> </span></code>
-     <table>
-      <tbody>
-       <tr id="type-private_variant.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-private_variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-private_variant.A" class="anchored">
+       <a href="#type-private_variant.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span></span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-record">
      <a href="#type-record" class="anchor"></a><code><span><span class="keyword">type</span> record</span><span> = </span><span>{</span></code>
-     <table>
-      <tbody>
-       <tr id="type-record.a" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.a" class="anchor"></a><code><span>a: int,</span></code>
-        </td>
-       </tr>
-       <tr id="type-record.b" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.b" class="anchor"></a><code><span><span class="keyword">mutable</span> b: int,</span></code>
-        </td>
-       </tr>
-       <tr id="type-record.c" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.c" class="anchor"></a><code><span>c: int,</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          foo
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-record.d" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.d" class="anchor"></a><code><span>d: int,</span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          <em>bar</em>
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="type-record.e" class="anchored">
-        <td class="def record field">
-         <a href="#type-record.e" class="anchor"></a><code><span>e: a. <span class="type-var">'a</span>,</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-record.a" class="anchored">
+       <a href="#type-record.a" class="anchor"></a><code><span>a: int,</span></code>
+      </li>
+      <li id="type-record.b" class="anchored">
+       <a href="#type-record.b" class="anchor"></a><code><span><span class="keyword">mutable</span> b: int,</span></code>
+      </li>
+      <li id="type-record.c" class="anchored">
+       <a href="#type-record.c" class="anchor"></a><code><span>c: int,</span></code><span class="def-doc"><span class="comment-delim">/*</span>foo<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-record.d" class="anchored">
+       <a href="#type-record.d" class="anchor"></a><code><span>d: int,</span></code><span class="def-doc"><span class="comment-delim">/*</span><em>bar</em><span class="comment-delim">*/</span></span>
+      </li>
+      <li id="type-record.e" class="anchored">
+       <a href="#type-record.e" class="anchor"></a><code><span>e: a. <span class="type-var">'a</span>,</span></code>
+      </li>
+     </ol>
      <code><span>}</span><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-polymorphic_variant">
      <a href="#type-polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.B" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(int)</span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.C" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C(<span>(int, unit)</span>)</span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant.D" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-polymorphic_variant.A" class="anchored">
+       <a href="#type-polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A</span></code>
+      </li>
+      <li id="type-polymorphic_variant.B" class="anchored">
+       <a href="#type-polymorphic_variant.B" class="anchor"></a><code><span>| </span></code><code><span>`B(int)</span></code>
+      </li>
+      <li id="type-polymorphic_variant.C" class="anchored">
+       <a href="#type-polymorphic_variant.C" class="anchor"></a><code><span>| </span></code><code><span>`C(<span>(int, unit)</span>)</span></code>
+      </li>
+      <li id="type-polymorphic_variant.D" class="anchored">
+       <a href="#type-polymorphic_variant.D" class="anchor"></a><code><span>| </span></code><code><span>`D</span></code>
+      </li>
+     </ol>
      <code><span> ]</span><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-polymorphic_variant_extension">
      <a href="#type-polymorphic_variant_extension" class="anchor"></a><code><span><span class="keyword">type</span> polymorphic_variant_extension</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
-        <td class="def type">
-         <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
-        </td>
-       </tr>
-       <tr id="type-polymorphic_variant_extension.E" class="anchored">
-        <td class="def constructor">
-         <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span>| </span></code><code><span>`E</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-polymorphic_variant_extension.polymorphic_variant" class="anchored">
+       <a href="#type-polymorphic_variant_extension.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
+      </li>
+      <li id="type-polymorphic_variant_extension.E" class="anchored">
+       <a href="#type-polymorphic_variant_extension.E" class="anchor"></a><code><span>| </span></code><code><span>`E</span></code>
+      </li>
+     </ol>
      <code><span> ]</span><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-nested_polymorphic_variant">
      <a href="#type-nested_polymorphic_variant" class="anchor"></a><code><span><span class="keyword">type</span> nested_polymorphic_variant</span><span> = </span><span>[ </span></code>
-     <table>
-      <tbody>
-       <tr id="type-nested_polymorphic_variant.A" class="anchored">
-        <td class="def constructor">
-         <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A(<span>[ `B <span>| `C</span> ]</span>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-nested_polymorphic_variant.A" class="anchored">
+       <a href="#type-nested_polymorphic_variant.A" class="anchor"></a><code><span>| </span></code><code><span>`A(<span>[ `B <span>| `C</span> ]</span>)</span></code>
+      </li>
+     </ol>
      <code><span> ]</span><span>;</span></code>
     </div>
    </div>
@@ -359,15 +263,11 @@
    <div class="odoc-spec">
     <div class="spec type" id="type-private_extenion">
      <a href="#type-private_extenion" class="anchor"></a><code><span><span class="keyword">and</span> private_extenion</span><span> = <span class="keyword">pri</span> </span><span>[&gt; </span></code>
-     <table>
-      <tbody>
-       <tr id="type-private_extenion.polymorphic_variant" class="anchored">
-        <td class="def type">
-         <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-private_extenion.polymorphic_variant" class="anchored">
+       <a href="#type-private_extenion.polymorphic_variant" class="anchor"></a><code><span>| </span></code><code><span><a href="#type-polymorphic_variant">polymorphic_variant</a></span></code>
+      </li>
+     </ol>
      <code><span> ]</span><span>;</span></code>
     </div>
    </div>
@@ -484,64 +384,36 @@
    <div class="odoc-spec">
     <div class="spec type extension">
      <code><span><span class="keyword">type</span> <a href="#type-extensible">extensible</a> += </span></code>
-     <table>
-      <tbody>
-       <tr id="extension-Extension" class="anchored">
-        <td class="def extension">
-         <a href="#extension-Extension" class="anchor"></a><code><span>| </span><span><span class="extension">Extension</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          Documentation for <a href="#extension-Extension"><code>Extension</code></a>.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-       <tr id="extension-Another_extension" class="anchored">
-        <td class="def extension">
-         <a href="#extension-Another_extension" class="anchor"></a><code><span>| </span><span><span class="extension">Another_extension</span></span></code>
-        </td>
-        <td class="def-doc">
-         <span class="comment-delim">/*</span>
-         <p>
-          Documentation for <a href="#extension-Another_extension"><code>Another_extension</code></a>.
-         </p>
-         <span class="comment-delim">*/</span>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="extension-Extension" class="anchored">
+       <a href="#extension-Extension" class="anchor"></a><code><span>| </span><span><span class="extension">Extension</span></span></code><span class="def-doc"><span class="comment-delim">/*</span>Documentation for <a href="#extension-Extension"><code>Extension</code></a>.<span class="comment-delim">*/</span></span>
+      </li>
+      <li id="extension-Another_extension" class="anchored">
+       <a href="#extension-Another_extension" class="anchor"></a><code><span>| </span><span><span class="extension">Another_extension</span></span></code><span class="def-doc"><span class="comment-delim">/*</span>Documentation for <a href="#extension-Another_extension"><code>Another_extension</code></a>.<span class="comment-delim">*/</span></span>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-mutually">
      <a href="#type-mutually" class="anchor"></a><code><span><span class="keyword">type</span> mutually</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-mutually.A" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-mutually.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span>(<a href="#type-recursive">recursive</a>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-mutually.A" class="anchored">
+       <a href="#type-mutually.A" class="anchor"></a><code><span>| </span><span><span class="constructor">A</span>(<a href="#type-recursive">recursive</a>)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>
    <div class="odoc-spec">
     <div class="spec type" id="type-recursive">
      <a href="#type-recursive" class="anchor"></a><code><span><span class="keyword">and</span> recursive</span><span> = </span></code>
-     <table>
-      <tbody>
-       <tr id="type-recursive.B" class="anchored">
-        <td class="def variant constructor">
-         <a href="#type-recursive.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(<a href="#type-mutually">mutually</a>)</span></code>
-        </td>
-       </tr>
-      </tbody>
-     </table>
+     <ol>
+      <li id="type-recursive.B" class="anchored">
+       <a href="#type-recursive.B" class="anchor"></a><code><span>| </span><span><span class="constructor">B</span>(<a href="#type-mutually">mutually</a>)</span></code>
+      </li>
+     </ol>
      <code><span>;</span></code>
     </div>
    </div>


### PR DESCRIPTION
This implements #614 : It uses lists instead of tables to layout datatypes, and add some heuristics to simplify the layout when the documentation payload is a single paragraph.

In practice, the layout for a sum datatype with a single-paragraph comment now looks like this:
```html
<ol>
  <li id="type-variant.TagA" class="anchored">
    <a href="#type-variant.TagA" class="anchor"></a>
    <code><span>| </span><span><span class="constructor">TagA</span></span></code>
    <span class="def-doc">
      <span class="comment-delim">(*</span>This comment is for <code>TagA</code>.<span class="comment-delim">*)</span>
    </span>
  </li>
  ......
</ol>
```

The span def-doc is changed for a div for longer documentation comments.
The CSS has not been adapted yet (cue @dbuenzli !).