### PR TITLE
Minimal 4.13 support

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -292,9 +292,9 @@ and items ~resolve l : item Html.elt list =
             | _ -> Stop_and_keep)
         in
         let content = flow_to_item @@ block ~resolve text in
-        content |> (continue_with [@tailcall]) rest
+        (continue_with [@tailcall]) rest content
     | Heading h :: rest ->
-        [ heading ~resolve h ] |> (continue_with [@tailcall]) rest
+        (continue_with [@tailcall]) rest [ heading ~resolve h ]
     | Include { attr; anchor; doc; content = { summary; status; content } }
       :: rest ->
         let doc = spec_doc_div ~resolve doc in

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -202,9 +202,18 @@ let mark_type ty =
           List.iter (fun t -> add_alias t) tyl;
           loop visited ty
       | Tunivar name -> reserve_name name
+#if OCAML_VERSION>=(4,13,0)
+      | Tpackage(_,tyl) ->
+          List.iter (fun (_,x) -> loop visited x) tyl
+#else
       | Tpackage(_, _, tyl) ->
           List.iter (loop visited) tyl
+#endif
+#if OCAML_VERSION<(4,13,0)
       | Tsubst ty -> loop visited ty
+#else
+      | Tsubst (ty,_) -> loop visited ty
+#endif
       | Tlink _ -> assert false
   in
   loop [] ty
@@ -227,12 +236,20 @@ let mark_type_parameter param =
   mark_type param;
   if aliasable param then use_alias (Btype.proxy param)
 
+#if OCAML_VERSION<(4,13,0)
+let tsubst x = Tsubst x
+let tvar_none ty = ty.desc <- Tvar None
+#else
+let tsubst x = Tsubst(x,None)
+let tvar_none ty = Types.Private_type_expr.set_desc ty (Tvar None)
+#endif
+
 let prepare_type_parameters params manifest =
   let params =
     List.fold_left
       (fun params param ->
         let param = Btype.repr param in
-        if List.memq param params then Btype.newgenty (Tsubst param) :: params
+        if List.memq param params then Btype.newgenty (tsubst param) :: params
         else param :: params)
       [] params
   in
@@ -242,7 +259,7 @@ let prepare_type_parameters params manifest =
         let vars = Ctype.free_variables ty in
           List.iter
             (function {desc = Tvar (Some "_"); _} as ty ->
-              if List.memq ty vars then ty.desc <- Tvar None
+              if List.memq ty vars then tvar_none ty
                     | _ -> ())
             params
     | None -> ()
@@ -261,7 +278,11 @@ let mark_constructor_args =
 
 let mark_type_kind = function
   | Type_abstract -> ()
+#if OCAML_VERSION >= (4,13,0)
+  | Type_variant (cds,_) ->
+#else
   | Type_variant cds ->
+#endif
       List.iter
         (fun cd ->
            mark_constructor_args cd.cd_args;
@@ -380,19 +401,29 @@ let rec read_type_expr env typ =
             remove_names tyl;
             Poly(vars, typ)
       | Tunivar _ -> Var (name_of_type typ)
+#if OCAML_VERSION>=(4,13,0)
+      | Tpackage(p,eqs) ->
+#else
       | Tpackage(p, frags, tyl) ->
+        let eqs = List.combine frags tyl in
+#endif
           let open TypeExpr.Package in
           let path = Env.Path.read_module_type env p in
           let substitutions =
-            List.map2
-              (fun frag typ ->
+            List.map
+              (fun (frag,typ) ->
                  let frag = Env.Fragment.read_type frag in
                  let typ = read_type_expr env typ in
                    (frag, typ))
-              frags tyl
+              eqs
           in
-            Package {path; substitutions}
+
+          Package {path; substitutions}
+#if OCAML_VERSION<(4,13,0)
       | Tsubst typ -> read_type_expr env typ
+#else
+      | Tsubst (typ,_) -> read_type_expr env typ
+#endif
       | Tlink _ -> assert false
     in
       match alias with
@@ -564,7 +595,11 @@ let read_constructor_declaration env parent cd =
 let read_type_kind env parent =
   let open TypeDecl.Representation in function
     | Type_abstract -> None
-    | Type_variant cstrs ->
+#if OCAML_VERSION >= (4,13,0)
+  | Type_variant (cstrs,_) ->
+#else
+  | Type_variant cstrs ->
+#endif
         let cstrs =
           List.map (read_constructor_declaration env parent) cstrs
         in
@@ -628,7 +663,11 @@ let read_type_declaration env parent id decl =
         decl.type_manifest = None || decl.type_private = Private
     | Type_record _ ->
         decl.type_private = Private
-    | Type_variant tll ->
+#if OCAML_VERSION >= (4,13,0)
+  | Type_variant (tll,_) ->
+#else
+  | Type_variant tll ->
+#endif
         decl.type_private = Private ||
         List.exists (fun cd -> cd.cd_res <> None) tll
     | Type_open ->

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -48,7 +48,11 @@ let rec read_pattern env parent doc pat =
     | Tpat_constant _ -> []
     | Tpat_tuple pats ->
         List.concat (List.map (read_pattern env parent doc) pats)
+#if OCAML_VERSION < (4, 13, 0)
     | Tpat_construct(_, _, pats) ->
+#else
+    | Tpat_construct(_,_,pats,_) ->
+#endif
         List.concat (List.map (read_pattern env parent doc) pats)
     | Tpat_variant(_, None, _) -> []
     | Tpat_variant(_, Some pat, _) ->

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -470,6 +470,10 @@ let rec read_with_constraint env parent (_, frag, constr) =
         let frag = Env.Fragment.read_module frag.Location.txt in
         let p = Env.Path.read_module env p in
           ModuleSubst(frag, p)
+#if OCAML_VERSION >= (4,13,0)
+   | Twith_modtype _ -> failwith "with module type not yet implemented"
+   | Twith_modtypesubst _ -> failwith "with module type not yet implemented"
+#endif
 
 and read_module_type env parent label_parent mty =
   let open ModuleType in
@@ -681,6 +685,10 @@ and read_signature_item env parent item =
         read_type_substitutions env parent tst
     | Tsig_modsubst mst ->
         [ModuleSubstitution (read_module_substitution env parent mst)]
+#if OCAML_VERSION >= (4,13,0)
+    | Tsig_modtypesubst _ -> failwith "local module type substitution not yet implemented"
+#endif
+
 
 and read_module_substitution env parent ms =
   let open ModuleSubstitution in

--- a/src/loader/ident_env.cppo.ml
+++ b/src/loader/ident_env.cppo.ml
@@ -229,6 +229,10 @@ let rec extract_signature_tree_items hide_item items =
       List.map (fun decl -> `Type (decl.typ_id, hide_item)) 
         ts @ extract_signature_tree_items hide_item rest
 #endif
+#if OCAML_VERSION >= (4,13,0)
+    | { sig_desc = Tsig_modtypesubst mtd; _ } :: rest ->
+      [`ModuleType (mtd.mtd_id, hide_item)] @ extract_signature_tree_items hide_item rest
+#endif
     | { sig_desc = Tsig_typext _; _} :: rest
     | { sig_desc = Tsig_exception _; _} :: rest
     | { sig_desc = Tsig_open _;_} :: rest -> extract_signature_tree_items hide_item rest
@@ -241,7 +245,11 @@ let rec read_pattern hide_item pat =
   | Tpat_alias(pat, id, _) -> `Value(id, hide_item) :: read_pattern hide_item pat
   | Tpat_record(pats, _) -> 
       List.concat (List.map (fun (_, _, pat) -> read_pattern hide_item pat) pats)
-  | Tpat_construct(_, _, pats) 
+#if OCAML_VERSION < (4,13,0)
+  | Tpat_construct(_, _, pats)
+#else
+  | Tpat_construct(_, _, pats, _)
+#endif
   | Tpat_array pats
   | Tpat_tuple pats -> List.concat (List.map (fun pat -> read_pattern hide_item pat) pats)
   | Tpat_or(pat, _, _)

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -272,23 +272,23 @@ let add_type identifier t env =
   |> add_cdocs identifier t.doc
   |> List.fold_right (add_cdocs identifier) docs
 
-let add_module_type identifier t env =
+let add_module_type identifier (t : Component.ModuleType.t) env =
   add_to_elts Kind_ModuleType identifier (`ModuleType (identifier, t)) env
   |> add_cdocs identifier t.doc
 
-let add_value identifier t env =
+let add_value identifier (t : Component.Value.t) env =
   add_to_elts Kind_Value identifier (`Value (identifier, t)) env
   |> add_cdocs identifier t.doc
 
-let add_external identifier t env =
+let add_external identifier (t : Component.External.t) env =
   add_to_elts Kind_External identifier (`External (identifier, t)) env
   |> add_cdocs identifier t.doc
 
-let add_class identifier t env =
+let add_class identifier (t : Component.Class.t) env =
   add_to_elts Kind_Class identifier (`Class (identifier, t)) env
   |> add_cdocs identifier t.doc
 
-let add_class_type identifier t env =
+let add_class_type identifier (t : Component.ClassType.t) env =
   add_to_elts Kind_ClassType identifier (`ClassType (identifier, t)) env
   |> add_cdocs identifier t.doc
 
@@ -296,11 +296,12 @@ let add_method _identifier _t env =
   (* TODO *)
   env
 
-let add_exception identifier e env =
+let add_exception identifier (e : Component.Exception.t) env =
   add_to_elts Kind_Exception identifier (`Exception (identifier, e)) env
   |> add_cdocs identifier e.doc
 
-let add_extension_constructor identifier ec env =
+let add_extension_constructor identifier
+    (ec : Component.Extension.Constructor.t) env =
   add_to_elts Kind_Extension identifier (`Extension (identifier, ec)) env
   |> add_cdocs identifier ec.doc
 

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -66,7 +66,11 @@ let model_of_string str =
     Odoc_loader__Cmti.read_interface parent "Root" cmti
 
 let model_of_string_impl str =
+#if OCAML_VERSION < (4,13,0)
     let (cmt,_) = cmt_of_string str in
+#else
+    let cmt = (cmt_of_string str).structure in
+#endif
     Odoc_loader__Cmt.read_implementation parent "Root" cmt
 
 let signature_of_mli_string str =


### PR DESCRIPTION
This PR makes odoc build on OCaml 4.13 but does not handle the new `with module type` feature.
This PR mostly adapts the loaders code to the few ASTs change in 4.13 .
There are also few fixed related to the change of typing for `|>`.