### PR TITLE
Aggregate "root" lookup failures

### DIFF
--- a/src/xref2/lookup_failures.mli
+++ b/src/xref2/lookup_failures.mli
@@ -1,27 +1,24 @@
 (** Report non-fatal errors.
 
-    This is internally using {!Odoc_model.Error}. The main difference is that no
-    precise location is attached to each failures, instead a filename is given
-    to {!catch_failures}.
-
-    Each failure has a [kind] which specify whether it's a lookup failure
-    ([`Root] or [`Internal]) or a warning. [`Root] failures are never turned
-    into fatal warnings. *)
+    The main difference with {!Odoc_model.Error} is that no precise location is
+    attached to each failures, instead a filename is given to {!catch_failures}. *)
 
 open Odoc_model
 
-type kind = [ `Root | `Internal | `Warning ]
-(** [`Root] failures won't be turned into fatal warnings. [`Internal] is for
-    lookup failures other than root modules and [`Warning] for messages to the
-    users. They may be turned into fatal warnings depending on [~warn_error]. *)
-
 val catch_failures : filename:string -> (unit -> 'a) -> 'a Error.with_warnings
-(** Catch failures thrown by [report]. [filename] is the initial location of
-    generated errors, more precise locations can be specified with
+(** Catch failures that are reported by [f]. [filename] is the initial location
+    of generated errors, more precise locations can be specified with
     [with_location]. *)
 
-val report : ?kind:kind -> ('fmt, Format.formatter, unit, unit) format4 -> 'fmt
-(** Report a lookup failure to the enclosing [catch_failures] call. *)
+val report_internal : ('fmt, Format.formatter, unit, unit) format4 -> 'fmt
+(** Internal errors happens during compiling and linking. *)
+
+val report_root : name:string -> unit
+(** Root errors happens when a dependency couldn't be loaded. These errors won't
+    be made fatal in "warn error" mode. *)
+
+val report_warning : ('fmt, Format.formatter, unit, unit) format4 -> 'fmt
+(** Warnings are user errors. *)
 
 val with_location : Location_.span -> (unit -> 'a) -> 'a
 (** Failures reported indirectly by this function will have a location attached. *)

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -101,7 +101,7 @@ let ref_kind_of_find = function
 let ambiguous_ref_warning name results =
   let pp_sep pp () = Format.fprintf pp ", "
   and pp_kind pp r = Format.fprintf pp "%s-%s" r name in
-  Lookup_failures.report ~kind:`Warning
+  Lookup_failures.report_warning
     "Reference to '%s' is ambiguous. Please specify its kind: %a." name
     (Format.pp_print_list ~pp_sep pp_kind)
     results

--- a/test/xref2/resolve/test.md
+++ b/test/xref2/resolve/test.md
@@ -1638,13 +1638,13 @@ Functor app nightmare:
   *)
     |}
 File "<test>":
-Failed to compile expansion for module type expression identifier((param (root Root).App.result F), false)(identifier((param (root Root).App T), false)).T OpaqueModule
-File "<test>":
-Failed to compile expansion for module type expression identifier((param (root Root).App.result F), false)(identifier((param (root Root).App T), false)).T OpaqueModule
-File "<test>":
 Failed to compile expansion for module type expression identifier((param (root Root).Foo T), false).T OpaqueModule
 File "<test>":
 Failed to compile expansion for module type expression identifier((param (root Root).Foo T), false).T OpaqueModule
+File "<test>":
+Failed to compile expansion for module type expression identifier((param (root Root).App.result F), false)(identifier((param (root Root).App T), false)).T OpaqueModule
+File "<test>":
+Failed to compile expansion for module type expression identifier((param (root Root).App.result F), false)(identifier((param (root Root).App T), false)).T OpaqueModule
 - : Odoc_model.Lang.Compilation_unit.t =
 {Odoc_model.Lang.Compilation_unit.id =
   `Root (Some (`Page (None, None)), Root);

--- a/test/xref2/warnings.t/run.t
+++ b/test/xref2/warnings.t/run.t
@@ -30,7 +30,8 @@ A contains linking errors:
 
   $ odoc link a.odoc
   File "a.odoc":
-  Failed to lookup type unresolvedroot(B).t Parent_module: Lookup failure (root module): B
+  Couldn't find the following modules:
+    B
 
   $ odoc errors a.odocl
   File "a.mli", line 8, characters 23-23:
@@ -38,7 +39,8 @@ A contains linking errors:
   File "a.mli", line 8, characters 22-23:
   Identifier in reference should not be empty.
   File "a.odoc":
-  Failed to lookup type unresolvedroot(B).t Parent_module: Lookup failure (root module): B
+  Couldn't find the following modules:
+    B
 
 It is possible to hide the warnings too:
 


### PR DESCRIPTION
Fixes https://github.com/ocaml/odoc/issues/635

These errors are common and are usually repeated several time. With this commit, they are merged into one message with only the necessary informations:

```
File "<test>":
Couldn't find the following modules:
  Stdlib
```

I initially tried to handle these errors while resolving imports but it was showing mangled names (eg. `Stdlib__bytes Stdlib__string ...` instead of `Stdlib`) and unused modules (eg. `CamlinternalFormatBasics`) and decreased performances a bit.
