### PR TITLE
Flat files

### DIFF
--- a/commits-to-take
+++ b/commits-to-take
@@ -1,0 +1,2 @@
+bea122919d799 d6ef4ca0f0a2cf6d74
+59d171ed

--- a/src/document/renderer.ml
+++ b/src/document/renderer.ml
@@ -17,10 +17,7 @@ let traverse ~f t =
   in
   aux t
 
-type 'a t = {
-  name : string;
-  render : 'a -> Types.Page.t -> page;
-}
+type 'a t = { name : string; render : 'a -> Types.Page.t -> page }
 
 let document_of_page ~syntax v =
   match syntax with Reason -> Reason.page v | OCaml -> ML.page v

--- a/src/document/renderer.ml
+++ b/src/document/renderer.ml
@@ -20,7 +20,6 @@ let traverse ~f t =
 type 'a t = {
   name : string;
   render : 'a -> Types.Page.t -> page;
-  files_of_url : Url.Path.t -> Fpath.t list;
 }
 
 let document_of_page ~syntax v =

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -76,35 +76,6 @@ module Path = struct
 
   type t = { kind : string; parent : t option; name : string }
 
-  (* 
-  
-  If we have a module that looks like this:
-
-  {[
-    module M : sig
-      module type MT = sig
-        type t
-      end
-    end
-  ]}
-
-  and this has parent page 'toppage', then the Path.t for module type MT will look like this:
-
-  { kind="module-type";
-    name="MT";
-    parent=Some {
-      kind="module";
-      name="M";
-      parent = Some {
-        kind="container-page";
-        name="toppage"
-        parent=None;
-      }
-    }
-  }
-
-  *)
-
   let mk ?parent kind name = { kind; parent; name }
 
   let rec from_identifier : source -> t = function

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -76,6 +76,35 @@ module Path = struct
 
   type t = { kind : string; parent : t option; name : string }
 
+  (* 
+  
+  If we have a module that looks like this:
+
+  {[
+    module M : sig
+      module type MT = sig
+        type t
+      end
+    end
+  ]}
+
+  and this has parent page 'toppage', then the Path.t for module type MT will look like this:
+
+  { kind="module-type";
+    name="MT";
+    parent=Some {
+      kind="module";
+      name="M";
+      parent = Some {
+        kind="container-page";
+        name="toppage"
+        parent=None;
+      }
+    }
+  }
+
+  *)
+
   let mk ?parent kind name = { kind; parent; name }
 
   let rec from_identifier : source -> t = function

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -370,30 +370,30 @@ module Page = struct
         | `Closed | `Open | `Default -> None
         | `Inline -> Some 0)
 
-  let rec include_ ?theme_uri indent { Subpage.content; _ } =
-    [ page ?theme_uri indent content ]
+  let rec include_ ?theme_uri extra_suffix indent { Subpage.content; _ } =
+    [ page ?theme_uri extra_suffix indent content ]
 
-  and subpages ?theme_uri indent i =
-    Utils.list_concat_map ~f:(include_ ?theme_uri indent)
+  and subpages ?theme_uri extra_suffix indent i =
+    Utils.list_concat_map ~f:(include_ ?theme_uri extra_suffix indent)
     @@ Doctree.Subpages.compute i
 
-  and page ?theme_uri ?support_uri indent
+  and page ?theme_uri ?support_uri extra_suffix indent
       ({ Page.title; header; items = i; url } as p) =
     let resolve = Link.Current url in
     let i = Doctree.Shift.compute ~on_sub i in
     let toc = Toc.from_items ~resolve ~path:url i in
-    let subpages = subpages ?theme_uri indent p in
+    let subpages = subpages ?theme_uri extra_suffix indent p in
     let header = items ~resolve header in
     let content = (items ~resolve i :> any Html.elt list) in
     let page =
-      Tree.make ?theme_uri ?support_uri ~indent ~header ~toc ~url title content
-        subpages
+      Tree.make ?theme_uri ?support_uri ~indent ~header ~toc ~url ~extra_suffix
+        title content subpages
     in
     page
 end
 
-let render ?theme_uri ?support_uri ~indent page =
-  Page.page ?theme_uri ?support_uri indent page
+let render ?theme_uri ?support_uri ~indent ~extra_suffix page =
+  Page.page ?theme_uri ?support_uri extra_suffix indent page
 
 let doc ~xref_base_uri b =
   let resolve = Link.Base xref_base_uri in

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -377,7 +377,8 @@ module Page = struct
     Utils.list_concat_map ~f:(include_ ?theme_uri indent)
     @@ Doctree.Subpages.compute i
 
-  and page ?theme_uri indent ({ Page.title; header; items = i; url } as p) =
+  and page ?theme_uri ?support_uri indent
+      ({ Page.title; header; items = i; url } as p) =
     let resolve = Link.Current url in
     let i = Doctree.Shift.compute ~on_sub i in
     let toc = Toc.from_items ~resolve ~path:url i in
@@ -385,12 +386,14 @@ module Page = struct
     let header = items ~resolve header in
     let content = (items ~resolve i :> any Html.elt list) in
     let page =
-      Tree.make ?theme_uri ~indent ~header ~toc ~url title content subpages
+      Tree.make ?theme_uri ?support_uri ~indent ~header ~toc ~url title content
+        subpages
     in
     page
 end
 
-let render ?theme_uri ~indent page = Page.page ?theme_uri indent page
+let render ?theme_uri ?support_uri ~indent page =
+  Page.page ?theme_uri ?support_uri indent page
 
 let doc ~xref_base_uri b =
   let resolve = Link.Base xref_base_uri in

--- a/src/html/generator.mli
+++ b/src/html/generator.mli
@@ -1,6 +1,11 @@
 open Odoc_document
 
-val render : ?theme_uri:Tree.uri -> indent:bool -> Types.Page.t -> Renderer.page
+val render :
+  ?theme_uri:Tree.uri ->
+  ?support_uri:Tree.uri ->
+  indent:bool ->
+  Types.Page.t ->
+  Renderer.page
 
 val doc :
   xref_base_uri:string ->

--- a/src/html/generator.mli
+++ b/src/html/generator.mli
@@ -4,6 +4,7 @@ val render :
   ?theme_uri:Tree.uri ->
   ?support_uri:Tree.uri ->
   indent:bool ->
+  extra_suffix:string ->
   Types.Page.t ->
   Renderer.page
 

--- a/src/html/link.ml
+++ b/src/html/link.ml
@@ -17,16 +17,21 @@ module Path = struct
     | "module" | "container-page" -> name
     | _ -> Printf.sprintf "%s-%s" kind name
 
-  let is_leaf_page url = url.Url.Path.kind = "page"
+  let is_leaf_page url =
+    url.Url.Path.kind = "page" || url.Url.Path.kind = "file"
 
   let rec get_dir { Url.Path.parent; name; kind } =
     let ppath = match parent with Some p -> get_dir p | None -> [] in
     match kind with
-    | "page" -> ppath
+    | "page" | "file" -> ppath
     | _ -> ppath @ [ segment_to_string (kind, name) ]
 
   let get_file : Url.Path.t -> string =
-   fun t -> match t.kind with "page" -> t.name ^ ".html" | _ -> "index.html"
+   fun t ->
+    match t.kind with
+    | "page" -> t.name ^ ".html"
+    | "file" -> t.name
+    | _ -> "index.html"
 
   let for_linking : Url.Path.t -> string list =
    fun url -> get_dir url @ [ get_file url ]

--- a/src/html/link.ml
+++ b/src/html/link.ml
@@ -1,6 +1,6 @@
 module Url = Odoc_document.Url
 
-let flat = ref false
+let flat = ref true
 
 (* Translation from Url.Path *)
 module Path = struct

--- a/src/html/link.ml
+++ b/src/html/link.ml
@@ -1,6 +1,6 @@
 module Url = Odoc_document.Url
 
-let flat = ref true
+let flat = ref false
 
 (* Translation from Url.Path *)
 module Path = struct

--- a/src/html/link.mli
+++ b/src/html/link.mli
@@ -2,6 +2,8 @@
 
 module Url = Odoc_document.Url
 
+val flat : bool ref
+
 val semantic_uris : bool ref
 (** Whether to generate pretty/semantics links or not. *)
 

--- a/src/html/link.mli
+++ b/src/html/link.mli
@@ -10,6 +10,10 @@ type resolve = Current of Url.Path.t | Base of string
 val href : resolve:resolve -> Url.t -> string
 
 module Path : sig
+  val to_list : Url.Path.t -> (string * string) list
+
+  val of_list : (string * string) list -> Url.Path.t option
+
   val is_leaf_page : Url.Path.t -> bool
 
   val for_printing : Url.Path.t -> string list

--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -20,11 +20,7 @@ type uri = Absolute of string | Relative of Odoc_document.Url.Path.t option
 
 let page_creator ?(theme_uri = Relative None) ?(support_uri = Relative None)
     ~url name header toc content =
-  let is_leaf_page = Link.Path.is_leaf_page url in
   let path = Link.Path.for_printing url in
-  let rec add_dotdot ~n acc =
-    if n <= 0 then acc else add_dotdot ~n:(n - 1) ("../" ^ acc)
-  in
 
   let head : Html_types.head Html.elt =
     let title_string = Printf.sprintf "%s (%s)" name (String.concat "." path) in
@@ -64,33 +60,43 @@ let page_creator ?(theme_uri = Relative None) ?(support_uri = Relative None)
   in
 
   let breadcrumbs =
-    let dot = if !Link.semantic_uris then "" else "index.html" in
-    let dotdot = add_dotdot ~n:1 dot in
-    let up_href = if is_leaf_page && name <> "index" then dot else dotdot in
-    let has_parent = List.length path > 1 in
+    let rec get_parents x =
+      match x with
+      | [] -> []
+      | x :: xs -> (
+          match Link.Path.of_list (List.rev (x :: xs)) with
+          | Some x -> x :: get_parents xs
+          | None -> get_parents xs)
+    in
+    let parents = get_parents (List.rev (Link.Path.to_list url)) |> List.rev in
+    let has_parent = List.length parents > 1 in
+    let href page =
+      Link.href ~resolve:(Current url)
+        Odoc_document.Url.Anchor.{ page; anchor = ""; kind = "" }
+    in
     if has_parent then
+      let up_url = List.hd (List.tl (List.rev parents)) in
       let l =
         [
-          Html.a ~a:[ Html.a_href up_href ] [ Html.txt "Up" ]; Html.txt " – ";
+          Html.a ~a:[ Html.a_href (href up_url) ] [ Html.txt "Up" ];
+          Html.txt " – ";
         ]
         @
         (* Create breadcrumbs *)
         let space = Html.txt " " in
-        let breadcrumb_spec =
-          if is_leaf_page then fun n x -> (n, dot, x)
-          else fun n x -> (n, add_dotdot ~n dot, x)
-        in
-        let rev_path =
-          if is_leaf_page && name = "index" then List.tl (List.rev path)
-          else List.rev path
-        in
-        rev_path |> List.mapi breadcrumb_spec |> List.rev
+        parents
         |> Utils.list_concat_map
              ?sep:(Some [ space; Html.entity "#x00BB"; space ])
-             ~f:(fun (n, addr, lbl) ->
-               if n > 0 then
-                 [ [ Html.a ~a:[ Html.a_href addr ] [ Html.txt lbl ] ] ]
-               else [ [ Html.txt lbl ] ])
+             ~f:(fun url' ->
+               [
+                 [
+                   (if url = url' then Html.txt url.name
+                   else
+                     Html.a
+                       ~a:[ Html.a_href (href url') ]
+                       [ Html.txt url'.name ]);
+                 ];
+               ])
         |> List.flatten
       in
       [ Html.nav ~a:[ Html.a_class [ "odoc-nav" ] ] l ]

--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -111,9 +111,9 @@ let page_creator ?(theme_uri = Relative None) ?(support_uri = Relative None)
   in
   Html.html head (Html.body ~a:[ Html.a_class [ "odoc" ] ] body)
 
-let make ?theme_uri ?support_uri ~indent ~url ~header ~toc title content
-    children =
-  let filename = Link.Path.as_filename url in
+let make ?theme_uri ?support_uri ~indent ~url ~header ~extra_suffix ~toc title
+    content children =
+  let filename = Fpath.add_ext extra_suffix (Link.Path.as_filename url) in
   let html =
     page_creator ?theme_uri ?support_uri ~url title header toc content
   in

--- a/src/html/tree.mli
+++ b/src/html/tree.mli
@@ -21,7 +21,7 @@ module Html = Tyxml.Html
 
 type uri =
   | Absolute of string
-  | Relative of string
+  | Relative of Odoc_document.Url.Path.t option
       (** The type for absolute and relative URIs. The relative URIs are resolved
     using the HTML output directory as a target. *)
 
@@ -29,6 +29,7 @@ type uri =
 
 val make :
   ?theme_uri:uri ->
+  ?support_uri:uri ->
   indent:bool ->
   url:Url.Path.t ->
   header:Html_types.flow5_without_header_footer Html.elt list ->

--- a/src/html/tree.mli
+++ b/src/html/tree.mli
@@ -33,6 +33,7 @@ val make :
   indent:bool ->
   url:Url.Path.t ->
   header:Html_types.flow5_without_header_footer Html.elt list ->
+  extra_suffix:string ->
   toc:Html_types.flow5 Html.elt list ->
   string ->
   Html_types.div_content Html.elt list ->

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -479,6 +479,3 @@ module Page = struct
 end
 
 let render ~with_children ~flat page = Page.page ~with_children ~flat page 
-
-let files_of_url url =
-  if Link.is_class_or_module_path url then [ Link.filename ~flat:false url ] else []

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -53,8 +53,9 @@ module Link = struct
       | _ -> (
           match url.parent with
           | None ->
-              assert false
-              (* Only container-pages are allowed to have no parent *)
+              (* Only container-pages are allowed to have no parent, so we must be in flat mode *)
+              assert flat;
+              acc
           | Some p -> l p (url.name :: acc))
     in
     String.concat "." (l url []) 

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -55,15 +55,16 @@ module Link = struct
           | None ->
               (* Only container-pages are allowed to have no parent, so we must be in flat mode *)
               assert flat;
-              acc
+              url.name :: acc
           | Some p -> l p (url.name :: acc))
     in
-    String.concat "." (l url []) 
+    let result = (l url []) in
+    String.concat "." result
 
   let filename ~flat url =
     let file = file ~flat url |> Fpath.v in
     if flat
-      then Fpath.set_ext "tex" file
+      then Fpath.add_ext "tex" file
     else 
       let dir = dir url in
       Fpath.(dir // file |> Fpath.add_ext "tex")

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -442,8 +442,8 @@ module Doc = struct
     in
     Fmt.list input_child ppf children
 
-  let make ~with_children ~flat url content children =
-    let filename = Link.filename ~flat url in
+  let make ~with_children ~flat ~extra_suffix url content children =
+    let filename = Link.filename ~flat url |> Fpath.add_ext extra_suffix in
     let label = Label (Link.page url) in
     let content =
       match content with
@@ -461,22 +461,22 @@ end
 module Page = struct
   let on_sub = function `Page _ -> Some 1 | `Include _ -> None
 
-  let rec subpage ~with_children ~flat (p : Subpage.t) =
+  let rec subpage ~with_children ~flat ~extra_suffix (p : Subpage.t) =
     if Link.should_inline p.status p.content.url then []
-    else [ page ~with_children ~flat p.content ]
+    else [ page ~with_children ~flat ~extra_suffix p.content ]
 
-  and subpages ~with_children ~flat i =
+  and subpages ~with_children ~flat ~extra_suffix i =
     List.flatten
-    @@ List.map (subpage ~with_children ~flat)
+    @@ List.map (subpage ~with_children ~flat ~extra_suffix)
     @@ Doctree.Subpages.compute i
 
-  and page ~with_children ~flat ({ Page.title = _; header; items = i; url } as p) =
+  and page ~with_children ~flat ~extra_suffix ({ Page.title = _; header; items = i; url } as p) =
     let i = Doctree.Shift.compute ~on_sub i in
-    let subpages = subpages ~with_children ~flat p in
+    let subpages = subpages ~with_children ~flat ~extra_suffix p in
     let header = items header in
     let content = items i in
-    let page = Doc.make ~with_children ~flat url (header @ content) subpages in
+    let page = Doc.make ~with_children ~flat ~extra_suffix url (header @ content) subpages in
     page
 end
 
-let render ~with_children ~flat page = Page.page ~with_children ~flat page 
+let render ~with_children ~flat ~extra_suffix page = Page.page ~with_children ~flat ~extra_suffix page 

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -58,17 +58,15 @@ module Link = struct
               url.name :: acc
           | Some p -> l p (url.name :: acc))
     in
-    let result = (l url []) in
+    let result = l url [] in
     String.concat "." result
 
   let filename ~flat url =
     let file = file ~flat url |> Fpath.v in
-    if flat
-      then Fpath.add_ext "tex" file
-    else 
+    if flat then Fpath.add_ext "tex" file
+    else
       let dir = dir url in
       Fpath.(dir // file |> Fpath.add_ext "tex")
-
 end
 
 let style = function
@@ -470,13 +468,18 @@ module Page = struct
     @@ List.map (subpage ~with_children ~flat ~extra_suffix)
     @@ Doctree.Subpages.compute i
 
-  and page ~with_children ~flat ~extra_suffix ({ Page.title = _; header; items = i; url } as p) =
+  and page ~with_children ~flat ~extra_suffix
+      ({ Page.title = _; header; items = i; url } as p) =
     let i = Doctree.Shift.compute ~on_sub i in
     let subpages = subpages ~with_children ~flat ~extra_suffix p in
     let header = items header in
     let content = items i in
-    let page = Doc.make ~with_children ~flat ~extra_suffix url (header @ content) subpages in
+    let page =
+      Doc.make ~with_children ~flat ~extra_suffix url (header @ content)
+        subpages
+    in
     page
 end
 
-let render ~with_children ~flat ~extra_suffix page = Page.page ~with_children ~flat ~extra_suffix page 
+let render ~with_children ~flat ~extra_suffix page =
+  Page.page ~with_children ~flat ~extra_suffix page

--- a/src/latex/generator.mli
+++ b/src/latex/generator.mli
@@ -2,5 +2,6 @@ val files_of_url : Odoc_document.Url.Path.t -> Fpath.t list
 
 val render :
   with_children:bool ->
+  flat:bool ->
   Odoc_document.Types.Page.t ->
   Odoc_document.Renderer.page

--- a/src/latex/generator.mli
+++ b/src/latex/generator.mli
@@ -1,5 +1,3 @@
-val files_of_url : Odoc_document.Url.Path.t -> Fpath.t list
-
 val render :
   with_children:bool ->
   flat:bool ->

--- a/src/latex/generator.mli
+++ b/src/latex/generator.mli
@@ -1,5 +1,6 @@
 val render :
   with_children:bool ->
   flat:bool ->
+  extra_suffix:string ->
   Odoc_document.Types.Page.t ->
   Odoc_document.Renderer.page

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -485,11 +485,13 @@ let page { Page.title; header; items = i; url } =
 
 let rec subpage ~flat ~extra_suffix subp =
   let p = subp.Subpage.content in
-  if Link.should_inline p.url then [] else [ render ~flat ~extra_suffix p]
+  if Link.should_inline p.url then [] else [ render ~flat ~extra_suffix p ]
 
 and render ~flat ~extra_suffix (p : Page.t) =
   let content ppf = Format.fprintf ppf "%a@." Roff.pp (page p) in
-  let children = List.map (fun r -> subpage ~flat ~extra_suffix r) (Subpages.compute p)
-    |> List.concat in
+  let children =
+    List.map (fun r -> subpage ~flat ~extra_suffix r) (Subpages.compute p)
+    |> List.concat
+  in
   let filename = Link.as_filename ~flat p.url |> Fpath.add_ext extra_suffix in
   { Renderer.filename; content; children }

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -483,12 +483,13 @@ let page { Page.title; header; items = i; url } =
   ++ macro "SH" "Documentation" ++ vspace ++ macro "nf" ""
   ++ item ~nested:false i
 
-let rec subpage subp =
+let rec subpage ~flat ~extra_suffix subp =
   let p = subp.Subpage.content in
-  if Link.should_inline p.url then [] else [ render p ]
+  if Link.should_inline p.url then [] else [ render ~flat ~extra_suffix p]
 
-and render (p : Page.t) =
+and render ~flat ~extra_suffix (p : Page.t) =
   let content ppf = Format.fprintf ppf "%a@." Roff.pp (page p) in
-  let children = Utils.flatmap ~f:subpage @@ Subpages.compute p in
-  let filename = Link.as_filename p.url in
+  let children = List.map (fun r -> subpage ~flat ~extra_suffix r) (Subpages.compute p)
+    |> List.concat in
+  let filename = Link.as_filename ~flat p.url |> Fpath.add_ext extra_suffix in
   { Renderer.filename; content; children }

--- a/src/manpage/generator.mli
+++ b/src/manpage/generator.mli
@@ -1,1 +1,1 @@
-val render : Odoc_document.Types.Page.t -> Odoc_document.Renderer.page
+val render: flat: bool -> extra_suffix: string -> Odoc_document.Types.Page.t -> Odoc_document.Renderer.page

--- a/src/manpage/generator.mli
+++ b/src/manpage/generator.mli
@@ -1,1 +1,5 @@
-val render: flat: bool -> extra_suffix: string -> Odoc_document.Types.Page.t -> Odoc_document.Renderer.page
+val render :
+  flat:bool ->
+  extra_suffix:string ->
+  Odoc_document.Types.Page.t ->
+  Odoc_document.Renderer.page

--- a/src/manpage/link.ml
+++ b/src/manpage/link.ml
@@ -25,7 +25,7 @@ let as_filename ~flat (url : Url.Path.t) =
         (name, name :: acc)
     | Some p ->
         let dir, path = get_components p [] in
-        (dir, segment_to_string (kind, name) :: name :: path)
+        (dir, segment_to_string (kind, name) :: path)
   in
   let dir, path = get_components url [] in
   let s = String.concat "." @@ List.rev path in

--- a/src/manpage/link.ml
+++ b/src/manpage/link.ml
@@ -27,7 +27,7 @@ let as_filename (url : Url.Path.t) =
   in
   let dir, path = get_components url in
   let s = String.concat "." @@ List.rev path in
-  (dir ^ "-" ^ s) ^ ".3o" |> Fpath.v
+  Fpath.((v dir / s) + ".3o")
 
 let rec is_class_or_module_path (url : Url.Path.t) =
   match url.kind with

--- a/src/manpage/link.ml
+++ b/src/manpage/link.ml
@@ -17,17 +17,21 @@ let segment_to_string (kind, name) =
   then name
   else Printf.sprintf "%s-%s" kind name
 
-let as_filename (url : Url.Path.t) =
-  let rec get_components { Url.Path.parent; name; kind } =
+let as_filename ~flat (url : Url.Path.t) =
+  let rec get_components { Url.Path.parent; name; kind } acc =
     match parent with
-    | None -> (name, [])
+    | None -> assert flat; (name, name :: acc)
     | Some p ->
-        let dir, path = get_components p in
-        (dir, segment_to_string (kind, name) :: path)
+        let dir, path = get_components p [] in
+        (dir, segment_to_string (kind, name) :: (name :: path))
   in
-  let dir, path = get_components url in
+  let dir, path = get_components url [] in
   let s = String.concat "." @@ List.rev path in
-  Fpath.((v dir / s) + ".3o")
+  let file = Fpath.v s in
+  if flat
+    then Fpath.add_ext ".3o" file
+  else
+    Fpath.(v dir // file |> Fpath.add_ext ".3o")
 
 let rec is_class_or_module_path (url : Url.Path.t) =
   match url.kind with

--- a/src/manpage/link.ml
+++ b/src/manpage/link.ml
@@ -20,18 +20,18 @@ let segment_to_string (kind, name) =
 let as_filename ~flat (url : Url.Path.t) =
   let rec get_components { Url.Path.parent; name; kind } acc =
     match parent with
-    | None -> assert flat; (name, name :: acc)
+    | None ->
+        assert flat;
+        (name, name :: acc)
     | Some p ->
         let dir, path = get_components p [] in
-        (dir, segment_to_string (kind, name) :: (name :: path))
+        (dir, segment_to_string (kind, name) :: name :: path)
   in
   let dir, path = get_components url [] in
   let s = String.concat "." @@ List.rev path in
   let file = Fpath.v s in
-  if flat
-    then Fpath.add_ext ".3o" file
-  else
-    Fpath.(v dir // file |> Fpath.add_ext ".3o")
+  if flat then Fpath.add_ext ".3o" file
+  else Fpath.(v dir // file |> Fpath.add_ext ".3o")
 
 let rec is_class_or_module_path (url : Url.Path.t) =
   match url.kind with

--- a/src/manpage/link.ml
+++ b/src/manpage/link.ml
@@ -38,6 +38,3 @@ let rec is_class_or_module_path (url : Url.Path.t) =
   | _ -> false
 
 let should_inline x = not @@ is_class_or_module_path x
-
-let files_of_url url =
-  if is_class_or_module_path url then [ as_filename url ] else []

--- a/src/manpage/link.ml
+++ b/src/manpage/link.ml
@@ -27,7 +27,7 @@ let as_filename (url : Url.Path.t) =
   in
   let dir, path = get_components url in
   let s = String.concat "." @@ List.rev path in
-  Fpath.((v dir / s) + ".3o")
+  (dir ^ "-" ^ s) ^ ".3o" |> Fpath.v
 
 let rec is_class_or_module_path (url : Url.Path.t) =
   match url.kind with

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -424,12 +424,26 @@ module Odoc_html = Make_renderer (struct
           || str.[0] = '/'
         in
         let last_char = str.[String.length str - 1] in
-        let str = if last_char <> '/' then str ^ "/" else str in
-        `Ok Odoc_html.Tree.(if is_absolute then Absolute str else Relative str)
+        let str =
+          if last_char <> '/' then str
+          else String.sub str ~pos:0 ~len:(String.length str - 1)
+        in
+        let conv_rel rel =
+          let l = Astring.String.cuts ~sep:"/" rel in
+          List.fold_left
+            ~f:(fun acc seg ->
+              Some
+                Odoc_document.Url.Path.
+                  { kind = "container-page"; parent = acc; name = seg })
+            l ~init:None
+        in
+        `Ok
+          Odoc_html.Tree.(
+            if is_absolute then Absolute str else Relative (conv_rel str))
     in
     let printer ppf = function
-      | Odoc_html.Tree.Absolute uri | Odoc_html.Tree.Relative uri ->
-          Format.pp_print_string ppf uri
+      | Odoc_html.Tree.Absolute uri -> Format.pp_print_string ppf uri
+      | Odoc_html.Tree.Relative _uri -> Format.pp_print_string ppf ""
     in
     (parser, printer)
 
@@ -438,15 +452,32 @@ module Odoc_html = Make_renderer (struct
       "Where to look for theme files (e.g. `URI/odoc.css'). Relative URIs are \
        resolved using `--output-dir' as a target."
     in
-    let default = Odoc_html.Tree.Relative "./" in
+    let default = Odoc_html.Tree.Relative None in
     Arg.(
       value & opt convert_uri default & info ~docv:"URI" ~doc [ "theme-uri" ])
 
-  let extra_args =
-    let f semantic_uris closed_details indent theme_uri =
-      { Html_page.semantic_uris; closed_details; theme_uri; indent }
+  let support_uri =
+    let doc =
+      "Where to look for support files (e.g. `URI/highlite.pack.js'). Relative \
+       URIs are resolved using `--output-dir' as a target."
     in
-    Term.(const f $ semantic_uris $ closed_details $ indent $ theme_uri)
+    let default = Odoc_html.Tree.Relative None in
+    Arg.(
+      value & opt convert_uri default & info ~docv:"URI" ~doc [ "support-uri" ])
+
+  let extra_args =
+    let f semantic_uris closed_details indent theme_uri support_uri =
+      {
+        Html_page.semantic_uris;
+        closed_details;
+        theme_uri;
+        support_uri;
+        indent;
+      }
+    in
+    Term.(
+      const f $ semantic_uris $ closed_details $ indent $ theme_uri
+      $ support_uri)
 end)
 
 module Html_fragment : sig

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -407,6 +407,13 @@ module Odoc_html = Make_renderer (struct
     in
     Arg.(value & flag (info ~doc [ "closed-details" ]))
 
+  let flat_output =
+    let doc =
+      "Output the resulting HTML files into one directory rather than a \
+       hierarchy"
+    in
+    Arg.(value & flag (info ~doc [ "flat" ]))
+
   let indent =
     let doc = "Format the output HTML files with indentation" in
     Arg.(value & flag (info ~doc [ "indent" ]))
@@ -466,18 +473,19 @@ module Odoc_html = Make_renderer (struct
       value & opt convert_uri default & info ~docv:"URI" ~doc [ "support-uri" ])
 
   let extra_args =
-    let f semantic_uris closed_details indent theme_uri support_uri =
+    let f semantic_uris closed_details indent theme_uri support_uri flat =
       {
         Html_page.semantic_uris;
         closed_details;
         theme_uri;
         support_uri;
         indent;
+        flat;
       }
     in
     Term.(
       const f $ semantic_uris $ closed_details $ indent $ theme_uri
-      $ support_uri)
+      $ support_uri $ flat_output)
 end)
 
 module Html_fragment : sig

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -62,6 +62,15 @@ let flat_output =
   in
   Arg.(value & flag (info ~doc [ "flat" ]))
 
+let extra_suffix =
+  let doc =
+    "Extra suffix to append to generated filenames. This is intended for \
+      expect tests to use."
+  in
+  let default = "" in
+  Arg.(
+    value & opt string default & info ~docv:"SUFFIX" ~doc [ "extra-suffix" ])
+
 let warnings_options =
   let warn_error =
     let doc = "Turn warnings into errors." in
@@ -472,15 +481,6 @@ module Odoc_html = Make_renderer (struct
     Arg.(
       value & opt convert_uri default & info ~docv:"URI" ~doc [ "support-uri" ])
 
-  let extra_suffix =
-    let doc =
-      "Extra suffix to append to generated filenames. This is intended for \
-       expect tests to use."
-    in
-    let default = "" in
-    Arg.(
-      value & opt string default & info ~docv:"SUFFIX" ~doc [ "extra-suffix" ])
-
   let extra_args =
     let f semantic_uris closed_details indent theme_uri support_uri flat
         extra_suffix =
@@ -566,8 +566,8 @@ module Odoc_latex = Make_renderer (struct
     Arg.(value & opt bool true & info ~docv:"BOOL" ~doc [ "with-children" ])
 
   let extra_args =
-    let f with_children flat = { Latex.with_children; flat } in
-    Term.(const f $ with_children $ flat_output)
+    let f with_children flat extra_suffix = { Latex.with_children; flat; extra_suffix } in
+    Term.(const f $ with_children $ flat_output $ extra_suffix)
 end)
 
 module Depends = struct

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -55,6 +55,13 @@ let hidden =
   in
   Arg.(value & flag & info ~docs ~doc [ "hidden" ])
 
+let flat_output =
+  let doc =
+    "Output the resulting files into one directory rather than a \
+      hierarchy"
+  in
+  Arg.(value & flag (info ~doc [ "flat" ]))
+
 let warnings_options =
   let warn_error =
     let doc = "Turn warnings into errors." in
@@ -407,13 +414,6 @@ module Odoc_html = Make_renderer (struct
     in
     Arg.(value & flag (info ~doc [ "closed-details" ]))
 
-  let flat_output =
-    let doc =
-      "Output the resulting HTML files into one directory rather than a \
-       hierarchy"
-    in
-    Arg.(value & flag (info ~doc [ "flat" ]))
-
   let indent =
     let doc = "Format the output HTML files with indentation" in
     Arg.(value & flag (info ~doc [ "indent" ]))
@@ -566,8 +566,8 @@ module Odoc_latex = Make_renderer (struct
     Arg.(value & opt bool true & info ~docv:"BOOL" ~doc [ "with-children" ])
 
   let extra_args =
-    let f with_children = { Latex.with_children } in
-    Term.(const f $ with_children)
+    let f with_children flat = { Latex.with_children; flat } in
+    Term.(const f $ with_children $ flat_output)
 end)
 
 module Depends = struct

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -549,11 +549,13 @@ end = struct
 end
 
 module Odoc_manpage = Make_renderer (struct
-  type args = unit
+  type args = Man_page.args
 
   let renderer = Man_page.renderer
 
-  let extra_args = Term.const ()
+  let extra_args = 
+    let f flat extra_suffix = { Man_page.flat; extra_suffix } in
+    Term.(const f $ flat_output $ extra_suffix)
 end)
 
 module Odoc_latex = Make_renderer (struct

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -57,19 +57,17 @@ let hidden =
 
 let flat_output =
   let doc =
-    "Output the resulting files into one directory rather than a \
-      hierarchy"
+    "Output the resulting files into one directory rather than a hierarchy"
   in
   Arg.(value & flag (info ~doc [ "flat" ]))
 
 let extra_suffix =
   let doc =
     "Extra suffix to append to generated filenames. This is intended for \
-      expect tests to use."
+     expect tests to use."
   in
   let default = "" in
-  Arg.(
-    value & opt string default & info ~docv:"SUFFIX" ~doc [ "extra-suffix" ])
+  Arg.(value & opt string default & info ~docv:"SUFFIX" ~doc [ "extra-suffix" ])
 
 let warnings_options =
   let warn_error =
@@ -553,7 +551,7 @@ module Odoc_manpage = Make_renderer (struct
 
   let renderer = Man_page.renderer
 
-  let extra_args = 
+  let extra_args =
     let f flat extra_suffix = { Man_page.flat; extra_suffix } in
     Term.(const f $ flat_output $ extra_suffix)
 end)
@@ -568,7 +566,9 @@ module Odoc_latex = Make_renderer (struct
     Arg.(value & opt bool true & info ~docv:"BOOL" ~doc [ "with-children" ])
 
   let extra_args =
-    let f with_children flat extra_suffix = { Latex.with_children; flat; extra_suffix } in
+    let f with_children flat extra_suffix =
+      { Latex.with_children; flat; extra_suffix }
+    in
     Term.(const f $ with_children $ flat_output $ extra_suffix)
 end)
 

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -472,8 +472,18 @@ module Odoc_html = Make_renderer (struct
     Arg.(
       value & opt convert_uri default & info ~docv:"URI" ~doc [ "support-uri" ])
 
+  let extra_suffix =
+    let doc =
+      "Extra suffix to append to generated filenames. This is intended for \
+       expect tests to use."
+    in
+    let default = "" in
+    Arg.(
+      value & opt string default & info ~docv:"SUFFIX" ~doc [ "extra-suffix" ])
+
   let extra_args =
-    let f semantic_uris closed_details indent theme_uri support_uri flat =
+    let f semantic_uris closed_details indent theme_uri support_uri flat
+        extra_suffix =
       {
         Html_page.semantic_uris;
         closed_details;
@@ -481,11 +491,12 @@ module Odoc_html = Make_renderer (struct
         support_uri;
         indent;
         flat;
+        extra_suffix;
       }
     in
     Term.(
       const f $ semantic_uris $ closed_details $ indent $ theme_uri
-      $ support_uri $ flat_output)
+      $ support_uri $ flat_output $ extra_suffix)
 end)
 
 module Html_fragment : sig

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -21,12 +21,14 @@ type args = {
   closed_details : bool;
   indent : bool;
   theme_uri : Odoc_html.Tree.uri;
+  support_uri : Odoc_html.Tree.uri;
 }
 
 let render args page =
   Odoc_html.Link.semantic_uris := args.semantic_uris;
   Odoc_html.Tree.open_details := not args.closed_details;
-  Odoc_html.Generator.render ~theme_uri:args.theme_uri ~indent:args.indent page
+  Odoc_html.Generator.render ~theme_uri:args.theme_uri
+    ~support_uri:args.support_uri ~indent:args.indent page
 
 let files_of_url url = [ Odoc_html.Link.Path.as_filename url ]
 

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -34,6 +34,4 @@ let render args page =
     ~support_uri:args.support_uri ~indent:args.indent
     ~extra_suffix:args.extra_suffix page
 
-let files_of_url url = [ Odoc_html.Link.Path.as_filename url ]
-
-let renderer = { Renderer.name = "html"; render; files_of_url }
+let renderer = { Renderer.name = "html"; render }

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -22,11 +22,13 @@ type args = {
   indent : bool;
   theme_uri : Odoc_html.Tree.uri;
   support_uri : Odoc_html.Tree.uri;
+  flat : bool;
 }
 
 let render args page =
   Odoc_html.Link.semantic_uris := args.semantic_uris;
   Odoc_html.Tree.open_details := not args.closed_details;
+  Odoc_html.Link.flat := args.flat;
   Odoc_html.Generator.render ~theme_uri:args.theme_uri
     ~support_uri:args.support_uri ~indent:args.indent page
 

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -23,6 +23,7 @@ type args = {
   theme_uri : Odoc_html.Tree.uri;
   support_uri : Odoc_html.Tree.uri;
   flat : bool;
+  extra_suffix : string;
 }
 
 let render args page =
@@ -30,7 +31,8 @@ let render args page =
   Odoc_html.Tree.open_details := not args.closed_details;
   Odoc_html.Link.flat := args.flat;
   Odoc_html.Generator.render ~theme_uri:args.theme_uri
-    ~support_uri:args.support_uri ~indent:args.indent page
+    ~support_uri:args.support_uri ~indent:args.indent
+    ~extra_suffix:args.extra_suffix page
 
 let files_of_url url = [ Odoc_html.Link.Path.as_filename url ]
 

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -22,6 +22,7 @@ type args = {
   indent : bool;
   theme_uri : Odoc_html.Tree.uri;
   support_uri : Odoc_html.Tree.uri;
+  flat : bool;
 }
 
 val renderer : args Renderer.t

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -21,6 +21,7 @@ type args = {
   closed_details : bool;
   indent : bool;
   theme_uri : Odoc_html.Tree.uri;
+  support_uri : Odoc_html.Tree.uri;
 }
 
 val renderer : args Renderer.t

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -23,6 +23,7 @@ type args = {
   theme_uri : Odoc_html.Tree.uri;
   support_uri : Odoc_html.Tree.uri;
   flat : bool;
+  extra_suffix : string;
 }
 
 val renderer : args Renderer.t

--- a/src/odoc/latex.ml
+++ b/src/odoc/latex.ml
@@ -1,8 +1,8 @@
 open Odoc_document
 
-type args = { with_children : bool; flat : bool }
+type args = { with_children : bool; flat : bool; extra_suffix : string }
 
 let render args page =
-  Odoc_latex.Generator.render ~with_children:args.with_children page ~flat:args.flat
+  Odoc_latex.Generator.render ~with_children:args.with_children page ~flat:args.flat ~extra_suffix:args.extra_suffix
 
 let renderer = { Renderer.name = "latex"; render }

--- a/src/odoc/latex.ml
+++ b/src/odoc/latex.ml
@@ -3,6 +3,7 @@ open Odoc_document
 type args = { with_children : bool; flat : bool; extra_suffix : string }
 
 let render args page =
-  Odoc_latex.Generator.render ~with_children:args.with_children page ~flat:args.flat ~extra_suffix:args.extra_suffix
+  Odoc_latex.Generator.render ~with_children:args.with_children page
+    ~flat:args.flat ~extra_suffix:args.extra_suffix
 
 let renderer = { Renderer.name = "latex"; render }

--- a/src/odoc/latex.ml
+++ b/src/odoc/latex.ml
@@ -5,6 +5,4 @@ type args = { with_children : bool; flat : bool }
 let render args page =
   Odoc_latex.Generator.render ~with_children:args.with_children page ~flat:args.flat
 
-let files_of_url url = Odoc_latex.Generator.files_of_url url
-
-let renderer = { Renderer.name = "latex"; render; files_of_url }
+let renderer = { Renderer.name = "latex"; render }

--- a/src/odoc/latex.ml
+++ b/src/odoc/latex.ml
@@ -1,9 +1,9 @@
 open Odoc_document
 
-type args = { with_children : bool }
+type args = { with_children : bool; flat : bool }
 
 let render args page =
-  Odoc_latex.Generator.render ~with_children:args.with_children page
+  Odoc_latex.Generator.render ~with_children:args.with_children page ~flat:args.flat
 
 let files_of_url url = Odoc_latex.Generator.files_of_url url
 

--- a/src/odoc/man_page.ml
+++ b/src/odoc/man_page.ml
@@ -2,6 +2,4 @@ open Odoc_document
 
 let render _ page = Odoc_manpage.Generator.render page
 
-let files_of_url url = Odoc_manpage.Link.files_of_url url
-
-let renderer = { Renderer.name = "man"; render; files_of_url }
+let renderer = { Renderer.name = "man"; render }

--- a/src/odoc/man_page.ml
+++ b/src/odoc/man_page.ml
@@ -3,6 +3,7 @@ open Odoc_document
 type args = { flat : bool; extra_suffix : string }
 
 let render args page =
-  Odoc_manpage.Generator.render page ~flat:args.flat ~extra_suffix:args.extra_suffix
+  Odoc_manpage.Generator.render page ~flat:args.flat
+    ~extra_suffix:args.extra_suffix
 
-let renderer = { Renderer.name = "man"; render}
+let renderer = { Renderer.name = "man"; render }

--- a/src/odoc/man_page.ml
+++ b/src/odoc/man_page.ml
@@ -1,5 +1,8 @@
 open Odoc_document
 
-let render _ page = Odoc_manpage.Generator.render page
+type args = { flat : bool; extra_suffix : string }
 
-let renderer = { Renderer.name = "man"; render }
+let render args page =
+  Odoc_manpage.Generator.render page ~flat:args.flat ~extra_suffix:args.extra_suffix
+
+let renderer = { Renderer.name = "man"; render}


### PR DESCRIPTION
This PR is not from a tracked issue rather is built from @jonludlam’s idea of outputting the output files in one dir, which is a plus for the ‘improving generator tests v2’ PR that is a work in progress. (https://github.com/ocaml/odoc/pull/665 being v1).

**TODO:** 
- [ ] add tests