### PR TITLE
Minimal 4.13 support for 1.5 branch

### DIFF
--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -62,7 +62,11 @@ let rec read_pattern env parent doc pat =
     | Tpat_constant _ -> []
     | Tpat_tuple pats ->
         List.concat (List.map (read_pattern env parent doc) pats)
+#if OCAML_VERSION < (4, 13, 0)
     | Tpat_construct(_, _, pats) ->
+#else
+    | Tpat_construct(_,_,pats,_) ->
+#endif
         List.concat (List.map (read_pattern env parent doc) pats)
     | Tpat_variant(_, None, _) -> []
     | Tpat_variant(_, Some pat, _) ->

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -485,6 +485,10 @@ let rec read_with_constraint env parent (_, frag, constr) =
         let frag = Env.Fragment.read_module frag.Location.txt in
         let p = Env.Path.read_module env p in
           ModuleSubst(frag, p)
+#if OCAML_VERSION >= (4,13,0)
+   | Twith_modtype _ -> failwith "with module type is only supported by odoc 2.0 and later"
+   | Twith_modtypesubst _ -> failwith "with module type is only supported by odoc 2.0 and later"
+#endif
 
 and read_module_type env parent label_parent pos mty =
   let open ModuleType in
@@ -701,6 +705,10 @@ and read_signature_item env parent item =
         read_type_substitutions env parent tst
     | Tsig_modsubst mst ->
         [ModuleSubstitution (read_module_substitution env parent mst)]
+#if OCAML_VERSION >= (4,13,0)
+    | Tsig_modtypesubst _ -> failwith "local module type substitution is only supported by odoc 2.0 and later"
+#endif
+
 
 and read_module_substitution env parent ms =
   let open ModuleSubstitution in

--- a/src/model/ident_env.cppo.ml
+++ b/src/model/ident_env.cppo.ml
@@ -244,6 +244,10 @@ let add_signature_tree_item parent item env =
         (fun decl env -> add_type parent decl.typ_id (TypeName.of_ident decl.typ_id) env)
         ts env
 #endif
+#if OCAML_VERSION >= (4,13,0)
+    | Tsig_modtypesubst mtd ->
+      add_module_type parent mtd.mtd_id (ModuleTypeName.of_ident mtd.mtd_id) env
+#endif
     | Tsig_value _ | Tsig_typext _
     | Tsig_exception _ | Tsig_open _
     | Tsig_attribute _ -> env


### PR DESCRIPTION
Cherry-picked from the 2.0 version, with a failure message which mentions that the new 4.13 features are only supported by odoc 2.0 and later.