### PR TITLE
Fix spurious error in generator tests

### DIFF
--- a/test/generators/gen_rules/gen_rules.ml
+++ b/test/generators/gen_rules/gen_rules.ml
@@ -1,3 +1,7 @@
+let die s =
+  prerr_endline s;
+  exit 1
+
 let html_target_rule path : Gen_rules_lib.sexp =
   List
     [
@@ -63,40 +67,70 @@ let man_target_rule path : Gen_rules_lib.sexp =
         ];
     ]
 
-let read_file_from_dir dir =
-  let filenames =
-    let arr = Sys.readdir dir in
-    Array.sort String.compare arr;
-    Array.to_list arr
-  in
-  let dir = Fpath.v dir in
-  List.map (Fpath.( / ) dir) filenames
+(** Returns filenames, not paths. *)
+let read_files_from_dir dir =
+  let arr = Sys.readdir (Fpath.to_string dir) in
+  Array.sort String.compare arr;
+  Array.to_list arr
 
 let constraints =
   let open Gen_rules_lib in
   [
-    (Fpath.v "stop_dead_link_doc.mli", Min "4.04");
-    (Fpath.v "bugs_post_406.mli", Min "4.06");
-    (Fpath.v "ocamlary.mli", Min "4.07");
-    (Fpath.v "recent.mli", Min "4.09");
-    (Fpath.v "labels.mli", Min "4.09");
-    (Fpath.v "recent_impl.ml", Min "4.09");
-    (Fpath.v "bugs_pre_410.ml", Max "4.09");
-    (Fpath.v "module_type_subst.mli", Min "4.13");
+    ("stop_dead_link_doc.mli", Min "4.04");
+    ("bugs_post_406.mli", Min "4.06");
+    ("ocamlary.mli", Min "4.07");
+    ("recent.mli", Min "4.09");
+    ("labels.mli", Min "4.09");
+    ("recent_impl.ml", Min "4.09");
+    ("bugs_pre_410.ml", Max "4.09");
+    ("module_type_subst.mli", Min "4.13");
   ]
 
-let () =
-  let paths = read_file_from_dir (Fpath.filename Gen_rules_lib.cases) in
-  let paths =
-    List.filter (fun p -> not (Gen_rules_lib.is_dot_ocamlformat p)) paths
+let test_cases_dir = Fpath.v "cases"
+
+(** Make a test cases or return the empty list if the given file should be
+    ignored. Might abort the program with an error. *)
+let make_test_case case_name =
+  let input = Fpath.(/) test_cases_dir case_name in
+  let mk odoc_prefix cmt_suffix =
+    let base_out_path = Fpath.v (odoc_prefix ^ case_name) in
+    let cmt =
+      match cmt_suffix with
+      | Some suf -> Some (Fpath.set_ext suf base_out_path)
+      | None -> None
+    in
+    let odoc = Fpath.set_ext ".odoc" base_out_path in
+    let odocl = Fpath.set_ext ".odocl" base_out_path in
+    let enabledif =
+      try Some (List.assoc case_name constraints) with Not_found -> None
+    in
+    { Gen_rules_lib.input; cmt; odoc; odocl; enabledif }
   in
+  match Fpath.get_ext input with
+  | ".ml" -> [ mk "" (Some ".cmt") ]
+  | ".mli" -> [ mk "" (Some ".cmti") ]
+  | ".mld" -> [ mk "page-" None ]
+  (* Dune creates directories starting with a dot, which result in an empty
+     extension with Fpath. Also, there's [.ocamlformat]. *)
+  | "" -> []
+  | ext ->
+      die
+        (Format.asprintf
+           "Don't know what to do with %a because of unrecognized %s extension."
+           Fpath.pp input ext)
+
+let read_test_cases () =
+  read_files_from_dir test_cases_dir |> List.map make_test_case |> List.concat
+
+let () =
+  let cases = read_test_cases () in
   let stanzas =
-    Gen_rules_lib.gen_rule constraints
+    Gen_rules_lib.gen_rule
       [
         (html_target_rule, Fpath.v "html", Some "--flat");
         (latex_target_rule, Fpath.v "latex", None);
         (man_target_rule, Fpath.v "man", None);
       ]
-      paths
+      cases
   in
   List.iter (Sexplib0.Sexp.pp Format.std_formatter) stanzas

--- a/test/generators/gen_rules/gen_rules.ml
+++ b/test/generators/gen_rules/gen_rules.ml
@@ -2,70 +2,40 @@ let die s =
   prerr_endline s;
   exit 1
 
-let html_target_rule path : Gen_rules_lib.sexp =
-  List
-    [
-      Atom "action";
-      List
-        [
-          Atom "progn";
-          List
-            [
-              Atom "run";
-              Atom "odoc";
-              Atom "html-generate";
-              Atom "--indent";
-              Atom "--flat";
-              Atom "--extra-suffix";
-              Atom "gen";
-              Atom "-o";
-              Atom ".";
-              Atom ("%{dep:" ^ Fpath.to_string path ^ "}");
-            ];
-        ];
-    ]
+let html_target_rule path =
+  [
+    "odoc";
+    "html-generate";
+    "--indent";
+    "--flat";
+    "--extra-suffix";
+    "gen";
+    "-o";
+    ".";
+    Gen_rules_lib.Dune.arg_dep path;
+  ]
 
-let latex_target_rule path : Gen_rules_lib.sexp =
-  List
-    [
-      Atom "action";
-      List
-        [
-          Atom "progn";
-          List
-            [
-              Atom "run";
-              Atom "odoc";
-              Atom "latex-generate";
-              Atom "-o";
-              Atom ".";
-              Atom "--extra-suffix";
-              Atom "gen";
-              Atom ("%{dep:" ^ Fpath.to_string path ^ "}");
-            ];
-        ];
-    ]
+let latex_target_rule path =
+  [
+    "odoc";
+    "latex-generate";
+    "-o";
+    ".";
+    "--extra-suffix";
+    "gen";
+    Gen_rules_lib.Dune.arg_dep path;
+  ]
 
-let man_target_rule path : Gen_rules_lib.sexp =
-  List
-    [
-      Atom "action";
-      List
-        [
-          Atom "progn";
-          List
-            [
-              Atom "run";
-              Atom "odoc";
-              Atom "man-generate";
-              Atom "-o";
-              Atom ".";
-              Atom "--extra-suffix";
-              Atom "gen";
-              Atom ("%{dep:" ^ Fpath.to_string path ^ "}");
-            ];
-        ];
-    ]
+let man_target_rule path =
+  [
+    "odoc";
+    "man-generate";
+    "-o";
+    ".";
+    "--extra-suffix";
+    "gen";
+    Gen_rules_lib.Dune.arg_dep path;
+  ]
 
 (** Returns filenames, not paths. *)
 let read_files_from_dir dir =
@@ -91,7 +61,7 @@ let test_cases_dir = Fpath.v "cases"
 (** Make a test cases or return the empty list if the given file should be
     ignored. Might abort the program with an error. *)
 let make_test_case case_name =
-  let input = Fpath.(/) test_cases_dir case_name in
+  let input = Fpath.( / ) test_cases_dir case_name in
   let mk odoc_prefix cmt_suffix =
     let base_out_path = Fpath.v (odoc_prefix ^ case_name) in
     let cmt =

--- a/test/generators/gen_rules_lib.ml
+++ b/test/generators/gen_rules_lib.ml
@@ -10,154 +10,98 @@ type test_case = {
   enabledif : enabledif option;
 }
 
-let render_enabledif = function
-  | Some (Min v) ->
+module Dune = struct
+  let arg_fpath f = Fpath.to_string f
+
+  let arg_dep f = "%{dep:" ^ Fpath.to_string f ^ "}"
+
+  let arg_list args = List.map (fun x -> Atom x) args
+
+  let render_enabledif = function
+    | Some (Min v) ->
+        [
+          List
+            [
+              Atom "enabled_if";
+              List [ Atom ">="; Atom "%{ocaml_version}"; Atom v ];
+            ];
+        ]
+    | Some (Max v) ->
+        [
+          List
+            [
+              Atom "enabled_if";
+              List [ Atom "<="; Atom "%{ocaml_version}"; Atom v ];
+            ];
+        ]
+    | Some (MinMax (min, max)) ->
+        [
+          List
+            [
+              Atom "enabled_if";
+              List
+                [
+                  Atom "and";
+                  List [ Atom ">="; Atom "%{ocaml_version}"; Atom min ];
+                  List [ Atom "<="; Atom "%{ocaml_version}"; Atom max ];
+                ];
+            ];
+        ]
+    | None -> []
+
+  let run cmd = List (Atom "run" :: arg_list cmd)
+
+  let action x = List [ Atom "action"; x ]
+
+  let rule ?enabledif fields =
+    List (Atom "rule" :: fields @ render_enabledif enabledif)
+
+  let simple_rule ?enabledif target cmd =
+    rule ?enabledif
+      [ List [ Atom "target"; Atom (arg_fpath target) ]; action (run cmd) ]
+
+  let rule_with_output_to ?enabledif target cmd =
+    rule ?enabledif
       [
-        List
-          [
-            Atom "enabled_if";
-            List [ Atom ">="; Atom "%{ocaml_version}"; Atom v ];
-          ];
+        action
+          (List [ Atom "with-outputs-to"; Atom (arg_fpath target); run cmd ]);
       ]
-  | Some (Max v) ->
+
+  let runtest_diff ?enabledif file_a file_b =
+    rule ?enabledif
       [
-        List
-          [
-            Atom "enabled_if";
-            List [ Atom "<="; Atom "%{ocaml_version}"; Atom v ];
-          ];
+        List [ Atom "alias"; Atom "runtest" ];
+        action
+          (List
+             [ Atom "diff"; Atom (arg_fpath file_a); Atom (arg_fpath file_b) ]);
       ]
-  | Some (MinMax (min, max)) ->
-      [
-        List
-          [
-            Atom "enabled_if";
-            List
-              [
-                Atom "and";
-                List [ Atom ">="; Atom "%{ocaml_version}"; Atom min ];
-                List [ Atom "<="; Atom "%{ocaml_version}"; Atom max ];
-              ];
-          ];
-      ]
-  | None -> []
 
-let cu_target_rule enabledif dep_path target_path =
-  List
-    ([
-       Atom "rule";
-       List [ Atom "target"; Atom (Fpath.to_string target_path) ];
-       List [ Atom "deps"; Atom (Fpath.to_string dep_path) ];
-       List
-         [
-           Atom "action";
-           List
-             [
-               Atom "run";
-               Atom "ocamlc";
-               Atom "-c";
-               Atom "-bin-annot";
-               Atom "-o";
-               Atom "%{target}";
-               Atom "%{deps}";
-             ];
-         ];
-     ]
-    @ enabledif)
+  let subdir dir rules = List (Atom "subdir" :: Atom (arg_fpath dir) :: rules)
+end
 
-let odoc_target_rule enabledif dep_path target_path =
-  List
-    ([
-       Atom "rule";
-       List [ Atom "target"; Atom (Fpath.basename target_path) ];
-       List [ Atom "deps"; Atom (Fpath.basename dep_path) ];
-       List
-         [
-           Atom "action";
-           List
-             [
-               Atom "run";
-               Atom "odoc";
-               Atom "compile";
-               Atom "-o";
-               Atom "%{target}";
-               Atom "%{deps}";
-             ];
-         ];
-     ]
-    @ enabledif)
+let cu_target_rule enabledif dep target =
+  Dune.simple_rule ?enabledif target
+    [ "ocamlc"; "-c"; "-bin-annot"; "-o"; "%{target}"; Dune.arg_dep dep ]
 
-let odocl_target_rule enabledif dep_path target_path =
-  List
-    ([
-       Atom "rule";
-       List [ Atom "target"; Atom (Fpath.basename target_path) ];
-       List [ Atom "deps"; Atom (Fpath.basename dep_path) ];
-       List
-         [
-           Atom "action";
-           List
-             [
-               Atom "run";
-               Atom "odoc";
-               Atom "link";
-               Atom "-o";
-               Atom "%{target}";
-               Atom "%{deps}";
-             ];
-         ];
-     ]
-    @ enabledif)
+let odoc_target_rule enabledif dep target =
+  Dune.simple_rule ?enabledif target
+    [ "odoc"; "compile"; "-o"; "%{target}"; Dune.arg_dep dep ]
 
-let mld_odoc_target_rule enabledif dep_path target_path =
-  List
-    ([
-       Atom "rule";
-       List [ Atom "target"; Atom (Fpath.basename target_path) ];
-       List [ Atom "deps"; Atom (Fpath.to_string dep_path) ];
-       List
-         [
-           Atom "action";
-           List
-             [
-               Atom "run";
-               Atom "odoc";
-               Atom "compile";
-               Atom "-o";
-               Atom "%{target}";
-               Atom "%{deps}";
-             ];
-         ];
-     ]
-    @ enabledif)
+let odocl_target_rule enabledif dep target =
+  Dune.simple_rule ?enabledif target
+    [ "odoc"; "link"; "-o"; "%{target}"; Dune.arg_dep dep ]
 
-let file_rule { input; odoc; odocl; enabledif; _ } cmt =
-  let enabledif = render_enabledif enabledif in
-  [
-    cu_target_rule enabledif input cmt;
-    odoc_target_rule enabledif cmt odoc;
-    odocl_target_rule enabledif odoc odocl;
-  ]
-
-let mld_file_rule { input; odoc; odocl; enabledif; _ } =
-  let enabledif = render_enabledif enabledif in
-  [
-    mld_odoc_target_rule enabledif input odoc;
-    odocl_target_rule enabledif odoc odocl;
-  ]
-
-let path' () f = Filename.quote (Fpath.to_string f)
-
-let ext' () f = Filename.quote (Fpath.get_ext f)
-
-let gen_rule_for_source_file case =
-  match case.cmt with
-  | Some cmt -> file_rule case cmt
-  | None -> mld_file_rule case
-
-let odocls backend p =
-  let path = Fpath.relativize ~root:backend p in
-  match path with Some p -> p | None -> assert false
+let gen_rule_for_source_file { input; cmt; odoc; odocl; enabledif } =
+  let cmt_rule, input =
+    match cmt with
+    | Some cmt -> ([ cu_target_rule enabledif input cmt ], cmt)
+    | None -> ([], input)
+  in
+  cmt_rule
+  @ [
+      odoc_target_rule enabledif input odoc;
+      odocl_target_rule enabledif odoc odocl;
+    ]
 
 let read_lines ic =
   let lines = ref [] in
@@ -174,154 +118,64 @@ let lines_of_file path =
   close_in ic;
   lines
 
-let create_targets_file f = Fpath.(base f |> set_ext ".targets")
-
-let get_path_to_targets_file backend f =
-  create_targets_file f |> Fpath.to_string |> Fpath.( / ) backend
+let targets_file_path f = Fpath.(base f |> set_ext ".targets")
 
 let expected_targets backend test_case =
-  let targets_file = get_path_to_targets_file backend test_case in
-  try lines_of_file targets_file with _ -> []
+  let targets_file = Fpath.( // ) backend (targets_file_path test_case) in
+  try lines_of_file targets_file |> List.map Fpath.v with _ -> []
 
-let expected_targets' backend test_case =
-  expected_targets backend test_case |> List.map (fun t -> Atom (t ^ ".gen"))
+let gen_targets_file enabledif ?flat_flag backend target_path relinput =
+  let flat_flag = match flat_flag with None -> [] | Some x -> [ x ] in
+  let gen_path = Fpath.add_ext ".gen" target_path in
+  [
+    Dune.subdir backend
+      [
+        Dune.rule_with_output_to ?enabledif gen_path
+          ([
+             "odoc";
+             Fpath.to_string backend ^ "-targets";
+             "-o";
+             ".";
+             Dune.arg_dep relinput;
+           ]
+          @ flat_flag);
+        Dune.runtest_diff ?enabledif target_path gen_path;
+      ];
+  ]
 
-let gen_targets_file enabledif ?flat_flag backend target_path path =
-  let flat_flag = match flat_flag with None -> [] | Some x -> [ Atom x ] in
-  List
-    [
-      Atom "subdir";
-      Atom (Fpath.to_string backend);
-      List
-        ([
-           Atom "rule";
-           List
-             [
-               Atom "action";
-               List
-                 [
-                   Atom "with-outputs-to";
-                   Atom Fpath.(to_string (set_ext ".gen" target_path));
-                   List
-                     ([
-                        Atom "run";
-                        Atom "odoc";
-                        Atom (Fpath.to_string backend ^ "-targets");
-                        Atom "-o";
-                        Atom ".";
-                        Atom ("%{dep:" ^ Fpath.to_string path ^ "}");
-                      ]
-                     @ flat_flag);
-                 ];
-             ];
-         ]
-        @ enabledif);
-    ]
-
-let target_diff_rule enabledif backend path =
-  let p = Fpath.( // ) backend path in
-  List
-    ([
-       Atom "rule";
-       List [ Atom "alias"; Atom "runtest" ];
-       List
-         [
-           Atom "action";
-           List
-             [
-               Atom "diff";
-               Atom (Fpath.to_string p);
-               Atom Fpath.(to_string (p |> set_ext ".gen"));
-             ];
-         ];
-     ]
-    @ enabledif)
-
-let gen_and_diff_target_files_rules enabledif ?flat_flag backend p =
-  match flat_flag with
-  | Some flat_flag -> (
-      let path = Fpath.relativize ~root:backend p in
-      match path with
-      | Some p ->
-          let p' = create_targets_file p in
-          [
-            gen_targets_file enabledif ~flat_flag backend p' p;
-            target_diff_rule enabledif backend p';
-          ]
-      | None -> [])
-  | None -> (
-      let path = Fpath.relativize ~root:backend p in
-      match path with
-      | Some p ->
-          let p' = create_targets_file p in
-          [
-            gen_targets_file enabledif backend p' p;
-            target_diff_rule enabledif backend p';
-          ]
-      | None -> [])
-
-let gen_backend_diff_rule enabledif (b_t_r, b, _) p =
-  let p = odocls b p in
-  match expected_targets' b p with
+let gen_backend_diff_rule enabledif ~targets (b_t_r, b, _) p =
+  match targets with
   | [] -> []
   | _ ->
-      [
-        List
-          [
-            Atom "subdir";
-            Atom (Fpath.to_string b);
-            List
-              ([
-                 Atom "rule";
-                 List (Atom "targets" :: expected_targets' b p);
-                 b_t_r p;
+      let targets_gen = List.map (Fpath.add_ext ".gen") targets in
+      Dune.
+        [
+          subdir b
+            (rule ?enabledif
+               [
+                 List
+                   (Atom "targets"
+                    :: List.map (fun t -> Atom (Dune.arg_fpath t)) targets_gen);
+                 action (run (b_t_r p));
                ]
-              @ enabledif);
-          ];
-      ]
-
-let diff_rule enabledif backend t =
-  let t' = Fpath.( // ) backend t in
-  List
-    ([
-       Atom "rule";
-       List [ Atom "alias"; Atom "runtest" ];
-       List
-         [
-           Atom "action";
-           List
-             [
-               Atom "diff";
-               Atom (Fpath.to_string t');
-               Atom (Fpath.to_string t' ^ ".gen");
-             ];
-         ];
-     ]
-    @ enabledif)
-
-let diff_rule enabledif backend p =
-  let t = expected_targets backend p |> List.map Fpath.v in
-  List.map (diff_rule enabledif backend) t
+             :: List.map2 (Dune.runtest_diff ?enabledif) targets targets_gen);
+        ]
 
 let gen_backend_rule enabledif backend_target_rules path =
   List.map
     (fun b_t_r ->
-      let _, b, flag = b_t_r in
-      match flag with
-      | Some flat_flag ->
-          [
-            gen_backend_diff_rule enabledif b_t_r path;
-            diff_rule enabledif b path;
-            gen_and_diff_target_files_rules enabledif ~flat_flag b path;
-          ]
-          |> List.concat
-      | None ->
-          [
-            gen_backend_diff_rule enabledif b_t_r path;
-            diff_rule enabledif b path;
-            gen_and_diff_target_files_rules enabledif b path;
-          ]
-          |> List.concat)
+      let _, b, flat_flag = b_t_r in
+      let targets = expected_targets b path in
+      let relpath =
+        let path = Fpath.relativize ~root:b path in
+        match path with Some p -> p | None -> assert false
+      in
+      let targets_file = targets_file_path relpath in
+      [
+        gen_backend_diff_rule enabledif ~targets b_t_r relpath;
+        gen_targets_file enabledif ?flat_flag b targets_file relpath;
+      ]
+      |> List.concat)
     backend_target_rules
   |> List.flatten
 
@@ -331,9 +185,7 @@ let gen_rule backend_target_rules test_cases =
       List.(concat (map gen_rule_for_source_file test_cases));
       List.map
         (fun case ->
-          gen_backend_rule
-            (render_enabledif case.enabledif)
-            backend_target_rules case.odocl)
+          gen_backend_rule case.enabledif backend_target_rules case.odocl)
         test_cases
       |> List.flatten;
     ]

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -1,747 +1,641 @@
 (rule
  (target alias.cmt)
- (deps cases/alias.ml)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/alias.ml})))
 
 (rule
  (target alias.odoc)
- (deps alias.cmt)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:alias.cmt})))
 
 (rule
  (target alias.odocl)
- (deps alias.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:alias.odoc})))
 
 (rule
  (target bugs.cmt)
- (deps cases/bugs.ml)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/bugs.ml})))
 
 (rule
  (target bugs.odoc)
- (deps bugs.cmt)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:bugs.cmt})))
 
 (rule
  (target bugs.odocl)
- (deps bugs.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:bugs.odoc})))
 
 (rule
  (target bugs_post_406.cmti)
- (deps cases/bugs_post_406.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps}))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/bugs_post_406.mli}))
  (enabled_if
   (>= %{ocaml_version} 4.06)))
 
 (rule
  (target bugs_post_406.odoc)
- (deps bugs_post_406.cmti)
  (action
-  (run odoc compile -o %{target} %{deps}))
+  (run odoc compile -o %{target} %{dep:bugs_post_406.cmti}))
  (enabled_if
   (>= %{ocaml_version} 4.06)))
 
 (rule
  (target bugs_post_406.odocl)
- (deps bugs_post_406.odoc)
  (action
-  (run odoc link -o %{target} %{deps}))
+  (run odoc link -o %{target} %{dep:bugs_post_406.odoc}))
  (enabled_if
   (>= %{ocaml_version} 4.06)))
 
 (rule
  (target bugs_pre_410.cmt)
- (deps cases/bugs_pre_410.ml)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps}))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/bugs_pre_410.ml}))
  (enabled_if
   (<= %{ocaml_version} 4.09)))
 
 (rule
  (target bugs_pre_410.odoc)
- (deps bugs_pre_410.cmt)
  (action
-  (run odoc compile -o %{target} %{deps}))
+  (run odoc compile -o %{target} %{dep:bugs_pre_410.cmt}))
  (enabled_if
   (<= %{ocaml_version} 4.09)))
 
 (rule
  (target bugs_pre_410.odocl)
- (deps bugs_pre_410.odoc)
  (action
-  (run odoc link -o %{target} %{deps}))
+  (run odoc link -o %{target} %{dep:bugs_pre_410.odoc}))
  (enabled_if
   (<= %{ocaml_version} 4.09)))
 
 (rule
  (target class.cmti)
- (deps cases/class.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/class.mli})))
 
 (rule
  (target class.odoc)
- (deps class.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:class.cmti})))
 
 (rule
  (target class.odocl)
- (deps class.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:class.odoc})))
 
 (rule
  (target external.cmti)
- (deps cases/external.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/external.mli})))
 
 (rule
  (target external.odoc)
- (deps external.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:external.cmti})))
 
 (rule
  (target external.odocl)
- (deps external.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:external.odoc})))
 
 (rule
  (target functor.cmti)
- (deps cases/functor.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/functor.mli})))
 
 (rule
  (target functor.odoc)
- (deps functor.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:functor.cmti})))
 
 (rule
  (target functor.odocl)
- (deps functor.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:functor.odoc})))
 
 (rule
  (target functor2.cmti)
- (deps cases/functor2.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/functor2.mli})))
 
 (rule
  (target functor2.odoc)
- (deps functor2.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:functor2.cmti})))
 
 (rule
  (target functor2.odocl)
- (deps functor2.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:functor2.odoc})))
 
 (rule
  (target include.cmti)
- (deps cases/include.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/include.mli})))
 
 (rule
  (target include.odoc)
- (deps include.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:include.cmti})))
 
 (rule
  (target include.odocl)
- (deps include.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:include.odoc})))
 
 (rule
  (target include2.cmt)
- (deps cases/include2.ml)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/include2.ml})))
 
 (rule
  (target include2.odoc)
- (deps include2.cmt)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:include2.cmt})))
 
 (rule
  (target include2.odocl)
- (deps include2.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:include2.odoc})))
 
 (rule
  (target include_sections.cmti)
- (deps cases/include_sections.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/include_sections.mli})))
 
 (rule
  (target include_sections.odoc)
- (deps include_sections.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:include_sections.cmti})))
 
 (rule
  (target include_sections.odocl)
- (deps include_sections.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:include_sections.odoc})))
 
 (rule
  (target interlude.cmti)
- (deps cases/interlude.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/interlude.mli})))
 
 (rule
  (target interlude.odoc)
- (deps interlude.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:interlude.cmti})))
 
 (rule
  (target interlude.odocl)
- (deps interlude.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:interlude.odoc})))
 
 (rule
  (target labels.cmti)
- (deps cases/labels.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps}))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/labels.mli}))
  (enabled_if
   (>= %{ocaml_version} 4.09)))
 
 (rule
  (target labels.odoc)
- (deps labels.cmti)
  (action
-  (run odoc compile -o %{target} %{deps}))
+  (run odoc compile -o %{target} %{dep:labels.cmti}))
  (enabled_if
   (>= %{ocaml_version} 4.09)))
 
 (rule
  (target labels.odocl)
- (deps labels.odoc)
  (action
-  (run odoc link -o %{target} %{deps}))
+  (run odoc link -o %{target} %{dep:labels.odoc}))
  (enabled_if
   (>= %{ocaml_version} 4.09)))
 
 (rule
  (target markup.cmti)
- (deps cases/markup.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/markup.mli})))
 
 (rule
  (target markup.odoc)
- (deps markup.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:markup.cmti})))
 
 (rule
  (target markup.odocl)
- (deps markup.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:markup.odoc})))
 
 (rule
  (target page-mld.odoc)
- (deps cases/mld.mld)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:cases/mld.mld})))
 
 (rule
  (target page-mld.odocl)
- (deps page-mld.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:page-mld.odoc})))
 
 (rule
  (target module.cmti)
- (deps cases/module.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/module.mli})))
 
 (rule
  (target module.odoc)
- (deps module.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:module.cmti})))
 
 (rule
  (target module.odocl)
- (deps module.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:module.odoc})))
 
 (rule
  (target module_type_alias.cmti)
- (deps cases/module_type_alias.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/module_type_alias.mli})))
 
 (rule
  (target module_type_alias.odoc)
- (deps module_type_alias.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:module_type_alias.cmti})))
 
 (rule
  (target module_type_alias.odocl)
- (deps module_type_alias.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:module_type_alias.odoc})))
 
 (rule
  (target module_type_subst.cmti)
- (deps cases/module_type_subst.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps}))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/module_type_subst.mli}))
  (enabled_if
   (>= %{ocaml_version} 4.13)))
 
 (rule
  (target module_type_subst.odoc)
- (deps module_type_subst.cmti)
  (action
-  (run odoc compile -o %{target} %{deps}))
+  (run odoc compile -o %{target} %{dep:module_type_subst.cmti}))
  (enabled_if
   (>= %{ocaml_version} 4.13)))
 
 (rule
  (target module_type_subst.odocl)
- (deps module_type_subst.odoc)
  (action
-  (run odoc link -o %{target} %{deps}))
+  (run odoc link -o %{target} %{dep:module_type_subst.odoc}))
  (enabled_if
   (>= %{ocaml_version} 4.13)))
 
 (rule
  (target nested.cmti)
- (deps cases/nested.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/nested.mli})))
 
 (rule
  (target nested.odoc)
- (deps nested.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:nested.cmti})))
 
 (rule
  (target nested.odocl)
- (deps nested.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:nested.odoc})))
 
 (rule
  (target ocamlary.cmti)
- (deps cases/ocamlary.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps}))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/ocamlary.mli}))
  (enabled_if
   (>= %{ocaml_version} 4.07)))
 
 (rule
  (target ocamlary.odoc)
- (deps ocamlary.cmti)
  (action
-  (run odoc compile -o %{target} %{deps}))
+  (run odoc compile -o %{target} %{dep:ocamlary.cmti}))
  (enabled_if
   (>= %{ocaml_version} 4.07)))
 
 (rule
  (target ocamlary.odocl)
- (deps ocamlary.odoc)
  (action
-  (run odoc link -o %{target} %{deps}))
+  (run odoc link -o %{target} %{dep:ocamlary.odoc}))
  (enabled_if
   (>= %{ocaml_version} 4.07)))
 
 (rule
  (target recent.cmti)
- (deps cases/recent.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps}))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/recent.mli}))
  (enabled_if
   (>= %{ocaml_version} 4.09)))
 
 (rule
  (target recent.odoc)
- (deps recent.cmti)
  (action
-  (run odoc compile -o %{target} %{deps}))
+  (run odoc compile -o %{target} %{dep:recent.cmti}))
  (enabled_if
   (>= %{ocaml_version} 4.09)))
 
 (rule
  (target recent.odocl)
- (deps recent.odoc)
  (action
-  (run odoc link -o %{target} %{deps}))
+  (run odoc link -o %{target} %{dep:recent.odoc}))
  (enabled_if
   (>= %{ocaml_version} 4.09)))
 
 (rule
  (target recent_impl.cmt)
- (deps cases/recent_impl.ml)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps}))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/recent_impl.ml}))
  (enabled_if
   (>= %{ocaml_version} 4.09)))
 
 (rule
  (target recent_impl.odoc)
- (deps recent_impl.cmt)
  (action
-  (run odoc compile -o %{target} %{deps}))
+  (run odoc compile -o %{target} %{dep:recent_impl.cmt}))
  (enabled_if
   (>= %{ocaml_version} 4.09)))
 
 (rule
  (target recent_impl.odocl)
- (deps recent_impl.odoc)
  (action
-  (run odoc link -o %{target} %{deps}))
+  (run odoc link -o %{target} %{dep:recent_impl.odoc}))
  (enabled_if
   (>= %{ocaml_version} 4.09)))
 
 (rule
  (target section.cmti)
- (deps cases/section.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/section.mli})))
 
 (rule
  (target section.odoc)
- (deps section.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:section.cmti})))
 
 (rule
  (target section.odocl)
- (deps section.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:section.odoc})))
 
 (rule
  (target stop.cmti)
- (deps cases/stop.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/stop.mli})))
 
 (rule
  (target stop.odoc)
- (deps stop.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:stop.cmti})))
 
 (rule
  (target stop.odocl)
- (deps stop.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:stop.odoc})))
 
 (rule
  (target stop_dead_link_doc.cmti)
- (deps cases/stop_dead_link_doc.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps}))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/stop_dead_link_doc.mli}))
  (enabled_if
   (>= %{ocaml_version} 4.04)))
 
 (rule
  (target stop_dead_link_doc.odoc)
- (deps stop_dead_link_doc.cmti)
  (action
-  (run odoc compile -o %{target} %{deps}))
+  (run odoc compile -o %{target} %{dep:stop_dead_link_doc.cmti}))
  (enabled_if
   (>= %{ocaml_version} 4.04)))
 
 (rule
  (target stop_dead_link_doc.odocl)
- (deps stop_dead_link_doc.odoc)
  (action
-  (run odoc link -o %{target} %{deps}))
+  (run odoc link -o %{target} %{dep:stop_dead_link_doc.odoc}))
  (enabled_if
   (>= %{ocaml_version} 4.04)))
 
 (rule
  (target toplevel_comments.cmti)
- (deps cases/toplevel_comments.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/toplevel_comments.mli})))
 
 (rule
  (target toplevel_comments.odoc)
- (deps toplevel_comments.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:toplevel_comments.cmti})))
 
 (rule
  (target toplevel_comments.odocl)
- (deps toplevel_comments.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:toplevel_comments.odoc})))
 
 (rule
  (target type.cmti)
- (deps cases/type.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/type.mli})))
 
 (rule
  (target type.odoc)
- (deps type.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:type.cmti})))
 
 (rule
  (target type.odocl)
- (deps type.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:type.odoc})))
 
 (rule
  (target val.cmti)
- (deps cases/val.mli)
  (action
-  (run ocamlc -c -bin-annot -o %{target} %{deps})))
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/val.mli})))
 
 (rule
  (target val.odoc)
- (deps val.cmti)
  (action
-  (run odoc compile -o %{target} %{deps})))
+  (run odoc compile -o %{target} %{dep:val.cmti})))
 
 (rule
  (target val.odocl)
- (deps val.odoc)
  (action
-  (run odoc link -o %{target} %{deps})))
+  (run odoc link -o %{target} %{dep:val.odoc})))
 
 (subdir
  html
  (rule
   (targets Alias.html.gen Alias-Foo__X.html.gen Alias-X.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../alias.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Alias.html html/Alias.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Alias-Foo__X.html html/Alias-Foo__X.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Alias-X.html html/Alias-X.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../alias.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alias.html Alias.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alias-Foo__X.html Alias-Foo__X.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alias-X.html Alias-X.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    alias.gen
-    (run odoc html-targets -o . %{dep:../alias.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/alias.targets html/alias.gen)))
+    alias.targets.gen
+    (run odoc html-targets -o . %{dep:../alias.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff alias.targets alias.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Alias.tex.gen Alias.X.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../alias.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Alias.tex latex/Alias.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Alias.X.tex latex/Alias.X.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../alias.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alias.tex Alias.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alias.X.tex Alias.X.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    alias.gen
-    (run odoc latex-targets -o . %{dep:../alias.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/alias.targets latex/alias.gen)))
+    alias.targets.gen
+    (run odoc latex-targets -o . %{dep:../alias.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff alias.targets alias.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Alias.3o.gen Alias.Foo__X.3o.gen Alias.X.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../alias.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Alias.3o man/Alias.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Alias.Foo__X.3o man/Alias.Foo__X.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Alias.X.3o man/Alias.X.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../alias.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alias.3o Alias.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alias.Foo__X.3o Alias.Foo__X.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alias.X.3o Alias.X.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    alias.gen
-    (run odoc man-targets -o . %{dep:../alias.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/alias.targets man/alias.gen)))
+    alias.targets.gen
+    (run odoc man-targets -o . %{dep:../alias.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff alias.targets alias.targets.gen))))
 
 (subdir
  html
  (rule
   (targets Bugs.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../bugs.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Bugs.html html/Bugs.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../bugs.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs.html Bugs.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    bugs.gen
-    (run odoc html-targets -o . %{dep:../bugs.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/bugs.targets html/bugs.gen)))
+    bugs.targets.gen
+    (run odoc html-targets -o . %{dep:../bugs.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff bugs.targets bugs.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Bugs.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../bugs.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Bugs.tex latex/Bugs.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../bugs.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs.tex Bugs.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    bugs.gen
-    (run odoc latex-targets -o . %{dep:../bugs.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/bugs.targets latex/bugs.gen)))
+    bugs.targets.gen
+    (run odoc latex-targets -o . %{dep:../bugs.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff bugs.targets bugs.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Bugs.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../bugs.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Bugs.3o man/Bugs.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../bugs.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs.3o Bugs.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    bugs.gen
-    (run odoc man-targets -o . %{dep:../bugs.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/bugs.targets man/bugs.gen)))
+    bugs.targets.gen
+    (run odoc man-targets -o . %{dep:../bugs.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff bugs.targets bugs.targets.gen))))
 
 (subdir
  html
@@ -751,284 +645,260 @@
    Bugs_post_406-class-type-let_open.html.gen
    Bugs_post_406-class-let_open'.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../bugs_post_406.odocl})))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../bugs_post_406.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.06)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs_post_406.html Bugs_post_406.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.06)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Bugs_post_406-class-type-let_open.html
+    Bugs_post_406-class-type-let_open.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.06)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Bugs_post_406-class-let_open'.html
+    Bugs_post_406-class-let_open'.html.gen))
   (enabled_if
    (>= %{ocaml_version} 4.06))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Bugs_post_406.html html/Bugs_post_406.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.06)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Bugs_post_406-class-type-let_open.html
-   html/Bugs_post_406-class-type-let_open.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.06)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Bugs_post_406-class-let_open'.html
-   html/Bugs_post_406-class-let_open'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.06)))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    bugs_post_406.gen
+    bugs_post_406.targets.gen
     (run odoc html-targets -o . %{dep:../bugs_post_406.odocl} --flat)))
   (enabled_if
+   (>= %{ocaml_version} 4.06)))
+ (rule
+  (alias runtest)
+  (action
+   (diff bugs_post_406.targets bugs_post_406.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.06))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/bugs_post_406.targets html/bugs_post_406.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.06)))
 
 (subdir
  latex
  (rule
   (targets Bugs_post_406.tex.gen Bugs_post_406.let_open'.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../bugs_post_406.odocl})))
+   (run
+    odoc
+    latex-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../bugs_post_406.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.06)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs_post_406.tex Bugs_post_406.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.06)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs_post_406.let_open'.tex Bugs_post_406.let_open'.tex.gen))
   (enabled_if
    (>= %{ocaml_version} 4.06))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Bugs_post_406.tex latex/Bugs_post_406.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.06)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   latex/Bugs_post_406.let_open'.tex
-   latex/Bugs_post_406.let_open'.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.06)))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    bugs_post_406.gen
+    bugs_post_406.targets.gen
     (run odoc latex-targets -o . %{dep:../bugs_post_406.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.06)))
+ (rule
+  (alias runtest)
+  (action
+   (diff bugs_post_406.targets bugs_post_406.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.06))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/bugs_post_406.targets latex/bugs_post_406.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.06)))
 
 (subdir
  man
  (rule
   (targets Bugs_post_406.3o.gen Bugs_post_406.let_open'.3o.gen)
   (action
-   (progn
-    (run
-     odoc
-     man-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../bugs_post_406.odocl})))
+   (run
+    odoc
+    man-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../bugs_post_406.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.06)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs_post_406.3o Bugs_post_406.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.06)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs_post_406.let_open'.3o Bugs_post_406.let_open'.3o.gen))
   (enabled_if
    (>= %{ocaml_version} 4.06))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Bugs_post_406.3o man/Bugs_post_406.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.06)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Bugs_post_406.let_open'.3o man/Bugs_post_406.let_open'.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.06)))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    bugs_post_406.gen
+    bugs_post_406.targets.gen
     (run odoc man-targets -o . %{dep:../bugs_post_406.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.06)))
+ (rule
+  (alias runtest)
+  (action
+   (diff bugs_post_406.targets bugs_post_406.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.06))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/bugs_post_406.targets man/bugs_post_406.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.06)))
 
 (subdir
  html
  (rule
   (targets Bugs_pre_410.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../bugs_pre_410.odocl})))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../bugs_pre_410.odocl}))
+  (enabled_if
+   (<= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs_pre_410.html Bugs_pre_410.html.gen))
   (enabled_if
    (<= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Bugs_pre_410.html html/Bugs_pre_410.html.gen))
- (enabled_if
-  (<= %{ocaml_version} 4.09)))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    bugs_pre_410.gen
+    bugs_pre_410.targets.gen
     (run odoc html-targets -o . %{dep:../bugs_pre_410.odocl} --flat)))
   (enabled_if
+   (<= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff bugs_pre_410.targets bugs_pre_410.targets.gen))
+  (enabled_if
    (<= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/bugs_pre_410.targets html/bugs_pre_410.gen))
- (enabled_if
-  (<= %{ocaml_version} 4.09)))
 
 (subdir
  latex
  (rule
   (targets Bugs_pre_410.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../bugs_pre_410.odocl})))
+   (run
+    odoc
+    latex-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../bugs_pre_410.odocl}))
+  (enabled_if
+   (<= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs_pre_410.tex Bugs_pre_410.tex.gen))
   (enabled_if
    (<= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Bugs_pre_410.tex latex/Bugs_pre_410.tex.gen))
- (enabled_if
-  (<= %{ocaml_version} 4.09)))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    bugs_pre_410.gen
+    bugs_pre_410.targets.gen
     (run odoc latex-targets -o . %{dep:../bugs_pre_410.odocl})))
   (enabled_if
+   (<= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff bugs_pre_410.targets bugs_pre_410.targets.gen))
+  (enabled_if
    (<= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/bugs_pre_410.targets latex/bugs_pre_410.gen))
- (enabled_if
-  (<= %{ocaml_version} 4.09)))
 
 (subdir
  man
  (rule
   (targets Bugs_pre_410.3o.gen)
   (action
-   (progn
-    (run
-     odoc
-     man-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../bugs_pre_410.odocl})))
+   (run
+    odoc
+    man-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../bugs_pre_410.odocl}))
+  (enabled_if
+   (<= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Bugs_pre_410.3o Bugs_pre_410.3o.gen))
   (enabled_if
    (<= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Bugs_pre_410.3o man/Bugs_pre_410.3o.gen))
- (enabled_if
-  (<= %{ocaml_version} 4.09)))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    bugs_pre_410.gen
+    bugs_pre_410.targets.gen
     (run odoc man-targets -o . %{dep:../bugs_pre_410.odocl})))
   (enabled_if
+   (<= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff bugs_pre_410.targets bugs_pre_410.targets.gen))
+  (enabled_if
    (<= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/bugs_pre_410.targets man/bugs_pre_410.gen))
- (enabled_if
-  (<= %{ocaml_version} 4.09)))
 
 (subdir
  html
@@ -1045,96 +915,72 @@
    Class-class-type-polymorphic.html.gen
    Class-class-polymorphic'.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../class.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Class.html html/Class.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Class-class-type-empty.html
-   html/Class-class-type-empty.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Class-class-type-mutually.html
-   html/Class-class-type-mutually.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Class-class-type-recursive.html
-   html/Class-class-type-recursive.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Class-class-mutually'.html html/Class-class-mutually'.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Class-class-recursive'.html
-   html/Class-class-recursive'.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Class-class-type-empty_virtual.html
-   html/Class-class-type-empty_virtual.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Class-class-empty_virtual'.html
-   html/Class-class-empty_virtual'.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Class-class-type-polymorphic.html
-   html/Class-class-type-polymorphic.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Class-class-polymorphic'.html
-   html/Class-class-polymorphic'.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../class.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.html Class.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class-class-type-empty.html Class-class-type-empty.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class-class-type-mutually.html Class-class-type-mutually.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class-class-type-recursive.html Class-class-type-recursive.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class-class-mutually'.html Class-class-mutually'.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class-class-recursive'.html Class-class-recursive'.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Class-class-type-empty_virtual.html
+    Class-class-type-empty_virtual.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class-class-empty_virtual'.html Class-class-empty_virtual'.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Class-class-type-polymorphic.html
+    Class-class-type-polymorphic.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class-class-polymorphic'.html Class-class-polymorphic'.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    class.gen
-    (run odoc html-targets -o . %{dep:../class.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/class.targets html/class.gen)))
+    class.targets.gen
+    (run odoc html-targets -o . %{dep:../class.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff class.targets class.targets.gen))))
 
 (subdir
  latex
@@ -1146,46 +992,39 @@
    Class.empty_virtual'.tex.gen
    Class.polymorphic'.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../class.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Class.tex latex/Class.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Class.mutually'.tex latex/Class.mutually'.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Class.recursive'.tex latex/Class.recursive'.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Class.empty_virtual'.tex latex/Class.empty_virtual'.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Class.polymorphic'.tex latex/Class.polymorphic'.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../class.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.tex Class.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.mutually'.tex Class.mutually'.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.recursive'.tex Class.recursive'.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.empty_virtual'.tex Class.empty_virtual'.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.polymorphic'.tex Class.polymorphic'.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    class.gen
-    (run odoc latex-targets -o . %{dep:../class.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/class.targets latex/class.gen)))
+    class.targets.gen
+    (run odoc latex-targets -o . %{dep:../class.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff class.targets class.targets.gen))))
 
 (subdir
  man
@@ -1197,140 +1036,117 @@
    Class.empty_virtual'.3o.gen
    Class.polymorphic'.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../class.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Class.3o man/Class.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Class.mutually'.3o man/Class.mutually'.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Class.recursive'.3o man/Class.recursive'.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Class.empty_virtual'.3o man/Class.empty_virtual'.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Class.polymorphic'.3o man/Class.polymorphic'.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../class.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.3o Class.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.mutually'.3o Class.mutually'.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.recursive'.3o Class.recursive'.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.empty_virtual'.3o Class.empty_virtual'.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Class.polymorphic'.3o Class.polymorphic'.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    class.gen
-    (run odoc man-targets -o . %{dep:../class.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/class.targets man/class.gen)))
+    class.targets.gen
+    (run odoc man-targets -o . %{dep:../class.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff class.targets class.targets.gen))))
 
 (subdir
  html
  (rule
   (targets External.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../external.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/External.html html/External.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../external.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff External.html External.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    external.gen
-    (run odoc html-targets -o . %{dep:../external.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/external.targets html/external.gen)))
+    external.targets.gen
+    (run odoc html-targets -o . %{dep:../external.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff external.targets external.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets External.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../external.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/External.tex latex/External.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../external.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff External.tex External.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    external.gen
-    (run odoc latex-targets -o . %{dep:../external.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/external.targets latex/external.gen)))
+    external.targets.gen
+    (run odoc latex-targets -o . %{dep:../external.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff external.targets external.targets.gen))))
 
 (subdir
  man
  (rule
   (targets External.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../external.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/External.3o man/External.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../external.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff External.3o External.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    external.gen
-    (run odoc man-targets -o . %{dep:../external.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/external.targets man/external.gen)))
+    external.targets.gen
+    (run odoc man-targets -o . %{dep:../external.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff external.targets external.targets.gen))))
 
 (subdir
  html
@@ -1350,107 +1166,82 @@
    Functor-F4-argument-1-Arg.html.gen
    Functor-F5.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../functor.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Functor.html html/Functor.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Functor-module-type-S.html html/Functor-module-type-S.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor-module-type-S1.html
-   html/Functor-module-type-S1.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor-module-type-S1-argument-1-_.html
-   html/Functor-module-type-S1-argument-1-_.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Functor-F1.html html/Functor-F1.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor-F1-argument-1-Arg.html
-   html/Functor-F1-argument-1-Arg.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Functor-F2.html html/Functor-F2.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor-F2-argument-1-Arg.html
-   html/Functor-F2-argument-1-Arg.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Functor-F3.html html/Functor-F3.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor-F3-argument-1-Arg.html
-   html/Functor-F3-argument-1-Arg.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Functor-F4.html html/Functor-F4.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor-F4-argument-1-Arg.html
-   html/Functor-F4-argument-1-Arg.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Functor-F5.html html/Functor-F5.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../functor.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.html Functor.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-module-type-S.html Functor-module-type-S.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-module-type-S1.html Functor-module-type-S1.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Functor-module-type-S1-argument-1-_.html
+    Functor-module-type-S1-argument-1-_.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-F1.html Functor-F1.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-F1-argument-1-Arg.html Functor-F1-argument-1-Arg.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-F2.html Functor-F2.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-F2-argument-1-Arg.html Functor-F2-argument-1-Arg.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-F3.html Functor-F3.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-F3-argument-1-Arg.html Functor-F3-argument-1-Arg.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-F4.html Functor-F4.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-F4-argument-1-Arg.html Functor-F4-argument-1-Arg.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor-F5.html Functor-F5.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    functor.gen
-    (run odoc html-targets -o . %{dep:../functor.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/functor.targets html/functor.gen)))
+    functor.targets.gen
+    (run odoc html-targets -o . %{dep:../functor.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff functor.targets functor.targets.gen))))
 
 (subdir
  latex
@@ -1463,51 +1254,43 @@
    Functor.F4.tex.gen
    Functor.F5.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../functor.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Functor.tex latex/Functor.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Functor.F1.tex latex/Functor.F1.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Functor.F2.tex latex/Functor.F2.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Functor.F3.tex latex/Functor.F3.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Functor.F4.tex latex/Functor.F4.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Functor.F5.tex latex/Functor.F5.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../functor.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.tex Functor.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.F1.tex Functor.F1.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.F2.tex Functor.F2.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.F3.tex Functor.F3.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.F4.tex Functor.F4.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.F5.tex Functor.F5.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    functor.gen
-    (run odoc latex-targets -o . %{dep:../functor.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/functor.targets latex/functor.gen)))
+    functor.targets.gen
+    (run odoc latex-targets -o . %{dep:../functor.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff functor.targets functor.targets.gen))))
 
 (subdir
  man
@@ -1520,51 +1303,43 @@
    Functor.F4.3o.gen
    Functor.F5.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../functor.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Functor.3o man/Functor.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Functor.F1.3o man/Functor.F1.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Functor.F2.3o man/Functor.F2.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Functor.F3.3o man/Functor.F3.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Functor.F4.3o man/Functor.F4.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Functor.F5.3o man/Functor.F5.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../functor.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.3o Functor.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.F1.3o Functor.F1.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.F2.3o Functor.F2.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.F3.3o Functor.F3.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.F4.3o Functor.F4.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor.F5.3o Functor.F5.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    functor.gen
-    (run odoc man-targets -o . %{dep:../functor.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/functor.targets man/functor.gen)))
+    functor.targets.gen
+    (run odoc man-targets -o . %{dep:../functor.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff functor.targets functor.targets.gen))))
 
 (subdir
  html
@@ -1579,151 +1354,118 @@
    Functor2-module-type-XF-argument-1-Y.html.gen
    Functor2-module-type-XF-argument-2-Z.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../functor2.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Functor2.html html/Functor2.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor2-module-type-S.html
-   html/Functor2-module-type-S.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Functor2-X.html html/Functor2-X.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor2-X-argument-1-Y.html
-   html/Functor2-X-argument-1-Y.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor2-X-argument-2-Z.html
-   html/Functor2-X-argument-2-Z.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor2-module-type-XF.html
-   html/Functor2-module-type-XF.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor2-module-type-XF-argument-1-Y.html
-   html/Functor2-module-type-XF-argument-1-Y.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Functor2-module-type-XF-argument-2-Z.html
-   html/Functor2-module-type-XF-argument-2-Z.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../functor2.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor2.html Functor2.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor2-module-type-S.html Functor2-module-type-S.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor2-X.html Functor2-X.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor2-X-argument-1-Y.html Functor2-X-argument-1-Y.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor2-X-argument-2-Z.html Functor2-X-argument-2-Z.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor2-module-type-XF.html Functor2-module-type-XF.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Functor2-module-type-XF-argument-1-Y.html
+    Functor2-module-type-XF-argument-1-Y.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Functor2-module-type-XF-argument-2-Z.html
+    Functor2-module-type-XF-argument-2-Z.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    functor2.gen
-    (run odoc html-targets -o . %{dep:../functor2.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/functor2.targets html/functor2.gen)))
+    functor2.targets.gen
+    (run odoc html-targets -o . %{dep:../functor2.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff functor2.targets functor2.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Functor2.tex.gen Functor2.X.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../functor2.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Functor2.tex latex/Functor2.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Functor2.X.tex latex/Functor2.X.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../functor2.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor2.tex Functor2.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor2.X.tex Functor2.X.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    functor2.gen
-    (run odoc latex-targets -o . %{dep:../functor2.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/functor2.targets latex/functor2.gen)))
+    functor2.targets.gen
+    (run odoc latex-targets -o . %{dep:../functor2.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff functor2.targets functor2.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Functor2.3o.gen Functor2.X.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../functor2.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Functor2.3o man/Functor2.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Functor2.X.3o man/Functor2.X.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../functor2.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor2.3o Functor2.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Functor2.X.3o Functor2.X.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    functor2.gen
-    (run odoc man-targets -o . %{dep:../functor2.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/functor2.targets man/functor2.gen)))
+    functor2.targets.gen
+    (run odoc man-targets -o . %{dep:../functor2.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff functor2.targets functor2.targets.gen))))
 
 (subdir
  html
@@ -1737,129 +1479,114 @@
    Include-module-type-Inherent_Module.html.gen
    Include-module-type-Dorminant_Module.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../include.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Include.html html/Include.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Include-module-type-Not_inlined.html
-   html/Include-module-type-Not_inlined.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Include-module-type-Inlined.html
-   html/Include-module-type-Inlined.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Include-module-type-Not_inlined_and_closed.html
-   html/Include-module-type-Not_inlined_and_closed.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Include-module-type-Not_inlined_and_opened.html
-   html/Include-module-type-Not_inlined_and_opened.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Include-module-type-Inherent_Module.html
-   html/Include-module-type-Inherent_Module.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Include-module-type-Dorminant_Module.html
-   html/Include-module-type-Dorminant_Module.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../include.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include.html Include.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Include-module-type-Not_inlined.html
+    Include-module-type-Not_inlined.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Include-module-type-Inlined.html
+    Include-module-type-Inlined.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Include-module-type-Not_inlined_and_closed.html
+    Include-module-type-Not_inlined_and_closed.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Include-module-type-Not_inlined_and_opened.html
+    Include-module-type-Not_inlined_and_opened.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Include-module-type-Inherent_Module.html
+    Include-module-type-Inherent_Module.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Include-module-type-Dorminant_Module.html
+    Include-module-type-Dorminant_Module.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    include.gen
-    (run odoc html-targets -o . %{dep:../include.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/include.targets html/include.gen)))
+    include.targets.gen
+    (run odoc html-targets -o . %{dep:../include.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff include.targets include.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Include.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../include.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Include.tex latex/Include.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../include.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include.tex Include.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    include.gen
-    (run odoc latex-targets -o . %{dep:../include.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/include.targets latex/include.gen)))
+    include.targets.gen
+    (run odoc latex-targets -o . %{dep:../include.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff include.targets include.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Include.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../include.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Include.3o man/Include.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../include.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include.3o Include.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    include.gen
-    (run odoc man-targets -o . %{dep:../include.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/include.targets man/include.gen)))
+    include.targets.gen
+    (run odoc man-targets -o . %{dep:../include.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff include.targets include.targets.gen))))
 
 (subdir
  html
@@ -1871,92 +1598,73 @@
    Include2-Y_include_synopsis.html.gen
    Include2-Y_include_doc.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../include2.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Include2.html html/Include2.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Include2-X.html html/Include2-X.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Include2-Y.html html/Include2-Y.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Include2-Y_include_synopsis.html
-   html/Include2-Y_include_synopsis.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Include2-Y_include_doc.html
-   html/Include2-Y_include_doc.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../include2.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include2.html Include2.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include2-X.html Include2-X.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include2-Y.html Include2-Y.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Include2-Y_include_synopsis.html
+    Include2-Y_include_synopsis.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include2-Y_include_doc.html Include2-Y_include_doc.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    include2.gen
-    (run odoc html-targets -o . %{dep:../include2.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/include2.targets html/include2.gen)))
+    include2.targets.gen
+    (run odoc html-targets -o . %{dep:../include2.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff include2.targets include2.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Include2.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../include2.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Include2.tex latex/Include2.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../include2.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include2.tex Include2.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    include2.gen
-    (run odoc latex-targets -o . %{dep:../include2.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/include2.targets latex/include2.gen)))
+    include2.targets.gen
+    (run odoc latex-targets -o . %{dep:../include2.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff include2.targets include2.targets.gen))))
 
 (subdir
  man
@@ -1968,48 +1676,39 @@
    Include2.Y_include_synopsis.3o.gen
    Include2.Y_include_doc.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../include2.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Include2.3o man/Include2.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Include2.X.3o man/Include2.X.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Include2.Y.3o man/Include2.Y.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Include2.Y_include_synopsis.3o
-   man/Include2.Y_include_synopsis.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Include2.Y_include_doc.3o man/Include2.Y_include_doc.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../include2.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include2.3o Include2.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include2.X.3o Include2.X.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include2.Y.3o Include2.Y.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include2.Y_include_synopsis.3o Include2.Y_include_synopsis.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include2.Y_include_doc.3o Include2.Y_include_doc.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    include2.gen
-    (run odoc man-targets -o . %{dep:../include2.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/include2.targets man/include2.gen)))
+    include2.targets.gen
+    (run odoc man-targets -o . %{dep:../include2.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff include2.targets include2.targets.gen))))
 
 (subdir
  html
@@ -2018,202 +1717,183 @@
    Include_sections.html.gen
    Include_sections-module-type-Something.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../include_sections.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Include_sections.html html/Include_sections.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Include_sections-module-type-Something.html
-   html/Include_sections-module-type-Something.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../include_sections.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include_sections.html Include_sections.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Include_sections-module-type-Something.html
+    Include_sections-module-type-Something.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    include_sections.gen
-    (run odoc html-targets -o . %{dep:../include_sections.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/include_sections.targets html/include_sections.gen)))
+    include_sections.targets.gen
+    (run odoc html-targets -o . %{dep:../include_sections.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff include_sections.targets include_sections.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Include_sections.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../include_sections.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Include_sections.tex latex/Include_sections.tex.gen)))
+   (run
+    odoc
+    latex-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../include_sections.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include_sections.tex Include_sections.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    include_sections.gen
-    (run odoc latex-targets -o . %{dep:../include_sections.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/include_sections.targets latex/include_sections.gen)))
+    include_sections.targets.gen
+    (run odoc latex-targets -o . %{dep:../include_sections.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff include_sections.targets include_sections.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Include_sections.3o.gen)
   (action
-   (progn
-    (run
-     odoc
-     man-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../include_sections.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Include_sections.3o man/Include_sections.3o.gen)))
+   (run
+    odoc
+    man-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../include_sections.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Include_sections.3o Include_sections.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    include_sections.gen
-    (run odoc man-targets -o . %{dep:../include_sections.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/include_sections.targets man/include_sections.gen)))
+    include_sections.targets.gen
+    (run odoc man-targets -o . %{dep:../include_sections.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff include_sections.targets include_sections.targets.gen))))
 
 (subdir
  html
  (rule
   (targets Interlude.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../interlude.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Interlude.html html/Interlude.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../interlude.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Interlude.html Interlude.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    interlude.gen
-    (run odoc html-targets -o . %{dep:../interlude.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/interlude.targets html/interlude.gen)))
+    interlude.targets.gen
+    (run odoc html-targets -o . %{dep:../interlude.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff interlude.targets interlude.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Interlude.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../interlude.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Interlude.tex latex/Interlude.tex.gen)))
+   (run
+    odoc
+    latex-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../interlude.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Interlude.tex Interlude.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    interlude.gen
-    (run odoc latex-targets -o . %{dep:../interlude.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/interlude.targets latex/interlude.gen)))
+    interlude.targets.gen
+    (run odoc latex-targets -o . %{dep:../interlude.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff interlude.targets interlude.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Interlude.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../interlude.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Interlude.3o man/Interlude.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../interlude.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Interlude.3o Interlude.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    interlude.gen
-    (run odoc man-targets -o . %{dep:../interlude.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/interlude.targets man/interlude.gen)))
+    interlude.targets.gen
+    (run odoc man-targets -o . %{dep:../interlude.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff interlude.targets interlude.targets.gen))))
 
 (subdir
  html
@@ -2225,341 +1905,300 @@
    Labels-class-c.html.gen
    Labels-class-type-cs.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../labels.odocl})))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../labels.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Labels.html Labels.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Labels-A.html Labels-A.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Labels-module-type-S.html Labels-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Labels-class-c.html Labels-class-c.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Labels-class-type-cs.html Labels-class-type-cs.html.gen))
   (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Labels.html html/Labels.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Labels-A.html html/Labels-A.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Labels-module-type-S.html html/Labels-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Labels-class-c.html html/Labels-class-c.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Labels-class-type-cs.html html/Labels-class-type-cs.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    labels.gen
+    labels.targets.gen
     (run odoc html-targets -o . %{dep:../labels.odocl} --flat)))
   (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff labels.targets labels.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/labels.targets html/labels.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  latex
  (rule
   (targets Labels.tex.gen Labels.c.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../labels.odocl})))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../labels.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Labels.tex Labels.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Labels.c.tex Labels.c.tex.gen))
   (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Labels.tex latex/Labels.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Labels.c.tex latex/Labels.c.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    labels.gen
+    labels.targets.gen
     (run odoc latex-targets -o . %{dep:../labels.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff labels.targets labels.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/labels.targets latex/labels.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  man
  (rule
   (targets Labels.3o.gen Labels.A.3o.gen Labels.c.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../labels.odocl})))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../labels.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Labels.3o Labels.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Labels.A.3o Labels.A.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Labels.c.3o Labels.c.3o.gen))
   (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Labels.3o man/Labels.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Labels.A.3o man/Labels.A.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Labels.c.3o man/Labels.c.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    labels.gen
+    labels.targets.gen
     (run odoc man-targets -o . %{dep:../labels.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff labels.targets labels.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/labels.targets man/labels.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  html
  (rule
   (targets Markup.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../markup.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Markup.html html/Markup.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../markup.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Markup.html Markup.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    markup.gen
-    (run odoc html-targets -o . %{dep:../markup.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/markup.targets html/markup.gen)))
+    markup.targets.gen
+    (run odoc html-targets -o . %{dep:../markup.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff markup.targets markup.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Markup.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../markup.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Markup.tex latex/Markup.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../markup.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Markup.tex Markup.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    markup.gen
-    (run odoc latex-targets -o . %{dep:../markup.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/markup.targets latex/markup.gen)))
+    markup.targets.gen
+    (run odoc latex-targets -o . %{dep:../markup.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff markup.targets markup.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Markup.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../markup.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Markup.3o man/Markup.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../markup.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Markup.3o Markup.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    markup.gen
-    (run odoc man-targets -o . %{dep:../markup.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/markup.targets man/markup.gen)))
+    markup.targets.gen
+    (run odoc man-targets -o . %{dep:../markup.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff markup.targets markup.targets.gen))))
 
 (subdir
  html
  (rule
   (targets mld.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../page-mld.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/mld.html html/mld.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../page-mld.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff mld.html mld.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    page-mld.gen
-    (run odoc html-targets -o . %{dep:../page-mld.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/page-mld.targets html/page-mld.gen)))
+    page-mld.targets.gen
+    (run odoc html-targets -o . %{dep:../page-mld.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff page-mld.targets page-mld.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets mld.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../page-mld.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/mld.tex latex/mld.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../page-mld.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff mld.tex mld.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    page-mld.gen
-    (run odoc latex-targets -o . %{dep:../page-mld.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/page-mld.targets latex/page-mld.gen)))
+    page-mld.targets.gen
+    (run odoc latex-targets -o . %{dep:../page-mld.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff page-mld.targets page-mld.targets.gen))))
 
 (subdir
  man
  (rule
   (targets mld.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../page-mld.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/mld.3o man/mld.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../page-mld.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff mld.3o mld.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    page-mld.gen
-    (run odoc man-targets -o . %{dep:../page-mld.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/page-mld.targets man/page-mld.gen)))
+    page-mld.targets.gen
+    (run odoc man-targets -o . %{dep:../page-mld.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff page-mld.targets page-mld.targets.gen))))
 
 (subdir
  html
@@ -2583,151 +2222,119 @@
    Module-Mutually.html.gen
    Module-Recursive.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../module.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module.html html/Module.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-module-type-S.html html/Module-module-type-S.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module-module-type-S-M.html
-   html/Module-module-type-S-M.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-module-type-S3.html html/Module-module-type-S3.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module-module-type-S3-M.html
-   html/Module-module-type-S3-M.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-module-type-S4.html html/Module-module-type-S4.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module-module-type-S4-M.html
-   html/Module-module-type-S4-M.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-module-type-S5.html html/Module-module-type-S5.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module-module-type-S5-M.html
-   html/Module-module-type-S5-M.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-module-type-S6.html html/Module-module-type-S6.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module-module-type-S6-M.html
-   html/Module-module-type-S6-M.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-M'.html html/Module-M'.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-module-type-S7.html html/Module-module-type-S7.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-module-type-S8.html html/Module-module-type-S8.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-module-type-S9.html html/Module-module-type-S9.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-Mutually.html html/Module-Mutually.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module-Recursive.html html/Module-Recursive.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../module.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module.html Module.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S.html Module-module-type-S.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S-M.html Module-module-type-S-M.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S3.html Module-module-type-S3.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S3-M.html Module-module-type-S3-M.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S4.html Module-module-type-S4.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S4-M.html Module-module-type-S4-M.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S5.html Module-module-type-S5.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S5-M.html Module-module-type-S5-M.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S6.html Module-module-type-S6.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S6-M.html Module-module-type-S6-M.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-M'.html Module-M'.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S7.html Module-module-type-S7.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S8.html Module-module-type-S8.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-module-type-S9.html Module-module-type-S9.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-Mutually.html Module-Mutually.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module-Recursive.html Module-Recursive.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    module.gen
-    (run odoc html-targets -o . %{dep:../module.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/module.targets html/module.gen)))
+    module.targets.gen
+    (run odoc html-targets -o . %{dep:../module.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff module.targets module.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Module.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../module.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Module.tex latex/Module.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../module.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module.tex Module.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    module.gen
-    (run odoc latex-targets -o . %{dep:../module.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/module.targets latex/module.gen)))
+    module.targets.gen
+    (run odoc latex-targets -o . %{dep:../module.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff module.targets module.targets.gen))))
 
 (subdir
  man
@@ -2738,41 +2345,35 @@
    Module.Mutually.3o.gen
    Module.Recursive.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../module.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Module.3o man/Module.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Module.M'.3o man/Module.M'.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Module.Mutually.3o man/Module.Mutually.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Module.Recursive.3o man/Module.Recursive.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../module.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module.3o Module.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module.M'.3o Module.M'.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module.Mutually.3o Module.Mutually.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module.Recursive.3o Module.Recursive.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    module.gen
-    (run odoc man-targets -o . %{dep:../module.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/module.targets man/module.gen)))
+    module.targets.gen
+    (run odoc man-targets -o . %{dep:../module.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff module.targets module.targets.gen))))
 
 (subdir
  html
@@ -2788,208 +2389,188 @@
    Module_type_alias-module-type-G.html.gen
    Module_type_alias-module-type-G-argument-1-H.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../module_type_alias.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Module_type_alias.html html/Module_type_alias.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module_type_alias-module-type-A.html
-   html/Module_type_alias-module-type-A.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module_type_alias-module-type-B.html
-   html/Module_type_alias-module-type-B.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module_type_alias-module-type-B-argument-1-C.html
-   html/Module_type_alias-module-type-B-argument-1-C.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module_type_alias-module-type-E.html
-   html/Module_type_alias-module-type-E.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module_type_alias-module-type-E-argument-1-F.html
-   html/Module_type_alias-module-type-E-argument-1-F.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module_type_alias-module-type-E-argument-1-C.html
-   html/Module_type_alias-module-type-E-argument-1-C.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module_type_alias-module-type-G.html
-   html/Module_type_alias-module-type-G.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Module_type_alias-module-type-G-argument-1-H.html
-   html/Module_type_alias-module-type-G-argument-1-H.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../module_type_alias.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module_type_alias.html Module_type_alias.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Module_type_alias-module-type-A.html
+    Module_type_alias-module-type-A.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Module_type_alias-module-type-B.html
+    Module_type_alias-module-type-B.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Module_type_alias-module-type-B-argument-1-C.html
+    Module_type_alias-module-type-B-argument-1-C.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Module_type_alias-module-type-E.html
+    Module_type_alias-module-type-E.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Module_type_alias-module-type-E-argument-1-F.html
+    Module_type_alias-module-type-E-argument-1-F.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Module_type_alias-module-type-E-argument-1-C.html
+    Module_type_alias-module-type-E-argument-1-C.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Module_type_alias-module-type-G.html
+    Module_type_alias-module-type-G.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Module_type_alias-module-type-G-argument-1-H.html
+    Module_type_alias-module-type-G-argument-1-H.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    module_type_alias.gen
-    (run odoc html-targets -o . %{dep:../module_type_alias.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/module_type_alias.targets html/module_type_alias.gen)))
+    module_type_alias.targets.gen
+    (run odoc html-targets -o . %{dep:../module_type_alias.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff module_type_alias.targets module_type_alias.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Module_type_alias.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../module_type_alias.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Module_type_alias.tex latex/Module_type_alias.tex.gen)))
+   (run
+    odoc
+    latex-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../module_type_alias.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module_type_alias.tex Module_type_alias.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    module_type_alias.gen
-    (run odoc latex-targets -o . %{dep:../module_type_alias.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/module_type_alias.targets latex/module_type_alias.gen)))
+    module_type_alias.targets.gen
+    (run odoc latex-targets -o . %{dep:../module_type_alias.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff module_type_alias.targets module_type_alias.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Module_type_alias.3o.gen)
   (action
-   (progn
-    (run
-     odoc
-     man-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../module_type_alias.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Module_type_alias.3o man/Module_type_alias.3o.gen)))
+   (run
+    odoc
+    man-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../module_type_alias.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Module_type_alias.3o Module_type_alias.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    module_type_alias.gen
-    (run odoc man-targets -o . %{dep:../module_type_alias.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/module_type_alias.targets man/module_type_alias.gen)))
+    module_type_alias.targets.gen
+    (run odoc man-targets -o . %{dep:../module_type_alias.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff module_type_alias.targets module_type_alias.targets.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    module_type_subst.gen
+    module_type_subst.targets.gen
     (run odoc html-targets -o . %{dep:../module_type_subst.odocl} --flat)))
   (enabled_if
+   (>= %{ocaml_version} 4.13)))
+ (rule
+  (alias runtest)
+  (action
+   (diff module_type_subst.targets module_type_subst.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.13))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/module_type_subst.targets html/module_type_subst.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.13)))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    module_type_subst.gen
+    module_type_subst.targets.gen
     (run odoc latex-targets -o . %{dep:../module_type_subst.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.13)))
+ (rule
+  (alias runtest)
+  (action
+   (diff module_type_subst.targets module_type_subst.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.13))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/module_type_subst.targets latex/module_type_subst.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.13)))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    module_type_subst.gen
+    module_type_subst.targets.gen
     (run odoc man-targets -o . %{dep:../module_type_subst.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.13)))
+ (rule
+  (alias runtest)
+  (action
+   (diff module_type_subst.targets module_type_subst.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.13))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/module_type_subst.targets man/module_type_subst.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.13)))
 
 (subdir
  html
@@ -3004,74 +2585,60 @@
    Nested-class-z.html.gen
    Nested-class-inherits.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../nested.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Nested.html html/Nested.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Nested-X.html html/Nested-X.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Nested-module-type-Y.html html/Nested-module-type-Y.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Nested-F.html html/Nested-F.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Nested-F-argument-1-Arg1.html
-   html/Nested-F-argument-1-Arg1.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Nested-F-argument-2-Arg2.html
-   html/Nested-F-argument-2-Arg2.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Nested-class-z.html html/Nested-class-z.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Nested-class-inherits.html html/Nested-class-inherits.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../nested.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested.html Nested.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested-X.html Nested-X.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested-module-type-Y.html Nested-module-type-Y.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested-F.html Nested-F.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested-F-argument-1-Arg1.html Nested-F-argument-1-Arg1.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested-F-argument-2-Arg2.html Nested-F-argument-2-Arg2.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested-class-z.html Nested-class-z.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested-class-inherits.html Nested-class-inherits.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    nested.gen
-    (run odoc html-targets -o . %{dep:../nested.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/nested.targets html/nested.gen)))
+    nested.targets.gen
+    (run odoc html-targets -o . %{dep:../nested.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff nested.targets nested.targets.gen))))
 
 (subdir
  latex
@@ -3082,41 +2649,35 @@
    Nested.z.tex.gen
    Nested.inherits.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../nested.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Nested.tex latex/Nested.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Nested.F.tex latex/Nested.F.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Nested.z.tex latex/Nested.z.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Nested.inherits.tex latex/Nested.inherits.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../nested.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested.tex Nested.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested.F.tex Nested.F.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested.z.tex Nested.z.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested.inherits.tex Nested.inherits.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    nested.gen
-    (run odoc latex-targets -o . %{dep:../nested.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/nested.targets latex/nested.gen)))
+    nested.targets.gen
+    (run odoc latex-targets -o . %{dep:../nested.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff nested.targets nested.targets.gen))))
 
 (subdir
  man
@@ -3128,46 +2689,39 @@
    Nested.z.3o.gen
    Nested.inherits.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../nested.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Nested.3o man/Nested.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Nested.X.3o man/Nested.X.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Nested.F.3o man/Nested.F.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Nested.z.3o man/Nested.z.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Nested.inherits.3o man/Nested.inherits.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../nested.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested.3o Nested.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested.X.3o Nested.X.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested.F.3o Nested.F.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested.z.3o Nested.z.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Nested.inherits.3o Nested.inherits.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    nested.gen
-    (run odoc man-targets -o . %{dep:../nested.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/nested.targets man/nested.gen)))
+    nested.targets.gen
+    (run odoc man-targets -o . %{dep:../nested.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff nested.targets nested.targets.gen))))
 
 (subdir
  html
@@ -3363,1645 +2917,1382 @@
    Ocamlary-module-type-TypeExt.html.gen
    Ocamlary-module-type-TypeExtPruned.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../ocamlary.odocl})))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../ocamlary.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.html Ocamlary.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Empty.html Ocamlary-Empty.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-Empty.html Ocamlary-module-type-Empty.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-MissingComment.html
+    Ocamlary-module-type-MissingComment.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-EmptySig.html
+    Ocamlary-module-type-EmptySig.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-ModuleWithSignature.html
+    Ocamlary-ModuleWithSignature.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-ModuleWithSignatureAlias.html
+    Ocamlary-ModuleWithSignatureAlias.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-One.html Ocamlary-One.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-SigForMod.html
+    Ocamlary-module-type-SigForMod.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-SigForMod-Inner.html
+    Ocamlary-module-type-SigForMod-Inner.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-SigForMod-Inner-module-type-Empty.html
+    Ocamlary-module-type-SigForMod-Inner-module-type-Empty.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-SuperSig.html
+    Ocamlary-module-type-SuperSig.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-SuperSig-module-type-SubSigA.html
+    Ocamlary-module-type-SuperSig-module-type-SubSigA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html
+    Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-SuperSig-module-type-SubSigB.html
+    Ocamlary-module-type-SuperSig-module-type-SubSigB.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-SuperSig-module-type-EmptySig.html
+    Ocamlary-module-type-SuperSig-module-type-EmptySig.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-SuperSig-module-type-One.html
+    Ocamlary-module-type-SuperSig-module-type-One.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-SuperSig-module-type-SuperSig.html
+    Ocamlary-module-type-SuperSig-module-type-SuperSig.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Buffer.html Ocamlary-Buffer.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-CollectionModule.html Ocamlary-CollectionModule.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-CollectionModule-InnerModuleA.html
+    Ocamlary-CollectionModule-InnerModuleA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html
+    Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
+    Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-COLLECTION.html
+    Ocamlary-module-type-COLLECTION.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-COLLECTION-InnerModuleA.html
+    Ocamlary-module-type-COLLECTION-InnerModuleA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html
+    Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html
+    Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Recollection.html Ocamlary-Recollection.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Recollection-argument-1-C.html
+    Ocamlary-Recollection-argument-1-C.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Recollection-argument-1-C-InnerModuleA.html
+    Ocamlary-Recollection-argument-1-C-InnerModuleA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html
+    Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html
+    Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Recollection-InnerModuleA.html
+    Ocamlary-Recollection-InnerModuleA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html
+    Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html
+    Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-MMM.html Ocamlary-module-type-MMM.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-MMM-C.html Ocamlary-module-type-MMM-C.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-MMM-C-InnerModuleA.html
+    Ocamlary-module-type-MMM-C-InnerModuleA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html
+    Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html
+    Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-RECOLLECTION.html
+    Ocamlary-module-type-RECOLLECTION.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-RecollectionModule.html
+    Ocamlary-module-type-RecollectionModule.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-RecollectionModule-InnerModuleA.html
+    Ocamlary-module-type-RecollectionModule-InnerModuleA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html
+    Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
+    Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-A.html Ocamlary-module-type-A.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-A-Q.html Ocamlary-module-type-A-Q.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-A-Q-InnerModuleA.html
+    Ocamlary-module-type-A-Q-InnerModuleA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html
+    Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+    Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-B.html Ocamlary-module-type-B.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-B-Q.html Ocamlary-module-type-B-Q.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-B-Q-InnerModuleA.html
+    Ocamlary-module-type-B-Q-InnerModuleA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html
+    Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+    Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-C.html Ocamlary-module-type-C.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-C-Q.html Ocamlary-module-type-C-Q.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-C-Q-InnerModuleA.html
+    Ocamlary-module-type-C-Q-InnerModuleA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html
+    Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+    Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-FunctorTypeOf.html Ocamlary-FunctorTypeOf.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-FunctorTypeOf-argument-1-Collection.html
+    Ocamlary-FunctorTypeOf-argument-1-Collection.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html
+    Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html
+    Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html
+    Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-IncludeModuleType.html
+    Ocamlary-module-type-IncludeModuleType.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-ToInclude.html
+    Ocamlary-module-type-ToInclude.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-ToInclude-IncludedA.html
+    Ocamlary-module-type-ToInclude-IncludedA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-ToInclude-module-type-IncludedB.html
+    Ocamlary-module-type-ToInclude-module-type-IncludedB.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-IncludedA.html Ocamlary-IncludedA.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-IncludedB.html
+    Ocamlary-module-type-IncludedB.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-ExtMod.html Ocamlary-ExtMod.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-class-empty_class.html Ocamlary-class-empty_class.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-class-one_method_class.html
+    Ocamlary-class-one_method_class.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-class-two_method_class.html
+    Ocamlary-class-two_method_class.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-class-param_class.html Ocamlary-class-param_class.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep1.html Ocamlary-Dep1.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep1-module-type-S.html
+    Ocamlary-Dep1-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep1-module-type-S-class-c.html
+    Ocamlary-Dep1-module-type-S-class-c.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep1-X.html Ocamlary-Dep1-X.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep1-X-Y.html Ocamlary-Dep1-X-Y.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep1-X-Y-class-c.html Ocamlary-Dep1-X-Y-class-c.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep2.html Ocamlary-Dep2.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep2-argument-1-Arg.html
+    Ocamlary-Dep2-argument-1-Arg.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep2-argument-1-Arg-X.html
+    Ocamlary-Dep2-argument-1-Arg-X.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep2-A.html Ocamlary-Dep2-A.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep3.html Ocamlary-Dep3.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep4.html Ocamlary-Dep4.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep4-module-type-T.html
+    Ocamlary-Dep4-module-type-T.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep4-module-type-S.html
+    Ocamlary-Dep4-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep4-module-type-S-X.html
+    Ocamlary-Dep4-module-type-S-X.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep4-module-type-S-Y.html
+    Ocamlary-Dep4-module-type-S-Y.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep4-X.html Ocamlary-Dep4-X.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep5.html Ocamlary-Dep5.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep5-argument-1-Arg.html
+    Ocamlary-Dep5-argument-1-Arg.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep5-argument-1-Arg-module-type-S.html
+    Ocamlary-Dep5-argument-1-Arg-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html
+    Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep5-Z.html Ocamlary-Dep5-Z.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep6.html Ocamlary-Dep6.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep6-module-type-S.html
+    Ocamlary-Dep6-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep6-module-type-T.html
+    Ocamlary-Dep6-module-type-T.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep6-module-type-T-Y.html
+    Ocamlary-Dep6-module-type-T-Y.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep6-X.html Ocamlary-Dep6-X.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep6-X-Y.html Ocamlary-Dep6-X-Y.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep7.html Ocamlary-Dep7.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep7-argument-1-Arg.html
+    Ocamlary-Dep7-argument-1-Arg.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep7-argument-1-Arg-module-type-T.html
+    Ocamlary-Dep7-argument-1-Arg-module-type-T.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep7-argument-1-Arg-X.html
+    Ocamlary-Dep7-argument-1-Arg-X.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep7-M.html Ocamlary-Dep7-M.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep8.html Ocamlary-Dep8.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep8-module-type-T.html
+    Ocamlary-Dep8-module-type-T.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep9.html Ocamlary-Dep9.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep9-argument-1-X.html Ocamlary-Dep9-argument-1-X.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-Dep10.html Ocamlary-module-type-Dep10.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep11.html Ocamlary-Dep11.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep11-module-type-S.html
+    Ocamlary-Dep11-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep11-module-type-S-class-c.html
+    Ocamlary-Dep11-module-type-S-class-c.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep12.html Ocamlary-Dep12.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-Dep12-argument-1-Arg.html
+    Ocamlary-Dep12-argument-1-Arg.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep13.html Ocamlary-Dep13.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Dep13-class-c.html Ocamlary-Dep13-class-c.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-With1.html Ocamlary-module-type-With1.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-With1-M.html
+    Ocamlary-module-type-With1-M.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With2.html Ocamlary-With2.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-With2-module-type-S.html
+    Ocamlary-With2-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With3.html Ocamlary-With3.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With3-N.html Ocamlary-With3-N.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With4.html Ocamlary-With4.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With4-N.html Ocamlary-With4-N.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With5.html Ocamlary-With5.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-With5-module-type-S.html
+    Ocamlary-With5-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With5-N.html Ocamlary-With5-N.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With6.html Ocamlary-With6.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-With6-module-type-T.html
+    Ocamlary-With6-module-type-T.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-With6-module-type-T-M.html
+    Ocamlary-With6-module-type-T-M.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With7.html Ocamlary-With7.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-With7-argument-1-X.html
+    Ocamlary-With7-argument-1-X.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-With8.html Ocamlary-module-type-With8.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-With8-M.html
+    Ocamlary-module-type-With8-M.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-With8-M-module-type-S.html
+    Ocamlary-module-type-With8-M-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-With8-M-N.html
+    Ocamlary-module-type-With8-M-N.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With9.html Ocamlary-With9.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-With9-module-type-S.html
+    Ocamlary-With9-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-With10.html Ocamlary-With10.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-With10-module-type-T.html
+    Ocamlary-With10-module-type-T.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-With10-module-type-T-M.html
+    Ocamlary-With10-module-type-T-M.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-With11.html
+    Ocamlary-module-type-With11.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-With11-N.html
+    Ocamlary-module-type-With11-N.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-NestedInclude1.html
+    Ocamlary-module-type-NestedInclude1.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html
+    Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-NestedInclude2.html
+    Ocamlary-module-type-NestedInclude2.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-DoubleInclude1.html Ocamlary-DoubleInclude1.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-DoubleInclude1-DoubleInclude2.html
+    Ocamlary-DoubleInclude1-DoubleInclude2.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-DoubleInclude3.html Ocamlary-DoubleInclude3.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-DoubleInclude3-DoubleInclude2.html
+    Ocamlary-DoubleInclude3-DoubleInclude2.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-IncludeInclude1.html Ocamlary-IncludeInclude1.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html
+    Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-IncludeInclude2.html
+    Ocamlary-module-type-IncludeInclude2.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-CanonicalTest.html Ocamlary-CanonicalTest.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-CanonicalTest-Base__List.html
+    Ocamlary-CanonicalTest-Base__List.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-CanonicalTest-Base__.html
+    Ocamlary-CanonicalTest-Base__.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-CanonicalTest-Base.html
+    Ocamlary-CanonicalTest-Base.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-CanonicalTest-Base-List.html
+    Ocamlary-CanonicalTest-Base-List.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-CanonicalTest-Base__Tests.html
+    Ocamlary-CanonicalTest-Base__Tests.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-CanonicalTest-Base__Tests-C.html
+    Ocamlary-CanonicalTest-Base__Tests-C.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-CanonicalTest-List_modif.html
+    Ocamlary-CanonicalTest-List_modif.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases.html Ocamlary-Aliases.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo__A.html Ocamlary-Aliases-Foo__A.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo__B.html Ocamlary-Aliases-Foo__B.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo__C.html Ocamlary-Aliases-Foo__C.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo__D.html Ocamlary-Aliases-Foo__D.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo__E.html Ocamlary-Aliases-Foo__E.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo__.html Ocamlary-Aliases-Foo__.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo.html Ocamlary-Aliases-Foo.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo-A.html Ocamlary-Aliases-Foo-A.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo-B.html Ocamlary-Aliases-Foo-B.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo-C.html Ocamlary-Aliases-Foo-C.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo-D.html Ocamlary-Aliases-Foo-D.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Foo-E.html Ocamlary-Aliases-Foo-E.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-Std.html Ocamlary-Aliases-Std.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-E.html Ocamlary-Aliases-E.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-P1.html Ocamlary-Aliases-P1.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-P1-Y.html Ocamlary-Aliases-P1-Y.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Aliases-P2.html Ocamlary-Aliases-P2.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-module-type-M.html Ocamlary-module-type-M.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-M.html Ocamlary-M.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary-Only_a_module.html Ocamlary-Only_a_module.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-TypeExt.html
+    Ocamlary-module-type-TypeExt.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary-module-type-TypeExtPruned.html
+    Ocamlary-module-type-TypeExtPruned.html.gen))
   (enabled_if
    (>= %{ocaml_version} 4.07))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary.html html/Ocamlary.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Empty.html html/Ocamlary-Empty.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-Empty.html
-   html/Ocamlary-module-type-Empty.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-MissingComment.html
-   html/Ocamlary-module-type-MissingComment.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-EmptySig.html
-   html/Ocamlary-module-type-EmptySig.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-ModuleWithSignature.html
-   html/Ocamlary-ModuleWithSignature.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-ModuleWithSignatureAlias.html
-   html/Ocamlary-ModuleWithSignatureAlias.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-One.html html/Ocamlary-One.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-SigForMod.html
-   html/Ocamlary-module-type-SigForMod.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-SigForMod-Inner.html
-   html/Ocamlary-module-type-SigForMod-Inner.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-SigForMod-Inner-module-type-Empty.html
-   html/Ocamlary-module-type-SigForMod-Inner-module-type-Empty.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-SuperSig.html
-   html/Ocamlary-module-type-SuperSig.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-SuperSig-module-type-SubSigA.html
-   html/Ocamlary-module-type-SuperSig-module-type-SubSigA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html
-   html/Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-SuperSig-module-type-SubSigB.html
-   html/Ocamlary-module-type-SuperSig-module-type-SubSigB.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-SuperSig-module-type-EmptySig.html
-   html/Ocamlary-module-type-SuperSig-module-type-EmptySig.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-SuperSig-module-type-One.html
-   html/Ocamlary-module-type-SuperSig-module-type-One.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-SuperSig-module-type-SuperSig.html
-   html/Ocamlary-module-type-SuperSig-module-type-SuperSig.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Buffer.html html/Ocamlary-Buffer.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CollectionModule.html
-   html/Ocamlary-CollectionModule.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CollectionModule-InnerModuleA.html
-   html/Ocamlary-CollectionModule-InnerModuleA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html
-   html/Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
-   html/Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-COLLECTION.html
-   html/Ocamlary-module-type-COLLECTION.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-COLLECTION-InnerModuleA.html
-   html/Ocamlary-module-type-COLLECTION-InnerModuleA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html
-   html/Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html
-   html/Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Recollection.html html/Ocamlary-Recollection.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Recollection-argument-1-C.html
-   html/Ocamlary-Recollection-argument-1-C.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Recollection-argument-1-C-InnerModuleA.html
-   html/Ocamlary-Recollection-argument-1-C-InnerModuleA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html
-   html/Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html
-   html/Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Recollection-InnerModuleA.html
-   html/Ocamlary-Recollection-InnerModuleA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html
-   html/Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html
-   html/Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-MMM.html
-   html/Ocamlary-module-type-MMM.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-MMM-C.html
-   html/Ocamlary-module-type-MMM-C.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-MMM-C-InnerModuleA.html
-   html/Ocamlary-module-type-MMM-C-InnerModuleA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html
-   html/Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html
-   html/Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-RECOLLECTION.html
-   html/Ocamlary-module-type-RECOLLECTION.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-RecollectionModule.html
-   html/Ocamlary-module-type-RecollectionModule.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-RecollectionModule-InnerModuleA.html
-   html/Ocamlary-module-type-RecollectionModule-InnerModuleA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html
-   html/Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
-   html/Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-A.html
-   html/Ocamlary-module-type-A.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-A-Q.html
-   html/Ocamlary-module-type-A-Q.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-A-Q-InnerModuleA.html
-   html/Ocamlary-module-type-A-Q-InnerModuleA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html
-   html/Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
-   html/Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-B.html
-   html/Ocamlary-module-type-B.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-B-Q.html
-   html/Ocamlary-module-type-B-Q.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-B-Q-InnerModuleA.html
-   html/Ocamlary-module-type-B-Q-InnerModuleA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html
-   html/Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
-   html/Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-C.html
-   html/Ocamlary-module-type-C.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-C-Q.html
-   html/Ocamlary-module-type-C-Q.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-C-Q-InnerModuleA.html
-   html/Ocamlary-module-type-C-Q-InnerModuleA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html
-   html/Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
-   html/Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-FunctorTypeOf.html
-   html/Ocamlary-FunctorTypeOf.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
-   html/Ocamlary-FunctorTypeOf-argument-1-Collection.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html
-   html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html
-   html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html
-   html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-IncludeModuleType.html
-   html/Ocamlary-module-type-IncludeModuleType.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-ToInclude.html
-   html/Ocamlary-module-type-ToInclude.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-ToInclude-IncludedA.html
-   html/Ocamlary-module-type-ToInclude-IncludedA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-ToInclude-module-type-IncludedB.html
-   html/Ocamlary-module-type-ToInclude-module-type-IncludedB.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-IncludedA.html html/Ocamlary-IncludedA.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-IncludedB.html
-   html/Ocamlary-module-type-IncludedB.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-ExtMod.html html/Ocamlary-ExtMod.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-class-empty_class.html
-   html/Ocamlary-class-empty_class.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-class-one_method_class.html
-   html/Ocamlary-class-one_method_class.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-class-two_method_class.html
-   html/Ocamlary-class-two_method_class.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-class-param_class.html
-   html/Ocamlary-class-param_class.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep1.html html/Ocamlary-Dep1.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep1-module-type-S.html
-   html/Ocamlary-Dep1-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep1-module-type-S-class-c.html
-   html/Ocamlary-Dep1-module-type-S-class-c.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep1-X.html html/Ocamlary-Dep1-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep1-X-Y.html html/Ocamlary-Dep1-X-Y.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep1-X-Y-class-c.html
-   html/Ocamlary-Dep1-X-Y-class-c.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep2.html html/Ocamlary-Dep2.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep2-argument-1-Arg.html
-   html/Ocamlary-Dep2-argument-1-Arg.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep2-argument-1-Arg-X.html
-   html/Ocamlary-Dep2-argument-1-Arg-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep2-A.html html/Ocamlary-Dep2-A.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep3.html html/Ocamlary-Dep3.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep4.html html/Ocamlary-Dep4.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep4-module-type-T.html
-   html/Ocamlary-Dep4-module-type-T.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep4-module-type-S.html
-   html/Ocamlary-Dep4-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep4-module-type-S-X.html
-   html/Ocamlary-Dep4-module-type-S-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep4-module-type-S-Y.html
-   html/Ocamlary-Dep4-module-type-S-Y.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep4-X.html html/Ocamlary-Dep4-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep5.html html/Ocamlary-Dep5.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep5-argument-1-Arg.html
-   html/Ocamlary-Dep5-argument-1-Arg.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep5-argument-1-Arg-module-type-S.html
-   html/Ocamlary-Dep5-argument-1-Arg-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html
-   html/Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep5-Z.html html/Ocamlary-Dep5-Z.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep6.html html/Ocamlary-Dep6.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep6-module-type-S.html
-   html/Ocamlary-Dep6-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep6-module-type-T.html
-   html/Ocamlary-Dep6-module-type-T.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep6-module-type-T-Y.html
-   html/Ocamlary-Dep6-module-type-T-Y.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep6-X.html html/Ocamlary-Dep6-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep6-X-Y.html html/Ocamlary-Dep6-X-Y.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep7.html html/Ocamlary-Dep7.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep7-argument-1-Arg.html
-   html/Ocamlary-Dep7-argument-1-Arg.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep7-argument-1-Arg-module-type-T.html
-   html/Ocamlary-Dep7-argument-1-Arg-module-type-T.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep7-argument-1-Arg-X.html
-   html/Ocamlary-Dep7-argument-1-Arg-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep7-M.html html/Ocamlary-Dep7-M.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep8.html html/Ocamlary-Dep8.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep8-module-type-T.html
-   html/Ocamlary-Dep8-module-type-T.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep9.html html/Ocamlary-Dep9.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep9-argument-1-X.html
-   html/Ocamlary-Dep9-argument-1-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-Dep10.html
-   html/Ocamlary-module-type-Dep10.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep11.html html/Ocamlary-Dep11.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep11-module-type-S.html
-   html/Ocamlary-Dep11-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep11-module-type-S-class-c.html
-   html/Ocamlary-Dep11-module-type-S-class-c.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep12.html html/Ocamlary-Dep12.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep12-argument-1-Arg.html
-   html/Ocamlary-Dep12-argument-1-Arg.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Dep13.html html/Ocamlary-Dep13.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Dep13-class-c.html
-   html/Ocamlary-Dep13-class-c.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-With1.html
-   html/Ocamlary-module-type-With1.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-With1-M.html
-   html/Ocamlary-module-type-With1-M.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With2.html html/Ocamlary-With2.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-With2-module-type-S.html
-   html/Ocamlary-With2-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With3.html html/Ocamlary-With3.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With3-N.html html/Ocamlary-With3-N.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With4.html html/Ocamlary-With4.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With4-N.html html/Ocamlary-With4-N.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With5.html html/Ocamlary-With5.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-With5-module-type-S.html
-   html/Ocamlary-With5-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With5-N.html html/Ocamlary-With5-N.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With6.html html/Ocamlary-With6.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-With6-module-type-T.html
-   html/Ocamlary-With6-module-type-T.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-With6-module-type-T-M.html
-   html/Ocamlary-With6-module-type-T-M.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With7.html html/Ocamlary-With7.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-With7-argument-1-X.html
-   html/Ocamlary-With7-argument-1-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-With8.html
-   html/Ocamlary-module-type-With8.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-With8-M.html
-   html/Ocamlary-module-type-With8-M.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-With8-M-module-type-S.html
-   html/Ocamlary-module-type-With8-M-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-With8-M-N.html
-   html/Ocamlary-module-type-With8-M-N.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With9.html html/Ocamlary-With9.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-With9-module-type-S.html
-   html/Ocamlary-With9-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-With10.html html/Ocamlary-With10.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-With10-module-type-T.html
-   html/Ocamlary-With10-module-type-T.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-With10-module-type-T-M.html
-   html/Ocamlary-With10-module-type-T-M.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-With11.html
-   html/Ocamlary-module-type-With11.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-With11-N.html
-   html/Ocamlary-module-type-With11-N.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-NestedInclude1.html
-   html/Ocamlary-module-type-NestedInclude1.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html
-   html/Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-NestedInclude2.html
-   html/Ocamlary-module-type-NestedInclude2.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-DoubleInclude1.html
-   html/Ocamlary-DoubleInclude1.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-DoubleInclude1-DoubleInclude2.html
-   html/Ocamlary-DoubleInclude1-DoubleInclude2.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-DoubleInclude3.html
-   html/Ocamlary-DoubleInclude3.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-DoubleInclude3-DoubleInclude2.html
-   html/Ocamlary-DoubleInclude3-DoubleInclude2.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-IncludeInclude1.html
-   html/Ocamlary-IncludeInclude1.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html
-   html/Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-IncludeInclude2.html
-   html/Ocamlary-module-type-IncludeInclude2.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CanonicalTest.html
-   html/Ocamlary-CanonicalTest.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CanonicalTest-Base__List.html
-   html/Ocamlary-CanonicalTest-Base__List.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CanonicalTest-Base__.html
-   html/Ocamlary-CanonicalTest-Base__.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CanonicalTest-Base.html
-   html/Ocamlary-CanonicalTest-Base.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CanonicalTest-Base-List.html
-   html/Ocamlary-CanonicalTest-Base-List.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CanonicalTest-Base__Tests.html
-   html/Ocamlary-CanonicalTest-Base__Tests.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CanonicalTest-Base__Tests-C.html
-   html/Ocamlary-CanonicalTest-Base__Tests-C.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-CanonicalTest-List_modif.html
-   html/Ocamlary-CanonicalTest-List_modif.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Aliases.html html/Ocamlary-Aliases.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo__A.html
-   html/Ocamlary-Aliases-Foo__A.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo__B.html
-   html/Ocamlary-Aliases-Foo__B.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo__C.html
-   html/Ocamlary-Aliases-Foo__C.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo__D.html
-   html/Ocamlary-Aliases-Foo__D.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo__E.html
-   html/Ocamlary-Aliases-Foo__E.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo__.html
-   html/Ocamlary-Aliases-Foo__.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Aliases-Foo.html html/Ocamlary-Aliases-Foo.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo-A.html
-   html/Ocamlary-Aliases-Foo-A.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo-B.html
-   html/Ocamlary-Aliases-Foo-B.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo-C.html
-   html/Ocamlary-Aliases-Foo-C.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo-D.html
-   html/Ocamlary-Aliases-Foo-D.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Aliases-Foo-E.html
-   html/Ocamlary-Aliases-Foo-E.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Aliases-Std.html html/Ocamlary-Aliases-Std.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Aliases-E.html html/Ocamlary-Aliases-E.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Aliases-P1.html html/Ocamlary-Aliases-P1.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Aliases-P1-Y.html html/Ocamlary-Aliases-P1-Y.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-Aliases-P2.html html/Ocamlary-Aliases-P2.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-M.html
-   html/Ocamlary-module-type-M.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Ocamlary-M.html html/Ocamlary-M.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-Only_a_module.html
-   html/Ocamlary-Only_a_module.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-TypeExt.html
-   html/Ocamlary-module-type-TypeExt.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Ocamlary-module-type-TypeExtPruned.html
-   html/Ocamlary-module-type-TypeExtPruned.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    ocamlary.gen
+    ocamlary.targets.gen
     (run odoc html-targets -o . %{dep:../ocamlary.odocl} --flat)))
   (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff ocamlary.targets ocamlary.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.07))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/ocamlary.targets html/ocamlary.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
 
 (subdir
  latex
@@ -5031,205 +4322,167 @@
    Ocamlary.With4.N.tex.gen
    Ocamlary.With7.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../ocamlary.odocl})))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../ocamlary.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.tex Ocamlary.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.ModuleWithSignature.tex
+    Ocamlary.ModuleWithSignature.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.ModuleWithSignatureAlias.tex
+    Ocamlary.ModuleWithSignatureAlias.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Recollection.tex Ocamlary.Recollection.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.FunctorTypeOf.tex Ocamlary.FunctorTypeOf.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.empty_class.tex Ocamlary.empty_class.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.one_method_class.tex Ocamlary.one_method_class.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.two_method_class.tex Ocamlary.two_method_class.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.param_class.tex Ocamlary.param_class.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep2.tex Ocamlary.Dep2.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep5.tex Ocamlary.Dep5.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep5.Z.tex Ocamlary.Dep5.Z.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep7.tex Ocamlary.Dep7.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep7.M.tex Ocamlary.Dep7.M.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep9.tex Ocamlary.Dep9.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep12.tex Ocamlary.Dep12.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep13.tex Ocamlary.Dep13.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep13.c.tex Ocamlary.Dep13.c.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With3.tex Ocamlary.With3.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With3.N.tex Ocamlary.With3.N.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With4.tex Ocamlary.With4.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With4.N.tex Ocamlary.With4.N.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With7.tex Ocamlary.With7.tex.gen))
   (enabled_if
    (>= %{ocaml_version} 4.07))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.tex latex/Ocamlary.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   latex/Ocamlary.ModuleWithSignature.tex
-   latex/Ocamlary.ModuleWithSignature.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   latex/Ocamlary.ModuleWithSignatureAlias.tex
-   latex/Ocamlary.ModuleWithSignatureAlias.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.Recollection.tex latex/Ocamlary.Recollection.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   latex/Ocamlary.FunctorTypeOf.tex
-   latex/Ocamlary.FunctorTypeOf.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.empty_class.tex latex/Ocamlary.empty_class.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   latex/Ocamlary.one_method_class.tex
-   latex/Ocamlary.one_method_class.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   latex/Ocamlary.two_method_class.tex
-   latex/Ocamlary.two_method_class.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.param_class.tex latex/Ocamlary.param_class.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.Dep2.tex latex/Ocamlary.Dep2.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.Dep5.tex latex/Ocamlary.Dep5.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.Dep5.Z.tex latex/Ocamlary.Dep5.Z.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.Dep7.tex latex/Ocamlary.Dep7.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.Dep7.M.tex latex/Ocamlary.Dep7.M.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.Dep9.tex latex/Ocamlary.Dep9.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.Dep12.tex latex/Ocamlary.Dep12.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.Dep13.tex latex/Ocamlary.Dep13.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.Dep13.c.tex latex/Ocamlary.Dep13.c.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.With3.tex latex/Ocamlary.With3.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.With3.N.tex latex/Ocamlary.With3.N.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.With4.tex latex/Ocamlary.With4.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.With4.N.tex latex/Ocamlary.With4.N.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Ocamlary.With7.tex latex/Ocamlary.With7.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    ocamlary.gen
+    ocamlary.targets.gen
     (run odoc latex-targets -o . %{dep:../ocamlary.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff ocamlary.targets ocamlary.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.07))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/ocamlary.targets latex/ocamlary.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
 
 (subdir
  man
@@ -5321,658 +4574,561 @@
    Ocamlary.M.3o.gen
    Ocamlary.Only_a_module.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../ocamlary.odocl})))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../ocamlary.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.3o Ocamlary.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Empty.3o Ocamlary.Empty.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.ModuleWithSignature.3o Ocamlary.ModuleWithSignature.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.ModuleWithSignatureAlias.3o
+    Ocamlary.ModuleWithSignatureAlias.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.One.3o Ocamlary.One.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Buffer.3o Ocamlary.Buffer.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.CollectionModule.3o Ocamlary.CollectionModule.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.CollectionModule.InnerModuleA.3o
+    Ocamlary.CollectionModule.InnerModuleA.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.CollectionModule.InnerModuleA.InnerModuleA'.3o
+    Ocamlary.CollectionModule.InnerModuleA.InnerModuleA'.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Recollection.3o Ocamlary.Recollection.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.Recollection.InnerModuleA.3o
+    Ocamlary.Recollection.InnerModuleA.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.Recollection.InnerModuleA.InnerModuleA'.3o
+    Ocamlary.Recollection.InnerModuleA.InnerModuleA'.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.FunctorTypeOf.3o Ocamlary.FunctorTypeOf.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.IncludedA.3o Ocamlary.IncludedA.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.ExtMod.3o Ocamlary.ExtMod.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.empty_class.3o Ocamlary.empty_class.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.one_method_class.3o Ocamlary.one_method_class.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.two_method_class.3o Ocamlary.two_method_class.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.param_class.3o Ocamlary.param_class.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep1.3o Ocamlary.Dep1.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep1.X.3o Ocamlary.Dep1.X.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep1.X.Y.3o Ocamlary.Dep1.X.Y.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep1.X.Y.c.3o Ocamlary.Dep1.X.Y.c.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep2.3o Ocamlary.Dep2.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep2.A.3o Ocamlary.Dep2.A.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep3.3o Ocamlary.Dep3.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep4.3o Ocamlary.Dep4.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep4.X.3o Ocamlary.Dep4.X.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep5.3o Ocamlary.Dep5.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep5.Z.3o Ocamlary.Dep5.Z.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep6.3o Ocamlary.Dep6.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep6.X.3o Ocamlary.Dep6.X.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep6.X.Y.3o Ocamlary.Dep6.X.Y.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep7.3o Ocamlary.Dep7.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep7.M.3o Ocamlary.Dep7.M.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep8.3o Ocamlary.Dep8.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep9.3o Ocamlary.Dep9.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep11.3o Ocamlary.Dep11.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep12.3o Ocamlary.Dep12.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep13.3o Ocamlary.Dep13.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Dep13.c.3o Ocamlary.Dep13.c.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With2.3o Ocamlary.With2.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With3.3o Ocamlary.With3.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With3.N.3o Ocamlary.With3.N.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With4.3o Ocamlary.With4.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With4.N.3o Ocamlary.With4.N.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With5.3o Ocamlary.With5.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With5.N.3o Ocamlary.With5.N.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With6.3o Ocamlary.With6.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With7.3o Ocamlary.With7.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With9.3o Ocamlary.With9.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.With10.3o Ocamlary.With10.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.DoubleInclude1.3o Ocamlary.DoubleInclude1.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.DoubleInclude1.DoubleInclude2.3o
+    Ocamlary.DoubleInclude1.DoubleInclude2.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.DoubleInclude3.3o Ocamlary.DoubleInclude3.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.DoubleInclude3.DoubleInclude2.3o
+    Ocamlary.DoubleInclude3.DoubleInclude2.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.IncludeInclude1.3o Ocamlary.IncludeInclude1.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.CanonicalTest.3o Ocamlary.CanonicalTest.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.CanonicalTest.Base__List.3o
+    Ocamlary.CanonicalTest.Base__List.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.CanonicalTest.Base__.3o
+    Ocamlary.CanonicalTest.Base__.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.CanonicalTest.Base.3o Ocamlary.CanonicalTest.Base.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.CanonicalTest.Base.List.3o
+    Ocamlary.CanonicalTest.Base.List.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.CanonicalTest.Base__Tests.3o
+    Ocamlary.CanonicalTest.Base__Tests.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.CanonicalTest.Base__Tests.C.3o
+    Ocamlary.CanonicalTest.Base__Tests.C.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Ocamlary.CanonicalTest.List_modif.3o
+    Ocamlary.CanonicalTest.List_modif.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.3o Ocamlary.Aliases.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo__A.3o Ocamlary.Aliases.Foo__A.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo__B.3o Ocamlary.Aliases.Foo__B.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo__C.3o Ocamlary.Aliases.Foo__C.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo__D.3o Ocamlary.Aliases.Foo__D.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo__E.3o Ocamlary.Aliases.Foo__E.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo__.3o Ocamlary.Aliases.Foo__.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo.3o Ocamlary.Aliases.Foo.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo.A.3o Ocamlary.Aliases.Foo.A.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo.B.3o Ocamlary.Aliases.Foo.B.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo.C.3o Ocamlary.Aliases.Foo.C.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo.D.3o Ocamlary.Aliases.Foo.D.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Foo.E.3o Ocamlary.Aliases.Foo.E.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.Std.3o Ocamlary.Aliases.Std.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.E.3o Ocamlary.Aliases.E.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.P1.3o Ocamlary.Aliases.P1.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.P1.Y.3o Ocamlary.Aliases.P1.Y.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Aliases.P2.3o Ocamlary.Aliases.P2.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.M.3o Ocamlary.M.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Ocamlary.Only_a_module.3o Ocamlary.Only_a_module.3o.gen))
   (enabled_if
    (>= %{ocaml_version} 4.07))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.3o man/Ocamlary.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Empty.3o man/Ocamlary.Empty.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.ModuleWithSignature.3o
-   man/Ocamlary.ModuleWithSignature.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.ModuleWithSignatureAlias.3o
-   man/Ocamlary.ModuleWithSignatureAlias.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.One.3o man/Ocamlary.One.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Buffer.3o man/Ocamlary.Buffer.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.CollectionModule.3o
-   man/Ocamlary.CollectionModule.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.CollectionModule.InnerModuleA.3o
-   man/Ocamlary.CollectionModule.InnerModuleA.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.CollectionModule.InnerModuleA.InnerModuleA'.3o
-   man/Ocamlary.CollectionModule.InnerModuleA.InnerModuleA'.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Recollection.3o man/Ocamlary.Recollection.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.Recollection.InnerModuleA.3o
-   man/Ocamlary.Recollection.InnerModuleA.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.Recollection.InnerModuleA.InnerModuleA'.3o
-   man/Ocamlary.Recollection.InnerModuleA.InnerModuleA'.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.FunctorTypeOf.3o man/Ocamlary.FunctorTypeOf.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.IncludedA.3o man/Ocamlary.IncludedA.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.ExtMod.3o man/Ocamlary.ExtMod.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.empty_class.3o man/Ocamlary.empty_class.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.one_method_class.3o
-   man/Ocamlary.one_method_class.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.two_method_class.3o
-   man/Ocamlary.two_method_class.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.param_class.3o man/Ocamlary.param_class.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep1.3o man/Ocamlary.Dep1.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep1.X.3o man/Ocamlary.Dep1.X.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep1.X.Y.3o man/Ocamlary.Dep1.X.Y.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep1.X.Y.c.3o man/Ocamlary.Dep1.X.Y.c.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep2.3o man/Ocamlary.Dep2.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep2.A.3o man/Ocamlary.Dep2.A.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep3.3o man/Ocamlary.Dep3.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep4.3o man/Ocamlary.Dep4.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep4.X.3o man/Ocamlary.Dep4.X.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep5.3o man/Ocamlary.Dep5.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep5.Z.3o man/Ocamlary.Dep5.Z.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep6.3o man/Ocamlary.Dep6.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep6.X.3o man/Ocamlary.Dep6.X.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep6.X.Y.3o man/Ocamlary.Dep6.X.Y.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep7.3o man/Ocamlary.Dep7.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep7.M.3o man/Ocamlary.Dep7.M.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep8.3o man/Ocamlary.Dep8.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep9.3o man/Ocamlary.Dep9.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep11.3o man/Ocamlary.Dep11.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep12.3o man/Ocamlary.Dep12.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep13.3o man/Ocamlary.Dep13.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Dep13.c.3o man/Ocamlary.Dep13.c.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With2.3o man/Ocamlary.With2.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With3.3o man/Ocamlary.With3.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With3.N.3o man/Ocamlary.With3.N.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With4.3o man/Ocamlary.With4.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With4.N.3o man/Ocamlary.With4.N.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With5.3o man/Ocamlary.With5.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With5.N.3o man/Ocamlary.With5.N.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With6.3o man/Ocamlary.With6.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With7.3o man/Ocamlary.With7.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With9.3o man/Ocamlary.With9.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.With10.3o man/Ocamlary.With10.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.DoubleInclude1.3o man/Ocamlary.DoubleInclude1.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.DoubleInclude1.DoubleInclude2.3o
-   man/Ocamlary.DoubleInclude1.DoubleInclude2.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.DoubleInclude3.3o man/Ocamlary.DoubleInclude3.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.DoubleInclude3.DoubleInclude2.3o
-   man/Ocamlary.DoubleInclude3.DoubleInclude2.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.IncludeInclude1.3o man/Ocamlary.IncludeInclude1.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.CanonicalTest.3o man/Ocamlary.CanonicalTest.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.CanonicalTest.Base__List.3o
-   man/Ocamlary.CanonicalTest.Base__List.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.CanonicalTest.Base__.3o
-   man/Ocamlary.CanonicalTest.Base__.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.CanonicalTest.Base.3o
-   man/Ocamlary.CanonicalTest.Base.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.CanonicalTest.Base.List.3o
-   man/Ocamlary.CanonicalTest.Base.List.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.CanonicalTest.Base__Tests.3o
-   man/Ocamlary.CanonicalTest.Base__Tests.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.CanonicalTest.Base__Tests.C.3o
-   man/Ocamlary.CanonicalTest.Base__Tests.C.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Ocamlary.CanonicalTest.List_modif.3o
-   man/Ocamlary.CanonicalTest.List_modif.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.3o man/Ocamlary.Aliases.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo__A.3o man/Ocamlary.Aliases.Foo__A.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo__B.3o man/Ocamlary.Aliases.Foo__B.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo__C.3o man/Ocamlary.Aliases.Foo__C.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo__D.3o man/Ocamlary.Aliases.Foo__D.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo__E.3o man/Ocamlary.Aliases.Foo__E.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo__.3o man/Ocamlary.Aliases.Foo__.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo.3o man/Ocamlary.Aliases.Foo.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo.A.3o man/Ocamlary.Aliases.Foo.A.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo.B.3o man/Ocamlary.Aliases.Foo.B.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo.C.3o man/Ocamlary.Aliases.Foo.C.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo.D.3o man/Ocamlary.Aliases.Foo.D.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Foo.E.3o man/Ocamlary.Aliases.Foo.E.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.Std.3o man/Ocamlary.Aliases.Std.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.E.3o man/Ocamlary.Aliases.E.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.P1.3o man/Ocamlary.Aliases.P1.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.P1.Y.3o man/Ocamlary.Aliases.P1.Y.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Aliases.P2.3o man/Ocamlary.Aliases.P2.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.M.3o man/Ocamlary.M.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Ocamlary.Only_a_module.3o man/Ocamlary.Only_a_module.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    ocamlary.gen
+    ocamlary.targets.gen
     (run odoc man-targets -o . %{dep:../ocamlary.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.07)))
+ (rule
+  (alias runtest)
+  (action
+   (diff ocamlary.targets ocamlary.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.07))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/ocamlary.targets man/ocamlary.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.07)))
 
 (subdir
  html
@@ -5988,137 +5144,121 @@
    Recent-X.html.gen
    Recent-module-type-PolyS.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../recent.odocl})))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../recent.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent.html Recent.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent-module-type-S.html Recent-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent-module-type-S1.html Recent-module-type-S1.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Recent-module-type-S1-argument-1-_.html
+    Recent-module-type-S1-argument-1-_.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent-Z.html Recent-Z.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent-Z-Y.html Recent-Z-Y.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent-Z-Y-X.html Recent-Z-Y-X.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent-X.html Recent-X.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent-module-type-PolyS.html Recent-module-type-PolyS.html.gen))
   (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent.html html/Recent.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent-module-type-S.html html/Recent-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent-module-type-S1.html html/Recent-module-type-S1.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Recent-module-type-S1-argument-1-_.html
-   html/Recent-module-type-S1-argument-1-_.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent-Z.html html/Recent-Z.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent-Z-Y.html html/Recent-Z-Y.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent-Z-Y-X.html html/Recent-Z-Y-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent-X.html html/Recent-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Recent-module-type-PolyS.html
-   html/Recent-module-type-PolyS.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    recent.gen
+    recent.targets.gen
     (run odoc html-targets -o . %{dep:../recent.odocl} --flat)))
   (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff recent.targets recent.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/recent.targets html/recent.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  latex
  (rule
   (targets Recent.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../recent.odocl})))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../recent.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent.tex Recent.tex.gen))
   (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Recent.tex latex/Recent.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    recent.gen
+    recent.targets.gen
     (run odoc latex-targets -o . %{dep:../recent.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff recent.targets recent.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/recent.targets latex/recent.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  man
@@ -6130,62 +5270,55 @@
    Recent.Z.Y.X.3o.gen
    Recent.X.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../recent.odocl})))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../recent.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent.3o Recent.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent.Z.3o Recent.Z.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent.Z.Y.3o Recent.Z.Y.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent.Z.Y.X.3o Recent.Z.Y.X.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent.X.3o Recent.X.3o.gen))
   (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Recent.3o man/Recent.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Recent.Z.3o man/Recent.Z.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Recent.Z.Y.3o man/Recent.Z.Y.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Recent.Z.Y.X.3o man/Recent.Z.Y.X.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Recent.X.3o man/Recent.X.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    recent.gen
+    recent.targets.gen
     (run odoc man-targets -o . %{dep:../recent.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff recent.targets recent.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/recent.targets man/recent.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  html
@@ -6201,155 +5334,138 @@
    Recent_impl-module-type-S-F-argument-1-_.html.gen
    Recent_impl-module-type-S-X.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../recent_impl.odocl})))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../recent_impl.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl.html Recent_impl.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl-Foo.html Recent_impl-Foo.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl-Foo-A.html Recent_impl-Foo-A.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl-Foo-B.html Recent_impl-Foo-B.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl-B.html Recent_impl-B.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl-module-type-S.html Recent_impl-module-type-S.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Recent_impl-module-type-S-F.html
+    Recent_impl-module-type-S-F.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Recent_impl-module-type-S-F-argument-1-_.html
+    Recent_impl-module-type-S-F-argument-1-_.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Recent_impl-module-type-S-X.html
+    Recent_impl-module-type-S-X.html.gen))
   (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent_impl.html html/Recent_impl.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent_impl-Foo.html html/Recent_impl-Foo.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent_impl-Foo-A.html html/Recent_impl-Foo-A.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent_impl-Foo-B.html html/Recent_impl-Foo-B.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Recent_impl-B.html html/Recent_impl-B.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Recent_impl-module-type-S.html
-   html/Recent_impl-module-type-S.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Recent_impl-module-type-S-F.html
-   html/Recent_impl-module-type-S-F.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Recent_impl-module-type-S-F-argument-1-_.html
-   html/Recent_impl-module-type-S-F-argument-1-_.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Recent_impl-module-type-S-X.html
-   html/Recent_impl-module-type-S-X.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    recent_impl.gen
+    recent_impl.targets.gen
     (run odoc html-targets -o . %{dep:../recent_impl.odocl} --flat)))
   (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff recent_impl.targets recent_impl.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/recent_impl.targets html/recent_impl.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  latex
  (rule
   (targets Recent_impl.tex.gen Recent_impl.B.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../recent_impl.odocl})))
+   (run
+    odoc
+    latex-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../recent_impl.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl.tex Recent_impl.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl.B.tex Recent_impl.B.tex.gen))
   (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Recent_impl.tex latex/Recent_impl.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Recent_impl.B.tex latex/Recent_impl.B.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    recent_impl.gen
+    recent_impl.targets.gen
     (run odoc latex-targets -o . %{dep:../recent_impl.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff recent_impl.targets recent_impl.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/recent_impl.targets latex/recent_impl.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  man
@@ -6361,394 +5477,354 @@
    Recent_impl.Foo.B.3o.gen
    Recent_impl.B.3o.gen)
   (action
-   (progn
-    (run
-     odoc
-     man-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../recent_impl.odocl})))
+   (run
+    odoc
+    man-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../recent_impl.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl.3o Recent_impl.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl.Foo.3o Recent_impl.Foo.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl.Foo.A.3o Recent_impl.Foo.A.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl.Foo.B.3o Recent_impl.Foo.B.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Recent_impl.B.3o Recent_impl.B.3o.gen))
   (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Recent_impl.3o man/Recent_impl.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Recent_impl.Foo.3o man/Recent_impl.Foo.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Recent_impl.Foo.A.3o man/Recent_impl.Foo.A.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Recent_impl.Foo.B.3o man/Recent_impl.Foo.B.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Recent_impl.B.3o man/Recent_impl.B.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    recent_impl.gen
+    recent_impl.targets.gen
     (run odoc man-targets -o . %{dep:../recent_impl.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.09)))
+ (rule
+  (alias runtest)
+  (action
+   (diff recent_impl.targets recent_impl.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.09))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/recent_impl.targets man/recent_impl.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.09)))
 
 (subdir
  html
  (rule
   (targets Section.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../section.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Section.html html/Section.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../section.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Section.html Section.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    section.gen
-    (run odoc html-targets -o . %{dep:../section.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/section.targets html/section.gen)))
+    section.targets.gen
+    (run odoc html-targets -o . %{dep:../section.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff section.targets section.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Section.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../section.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Section.tex latex/Section.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../section.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Section.tex Section.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    section.gen
-    (run odoc latex-targets -o . %{dep:../section.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/section.targets latex/section.gen)))
+    section.targets.gen
+    (run odoc latex-targets -o . %{dep:../section.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff section.targets section.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Section.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../section.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Section.3o man/Section.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../section.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Section.3o Section.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    section.gen
-    (run odoc man-targets -o . %{dep:../section.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/section.targets man/section.gen)))
+    section.targets.gen
+    (run odoc man-targets -o . %{dep:../section.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff section.targets section.targets.gen))))
 
 (subdir
  html
  (rule
   (targets Stop.html.gen Stop-N.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../stop.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Stop.html html/Stop.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Stop-N.html html/Stop-N.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../stop.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop.html Stop.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop-N.html Stop-N.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    stop.gen
-    (run odoc html-targets -o . %{dep:../stop.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/stop.targets html/stop.gen)))
+    stop.targets.gen
+    (run odoc html-targets -o . %{dep:../stop.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff stop.targets stop.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Stop.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../stop.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Stop.tex latex/Stop.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../stop.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop.tex Stop.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    stop.gen
-    (run odoc latex-targets -o . %{dep:../stop.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/stop.targets latex/stop.gen)))
+    stop.targets.gen
+    (run odoc latex-targets -o . %{dep:../stop.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff stop.targets stop.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Stop.3o.gen Stop.N.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../stop.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Stop.3o man/Stop.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Stop.N.3o man/Stop.N.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../stop.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop.3o Stop.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop.N.3o Stop.N.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    stop.gen
-    (run odoc man-targets -o . %{dep:../stop.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/stop.targets man/stop.gen)))
+    stop.targets.gen
+    (run odoc man-targets -o . %{dep:../stop.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff stop.targets stop.targets.gen))))
 
 (subdir
  html
  (rule
   (targets Stop_dead_link_doc.html.gen Stop_dead_link_doc-Foo.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../stop_dead_link_doc.odocl})))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../stop_dead_link_doc.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop_dead_link_doc.html Stop_dead_link_doc.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop_dead_link_doc-Foo.html Stop_dead_link_doc-Foo.html.gen))
   (enabled_if
    (>= %{ocaml_version} 4.04))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Stop_dead_link_doc.html html/Stop_dead_link_doc.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.04)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Stop_dead_link_doc-Foo.html
-   html/Stop_dead_link_doc-Foo.html.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.04)))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    stop_dead_link_doc.gen
+    stop_dead_link_doc.targets.gen
     (run odoc html-targets -o . %{dep:../stop_dead_link_doc.odocl} --flat)))
   (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (action
+   (diff stop_dead_link_doc.targets stop_dead_link_doc.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.04))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/stop_dead_link_doc.targets html/stop_dead_link_doc.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.04)))
 
 (subdir
  latex
  (rule
   (targets Stop_dead_link_doc.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../stop_dead_link_doc.odocl})))
+   (run
+    odoc
+    latex-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../stop_dead_link_doc.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop_dead_link_doc.tex Stop_dead_link_doc.tex.gen))
   (enabled_if
    (>= %{ocaml_version} 4.04))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Stop_dead_link_doc.tex latex/Stop_dead_link_doc.tex.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.04)))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    stop_dead_link_doc.gen
+    stop_dead_link_doc.targets.gen
     (run odoc latex-targets -o . %{dep:../stop_dead_link_doc.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (action
+   (diff stop_dead_link_doc.targets stop_dead_link_doc.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.04))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/stop_dead_link_doc.targets latex/stop_dead_link_doc.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.04)))
 
 (subdir
  man
  (rule
   (targets Stop_dead_link_doc.3o.gen Stop_dead_link_doc.Foo.3o.gen)
   (action
-   (progn
-    (run
-     odoc
-     man-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../stop_dead_link_doc.odocl})))
+   (run
+    odoc
+    man-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../stop_dead_link_doc.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop_dead_link_doc.3o Stop_dead_link_doc.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop_dead_link_doc.Foo.3o Stop_dead_link_doc.Foo.3o.gen))
   (enabled_if
    (>= %{ocaml_version} 4.04))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Stop_dead_link_doc.3o man/Stop_dead_link_doc.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.04)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Stop_dead_link_doc.Foo.3o man/Stop_dead_link_doc.Foo.3o.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.04)))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    stop_dead_link_doc.gen
+    stop_dead_link_doc.targets.gen
     (run odoc man-targets -o . %{dep:../stop_dead_link_doc.odocl})))
   (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (action
+   (diff stop_dead_link_doc.targets stop_dead_link_doc.targets.gen))
+  (enabled_if
    (>= %{ocaml_version} 4.04))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/stop_dead_link_doc.targets man/stop_dead_link_doc.gen))
- (enabled_if
-  (>= %{ocaml_version} 4.04)))
 
 (subdir
  html
@@ -6769,120 +5845,98 @@
    Toplevel_comments-class-c2.html.gen
    Toplevel_comments-Ref_in_synopsis.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../toplevel_comments.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Toplevel_comments.html html/Toplevel_comments.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Toplevel_comments-module-type-T.html
-   html/Toplevel_comments-module-type-T.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Toplevel_comments-Include_inline.html
-   html/Toplevel_comments-Include_inline.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Toplevel_comments-Include_inline'.html
-   html/Toplevel_comments-Include_inline'.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Toplevel_comments-module-type-Include_inline_T.html
-   html/Toplevel_comments-module-type-Include_inline_T.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Toplevel_comments-module-type-Include_inline_T'.html
-   html/Toplevel_comments-module-type-Include_inline_T'.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Toplevel_comments-M.html html/Toplevel_comments-M.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Toplevel_comments-M'.html html/Toplevel_comments-M'.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Toplevel_comments-M''.html html/Toplevel_comments-M''.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Toplevel_comments-Alias.html
-   html/Toplevel_comments-Alias.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Toplevel_comments-class-c1.html
-   html/Toplevel_comments-class-c1.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Toplevel_comments-class-type-ct.html
-   html/Toplevel_comments-class-type-ct.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Toplevel_comments-class-c2.html
-   html/Toplevel_comments-class-c2.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   html/Toplevel_comments-Ref_in_synopsis.html
-   html/Toplevel_comments-Ref_in_synopsis.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../toplevel_comments.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.html Toplevel_comments.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Toplevel_comments-module-type-T.html
+    Toplevel_comments-module-type-T.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Toplevel_comments-Include_inline.html
+    Toplevel_comments-Include_inline.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Toplevel_comments-Include_inline'.html
+    Toplevel_comments-Include_inline'.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Toplevel_comments-module-type-Include_inline_T.html
+    Toplevel_comments-module-type-Include_inline_T.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Toplevel_comments-module-type-Include_inline_T'.html
+    Toplevel_comments-module-type-Include_inline_T'.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments-M.html Toplevel_comments-M.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments-M'.html Toplevel_comments-M'.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments-M''.html Toplevel_comments-M''.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments-Alias.html Toplevel_comments-Alias.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments-class-c1.html Toplevel_comments-class-c1.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Toplevel_comments-class-type-ct.html
+    Toplevel_comments-class-type-ct.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments-class-c2.html Toplevel_comments-class-c2.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Toplevel_comments-Ref_in_synopsis.html
+    Toplevel_comments-Ref_in_synopsis.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    toplevel_comments.gen
-    (run odoc html-targets -o . %{dep:../toplevel_comments.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/toplevel_comments.targets html/toplevel_comments.gen)))
+    toplevel_comments.targets.gen
+    (run odoc html-targets -o . %{dep:../toplevel_comments.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff toplevel_comments.targets toplevel_comments.targets.gen))))
 
 (subdir
  latex
@@ -6893,50 +5947,42 @@
    Toplevel_comments.c1.tex.gen
    Toplevel_comments.c2.tex.gen)
   (action
-   (progn
-    (run
-     odoc
-     latex-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../toplevel_comments.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Toplevel_comments.tex latex/Toplevel_comments.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   latex/Toplevel_comments.Alias.tex
-   latex/Toplevel_comments.Alias.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Toplevel_comments.c1.tex latex/Toplevel_comments.c1.tex.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Toplevel_comments.c2.tex latex/Toplevel_comments.c2.tex.gen)))
+   (run
+    odoc
+    latex-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../toplevel_comments.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.tex Toplevel_comments.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.Alias.tex Toplevel_comments.Alias.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.c1.tex Toplevel_comments.c1.tex.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.c2.tex Toplevel_comments.c2.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    toplevel_comments.gen
-    (run odoc latex-targets -o . %{dep:../toplevel_comments.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/toplevel_comments.targets latex/toplevel_comments.gen)))
+    toplevel_comments.targets.gen
+    (run odoc latex-targets -o . %{dep:../toplevel_comments.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff toplevel_comments.targets toplevel_comments.targets.gen))))
 
 (subdir
  man
@@ -6953,260 +5999,229 @@
    Toplevel_comments.c2.3o.gen
    Toplevel_comments.Ref_in_synopsis.3o.gen)
   (action
-   (progn
-    (run
-     odoc
-     man-generate
-     -o
-     .
-     --extra-suffix
-     gen
-     %{dep:../toplevel_comments.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Toplevel_comments.3o man/Toplevel_comments.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Toplevel_comments.Include_inline.3o
-   man/Toplevel_comments.Include_inline.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Toplevel_comments.Include_inline'.3o
-   man/Toplevel_comments.Include_inline'.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Toplevel_comments.M.3o man/Toplevel_comments.M.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Toplevel_comments.M'.3o man/Toplevel_comments.M'.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Toplevel_comments.M''.3o man/Toplevel_comments.M''.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Toplevel_comments.Alias.3o man/Toplevel_comments.Alias.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Toplevel_comments.c1.3o man/Toplevel_comments.c1.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Toplevel_comments.c2.3o man/Toplevel_comments.c2.3o.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff
-   man/Toplevel_comments.Ref_in_synopsis.3o
-   man/Toplevel_comments.Ref_in_synopsis.3o.gen)))
+   (run
+    odoc
+    man-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../toplevel_comments.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.3o Toplevel_comments.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Toplevel_comments.Include_inline.3o
+    Toplevel_comments.Include_inline.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Toplevel_comments.Include_inline'.3o
+    Toplevel_comments.Include_inline'.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.M.3o Toplevel_comments.M.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.M'.3o Toplevel_comments.M'.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.M''.3o Toplevel_comments.M''.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.Alias.3o Toplevel_comments.Alias.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.c1.3o Toplevel_comments.c1.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Toplevel_comments.c2.3o Toplevel_comments.c2.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff
+    Toplevel_comments.Ref_in_synopsis.3o
+    Toplevel_comments.Ref_in_synopsis.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    toplevel_comments.gen
-    (run odoc man-targets -o . %{dep:../toplevel_comments.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/toplevel_comments.targets man/toplevel_comments.gen)))
+    toplevel_comments.targets.gen
+    (run odoc man-targets -o . %{dep:../toplevel_comments.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff toplevel_comments.targets toplevel_comments.targets.gen))))
 
 (subdir
  html
  (rule
   (targets Type.html.gen Type-module-type-X.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../type.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Type.html html/Type.html.gen)))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Type-module-type-X.html html/Type-module-type-X.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../type.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Type.html Type.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Type-module-type-X.html Type-module-type-X.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    type.gen
-    (run odoc html-targets -o . %{dep:../type.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/type.targets html/type.gen)))
+    type.targets.gen
+    (run odoc html-targets -o . %{dep:../type.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff type.targets type.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Type.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../type.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Type.tex latex/Type.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../type.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Type.tex Type.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    type.gen
-    (run odoc latex-targets -o . %{dep:../type.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/type.targets latex/type.gen)))
+    type.targets.gen
+    (run odoc latex-targets -o . %{dep:../type.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff type.targets type.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Type.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../type.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Type.3o man/Type.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../type.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Type.3o Type.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    type.gen
-    (run odoc man-targets -o . %{dep:../type.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/type.targets man/type.gen)))
+    type.targets.gen
+    (run odoc man-targets -o . %{dep:../type.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff type.targets type.targets.gen))))
 
 (subdir
  html
  (rule
   (targets Val.html.gen)
   (action
-   (progn
-    (run
-     odoc
-     html-generate
-     --indent
-     --flat
-     --extra-suffix
-     gen
-     -o
-     .
-     %{dep:../val.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/Val.html html/Val.html.gen)))
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../val.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Val.html Val.html.gen))))
 
 (subdir
  html
  (rule
   (action
    (with-outputs-to
-    val.gen
-    (run odoc html-targets -o . %{dep:../val.odocl} --flat)))))
-
-(rule
- (alias runtest)
- (action
-  (diff html/val.targets html/val.gen)))
+    val.targets.gen
+    (run odoc html-targets -o . %{dep:../val.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff val.targets val.targets.gen))))
 
 (subdir
  latex
  (rule
   (targets Val.tex.gen)
   (action
-   (progn
-    (run odoc latex-generate -o . --extra-suffix gen %{dep:../val.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/Val.tex latex/Val.tex.gen)))
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../val.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Val.tex Val.tex.gen))))
 
 (subdir
  latex
  (rule
   (action
    (with-outputs-to
-    val.gen
-    (run odoc latex-targets -o . %{dep:../val.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff latex/val.targets latex/val.gen)))
+    val.targets.gen
+    (run odoc latex-targets -o . %{dep:../val.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff val.targets val.targets.gen))))
 
 (subdir
  man
  (rule
   (targets Val.3o.gen)
   (action
-   (progn
-    (run odoc man-generate -o . --extra-suffix gen %{dep:../val.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/Val.3o man/Val.3o.gen)))
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../val.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Val.3o Val.3o.gen))))
 
 (subdir
  man
  (rule
   (action
    (with-outputs-to
-    val.gen
-    (run odoc man-targets -o . %{dep:../val.odocl})))))
-
-(rule
- (alias runtest)
- (action
-  (diff man/val.targets man/val.gen)))
+    val.targets.gen
+    (run odoc man-targets -o . %{dep:../val.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff val.targets val.targets.gen))))


### PR DESCRIPTION
The first commit fixes an error due to Dune generating a `.formatted` directory:

```
   gen_rules test/generators/link.dune.inc.gen (exit 1)
(cd _build/default/test/generators && gen_rules/gen_rules.exe) > /run/user/1000/build5576de.dune/dune-pipe-action-c4bd75.stdout
Don't know what to do with 'cases/.formatted' because of unrecognized '' extension.
```

Input paths were handled in several places so I factorized that part of the code with the help of an intermediate type.
The second commit removes the duplication of code related to generating Dune rules with the help of more general functions and fixes some mishandling of paths (eg. related to extensions or conversions to string). 

The diff is huge because the generated dune file changes a lot.