### PR TITLE
Update the representation of code blocks

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -23,7 +23,7 @@ delimited with `(** ... *)`, and outputs HTML.
 """
 
 depends: [
-  "odoc-parser" {>= "0.9.0"}
+  "odoc-parser" {= "dev"}
   "astring"
   "cmdliner"
   "cppo" {build}
@@ -49,6 +49,10 @@ depends: [
 
   "bisect_ppx" {with-test & = "2.5.0"}
   "ppx_expect" {with-test}
+]
+
+pin-depends: [
+  [ "odoc-parser.dev" "git+https://github.com/ocaml-doc/odoc-parser#626ccc9e319d7d3cc67251425ddbb48e33bc2de8" ]
 ]
 
 build: [

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -196,8 +196,9 @@ let rec nestable_block_element : Comment.nestable_block_element -> Block.one =
  fun content ->
   match content with
   | `Paragraph p -> paragraph p
-  | `Code_block (_, code) ->
-      block @@ Source (source_of_code (Odoc_model.Location_.value code))
+  | `Code_block b ->
+      let content = Odoc_model.Location_.value b.Comment.code_block_content in
+      block @@ Source (source_of_code content)
   | `Verbatim s -> block @@ Verbatim s
   | `Modules ms -> module_references ms
   | `List (kind, items) ->

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -38,9 +38,14 @@ type module_reference = {
 (** The [{!modules: ...}] markup. [module_synopsis] is initially [None], it is
     resolved during linking. *)
 
+type code_block = {
+  code_block_lang : string with_location option;
+  code_block_content : string with_location;
+}
+
 type nestable_block_element =
   [ `Paragraph of paragraph
-  | `Code_block of string with_location option * string with_location
+  | `Code_block of code_block
   | `Verbatim of string
   | `Modules of module_reference list
   | `List of

--- a/src/model/semantics.ml
+++ b/src/model/semantics.ml
@@ -224,8 +224,14 @@ let rec nestable_block_element :
   match element with
   | { value = `Paragraph content; location } ->
       Location.at location (`Paragraph (inline_elements status content))
-  | ({ value = `Code_block _; _ } | { value = `Verbatim _; _ }) as element ->
-      element
+  | { value = `Verbatim _; _ } as element -> element
+  | { value = `Code_block (metadata, code_block_content); location } ->
+      let code_block_lang =
+        (* Ignore the second field. *)
+        match metadata with Some (lang_tag, _) -> Some lang_tag | None -> None
+      in
+      let code_block = { Comment.code_block_lang; code_block_content } in
+      Location.at location (`Code_block code_block)
   | { value = `Modules modules; location } ->
       let modules =
         List.fold_left

--- a/src/model_desc/comment_desc.ml
+++ b/src/model_desc/comment_desc.ml
@@ -18,7 +18,7 @@ and general_link_content = general_inline_element with_location list
 
 type general_block_element =
   [ `Paragraph of general_link_content
-  | `Code_block of string with_location option * string with_location
+  | `Code_block of Comment.code_block
   | `Verbatim of string
   | `Modules of Comment.module_reference list
   | `List of
@@ -70,6 +70,16 @@ let module_reference =
   in
   Indirect (simplify, Pair (reference, Option link_content))
 
+let code_block =
+  Record
+    [
+      F
+        ( "lang",
+          (fun b -> b.code_block_lang),
+          Option (Indirect (ignore_loc, string)) );
+      F ("content", (fun b -> ignore_loc b.code_block_content), string);
+    ]
+
 let rec block_element : general_block_element t =
   let heading_level =
     Variant
@@ -88,12 +98,7 @@ let rec block_element : general_block_element t =
   Variant
     (function
     | `Paragraph x -> C ("`Paragraph", x, link_content)
-    | `Code_block (x, y) ->
-        C
-          ( "`Code_block",
-            ( (match x with None -> None | Some x -> Some (ignore_loc x)),
-              ignore_loc y ),
-            Pair (Option string, string) )
+    | `Code_block b -> C ("`Code_block", b, code_block)
     | `Verbatim x -> C ("`Verbatim", x, string)
     | `Modules x -> C ("`Modules", x, List module_reference)
     | `List (x1, x2) ->

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -1919,7 +1919,7 @@ let%expect_test _ =
         {
           "value": [
             { "`Tag": { "`Author": "Foo" } },
-            { "`Code_block": [ "None", "bar" ] }
+            { "`Code_block": { "lang": "None", "content": "bar" } }
           ],
           "warnings": [
             "File \"f.ml\", line 2, characters 0-7:\n'{[...]}' (code block) is not allowed in the tags section.\nSuggestion: move '{[...]}' (code block) before any tags."
@@ -2307,7 +2307,12 @@ let%expect_test _ =
       test "{[@author Foo]}";
       [%expect
         {|
-          { "value": [ { "`Code_block": [ "None", "@author Foo" ] } ], "warnings": [] } |}]
+          {
+            "value": [
+              { "`Code_block": { "lang": "None", "content": "@author Foo" } }
+            ],
+            "warnings": []
+          } |}]
 
     let in_verbatim =
       test "{v @author Foo v}";
@@ -2321,7 +2326,7 @@ let%expect_test _ =
         {|
         {
           "value": [
-            { "`Code_block": [ "None", "foo" ] },
+            { "`Code_block": { "lang": "None", "content": "foo" } },
             { "`Tag": { "`Author": "Bar" } }
           ],
           "warnings": [


### PR DESCRIPTION
The representation of code blocks will change slightly: https://github.com/ocaml-doc/odoc-parser/pull/2
This doesn't make use of the language tag yet.