### PR TITLE
correct usage example

### DIFF
--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -10,7 +10,6 @@ utop # let id, sg, docs = Common.model_of_string test_data;;
 utop # let env = Env.open_signature sg Env.empty;;
 utop # let unit = Common.my_compilation_unit id sg;
 utop # Common.resolve unit
-utop # Resolve.signature Env.empty sg
 
 *)
 

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -2,13 +2,13 @@ open Result
 
 (* Example usage of these:
 
-$ dune utop src/xref2/test/lib
+$ dune utop test/xref2/lib
 utop # open Odoc_xref2;;
 utop # open Odoc_xref_test;;
 utop # let test_data = "module type M = sig type t end module N : M type u = N.t";;
-utop # let id, docs, sg = Common.model_of_string test_data;;
+utop # let id, sg, docs = Common.model_of_string test_data;;
 utop # let env = Env.open_signature sg Env.empty;;
-utop # let unit = Common.my_compilation_unit id docs sg;
+utop # let unit = Common.my_compilation_unit id sg;
 utop # Common.resolve unit
 utop # Resolve.signature Env.empty sg
 


### PR DESCRIPTION
correct usage example in `test/xref2/lib/common.cppo.ml`