### PR TITLE
Remove the prefix when rendering a label reference

### DIFF
--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -55,7 +55,7 @@ module Reference = struct
     | `InstanceVariable (r, s) ->
         (* CR trefis: the following makes no sense to me... *)
         render_resolved (r :> t) ^ "." ^ InstanceVariableName.to_string s
-    | `Label (r, s) -> render_resolved (r :> t) ^ ":" ^ LabelName.to_string s
+    | `Label (_, s) -> LabelName.to_string s
 
   (* This is the entry point. stop_before is false on entry, true on recursive
      call. *)

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -2815,7 +2815,7 @@
      <code>SuperSig</code>.SubSigA.subSig
     </li>
     <li><code>{!Aliases.incl}</code> : 
-     <a href="Ocamlary-Aliases.html#incl"><code>Aliases:incl</code></a>
+     <a href="Ocamlary-Aliases.html#incl"><code>incl</code></a>
     </li>
    </ul><p>And just to make sure we do not mess up:</p>
    <ul>

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -880,7 +880,7 @@ I can refer to
 But also to things in submodules:
 
 \begin{itemize}\item{\ocamlinlinecode{\{!section:SuperSig.\allowbreak{}SubSigA.\allowbreak{}subSig\}} : \ocamlinlinecode{SuperSig}.SubSigA.subSig}%
-\item{\ocamlinlinecode{\{!Aliases.\allowbreak{}incl\}} : \hyperref[module-Ocamlary-module-Aliases-incl]{\ocamlinlinecode{\ocamlinlinecode{Aliases:incl}}[p\pageref*{module-Ocamlary-module-Aliases-incl}]}}\end{itemize}%
+\item{\ocamlinlinecode{\{!Aliases.\allowbreak{}incl\}} : \hyperref[module-Ocamlary-module-Aliases-incl]{\ocamlinlinecode{\ocamlinlinecode{incl}}[p\pageref*{module-Ocamlary-module-Aliases-incl}]}}\end{itemize}%
 And just to make sure we do not mess up:
 
 \begin{itemize}\item{\ocamlinlinecode{\{\{!section:indexmodules\}A\}} : \hyperref[module-Ocamlary-indexmodules]{\ocamlinlinecode{A}[p\pageref*{module-Ocamlary-indexmodules}]}}%

--- a/test/generators/man/Ocamlary.3o
+++ b/test/generators/man/Ocamlary.3o
@@ -1811,7 +1811,7 @@ But also to things in submodules:
 .sp 
 \(bu {!section:SuperSig\.SubSigA\.subSig} : SuperSig\.SubSigA\.subSig
 .br 
-\(bu {!Aliases\.incl} : \f[CI]Aliases:incl\fR
+\(bu {!Aliases\.incl} : \f[CI]incl\fR
 .sp 
 And just to make sure we do not mess up:
 .sp 

--- a/test/xref2/v407_and_above/labels.t/run.t
+++ b/test/xref2/v407_and_above/labels.t/run.t
@@ -53,7 +53,7 @@ There are two references in N, one should point to a local label and the other t
     <div class="odoc-content">
      <h2 id="B"><a href="#B" class="anchor"></a>An other conflicting label</h2>
      <p><a href="#B">An other conflicting label</a> 
-      <a href="../M/index.html#B"><code>M:B</code></a>
+      <a href="../M/index.html#B"><code>B</code></a>
      </p>
     </div>
    </body>


### PR DESCRIPTION
Fixes ocaml/v3.ocaml.org-server#83