### PR TITLE
Resolve definition point comments in the context of any expansion

### DIFF
--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -739,6 +739,12 @@ module Fragment = struct
             | Branch (base, m) ->
                 (ModuleName.to_string base, Some (`Module (m, name))))
         | `OpaqueModule m -> split m
+
+      let rec identifier : t -> Identifier.Path.Module.t = function
+        | `Subst (_, s) -> identifier s
+        | `Alias (i, _) -> Path.Resolved.Module.identifier i
+        | `Module (m, n) -> `Module (Signature.identifier m, n)
+        | `OpaqueModule m -> identifier m
     end
 
     module ModuleType = struct

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -500,6 +500,8 @@ module Fragment : sig
       type t = Paths_types.Resolved_fragment.module_
 
       val split : t -> string * t option
+
+      val identifier : t -> Identifier.Path.Module.t
     end
 
     module ModuleType : sig

--- a/src/xref2/expand_tools.ml
+++ b/src/xref2/expand_tools.ml
@@ -213,7 +213,7 @@ let expansion_of_u_module_type_expr env id expr =
 let expansion_of_module_alias env id path =
   let open Paths.Identifier in
   aux_expansion_of_module_alias ~strengthen:false env path
-  >>= handle_expansion env (id : Module.t :> Signature.t)
+  >>= handle_expansion env (id : Path.Module.t :> Signature.t)
   >>= fun (env, r) -> Ok (env, false, r)
 
 let expansion_of_module_type_of_desc env id t_desc =

--- a/src/xref2/link.mli
+++ b/src/xref2/link.mli
@@ -3,7 +3,10 @@
 open Odoc_model
 
 val signature :
-  Env.t -> Paths.Identifier.Signature.t -> Lang.Signature.t -> Lang.Signature.t
+  Env.t ->
+  Paths.Identifier.Signature.t ->
+  Lang.Signature.t * Comment.docs ->
+  Lang.Signature.t * Comment.docs
 (** For testing purpose. May call [Lookup_failures.report]. *)
 
 val link :

--- a/src/xref2/test.md
+++ b/src/xref2/test.md
@@ -1572,63 +1572,64 @@ let sg = Common.signature_of_mli_string test_data;;
 ```
 
 ```ocaml env=e1
-# Link.signature Env.empty id sg
-- : Odoc_model.Lang.Signature.t =
-{Odoc_model.Lang.Signature.items =
-  [Odoc_model.Lang.Signature.ModuleType
-    {Odoc_model.Lang.ModuleType.id =
-      `ModuleType (`Root (Some (`Page (None, None)), Root), M);
-     doc = []; canonical = None;
-     expr =
-      Some
-       (Odoc_model.Lang.ModuleType.Signature
-         {Odoc_model.Lang.Signature.items =
-           [Odoc_model.Lang.Signature.Type
-             (Odoc_model.Lang.Signature.Ordinary,
-             {Odoc_model.Lang.TypeDecl.id =
-               `Type
-                 (`ModuleType (`Root (Some (`Page (None, None)), Root), M),
-                  t);
-              doc = []; canonical = None;
-              equation =
-               {Odoc_model.Lang.TypeDecl.Equation.params = [];
-                private_ = false; manifest = None; constraints = []};
-              representation = None})];
-          compiled = false; doc = []})};
-   Odoc_model.Lang.Signature.Type (Odoc_model.Lang.Signature.Ordinary,
-    {Odoc_model.Lang.TypeDecl.id =
-      `Type (`Root (Some (`Page (None, None)), Root), u);
-     doc = []; canonical = None;
-     equation =
-      {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
-       manifest = None; constraints = []};
-     representation = None});
-   Odoc_model.Lang.Signature.ModuleType
-    {Odoc_model.Lang.ModuleType.id =
-      `ModuleType (`Root (Some (`Page (None, None)), Root), M1);
-     doc = []; canonical = None;
-     expr =
-      Some
-       (Odoc_model.Lang.ModuleType.With
-         {Odoc_model.Lang.ModuleType.w_substitutions =
-           [Odoc_model.Lang.ModuleType.TypeEq (`Dot (`Root, "t"),
-             {Odoc_model.Lang.TypeDecl.Equation.params = [];
-              private_ = false;
-              manifest =
-               Some
-                (Odoc_model.Lang.TypeExpr.Constr
-                  (`Resolved
-                     (`Identifier
-                        (`Type (`Root (Some (`Page (None, None)), Root), u))),
-                  []));
-              constraints = []})];
-          w_expansion = None;
-          w_expr =
-           Odoc_model.Lang.ModuleType.U.Path
-            (`Resolved
-               (`Identifier
-                  (`ModuleType (`Root (Some (`Page (None, None)), Root), M))))})}];
- compiled = false; doc = []}
+# Link.signature Env.empty id (sg, [])
+- : Odoc_model.Lang.Signature.t * Odoc_model.Comment.docs =
+({Odoc_model.Lang.Signature.items =
+   [Odoc_model.Lang.Signature.ModuleType
+     {Odoc_model.Lang.ModuleType.id =
+       `ModuleType (`Root (Some (`Page (None, None)), Root), M);
+      doc = []; canonical = None;
+      expr =
+       Some
+        (Odoc_model.Lang.ModuleType.Signature
+          {Odoc_model.Lang.Signature.items =
+            [Odoc_model.Lang.Signature.Type
+              (Odoc_model.Lang.Signature.Ordinary,
+              {Odoc_model.Lang.TypeDecl.id =
+                `Type
+                  (`ModuleType (`Root (Some (`Page (None, None)), Root), M),
+                   t);
+               doc = []; canonical = None;
+               equation =
+                {Odoc_model.Lang.TypeDecl.Equation.params = [];
+                 private_ = false; manifest = None; constraints = []};
+               representation = None})];
+           compiled = false; doc = []})};
+    Odoc_model.Lang.Signature.Type (Odoc_model.Lang.Signature.Ordinary,
+     {Odoc_model.Lang.TypeDecl.id =
+       `Type (`Root (Some (`Page (None, None)), Root), u);
+      doc = []; canonical = None;
+      equation =
+       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
+        manifest = None; constraints = []};
+      representation = None});
+    Odoc_model.Lang.Signature.ModuleType
+     {Odoc_model.Lang.ModuleType.id =
+       `ModuleType (`Root (Some (`Page (None, None)), Root), M1);
+      doc = []; canonical = None;
+      expr =
+       Some
+        (Odoc_model.Lang.ModuleType.With
+          {Odoc_model.Lang.ModuleType.w_substitutions =
+            [Odoc_model.Lang.ModuleType.TypeEq (`Dot (`Root, "t"),
+              {Odoc_model.Lang.TypeDecl.Equation.params = [];
+               private_ = false;
+               manifest =
+                Some
+                 (Odoc_model.Lang.TypeExpr.Constr
+                   (`Resolved
+                      (`Identifier
+                         (`Type (`Root (Some (`Page (None, None)), Root), u))),
+                   []));
+               constraints = []})];
+           w_expansion = None;
+           w_expr =
+            Odoc_model.Lang.ModuleType.U.Path
+             (`Resolved
+                (`Identifier
+                   (`ModuleType (`Root (Some (`Page (None, None)), Root), M))))})}];
+  compiled = false; doc = []},
+ [])
 ```
 
 # Expansion continued
@@ -1644,7 +1645,7 @@ module M : Foo(Bar).S
 |};;
 let sg = Common.signature_of_mli_string test_data;;
 let resolved = Common.compile_signature sg;;
-let expanded = Link.signature Env.empty id resolved;;
+let expanded, _ = Link.signature Env.empty id (resolved, []);;
 let module_M_expansion =
   let open Common.LangUtils.Lens in
   Signature.module_ "M" |-- Module.type_ |-~ Module.decl_moduletype

--- a/test/xref2/preamble_references.t/m.mli
+++ b/test/xref2/preamble_references.t/m.mli
@@ -1,0 +1,12 @@
+(** {!t}. *)
+module M : sig 
+
+  type t
+end
+
+module M2 : sig 
+(** {!t}. *)
+
+  type t
+end
+

--- a/test/xref2/preamble_references.t/run.t
+++ b/test/xref2/preamble_references.t/run.t
@@ -1,0 +1,8 @@
+This is a test for the issue https://github.com/ocaml/odoc/issues/713
+
+  $ compile m.mli
+
+  $ jq_scan_references() { jq -c '.. | .["`Reference"]? | select(.) | .[0]'; }
+  $ odoc_print m.odocl | jq_scan_references
+  {"`Resolved":{"`Identifier":{"`Type":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"M"]},"M"]},"t"]}}}
+  {"`Resolved":{"`Identifier":{"`Type":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"M"]},"M2"]},"t"]}}}


### PR DESCRIPTION
Fixes #713 

I tested this on the deps of odoc and found changes in `Astring.String` and `Cmdliner.{Arg, Manpage, Term}`, which looked correct. However, I also found changes in tyxml that were not so obviously right - e.g. in `Html_sigs`. Compare these:

https://jonludlam.github.io/odoc/deps/tyxml/Html_sigs/module-type-T/Xml/index.html
https://ocsigen.org/tyxml/4.4.0/api/Html_sigs.T.Xml

In both of these the links from `elt` and `attrib` go to the parent page, which looks correct to me. With this change, that comment is now resolved in the context of the module `Xml` and therefore they both link to the definitions of `elt` and `attrib` in that page instead of the parent. This looks incorrect to me (neither has a type variable!)
