### PR TITLE
Stay compatible with two versions of the parser

### DIFF
--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -196,7 +196,7 @@ let rec nestable_block_element : Comment.nestable_block_element -> Block.one =
  fun content ->
   match content with
   | `Paragraph p -> paragraph p
-  | `Code_block (_, code) ->
+  | `Code_block code ->
       block @@ Source (source_of_code (Odoc_model.Location_.value code))
   | `Verbatim s -> block @@ Verbatim s
   | `Modules ms -> module_references ms

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -40,7 +40,7 @@ type module_reference = {
 
 type nestable_block_element =
   [ `Paragraph of paragraph
-  | `Code_block of string with_location option * string with_location
+  | `Code_block of string with_location
   | `Verbatim of string
   | `Modules of module_reference list
   | `List of

--- a/src/model/semantics.ml
+++ b/src/model/semantics.ml
@@ -224,8 +224,9 @@ let rec nestable_block_element :
   match element with
   | { value = `Paragraph content; location } ->
       Location.at location (`Paragraph (inline_elements status content))
-  | ({ value = `Code_block _; _ } | { value = `Verbatim _; _ }) as element ->
-      element
+  | { value = `Code_block (_, code); _ } ->
+      Location.same element (`Code_block code)
+  | { value = `Verbatim _; _ } as element -> element
   | { value = `Modules modules; location } ->
       let modules =
         List.fold_left

--- a/src/model_desc/comment_desc.ml
+++ b/src/model_desc/comment_desc.ml
@@ -18,7 +18,7 @@ and general_link_content = general_inline_element with_location list
 
 type general_block_element =
   [ `Paragraph of general_link_content
-  | `Code_block of string with_location option * string with_location
+  | `Code_block of string with_location
   | `Verbatim of string
   | `Modules of Comment.module_reference list
   | `List of
@@ -88,12 +88,7 @@ let rec block_element : general_block_element t =
   Variant
     (function
     | `Paragraph x -> C ("`Paragraph", x, link_content)
-    | `Code_block (x, y) ->
-        C
-          ( "`Code_block",
-            ( (match x with None -> None | Some x -> Some (ignore_loc x)),
-              ignore_loc y ),
-            Pair (Option string, string) )
+    | `Code_block x -> C ("`Code_block", ignore_loc x, string)
     | `Verbatim x -> C ("`Verbatim", x, string)
     | `Modules x -> C ("`Modules", x, List module_reference)
     | `List (x1, x2) ->

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -1917,10 +1917,7 @@ let%expect_test _ =
       [%expect
         {|
         {
-          "value": [
-            { "`Tag": { "`Author": "Foo" } },
-            { "`Code_block": [ "None", "bar" ] }
-          ],
+          "value": [ { "`Tag": { "`Author": "Foo" } }, { "`Code_block": "bar" } ],
           "warnings": [
             "File \"f.ml\", line 2, characters 0-7:\n'{[...]}' (code block) is not allowed in the tags section.\nSuggestion: move '{[...]}' (code block) before any tags."
           ]
@@ -2307,7 +2304,7 @@ let%expect_test _ =
       test "{[@author Foo]}";
       [%expect
         {|
-          { "value": [ { "`Code_block": [ "None", "@author Foo" ] } ], "warnings": [] } |}]
+          { "value": [ { "`Code_block": "@author Foo" } ], "warnings": [] } |}]
 
     let in_verbatim =
       test "{v @author Foo v}";
@@ -2320,10 +2317,7 @@ let%expect_test _ =
       [%expect
         {|
         {
-          "value": [
-            { "`Code_block": [ "None", "foo" ] },
-            { "`Tag": { "`Author": "Bar" } }
-          ],
+          "value": [ { "`Code_block": "foo" }, { "`Tag": { "`Author": "Bar" } } ],
           "warnings": [
             "File \"f.ml\", line 1, characters 8-19:\n'@author' should begin on its own line."
           ]


### PR DESCRIPTION
In the next version of 'odoc-parser', the representation of code blocks
changes. We can make Odoc work with both versions easily.

With this change, Odoc will be compatible with the current and next versions of Mdx and OCamlformat.
