### PR TITLE
Fix splitting of URLs to pages

### DIFF
--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -184,6 +184,9 @@ module Path = struct
       (kind * string) list * (kind * string) list =
    fun ~is_dir l ->
     let rec inner = function
+      | [ _ ] as xs ->
+          (* Don't let the right part be empty. eg. url to a directory. *)
+          ([], xs)
       | ((kind, _) as x) :: xs when is_dir kind ->
           let dirs, files = inner xs in
           (x :: dirs, files)

--- a/src/html/link.ml
+++ b/src/html/link.ml
@@ -19,17 +19,19 @@ module Path = struct
       if !flat then function `Page -> true | _ -> false
       else function `LeafPage -> false | `File -> false | _ -> true
     in
-    let dir, file = Url.Path.split ~is_dir l in
-    let dir = List.map segment_to_string dir in
-    let file =
+    let dir, file =
+      let dir, file = Url.Path.split ~is_dir l in
       match file with
-      | [] -> "index.html"
-      | [ (`LeafPage, name) ] -> name ^ ".html"
-      | [ (`File, name) ] -> name
+      | [ (`LeafPage, name) ] -> (dir, name ^ ".html")
+      | [ (`File, name) ] -> (dir, name)
+      | [ (kind, _) ] when is_dir kind ->
+          (* Pointing to a directory. *)
+          (dir @ file, "index.html")
       | xs ->
           assert !flat;
-          String.concat "-" (List.map segment_to_string xs) ^ ".html"
+          (dir, String.concat "-" (List.map segment_to_string xs) ^ ".html")
     in
+    let dir = List.map segment_to_string dir in
     (dir, file)
 
   let for_linking url =

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -46,14 +46,7 @@ module Link = struct
     let dir, file = Url.Path.split ~is_dir l in
     let segment_to_string (_kind, name) = name in
     let dir = List.map segment_to_string dir in
-    match (dir, file) with
-    | [], [] -> assert false
-    | dir, [] ->
-        let rev_dir = List.rev dir in
-        let file' = List.hd rev_dir in
-        let dir' = List.tl rev_dir |> List.rev in
-        (dir', file')
-    | _, xs -> (dir, String.concat "." (List.map segment_to_string xs))
+    (dir, String.concat "." (List.map segment_to_string file))
 
   let filename url =
     let dir, file = get_dir_and_file url in


### PR DESCRIPTION
The man page and the future markdown generators are throwing an exception when the input is a page.

This is due to the "splitting" function deciding which segments of an identifier are the "directory" part and the "file name" part leading to paths like `foo/bar.3o/`.