### PR TITLE
Add context around errors from expansion of includes

### DIFF
--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -1025,3 +1025,14 @@ let read_interface root name intf =
   let id = `Root (root, Odoc_model.Names.ModuleName.make_std name) in
   let items = read_signature Env.empty id intf in
   (id, items)
+
+let point_of_pos { Lexing.pos_lnum; pos_bol; pos_cnum; _ } =
+  let column = pos_cnum - pos_bol in
+  { Odoc_model.Location_.line = pos_lnum; column }
+
+let read_location { Location.loc_start; loc_end; _ } =
+  {
+    Odoc_model.Location_.file = loc_start.pos_fname;
+    start = point_of_pos loc_start;
+    end_ = point_of_pos loc_end;
+  }

--- a/src/loader/cmi.mli
+++ b/src/loader/cmi.mli
@@ -83,3 +83,5 @@ val read_extension_constructor : Ident_env.t ->
 val read_exception : Ident_env.t ->
   Paths.Identifier.Signature.t -> Ident.t ->
   Types.extension_constructor -> Odoc_model.Lang.Exception.t
+
+val read_location : Location.t -> Odoc_model.Location_.span

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -527,6 +527,7 @@ and read_structure_item env parent item =
 
 and read_include env parent incl =
   let open Include in
+  let loc = Cmi.read_location incl.incl_loc in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, status = Doc_attr.attached Odoc_model.Semantics.Expect_status container incl.incl_attributes in
   let decl_modty =
@@ -548,7 +549,7 @@ and read_include env parent incl =
   | Some m when not (contains_signature m) ->
     let decl = ModuleType m in
     let expansion = { content; shadowed; } in
-    [Include {parent; doc; decl; expansion; status; strengthened=None }]
+    [Include {parent; doc; decl; expansion; status; strengthened=None; loc }]
   | Some (ModuleType.U.Signature { items; _ }) ->
     items
   | _ ->

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -729,6 +729,7 @@ and read_module_type_substitution env parent mtd =
 
 and read_include env parent incl =
   let open Include in
+  let loc = Cmi.read_location incl.incl_loc in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, status = Doc_attr.attached Odoc_model.Semantics.Expect_status container incl.incl_attributes in
   let content, shadowed = Cmi.read_signature_noenv env parent (Odoc_model.Compat.signature incl.incl_type) in
@@ -753,7 +754,7 @@ and read_include env parent incl =
   | Some uexpr when not (contains_signature uexpr) ->
     let decl = Include.ModuleType uexpr in
     let expansion = { content; shadowed; } in
-    [Include {parent; doc; decl; expansion; status; strengthened=None }]
+    [Include {parent; doc; decl; expansion; status; strengthened=None; loc }]
   | Some ModuleType.U.Signature { items; _ } when is_inlinable items ->
     items
   | _ ->

--- a/src/model/error.ml
+++ b/src/model/error.ml
@@ -31,19 +31,9 @@ let filename_only ?suggestion format =
 
 let to_string = function
   | `With_full_location { location; message } ->
-      let location_string =
-        if location.start.line = location.end_.line then
-          Printf.sprintf "line %i, characters %i-%i" location.start.line
-            location.start.column location.end_.column
-        else
-          Printf.sprintf "line %i, character %i to line %i, character %i"
-            location.start.line location.start.column location.end_.line
-            location.end_.column
-      in
-      Printf.sprintf "File \"%s\", %s:\n%s" location.file location_string
-        message
+      Format.asprintf "%a:@\n%s" Location_.pp location message
   | `With_filename_only { file; message } ->
-      Printf.sprintf "File \"%s\":\n%s" file message
+      Format.asprintf "File \"%s\":@\n%s" file message
 
 exception Conveyed_by_exception of t
 

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -178,6 +178,7 @@ and Include : sig
   type decl = Alias of Path.Module.t | ModuleType of ModuleType.U.expr
 
   type t = {
+    loc : Location_.span;
     parent : Identifier.Signature.t;
     strengthened : Path.Module.t option;
     doc : Comment.docs;

--- a/src/model/location_.ml
+++ b/src/model/location_.ml
@@ -26,6 +26,15 @@ let in_string s ~offset ~length s_span =
     end_ = point_in_string s (offset + length) s_span.start;
   }
 
+let pp fmt l =
+  Format.fprintf fmt "File \"%s\", " l.file;
+  if l.start.line = l.end_.line then
+    Format.fprintf fmt "line %i, characters %i-%i" l.start.line l.start.column
+      l.end_.column
+  else
+    Format.fprintf fmt "line %i, character %i to line %i, character %i"
+      l.start.line l.start.column l.end_.line l.end_.column
+
 let pp_span_start fmt s =
   Format.fprintf fmt "File \"%s\", line %d, character %d" s.file s.start.line
     s.start.column

--- a/src/model/location_.mli
+++ b/src/model/location_.mli
@@ -6,4 +6,6 @@ val set_end_as_offset_from_start : int -> span -> span
 
 val in_string : string -> offset:int -> length:int -> span -> span
 
+val pp : Format.formatter -> span -> unit
+
 val pp_span_start : Format.formatter -> span -> unit

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -342,6 +342,7 @@ and Include : sig
     shadowed : Odoc_model.Lang.Include.shadowed;
     expansion_ : Signature.t;
     decl : decl;
+    loc : Odoc_model.Location_.span;
   }
 end =
   Include
@@ -2189,6 +2190,7 @@ module Of_Lang = struct
       status = i.status;
       strengthened = option module_path ident_map i.strengthened;
       decl;
+      loc = i.loc;
     }
 
   and class_ ident_map c =

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -313,6 +313,7 @@ and Include : sig
     shadowed : Odoc_model.Lang.Include.shadowed;
     expansion_ : Signature.t;
     decl : decl;
+    loc : Odoc_model.Location_.span;
   }
 end
 

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -613,6 +613,7 @@ and include_ parent map i =
       };
     status = i.status;
     strengthened = Opt.map (Path.module_ map) i.strengthened;
+    loc = i.loc;
   }
 
 and open_ parent map o =

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -469,7 +469,12 @@ and include_ : Env.t -> Include.t -> Include.t =
         (Component.Of_Lang.(module_decl empty i.decl)); *)
   let doc = comment_docs env i.parent i.doc in
   let expansion =
-    let content = signature env i.parent i.expansion.content in
+    let content =
+      (* Add context around errors from the expansion. *)
+      Lookup_failures.with_context
+        "While resolving the expansion of include at %a" Location_.pp_span_start
+        i.loc (fun () -> signature env i.parent i.expansion.content)
+    in
     { i.expansion with content }
   in
   { i with decl; expansion; doc }

--- a/src/xref2/lookup_failures.ml
+++ b/src/xref2/lookup_failures.ml
@@ -46,7 +46,9 @@ let raise_warnings ~filename failures =
             | [] -> ()
           in
           let pp_failure fmt () =
-            Format.fprintf fmt "%a%s" pp_context context.c_context msg
+            let prefix = if non_fatal then "Warning" else "Error" in
+            Format.fprintf fmt "%s: %a%s" prefix pp_context context.c_context
+              msg
           in
           let err =
             match context.c_loc with

--- a/src/xref2/lookup_failures.mli
+++ b/src/xref2/lookup_failures.mli
@@ -22,3 +22,8 @@ val report_warning : ('fmt, Format.formatter, unit, unit) format4 -> 'fmt
 
 val with_location : Location_.span -> (unit -> 'a) -> 'a
 (** Failures reported indirectly by this function will have a location attached. *)
+
+val with_context :
+  ('fmt, Format.formatter, unit, (unit -> 'a) -> 'a) format4 -> 'fmt
+(** [with_context "format string" format_arguments f] adds context to failures
+    reported by [f ()]. *)

--- a/test/pages/errors.t/run.t
+++ b/test/pages/errors.t/run.t
@@ -34,5 +34,5 @@ Linking checks the children are all present:
   $ odoc compile top1.mld --child foo
   $ odoc link page-top1.odoc -I .
   File "page-top1.odoc":
-  Failed to resolve child reference unresolvedroot(foo)
+  Warning: Failed to resolve child reference unresolvedroot(foo)
 

--- a/test/xref2/ambiguous_label.t/run.t
+++ b/test/xref2/ambiguous_label.t/run.t
@@ -4,14 +4,14 @@ Labels don't follow OCaml's scoping rules:
 
   $ compile test.ml test_2.ml
   File "test.ml", line 25, characters 4-36:
-  Failed to resolve reference unresolvedroot(example_2) Couldn't find "example_2"
+  Warning: Failed to resolve reference unresolvedroot(example_2) Couldn't find "example_2"
   File "test.ml", line 16, characters 4-50:
-  Reference to label 'example' is ambiguous.
+  Error: Reference to label 'example' is ambiguous.
   This reference will point to the first occurence of 'example'.
   Hint:
     Define labels explicitly using the syntax '{1:explicit-label Heading text}'.
   File "test_2.ml", line 1, characters 4-55:
-  Failed to resolve reference unresolvedroot(Test).example Couldn't find "example"
+  Warning: Failed to resolve reference unresolvedroot(Test).example Couldn't find "example"
 
 Contains some ambiguous labels:
 

--- a/test/xref2/labels.t/run.t
+++ b/test/xref2/labels.t/run.t
@@ -1,33 +1,33 @@
 
   $ compile test.mli
   File "test.mli", line 27, characters 14-20:
-  Failed to resolve reference unresolvedroot(M).C Couldn't find "C"
+  Warning: Failed to resolve reference unresolvedroot(M).C Couldn't find "C"
   File "test.mli", line 27, characters 9-13:
-  Reference to label 'B' is ambiguous.
+  Error: Reference to label 'B' is ambiguous.
   This reference will point to the first occurence of 'B'.
   Hint:
     Define labels explicitly using the syntax '{1:explicit-label Heading text}'.
   File "test.mli", line 21, characters 4-22:
-  Label 'B' is ambiguous. The other occurences are:
+  Error: Label 'B' is ambiguous. The other occurences are:
     File "test.mli", line 21, character 4
     File "test.mli", line 3, character 4
   File "test.mli", line 18, characters 6-10:
-  Reference to label 'B' is ambiguous.
+  Error: Reference to label 'B' is ambiguous.
   This reference will point to the first occurence of 'B'.
   Hint:
     Define labels explicitly using the syntax '{1:explicit-label Heading text}'.
   File "test.mli", line 16, characters 6-38:
-  Label 'B' is ambiguous. The other occurences are:
+  Error: Label 'B' is ambiguous. The other occurences are:
     File "test.mli", line 16, character 6
     File "test.mli", line 21, character 4
     File "test.mli", line 3, character 4
   File "test.mli", line 10, characters 6-41:
-  Label 'B' is ambiguous. The other occurences are:
+  Error: Label 'B' is ambiguous. The other occurences are:
     File "test.mli", line 10, character 6
     File "test.mli", line 21, character 4
     File "test.mli", line 3, character 4
   File "test.mli", line 3, characters 4-24:
-  Label 'B' is ambiguous. The other occurences are:
+  Error: Label 'B' is ambiguous. The other occurences are:
     File "test.mli", line 21, character 4
     File "test.mli", line 3, character 4
 

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -2,15 +2,15 @@
 
   $ compile external.mli starts_with_open.mli main.mli
   File "main.mli", line 63, characters 22-43:
-  Failed to resolve reference unresolvedroot(Resolve_synopsis).t Couldn't find "Resolve_synopsis"
+  Warning: Failed to resolve reference unresolvedroot(Resolve_synopsis).t Couldn't find "Resolve_synopsis"
   File "main.mli", line 63, characters 17-21:
-  Failed to resolve reference unresolvedroot(t) Couldn't find "t"
+  Warning: Failed to resolve reference unresolvedroot(t) Couldn't find "t"
   File "external.mli", line 9, characters 6-10:
-  Failed to resolve reference unresolvedroot(t) Couldn't find "t"
+  Warning: Failed to resolve reference unresolvedroot(t) Couldn't find "t"
   File "main.mli", line 63, characters 22-43:
-  Failed to resolve reference unresolvedroot(Resolve_synopsis).t Couldn't find "Resolve_synopsis"
+  Warning: Failed to resolve reference unresolvedroot(Resolve_synopsis).t Couldn't find "Resolve_synopsis"
   File "main.mli", line 63, characters 17-21:
-  Failed to resolve reference unresolvedroot(t) Couldn't find "t"
+  Warning: Failed to resolve reference unresolvedroot(t) Couldn't find "t"
 
 Everything should resolve:
 

--- a/test/xref2/multi_file_module_type_of.t/run.t
+++ b/test/xref2/multi_file_module_type_of.t/run.t
@@ -28,14 +28,14 @@ on test1.cmti:
 
   $ odoc compile --package foo test1.cmti
   File "test1.cmti":
-  Failed to compile expansion for module type expression module type of unresolvedroot(Test0) Unexpanded `module type of` expression: module type of unresolvedroot(Test0)
+  Warning: Failed to compile expansion for module type expression module type of unresolvedroot(Test0) Unexpanded `module type of` expression: module type of unresolvedroot(Test0)
 
 Similarly, module `T` also can not be expanded, therefore we expect
 another warning when we run `odoc compile` on test2.cmti:
 
   $ odoc compile --package foo test2.cmti -I .
   File "test2.cmti":
-  Failed to compile expansion for module type expression module type of unresolvedroot(Test1).S Unexpanded `module type of` expression: module type of unresolvedroot(Test1).S
+  Warning: Failed to compile expansion for module type expression module type of unresolvedroot(Test1).S Unexpanded `module type of` expression: module type of unresolvedroot(Test1).S
 
 Crucially though, we do expect this command to have terminated!
 

--- a/test/xref2/references_scope.t/run.t
+++ b/test/xref2/references_scope.t/run.t
@@ -2,7 +2,7 @@
 
   $ compile a.mli shadowed.mli shadowed_through_open.mli
   File "a.mli", line 18, characters 6-24:
-  Failed to resolve reference unresolvedroot(C) Couldn't find "C"
+  Warning: Failed to resolve reference unresolvedroot(C) Couldn't find "C"
 
   $ jq_scan_references() { jq -c '.. | .["`Reference"]? | select(.)'; }
 

--- a/test/xref2/references_to_pages.t/run.t
+++ b/test/xref2/references_to_pages.t/run.t
@@ -2,9 +2,9 @@
 
   $ compile p.mld good_references.mli bad_references.mli
   File "bad_references.mli", line 6, characters 42-69:
-  Failed to resolve reference unresolvedroot(p).not_found Couldn't find page "not_found"
+  Warning: Failed to resolve reference unresolvedroot(p).not_found Couldn't find page "not_found"
   File "bad_references.mli", line 4, characters 20-37:
-  Failed to resolve reference unresolvedroot(not_found) Couldn't find page "not_found"
+  Warning: Failed to resolve reference unresolvedroot(not_found) Couldn't find page "not_found"
 
 Every references in `Good_references` should resolve:
 

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -964,11 +964,11 @@ Ambiguous in env:
 ```ocaml
 # resolve_ref "t" ;;
 File "<test>":
-Reference to 't' is ambiguous. Please specify its kind: type-t, val-t.
+Error: Reference to 't' is ambiguous. Please specify its kind: type-t, val-t.
 - : ref = `Identifier (`Value (`Root (Some (`Page (None, None)), Root), t))
 # resolve_ref "X" ;;
 File "<test>":
-Reference to 'X' is ambiguous. Please specify its kind: constructor-X, module-X.
+Error: Reference to 'X' is ambiguous. Please specify its kind: constructor-X, module-X.
 - : ref = `Identifier (`Module (`Root (Some (`Page (None, None)), Root), X))
 ```
 
@@ -977,12 +977,12 @@ Ambiguous in sig:
 ```ocaml
 # resolve_ref "X.u" ;;
 File "<test>":
-Reference to 'u' is ambiguous. Please specify its kind: type-u, val-u.
+Error: Reference to 'u' is ambiguous. Please specify its kind: type-u, val-u.
 - : ref =
 `Type (`Identifier (`Module (`Root (Some (`Page (None, None)), Root), X)), u)
 # resolve_ref "X.Y" ;;
 File "<test>":
-Reference to 'Y' is ambiguous. Please specify its kind: constructor-Y, module-Y.
+Error: Reference to 'Y' is ambiguous. Please specify its kind: constructor-Y, module-Y.
 - : ref =
 `Constructor
   (`Type
@@ -990,7 +990,7 @@ Reference to 'Y' is ambiguous. Please specify its kind: constructor-Y, module-Y.
    Y)
 # resolve_ref "Everything_ambiguous_in_sig.t" (* Some kinds are missing: label, type subst (would be "type-") *) ;;
 File "<test>":
-Reference to 't' is ambiguous. Please specify its kind: field-t, module-type-t, type-t, val-t.
+Error: Reference to 't' is ambiguous. Please specify its kind: field-t, module-type-t, type-t, val-t.
 - : ref =
 `Type
   (`Identifier
@@ -1000,7 +1000,7 @@ Reference to 't' is ambiguous. Please specify its kind: field-t, module-type-t, 
    t)
 # resolve_ref "Everything_ambiguous_in_sig.T" (* Missing kind: module subst (would be "module-") *) ;;
 File "<test>":
-Reference to 'T' is ambiguous. Please specify its kind: exception-T, extension-T, module-T.
+Error: Reference to 'T' is ambiguous. Please specify its kind: exception-T, extension-T, module-T.
 - : ref =
 `Module
   (`Identifier

--- a/test/xref2/unexpanded_module_type_of.t/run.t
+++ b/test/xref2/unexpanded_module_type_of.t/run.t
@@ -17,5 +17,5 @@ should _not_ result in an exception, merely a warning.
 
   $ odoc compile --package test test.cmti
   File "test.cmti":
-  Failed to compile expansion for include : module type of unresolvedroot(Test0) Unexpanded `module type of` expression: module type of unresolvedroot(Test0)
+  Warning: Failed to compile expansion for include : module type of unresolvedroot(Test0) Unexpanded `module type of` expression: module type of unresolvedroot(Test0)
 

--- a/test/xref2/warnings.t/run.t
+++ b/test/xref2/warnings.t/run.t
@@ -33,7 +33,7 @@ A contains linking errors:
   Couldn't find the following modules:
     B
   File "a.mli", line 6, characters 47-65:
-  Failed to resolve reference unresolvedroot(B).doesn't_exist Couldn't find "B"
+  Warning: Failed to resolve reference unresolvedroot(B).doesn't_exist Couldn't find "B"
 
   $ odoc errors a.odocl
   File "a.mli", line 8, characters 23-23:
@@ -44,7 +44,7 @@ A contains linking errors:
   Couldn't find the following modules:
     B
   File "a.mli", line 6, characters 47-65:
-  Failed to resolve reference unresolvedroot(B).doesn't_exist Couldn't find "B"
+  Warning: Failed to resolve reference unresolvedroot(B).doesn't_exist Couldn't find "B"
 
 It is possible to hide the warnings too:
 


### PR DESCRIPTION
When an error occurs when resolving an expansion, the error message doesn't mention input file being linked but where the error is written, which is not enough to fix the problem.

For example, when linking `A`, the error will look like:

    File "c.ml", line 1, character 1:
    While resolving the expansion of include at File "a.ml", line 1, character 0
    While resolving the expansion of include at File "b.ml", line 1, character 0
    While resolving the expansion of include at File "c.ml", line 1, character 1
    Some error