### PR TITLE
Allow referencing labels in the top comment

### DIFF
--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -182,8 +182,14 @@ and read_class_signature env parent params cltyp =
             [] csig.csig_fields
         in
         let items = constraints @ List.rev items in
-        let items, doc = Doc_attr.extract_top_comment_class items in
+        let items, (doc, doc_post) = Doc_attr.extract_top_comment_class items in
+        let items =
+          match doc_post with
+          | [] -> items
+          | _ -> Comment (`Docs doc_post) :: items
+        in
         Signature {self; items; doc}
+
     | Tcty_arrow _ -> assert false
 #if OCAML_VERSION >= (4,6,0)
     | Tcty_open _ -> assert false
@@ -270,7 +276,12 @@ and read_class_structure env parent params cl =
             [] cstr.cstr_fields
         in
         let items = constraints @ List.rev items in
-        let items, doc = Doc_attr.extract_top_comment_class items in
+        let items, (doc, doc_post) = Doc_attr.extract_top_comment_class items in
+        let items =
+          match doc_post with
+          | [] -> items
+          | _ -> Comment (`Docs doc_post) :: items
+        in
         Signature {self; items; doc}
     | Tcl_fun _ -> assert false
     | Tcl_let(_, _, _, cl) -> read_class_structure env parent params cl

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -565,7 +565,7 @@ and read_structure :
       _ * 'tags =
  fun internal_tags env parent str ->
   let env = Env.add_structure_tree_items parent str env in
-  let items, doc, tags =
+  let items, (doc, doc_post), tags =
     let classify item =
       match item.str_desc with
       | Tstr_open _ -> Some `Open
@@ -581,7 +581,11 @@ and read_structure :
       [] items
     |> List.rev
   in
-  ({ Signature.items; compiled = false; doc }, tags)
+  match doc_post with
+  | [] ->
+    ({ Signature.items; compiled = false; doc }, tags)
+  | _ ->
+    ({ Signature.items = Comment (`Docs doc_post) :: items; compiled=false; doc }, tags)
 
 let read_implementation root name impl =
   let id = `Root (root, Odoc_model.Names.ModuleName.make_std name) in

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -387,7 +387,12 @@ and read_class_signature env parent label_parent cltyp =
             [] csig.csig_fields
         in
         let items = List.rev items in
-        let items, doc = Doc_attr.extract_top_comment_class items in
+        let items, (doc, doc_post) = Doc_attr.extract_top_comment_class items in
+        let items =
+          match doc_post with
+          | [] -> items
+          | _ -> Comment (`Docs doc_post) :: items
+        in
         Signature {self; items; doc}
     | Tcty_arrow _ -> assert false
 #if OCAML_VERSION >= (4,8,0)

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -770,7 +770,7 @@ and read_signature :
       _ * 'tags =
  fun internal_tags env parent sg ->
   let env = Env.add_signature_tree_items parent sg env in
-  let items, doc, tags =
+  let items, (doc, doc_post), tags =
     let classify item =
       match item.sig_desc with
       | Tsig_attribute attr -> Some (`Attribute attr)
@@ -786,7 +786,11 @@ and read_signature :
       [] items
     |> List.rev
   in
-  ({ Signature.items; compiled = false; doc }, tags)
+  match doc_post with
+  | [] ->
+    ({ Signature.items; compiled = false; doc }, tags)
+  | _ ->
+    ({ Signature.items = Comment (`Docs doc_post) :: items; compiled=false; doc }, tags)
 
 let read_interface root name intf =
   let id = `Root (root, Odoc_model.Names.ModuleName.make_std name) in

--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -126,6 +126,15 @@ let standalone_multiple parent attrs =
   in
     List.rev coms
 
+let split_docs docs =
+  let rec inner first x =
+    match x with
+    | { Location_.value = `Heading _; _ } :: _ -> List.rev first, x
+    | x :: y -> inner (x::first) y
+    | [] -> List.rev first, []
+  in
+  inner [] docs
+
 let extract_top_comment internal_tags ~classify parent items =
   let rec extract ~classify = function
     | hd :: tl as items -> (
@@ -151,18 +160,9 @@ let extract_top_comment internal_tags ~classify parent items =
       (parent : Paths.Identifier.Signature.t :> Paths.Identifier.LabelParent.t)
       ast_docs
   in
-  let split_docs =
-    let rec inner first x =
-      match x with
-      | { Location_.value = `Heading _; _ } :: _ -> List.rev first, x
-      | x :: y -> inner (x::first) y
-      | [] -> List.rev first, []
-    in
-    inner [] docs
-  in
-  (items, split_docs, tags)
+  (items, split_docs docs, tags)
 
 let extract_top_comment_class items =
   match items with
-  | Lang.ClassSignature.Comment (`Docs doc) :: tl -> (tl, doc)
-  | _ -> items, empty
+  | Lang.ClassSignature.Comment (`Docs doc) :: tl -> (tl, split_docs doc)
+  | _ -> items, (empty,empty)

--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -151,7 +151,16 @@ let extract_top_comment internal_tags ~classify parent items =
       (parent : Paths.Identifier.Signature.t :> Paths.Identifier.LabelParent.t)
       ast_docs
   in
-  (items, docs, tags)
+  let split_docs =
+    let rec inner first x =
+      match x with
+      | { Location_.value = `Heading _; _ } :: _ -> List.rev first, x
+      | x :: y -> inner (x::first) y
+      | [] -> List.rev first, []
+    in
+    inner [] docs
+  in
+  (items, split_docs, tags)
 
 let extract_top_comment_class items =
   match items with

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -60,8 +60,9 @@ val extract_top_comment :
   classify:('item -> [ `Attribute of Parsetree.attribute | `Open ] option) ->
   Paths.Identifier.Signature.t ->
   'item list ->
-  'item list * Comment.docs * 'tags
-(** Extract the first comment of a signature. Returns the remaining items. *)
+  'item list * (Comment.docs * Comment.docs) * 'tags
+(** Extract the first comment of a signature. Returns the remaining items.
+    Splits the docs on the first heading *)
 
 val extract_top_comment_class :
   Lang.ClassSignature.item list -> Lang.ClassSignature.item list * Comment.docs

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -65,5 +65,6 @@ val extract_top_comment :
     Splits the docs on the first heading *)
 
 val extract_top_comment_class :
-  Lang.ClassSignature.item list -> Lang.ClassSignature.item list * Comment.docs
+  Lang.ClassSignature.item list ->
+  Lang.ClassSignature.item list * (Comment.docs * Comment.docs)
 (** Extract the first comment of a class signature. Returns the remaining items. *)

--- a/test/generators/html/Nested-F.html
+++ b/test/generators/html/Nested-F.html
@@ -15,13 +15,12 @@
    <p>This is a functor F.</p><p>Some additional comments.</p>
   </header>
   <nav class="odoc-toc">
-   <ul><li><a href="#type">Type</a></li>
-    <li><a href="#parameters">Parameters</a></li>
+   <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
+    <li><a href="#type_3">Type</a></li>
    </ul>
   </nav>
   <div class="odoc-content">
-   <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
@@ -45,6 +44,7 @@
     </div>
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+   <h2 id="type_3"><a href="#type_3" class="anchor"></a>Type</h2>
    <div class="odoc-spec">
     <div class="spec type" id="type-t" class="anchored">
      <a href="#type-t" class="anchor"></a>

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -259,8 +259,13 @@
      </code>
     </div>
    </div>
-   <p>For a good time, see <code>SuperSig</code>.SubSigA.subSig or 
-    <code>SuperSig</code>.SubSigB.subSig or 
+   <p>For a good time, see 
+    <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig">
+     <code>subSig</code>
+    </a> or 
+    <a href="Ocamlary-module-type-SuperSig-module-type-SubSigB.html#subSig">
+     <code>subSig</code>
+    </a> or 
     <a href="Ocamlary-module-type-SuperSig-module-type-EmptySig.html">
      <code>SuperSig.EmptySig</code>
     </a>. Section <a href="#s9000">Section 9000</a> is also interesting.
@@ -2830,7 +2835,9 @@
    </ul><p>But also to things in submodules:</p>
    <ul>
     <li><code>{!section:SuperSig.SubSigA.subSig}</code> : 
-     <code>SuperSig</code>.SubSigA.subSig
+     <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig">
+      <code>subSig</code>
+     </a>
     </li>
     <li><code>{!Aliases.incl}</code> : 
      <a href="Ocamlary-Aliases.html#incl"><code>incl</code></a>
@@ -2841,7 +2848,9 @@
      <a href="#indexmodules">A</a>
     </li><li><code>{{!aliases}B}</code> : <a href="#aliases">B</a></li>
     <li><code>{{!section:SuperSig.SubSigA.subSig}C}</code> : 
-     <span class="xref-unresolved">C</span>
+     <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig">
+      C
+     </a>
     </li>
     <li><code>{{!Aliases.incl}D}</code> : 
      <a href="Ocamlary-Aliases.html#incl">D</a>

--- a/test/generators/html/highlight.pack.js
+++ b/test/generators/html/highlight.pack.js
@@ -1,0 +1,1 @@
+../../../src/vendor/highlight.pack.js

--- a/test/generators/html/odoc.css
+++ b/test/generators/html/odoc.css
@@ -1,0 +1,1 @@
+../../../src/odoc/etc/odoc.css

--- a/test/generators/latex/Nested.F.tex
+++ b/test/generators/latex/Nested.F.tex
@@ -3,9 +3,8 @@ This is a functor F.
 
 Some additional comments.
 
-\subsection{Type\label{type}}%
 \subsection{Parameters\label{parameters}}%
-\label{module-Nested-module-F-argument-1-Arg1}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Nested-module-F-argument-1-Arg1]{\ocamlinlinecode{Arg1}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type+u+2}}%
+\label{module-Nested-module-F-argument-1-Arg1}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Nested-module-F-argument-1-Arg1]{\ocamlinlinecode{Arg1}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
 \label{module-Nested-module-F-argument-1-Arg1-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \subsubsection{Values\label{values}}%
@@ -13,12 +12,13 @@ Some additional comments.
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{module-Nested-module-F-argument-2-Arg2}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Nested-module-F-argument-2-Arg2]{\ocamlinlinecode{Arg2}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type+u+3}}%
+\label{module-Nested-module-F-argument-2-Arg2}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Nested-module-F-argument-2-Arg2]{\ocamlinlinecode{Arg2}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type+u+2}}%
 \label{module-Nested-module-F-argument-2-Arg2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \subsection{Signature\label{signature}}%
+\subsection{Type\label{type+u+3}}%
 \label{module-Nested-module-F-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[module-Nested-module-F-argument-1-Arg1-type-t]{\ocamlinlinecode{Arg1.\allowbreak{}t}} * \hyperref[module-Nested-module-F-argument-2-Arg2-type-t]{\ocamlinlinecode{Arg2.\allowbreak{}t}}}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -111,7 +111,7 @@ An unassociated comment
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-For a good time, see \ocamlinlinecode{SuperSig}.SubSigA.subSig or \ocamlinlinecode{SuperSig}.SubSigB.subSig or \hyperref[module-Ocamlary-module-type-SuperSig-module-type-EmptySig]{\ocamlinlinecode{\ocamlinlinecode{SuperSig.\allowbreak{}EmptySig}}[p\pageref*{module-Ocamlary-module-type-SuperSig-module-type-EmptySig}]}. Section \hyperref[module-Ocamlary-s9000]{\ocamlinlinecode{Section 9000}[p\pageref*{module-Ocamlary-s9000}]} is also interesting. \hyperref[module-Ocamlary-emptySig]{\ocamlinlinecode{EmptySig}[p\pageref*{module-Ocamlary-emptySig}]} is the section and \hyperref[module-Ocamlary-module-type-EmptySig]{\ocamlinlinecode{\ocamlinlinecode{EmptySig}}[p\pageref*{module-Ocamlary-module-type-EmptySig}]} is the module signature.
+For a good time, see \hyperref[module-Ocamlary-module-type-SuperSig-module-type-SubSigA-subSig]{\ocamlinlinecode{\ocamlinlinecode{subSig}}[p\pageref*{module-Ocamlary-module-type-SuperSig-module-type-SubSigA-subSig}]} or \hyperref[module-Ocamlary-module-type-SuperSig-module-type-SubSigB-subSig]{\ocamlinlinecode{\ocamlinlinecode{subSig}}[p\pageref*{module-Ocamlary-module-type-SuperSig-module-type-SubSigB-subSig}]} or \hyperref[module-Ocamlary-module-type-SuperSig-module-type-EmptySig]{\ocamlinlinecode{\ocamlinlinecode{SuperSig.\allowbreak{}EmptySig}}[p\pageref*{module-Ocamlary-module-type-SuperSig-module-type-EmptySig}]}. Section \hyperref[module-Ocamlary-s9000]{\ocamlinlinecode{Section 9000}[p\pageref*{module-Ocamlary-s9000}]} is also interesting. \hyperref[module-Ocamlary-emptySig]{\ocamlinlinecode{EmptySig}[p\pageref*{module-Ocamlary-emptySig}]} is the section and \hyperref[module-Ocamlary-module-type-EmptySig]{\ocamlinlinecode{\ocamlinlinecode{EmptySig}}[p\pageref*{module-Ocamlary-module-type-EmptySig}]} is the module signature.
 
 \label{module-Ocamlary-module-Buffer}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-Buffer]{\ocamlinlinecode{Buffer}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-Buffer-val-f}\ocamlcodefragment{\ocamltag{keyword}{val} f : int \ocamltag{arrow}{$\rightarrow$} unit}\\
 \end{ocamlindent}%
@@ -845,13 +845,13 @@ I can refer to
 \item{\ocamlinlinecode{\{!aliases\}} : \hyperref[module-Ocamlary-aliases]{\ocamlinlinecode{Aliases again}[p\pageref*{module-Ocamlary-aliases}]}}\end{itemize}%
 But also to things in submodules:
 
-\begin{itemize}\item{\ocamlinlinecode{\{!section:SuperSig.\allowbreak{}SubSigA.\allowbreak{}subSig\}} : \ocamlinlinecode{SuperSig}.SubSigA.subSig}%
+\begin{itemize}\item{\ocamlinlinecode{\{!section:SuperSig.\allowbreak{}SubSigA.\allowbreak{}subSig\}} : \hyperref[module-Ocamlary-module-type-SuperSig-module-type-SubSigA-subSig]{\ocamlinlinecode{\ocamlinlinecode{subSig}}[p\pageref*{module-Ocamlary-module-type-SuperSig-module-type-SubSigA-subSig}]}}%
 \item{\ocamlinlinecode{\{!Aliases.\allowbreak{}incl\}} : \hyperref[module-Ocamlary-module-Aliases-incl]{\ocamlinlinecode{\ocamlinlinecode{incl}}[p\pageref*{module-Ocamlary-module-Aliases-incl}]}}\end{itemize}%
 And just to make sure we do not mess up:
 
 \begin{itemize}\item{\ocamlinlinecode{\{\{!section:indexmodules\}A\}} : \hyperref[module-Ocamlary-indexmodules]{\ocamlinlinecode{A}[p\pageref*{module-Ocamlary-indexmodules}]}}%
 \item{\ocamlinlinecode{\{\{!aliases\}B\}} : \hyperref[module-Ocamlary-aliases]{\ocamlinlinecode{B}[p\pageref*{module-Ocamlary-aliases}]}}%
-\item{\ocamlinlinecode{\{\{!section:SuperSig.\allowbreak{}SubSigA.\allowbreak{}subSig\}C\}} : \hyperref[xref-unresolved]{\ocamlinlinecode{C}[p\pageref*{xref-unresolved}]}}%
+\item{\ocamlinlinecode{\{\{!section:SuperSig.\allowbreak{}SubSigA.\allowbreak{}subSig\}C\}} : \hyperref[module-Ocamlary-module-type-SuperSig-module-type-SubSigA-subSig]{\ocamlinlinecode{C}[p\pageref*{module-Ocamlary-module-type-SuperSig-module-type-SubSigA-subSig}]}}%
 \item{\ocamlinlinecode{\{\{!Aliases.\allowbreak{}incl\}D\}} : \hyperref[module-Ocamlary-module-Aliases-incl]{\ocamlinlinecode{D}[p\pageref*{module-Ocamlary-module-Aliases-incl}]}}\end{itemize}%
 \subsection{New reference syntax\label{new-reference-syntax}}%
 \label{module-Ocamlary-module-type-M}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-M]{\ocamlinlinecode{M}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-M-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\

--- a/test/generators/man/Nested.F.3o
+++ b/test/generators/man/Nested.F.3o
@@ -20,11 +20,7 @@ Some additional comments\.
 .nf 
 .sp 
 .in 3
-\fB1 Type\fR
-.in 
-.sp 
-.in 3
-\fB2 Parameters\fR
+\fB1 Parameters\fR
 .in 
 .sp 
 \f[CB]module\fR Arg1 : \f[CB]sig\fR
@@ -32,7 +28,7 @@ Some additional comments\.
 .ti +2
 .sp 
 .ti +2
-\fB2\.1\.1 Type\fR
+\fB1\.1\.1 Type\fR
 .sp 
 .ti +2
 \f[CB]type\fR t
@@ -43,7 +39,7 @@ Some type\.
 .nf 
 .sp 
 .ti +2
-\fB2\.1\.2 Values\fR
+\fB1\.1\.2 Values\fR
 .sp 
 .ti +2
 \f[CB]val\fR y : t
@@ -61,7 +57,7 @@ The value of y\.
 .ti +2
 .sp 
 .ti +2
-\fB2\.1\.3 Type\fR
+\fB1\.1\.3 Type\fR
 .sp 
 .ti +2
 \f[CB]type\fR t
@@ -75,7 +71,11 @@ Some type\.
 \f[CB]end\fR
 .sp 
 .in 3
-\fB3 Signature\fR
+\fB2 Signature\fR
+.in 
+.sp 
+.in 3
+\fB3 Type\fR
 .in 
 .sp 
 \f[CB]type\fR t = Arg1\.t * Arg2\.t

--- a/test/generators/man/Ocamlary.3o
+++ b/test/generators/man/Ocamlary.3o
@@ -299,7 +299,7 @@ There's a signature in a module in this signature\.
 \f[CB]end\fR
 .sp 
 .fi 
-For a good time, see SuperSig\.SubSigA\.subSig or SuperSig\.SubSigB\.subSig or \f[CI]SuperSig\.EmptySig\fR\. Section \f[CI]Section 9000\fR is also interesting\. \f[CI]EmptySig\fR is the section and \f[CI]EmptySig\fR is the module signature\.
+For a good time, see \f[CI]subSig\fR or \f[CI]subSig\fR or \f[CI]SuperSig\.EmptySig\fR\. Section \f[CI]Section 9000\fR is also interesting\. \f[CI]EmptySig\fR is the section and \f[CI]EmptySig\fR is the module signature\.
 .nf 
 .sp 
 \f[CB]module\fR Buffer : \f[CB]sig\fR \.\.\. \f[CB]end\fR
@@ -1801,7 +1801,7 @@ I can refer to
 .sp 
 But also to things in submodules:
 .sp 
-\(bu {!section:SuperSig\.SubSigA\.subSig} : SuperSig\.SubSigA\.subSig
+\(bu {!section:SuperSig\.SubSigA\.subSig} : \f[CI]subSig\fR
 .br 
 \(bu {!Aliases\.incl} : \f[CI]incl\fR
 .sp 

--- a/test/xref2/ambiguous_label.t/run.t
+++ b/test/xref2/ambiguous_label.t/run.t
@@ -12,8 +12,6 @@ Labels don't follow OCaml's scoping rules:
   This reference will point to the first occurence of 'example'.
   Hint:
     Define labels explicitly using the syntax '{1:explicit-label Heading text}'.
-  File "test_2.ml", line 1, characters 4-55:
-  Failed to resolve reference unresolvedroot(Test).example Couldn't find "example"
 
 Contains some ambiguous labels:
 
@@ -54,4 +52,4 @@ not possible to use the internal label name in references:
 A second module has a reference to the ambiguous label:
 
   $ odoc_print test_2.odocl | jq -c '.. | .["`Reference"]? | select(.)'
-  [{"`Dot":[{"`Root":["Test","`TUnknown"]},"example"]},[{"`Word":"Should"},"`Space",{"`Word":"resolve"},"`Space",{"`Word":"to"},"`Space",{"`Word":"the"},"`Space",{"`Word":"first"},"`Space",{"`Word":"label"}]]
+  [{"`Resolved":{"`Label":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]}},"example"]}},[{"`Word":"Should"},"`Space",{"`Word":"resolve"},"`Space",{"`Word":"to"},"`Space",{"`Word":"the"},"`Space",{"`Word":"first"},"`Space",{"`Word":"label"}]]

--- a/test/xref2/labels.t/run.t
+++ b/test/xref2/labels.t/run.t
@@ -1,8 +1,6 @@
 
   $ compile test.mli
   Duplicate found: (root Test).B
-  File "test.mli", line 27, characters 14-20:
-  Failed to resolve reference unresolvedroot(M).C Couldn't find "C"
   File "test.mli", line 27, characters 9-13:
   Reference to label 'B' is ambiguous.
   This reference will point to the first occurence of 'B'.
@@ -36,13 +34,13 @@ Labels:
 Some are not in order because the 'doc' field appears after the rest in the output.
 
   $ odoc_print test.odocl | jq -c '.. | .["`Heading"]? | select(.) | .[1]'
+  {"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"A"]}
   {"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"B"]}
+  {"`Label":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]},"C"]}
   {"`Label":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]},"D"]}
   {"`Label":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]},"B"]}
-  {"`Label":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]},"C"]}
   {"`Label":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"N"]},"B"]}
   {"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"B"]}
-  {"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"A"]}
 
 References to the labels:
 We expect resolved references and the heading text filled in.
@@ -52,7 +50,7 @@ We expect resolved references and the heading text filled in.
   [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"B"]}},[]]
   [{"`Resolved":{"`Identifier":{"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"A"]}}},[{"`Word":"First"},"`Space",{"`Word":"label"}]]
   [{"`Resolved":{"`Identifier":{"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"B"]}}},[{"`Word":"Dupplicate"},"`Space",{"`Word":"B"}]]
-  [{"`Dot":[{"`Root":["M","`TUnknown"]},"C"]},[]]
+  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"C"]}},[]]
   [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"D"]}},[]]
   [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"B"]}},[]]
   [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"N"]}},"B"]}},[]]
@@ -145,7 +143,8 @@ The second occurence of 'B' in the main page should be disambiguated
      <p>Define <code>B</code> again in the same scope.</p>
      <p>References to the labels:</p>
      <p><a href="#A">First label</a> <a href="#B">Dupplicate B</a> 
-      <code>M</code>.C <a href="M/index.html#D"><code>D</code></a> 
+      <a href="M/index.html#C"><code>C</code></a> 
+      <a href="M/index.html#D"><code>D</code></a> 
       <a href="M/index.html#B"><code>B</code></a> 
       <a href="N/index.html#B"><code>B</code></a>
      </p>

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -237,7 +237,9 @@ Exception: Failure "resolve_reference: Couldn't find \"M\"".
      (`Identifier (`Module (`Root (Some (`Page (None, None)), Root), M)), r2),
    rf2)
 # resolve_ref "section:M.L2" ;;
-Exception: Failure "resolve_reference: Couldn't find label \"L2\"".
+- : ref =
+`Label
+  (`Identifier (`Module (`Root (Some (`Page (None, None)), Root), M)), L2)
 ```
 
 Implicit, root:
@@ -389,7 +391,9 @@ Implicit, in sig:
      (`Identifier (`Module (`Root (Some (`Page (None, None)), Root), M)), r2),
    rf2)
 # resolve_ref "M.L2" ;;
-Exception: Failure "resolve_reference: Couldn't find \"L2\"".
+- : ref =
+`Label
+  (`Identifier (`Module (`Root (Some (`Page (None, None)), Root), M)), L2)
 ```
 
 Known kind:
@@ -524,7 +528,9 @@ Known kind:
      (`Identifier (`Module (`Root (Some (`Page (None, None)), Root), M)), r2),
    rf2)
 # resolve_ref "M.section-L2" ;;
-Exception: Failure "resolve_reference: Couldn't find label \"L2\"".
+- : ref =
+`Label
+  (`Identifier (`Module (`Root (Some (`Page (None, None)), Root), M)), L2)
 # resolve_ref "module-M.type-t2" ;;
 - : ref =
 `Type
@@ -584,7 +590,9 @@ Exception: Failure "resolve_reference: Couldn't find label \"L2\"".
      (`Identifier (`Module (`Root (Some (`Page (None, None)), Root), M)), r2),
    rf2)
 # resolve_ref "module-M.section-L2" ;;
-Exception: Failure "resolve_reference: Couldn't find label \"L2\"".
+- : ref =
+`Label
+  (`Identifier (`Module (`Root (Some (`Page (None, None)), Root), M)), L2)
 # resolve_ref "module-M.field-rf2" ;;
 - : ref =
 `Field


### PR DESCRIPTION
This PR splits the first comment in a signature at the firstheading. This means everything before will be put into the preamble of the page, and the rest of the comment becomes part of the signature. Since the top comment has never been put into the environment, previously this meant that the labels couldn't be referenced. Now they are part of the signature this starts to work.

Fixes #740 