### PR TITLE
Warn on reference to ambiguous label

### DIFF
--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -452,7 +452,7 @@ let lookup_by_name scope name env =
   | ([ x ] as results), Some c -> (
       record_lookup_results env results;
       match c env x with
-      | Some (`Ambiguous (x, y)) -> Error (`Ambiguous (x, y))
+      | Some (`Ambiguous (x, y)) -> Result.Error (`Ambiguous (x, y))
       | None -> Result.Ok x)
   | ([ x ] as results), None ->
       record_lookup_results env results;

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -452,7 +452,7 @@ let lookup_by_name scope name env =
   | ([ x ] as results), Some c -> (
       record_lookup_results env results;
       match c env x with
-      | Some (`Ambiguous (x, y)) -> Result.Error (`Ambiguous (x, y))
+      | Some (`Ambiguous _ as e) -> Result.Error e
       | None -> Result.Ok x)
   | ([ x ] as results), None ->
       record_lookup_results env results;

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -114,7 +114,7 @@ let ambiguous_label_warning name (labels : Component.Element.any list) =
 let ambiguous_warning name (results : [< Component.Element.any ] list) =
   let results = (results :> Component.Element.any list) in
   if List.for_all (function `Label _ -> true | _ -> false) results then
-    ambiguous_label_warning name (results :> [> Component.Element.any ] list)
+    ambiguous_label_warning name results
   else ambiguous_generic_ref_warning name (List.map ref_kind_of_element results)
 
 let env_lookup_by_name ?(kind = `Any) scope name env =

--- a/test/xref2/labels/ambiguous_label.t/run.t
+++ b/test/xref2/labels/ambiguous_label.t/run.t
@@ -3,10 +3,13 @@ Labels don't follow OCaml's scoping rules:
 - No nesting: It is not possible to disambiguate labels by nesting them inside sections.
 
   $ compile test.ml test_2.ml
-  Duplicate label found: (root Test).example
-  Duplicate label found: (root Test).example
   File "test.ml", line 25, characters 4-36:
   Warning: Failed to resolve reference unresolvedroot(example_2) Couldn't find "example_2"
+  File "test.ml", line 16, characters 4-50:
+  Error: Multiple sections named 'example' found. Please alter one to ensure reference is unambiguous. Locations:
+    File "test.ml", line 3, character 4
+    File "test.ml", line 18, character 4
+    File "test.ml", line 9, character 4
 
 Contains some ambiguous labels:
 

--- a/test/xref2/labels/ambiguous_label_warning.t/run.t
+++ b/test/xref2/labels/ambiguous_label_warning.t/run.t
@@ -1,7 +1,13 @@
 The warning only shows up for explicitly defined labels.
 
   $ compile test.mli
-  Duplicate label found: (root Test).foo
+  File "test.mli", line 11, characters 4-14:
+  Error: Multiple sections named 'heading' found. Please alter one to ensure reference is unambiguous. Locations:
+    File "test.mli", line 7, character 4
+    File "test.mli", line 9, character 4
+  File "test.mli", line 5, characters 4-14:
+  Error: Label 'foo' is ambiguous. The other occurences are:
+    File "test.mli", line 3, character 4
   File "test.mli", line 3, characters 4-14:
   Error: Label 'foo' is ambiguous. The other occurences are:
     File "test.mli", line 5, character 4

--- a/test/xref2/labels/ambiguous_label_warning.t/test.mli
+++ b/test/xref2/labels/ambiguous_label_warning.t/test.mli
@@ -3,3 +3,18 @@
 (** {1:foo H1}
 
     {1:foo H2} *)
+
+(** {1 heading} *)
+
+(** {1 heading} *)
+
+(** {!heading} *)
+
+module M : sig
+  (** Test of scoping rules *)
+
+  (** {1 heading} *)
+
+  (** {!heading} should be unambiguous *)
+end
+

--- a/test/xref2/labels/labels.t/run.t
+++ b/test/xref2/labels/labels.t/run.t
@@ -1,6 +1,12 @@
 
   $ compile test.mli
-  Duplicate label found: (root Test).B
+  File "test.mli", line 27, characters 9-13:
+  Error: Multiple sections named 'B' found. Please alter one to ensure reference is unambiguous. Locations:
+    File "test.mli", line 3, character 4
+    File "test.mli", line 21, character 4
+  File "test.mli", line 21, characters 4-22:
+  Error: Label 'B' is ambiguous. The other occurences are:
+    File "test.mli", line 3, character 4
   File "test.mli", line 3, characters 4-24:
   Error: Label 'B' is ambiguous. The other occurences are:
     File "test.mli", line 21, character 4


### PR DESCRIPTION
We already warn when defining an explicit label that conflicts with another,
but this PR adds a warning when trying to reference a label that is ambiguous.