### PR TITLE
Fix the warning/error prefix

### DIFF
--- a/src/xref2/lookup_failures.ml
+++ b/src/xref2/lookup_failures.ml
@@ -46,9 +46,7 @@ let raise_warnings ~filename failures =
             | [] -> ()
           in
           let pp_failure fmt () =
-            let prefix = if non_fatal then "Warning" else "Error" in
-            Format.fprintf fmt "%s: %a%s" prefix pp_context context.c_context
-              msg
+            Format.fprintf fmt "%a%s" pp_context context.c_context msg
           in
           let err =
             match context.c_loc with

--- a/test/integration/compile.t/run.t
+++ b/test/integration/compile.t/run.t
@@ -5,161 +5,161 @@ Various tests for the 'compile' command.
   $ ocamlc -bin-annot -c ast.mli
   $ odoc compile --package foo ast.cmti
   File "ast.mli", line 1, characters 4-17:
-  Unknown tag '@TxtAttribute'.
+  Warning: Unknown tag '@TxtAttribute'.
   File "ast.mli", line 4, characters 4-21:
-  Unknown tag '@ValueDeclaration'.
+  Warning: Unknown tag '@ValueDeclaration'.
   File "ast.mli", line 6, characters 4-21:
-  Unknown tag '@ValueDeclaration'.
+  Warning: Unknown tag '@ValueDeclaration'.
   File "ast.mli", line 8, characters 4-21:
-  Unknown tag '@ValueDeclaration'.
+  Warning: Unknown tag '@ValueDeclaration'.
   File "ast.mli", line 11, characters 4-20:
-  Unknown tag '@TypeDeclaration'.
+  Warning: Unknown tag '@TypeDeclaration'.
   File "ast.mli", line 13, characters 4-20:
-  Unknown tag '@TypeDeclaration'.
+  Warning: Unknown tag '@TypeDeclaration'.
   File "ast.mli", line 14, characters 16-39:
-  Unknown tag '@ConstructorDeclaration'.
+  Warning: Unknown tag '@ConstructorDeclaration'.
   File "ast.mli", line 15, characters 16-39:
-  Unknown tag '@ConstructorDeclaration'.
+  Warning: Unknown tag '@ConstructorDeclaration'.
   File "ast.mli", line 22, characters 4-20:
-  Unknown tag '@TypeDeclaration'.
+  Warning: Unknown tag '@TypeDeclaration'.
   File "ast.mli", line 24, characters 15-32:
-  Unknown tag '@LabelDeclaration'.
+  Warning: Unknown tag '@LabelDeclaration'.
   File "ast.mli", line 25, characters 16-33:
-  Unknown tag '@LabelDeclaration'.
+  Warning: Unknown tag '@LabelDeclaration'.
   File "ast.mli", line 29, characters 4-20:
-  Unknown tag '@TypeDeclaration'.
+  Warning: Unknown tag '@TypeDeclaration'.
   File "ast.mli", line 31, characters 4-18:
-  Unknown tag '@TypeExtension'.
+  Warning: Unknown tag '@TypeExtension'.
   File "ast.mli", line 32, characters 17-27:
-  Unknown tag '@Extension'.
+  Warning: Unknown tag '@Extension'.
   File "ast.mli", line 33, characters 17-27:
-  Unknown tag '@Extension'.
+  Warning: Unknown tag '@Extension'.
   File "ast.mli", line 35, characters 4-26:
-  Unknown tag '@ModuleTypeDeclaration'.
+  Warning: Unknown tag '@ModuleTypeDeclaration'.
   File "ast.mli", line 37, characters 6-19:
-  Unknown tag '@TxtAttribute'.
+  Warning: Unknown tag '@TxtAttribute'.
   File "ast.mli", line 40, characters 6-22:
-  Unknown tag '@TypeDeclaration'.
+  Warning: Unknown tag '@TypeDeclaration'.
   File "ast.mli", line 43, characters 4-22:
-  Unknown tag '@ModuleDeclaration'.
+  Warning: Unknown tag '@ModuleDeclaration'.
   File "ast.mli", line 45, characters 6-19:
-  Unknown tag '@TxtAttribute'.
+  Warning: Unknown tag '@TxtAttribute'.
   File "ast.mli", line 47, characters 6-24:
-  Unknown tag '@ModuleDeclaration'.
+  Warning: Unknown tag '@ModuleDeclaration'.
   File "ast.mli", line 49, characters 8-21:
-  Unknown tag '@TxtAttribute'.
+  Warning: Unknown tag '@TxtAttribute'.
   File "ast.mli", line 52, characters 8-24:
-  Unknown tag '@TypeDeclaration'.
+  Warning: Unknown tag '@TypeDeclaration'.
   File "ast.mli", line 57, characters 4-14:
-  Unknown tag '@Exception'.
+  Warning: Unknown tag '@Exception'.
   File "ast.mli", line 60, characters 4-11:
-  Unknown tag '@Hidden'.
+  Warning: Unknown tag '@Hidden'.
   File "ast.mli", line 63, characters 4-23:
-  Unknown tag '@IncludeDescription'.
+  Warning: Unknown tag '@IncludeDescription'.
   File "ast.mli", line 68, characters 6-22:
-  Unknown tag '@TypeDeclaration'.
+  Warning: Unknown tag '@TypeDeclaration'.
   File "ast.mli", line 65, characters 6-19:
-  Unknown tag '@TxtAttribute'.
+  Warning: Unknown tag '@TxtAttribute'.
   File "ast.mli", line 68, characters 6-22:
-  Unknown tag '@TypeDeclaration'.
+  Warning: Unknown tag '@TypeDeclaration'.
   File "ast.mli", line 71, characters 4-10:
-  Unknown tag '@Class'.
+  Warning: Unknown tag '@Class'.
   File "ast.mli", line 74, characters 6-13:
-  Unknown tag '@Method'.
+  Warning: Unknown tag '@Method'.
 
 Test different parsing errors.
 
   $ ocamlc -bin-annot -c parser_errors.mli
   $ odoc compile --package foo parser_errors.cmti
   File "parser_errors.mli", line 1, characters 4-26:
-  '{x This is bad markup}': bad markup.
+  Warning: '{x This is bad markup}': bad markup.
   Suggestion: did you mean '{!x This is bad markup}' or '[x This is bad markup]'?
   File "parser_errors.mli", line 4, characters 4-24:
-  '9': bad heading level (0-5 allowed).
+  Warning: '9': bad heading level (0-5 allowed).
   File "parser_errors.mli", line 10, characters 8-11:
-  '{li ...}' should be followed by space, a tab, or a new line.
+  Warning: '{li ...}' should be followed by space, a tab, or a new line.
   File "parser_errors.mli", line 13, characters 4-7:
-  '{li ...}' (list item) is not allowed in top-level text.
+  Warning: '{li ...}' (list item) is not allowed in top-level text.
   Suggestion: move '{li ...}' into '{ul ...}' (bulleted list), or use '-' (bulleted list item).
   File "parser_errors.mli", line 13, characters 19-20:
-  Unpaired '}' (end of markup).
+  Warning: Unpaired '}' (end of markup).
   Suggestion: try '\}'.
   File "parser_errors.mli", line 16, characters 4-6:
-  '{v' should be followed by whitespace.
+  Warning: '{v' should be followed by whitespace.
   File "parser_errors.mli", line 19, characters 37-39:
-  'v}' should be preceded by whitespace.
+  Warning: 'v}' should be preceded by whitespace.
   File "parser_errors.mli", line 22, characters 4-5:
-  Stray '@'.
+  Warning: Stray '@'.
   File "parser_errors.mli", line 28, characters 4-11:
-  '@before' expects version number on the same line.
+  Warning: '@before' expects version number on the same line.
   File "parser_errors.mli", line 31, characters 4-10:
-  '@param' expects parameter name on the same line.
+  Warning: '@param' expects parameter name on the same line.
   File "parser_errors.mli", line 34, characters 4-10:
-  '@raise' expects exception constructor on the same line.
+  Warning: '@raise' expects exception constructor on the same line.
   File "parser_errors.mli", line 37, characters 4-11:
-  '@raises' expects exception constructor on the same line.
+  Warning: '@raises' expects exception constructor on the same line.
   File "parser_errors.mli", line 40, characters 4-8:
-  '@see' should be followed by <url>, 'file', or "document title".
+  Warning: '@see' should be followed by <url>, 'file', or "document title".
   File "parser_errors.mli", line 43, characters 4-15:
-  Unknown tag '@UnknownTag'.
+  Warning: Unknown tag '@UnknownTag'.
   File "parser_errors.mli", line 46, characters 4-5:
-  Unpaired '}' (end of markup).
+  Warning: Unpaired '}' (end of markup).
   Suggestion: try '\}'.
   File "parser_errors.mli", line 49, characters 4-5:
-  Unpaired ']' (end of code).
+  Warning: Unpaired ']' (end of code).
   Suggestion: try '\]'.
   File "parser_errors.mli", line 53, characters 4-5:
-  Unpaired '}' (end of markup).
+  Warning: Unpaired '}' (end of markup).
   Suggestion: try '\}'.
   File "parser_errors.mli", line 56, characters 4-18:
-  '{x bad markup}': bad markup.
+  Warning: '{x bad markup}': bad markup.
   Suggestion: did you mean '{!x bad markup}' or '[x bad markup]'?
 
 With warn-error enabled.
 
   $ odoc compile --package foo --warn-error parser_errors.cmti
   File "parser_errors.mli", line 1, characters 4-26:
-  '{x This is bad markup}': bad markup.
+  Error: '{x This is bad markup}': bad markup.
   Suggestion: did you mean '{!x This is bad markup}' or '[x This is bad markup]'?
   File "parser_errors.mli", line 4, characters 4-24:
-  '9': bad heading level (0-5 allowed).
+  Error: '9': bad heading level (0-5 allowed).
   File "parser_errors.mli", line 10, characters 8-11:
-  '{li ...}' should be followed by space, a tab, or a new line.
+  Error: '{li ...}' should be followed by space, a tab, or a new line.
   File "parser_errors.mli", line 13, characters 4-7:
-  '{li ...}' (list item) is not allowed in top-level text.
+  Error: '{li ...}' (list item) is not allowed in top-level text.
   Suggestion: move '{li ...}' into '{ul ...}' (bulleted list), or use '-' (bulleted list item).
   File "parser_errors.mli", line 13, characters 19-20:
-  Unpaired '}' (end of markup).
+  Error: Unpaired '}' (end of markup).
   Suggestion: try '\}'.
   File "parser_errors.mli", line 16, characters 4-6:
-  '{v' should be followed by whitespace.
+  Error: '{v' should be followed by whitespace.
   File "parser_errors.mli", line 19, characters 37-39:
-  'v}' should be preceded by whitespace.
+  Error: 'v}' should be preceded by whitespace.
   File "parser_errors.mli", line 22, characters 4-5:
-  Stray '@'.
+  Error: Stray '@'.
   File "parser_errors.mli", line 28, characters 4-11:
-  '@before' expects version number on the same line.
+  Error: '@before' expects version number on the same line.
   File "parser_errors.mli", line 31, characters 4-10:
-  '@param' expects parameter name on the same line.
+  Error: '@param' expects parameter name on the same line.
   File "parser_errors.mli", line 34, characters 4-10:
-  '@raise' expects exception constructor on the same line.
+  Error: '@raise' expects exception constructor on the same line.
   File "parser_errors.mli", line 37, characters 4-11:
-  '@raises' expects exception constructor on the same line.
+  Error: '@raises' expects exception constructor on the same line.
   File "parser_errors.mli", line 40, characters 4-8:
-  '@see' should be followed by <url>, 'file', or "document title".
+  Error: '@see' should be followed by <url>, 'file', or "document title".
   File "parser_errors.mli", line 43, characters 4-15:
-  Unknown tag '@UnknownTag'.
+  Error: Unknown tag '@UnknownTag'.
   File "parser_errors.mli", line 46, characters 4-5:
-  Unpaired '}' (end of markup).
+  Error: Unpaired '}' (end of markup).
   Suggestion: try '\}'.
   File "parser_errors.mli", line 49, characters 4-5:
-  Unpaired ']' (end of code).
+  Error: Unpaired ']' (end of code).
   Suggestion: try '\]'.
   File "parser_errors.mli", line 53, characters 4-5:
-  Unpaired '}' (end of markup).
+  Error: Unpaired '}' (end of markup).
   Suggestion: try '\}'.
   File "parser_errors.mli", line 56, characters 4-18:
-  '{x bad markup}': bad markup.
+  Error: '{x bad markup}': bad markup.
   Suggestion: did you mean '{!x bad markup}' or '[x bad markup]'?
   ERROR: Warnings have been generated.
   [1]
@@ -173,12 +173,12 @@ Check line numbers for errors in a '.mld' file.
 
   $ odoc compile line_numbers.mld
   File "line_numbers.mld", line 2, characters 0-4:
-  '{[...]}' (code block) should not be empty.
+  Warning: '{[...]}' (code block) should not be empty.
   File "line_numbers.mld", line 8, characters 0-12:
-  '{Bad Markup}': bad markup.
+  Warning: '{Bad Markup}': bad markup.
   Suggestion: did you mean '{!Bad Markup}' or '[Bad Markup]'?
   File "line_numbers.mld", line 32, characters 0-1:
-  '{': bad markup.
+  Warning: '{': bad markup.
   Suggestion: escape the brace with '\{'.
   File "line_numbers.mld", line 16, characters 0-11:
-  '6': bad heading level (0-5 allowed).
+  Warning: '6': bad heading level (0-5 allowed).

--- a/test/model/internal_tags.t/run.t
+++ b/test/model/internal_tags.t/run.t
@@ -8,12 +8,12 @@ We expect warnings to be emitted for each bad tags:
 
   $ compile bad.mli
   File "bad.mli", line 3, characters 4-11:
-  Unexpected tag '@inline' at this location.
+  Warning: Unexpected tag '@inline' at this location.
   File "bad.mli", line 7, characters 4-19:
-  Unexpected tag '@canonical' at this location.
+  Warning: Unexpected tag '@canonical' at this location.
   File "bad.mli", line 12, characters 4-19:
-  Unexpected tag '@canonical' at this location.
+  Warning: Unexpected tag '@canonical' at this location.
   File "bad.mli", line 17, characters 4-19:
-  Unexpected tag '@canonical' at this location.
+  Warning: Unexpected tag '@canonical' at this location.
   File "bad.mli", line 21, characters 4-11:
-  Unexpected tag '@inline' at this location.
+  Warning: Unexpected tag '@inline' at this location.

--- a/test/xref2/labels/ambiguous_label.t/run.t
+++ b/test/xref2/labels/ambiguous_label.t/run.t
@@ -6,7 +6,7 @@ Labels don't follow OCaml's scoping rules:
   File "test.ml", line 25, characters 4-36:
   Warning: Failed to resolve reference unresolvedroot(example_2) Couldn't find "example_2"
   File "test.ml", line 16, characters 4-50:
-  Error: Multiple sections named 'example' found. Please alter one to ensure reference is unambiguous. Locations:
+  Warning: Multiple sections named 'example' found. Please alter one to ensure reference is unambiguous. Locations:
     File "test.ml", line 3, character 4
     File "test.ml", line 18, character 4
     File "test.ml", line 9, character 4

--- a/test/xref2/labels/ambiguous_label_warning.t/run.t
+++ b/test/xref2/labels/ambiguous_label_warning.t/run.t
@@ -2,12 +2,12 @@ The warning only shows up for explicitly defined labels.
 
   $ compile test.mli
   File "test.mli", line 11, characters 4-14:
-  Error: Multiple sections named 'heading' found. Please alter one to ensure reference is unambiguous. Locations:
+  Warning: Multiple sections named 'heading' found. Please alter one to ensure reference is unambiguous. Locations:
     File "test.mli", line 7, character 4
     File "test.mli", line 9, character 4
   File "test.mli", line 5, characters 4-14:
-  Error: Label 'foo' is ambiguous. The other occurences are:
+  Warning: Label 'foo' is ambiguous. The other occurences are:
     File "test.mli", line 3, character 4
   File "test.mli", line 3, characters 4-14:
-  Error: Label 'foo' is ambiguous. The other occurences are:
+  Warning: Label 'foo' is ambiguous. The other occurences are:
     File "test.mli", line 5, character 4

--- a/test/xref2/labels/labels.t/run.t
+++ b/test/xref2/labels/labels.t/run.t
@@ -1,14 +1,14 @@
 
   $ compile test.mli
   File "test.mli", line 27, characters 9-13:
-  Error: Multiple sections named 'B' found. Please alter one to ensure reference is unambiguous. Locations:
+  Warning: Multiple sections named 'B' found. Please alter one to ensure reference is unambiguous. Locations:
     File "test.mli", line 3, character 4
     File "test.mli", line 21, character 4
   File "test.mli", line 21, characters 4-22:
-  Error: Label 'B' is ambiguous. The other occurences are:
+  Warning: Label 'B' is ambiguous. The other occurences are:
     File "test.mli", line 3, character 4
   File "test.mli", line 3, characters 4-24:
-  Error: Label 'B' is ambiguous. The other occurences are:
+  Warning: Label 'B' is ambiguous. The other occurences are:
     File "test.mli", line 21, character 4
 
 Labels:

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -14,7 +14,7 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
   $ odoc compile --pkg test -o a__b.odoc -I . a__b.cmti
   $ odoc compile --pkg test -o a.odoc -I . a.cmti
   File "a.mli", line 4, characters 4-17:
-  Canonical paths must contain a dot, eg. X.Y.
+  Warning: Canonical paths must contain a dot, eg. X.Y.
 
   $ odoc link -I . a__b.odoc
   $ odoc link -I . a.odoc

--- a/test/xref2/ocaml_stdlib.t/run.t
+++ b/test/xref2/ocaml_stdlib.t/run.t
@@ -10,7 +10,7 @@ Imitate the way the stdlib is built and how its documentation should be built.
 
   $ odoc compile --pkg ocaml -o main.odoc main.cmti -I .
   File "main.mli", line 3, characters 4-17:
-  Canonical paths must contain a dot, eg. X.Y.
+  Warning: Canonical paths must contain a dot, eg. X.Y.
   $ odoc compile --pkg ocaml -o main__x.odoc main__x.cmti -I .
 
   $ odoc html --indent -o html main__x.odoc -I .

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -972,11 +972,11 @@ Ambiguous in env:
 ```ocaml
 # resolve_ref "t" ;;
 File "<test>":
-Error: Reference to 't' is ambiguous. Please specify its kind: type-t, val-t.
+Warning: Reference to 't' is ambiguous. Please specify its kind: type-t, val-t.
 - : ref = `Identifier (`Value (`Root (Some (`Page (None, None)), Root), t))
 # resolve_ref "X" ;;
 File "<test>":
-Error: Reference to 'X' is ambiguous. Please specify its kind: constructor-X, module-X.
+Warning: Reference to 'X' is ambiguous. Please specify its kind: constructor-X, module-X.
 - : ref = `Identifier (`Module (`Root (Some (`Page (None, None)), Root), X))
 ```
 
@@ -985,12 +985,12 @@ Ambiguous in sig:
 ```ocaml
 # resolve_ref "X.u" ;;
 File "<test>":
-Error: Reference to 'u' is ambiguous. Please specify its kind: type-u, val-u.
+Warning: Reference to 'u' is ambiguous. Please specify its kind: type-u, val-u.
 - : ref =
 `Type (`Identifier (`Module (`Root (Some (`Page (None, None)), Root), X)), u)
 # resolve_ref "X.Y" ;;
 File "<test>":
-Error: Reference to 'Y' is ambiguous. Please specify its kind: constructor-Y, module-Y.
+Warning: Reference to 'Y' is ambiguous. Please specify its kind: constructor-Y, module-Y.
 - : ref =
 `Constructor
   (`Type
@@ -998,7 +998,7 @@ Error: Reference to 'Y' is ambiguous. Please specify its kind: constructor-Y, mo
    Y)
 # resolve_ref "Everything_ambiguous_in_sig.t" (* Some kinds are missing: label, type subst (would be "type-") *) ;;
 File "<test>":
-Error: Reference to 't' is ambiguous. Please specify its kind: field-t, module-type-t, type-t, val-t, val-t.
+Warning: Reference to 't' is ambiguous. Please specify its kind: field-t, module-type-t, type-t, val-t, val-t.
 - : ref =
 `Type
   (`Identifier
@@ -1008,7 +1008,7 @@ Error: Reference to 't' is ambiguous. Please specify its kind: field-t, module-t
    t)
 # resolve_ref "Everything_ambiguous_in_sig.T" (* Missing kind: module subst (would be "module-") *) ;;
 File "<test>":
-Error: Reference to 'T' is ambiguous. Please specify its kind: exception-T, extension-T, module-T.
+Warning: Reference to 'T' is ambiguous. Please specify its kind: exception-T, extension-T, module-T.
 - : ref =
 `Module
   (`Identifier

--- a/test/xref2/unexpanded_module_type_of.t/run.t
+++ b/test/xref2/unexpanded_module_type_of.t/run.t
@@ -18,4 +18,3 @@ should _not_ result in an exception, merely a warning.
   $ odoc compile --package test test.cmti
   File "test.cmti":
   Warning: Failed to compile expansion for include : module type of unresolvedroot(Test0) Unexpanded `module type of` expression: module type of unresolvedroot(Test0)
-

--- a/test/xref2/warnings.t/run.t
+++ b/test/xref2/warnings.t/run.t
@@ -7,18 +7,18 @@ A contains both parsing errors and a reference to B that isn't compiled yet:
 
   $ odoc compile --warn-error --package test a.cmti
   File "a.mli", line 8, characters 23-23:
-  End of text is not allowed in '{!...}' (cross-reference).
+  Error: End of text is not allowed in '{!...}' (cross-reference).
   File "a.mli", line 8, characters 22-23:
-  Identifier in reference should not be empty.
+  Error: Identifier in reference should not be empty.
   ERROR: Warnings have been generated.
   [1]
 
   $ odoc compile --package test b.cmti
   $ odoc compile --package test a.cmti
   File "a.mli", line 8, characters 23-23:
-  End of text is not allowed in '{!...}' (cross-reference).
+  Warning: End of text is not allowed in '{!...}' (cross-reference).
   File "a.mli", line 8, characters 22-23:
-  Identifier in reference should not be empty.
+  Warning: Identifier in reference should not be empty.
 
   $ odoc errors a.odoc
   File "a.mli", line 8, characters 23-23:
@@ -30,7 +30,7 @@ A contains linking errors:
 
   $ odoc link a.odoc
   File "a.odoc":
-  Couldn't find the following modules:
+  Warning: Couldn't find the following modules:
     B
   File "a.mli", line 6, characters 47-65:
   Warning: Failed to resolve reference unresolvedroot(B).doesn't_exist Couldn't find "B"
@@ -44,7 +44,7 @@ A contains linking errors:
   Couldn't find the following modules:
     B
   File "a.mli", line 6, characters 47-65:
-  Warning: Failed to resolve reference unresolvedroot(B).doesn't_exist Couldn't find "B"
+  Failed to resolve reference unresolvedroot(B).doesn't_exist Couldn't find "B"
 
 It is possible to hide the warnings too:
 


### PR DESCRIPTION
The prefix was incorrectly computed and was always "Error" for a class of warnings and "Warning" for others.
Now, correctly take into account the warn-error option.