### PR TITLE
Add compatibility with 4.14.0

### DIFF
--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -335,7 +335,9 @@ let prepare_type_parameters params manifest =
     | Some ty ->
         let vars = Ctype.free_variables ty in
           List.iter
-            (fun v -> if get_desc v = Tvar (Some "_") then (if List.memq ty vars then tvar_none ty))
+            (fun ty -> match get_desc ty with
+              | Tvar (Some "_") -> if List.memq ty vars then tvar_none ty
+              | _ -> ())
             params
     | None -> ()
   end;

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -294,7 +294,11 @@ let read_extension_constructor env parent ext =
   let doc = Doc_attr.attached_no_tag label_container ext.ext_attributes in
   match ext.ext_kind with
   | Text_rebind _ -> assert false
+  #if OCAML_VERSION >= (4, 14, 0)
+  | Text_decl(_, args, res) ->
+  #else
   | Text_decl(args, res) ->
+  #endif
     let args =
       read_constructor_declaration_arguments
         env container label_container args
@@ -324,7 +328,11 @@ let read_exception env parent (ext : extension_constructor) =
   let doc = Doc_attr.attached_no_tag label_container ext.ext_attributes in
   match ext.ext_kind with
   | Text_rebind _ -> assert false
+  #if OCAML_VERSION >= (4, 14, 0)
+  | Text_decl(_, args, res) ->
+  #else
   | Text_decl(args, res) ->
+  #endif
     let args =
       read_constructor_declaration_arguments
         env container label_container args


### PR DESCRIPTION
For some projects I might need to build using 4.14.X and I **hastily** ported odoc to `4.14.0+trunk`. Not sure I'll have time to properly test/finish the PR but this might be useful for anyone who does pick up that work.  