### PR TITLE
Fix error in xref

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Unreleased
+----------
+
+Bugs fixed
+- Fix a missing Result constructor during compile. This will cause some
+  functor arguments to have different filenames (@jonludlam, #795)
+
 2.0.2
 -----
 

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -615,7 +615,7 @@ and module_type_expr :
   | Functor (param, res) ->
       let param' = functor_parameter env param in
       let env' = Env.add_functor_parameter param env in
-      let res' = module_type_expr env' id res in
+      let res' = module_type_expr env' (`Result id) res in
       Functor (param', res')
   | TypeOf { t_desc; t_expansion } as e ->
       let t_expansion = get_expansion t_expansion e in

--- a/test/generators/html/Module_type_alias-module-type-E-argument-2-C.html
+++ b/test/generators/html/Module_type_alias-module-type-E-argument-2-C.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>C (Module_type_alias.E.1-C)</title>
+ <head><title>C (Module_type_alias.E.2-C)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Module_type_alias-module-type-E.html">Up</a>
     – <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB;
-    <a href="Module_type_alias-module-type-E.html">E</a> &#x00BB; 1-C
+    <a href="Module_type_alias-module-type-E.html">E</a> &#x00BB; 2-C
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>E.1-C</span></code></h1>
+   <h1>Parameter <code><span>E.2-C</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Module_type_alias-module-type-E.html
+++ b/test/generators/html/Module_type_alias-module-type-E.html
@@ -35,10 +35,10 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-C" class="anchored">
-     <a href="#argument-1-C" class="anchor"></a>
+    <div class="spec parameter" id="argument-2-C" class="anchored">
+     <a href="#argument-2-C" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
-      <span><a href="Module_type_alias-module-type-E-argument-1-C.html">C</a>
+      <span><a href="Module_type_alias-module-type-E-argument-2-C.html">C</a>
       </span>
       <span> : <span class="keyword">sig</span> ... 
        <span class="keyword">end</span>

--- a/test/generators/html/module_type_alias.targets
+++ b/test/generators/html/module_type_alias.targets
@@ -4,6 +4,6 @@ Module_type_alias-module-type-B.html
 Module_type_alias-module-type-B-argument-1-C.html
 Module_type_alias-module-type-E.html
 Module_type_alias-module-type-E-argument-1-F.html
-Module_type_alias-module-type-E-argument-1-C.html
+Module_type_alias-module-type-E-argument-2-C.html
 Module_type_alias-module-type-G.html
 Module_type_alias-module-type-G-argument-1-H.html

--- a/test/generators/latex/Module_type_alias.tex
+++ b/test/generators/latex/Module_type_alias.tex
@@ -17,7 +17,7 @@ Module Type Aliases
 \label{module-Module+u+type+u+alias-module-type-E-argument-1-F}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Module+u+type+u+alias-module-type-E-argument-1-F]{\ocamlinlinecode{F}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Module+u+type+u+alias-module-type-E-argument-1-F-type-f}\ocamlcodefragment{\ocamltag{keyword}{type} f}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{module-Module+u+type+u+alias-module-type-E-argument-1-C}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Module+u+type+u+alias-module-type-E-argument-1-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Module+u+type+u+alias-module-type-E-argument-1-C-type-c}\ocamlcodefragment{\ocamltag{keyword}{type} c}\\
+\label{module-Module+u+type+u+alias-module-type-E-argument-2-C}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Module+u+type+u+alias-module-type-E-argument-2-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Module+u+type+u+alias-module-type-E-argument-2-C-type-c}\ocamlcodefragment{\ocamltag{keyword}{type} c}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \subsubsection{Signature\label{signature+u+2}}%

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -2393,7 +2393,7 @@
    Module_type_alias-module-type-B-argument-1-C.html.gen
    Module_type_alias-module-type-E.html.gen
    Module_type_alias-module-type-E-argument-1-F.html.gen
-   Module_type_alias-module-type-E-argument-1-C.html.gen
+   Module_type_alias-module-type-E-argument-2-C.html.gen
    Module_type_alias-module-type-G.html.gen
    Module_type_alias-module-type-G-argument-1-H.html.gen)
   (action
@@ -2445,8 +2445,8 @@
   (alias runtest)
   (action
    (diff
-    Module_type_alias-module-type-E-argument-1-C.html
-    Module_type_alias-module-type-E-argument-1-C.html.gen)))
+    Module_type_alias-module-type-E-argument-2-C.html
+    Module_type_alias-module-type-E-argument-2-C.html.gen)))
  (rule
   (alias runtest)
   (action

--- a/test/xref2/resolve/test.md
+++ b/test/xref2/resolve/test.md
@@ -1529,8 +1529,9 @@ Resolve a functor:
                       (Odoc_model.Lang.Signature.Ordinary,
                       {Odoc_model.Lang.TypeDecl.id =
                         `Type
-                          (`ModuleType
-                             (`Root (Some (`Page (None, None)), Root), S1),
+                          (`Result
+                             (`ModuleType
+                                (`Root (Some (`Page (None, None)), Root), S1)),
                            t);
                        doc = []; canonical = None;
                        equation =
@@ -1561,10 +1562,7 @@ Resolve a functor:
                     (Odoc_model.Lang.ModuleType.Signature
                       {Odoc_model.Lang.Signature.items =
                         [Odoc_model.Lang.Signature.Type
-                          (Odoc_model.Lang.Signature.Ordinary,
-                          {Odoc_model.Lang.TypeDecl.id = ...; doc = ...;
-                           canonical = ...; equation = ...;
-                           representation = ...});
+                          (Odoc_model.Lang.Signature.Ordinary, ...);
                          ...];
                        compiled = ...; doc = ...});
                   p_path = ...}},


### PR DESCRIPTION
This was causing the module_type_alias test to produce a functor expansion with two arguments labelled '1'.