### PR TITLE
Better handling of substitutions

### DIFF
--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -217,16 +217,21 @@ and signature_items : Env.t -> Id.Signature.t -> Signature.item list -> _ =
               in
               (Module (r, m') :: items, env')
         | ModuleSubstitution m ->
-            std @@ ModuleSubstitution (module_substitution env m)
+            let env' = Env.open_module_substitution m env in
+            (ModuleSubstitution (module_substitution env m) :: items, env')
         | Type (r, t) -> std @@ Type (r, type_decl env t)
-        | TypeSubstitution t -> std @@ TypeSubstitution (type_decl env t)
+        | TypeSubstitution t ->
+            let env' = Env.open_type_substitution t env in
+            (TypeSubstitution (type_decl env t) :: items, env')
         | ModuleType mt ->
             let m' = module_type env mt in
             let ty = Component.Of_Lang.(module_type (empty ()) m') in
             let env' = Env.update_module_type mt.id ty env in
             (ModuleType (module_type env mt) :: items, env')
         | ModuleTypeSubstitution mt ->
-            std @@ ModuleTypeSubstitution (module_type_substitution env mt)
+            let env' = Env.open_module_type_substitution mt env in
+            ( ModuleTypeSubstitution (module_type_substitution env mt) :: items,
+              env' )
         | Value v -> std @@ Value (value_ env id v)
         | Comment c -> std @@ Comment c
         | TypExt t -> std @@ TypExt (extension env id t)

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -808,12 +808,13 @@ let rec close_signature : Odoc_model.Lang.Signature.t -> t -> t =
         | Type (_, t) -> remove t.L.TypeDecl.id env
         | Module (_, t) -> remove t.L.Module.id env
         | ModuleType t -> remove t.L.ModuleType.id env
-        | ModuleSubstitution t -> remove t.L.ModuleSubstitution.id env
         | Class (_, c) -> remove c.id env
         | ClassType (_, c) -> remove c.id env
         | Include i -> close_signature i.expansion.content env
         | Open o -> close_signature o.expansion env
-        | ModuleTypeSubstitution _ | TypeSubstitution _ -> env
+        | ModuleSubstitution _ | ModuleTypeSubstitution _ | TypeSubstitution _
+          ->
+            env
         (* The following are only added when linking *)
         | Exception _ -> env
         | TypExt _ -> env

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -152,6 +152,13 @@ val open_class_signature : Odoc_model.Lang.ClassSignature.t -> t -> t
 
 val open_signature : Odoc_model.Lang.Signature.t -> t -> t
 
+val open_type_substitution : Odoc_model.Lang.TypeDecl.t -> t -> t
+
+val open_module_substitution : Odoc_model.Lang.ModuleSubstitution.t -> t -> t
+
+val open_module_type_substitution :
+  Odoc_model.Lang.ModuleTypeSubstitution.t -> t -> t
+
 val open_page : Odoc_model.Lang.Page.t -> t -> t
 (** Add a page content to the env. *)
 

--- a/test/xref2/dune
+++ b/test/xref2/dune
@@ -22,6 +22,6 @@
 ; 4.08.0 and above
 
 (cram
- (applies_to github_issue_587)
+ (applies_to github_issue_587 github_issue_793)
  (enabled_if
   (>= %{ocaml_version} 4.08.0)))

--- a/test/xref2/dune
+++ b/test/xref2/dune
@@ -22,6 +22,13 @@
 ; 4.08.0 and above
 
 (cram
- (applies_to github_issue_587 github_issue_793)
+ (applies_to github_issue_587)
  (enabled_if
   (>= %{ocaml_version} 4.08.0)))
+
+; 4.13.0 and above
+
+(cram
+ (applies_to github_issue_793)
+ (enabled_if
+  (>= %{ocaml_version} 4.13.0)))

--- a/test/xref2/github_issue_793.t/irmin_layers_intf.ml
+++ b/test/xref2/github_issue_793.t/irmin_layers_intf.ml
@@ -1,11 +1,15 @@
 module Foo = struct end
 
+module type Foo_T = sig end
+
 module type A = sig
   type unrelated
 
   type conflicting_type := [ `Contents | `Node ]
 
   module Conflicting_module := Foo
+
+  module type Conflicting_module_type := Foo_T
 end
 
 module type B = sig
@@ -14,6 +18,8 @@ module type B = sig
   type conflicting_type = Foo
 
   module Conflicting_module = Foo
+
+  module type Conflicting_module_type = Foo_T
 end
 
 module type C = sig

--- a/test/xref2/github_issue_793.t/irmin_layers_intf.ml
+++ b/test/xref2/github_issue_793.t/irmin_layers_intf.ml
@@ -1,0 +1,33 @@
+module Irmin = struct
+  module type S_generic_key = sig
+    type repo
+
+    type kinded_key := [ `Contents | `Node ]
+
+    val f : kinded_key
+  end
+
+  module type S = sig
+    include S_generic_key
+  end
+
+  module Generic_key = struct
+    module type S = S_generic_key
+  end
+end
+
+module type Generic_key = sig
+  include Irmin.Generic_key.S
+
+  type kinded_key = Foo
+end
+
+module type S = sig
+  include Generic_key
+end
+
+module type Maker = sig
+  type hash
+
+  module Make (Schema : sig end) : S with type repo = int
+end

--- a/test/xref2/github_issue_793.t/irmin_layers_intf.ml
+++ b/test/xref2/github_issue_793.t/irmin_layers_intf.ml
@@ -1,33 +1,27 @@
-module Irmin = struct
-  module type S_generic_key = sig
-    type repo
+module Foo = struct end
 
-    type kinded_key := [ `Contents | `Node ]
+module type A = sig
+  type unrelated
 
-    val f : kinded_key
-  end
+  type conflicting_type := [ `Contents | `Node ]
 
-  module type S = sig
-    include S_generic_key
-  end
-
-  module Generic_key = struct
-    module type S = S_generic_key
-  end
+  module Conflicting_module := Foo
 end
 
-module type Generic_key = sig
-  include Irmin.Generic_key.S
+module type B = sig
+  include A
 
-  type kinded_key = Foo
+  type conflicting_type = Foo
+
+  module Conflicting_module = Foo
 end
 
-module type S = sig
-  include Generic_key
+module type C = sig
+  include B
 end
 
 module type Maker = sig
   type hash
 
-  module Make (Schema : sig end) : S with type repo = int
+  module Make (Schema : sig end) : C with type unrelated = int
 end

--- a/test/xref2/github_issue_793.t/run.t
+++ b/test/xref2/github_issue_793.t/run.t
@@ -1,0 +1,9 @@
+This test checks for handling of type substitutions.
+Specifically, there was an issue where the code in this test
+caused an exception during compilation. The absence of the
+exception shows this working correctly.
+
+  $ ocamlc -c irmin_layers_intf.ml -bin-annot -I .
+  $ odoc compile -I . irmin_layers_intf.cmt
+
+

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -730,9 +730,9 @@ let resolve_ref = resolve_ref_of_mli {|
 <!-- $MDX version>=4.08 -->
 ```ocaml
 # resolve_ref "s1" ;;
-- : ref = `Identifier (`Type (`Root (Some (`Page (None, None)), Root), s1))
+Exception: Failure "resolve_reference: Couldn't find \"s1\"".
 # resolve_ref "s1.rf1" ;;
-Exception: Failure "resolve_reference: Couldn't find \"rf1\"".
+Exception: Failure "resolve_reference: Couldn't find \"s1\"".
 # resolve_ref "M.s2" ;;
 Exception: Failure "resolve_reference: Couldn't find \"s2\"".
 # resolve_ref "M.s2.rf2" ;;


### PR DESCRIPTION
The scope of the substitutions shouldn't escape the signature. So
the substitutions are only added to the environment explicitly during
the compile/link processing of signatures, not in the more general
'Env.open_signature'. Included in this commit is a test for GH issue
793 which was a manifestation of the problem this caused.