### PR TITLE
Add a class and a css rule for empty includes

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -299,6 +299,10 @@ and items ~resolve l : item Html.elt list =
       :: rest ->
         let doc = spec_doc_div ~resolve doc in
         let included_html = (items content :> any Html.elt list) in
+        let a_class =
+          if List.length content = 0 then [ "odoc-include"; "shadowed-include" ]
+          else [ "odoc-include" ]
+        in
         let content =
           let details ~open' =
             let open' = if open' then [ Html.a_open () ] else [] in
@@ -315,9 +319,7 @@ and items ~resolve l : item Html.elt list =
           | `Open -> details ~open':true
           | `Default -> details ~open':!Tree.open_details
         in
-        let inc =
-          [ Html.div ~a:[ Html.a_class [ "odoc-include" ] ] (doc @ content) ]
-        in
+        let inc = [ Html.div ~a:[ Html.a_class a_class ] (doc @ content) ] in
         (continue_with [@tailcall]) rest inc
     | Declaration { Item.attr; anchor; content; doc } :: rest ->
         let anchor_attrib, anchor_link = mk_anchor anchor in

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -471,6 +471,10 @@ div.def-doc>*:first-child {
   position: relative;
 }
 
+.odoc-include.shadowed-include {
+  display: none;
+}
+
 .odoc-include details:after {
   z-index: -100;
   display: block;

--- a/test/generators/html/Include-module-type-Dorminant_Module.html
+++ b/test/generators/html/Include-module-type-Dorminant_Module.html
@@ -15,7 +15,7 @@
    <h1>Module type <code><span>Include.Dorminant_Module</span></code></h1>
   </header>
   <div class="odoc-content">
-   <div class="odoc-include">
+   <div class="odoc-include shadowed-include">
     <details open="open">
      <summary class="spec include">
       <code>

--- a/test/generators/html/Include.html
+++ b/test/generators/html/Include.html
@@ -152,7 +152,7 @@
      </code>
     </div>
    </div>
-   <div class="odoc-include">
+   <div class="odoc-include shadowed-include">
     <details open="open">
      <summary class="spec include">
       <code>
@@ -190,7 +190,7 @@
        </span>
       </code>
      </summary>
-     <div class="odoc-include">
+     <div class="odoc-include shadowed-include">
       <details open="open">
        <summary class="spec include">
         <code>

--- a/test/generators/html/Ocamlary-module-type-C.html
+++ b/test/generators/html/Ocamlary-module-type-C.html
@@ -52,7 +52,7 @@
      </div>
     </details>
    </div>
-   <div class="odoc-include">
+   <div class="odoc-include shadowed-include">
     <details open="open">
      <summary class="spec include">
       <code>

--- a/test/generators/html/Ocamlary-module-type-IncludeModuleType.html
+++ b/test/generators/html/Ocamlary-module-type-IncludeModuleType.html
@@ -16,7 +16,7 @@
    <p>This comment is for <code>IncludeModuleType</code>.</p>
   </header>
   <div class="odoc-content">
-   <div class="odoc-include">
+   <div class="odoc-include shadowed-include">
     <div class="spec-doc">
      <p>This comment is for <code>include EmptySigAlias</code>.</p>
     </div>


### PR DESCRIPTION
This PR propose a fix of #725.

It adds a class `"shadowed-include"` to the html element containing an empty include.
This way, it is easy to change how these elements are displayed without changing odoc itself, just adding css.
By default, in this PR, it is not displayed.
However, the first suggestion of @asavahista on #725, of having a special formatting for these, could be implemented as well.