### PR TITLE
Fix tests for old versions of ocaml (<4.08)

### DIFF
--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -510,11 +510,7 @@ and read_structure_item env parent item =
     | Tstr_modtype mtd ->
         [ModuleType (Cmti.read_module_type_declaration env parent mtd)]
     | Tstr_open o ->
-#if OCAML_VERSION < (4,8,0)
-        ignore(o); []
-#else
         [Open (read_open env parent o)]
-#endif
     | Tstr_include incl ->
         read_include env parent incl
     | Tstr_class cls ->
@@ -566,13 +562,16 @@ and read_include env parent incl =
   | _ ->
     content.items
 
-#if OCAML_VERSION >= (4,8,0)
 and read_open env parent o =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container o.open_attributes in
-  let expansion, _ = Cmi.read_signature_noenv env parent (Odoc_model.Compat.signature o.open_bound_items) in
+  #if OCAML_VERSION >= (4,8,0)
+  let signature = o.open_bound_items in
+  #else
+  let signature = [] in
+  #endif
+  let expansion, _ = Cmi.read_signature_noenv env parent (Odoc_model.Compat.signature signature) in
   Open.{expansion; doc}
-#endif
 
 and read_structure :
       'tags. 'tags Odoc_model.Semantics.handle_internal_tags -> _ -> _ -> _ ->

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -685,14 +685,10 @@ and read_signature_item env parent item =
         read_module_declarations env parent mds
     | Tsig_modtype mtd ->
         [ModuleType (read_module_type_declaration env parent mtd)]
-#if OCAML_VERSION >= (4,8,0)
     | Tsig_open o ->
         [
           Open (read_open env parent o)
         ]
-#else
-    | Tsig_open _ -> []
-#endif
     | Tsig_include incl ->
         read_include env parent incl
     | Tsig_class cls ->
@@ -773,13 +769,16 @@ and read_include env parent incl =
   | _ ->
     content.items
 
-#if OCAML_VERSION >= (4,8,0)
 and read_open env parent o =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container o.open_attributes in
-  let expansion, _ = Cmi.read_signature_noenv env parent (Odoc_model.Compat.signature o.open_bound_items) in
+  #if OCAML_VERSION >= (4,8,0)
+  let signature = o.open_bound_items in
+  #else
+  let signature = [] in
+  #endif
+  let expansion, _ = Cmi.read_signature_noenv env parent (Odoc_model.Compat.signature signature) in
   { expansion; doc }
-#endif
 
 and read_signature :
       'tags. 'tags Odoc_model.Semantics.handle_internal_tags -> _ -> _ -> _ ->


### PR DESCRIPTION
This PR fixes #745 for versions of ocaml older than 4.08. It solves the failure of tests introduced in #797 for those versions.