### PR TITLE
Loosen hard version dependency added as a workaround

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -44,7 +44,7 @@ depends: [
   "ppx_expect" {with-test}
   "bos" {with-test}
 
-  "bisect_ppx" {dev & = "2.5.0"}
+  "bisect_ppx" {dev & > "2.5.0"}
   ("ocaml" {< "4.03.0" & dev} | "mdx" {dev})
 ]
 


### PR DESCRIPTION
This was added when we had a circular dependency because odoc-parser
was part of odoc.