### PR TITLE
Preliminary `{math }`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ ocaml-re/
 result/
 tyxml/
 uutf/
+
+# Mac things
+.DS_Store

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -50,6 +50,10 @@ and raw_markup (t : Raw_markup.t) =
          the HTML tree from there.
       *)
       [ Html.Unsafe.data content ]
+  | "math" ->
+      [
+        Html.span ~a:[ Html.a_class [ "odoc-katex-math" ] ] [ Html.txt content ];
+      ]
   | _ -> []
 
 and source k ?a (t : Source.t) =

--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -37,14 +37,27 @@ let page_creator ?(theme_uri = Relative None) ?(support_uri = Relative None)
 
     let odoc_css_uri = file_uri theme_uri "odoc.css" in
     let highlight_js_uri = file_uri support_uri "highlight.pack.js" in
-    let katex_css_uri = {|https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css" integrity="sha384-MlJdn/WNKDGXveldHDdyRP1R4CTHr3FeuDNfhsLPYrq2t0UBkUdK2jyTnXPEK1NQ|} in
-    let katex_js_uri = {|https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.js" integrity="sha384-VQ8d8WVFw0yHhCk5E8I86oOhv48xLpnDZx5T9GogA/Y84DcCKWXDmSDfn13bzFZY|} in
+    let katex_css_uri =
+      "https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css"
+    in
+    (* let katex_css_integrity ="sha384-MlJdn/WNKDGXveldHDdyRP1R4CTHr3FeuDNfhsLPYrq2t0UBkUdK2jyTnXPEK1NQ" in *)
+    let katex_js_uri =
+      "https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.js"
+    in
+    let katex_js_integrity =
+      "sha384-VQ8d8WVFw0yHhCk5E8I86oOhv48xLpnDZx5T9GogA/Y84DcCKWXDmSDfn13bzFZY"
+    in
 
     Html.head
       (Html.title (Html.txt title_string))
       [
         Html.link ~rel:[ `Stylesheet ] ~href:odoc_css_uri ();
-        Html.link ~rel:[ `Stylesheet ] ~href:katex_css_uri ();
+        Html.link ~rel:[ `Stylesheet ] ~href:katex_css_uri
+          ~a:
+            [
+              Html.a_integrity katex_js_integrity; Html.a_crossorigin `Anonymous;
+            ]
+          ();
         Html.meta ~a:[ Html.a_charset "utf-8" ] ();
         Html.meta
           ~a:[ Html.a_name "generator"; Html.a_content "odoc %%VERSION%%" ]
@@ -58,7 +71,14 @@ let page_creator ?(theme_uri = Relative None) ?(support_uri = Relative None)
           ();
         Html.script ~a:[ Html.a_src highlight_js_uri ] (Html.txt "");
         Html.script (Html.txt "hljs.initHighlightingOnLoad();");
-        Html.script ~a:[ Html.a_src katex_js_uri ] (Html.txt "");
+        Html.script
+          ~a:
+            [
+              Html.a_src katex_js_uri;
+              Html.a_integrity katex_js_integrity;
+              Html.a_crossorigin `Anonymous;
+            ]
+          (Html.txt "");
         (* Unsafe is necessary to avoid escaping parts of the following code. *)
         Html.script
           (Html.Unsafe.data

--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -40,7 +40,9 @@ let page_creator ?(theme_uri = Relative None) ?(support_uri = Relative None)
     let katex_css_uri =
       "https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css"
     in
-    (* let katex_css_integrity ="sha384-MlJdn/WNKDGXveldHDdyRP1R4CTHr3FeuDNfhsLPYrq2t0UBkUdK2jyTnXPEK1NQ" in *)
+    let katex_css_integrity =
+      "sha384-MlJdn/WNKDGXveldHDdyRP1R4CTHr3FeuDNfhsLPYrq2t0UBkUdK2jyTnXPEK1NQ"
+    in
     let katex_js_uri =
       "https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.js"
     in
@@ -55,7 +57,7 @@ let page_creator ?(theme_uri = Relative None) ?(support_uri = Relative None)
         Html.link ~rel:[ `Stylesheet ] ~href:katex_css_uri
           ~a:
             [
-              Html.a_integrity katex_js_integrity; Html.a_crossorigin `Anonymous;
+              Html.a_integrity katex_css_integrity; Html.a_crossorigin `Anonymous;
             ]
           ();
         Html.meta ~a:[ Html.a_charset "utf-8" ] ();

--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -37,11 +37,14 @@ let page_creator ?(theme_uri = Relative None) ?(support_uri = Relative None)
 
     let odoc_css_uri = file_uri theme_uri "odoc.css" in
     let highlight_js_uri = file_uri support_uri "highlight.pack.js" in
+    let katex_css_uri = {|https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css" integrity="sha384-MlJdn/WNKDGXveldHDdyRP1R4CTHr3FeuDNfhsLPYrq2t0UBkUdK2jyTnXPEK1NQ|} in
+    let katex_js_uri = {|https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.js" integrity="sha384-VQ8d8WVFw0yHhCk5E8I86oOhv48xLpnDZx5T9GogA/Y84DcCKWXDmSDfn13bzFZY|} in
 
     Html.head
       (Html.title (Html.txt title_string))
       [
         Html.link ~rel:[ `Stylesheet ] ~href:odoc_css_uri ();
+        Html.link ~rel:[ `Stylesheet ] ~href:katex_css_uri ();
         Html.meta ~a:[ Html.a_charset "utf-8" ] ();
         Html.meta
           ~a:[ Html.a_name "generator"; Html.a_content "odoc %%VERSION%%" ]
@@ -55,6 +58,23 @@ let page_creator ?(theme_uri = Relative None) ?(support_uri = Relative None)
           ();
         Html.script ~a:[ Html.a_src highlight_js_uri ] (Html.txt "");
         Html.script (Html.txt "hljs.initHighlightingOnLoad();");
+        Html.script ~a:[ Html.a_src katex_js_uri ] (Html.txt "");
+        (* Unsafe is necessary to avoid escaping parts of the following code. *)
+        Html.script
+          (Html.Unsafe.data
+             {|
+          document.addEventListener("DOMContentLoaded", function () {
+            var elements = document.getElementsByClassName("odoc-katex-math");
+            for (var i = 0; i < elements.length; i++) {
+              var el = elements[i];
+              var content = el.textContent;
+              var new_el = document.createElement("span");
+              new_el.setAttribute("class", "odoc-katex-math-rendered");
+              katex.render(content, new_el, { throwOnError: false });
+              el.replaceWith(new_el);
+            }
+          });
+        |});
       ]
   in
 

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -219,6 +219,7 @@ let raw_markup (t : Raw_markup.t) =
   let target, content = t in
   match Astring.String.Ascii.lowercase target with
   | "latex" | "tex" -> [ Raw content ]
+  | "math" -> [ Raw (Printf.sprintf {|$%s$|} content) ]
   | _ -> []
 
 let source k (t : Source.t) =


### PR DESCRIPTION
⚠️ work in progress ⚠️ 

This is just to make progress on the discussion for #123.
This is a very simple implementation, and there are several points to discuss:
- Is it ok to reuse the target-specific markup?
- Should KaTeX be vendored? I started doing it, but there are ~70 font files to vendor in addition to the CSS and JS files. Since, dune hardcodes the support files, and it means we'd have to sync with a dune update and add some restrictions on the versions...
- A `defer` should probably be added to the css and js loading, to reduce the amount of time it takes to load the page.
- How to differentiate inline and block math? A solution is to have two targets: `math` and `mathi`. From the katex point of view, the only difference is a `displayMode: true` parameter for the render function
- It would be nice to optionally have server-side rendering, but that would require spinning a node instance to call katex which is deeply annoying. It could be an option though