### PR TITLE
Ignore non doc attributes at top level genrated by ppx

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Bugs fixed
   functor arguments to have different filenames (@jonludlam, #795)
 - Better memory/disk space usage when handling module alias chains (@jonludlam, #799)
 - Resolving class-type paths (ie., `val x : #c`) (@jonludlam, #???)
+- Skip top-level attributes while extracting the top comment. Fix top-comment extraction with PPX preprocessing (@jorisgio, #819)
 
 2.0.2
 -----

--- a/doc/odoc_for_authors.mld
+++ b/doc/odoc_for_authors.mld
@@ -576,10 +576,12 @@ module M : sig
   end
 ]}
 
-As an exception, [open] statements are allowed to be placed before the top-comment.
+As an exception, [open] statements and attributes are allowed to be placed before the top-comment.
 For example:
 
 {[
+[@@@ocaml.warning "-6"]
+
 (* Copyright header *)
 
 open Base

--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -147,7 +147,9 @@ let extract_top_comment internal_tags ~classify parent items =
                   |> Error.raise_parser_warnings
                 in
                 (tl, ast_docs)
-            | None -> (items, []))
+            | None ->
+                let items, ast_docs = extract ~classify tl in
+                (hd :: items, ast_docs))
         | Some `Open ->
             let items, ast_docs = extract ~classify tl in
             (hd :: items, ast_docs)


### PR DESCRIPTION
Currently, odoc fails to extract synopsis from a signature pre-processed by a ppx. This is because ppx add a "ocaml.ppx.context" attribute at top level before the top comment.
I'm not sure the current fix is the best way to fix, since it uses string matching "ocaml.text" to continue unrolling the list of items until it finds an attribute that is a document. 