### PR TITLE
Preview: upgrade ocamlformat to 0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version=0.19.0
+version=0.20.0

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version=0.20.0
+version=0.21.0

--- a/doc/examples/expansion.mli
+++ b/doc/examples/expansion.mli
@@ -114,7 +114,6 @@ module DeepEquality : sig
 
   module type MODTYPE = sig
     module X : SIG
-
     module Y : SIG
   end
 
@@ -187,7 +186,6 @@ module ModuleTypeOfComplications : sig
 
   module X1 : sig
     type t
-
     type u
   end
 

--- a/doc/examples/markup.mli
+++ b/doc/examples/markup.mli
@@ -154,9 +154,7 @@ module Scope : sig
   type t
 
   val v : t
-
   val x : int
-
   val y : int
 
   module A : sig

--- a/doc/examples/resolution.mli
+++ b/doc/examples/resolution.mli
@@ -67,7 +67,6 @@ module Fragments : sig
   end
 
   module C : A with type B.t = int
-
   module D : module type of C.B with type t := int
 end
 
@@ -77,13 +76,11 @@ module Hidden : sig
   (**/**)
 
   type t = int
-
   type u
 
   (**/**)
 
   type v = T of t
-
   type w = U of u
 end
 

--- a/src/document/ML.ml
+++ b/src/document/ML.ml
@@ -5,31 +5,20 @@ open O.Infix
 module ML = Generator.Make (struct
   module Obj = struct
     let close_tag_closed = " >"
-
     let close_tag_extendable = ".. >"
-
     let field_separator = "; "
-
     let open_tag_closed = "< "
-
     let open_tag_extendable = "< "
   end
 
   module Type = struct
     let annotation_separator = " : "
-
     let handle_params name args = O.span (args ++ O.sp ++ name)
-
     let handle_constructor_params = handle_params
-
     let handle_substitution_params name args = O.span (args ++ O.txt " " ++ name)
-
     let handle_format_params p = p
-
     let type_def_semicolon = false
-
     let private_keyword = "private"
-
     let parenthesize_constructor = false
 
     module Variant = struct
@@ -38,7 +27,6 @@ module ML = Generator.Make (struct
 
     module Tuple = struct
       let element_separator = O.sp ++ O.txt "* "
-
       let always_parenthesize = false
     end
 
@@ -47,9 +35,7 @@ module ML = Generator.Make (struct
     end
 
     let var_prefix = "'"
-
     let any = "_"
-
     let arrow = O.span ~attr:"arrow" (O.entity "#45" ++ O.entity "gt")
 
     module Exception = struct
@@ -70,27 +56,20 @@ module ML = Generator.Make (struct
 
   module Mod = struct
     let open_tag = O.keyword "sig"
-
     let close_tag = O.keyword "end"
-
     let close_tag_semicolon = false
-
     let include_semicolon = false
-
     let functor_keyword = true
-
     let functor_contraction = true
   end
 
   module Class = struct
     let open_tag = O.keyword "object"
-
     let close_tag = O.keyword "end"
   end
 
   module Value = struct
     let variable_keyword = "val"
-
     let semicolon = false
   end
 

--- a/src/document/codefmt.ml
+++ b/src/document/codefmt.ml
@@ -181,11 +181,8 @@ let spf fmt =
   Format.kfprintf (fun _ -> flush ()) ppf fmt
 
 let pf = Format.fprintf
-
 let elt t ppf = Tag.elt ppf t
-
 let entity e ppf = elt [ inline @@ Inline.Entity e ] ppf
-
 let ignore t ppf = Tag.ignore ppf t
 
 let ( ++ ) f g ppf =
@@ -193,15 +190,10 @@ let ( ++ ) f g ppf =
   g ppf
 
 let span ?(attr = "") f ppf = pf ppf "@{<%s>%t@}" attr f
-
 let txt s ppf = Format.pp_print_string ppf s
-
 let noop (_ : Format.formatter) = ()
-
 let break i j ppf = Format.pp_print_break ppf i j
-
 let cut = break 0 0
-
 let sp = break 1 0
 
 let rec list ?sep ~f = function
@@ -213,17 +205,11 @@ let rec list ?sep ~f = function
       match sep with None -> hd ++ tl | Some sep -> hd ++ sep ++ tl)
 
 let box_hv t ppf = pf ppf "@[<hv 2>%t@]" t
-
 let box_hv_no_indent t ppf = pf ppf "@[<hv 0>%t@]" t
-
 let render f = spf "@[<hv 2>%t@]" (span f)
-
 let code ?attr f = [ inline ?attr @@ Inline.Source (render f) ]
-
 let documentedSrc f = [ DocumentedSrc.Code (render f) ]
-
 let codeblock ?attr f = [ block ?attr @@ Block.Source (render f) ]
-
 let keyword keyword ppf = pf ppf "@{<keyword>%s@}" keyword
 
 module Infix = struct

--- a/src/document/codefmt.mli
+++ b/src/document/codefmt.mli
@@ -3,35 +3,20 @@ open Types
 type t
 
 val elt : Inline.t -> t
-
 val entity : Inline.entity -> t
-
 val ignore : t -> t
-
 val span : ?attr:string -> t -> t
-
 val txt : string -> t
-
 val noop : t
-
 val cut : t
-
 val sp : t
-
 val list : ?sep:t -> f:('a -> t) -> 'a list -> t
-
 val box_hv : t -> t
-
 val box_hv_no_indent : t -> t
-
 val render : t -> Source.t
-
 val code : ?attr:string list -> t -> Inline.t
-
 val documentedSrc : t -> DocumentedSrc.t
-
 val codeblock : ?attr:Class.t -> t -> Block.t
-
 val keyword : string -> t
 
 module Infix : sig

--- a/src/document/doctree.ml
+++ b/src/document/doctree.ml
@@ -46,14 +46,12 @@ end
 
 module Toc : sig
   type t = one list
-
   and one = { url : Url.t; text : Inline.t; children : t }
 
   val compute :
     Url.Path.t -> on_sub:(Include.status -> bool) -> Item.t list -> t
 end = struct
   type t = one list
-
   and one = { url : Url.t; text : Inline.t; children : t }
 
   let classify ~on_sub (i : Item.t) : _ Rewire.action =

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -47,9 +47,7 @@ let label t =
   | Optional s -> O.txt "?" ++ O.txt s
 
 let tag tag t = O.span ~attr:tag t
-
 let type_var tv = tag "type-var" (O.txt tv)
-
 let enclose ~l ~r x = O.span (O.txt l ++ x ++ O.txt r)
 
 let path p txt =
@@ -104,7 +102,6 @@ include Generator_signatures
 module Make (Syntax : SYNTAX) = struct
   module Link : sig
     val from_path : Paths.Path.t -> text
-
     val from_fragment : Paths.Fragment.leaf -> text
   end = struct
     open Paths
@@ -396,7 +393,6 @@ module Make (Syntax : SYNTAX) = struct
       Item.t
 
     val extension : Lang.Extension.t -> Item.t
-
     val exn : Lang.Exception.t -> Item.t
 
     val format_params :
@@ -847,7 +843,6 @@ module Make (Syntax : SYNTAX) = struct
     open Odoc_model
 
     val comment_items : Comment.docs -> Item.t list
-
     val docs : Comment.docs -> Item.t list * Item.t list
   end = struct
     let take_until_heading_or_end (docs : Odoc_model.Comment.docs) =
@@ -905,7 +900,6 @@ module Make (Syntax : SYNTAX) = struct
 
   module Class : sig
     val class_ : Lang.Class.t -> Item.t
-
     val class_type : Lang.ClassType.t -> Item.t
   end = struct
     let class_type_expr (cte : Odoc_model.Lang.ClassType.expr) =
@@ -1646,7 +1640,6 @@ module Make (Syntax : SYNTAX) = struct
 
   module Page : sig
     val compilation_unit : Lang.Compilation_unit.t -> Page.t
-
     val page : Lang.Page.t -> Page.t
   end = struct
     let pack : Odoc_model.Lang.Compilation_unit.Packed.t -> Item.t list =

--- a/src/document/generator.mli
+++ b/src/document/generator.mli
@@ -1,3 +1,2 @@
 open Generator_signatures
-
 module Make (Syntax : SYNTAX) : GENERATOR

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -2,7 +2,6 @@ open Types
 module Lang = Odoc_model.Lang
 
 type rendered_item = DocumentedSrc.t
-
 type text = Codefmt.t
 
 (** HTML generation syntax customization module. See {!ML} and
@@ -10,29 +9,19 @@ type text = Codefmt.t
 module type SYNTAX = sig
   module Obj : sig
     val close_tag_closed : string
-
     val close_tag_extendable : string
-
     val field_separator : string
-
     val open_tag_closed : string
-
     val open_tag_extendable : string
   end
 
   module Type : sig
     val annotation_separator : string
-
     val handle_constructor_params : text -> text -> text
-
     val handle_substitution_params : text -> text -> text
-
     val handle_format_params : string -> string
-
     val type_def_semicolon : bool
-
     val private_keyword : string
-
     val parenthesize_constructor : bool
 
     module Variant : sig
@@ -41,7 +30,6 @@ module type SYNTAX = sig
 
     module Tuple : sig
       val element_separator : text
-
       val always_parenthesize : bool
     end
 
@@ -50,9 +38,7 @@ module type SYNTAX = sig
     end
 
     val var_prefix : string
-
     val any : string
-
     val arrow : text
 
     module Exception : sig
@@ -65,34 +51,26 @@ module type SYNTAX = sig
 
     module External : sig
       val semicolon : bool
-
       val handle_primitives : string list -> Inline.t
     end
   end
 
   module Mod : sig
     val open_tag : text
-
     val close_tag : text
-
     val close_tag_semicolon : bool
-
     val include_semicolon : bool
-
     val functor_keyword : bool
-
     val functor_contraction : bool
   end
 
   module Class : sig
     val open_tag : text
-
     val close_tag : text
   end
 
   module Value : sig
     val variable_keyword : string
-
     val semicolon : bool
   end
 
@@ -103,6 +81,5 @@ end
 
 module type GENERATOR = sig
   val compilation_unit : Lang.Compilation_unit.t -> Page.t
-
   val page : Lang.Page.t -> Page.t
 end

--- a/src/document/reason.ml
+++ b/src/document/reason.ml
@@ -5,29 +5,19 @@ open O.Infix
 module Reason = Generator.Make (struct
   module Obj = struct
     let close_tag_closed = "}"
-
     let close_tag_extendable = "}"
-
     let field_separator = ", "
-
     let open_tag_closed = "{. "
-
     let open_tag_extendable = "{.. "
   end
 
   module Type = struct
     let annotation_separator = ": "
-
     let handle_constructor_params name args = name ++ args
-
     let handle_substitution_params name args = name ++ args
-
     let handle_format_params p = "(" ^ p ^ ")"
-
     let type_def_semicolon = true
-
     let private_keyword = "pri"
-
     let parenthesize_constructor = true
 
     module Variant = struct
@@ -36,7 +26,6 @@ module Reason = Generator.Make (struct
 
     module Tuple = struct
       let element_separator = O.txt ", "
-
       let always_parenthesize = true
     end
 
@@ -45,9 +34,7 @@ module Reason = Generator.Make (struct
     end
 
     let var_prefix = "'"
-
     let any = "_"
-
     let arrow = O.span ~attr:"arrow" (O.txt "=" ++ O.entity "gt")
 
     module Exception = struct
@@ -74,27 +61,20 @@ module Reason = Generator.Make (struct
 
   module Mod = struct
     let open_tag = O.txt "{"
-
     let close_tag = O.txt "}"
-
     let close_tag_semicolon = true
-
     let include_semicolon = true
-
     let functor_keyword = false
-
     let functor_contraction = false
   end
 
   module Class = struct
     let open_tag = O.txt "{"
-
     let close_tag = O.txt "}"
   end
 
   module Value = struct
     let variable_keyword = "let"
-
     let semicolon = true
   end
 

--- a/src/document/targets.ml
+++ b/src/document/targets.ml
@@ -71,5 +71,4 @@ and module_type (t : Odoc_model.Lang.ModuleType.t) =
       url :: subpages
 
 and include_ (t : Odoc_model.Lang.Include.t) = signature t.expansion.content
-
 and page (t : Odoc_model.Lang.Page.t) = [ Url.Path.from_identifier t.name ]

--- a/src/document/targets.mli
+++ b/src/document/targets.mli
@@ -8,5 +8,4 @@
 open Odoc_model.Lang
 
 val unit : Compilation_unit.t -> Url.Path.t list
-
 val page : Page.t -> Url.Path.t list

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -7,36 +7,29 @@ end =
 
 and InternalLink : sig
   type resolved = Url.t * Inline.t
-
   type unresolved = Inline.t
-
   type t = Resolved of resolved | Unresolved of Inline.t
 end =
   InternalLink
 
 and Raw_markup : sig
   type target = Odoc_model.Comment.raw_markup_target
-
   and t = target * string
 end =
   Raw_markup
 
 and Source : sig
   type t = token list
-
   and tag = string option
-
   and token = Elt of Inline.t | Tag of tag * t
 end =
   Source
 
 and Inline : sig
   type entity = string
-
   type href = string
 
   type t = one list
-
   and one = { attr : Class.t; desc : desc }
 
   and desc =
@@ -53,7 +46,6 @@ end =
 
 and Description : sig
   type one = { attr : Class.t; key : Inline.t; definition : Block.t }
-
   type t = one list
 end =
   Description
@@ -65,7 +57,6 @@ end =
 
 and Block : sig
   type t = one list
-
   and one = { attr : Class.t; desc : desc }
 
   and desc =
@@ -115,14 +106,12 @@ end =
 
 and Subpage : sig
   type status = [ `Inline | `Open | `Closed | `Default ]
-
   type t = { status : status; content : Page.t }
 end =
   Subpage
 
 and Include : sig
   type status = [ `Inline | `Open | `Closed | `Default ]
-
   type t = { status : status; content : Item.t list; summary : Source.t }
 end =
   Include
@@ -136,7 +125,6 @@ and Item : sig
   }
 
   type declaration = DocumentedSrc.t item
-
   type text = Block.t
 
   type t =
@@ -158,5 +146,4 @@ end =
   Page
 
 let inline ?(attr = []) desc = Inline.{ attr; desc }
-
 let block ?(attr = []) desc = Block.{ attr; desc }

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -372,7 +372,6 @@ module Anchor = struct
 end
 
 type kind = Anchor.kind
-
 type t = Anchor.t
 
 let from_path page =

--- a/src/document/url.mli
+++ b/src/document/url.mli
@@ -23,7 +23,6 @@ module Path : sig
     | `File ]
 
   val pp_kind : Format.formatter -> kind -> unit
-
   val string_of_kind : kind -> string
 
   type t = { kind : kind; parent : t option; name : string }
@@ -32,9 +31,7 @@ module Path : sig
     [ Identifier.Page.t | Identifier.Signature.t | Identifier.ClassSignature.t ]
 
   val from_identifier : [< source ] -> t
-
   val to_list : t -> (kind * string) list
-
   val of_list : (kind * string) list -> t option
 
   val split :
@@ -66,7 +63,6 @@ module Anchor : sig
     | `Field ]
 
   val pp_kind : Format.formatter -> kind -> unit
-
   val string_of_kind : kind -> string
 
   type t = {
@@ -91,13 +87,9 @@ module Anchor : sig
 end
 
 type kind = Anchor.kind
-
 type t = Anchor.t
 
 val from_path : Path.t -> t
-
 val from_identifier : stop_before:bool -> Identifier.t -> (t, Error.t) result
-
 val kind : Identifier.t -> kind
-
 val render_path : Odoc_model.Paths.Path.t -> string

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -247,8 +247,7 @@ let rec documentedSrc ~resolve (t : DocumentedSrc.t) : item Html.elt list =
             | doc ->
                 let opening, closing = markers in
                 [
-                  Html.td
-                    ~a:(class_ [ "def-doc" ])
+                  Html.td ~a:(class_ [ "def-doc" ])
                     (Html.span
                        ~a:(class_ [ "comment-delim" ])
                        [ Html.txt opening ]

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -19,13 +19,9 @@ module Html = Tyxml.Html
 module Doctree = Odoc_document.Doctree
 
 type any = Html_types.flow5
-
 type item = Html_types.flow5_without_header_footer
-
 type flow = Html_types.flow5_without_sectioning_heading_header_footer
-
 type phrasing = Html_types.phrasing
-
 type non_link_phrasing = Html_types.phrasing_without_interactive
 
 let mk_anchor_link id =

--- a/src/html/link.mli
+++ b/src/html/link.mli
@@ -13,10 +13,7 @@ val href : resolve:resolve -> Url.t -> string
 
 module Path : sig
   val is_leaf_page : Url.Path.t -> bool
-
   val for_printing : Url.Path.t -> string list
-
   val for_linking : Url.Path.t -> string list
-
   val as_filename : Url.Path.t -> Fpath.t
 end

--- a/src/latex/raw.ml
+++ b/src/latex/raw.ml
@@ -5,11 +5,8 @@
 *)
 
 type pr = Format.formatter -> unit
-
 type 'a with_options = ?options:pr list -> 'a
-
 type ('a, 'b) tr = 'a Fmt.t -> 'b Fmt.t
-
 type 'a t = ('a, 'a) tr
 
 module Escape = struct
@@ -63,13 +60,9 @@ let create2 name ?(options = []) pp_x pp_y ppf x y =
   Fmt.pf ppf {|\%s%a{%a}{%a}|} name (Fmt.list option) options pp_x x pp_y y
 
 let bind pp x ppf = pp ppf x
-
 let label ppf = create "label" Escape.ref ppf
-
 let mbegin ?options = create "begin" ?options Fmt.string
-
 let mend = create "end" Fmt.string
-
 let code_fragment pp = create "ocamlcodefragment" pp
 
 let break ppf level =
@@ -96,23 +89,14 @@ let env name pp ?(with_break = false) ?(opts = []) ?(args = []) ppf content =
   break ppf (if with_break then Simple else Aesthetic)
 
 let indent pp ppf x = env "ocamlindent" pp ppf x
-
 let inline_code pp = create "ocamlinlinecode" pp
-
 let verbatim ppf x = env "verbatim" Fmt.string ppf x
-
 let pageref_star x = create "pageref*" Escape.ref x
-
 let hyperref s = create "hyperref" ~options:[ bind Escape.ref s ]
-
 let ref x = create "ref" Escape.ref x
-
 let emph pp = create "emph" pp
-
 let bold pp = create "bold" pp
-
 let subscript pp = create "textsubscript" pp
-
 let superscript pp = create "textsuperscript" pp
 
 let code_block pp ppf x =
@@ -124,17 +108,11 @@ let code_block pp ppf x =
   mend ppf name
 
 let section pp = create "section" pp
-
 let subsection pp = create "subsection" pp
-
 let subsubsection pp = create "subsubsection" pp
-
 let paragraph pp = create "paragraph" pp
-
 let enumerate pp ppf x = env "enumerate" pp ppf x
-
 let itemize pp ppf x = env "itemize" pp ppf x
-
 let raw_description pp ppf x = env "description" pp ppf x
 
 let href x pp ppf y =
@@ -161,7 +139,6 @@ let url ppf s =
   create "url" Fmt.string ppf (Escape.text ~code_hyphenation:false s)
 
 let footnote x = create "footnote" url x
-
 let rightarrow ppf = math "rightarrow" ppf
 
 (** Latex uses forward slash even on Windows. *)

--- a/src/latex/raw.mli
+++ b/src/latex/raw.mli
@@ -7,64 +7,38 @@ type pr = Format.formatter -> unit
 (** {1 Helper types } *)
 
 type 'a with_options = ?options:pr list -> 'a
-
 type ('a, 'b) tr = 'a Fmt.t -> 'b Fmt.t
-
 type 'a t = ('a, 'a) tr
 
 (** {1 Helper functions } *)
 module Escape : sig
   val text : code_hyphenation:bool -> string -> string
-
   val ref : string Fmt.t
 end
 
 val break : Types.break_hierarchy Fmt.t
-
 val rightarrow : pr
-
 val label : string Fmt.t
-
 val verbatim : string Fmt.t
-
 val pageref_star : string Fmt.t
-
 val hyperref : string -> 'a t
-
 val href : string -> 'a t
-
 val ref : string Fmt.t
-
 val url : string Fmt.t
-
 val footnote : string Fmt.t
-
 val emph : 'a t
-
 val bold : 'a t
-
 val subscript : 'a t
-
 val superscript : 'a t
-
 val section : 'a t
-
 val subsection : 'a t
-
 val subsubsection : 'a t
-
 val paragraph : 'a t
-
 val enumerate : 'a t
-
 val itemize : 'a t
-
 val description : ('a, ('a * 'a) list) tr
-
 val item : 'a t with_options
-
 val small_table : ('a, 'a list list) tr
-
 val input : Fpath.t Fmt.t
 
 (** {1 Required OCaml-specific primitives }
@@ -76,7 +50,6 @@ val inline_code : 'a t
 (** {2 Code block customization} *)
 
 val code_fragment : 'a t
-
 val code_block : 'a t
 
 (** {2 Package-dependent primitives }*)

--- a/src/latex/types.ml
+++ b/src/latex/types.ml
@@ -27,11 +27,7 @@ type elt =
   | Ligaturable of string
 
 and section = { level : int; label : string option; content : t }
-
 and list_info = { typ : Odoc_document.Types.Block.list_type; items : t list }
-
 and table = { row_size : row_size; tbl : t list list }
-
 and t = elt list
-
 and reference = { short : bool; target : string; text : t option }

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -18,7 +18,6 @@ open Odoc_model
 module Paths = Odoc_model.Paths
 
 val empty : Odoc_model.Comment.docs
-
 val parse_attribute : Parsetree.attribute -> (string * Location.t) option
 
 val attached :

--- a/src/loader/ident_env.cppo.mli
+++ b/src/loader/ident_env.cppo.mli
@@ -34,36 +34,23 @@ val add_structure_tree_items :
 
 module Path : sig
   val read_module : t -> Path.t -> Paths.Path.Module.t
-
   val read_module_type : t -> Path.t -> Paths.Path.ModuleType.t
-
   val read_type : t -> Path.t -> Paths.Path.Type.t
-
   val read_class_type : t -> Path.t -> Paths.Path.ClassType.t
 end
 
 val find_module : t -> Ident.t -> Paths.Path.Module.t
-
 val find_module_identifier : t -> Ident.t -> Paths.Identifier.Module.t
-
 val find_module_type : t -> Ident.t -> Paths.Identifier.ModuleType.t
-
 val find_value_identifier : t -> Ident.t -> Paths.Identifier.Value.t
-
 val find_type : t -> Ident.t -> Paths.Identifier.Path.Type.t
-
 val find_type_identifier : t -> Ident.t -> Paths.Identifier.Type.t
-
 val find_class_identifier : t -> Ident.t -> Paths.Identifier.Class.t
-
 val is_shadowed : t -> Ident.t -> bool
-
 val find_class_type_identifier : t -> Ident.t -> Paths.Identifier.ClassType.t
 
 module Fragment : sig
   val read_module : Longident.t -> Paths.Fragment.Module.t
-
   val read_module_type : Longident.t -> Paths.Fragment.ModuleType.t
-
   val read_type : Longident.t -> Paths.Fragment.Type.t
 end

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -30,11 +30,8 @@ let error_msg file (msg : string) =
   Error.raise_exception (Error.filename_only "%s" msg file)
 
 exception Corrupted
-
 exception Not_an_implementation
-
 exception Not_an_interface
-
 exception Make_root_error of string
 
 let make_compilation_unit ~make_root ~imports ~interface ?sourcefile ~name ~id

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -45,11 +45,8 @@ module Roff = struct
     | Indent of int * t
 
   let noop = Concat []
-
   let sp = Space
-
   let break = Break
-
   let vspace = Vspace
 
   let append t1 t2 =
@@ -60,7 +57,6 @@ module Roff = struct
     | e1, e2 -> Concat [ e1; e2 ]
 
   let ( ++ ) = append
-
   let concat = List.fold_left ( ++ ) (Concat [])
 
   let rec intersperse ~sep = function
@@ -69,9 +65,7 @@ module Roff = struct
     | h1 :: (_ :: _ as t) -> h1 :: sep :: intersperse ~sep t
 
   let list ?(sep = Concat []) l = concat @@ intersperse ~sep l
-
   let indent i content = Indent (i, content)
-
   let macro id fmt = Format.ksprintf (fun s -> Macro (id, s)) fmt
 
   (* copied from cmdliner *)
@@ -103,13 +97,9 @@ module Roff = struct
       loop 0 0
 
   let str fmt = Format.ksprintf (fun s -> String (escape s)) fmt
-
   let escaped fmt = Format.ksprintf (fun s -> String s) fmt
-
   let env o c arg content = macro o "%s" arg ++ content ++ macro c ""
-
   let font s content = Font (s, content)
-
   let font_stack = Stack.create ()
 
   let pp_font ppf s fmt =

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -3,9 +3,7 @@ module Reference = Paths.Reference
 module Identifier = Paths.Identifier
 
 type 'a with_location = 'a Location_.with_location
-
 type style = [ `Bold | `Italic | `Emphasis | `Superscript | `Subscript ]
-
 type raw_markup_target = string
 
 type leaf_inline_element =
@@ -83,7 +81,6 @@ type block_element =
   | `Tag of tag ]
 
 type docs = block_element with_location list
-
 type docs_or_stop = [ `Docs of docs | `Stop ]
 
 (** The synopsis is the first element of a comment if it is a paragraph.

--- a/src/model/error.ml
+++ b/src/model/error.ml
@@ -46,7 +46,6 @@ let to_string e = _to_string e
 exception Conveyed_by_exception of t
 
 let raise_exception error = raise (Conveyed_by_exception error)
-
 let catch f = try Ok (f ()) with Conveyed_by_exception error -> Error error
 
 type warning = {
@@ -92,9 +91,7 @@ let raise_errors_and_warnings we =
   match raise_warnings we with Ok x -> x | Error e -> raise_exception e
 
 let catch_errors_and_warnings f = catch_warnings (fun () -> catch f)
-
 let print_error ?prefix t = prerr_endline (_to_string ?prefix t)
-
 let print_errors = List.iter print_error
 
 type warnings_options = { warn_error : bool; print_warnings : bool }

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -220,7 +220,6 @@ and TypeDecl : sig
   end
 
   type variance = Pos | Neg
-
   type param_desc = Any | Var of string
 
   type param = {
@@ -388,21 +387,17 @@ and TypeExpr : sig
     end
 
     type element = Type of TypeExpr.t | Constructor of Constructor.t
-
     type t = { kind : kind; elements : element list }
   end
 
   module Object : sig
     type method_ = { name : string; type_ : TypeExpr.t }
-
     type field = Method of method_ | Inherit of TypeExpr.t
-
     type t = { fields : field list; open_ : bool }
   end
 
   module Package : sig
     type substitution = Fragment.Type.t * TypeExpr.t
-
     type t = { path : Path.ModuleType.t; substitutions : substitution list }
   end
 
@@ -438,7 +433,6 @@ module rec Compilation_unit : sig
 
   module Packed : sig
     type item = { id : Identifier.Module.t; path : Path.Module.t }
-
     type t = item list
   end
 

--- a/src/model/location_.mli
+++ b/src/model/location_.mli
@@ -3,11 +3,7 @@ include module type of struct
 end
 
 val set_end_as_offset_from_start : int -> span -> span
-
 val in_string : string -> offset:int -> length:int -> span -> span
-
 val pp : Format.formatter -> span -> unit
-
 val pp_span_start : Format.formatter -> span -> unit
-
 val span_equal : span -> span -> bool

--- a/src/model/names.ml
+++ b/src/model/names.ml
@@ -19,25 +19,15 @@ module type Name = sig
   type t
 
   val to_string : t -> string
-
   val to_string_unsafe : t -> string
-
   val make_std : string -> t
-
   val of_ident : Ident.t -> t
-
   val internal_of_string : string -> t
-
   val internal_of_ident : Ident.t -> t
-
   val is_internal : t -> bool
-
   val equal : t -> t -> bool
-
   val compare : t -> t -> int
-
   val fmt : Format.formatter -> t -> unit
-
   val is_hidden : t -> bool
 end
 
@@ -63,13 +53,9 @@ module Name : Name = struct
     Internal (id, !internal_counter)
 
   let internal_of_ident id = internal_of_string (Ident.name id)
-
   let is_internal = function Std _ -> false | Internal _ -> true
-
   let equal (x : t) (y : t) = x = y
-
   let compare = compare
-
   let fmt ppf x = Format.fprintf ppf "%s" (to_string x)
 
   let is_hidden = function
@@ -88,17 +74,11 @@ module type SimpleName = sig
   type t
 
   val to_string : t -> string
-
   val make_std : string -> t
-
   val of_ident : Ident.t -> t
-
   val equal : t -> t -> bool
-
   val compare : t -> t -> int
-
   val fmt : Format.formatter -> t -> unit
-
   val is_hidden : t -> bool
 end
 
@@ -106,15 +86,10 @@ module SimpleName : SimpleName = struct
   type t = string
 
   let to_string s = s
-
   let make_std s = s
-
   let of_ident id = make_std (Ident.name id)
-
   let equal (x : t) (y : t) = x = y
-
   let compare x y = String.compare x y
-
   let fmt ppf t = Format.pp_print_string ppf (to_string t)
 
   let is_hidden s =

--- a/src/model/names.mli
+++ b/src/model/names.mli
@@ -28,19 +28,12 @@ module type Name = sig
         strings. Use with caution. *)
 
   val make_std : string -> t
-
   val of_ident : Ident.t -> t
-
   val internal_of_string : string -> t
-
   val internal_of_ident : Ident.t -> t
-
   val is_internal : t -> bool
-
   val equal : t -> t -> bool
-
   val compare : t -> t -> int
-
   val fmt : Format.formatter -> t -> unit
 
   val is_hidden : t -> bool
@@ -54,46 +47,26 @@ module type SimpleName = sig
   type t
 
   val to_string : t -> string
-
   val make_std : string -> t
-
   val of_ident : Ident.t -> t
-
   val equal : t -> t -> bool
-
   val compare : t -> t -> int
-
   val fmt : Format.formatter -> t -> unit
-
   val is_hidden : t -> bool
 end
 
 module ModuleName : Name
-
 module ParameterName : Name
-
 module ModuleTypeName : Name
-
 module TypeName : Name
-
 module ConstructorName : SimpleName
-
 module FieldName : SimpleName
-
 module ExtensionName : SimpleName
-
 module ExceptionName : SimpleName
-
 module ValueName : Name
-
 module ClassName : Name
-
 module ClassTypeName : Name
-
 module MethodName : SimpleName
-
 module InstanceVariableName : SimpleName
-
 module LabelName : SimpleName
-
 module PageName : SimpleName

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -69,11 +69,8 @@ module Identifier = struct
       | `Field (p, _) -> (p : parent :> label_parent)
 
   let label_parent n = label_parent_aux (n :> t)
-
   let equal = ( = )
-
   let hash = Hashtbl.hash
-
   let compare = compare
 
   type any = t
@@ -82,9 +79,7 @@ module Identifier = struct
     type t = any
 
     let equal = equal
-
     let hash = hash
-
     let compare = compare
   end
 
@@ -92,9 +87,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.signature
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -102,9 +95,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.class_signature
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -112,9 +103,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.datatype
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -122,9 +111,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.parent
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -132,9 +119,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.label_parent
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -142,9 +127,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.root_module
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -152,9 +135,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.module_
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -162,9 +143,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.functor_parameter
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -172,9 +151,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.functor_result
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash x = hash (x :> any)
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -182,9 +159,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.module_type
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -192,9 +167,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.type_
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -202,9 +175,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.constructor
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -212,9 +183,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.field
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -222,9 +191,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.extension
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -232,9 +199,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.exception_
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -242,9 +207,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.value
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -252,9 +215,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.class_
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -262,9 +223,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.class_type
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -272,9 +231,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.method_
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -282,9 +239,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.instance_variable
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -292,9 +247,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.label
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -302,9 +255,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.page
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -312,9 +263,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.container_page
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -322,9 +271,7 @@ module Identifier = struct
     type t = Paths_types.Identifier.odoc_id
 
     let equal x y = equal (x :> any) (y :> any)
-
     let hash = Hashtbl.hash
-
     let compare x y = compare (x :> any) (y :> any)
   end
 
@@ -333,9 +280,7 @@ module Identifier = struct
       type t = Paths_types.Identifier.path_module
 
       let equal x y = equal (x :> any) (y :> any)
-
       let hash = Hashtbl.hash
-
       let compare x y = compare (x :> any) (y :> any)
     end
 
@@ -343,9 +288,7 @@ module Identifier = struct
       type t = Paths_types.Identifier.path_module_type
 
       let equal x y = equal (x :> any) (y :> any)
-
       let hash = Hashtbl.hash
-
       let compare x y = compare (x :> any) (y :> any)
     end
 
@@ -353,9 +296,7 @@ module Identifier = struct
       type t = Paths_types.Identifier.path_type
 
       let equal x y = equal (x :> any) (y :> any)
-
       let hash = Hashtbl.hash
-
       let compare x y = compare (x :> any) (y :> any)
     end
 
@@ -363,9 +304,7 @@ module Identifier = struct
       type t = Paths_types.Identifier.path_class_type
 
       let equal x y = equal (x :> any) (y :> any)
-
       let hash = Hashtbl.hash
-
       let compare x y = compare (x :> any) (y :> any)
     end
 
@@ -689,7 +628,6 @@ end
 module Fragment = struct
   module Resolved = struct
     type t = Paths_types.Resolved_fragment.any
-
     type root = Paths_types.Resolved_fragment.root
 
     let sig_of_mod m =
@@ -1039,7 +977,6 @@ module Reference = struct
   end
 
   type t = Paths_types.Reference.any
-
   type tag_any = Paths_types.Reference.tag_any
 
   module Signature = struct

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -23,9 +23,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.any
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -33,9 +31,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.signature
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -43,9 +39,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.class_signature
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -53,9 +47,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.datatype
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -63,9 +55,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.parent
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -73,9 +63,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.label_parent
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -83,9 +71,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.root_module
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -93,9 +79,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.module_
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -103,9 +87,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.functor_parameter
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -113,9 +95,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.functor_result
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -123,9 +103,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.module_type
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -133,9 +111,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.type_
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -143,9 +119,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.constructor
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -153,9 +127,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.field
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -163,9 +135,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.extension
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -173,9 +143,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.exception_
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -183,9 +151,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.value
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -193,9 +159,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.class_
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -203,9 +167,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.class_type
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -213,9 +175,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.method_
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -223,9 +183,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.instance_variable
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -233,9 +191,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.label
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -243,9 +199,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.page
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -253,9 +207,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.container_page
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -263,9 +215,7 @@ module Identifier : sig
     type t = Paths_types.Identifier.odoc_id
 
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
@@ -274,9 +224,7 @@ module Identifier : sig
       type t = Paths_types.Identifier.path_module
 
       val equal : t -> t -> bool
-
       val hash : t -> int
-
       val compare : t -> t -> int
     end
 
@@ -284,9 +232,7 @@ module Identifier : sig
       type t = Paths_types.Identifier.path_module_type
 
       val equal : t -> t -> bool
-
       val hash : t -> int
-
       val compare : t -> t -> int
     end
 
@@ -294,9 +240,7 @@ module Identifier : sig
       type t = Paths_types.Identifier.path_type
 
       val equal : t -> t -> bool
-
       val hash : t -> int
-
       val compare : t -> t -> int
     end
 
@@ -304,9 +248,7 @@ module Identifier : sig
       type t = Paths_types.Identifier.path_class_type
 
       val equal : t -> t -> bool
-
       val hash : t -> int
-
       val compare : t -> t -> int
     end
 
@@ -316,109 +258,62 @@ module Identifier : sig
   type t = Paths_types.Identifier.any
 
   val hash : t -> int
-
   val name : [< t ] -> string
-
   val compare : t -> t -> int
-
   val equal : ([< t ] as 'a) -> 'a -> bool
-
   val label_parent : [< t ] -> LabelParent.t
 
   module Sets : sig
     module Signature : Set.S with type elt = Signature.t
-
     module ClassSignature : Set.S with type elt = ClassSignature.t
-
     module DataType : Set.S with type elt = DataType.t
-
     module Parent : Set.S with type elt = Parent.t
-
     module LabelParent : Set.S with type elt = LabelParent.t
-
     module Module : Set.S with type elt = Module.t
-
     module ModuleType : Set.S with type elt = ModuleType.t
-
     module Type : Set.S with type elt = Type.t
-
     module Constructor : Set.S with type elt = Constructor.t
-
     module Field : Set.S with type elt = Field.t
-
     module Extension : Set.S with type elt = Extension.t
-
     module Exception : Set.S with type elt = Exception.t
-
     module Value : Set.S with type elt = Value.t
-
     module Class : Set.S with type elt = Class.t
-
     module ClassType : Set.S with type elt = ClassType.t
-
     module Method : Set.S with type elt = Method.t
-
     module InstanceVariable : Set.S with type elt = InstanceVariable.t
-
     module Label : Set.S with type elt = Label.t
-
     module Page : Set.S with type elt = Page.t
-
     module ContainerPage : Set.S with type elt = ContainerPage.t
   end
 
   module Maps : sig
     module Any : Map.S with type key = Any.t
-
     module Signature : Map.S with type key = Signature.t
-
     module ClassSignature : Map.S with type key = ClassSignature.t
-
     module DataType : Map.S with type key = DataType.t
-
     module Parent : Map.S with type key = Parent.t
-
     module LabelParent : Map.S with type key = LabelParent.t
-
     module FunctorParameter : Map.S with type key = FunctorParameter.t
-
     module Module : Map.S with type key = Module.t
-
     module ModuleType : Map.S with type key = ModuleType.t
-
     module Type : Map.S with type key = Type.t
-
     module Constructor : Map.S with type key = Constructor.t
-
     module Field : Map.S with type key = Field.t
-
     module Extension : Map.S with type key = Extension.t
-
     module Exception : Map.S with type key = Exception.t
-
     module Value : Map.S with type key = Value.t
-
     module Class : Map.S with type key = Class.t
-
     module ClassType : Map.S with type key = ClassType.t
-
     module Method : Map.S with type key = Method.t
-
     module InstanceVariable : Map.S with type key = InstanceVariable.t
-
     module Label : Map.S with type key = Label.t
-
     module Page : Map.S with type key = Page.t
-
     module ContainerPage : Map.S with type key = ContainerPage.t
 
     module Path : sig
       module Module : Map.S with type key = Path.Module.t
-
       module ModuleType : Map.S with type key = Path.ModuleType.t
-
       module Type : Map.S with type key = Path.Type.t
-
       module ClassType : Map.S with type key = Path.ClassType.t
     end
   end
@@ -431,11 +326,8 @@ module rec Path : sig
       type t = Paths_types.Resolved_path.module_
 
       val of_ident : Identifier.Path.Module.t -> t
-
       val is_hidden : t -> bool
-
       val identifier : t -> Identifier.Path.Module.t
-
       val canonical_ident : t -> Identifier.Path.Module.t option
     end
 
@@ -443,11 +335,8 @@ module rec Path : sig
       type t = Paths_types.Resolved_path.module_type
 
       val of_ident : Identifier.Path.ModuleType.t -> t
-
       val is_hidden : t -> bool
-
       val identifier : t -> Identifier.Path.ModuleType.t
-
       val canonical_ident : t -> Identifier.Path.ModuleType.t option
     end
 
@@ -455,11 +344,8 @@ module rec Path : sig
       type t = Paths_types.Resolved_path.type_
 
       val of_ident : Identifier.Path.Type.t -> t
-
       val is_hidden : t -> bool
-
       val identifier : t -> Identifier.Path.Type.t
-
       val canonical_ident : t -> Identifier.Path.Type.t option
     end
 
@@ -467,9 +353,7 @@ module rec Path : sig
       type t = Paths_types.Resolved_path.class_type
 
       val of_ident : Identifier.Path.ClassType.t -> t
-
       val is_hidden : t -> bool
-
       val identifier : t -> Identifier.Path.ClassType.t
     end
 
@@ -527,13 +411,10 @@ module Fragment : sig
     end
 
     type leaf = Paths_types.Resolved_fragment.leaf
-
     type root = Paths_types.Resolved_fragment.root
-
     type t = Paths_types.Resolved_fragment.any
 
     val identifier : t -> Identifier.t
-
     val is_hidden : t -> bool
   end
 
@@ -562,7 +443,6 @@ module Fragment : sig
   end
 
   type leaf = Paths_types.Fragment.leaf
-
   type t = Paths_types.Fragment.any
 end
 
@@ -727,6 +607,5 @@ module rec Reference : sig
   end
 
   type t = Paths_types.Reference.any
-
   type tag_any = Paths_types.Reference.tag_any
 end

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -126,35 +126,20 @@ module Identifier = struct
   (** @canonical Odoc_model.Paths.Identifier.Path.t *)
 
   type fragment_module = path_module
-
   type fragment_type = path_type
-
   type reference_module = path_module
-
   type reference_module_type = path_module_type
-
   type reference_type = path_type
-
   type reference_constructor = [ constructor | extension | exception_ ]
-
   type reference_field = field
-
   type reference_extension = [ extension | exception_ ]
-
   type reference_exception = exception_
-
   type reference_value = value
-
   type reference_class = class_
-
   type reference_class_type = [ class_ | class_type ]
-
   type reference_method = method_
-
   type reference_instance_variable = instance_variable
-
   type reference_label = label
-
   type reference_page = page
 end
 
@@ -334,37 +319,21 @@ end =
 
 module rec Reference : sig
   type tag_only_module = [ `TModule ]
-
   type tag_only_module_type = [ `TModuleType ]
-
   type tag_only_type = [ `TType ]
-
   type tag_only_constructor = [ `TConstructor ]
-
   type tag_only_field = [ `TField ]
-
   type tag_only_extension = [ `TExtension ]
-
   type tag_only_exception = [ `TException ]
-
   type tag_only_value = [ `TValue ]
-
   type tag_only_class = [ `TClass ]
-
   type tag_only_class_type = [ `TClassType ]
-
   type tag_only_method = [ `TMethod ]
-
   type tag_only_instance_variable = [ `TInstanceVariable ]
-
   type tag_only_label = [ `TLabel ]
-
   type tag_only_page = [ `TPage ]
-
   type tag_unknown = [ `TUnknown ]
-
   type tag_only_child_page = [ `TChildPage ]
-
   type tag_only_child_module = [ `TChildModule ]
 
   type tag_any =
@@ -387,9 +356,7 @@ module rec Reference : sig
     | `TUnknown ]
 
   type tag_signature = [ `TUnknown | `TModule | `TModuleType ]
-
   type tag_class_signature = [ `TUnknown | `TClass | `TClassType ]
-
   type tag_datatype = [ `TUnknown | `TType ]
 
   type tag_parent =

--- a/src/model/predefined.ml
+++ b/src/model/predefined.ml
@@ -52,33 +52,19 @@ let invariant_equation =
   { params; private_; manifest; constraints }
 
 let bool_identifier = `CoreType (TypeName.make_std "bool")
-
 let int_identifier = `CoreType (TypeName.make_std "int")
-
 let char_identifier = `CoreType (TypeName.make_std "char")
-
 let bytes_identifier = `CoreType (TypeName.make_std "bytes")
-
 let string_identifier = `CoreType (TypeName.make_std "string")
-
 let float_identifier = `CoreType (TypeName.make_std "float")
-
 let unit_identifier = `CoreType (TypeName.make_std "unit")
-
 let exn_identifier = `CoreType (TypeName.make_std "exn")
-
 let array_identifier = `CoreType (TypeName.make_std "array")
-
 let list_identifier = `CoreType (TypeName.make_std "list")
-
 let option_identifier = `CoreType (TypeName.make_std "option")
-
 let int32_identifier = `CoreType (TypeName.make_std "int32")
-
 let int64_identifier = `CoreType (TypeName.make_std "int64")
-
 let nativeint_identifier = `CoreType (TypeName.make_std "nativeint")
-
 let lazy_t_identifier = `CoreType (TypeName.make_std "lazy_t")
 
 let extension_constructor_identifier =
@@ -117,7 +103,6 @@ let invalid_argument_identifier =
   `CoreException (ExceptionName.make_std "Invalid_argument")
 
 let failure_identifier = `CoreException (ExceptionName.make_std "Failure")
-
 let not_found_identifier = `CoreException (ExceptionName.make_std "Not_found")
 
 let out_of_memory_identifier =
@@ -188,106 +173,63 @@ let core_constructor_identifier = function
   | _ -> None
 
 let bool_path = `Resolved (`Identifier bool_identifier)
-
 let int_path = `Resolved (`Identifier int_identifier)
-
 let char_path = `Resolved (`Identifier char_identifier)
-
 let bytes_path = `Resolved (`Identifier bytes_identifier)
-
 let string_path = `Resolved (`Identifier string_identifier)
-
 let float_path = `Resolved (`Identifier float_identifier)
-
 let unit_path = `Resolved (`Identifier unit_identifier)
-
 let exn_path = `Resolved (`Identifier exn_identifier)
-
 let array_path = `Resolved (`Identifier array_identifier)
-
 let list_path = `Resolved (`Identifier list_identifier)
-
 let option_path = `Resolved (`Identifier option_identifier)
-
 let int32_path = `Resolved (`Identifier int32_identifier)
-
 let int64_path = `Resolved (`Identifier int64_identifier)
-
 let nativeint_path = `Resolved (`Identifier nativeint_identifier)
-
 let lazy_t_path = `Resolved (`Identifier lazy_t_identifier)
 
 let extension_constructor_path =
   `Resolved (`Identifier extension_constructor_identifier)
 
 let _floatarray_path = `Resolved (`Identifier floatarray_identifier)
-
 let bool_reference = `Resolved (`Identifier bool_identifier)
-
 let int_reference = `Resolved (`Identifier int_identifier)
-
 let char_reference = `Resolved (`Identifier char_identifier)
-
 let bytes_reference = `Resolved (`Identifier bytes_identifier)
-
 let string_reference = `Resolved (`Identifier string_identifier)
-
 let float_reference = `Resolved (`Identifier float_identifier)
-
 let unit_reference = `Resolved (`Identifier unit_identifier)
-
 let exn_reference = `Resolved (`Identifier exn_identifier)
-
 let array_reference = `Resolved (`Identifier array_identifier)
-
 let list_reference = `Resolved (`Identifier list_identifier)
-
 let option_reference = `Resolved (`Identifier option_identifier)
-
 let int32_reference = `Resolved (`Identifier int32_identifier)
-
 let int64_reference = `Resolved (`Identifier int64_identifier)
-
 let nativeint_reference = `Resolved (`Identifier nativeint_identifier)
-
 let lazy_t_reference = `Resolved (`Identifier lazy_t_identifier)
 
 let extension_constructor_reference =
   `Resolved (`Identifier extension_constructor_identifier)
 
 let _floatarray_reference = `Resolved (`Identifier floatarray_identifier)
-
 let false_reference = `Resolved (`Identifier false_identifier)
-
 let true_reference = `Resolved (`Identifier true_identifier)
-
 let void_reference = `Resolved (`Identifier void_identifier)
-
 let nil_reference = `Resolved (`Identifier nil_identifier)
-
 let cons_reference = `Resolved (`Identifier cons_identifier)
-
 let none_reference = `Resolved (`Identifier none_identifier)
-
 let some_reference = `Resolved (`Identifier some_identifier)
-
 let match_failure_reference = `Resolved (`Identifier match_failure_identifier)
-
 let assert_failure_reference = `Resolved (`Identifier assert_failure_identifier)
 
 let invalid_argument_reference =
   `Resolved (`Identifier invalid_argument_identifier)
 
 let failure_reference = `Resolved (`Identifier failure_identifier)
-
 let not_found_reference = `Resolved (`Identifier not_found_identifier)
-
 let out_of_memory_reference = `Resolved (`Identifier out_of_memory_identifier)
-
 let stack_overflow_reference = `Resolved (`Identifier stack_overflow_identifier)
-
 let sys_error_reference = `Resolved (`Identifier sys_error_identifier)
-
 let end_of_file_reference = `Resolved (`Identifier end_of_file_identifier)
 
 let division_by_zero_reference =

--- a/src/model/predefined.mli
+++ b/src/model/predefined.mli
@@ -19,247 +19,131 @@ open Paths
 (** {3 Identifiers} *)
 
 val bool_identifier : Identifier.Type.t
-
 val int_identifier : Identifier.Type.t
-
 val char_identifier : Identifier.Type.t
-
 val bytes_identifier : Identifier.Type.t
-
 val string_identifier : Identifier.Type.t
-
 val float_identifier : Identifier.Type.t
-
 val unit_identifier : Identifier.Type.t
-
 val exn_identifier : Identifier.Type.t
-
 val array_identifier : Identifier.Type.t
-
 val list_identifier : Identifier.Type.t
-
 val option_identifier : Identifier.Type.t
-
 val int32_identifier : Identifier.Type.t
-
 val int64_identifier : Identifier.Type.t
-
 val nativeint_identifier : Identifier.Type.t
-
 val lazy_t_identifier : Identifier.Type.t
-
 val extension_constructor_identifier : Identifier.Type.t
-
 val floatarray_identifier : Identifier.Type.t
-
 val false_identifier : Identifier.Constructor.t
-
 val true_identifier : Identifier.Constructor.t
-
 val void_identifier : Identifier.Constructor.t
-
 val nil_identifier : Identifier.Constructor.t
-
 val cons_identifier : Identifier.Constructor.t
-
 val none_identifier : Identifier.Constructor.t
-
 val some_identifier : Identifier.Constructor.t
-
 val match_failure_identifier : Identifier.Exception.t
-
 val assert_failure_identifier : Identifier.Exception.t
-
 val invalid_argument_identifier : Identifier.Exception.t
-
 val failure_identifier : Identifier.Exception.t
-
 val not_found_identifier : Identifier.Exception.t
-
 val out_of_memory_identifier : Identifier.Exception.t
-
 val stack_overflow_identifier : Identifier.Exception.t
-
 val sys_error_identifier : Identifier.Exception.t
-
 val end_of_file_identifier : Identifier.Exception.t
-
 val division_by_zero_identifier : Identifier.Exception.t
-
 val sys_blocked_io_identifier : Identifier.Exception.t
-
 val undefined_recursive_module_identifier : Identifier.Exception.t
-
 val core_type_identifier : string -> Identifier.Type.t option
-
 val core_exception_identifier : string -> Identifier.Exception.t option
-
 val core_constructor_identifier : string -> Identifier.Constructor.t option
 
 (** {3 Paths} *)
 
 val bool_path : Path.Type.t
-
 val int_path : Path.Type.t
-
 val char_path : Path.Type.t
-
 val bytes_path : Path.Type.t
-
 val string_path : Path.Type.t
-
 val float_path : Path.Type.t
-
 val unit_path : Path.Type.t
-
 val exn_path : Path.Type.t
-
 val array_path : Path.Type.t
-
 val list_path : Path.Type.t
-
 val option_path : Path.Type.t
-
 val int32_path : Path.Type.t
-
 val int64_path : Path.Type.t
-
 val nativeint_path : Path.Type.t
-
 val lazy_t_path : Path.Type.t
-
 val extension_constructor_path : Path.Type.t
 
 (** {3 References} *)
 
 val bool_reference : Reference.Type.t
-
 val int_reference : Reference.Type.t
-
 val char_reference : Reference.Type.t
-
 val bytes_reference : Reference.Type.t
-
 val string_reference : Reference.Type.t
-
 val float_reference : Reference.Type.t
-
 val unit_reference : Reference.Type.t
-
 val exn_reference : Reference.Type.t
-
 val array_reference : Reference.Type.t
-
 val list_reference : Reference.Type.t
-
 val option_reference : Reference.Type.t
-
 val int32_reference : Reference.Type.t
-
 val int64_reference : Reference.Type.t
-
 val nativeint_reference : Reference.Type.t
-
 val lazy_t_reference : Reference.Type.t
-
 val extension_constructor_reference : Reference.Type.t
-
 val false_reference : Reference.Constructor.t
-
 val true_reference : Reference.Constructor.t
-
 val void_reference : Reference.Constructor.t
-
 val nil_reference : Reference.Constructor.t
-
 val cons_reference : Reference.Constructor.t
-
 val none_reference : Reference.Constructor.t
-
 val some_reference : Reference.Constructor.t
-
 val match_failure_reference : Reference.Exception.t
-
 val assert_failure_reference : Reference.Exception.t
-
 val invalid_argument_reference : Reference.Exception.t
-
 val failure_reference : Reference.Exception.t
-
 val not_found_reference : Reference.Exception.t
-
 val out_of_memory_reference : Reference.Exception.t
-
 val stack_overflow_reference : Reference.Exception.t
-
 val sys_error_reference : Reference.Exception.t
-
 val end_of_file_reference : Reference.Exception.t
-
 val division_by_zero_reference : Reference.Exception.t
-
 val sys_blocked_io_reference : Reference.Exception.t
-
 val undefined_recursive_module_reference : Reference.Exception.t
 
 (** {3 Declarations} *)
 
 val int_decl : Lang.TypeDecl.t
-
 val char_decl : Lang.TypeDecl.t
-
 val bytes_decl : Lang.TypeDecl.t
-
 val string_decl : Lang.TypeDecl.t
-
 val float_decl : Lang.TypeDecl.t
-
 val bool_decl : Lang.TypeDecl.t
-
 val unit_decl : Lang.TypeDecl.t
-
 val exn_decl : Lang.TypeDecl.t
-
 val array_decl : Lang.TypeDecl.t
-
 val list_decl : Lang.TypeDecl.t
-
 val option_decl : Lang.TypeDecl.t
-
 val int32_decl : Lang.TypeDecl.t
-
 val int64_decl : Lang.TypeDecl.t
-
 val nativeint_decl : Lang.TypeDecl.t
-
 val lazy_t_decl : Lang.TypeDecl.t
-
 val extension_constructor_decl : Lang.TypeDecl.t
-
 val match_failure_decl : Lang.Exception.t
-
 val assert_failure_decl : Lang.Exception.t
-
 val invalid_argument_decl : Lang.Exception.t
-
 val failure_decl : Lang.Exception.t
-
 val not_found_decl : Lang.Exception.t
-
 val out_of_memory_decl : Lang.Exception.t
-
 val stack_overflow_decl : Lang.Exception.t
-
 val sys_error_decl : Lang.Exception.t
-
 val end_of_file_decl : Lang.Exception.t
-
 val division_by_zero_decl : Lang.Exception.t
-
 val sys_blocked_io_decl : Lang.Exception.t
-
 val undefined_recursive_module_decl : Lang.Exception.t
-
 val core_types : Lang.TypeDecl.t list
-
 val core_exceptions : Lang.Exception.t list

--- a/src/model/root.ml
+++ b/src/model/root.ml
@@ -30,14 +30,12 @@ module Package = struct
     type nonrec t = t
 
     let equal : t -> t -> bool = ( = )
-
     let hash : t -> int = Hashtbl.hash
   end)
 end
 
 module Odoc_file = struct
   type compilation_unit = { name : string; hidden : bool }
-
   type t = Page of string | Compilation_unit of compilation_unit
 
   let create_unit ~force_hidden name =
@@ -45,9 +43,7 @@ module Odoc_file = struct
     Compilation_unit { name; hidden }
 
   let create_page name = Page name
-
   let name = function Page name | Compilation_unit { name; _ } -> name
-
   let hidden = function Page _ -> false | Compilation_unit m -> m.hidden
 end
 
@@ -58,7 +54,6 @@ type t = {
 }
 
 let equal : t -> t -> bool = ( = )
-
 let hash : t -> int = Hashtbl.hash
 
 let to_string t =
@@ -86,6 +81,5 @@ module Hash_table = Hashtbl.Make (struct
   type nonrec t = t
 
   let equal = equal
-
   let hash = hash
 end)

--- a/src/model/root.mli
+++ b/src/model/root.mli
@@ -27,15 +27,11 @@ end
 
 module Odoc_file : sig
   type compilation_unit = { name : string; hidden : bool }
-
   type t = Page of string | Compilation_unit of compilation_unit
 
   val create_unit : force_hidden:bool -> string -> t
-
   val create_page : string -> t
-
   val name : t -> string
-
   val hidden : t -> bool
 end
 
@@ -46,11 +42,8 @@ type t = {
 }
 
 val equal : t -> t -> bool
-
 val hash : t -> int
-
 val compare : t -> t -> int
-
 val to_string : t -> string
 
 module Hash_table : Hashtbl.S with type key = t

--- a/src/model_desc/comment_desc.mli
+++ b/src/model_desc/comment_desc.mli
@@ -1,3 +1,2 @@
 val docs : Odoc_model.Comment.docs Type_desc.t
-
 val docs_or_stop : Odoc_model.Comment.docs_or_stop Type_desc.t

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -9,33 +9,19 @@ module Names = struct
   include Names
 
   let modulename = To_string ModuleName.to_string
-
   let moduletypename = To_string ModuleTypeName.to_string
-
   let typename = To_string TypeName.to_string
-
   let classname = To_string ClassName.to_string
-
   let classtypename = To_string ClassTypeName.to_string
-
   let constructorname = To_string ConstructorName.to_string
-
   let fieldname = To_string FieldName.to_string
-
   let exceptionname = To_string ExceptionName.to_string
-
   let extensionname = To_string ExtensionName.to_string
-
   let valuename = To_string ValueName.to_string
-
   let methodname = To_string MethodName.to_string
-
   let instancevariablename = To_string InstanceVariableName.to_string
-
   let labelname = To_string LabelName.to_string
-
   let pagename = To_string PageName.to_string
-
   let parametername = To_string ParameterName.to_string
 end
 
@@ -43,19 +29,12 @@ module General_paths = struct
   (** Simplified paths types that can be coerced to. *)
 
   type p = Paths.Path.t
-
   type rp = Paths.Path.Resolved.t
-
   type f = Paths.Fragment.t
-
   type rf = Paths.Fragment.Resolved.t
-
   type r = Paths.Reference.t
-
   type rr = Paths.Reference.Resolved.t
-
   type id_t = Paths.Identifier.t
-
   type tag = Paths.Reference.tag_any
 
   let rec identifier : Paths.Identifier.t t =
@@ -434,7 +413,6 @@ module General_paths = struct
 end
 
 let root = Root.t
-
 let modulename = Names.modulename
 
 (* Indirection seems to be required to make the type open. *)

--- a/src/model_desc/paths_desc.mli
+++ b/src/model_desc/paths_desc.mli
@@ -1,17 +1,10 @@
 open Odoc_model.Paths
 
 val root : Odoc_model.Root.t Type_desc.t
-
 val modulename : Odoc_model.Names.ModuleName.t Type_desc.t
-
 val identifier : [< Identifier.t ] Type_desc.t
-
 val resolved_path : [< Path.Resolved.t ] Type_desc.t
-
 val path : [< Path.t ] Type_desc.t
-
 val resolved_fragment : [< Fragment.Resolved.t ] Type_desc.t
-
 val fragment : [< Fragment.t ] Type_desc.t
-
 val reference : [< Reference.t ] Type_desc.t

--- a/src/model_desc/type_desc.ml
+++ b/src/model_desc/type_desc.ml
@@ -12,11 +12,8 @@ type 'a t =
   | Indirect : ('a -> 'b) * 'b t -> 'a t
 
 and 'a field = F : string * ('a -> 'b) * 'b t -> 'a field
-
 and case = C : string * 'b * 'b t -> case | C0 : string -> case
 
 let bool : bool t = To_string string_of_bool
-
 let string : string t = To_string (fun s -> s)
-
 let int : int t = To_string string_of_int

--- a/src/ocamlary/ocamlary.mli
+++ b/src/ocamlary/ocamlary.mli
@@ -220,7 +220,6 @@ val a_function : x:int -> int
 *)
 
 val fun_fun_fun : ((int, int) a_function, (unit, unit) a_function) a_function
-
 val fun_maybe : ?yes:unit -> unit -> int
 
 val not_found : unit -> unit
@@ -252,13 +251,9 @@ val changing : unit
 (** {3 Some Operators } *)
 
 val ( ~- ) : unit
-
 val ( ! ) : unit
-
 val ( @ ) : unit
-
 val ( $ ) : unit
-
 val ( % ) : unit
 
 (* Disabling the following four until we figure out what to do about
@@ -273,21 +268,13 @@ val ( % ) : unit
    val ( -| ) : unit *)
 
 val ( & ) : unit
-
 val ( * ) : unit
-
 val ( - ) : unit
-
 val ( + ) : unit
-
 val ( -? ) : unit
-
 val ( / ) : unit
-
 val ( := ) : unit
-
 val ( = ) : unit
-
 val ( land ) : unit
 
 (**/**)
@@ -363,7 +350,6 @@ end
    {- it includes {!module-type:B} with some substitution}} *)
 module type C = sig
   include A
-
   include B with type t := t and module Q := Q
 end
 
@@ -465,7 +451,6 @@ type poly_variant_union = [ poly_variant | `TagC ]
 (** This comment is for [poly_variant_union]. *)
 
 type 'a poly_poly_variant = [ `TagA of 'a ]
-
 type ('a, 'b) bin_poly_poly_variant = [ `TagA of 'a | `ConstrB of 'b ]
 
 (* TODO: figure out how to spec a conjunctive type
@@ -477,15 +462,10 @@ type ('a, 'b) bin_poly_poly_variant = [ `TagA of 'a | `ConstrB of 'b ]
 *)
 
 type 'a open_poly_variant = [> `TagA ] as 'a
-
 type 'a open_poly_variant2 = [> `ConstrB of int ] as 'a
-
 type 'a open_poly_variant_alias = 'a open_poly_variant open_poly_variant2
-
 type 'a poly_fun = ([> `ConstrB of int ] as 'a) -> 'a
-
 type 'a poly_fun_constraint = 'a -> 'a constraint 'a = [> `TagA ]
-
 type 'a closed_poly_variant = [< `One | `Two ] as 'a
 
 type 'a clopen_poly_variant =
@@ -523,45 +503,33 @@ and mutual_constr_b =
       (** This comment must be here for the next to associate correctly. *)
 
 type rec_obj = < f : int ; g : unit -> unit ; h : rec_obj >
-
 type 'a open_obj = < f : int ; g : unit -> unit ; .. > as 'a
-
 type 'a oof = (< a : unit ; .. > as 'a) -> 'a
-
 type 'a any_obj = < .. > as 'a
-
 type empty_obj = < >
-
 type one_meth = < meth : unit >
 
 type ext = ..
 (** A mystery wrapped in an ellipsis *)
 
 type ext += ExtA
-
 type ext += ExtB
-
 type ext += ExtC of unit | ExtD of ext
-
 type ext += ExtE
-
 type ext += private ExtF
 
 type 'a poly_ext = ..
 (** 'a poly_ext *)
 
 type 'b poly_ext += Foo of 'b | Bar of 'b * 'b  (** 'b poly_ext *)
-
 type 'c poly_ext += Quux of 'c  (** 'c poly_ext *)
 
 module ExtMod : sig
   type t = ..
-
   type t += Leisureforce
 end
 
 type ExtMod.t += ZzzTop0  (** It's got the rock *)
-
 type ExtMod.t += ZzzTop of unit  (** and it packs a unit. *)
 
 external launch_missiles : unit -> unit = "tetris"
@@ -580,7 +548,6 @@ class one_method_class :
 class two_method_class :
   object
     method one : one_method_class
-
     method undo : unit
   end
 
@@ -591,7 +558,6 @@ class ['a] param_class :
      end
 
 type my_unit_object = unit param_class
-
 type 'a my_unit_class = unit #param_class as 'a
 
 (* Bug in compiler breaks this example on cmi's *)
@@ -642,7 +608,6 @@ module Dep4 : sig
 
   module type S = sig
     module X : T
-
     module Y : sig end
   end
 
@@ -655,7 +620,6 @@ module Dep5 : functor
 
      module type S = sig
        module X : T
-
        module Y : sig end
      end
 
@@ -666,7 +630,6 @@ module Dep5 : functor
 end
 
 type dep2 = Dep5(Dep4).Z.X.b
-
 type dep3 = Dep5(Dep4).Z.Y.a
 
 module Dep6 : sig
@@ -817,7 +780,6 @@ module type NestedInclude1 = sig
 end
 
 include NestedInclude1
-
 include NestedInclude2 with type nested_include = int
 
 module DoubleInclude1 : sig
@@ -841,7 +803,6 @@ module IncludeInclude1 : sig
 end
 
 include module type of IncludeInclude1
-
 include IncludeInclude2
 
 (** {1:indexmodules Trying the \{!modules: ...\} command.}
@@ -879,12 +840,10 @@ module CanonicalTest : sig
 
   module Base_Tests : sig
     module C : module type of Base__.List
-
     open Base__
     module L = List
 
     val foo : int L.t -> float L.t
-
     val bar : 'a List.t -> 'a List.t
     (* This is just {!List.id}, or rather {!L.id} *)
 
@@ -963,13 +922,9 @@ module Aliases : sig
   module A' = Foo.A
 
   type tata = Foo.A.t
-
   type tbtb = Foo__.B.t
-
   type tete = Foo__.E.t
-
   type tata' = A'.t
-
   type tete2 = Foo.E.t
 
   module Std : sig
@@ -1009,7 +964,6 @@ module Aliases : sig
   module X2 = P2.Z
 
   type p1 = X1.t
-
   type p2 = X2.t
 end
 
@@ -1056,14 +1010,12 @@ end
 
 module type TypeExt = sig
   type t = ..
-
   type t += C
 
   val f : t -> unit
 end
 
 type new_t = ..
-
 type new_t += C
 
 module type TypeExtPruned = TypeExt with type t := new_t

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -103,13 +103,9 @@ let open_modules =
 
 module Compile : sig
   val output_file : dst:string option -> input:Fs.file -> Fs.file
-
   val input : string Term.t
-
   val dst : string option Term.t
-
   val cmd : unit Term.t
-
   val info : Term.info
 end = struct
   let has_page_prefix file =
@@ -249,7 +245,6 @@ end
 
 module Odoc_link : sig
   val cmd : unit Term.t
-
   val info : Term.info
 end = struct
   let get_output_file ~output_file ~input =
@@ -292,15 +287,12 @@ module type S = sig
   type args
 
   val renderer : args Odoc_document.Renderer.t
-
   val extra_args : args Cmdliner.Term.t
 end
 
 module Make_renderer (R : S) : sig
   val process : unit Term.t * Term.info
-
   val targets : unit Term.t * Term.info
-
   val generate : unit Term.t * Term.info
 end = struct
   let input =
@@ -503,7 +495,6 @@ end)
 
 module Html_fragment : sig
   val cmd : unit Term.t
-
   val info : Term.info
 end = struct
   let html_fragment directories xref_base_uri output_file input_file
@@ -554,7 +545,6 @@ module Odoc_manpage = Make_renderer (struct
   type args = unit
 
   let renderer = Man_page.renderer
-
   let extra_args = Term.const ()
 end)
 
@@ -675,7 +665,6 @@ module Targets = struct
       flush stdout
 
     let cmd = Term.(const list_targets $ Compile.dst $ Compile.input)
-
     let info = Term.info "compile-targets" ~doc:"TODO: Fill in."
   end
 

--- a/src/odoc/depends.ml
+++ b/src/odoc/depends.ml
@@ -21,7 +21,6 @@ module Compile = struct
   type t = { unit_name : string; digest : Digest.t }
 
   let name t = t.unit_name
-
   let digest t = t.digest
 end
 
@@ -46,9 +45,7 @@ module Hash_set : sig
   type t
 
   val create : unit -> t
-
   val add : t -> Odoc_model.Root.t -> unit
-
   val elements : t -> Odoc_model.Root.t list
 end = struct
   type t = unit Odoc_model.Root.Hash_table.t

--- a/src/odoc/depends.mli
+++ b/src/odoc/depends.mli
@@ -23,7 +23,6 @@ module Compile : sig
   type t
 
   val name : t -> string
-
   val digest : t -> Digest.t
 end
 

--- a/src/odoc/fs.ml
+++ b/src/odoc/fs.ml
@@ -18,22 +18,16 @@ open StdLabels
 open Or_error
 
 type directory = Fpath.t
-
 type file = Fpath.t
 
 module File = struct
   type t = file
 
   let dirname = Fpath.parent
-
   let basename = Fpath.base
-
   let append = Fpath.append
-
   let set_ext e p = Fpath.set_ext e p
-
   let has_ext e p = Fpath.has_ext e p
-
   let get_ext e = Fpath.get_ext e
 
   let create ~directory ~name =
@@ -95,7 +89,6 @@ module File = struct
     type nonrec t = t
 
     let equal = Fpath.equal
-
     let hash = Hashtbl.hash
   end)
 end
@@ -104,9 +97,7 @@ module Directory = struct
   type t = directory
 
   let dirname = Fpath.parent
-
   let basename = Fpath.base
-
   let append = Fpath.append
 
   let make_path p name =
@@ -178,7 +169,6 @@ module Directory = struct
     type nonrec t = t
 
     let equal = Fpath.equal
-
     let hash = Hashtbl.hash
   end)
 end

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -19,7 +19,6 @@ open Or_error
 (** Utilities to manipulate files and paths. *)
 
 type file = Fpath.t
-
 type directory
 
 module Directory : sig
@@ -28,18 +27,14 @@ module Directory : sig
   type t = directory
 
   val dirname : t -> t
-
   val basename : t -> t
-
   val append : t -> t -> t
 
   val reach_from : dir:t -> string -> t
   (** @raises Invalid_arg if [parent/name] exists but is not a directory. *)
 
   val mkdir_p : t -> unit
-
   val of_string : string -> t
-
   val to_string : t -> string
 
   val fold_files_rec_result :
@@ -59,23 +54,14 @@ module File : sig
   type t = file
 
   val create : directory:Directory.t -> name:string -> t
-
   val dirname : t -> Directory.t
-
   val basename : t -> t
-
   val append : Directory.t -> t -> t
-
   val set_ext : string -> t -> t
-
   val has_ext : string -> t -> bool
-
   val get_ext : t -> string
-
   val of_string : string -> t
-
   val to_string : t -> string
-
   val read : t -> (string, [> msg ]) result
 
   module Table : Hashtbl.S with type key = t

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -33,5 +33,4 @@ let render args page =
     ~support_uri:args.support_uri ~indent:args.indent page
 
 let files_of_url url = [ Odoc_html.Link.Path.as_filename url ]
-
 let renderer = { Renderer.name = "html"; render; files_of_url }

--- a/src/odoc/latex.ml
+++ b/src/odoc/latex.ml
@@ -6,5 +6,4 @@ let render args page =
   Odoc_latex.Generator.render ~with_children:args.with_children page
 
 let files_of_url url = Odoc_latex.Generator.files_of_url url
-
 let renderer = { Renderer.name = "latex"; render; files_of_url }

--- a/src/odoc/man_page.ml
+++ b/src/odoc/man_page.ml
@@ -1,7 +1,5 @@
 open Odoc_document
 
 let render _ page = Odoc_manpage.Generator.render page
-
 let files_of_url url = Odoc_manpage.Link.files_of_url url
-
 let renderer = { Renderer.name = "man"; render; files_of_url }

--- a/src/odoc/or_error.ml
+++ b/src/odoc/or_error.ml
@@ -1,5 +1,4 @@
 type ('a, 'e) result = ('a, 'e) Result.result = Ok of 'a | Error of 'e
-
 type msg = [ `Msg of string ]
 
 let ( >>= ) r f = match r with Ok v -> f v | Error _ as e -> e

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -37,7 +37,6 @@ module Accessible_paths : sig
   type t
 
   val create : directories:Fs.Directory.t list -> t
-
   val find : t -> string -> Fs.File.t list
 end = struct
   type t = { directories : Fs.Directory.t list }

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -108,21 +108,17 @@ and TypeExpr : sig
     end
 
     type element = Type of TypeExpr.t | Constructor of Constructor.t
-
     type t = { kind : kind; elements : element list }
   end
 
   module Object : sig
     type method_ = { name : string; type_ : TypeExpr.t }
-
     type field = Method of method_ | Inherit of TypeExpr.t
-
     type t = { fields : field list; open_ : bool }
   end
 
   module Package : sig
     type substitution = Cfrag.type_ * TypeExpr.t
-
     type t = { path : Cpath.module_type; substitutions : substitution list }
   end
 
@@ -174,7 +170,6 @@ end =
 
 and FunctorParameter : sig
   type parameter = { id : Ident.functor_parameter; expr : ModuleType.expr }
-
   type t = Named of parameter | Unit
 end =
   FunctorParameter
@@ -285,7 +280,6 @@ end =
 
 and Value : sig
   type value = Odoc_model.Lang.Value.value
-
   type t = { doc : CComment.docs; type_ : TypeExpr.t; value : value }
 end =
   Value
@@ -448,7 +442,6 @@ and CComment : sig
     | `Tag of Odoc_model.Comment.tag ]
 
   type docs = block_element Odoc_model.Comment.with_location list
-
   type docs_or_stop = [ `Docs of docs | `Stop ]
 end =
   CComment
@@ -467,21 +460,13 @@ module Element = struct
   open Odoc_model.Paths
 
   type module_ = [ `Module of Identifier.Path.Module.t * Module.t Delayed.t ]
-
   type module_type = [ `ModuleType of Identifier.ModuleType.t * ModuleType.t ]
-
   type type_ = [ `Type of Identifier.Type.t * TypeDecl.t ]
-
   type value = [ `Value of Identifier.Value.t * Value.t ]
-
   type label = [ `Label of Identifier.Label.t * Label.t ]
-
   type class_ = [ `Class of Identifier.Class.t * Class.t ]
-
   type class_type = [ `ClassType of Identifier.ClassType.t * ClassType.t ]
-
   type datatype = [ type_ | class_ | class_type ]
-
   type signature = [ module_ | module_type ]
 
   type constructor =
@@ -496,7 +481,6 @@ module Element = struct
 
   (* No component for pages yet *)
   type page = [ `Page of Identifier.Page.t * Odoc_model.Lang.Page.t ]
-
   type label_parent = [ signature | datatype | page ]
 
   type any =
@@ -664,7 +648,6 @@ module Fmt = struct
           class_decl decl
 
   and class_ ppf c = Format.fprintf ppf "%a" class_decl c.type_
-
   and class_type ppf _c = Format.fprintf ppf "<todo>"
 
   and include_ ppf i =
@@ -779,7 +762,6 @@ module Fmt = struct
     fpf ppf "%s%s : %a" mutable_ t.name type_expr t.type_
 
   and type_decl_fields ppf fs = fpp_list "; " "{ %a }" type_decl_field ppf fs
-
   and type_tuple ppf ts = fpp_list " * " "%a" type_expr ppf ts
 
   and type_param ppf t =
@@ -800,7 +782,6 @@ module Fmt = struct
     | Some m -> Format.fprintf ppf " = %a" type_expr m
 
   and exception_ _ppf _e = ()
-
   and extension ppf e = Format.fprintf ppf "%a" type_path e.Extension.type_path
 
   and substitution ppf t =

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -1,18 +1,14 @@
 (** Component module *)
 
 module ModuleMap : Map.S with type key = Ident.module_
-
 module TypeMap : Map.S with type key = Ident.type_
 
 module PathModuleMap : Map.S with type key = Ident.path_module
 (** Useful maps *)
 
 module ModuleTypeMap : Map.S with type key = Ident.module_type
-
 module PathTypeMap : Map.S with type key = Ident.path_type
-
 module PathClassTypeMap : Map.S with type key = Ident.path_class_type
-
 module IdentMap : Map.S with type key = Ident.any
 
 (** Delayed is a bit like Lazy.t but may in the future offer the chance to peek inside
@@ -25,9 +21,7 @@ module Delayed : sig
   type 'a t = { mutable v : 'a option; mutable get : (unit -> 'a) option }
 
   val get : 'a t -> 'a
-
   val put : (unit -> 'a) -> 'a t
-
   val put_val : 'a -> 'a t
 end
 
@@ -95,21 +89,17 @@ and TypeExpr : sig
     end
 
     type element = Type of TypeExpr.t | Constructor of Constructor.t
-
     type t = { kind : kind; elements : element list }
   end
 
   module Object : sig
     type method_ = { name : string; type_ : TypeExpr.t }
-
     type field = Method of method_ | Inherit of TypeExpr.t
-
     type t = { fields : field list; open_ : bool }
   end
 
   module Package : sig
     type substitution = Cfrag.type_ * TypeExpr.t
-
     type t = { path : Cpath.module_type; substitutions : substitution list }
   end
 
@@ -158,7 +148,6 @@ end
 
 and FunctorParameter : sig
   type parameter = { id : Ident.functor_parameter; expr : ModuleType.expr }
-
   type t = Named of parameter | Unit
 end
 
@@ -319,7 +308,6 @@ end
 
 and Value : sig
   type value = Odoc_model.Lang.Value.value
-
   type t = { doc : CComment.docs; type_ : TypeExpr.t; value : value }
 end
 
@@ -418,7 +406,6 @@ and CComment : sig
     | `Tag of Odoc_model.Comment.tag ]
 
   type docs = block_element Odoc_model.Comment.with_location list
-
   type docs_or_stop = [ `Docs of docs | `Stop ]
 end
 
@@ -435,21 +422,13 @@ module Element : sig
   open Odoc_model.Paths
 
   type module_ = [ `Module of Identifier.Path.Module.t * Module.t Delayed.t ]
-
   type module_type = [ `ModuleType of Identifier.ModuleType.t * ModuleType.t ]
-
   type type_ = [ `Type of Identifier.Type.t * TypeDecl.t ]
-
   type value = [ `Value of Identifier.Value.t * Value.t ]
-
   type label = [ `Label of Identifier.Label.t * Label.t ]
-
   type class_ = [ `Class of Identifier.Class.t * Class.t ]
-
   type class_type = [ `ClassType of Identifier.ClassType.t * ClassType.t ]
-
   type datatype = [ type_ | class_ | class_type ]
-
   type signature = [ module_ | module_type ]
 
   type constructor =
@@ -464,7 +443,6 @@ module Element : sig
 
   (* No component for pages yet *)
   type page = [ `Page of Identifier.Page.t * Odoc_model.Lang.Page.t ]
-
   type label_parent = [ signature | datatype | page ]
 
   type any =
@@ -486,57 +464,41 @@ end
 (** Formatting functions for components *)
 module Fmt : sig
   val signature : Format.formatter -> Signature.t -> unit
-
   val removed_item : Format.formatter -> Signature.removed_item -> unit
 
   val removed_item_list :
     Format.formatter -> Signature.removed_item list -> unit
 
   val class_ : Format.formatter -> Class.t -> unit
-
   val class_type : Format.formatter -> ClassType.t -> unit
-
   val include_ : Format.formatter -> Include.t -> unit
-
   val value : Format.formatter -> Value.t -> unit
-
   val module_decl : Format.formatter -> Module.decl -> unit
-
   val include_decl : Format.formatter -> Include.decl -> unit
-
   val module_ : Format.formatter -> Module.t -> unit
-
   val module_type : Format.formatter -> ModuleType.t -> unit
-
   val simple_expansion : Format.formatter -> ModuleType.simple_expansion -> unit
 
   val module_type_type_of_desc :
     Format.formatter -> ModuleType.type_of_desc -> unit
 
   val u_module_type_expr : Format.formatter -> ModuleType.U.expr -> unit
-
   val module_type_expr : Format.formatter -> ModuleType.expr -> unit
-
   val functor_parameter : Format.formatter -> FunctorParameter.t -> unit
 
   val functor_parameter_parameter :
     Format.formatter -> FunctorParameter.parameter -> unit
 
   val type_decl : Format.formatter -> TypeDecl.t -> unit
-
   val type_equation : Format.formatter -> TypeDecl.Equation.t -> unit
-
   val exception_ : Format.formatter -> Exception.t -> unit
-
   val extension : Format.formatter -> Extension.t -> unit
-
   val substitution : Format.formatter -> ModuleType.substitution -> unit
 
   val substitution_list :
     Format.formatter -> ModuleType.substitution list -> unit
 
   val type_expr_list : Format.formatter -> TypeExpr.t list -> unit
-
   val type_object : Format.formatter -> TypeExpr.Object.t -> unit
 
   val type_class :
@@ -548,27 +510,21 @@ module Fmt : sig
     Format.formatter -> TypeExpr.Polymorphic_variant.t -> unit
 
   val type_expr : Format.formatter -> TypeExpr.t -> unit
-
   val resolved_module_path : Format.formatter -> Cpath.Resolved.module_ -> unit
-
   val module_path : Format.formatter -> Cpath.module_ -> unit
 
   val resolved_module_type_path :
     Format.formatter -> Cpath.Resolved.module_type -> unit
 
   val module_type_path : Format.formatter -> Cpath.module_type -> unit
-
   val resolved_type_path : Format.formatter -> Cpath.Resolved.type_ -> unit
-
   val resolved_parent_path : Format.formatter -> Cpath.Resolved.parent -> unit
-
   val type_path : Format.formatter -> Cpath.type_ -> unit
 
   val resolved_class_type_path :
     Format.formatter -> Cpath.Resolved.class_type -> unit
 
   val class_type_path : Format.formatter -> Cpath.class_type -> unit
-
   val model_path : Format.formatter -> Odoc_model.Paths.Path.t -> unit
 
   val model_resolved_path :
@@ -591,13 +547,9 @@ module Fmt : sig
     Format.formatter -> Cfrag.resolved_module -> unit
 
   val resolved_type_fragment : Format.formatter -> Cfrag.resolved_type -> unit
-
   val signature_fragment : Format.formatter -> Cfrag.signature -> unit
-
   val module_fragment : Format.formatter -> Cfrag.module_ -> unit
-
   val module_type_fragment : Format.formatter -> Cfrag.module_type -> unit
-
   val type_fragment : Format.formatter -> Cfrag.type_ -> unit
 
   val model_resolved_reference :
@@ -700,9 +652,7 @@ module Of_Lang : sig
     map -> Odoc_model.Lang.TypeExpr.Package.t -> TypeExpr.Package.t
 
   val type_expression : map -> Odoc_model.Lang.TypeExpr.t -> TypeExpr.t
-
   val module_decl : map -> Odoc_model.Lang.Module.decl -> Module.decl
-
   val include_decl : map -> Odoc_model.Lang.Include.decl -> Include.decl
 
   val canonical :
@@ -738,17 +688,11 @@ module Of_Lang : sig
     map -> Odoc_model.Lang.ModuleType.expr -> ModuleType.expr
 
   val module_type : map -> Odoc_model.Lang.ModuleType.t -> ModuleType.t
-
   val value : map -> Odoc_model.Lang.Value.t -> Value.t
-
   val include_ : map -> Odoc_model.Lang.Include.t -> Include.t
-
   val class_ : map -> Odoc_model.Lang.Class.t -> Class.t
-
   val class_decl : map -> Odoc_model.Lang.Class.decl -> Class.decl
-
   val class_type_expr : map -> Odoc_model.Lang.ClassType.expr -> ClassType.expr
-
   val class_type : map -> Odoc_model.Lang.ClassType.t -> ClassType.t
 
   val class_signature :
@@ -766,11 +710,8 @@ module Of_Lang : sig
     map -> Odoc_model.Lang.ModuleSubstitution.t -> Module.t
 
   val signature : map -> Odoc_model.Lang.Signature.t -> Signature.t
-
   val open_ : map -> Odoc_model.Lang.Open.t -> Open.t
-
   val apply_sig_map : map -> Odoc_model.Lang.Signature.t -> Signature.t
-
   val docs : map -> Odoc_model.Comment.docs -> CComment.docs
 
   val docs_or_stop :
@@ -778,5 +719,4 @@ module Of_Lang : sig
 end
 
 val module_of_functor_argument : FunctorParameter.parameter -> Module.t
-
 val extract_signature_doc : Signature.t -> CComment.docs

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -90,16 +90,13 @@ module ElementsByName : sig
   type t
 
   val empty : t
-
   val add : kind -> string -> [< Component.Element.any ] -> t -> t
-
   val remove : [< Identifier.t ] -> t -> t
 
   val find_by_name :
     (Component.Element.any -> 'b option) -> string -> t -> 'b list
 end = struct
   type elem = { kind : kind; elem : Component.Element.any }
-
   type t = elem list StringMap.t
 
   let empty = StringMap.empty
@@ -138,11 +135,8 @@ module ElementsById : sig
   type t
 
   val empty : t
-
   val add : [< Identifier.t ] -> [< Component.Element.any ] -> t -> t
-
   val remove : [< Identifier.t ] -> t -> t
-
   val find_by_id : [< Identifier.t ] -> t -> Component.Element.any option
 end = struct
   module IdMap = Identifier.Maps.Any
@@ -181,9 +175,7 @@ type t = {
 }
 
 let set_resolver t resolver = { t with resolver = Some resolver }
-
 let has_resolver t = match t.resolver with None -> false | _ -> true
-
 let id t = t.id
 
 let with_recorded_lookups env f =
@@ -597,7 +589,6 @@ let s_label_parent : Component.Element.label_parent scope =
     | _ -> None)
 
 let len = ref 0
-
 let n = ref 0
 
 let lookup_fragment_root env =

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -33,15 +33,10 @@ val pp_lookup_type_list : Format.formatter -> lookup_type list -> unit
 type t
 
 val with_recorded_lookups : t -> (t -> 'a) -> LookupTypeSet.t * 'a
-
 val set_resolver : t -> resolver -> t
-
 val has_resolver : t -> bool
-
 val id : t -> int
-
 val empty : t
-
 val add_fragment_root : Component.Signature.t -> t -> t
 
 val add_module :
@@ -67,22 +62,16 @@ val update_module_type :
   Identifier.Path.ModuleType.t -> Component.ModuleType.t -> t -> t
 
 val add_value : Identifier.Value.t -> Component.Value.t -> t -> t
-
 val add_label : Identifier.Label.t -> Component.Label.t -> t -> t
-
 val add_class : Identifier.Class.t -> Component.Class.t -> t -> t
-
 val add_class_type : Identifier.ClassType.t -> Component.ClassType.t -> t -> t
-
 val add_exception : Identifier.Exception.t -> Component.Exception.t -> t -> t
 
 val add_extension_constructor :
   Identifier.Extension.t -> Component.Extension.Constructor.t -> t -> t
 
 val add_docs : Odoc_model.Comment.docs -> t -> t
-
 val add_comment : Odoc_model.Comment.docs_or_stop -> t -> t
-
 val add_method : Identifier.Method.t -> Component.Method.t -> t -> t
 
 val add_module_functor_args :
@@ -92,11 +81,8 @@ val add_module_type_functor_args :
   Component.ModuleType.t -> Identifier.ModuleType.t -> t -> t
 
 val lookup_fragment_root : t -> (int * Component.Signature.t) option
-
 val lookup_page : string -> t -> Odoc_model.Lang.Page.t option
-
 val module_of_unit : Odoc_model.Lang.Compilation_unit.t -> Component.Module.t
-
 val lookup_root_module : string -> t -> root option
 
 type 'a scope constraint 'a = [< Component.Element.any ]
@@ -114,46 +100,28 @@ val lookup_by_id : 'a scope -> [< Identifier.t ] -> t -> 'a option
 (** Like [lookup_by_name] but use an identifier as key. *)
 
 val s_any : Component.Element.any scope
-
 val s_signature : Component.Element.signature scope
-
 val s_module : Component.Element.module_ scope
-
 val s_module_type : Component.Element.module_type scope
-
 val s_datatype : Component.Element.datatype scope
-
 val s_type : Component.Element.type_ scope
-
 val s_class : Component.Element.class_ scope
-
 val s_class_type : Component.Element.class_type scope
-
 val s_value : Component.Element.value scope
-
 val s_label : Component.Element.label scope
-
 val s_constructor : Component.Element.constructor scope
-
 val s_exception : Component.Element.exception_ scope
-
 val s_extension : Component.Element.extension scope
-
 val s_field : Component.Element.field scope
-
 val s_label_parent : Component.Element.label_parent scope
 
 (* val open_component_signature :
    Odoc_model.Paths_types.Identifier.signature -> Component.Signature.t -> t -> t *)
 
 val add_functor_parameter : Odoc_model.Lang.FunctorParameter.t -> t -> t
-
 val open_class_signature : Odoc_model.Lang.ClassSignature.t -> t -> t
-
 val open_signature : Odoc_model.Lang.Signature.t -> t -> t
-
 val open_type_substitution : Odoc_model.Lang.TypeDecl.t -> t -> t
-
 val open_module_substitution : Odoc_model.Lang.ModuleSubstitution.t -> t -> t
 
 val open_module_type_substitution :
@@ -178,7 +146,5 @@ val inherit_resolver : t -> t
 (** Create an empty environment reusing the same resolver. *)
 
 val len : int ref
-
 val n : int ref
-
 val verify_lookups : t -> LookupTypeSet.t -> bool

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -2,9 +2,7 @@ open Odoc_model.Names
 open Component
 
 type module_ = [ `FModule of ModuleName.t * Module.t ]
-
 type module_type = [ `FModuleType of ModuleTypeName.t * ModuleType.t ]
-
 type datatype = [ `FType of TypeName.t * TypeDecl.t ]
 
 type class_ =
@@ -12,11 +10,8 @@ type class_ =
   | `FClassType of ClassTypeName.t * ClassType.t ]
 
 type value = [ `FValue of ValueName.t * Value.t ]
-
 type label = [ `FLabel of Label.t ]
-
 type exception_ = [ `FExn of ExceptionName.t * Exception.t ]
-
 type extension = [ `FExt of Extension.t * Extension.Constructor.t ]
 
 type substitution =
@@ -25,15 +20,10 @@ type substitution =
   | `FModuleType_subst of ModuleTypeSubstitution.t ]
 
 type signature = [ module_ | module_type ]
-
 type type_ = [ datatype | class_ ]
-
 type label_parent = [ signature | type_ ]
-
 type constructor = [ `FConstructor of TypeDecl.Constructor.t ]
-
 type field = [ `FField of TypeDecl.Field.t ]
-
 type any_in_type = [ constructor | field ]
 
 type any_in_type_in_sig =
@@ -52,7 +42,6 @@ type instance_variable =
   [ `FInstance_variable of InstanceVariableName.t * InstanceVariable.t ]
 
 type method_ = [ `FMethod of MethodName.t * Method.t ]
-
 type any_in_class_sig = [ instance_variable | method_ ]
 
 module N = Ident.Name
@@ -121,7 +110,6 @@ type careful_module_type =
   [ module_type | `FModuleType_removed of ModuleType.expr ]
 
 type careful_type = [ type_ | removed_type ]
-
 type careful_class = [ class_ | removed_type ]
 
 let careful_module_in_sig sg name =

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -3,9 +3,7 @@ open Odoc_model.Names
 open Component
 
 type module_ = [ `FModule of ModuleName.t * Module.t ]
-
 type module_type = [ `FModuleType of ModuleTypeName.t * ModuleType.t ]
-
 type datatype = [ `FType of TypeName.t * TypeDecl.t ]
 
 type class_ =
@@ -13,11 +11,8 @@ type class_ =
   | `FClassType of ClassTypeName.t * ClassType.t ]
 
 type value = [ `FValue of ValueName.t * Value.t ]
-
 type label = [ `FLabel of Label.t ]
-
 type exception_ = [ `FExn of ExceptionName.t * Exception.t ]
-
 type extension = [ `FExt of Extension.t * Extension.Constructor.t ]
 
 type substitution =
@@ -26,17 +21,11 @@ type substitution =
   | `FModuleType_subst of ModuleTypeSubstitution.t ]
 
 type signature = [ module_ | module_type ]
-
 type type_ = [ datatype | class_ ]
-
 type label_parent = [ signature | type_ ]
-
 type constructor = [ `FConstructor of TypeDecl.Constructor.t ]
-
 type field = [ `FField of TypeDecl.Field.t ]
-
 type any_in_type = [ constructor | field ]
-
 type any_in_type_in_sig = [ `In_type of TypeName.t * TypeDecl.t * any_in_type ]
 
 type any_in_sig =
@@ -52,27 +41,18 @@ type instance_variable =
   [ `FInstance_variable of InstanceVariableName.t * InstanceVariable.t ]
 
 type method_ = [ `FMethod of MethodName.t * Method.t ]
-
 type any_in_class_sig = [ instance_variable | method_ ]
 
 (** Lookup by name, unambiguous *)
 
 val module_in_sig : Signature.t -> string -> module_ option
-
 val type_in_sig : Signature.t -> string -> type_ option
-
 val datatype_in_sig : Signature.t -> string -> datatype option
-
 val module_type_in_sig : Signature.t -> string -> module_type option
-
 val exception_in_sig : Signature.t -> string -> exception_ option
-
 val extension_in_sig : Signature.t -> string -> extension option
-
 val any_in_type : TypeDecl.t -> string -> any_in_type option
-
 val any_in_typext : Extension.t -> string -> extension option
-
 val method_in_class_signature : ClassSignature.t -> string -> method_ option
 
 val instance_variable_in_class_signature :
@@ -81,19 +61,12 @@ val instance_variable_in_class_signature :
 (** Maybe ambiguous *)
 
 val class_in_sig : Signature.t -> string -> class_ list
-
 val signature_in_sig : Signature.t -> string -> signature list
-
 val value_in_sig : Signature.t -> string -> value list
-
 val label_in_sig : Signature.t -> string -> label list
-
 val label_parent_in_sig : Signature.t -> string -> label_parent list
-
 val any_in_sig : Signature.t -> string -> any_in_sig list
-
 val any_in_type_in_sig : Signature.t -> string -> any_in_type_in_sig list
-
 val any_in_class_signature : ClassSignature.t -> string -> any_in_class_sig list
 
 (** Lookup removed items *)
@@ -107,7 +80,6 @@ type careful_module_type =
   [ module_type | `FModuleType_removed of ModuleType.expr ]
 
 type careful_type = [ type_ | removed_type ]
-
 type careful_class = [ class_ | removed_type ]
 
 val careful_module_in_sig : Signature.t -> string -> careful_module option
@@ -116,5 +88,4 @@ val careful_module_type_in_sig :
   Signature.t -> string -> careful_module_type option
 
 val careful_type_in_sig : Signature.t -> string -> careful_type option
-
 val careful_class_in_sig : Signature.t -> string -> careful_class option

--- a/src/xref2/ident.ml
+++ b/src/xref2/ident.ml
@@ -15,47 +15,31 @@ type class_signature =
   [ `LClass of ClassName.t * int | `LClassType of ClassTypeName.t * int ]
 
 type datatype = [ `LType of TypeName.t * int | `LCoreType of TypeName.t ]
-
 type parent = [ signature | datatype | class_signature ]
 
 type label_parent =
   [ parent | `LPage of PageName.t * int | `LLeafPage of PageName.t * int ]
 
 type module_ = [ `LRoot of ModuleName.t * int | `LModule of ModuleName.t * int ]
-
 type functor_parameter = [ `LParameter of ParameterName.t * int ]
-
 type path_module = [ module_ | `LResult of signature * int | functor_parameter ]
-
 type module_type = [ `LModuleType of ModuleTypeName.t * int ]
-
 type type_ = datatype
-
 type constructor = [ `LConstructor of ConstructorName.t * int ]
-
 type field = [ `LField of FieldName.t * int ]
-
 type extension = [ `LExtension of ExtensionName.t * int ]
 
 type exception_ =
   [ `LException of ExceptionName.t * int | `LCoreException of ExceptionName.t ]
 
 type value = [ `LValue of ValueName.t * int ]
-
 type class_ = [ `LClass of ClassName.t * int ]
-
 type class_type = [ `LClassType of ClassTypeName.t * int ]
-
 type path_type = [ type_ | class_ | class_type ]
-
 type path_class_type = [ class_ | class_type ]
-
 type method_ = [ `LMethod of MethodName.t * int ]
-
 type instance_variable = [ `LInstanceVariable of InstanceVariableName.t * int ]
-
 type label = [ `LLabel of LabelName.t * int ]
-
 type page = [ `LPage of PageName.t * int | `LLeafPage of PageName.t * int ]
 
 type any =
@@ -261,9 +245,7 @@ module Name = struct
     | `LCoreType n -> TypeName.to_string n
 
   let class' : class_ -> ClassName.t = function `LClass (n, _) -> n
-
   let class_ c = ClassName.to_string (class' c)
-
   let typed_class : class_ -> ClassName.t = function `LClass (n, _) -> n
 
   let module_type : module_type -> string = function

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -54,7 +54,6 @@ let empty () =
   }
 
 let with_fragment_root r = { (empty ()) with fragment_root = Some r }
-
 let with_shadowed shadowed = { (empty ()) with shadowed }
 
 (** Raises [Not_found] *)
@@ -378,7 +377,6 @@ module ExtractIDs = struct
     }
 
   and include_ parent map i = signature parent map i.Include.expansion_
-
   and open_ parent map o = signature parent map o.Open.expansion
 
   and signature_items parent map items =

--- a/src/xref2/lang_of.mli
+++ b/src/xref2/lang_of.mli
@@ -4,24 +4,17 @@ open Odoc_model.Paths
 type maps
 
 val empty : unit -> maps
-
 val with_fragment_root : Cfrag.root -> maps
-
 val with_shadowed : Odoc_model.Lang.Include.shadowed -> maps
 
 module Opt = Component.Opt
 
 module Path : sig
   val module_ : maps -> Cpath.module_ -> Path.Module.t
-
   val module_type : maps -> Cpath.module_type -> Path.ModuleType.t
-
   val type_ : maps -> Cpath.type_ -> Path.Type.t
-
   val class_type : maps -> Cpath.class_type -> Path.ClassType.t
-
   val resolved_module : maps -> Cpath.Resolved.module_ -> Path.Resolved.Module.t
-
   val resolved_parent : maps -> Cpath.Resolved.parent -> Path.Resolved.Module.t
 
   val resolved_module_type :
@@ -33,9 +26,7 @@ module Path : sig
     maps -> Cpath.Resolved.class_type -> Path.Resolved.ClassType.t
 
   val module_fragment : maps -> Cfrag.module_ -> Fragment.Module.t
-
   val signature_fragment : maps -> Cfrag.signature -> Fragment.Signature.t
-
   val type_fragment : maps -> Cfrag.type_ -> Fragment.Type.t
 
   val resolved_module_fragment :

--- a/src/xref2/lookup_failures.ml
+++ b/src/xref2/lookup_failures.ml
@@ -4,7 +4,6 @@ type context = { c_loc : Location_.span option; c_context : string list }
 (** Context added by {!with_location} and {!with_context}. *)
 
 let context_acc = ref { c_loc = None; c_context = [] }
-
 let acc = ref []
 
 let with_ref r x f =
@@ -70,9 +69,7 @@ let report ~non_fatal fmt =
   kasprintf (fun msg -> add (`Warning (msg, !context_acc, non_fatal))) fmt
 
 let report_internal fmt = report ~non_fatal:true fmt
-
 let report_root ~name = add (`Root name)
-
 let report_warning fmt = report ~non_fatal:false fmt
 
 let with_location loc f =

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -13,11 +13,8 @@ type signature_lookup_result =
   Resolved.Signature.t * Cpath.Resolved.parent * Component.Signature.t
 
 type datatype_lookup_result = Resolved.DataType.t * Component.TypeDecl.t
-
 type class_lookup_result = Resolved.Class.t * Component.Class.t
-
 type class_type_lookup_result = Resolved.ClassType.t * Component.ClassType.t
-
 type page_lookup_result = Resolved.Page.t * Odoc_model.Lang.Page.t
 
 type type_lookup_result =
@@ -265,7 +262,6 @@ module DT = struct
   type t = datatype_lookup_result
 
   let of_component _env t ~parent_ref name = Ok (`Type (parent_ref, name), t)
-
   let of_element _env (`Type (id, t)) : t = (`Identifier id, t)
 
   let in_env env name =
@@ -654,7 +650,6 @@ let resolve_class_signature_reference env (r : ClassSignature.t) =
 let resolved1 r = Ok (r :> Resolved.t)
 
 let resolved3 (r, _, _) = resolved1 r
-
 and resolved2 (r, _) = resolved1 r
 
 let resolved_type_lookup = function

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -1,13 +1,10 @@
 open Component
 
 exception Invalidated
-
 exception MTOInvalidated
 
 type ('a, 'b) or_replaced = Not_replaced of 'a | Replaced of 'b
-
 type 'a type_or_replaced = ('a, TypeExpr.t * TypeDecl.Equation.t) or_replaced
-
 type 'a module_type_or_replaced = ('a, ModuleType.expr) or_replaced
 
 let map_replaced f = function
@@ -505,9 +502,7 @@ let rec type_fragment : t -> Cfrag.type_ -> Cfrag.type_ =
   | `Dot (sg, n) -> `Dot (signature_fragment t sg, n)
 
 let option_ conv s x = match x with Some x -> Some (conv s x) | None -> None
-
 let option_bind conv s x = match x with Some x -> conv s x | None -> None
-
 let list conv s xs = List.map (conv s) xs
 
 let rec type_ s t =

--- a/src/xref2/subst.mli
+++ b/src/xref2/subst.mli
@@ -4,11 +4,8 @@ open Component
 type t = Component.Substitution.t
 
 val identity : t
-
 val unresolve_opaque_paths : t -> t
-
 val path_invalidate_module : Ident.path_module -> t -> t
-
 val mto_invalidate_module : Ident.path_module -> t -> t
 
 val add_module :
@@ -29,15 +26,10 @@ val add_type_replacement :
   Ident.path_type -> TypeExpr.t -> TypeDecl.Equation.t -> t -> t
 
 val add_module_type_replacement : Ident.module_type -> ModuleType.expr -> t -> t
-
 val add_module_substitution : Ident.path_module -> t -> t
-
 val type_ : t -> Component.TypeDecl.t -> Component.TypeDecl.t
-
 val type_expr : t -> Component.TypeExpr.t -> Component.TypeExpr.t
-
 val module_ : t -> Component.Module.t -> Component.Module.t
-
 val module_type : t -> Component.ModuleType.t -> Component.ModuleType.t
 
 val module_type_substitution :
@@ -50,21 +42,13 @@ val module_type_expr :
   t -> Component.ModuleType.expr -> Component.ModuleType.expr
 
 val exception_ : t -> Component.Exception.t -> Component.Exception.t
-
 val extension : t -> Component.Extension.t -> Component.Extension.t
-
 val include_ : t -> Component.Include.t -> Component.Include.t
-
 val open_ : t -> Component.Open.t -> Component.Open.t
-
 val value : t -> Component.Value.t -> Component.Value.t
-
 val class_ : t -> Component.Class.t -> Component.Class.t
-
 val class_decl : t -> Component.Class.decl -> Component.Class.decl
-
 val class_type : t -> Component.ClassType.t -> Component.ClassType.t
-
 val signature : t -> Component.Signature.t -> Component.Signature.t
 
 val apply_sig_map :

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -199,9 +199,7 @@ module MakeMemo (X : MEMO) = struct
   module M = Hashtbl.Make (X)
 
   let cache : (X.result * int * Env.LookupTypeSet.t) M.t = M.create 10000
-
   let cache_hits : int M.t = M.create 10000
-
   let enabled = ref true
 
   let bump_counter arg =
@@ -255,7 +253,6 @@ module LookupModuleMemo = MakeMemo (struct
     Result.result
 
   let equal = ( = )
-
   let hash = Hashtbl.hash
 end)
 
@@ -268,27 +265,22 @@ module LookupParentMemo = MakeMemo (struct
     Result.result
 
   let equal = ( = )
-
   let hash = Hashtbl.hash
 end)
 
 module LookupAndResolveMemo = MakeMemo (struct
   type t = bool * bool * Cpath.module_
-
   type result = resolve_module_result
 
   let equal = ( = )
-
   let hash = Hashtbl.hash
 end)
 
 module SignatureOfModuleMemo = MakeMemo (struct
   type t = Cpath.Resolved.module_
-
   type result = (Component.Signature.t, signature_of_module_error) Result.result
 
   let equal = ( = )
-
   let hash = Hashtbl.hash
 end)
 

--- a/src/xref2/utils.ml
+++ b/src/xref2/utils.ml
@@ -4,11 +4,8 @@ module ResultMonad = struct
   type ('a, 'b) result = ('a, 'b) Result.result = Ok of 'a | Error of 'b
 
   let map_error f = function Ok _ as ok -> ok | Error e -> Error (f e)
-
   let of_option ~error = function Some x -> Ok x | None -> Error error
-
   let bind m f = match m with Ok x -> f x | Error _ as e -> e
-
   let ( >>= ) = bind
 end
 
@@ -16,11 +13,8 @@ end
 module OptionMonad = struct
   (* The error case become [None], the error value is ignored. *)
   let of_result = function Result.Ok x -> Some x | Error _ -> None
-
   let return x = Some x
-
   let bind m f = match m with Some x -> f x | None -> None
-
   let ( >>= ) = bind
 end
 
@@ -28,16 +22,10 @@ module EitherMonad = struct
   type ('a, 'b) t = Left of 'a | Right of 'b
 
   let return x = Right x
-
   let return_left x = Left x
-
   let bind m f = match m with Right x -> f x | Left y -> Left y
-
   let bind_left m f = match m with Left x -> f x | Right y -> Right y
-
   let ( >>= ) = bind
-
   let of_option ~left = function Some x -> Right x | None -> Left left
-
   let of_result = function Result.Ok x -> Right x | Error y -> Left y
 end

--- a/test/generators/gen_rules_lib.ml
+++ b/test/generators/gen_rules_lib.ml
@@ -1,5 +1,4 @@
 type sexp = Sexplib0.Sexp.t = Atom of string | List of sexp list
-
 type enabledif = Min of string | Max of string | MinMax of string * string
 
 type test_case = {
@@ -12,9 +11,7 @@ type test_case = {
 
 module Dune = struct
   let arg_fpath f = Fpath.to_string f
-
   let arg_dep f = "%{dep:" ^ Fpath.to_string f ^ "}"
-
   let arg_list args = List.map (fun x -> Atom x) args
 
   let render_enabledif = function
@@ -50,7 +47,6 @@ module Dune = struct
     | None -> []
 
   let run cmd = List (Atom "run" :: arg_list cmd)
-
   let action x = List [ Atom "action"; x ]
 
   let rule ?enabledif fields =


### PR DESCRIPTION
Built on top of #817

This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

As always, we are happy to hear your feedback!  Thank you for using ocamlformat!