### PR TITLE
Adjust spacing between spec items

### DIFF
--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -432,7 +432,11 @@ pre code {
 }
 
 div.spec, .def-doc {
-  margin-bottom: 20px;
+  margin-bottom: 10px;
+}
+
+div.odoc-spec {
+  margin-bottom: 25px;
 }
 
 .spec.type .variant {

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -202,19 +202,12 @@ sup, sub {
   margin-left: 0.2ex;
 }
 
-pre {
-  margin-top: 0.8em;
-  margin-bottom: 1.2em;
-}
-
-/* Restore default margin for paragraphs. */
-p {
+/* Restore default margin for block elements part of documentation. */
+p, pre, ul, ol {
   margin: 1em 0 1em 0;
 }
 
 ul, ol {
-  margin-top: 0.5em;
-  margin-bottom: 1em;
   list-style-position: outside
 }
 

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -423,7 +423,8 @@ pre code {
   margin-bottom: 10px;
 }
 
-div.odoc-spec {
+/* Spacing between items */
+div.odoc-spec,.odoc-include {
   margin-bottom: 2em;
 }
 
@@ -483,7 +484,7 @@ div.def-doc>*:first-child {
 
 .odoc-include summary {
   position: relative;
-  margin-bottom: 20px;
+  margin-bottom: 1em;
   cursor: pointer;
   outline: none;
 }

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -207,11 +207,14 @@ pre {
   margin-bottom: 1.2em;
 }
 
-p, ul, ol {
+/* Restore default margin for paragraphs. */
+p {
+  margin: 1em 0 1em 0;
+}
+
+ul, ol {
   margin-top: 0.5em;
   margin-bottom: 1em;
-}
-ul, ol {
   list-style-position: outside
 }
 
@@ -431,12 +434,12 @@ pre code {
   padding: 0.35em 0.5em;
 }
 
-div.spec, .def-doc {
+.def-doc {
   margin-bottom: 10px;
 }
 
 div.odoc-spec {
-  margin-bottom: 25px;
+  margin-bottom: 2em;
 }
 
 .spec.type .variant {

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -124,7 +124,6 @@
 /* Reset a few things. */
 
 html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {
-  margin: 0;
   padding: 0;
   border: 0;
   font: inherit;
@@ -200,11 +199,6 @@ sup, sub {
   font-size: 12px;
   line-height: 0;
   margin-left: 0.2ex;
-}
-
-/* Restore default margin for block elements part of documentation. */
-p, pre, ul, ol {
-  margin: 1em 0 1em 0;
 }
 
 ul, ol {
@@ -302,7 +296,6 @@ a.anchor {
 h1, h2, h3, h4, h5, h6, .h7, .h8, .h9, .h10 {
   font-family: "Fira Sans", Helvetica, Arial, sans-serif;
   font-weight: 400;
-  margin: 0.5em 0 0.5em 0;
   padding-top: 0.1em;
   line-height: 1.2;
   overflow-wrap: break-word;
@@ -311,7 +304,6 @@ h1, h2, h3, h4, h5, h6, .h7, .h8, .h9, .h10 {
 h1 {
   font-weight: 500;
   font-size: 2.441em;
-  margin-top: 1.214em;
 }
 
 h1 {


### PR DESCRIPTION
A small style fix: Make sure that the content is more obviously associated with the correct signature item.

Before:
<img width="742" alt="Screenshot 2022-02-04 at 19 10 54" src="https://user-images.githubusercontent.com/210963/152639637-73bdadb5-f461-4bc0-ad27-3aafeefb551d.png">

After:
<img width="790" alt="Screenshot 2022-02-04 at 19 12 04" src="https://user-images.githubusercontent.com/210963/152639676-01fa243e-efe2-4b05-8195-7952334732e0.png">

