### PR TITLE
Cmdliner constraint

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -27,7 +27,7 @@ delimited with `(** ... *)`, and outputs HTML.
 depends: [
   "odoc-parser" {>= "0.9.0"}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "1.1.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@opam/alcotest": "^0.8.5",
     "@opam/astring": "^0.8.3",
     "@opam/bisect_ppx": "^2.4.1",
-    "@opam/cmdliner": "^1.0.2",
+    "@opam/cmdliner": "1.0.4",
     "@opam/cppo": "^1.6.5",
     "@opam/dune": "~2.8.0",
     "@opam/fpath": "^0.7.2",


### PR DESCRIPTION
Cmdliner 1.1.0 has improved its API in an eventually incompatible way, deprecating the API that odoc currently uses.

Unfortunately cmdliner 1.1.0 is 4.08 and upwards only, and since odoc supports OCaml >= 4.02 we have to stay on the old API. Therefore I am constraining cmdliner to be < 1.1.0.