### PR TITLE
Cmdliner 1.1.0 compatibility take 2

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,4 +1,3 @@
-src/compat/*
 src/loader/cmi.ml
 src/loader/cmi.mli
 src/loader/cmt.ml

--- a/src/compat/compatcmdliner.ml
+++ b/src/compat/compatcmdliner.ml
@@ -6,23 +6,61 @@
    the OCaml compiler without causing deprecation alerts *)
 
 [@@@ocaml.warning "-3"]
-module Term = struct
-  include Cmdliner.Term
 
-  type info2 = Cmdliner.Term.info
+module Term = struct
+  open Cmdliner.Term
+
+  type 'a t = 'a Cmdliner.Term.t
+
+  type info = Cmdliner.Term.info
+
   let info = info
+
   let name = name
+
   let eval_choice = eval_choice
+
   let eval = eval
+
   let exit = Cmdliner.Term.exit
+
+  let ( $ ) = ( $ )
+
+  let const = const
 end
 
 module Arg = struct
-  include Cmdliner.Arg
+  open Cmdliner.Arg
 
-  type 'a converter2 = 'a Cmdliner.Arg.converter
+  type 'a conv = 'a Cmdliner.Arg.conv
+
   let env_var = env_var
-  let pconv = pconv
-end
-[@@@ocaml.warning "+3"]
 
+  let pconv = pconv
+
+  let string = string
+
+  let value = value
+
+  let opt = opt
+
+  let opt_all = opt_all
+
+  let info = info
+
+  let some = some
+
+  let flag = flag
+
+  let required = required
+
+  let pos = pos
+
+  let file = file
+
+  let bool = bool
+
+  let ( & ) = ( & )
+end
+
+[@@@ocaml.warning "+3"]

--- a/src/compat/compatcmdliner.ml
+++ b/src/compat/compatcmdliner.ml
@@ -1,0 +1,28 @@
+(* Compatibility module for Cmdliner *)
+
+(* Cmdliner 1.1.0 has deprecated the 'traditional' Term and Arg modules,
+   but is only available for OCaml 4.08 and above. This compatibility
+   module will work on 1.0.4 and 1.1.0 for all supported versions of
+   the OCaml compiler without causing deprecation alerts *)
+
+[@@@ocaml.warning "-3"]
+module Term = struct
+  include Cmdliner.Term
+
+  type info2 = Cmdliner.Term.info
+  let info = info
+  let name = name
+  let eval_choice = eval_choice
+  let eval = eval
+  let exit = Cmdliner.Term.exit
+end
+
+module Arg = struct
+  include Cmdliner.Arg
+
+  type 'a converter2 = 'a Cmdliner.Arg.converter
+  let env_var = env_var
+  let pconv = pconv
+end
+[@@@ocaml.warning "+3"]
+

--- a/src/compat/dune
+++ b/src/compat/dune
@@ -1,0 +1,3 @@
+(library
+ (name compatcmdliner)
+ (libraries cmdliner))

--- a/src/odoc/bin/dune
+++ b/src/odoc/bin/dune
@@ -2,7 +2,7 @@
  (name main)
  (package odoc)
  (public_name odoc)
- (libraries cmdliner odoc_model odoc_odoc)
+ (libraries compatcmdliner odoc_model odoc_odoc)
  (flags
   (:standard -open StdLabels))
  (instrumentation

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -4,9 +4,9 @@
    output the result to. *)
 
 open Odoc_odoc
-open Cmdliner
+open Compatcmdliner
 
-let convert_syntax : Odoc_document.Renderer.syntax Arg.converter =
+let convert_syntax : Odoc_document.Renderer.syntax Arg.converter2 =
   let syntax_parser str =
     match str with
     | "ml" | "ocaml" -> `Ok Odoc_document.Renderer.OCaml
@@ -18,7 +18,7 @@ let convert_syntax : Odoc_document.Renderer.syntax Arg.converter =
   in
   (syntax_parser, syntax_printer)
 
-let convert_directory ?(create = false) () : Fs.Directory.t Arg.converter =
+let convert_directory ?(create = false) () : Fs.Directory.t Arg.converter2 =
   let dir_parser, dir_printer = Arg.string in
   let odoc_dir_parser str =
     let () = if create then Fs.Directory.(mkdir_p (of_string str)) in
@@ -110,7 +110,7 @@ module Compile : sig
 
   val cmd : unit Term.t
 
-  val info : Term.info
+  val info : Term.info2
 end = struct
   let has_page_prefix file =
     file |> Fs.File.basename |> Fs.File.to_string
@@ -250,7 +250,7 @@ end
 module Odoc_link : sig
   val cmd : unit Term.t
 
-  val info : Term.info
+  val info : Term.info2
 end = struct
   let get_output_file ~output_file ~input =
     match output_file with
@@ -297,11 +297,11 @@ module type S = sig
 end
 
 module Make_renderer (R : S) : sig
-  val process : unit Term.t * Term.info
+  val process : unit Term.t * Term.info2
 
-  val targets : unit Term.t * Term.info
+  val targets : unit Term.t * Term.info2
 
-  val generate : unit Term.t * Term.info
+  val generate : unit Term.t * Term.info2
 end = struct
   let input =
     let doc = "Input file" in
@@ -406,7 +406,7 @@ end
 module Odoc_html_url : sig
   val cmd : unit Term.t
 
-  val info : Term.info
+  val info : Term.info2
 end = struct
   let root_url =
     let doc =
@@ -434,7 +434,7 @@ end
 module Odoc_latex_url : sig
   val cmd : unit Term.t
 
-  val info : Term.info
+  val info : Term.info2
 end = struct
   let reference =
     let doc = "The reference to be resolved and whose url to be generated." in
@@ -473,7 +473,7 @@ module Odoc_html = Make_renderer (struct
     Arg.(value & flag (info ~doc [ "indent" ]))
 
   (* Very basic validation and normalization for URI paths. *)
-  let convert_uri : Odoc_html.Tree.uri Arg.converter =
+  let convert_uri : Odoc_html.Tree.uri Arg.converter2 =
     let parser str =
       if String.length str = 0 then `Error "invalid URI"
       else
@@ -553,7 +553,7 @@ end)
 module Html_fragment : sig
   val cmd : unit Term.t
 
-  val info : Term.info
+  val info : Term.info2
 end = struct
   let html_fragment directories xref_base_uri output_file input_file
       warnings_options =

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -6,7 +6,7 @@
 open Odoc_odoc
 open Compatcmdliner
 
-let convert_syntax : Odoc_document.Renderer.syntax Arg.converter2 =
+let convert_syntax : Odoc_document.Renderer.syntax Arg.conv =
   let syntax_parser str =
     match str with
     | "ml" | "ocaml" -> `Ok Odoc_document.Renderer.OCaml
@@ -18,7 +18,7 @@ let convert_syntax : Odoc_document.Renderer.syntax Arg.converter2 =
   in
   (syntax_parser, syntax_printer)
 
-let convert_directory ?(create = false) () : Fs.Directory.t Arg.converter2 =
+let convert_directory ?(create = false) () : Fs.Directory.t Arg.conv =
   let dir_parser, dir_printer = Arg.string in
   let odoc_dir_parser str =
     let () = if create then Fs.Directory.(mkdir_p (of_string str)) in
@@ -110,7 +110,7 @@ module Compile : sig
 
   val cmd : unit Term.t
 
-  val info : Term.info2
+  val info : Term.info
 end = struct
   let has_page_prefix file =
     file |> Fs.File.basename |> Fs.File.to_string
@@ -250,7 +250,7 @@ end
 module Odoc_link : sig
   val cmd : unit Term.t
 
-  val info : Term.info2
+  val info : Term.info
 end = struct
   let get_output_file ~output_file ~input =
     match output_file with
@@ -297,11 +297,11 @@ module type S = sig
 end
 
 module Make_renderer (R : S) : sig
-  val process : unit Term.t * Term.info2
+  val process : unit Term.t * Term.info
 
-  val targets : unit Term.t * Term.info2
+  val targets : unit Term.t * Term.info
 
-  val generate : unit Term.t * Term.info2
+  val generate : unit Term.t * Term.info
 end = struct
   let input =
     let doc = "Input file" in
@@ -406,7 +406,7 @@ end
 module Odoc_html_url : sig
   val cmd : unit Term.t
 
-  val info : Term.info2
+  val info : Term.info
 end = struct
   let root_url =
     let doc =
@@ -434,7 +434,7 @@ end
 module Odoc_latex_url : sig
   val cmd : unit Term.t
 
-  val info : Term.info2
+  val info : Term.info
 end = struct
   let reference =
     let doc = "The reference to be resolved and whose url to be generated." in
@@ -473,7 +473,7 @@ module Odoc_html = Make_renderer (struct
     Arg.(value & flag (info ~doc [ "indent" ]))
 
   (* Very basic validation and normalization for URI paths. *)
-  let convert_uri : Odoc_html.Tree.uri Arg.converter2 =
+  let convert_uri : Odoc_html.Tree.uri Arg.conv =
     let parser str =
       if String.length str = 0 then `Error "invalid URI"
       else
@@ -553,7 +553,7 @@ end)
 module Html_fragment : sig
   val cmd : unit Term.t
 
-  val info : Term.info2
+  val info : Term.info
 end = struct
   let html_fragment directories xref_base_uri output_file input_file
       warnings_options =

--- a/test/odoc_print/dune
+++ b/test/odoc_print/dune
@@ -6,4 +6,5 @@
 (executable
  (name odoc_print)
  (modules odoc_print)
- (libraries odoc_odoc cmdliner type_desc_to_yojson odoc_model_desc))
+ (libraries odoc_odoc cmdliner type_desc_to_yojson odoc_model_desc
+   compatcmdliner))

--- a/test/odoc_print/odoc_print.ml
+++ b/test/odoc_print/odoc_print.ml
@@ -191,7 +191,7 @@ let run inp ref =
               | None -> Ok ())
           | _ -> Ok ()))
 
-open Cmdliner
+open Compatcmdliner
 
 let reference =
   let doc = "reference to print" in
@@ -211,4 +211,4 @@ let () =
   | `Ok (Error (`Msg msg)) ->
       Printf.eprintf "Error: %s\n" msg;
       exit 1
-  | cmdliner_error -> Term.exit cmdliner_error
+  | (`Version | `Help | `Error _) as x -> Term.exit x


### PR DESCRIPTION
Unfortunately cmdliner 1.1.0 is 4.08 and upwards only, and since odoc
supports OCaml 4.02.3 we have to stay on the old API. This commit introduces
a stub library that re-exposes the deprecated interface, supressing the
deprecation notices.