### PR TITLE
Lift `deprecated` and `alerts` attributes into odoc tags

### DIFF
--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -262,6 +262,8 @@ let tag : Comment.tag -> Description.one =
       let value = Inline.Text version in
       item ~tag:"before" ~value (nestable_block_element_list content)
   | `Version s -> item ~tag:"version" (text_def s)
+  | `Alert (tag, Some content) -> item ~tag (text_def content)
+  | `Alert (tag, None) -> item ~tag []
 
 let attached_block_element : Comment.attached_block_element -> Block.t =
   function

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -1069,14 +1069,3 @@ let read_interface root name intf =
   let id = `Root (root, Odoc_model.Names.ModuleName.make_std name) in
   let items = read_signature Env.empty id intf in
   (id, items)
-
-let point_of_pos { Lexing.pos_lnum; pos_bol; pos_cnum; _ } =
-  let column = pos_cnum - pos_bol in
-  { Odoc_model.Location_.line = pos_lnum; column }
-
-let read_location { Location.loc_start; loc_end; _ } =
-  {
-    Odoc_model.Location_.file = loc_start.pos_fname;
-    start = point_of_pos loc_start;
-    end_ = point_of_pos loc_end;
-  }

--- a/src/loader/cmi.mli
+++ b/src/loader/cmi.mli
@@ -69,7 +69,7 @@ val read_signature_noenv : Ident_env.t ->
                        Paths.Identifier.Signature.t ->
                        Odoc_model.Compat.signature ->
                        (Odoc_model.Lang.Signature.t * Odoc_model.Lang.Include.shadowed)
-  
+
 val read_signature : Ident_env.t ->
                      Paths.Identifier.Signature.t ->
                      Odoc_model.Compat.signature -> Odoc_model.Lang.Signature.t
@@ -83,5 +83,3 @@ val read_extension_constructor : Ident_env.t ->
 val read_exception : Ident_env.t ->
   Paths.Identifier.Signature.t -> Ident.t ->
   Types.extension_constructor -> Odoc_model.Lang.Exception.t
-
-val read_location : Location.t -> Odoc_model.Location_.span

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -534,7 +534,7 @@ and read_structure_item env parent item =
 
 and read_include env parent incl =
   let open Include in
-  let loc = Cmi.read_location incl.incl_loc in
+  let loc = Doc_attr.read_location incl.incl_loc in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, status = Doc_attr.attached Odoc_model.Semantics.Expect_status container incl.incl_attributes in
   let decl_modty =

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -738,7 +738,7 @@ and read_module_type_substitution env parent mtd =
 
 and read_include env parent incl =
   let open Include in
-  let loc = Cmi.read_location incl.incl_loc in
+  let loc = Doc_attr.read_location incl.incl_loc in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, status = Doc_attr.attached Odoc_model.Semantics.Expect_status container incl.incl_attributes in
   let content, shadowed = Cmi.read_signature_noenv env parent (Odoc_model.Compat.signature incl.incl_type) in

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -19,7 +19,7 @@ module Paths = Odoc_model.Paths
 
 val empty : Odoc_model.Comment.docs
 
-val parse_attribute : Parsetree.attribute -> (string * Location.t) option
+val is_stop_comment : Parsetree.attribute -> bool
 
 val attached :
   'tags Semantics.handle_internal_tags ->
@@ -68,3 +68,5 @@ val extract_top_comment_class :
   Lang.ClassSignature.item list ->
   Lang.ClassSignature.item list * (Comment.docs * Comment.docs)
 (** Extract the first comment of a class signature. Returns the remaining items. *)
+
+val read_location : Location.t -> Odoc_model.Location_.span

--- a/src/loader/ident_env.cppo.ml
+++ b/src/loader/ident_env.cppo.ml
@@ -192,11 +192,9 @@ let rec extract_signature_tree_items hide_item items =
       [`ModuleType (mtd.mtd_id, hide_item)] @ extract_signature_tree_items hide_item rest
   | {sig_desc = Tsig_include incl; _ } :: rest ->
       [`Include (extract_signature_type_items (Compat.signature incl.incl_type))] @ extract_signature_tree_items hide_item rest
-  | {sig_desc = Tsig_attribute attr; _ } :: rest -> begin
-      match Doc_attr.parse_attribute attr with
-      | Some ("/*", _) -> extract_signature_tree_items (not hide_item) rest 
-      | _ -> extract_signature_tree_items hide_item rest
-    end
+  | {sig_desc = Tsig_attribute attr; _ } :: rest ->
+      let hide_item = if Doc_attr.is_stop_comment attr then not hide_item else hide_item in
+      extract_signature_tree_items hide_item rest
   | {sig_desc = Tsig_class cls; _} :: rest ->
       List.map
         (fun cld ->
@@ -301,12 +299,9 @@ let rec extract_structure_tree_items hide_item items =
         [`ModuleType (mtd.mtd_id, hide_item)] @ extract_structure_tree_items hide_item rest
     | { str_desc = Tstr_include incl; _ } :: rest ->
         [`Include (extract_signature_type_items (Compat.signature incl.incl_type))] @ extract_structure_tree_items hide_item rest
-
-    | { str_desc = Tstr_attribute attr; _} :: rest -> begin
-        match Doc_attr.parse_attribute attr with
-        | Some ("/*", _) -> extract_structure_tree_items (not hide_item) rest
-        | _ -> extract_structure_tree_items hide_item rest
-      end
+    | { str_desc = Tstr_attribute attr; _} :: rest ->
+        let hide_item = if Doc_attr.is_stop_comment attr then not hide_item else hide_item in
+        extract_structure_tree_items hide_item rest
     | { str_desc = Tstr_class cls; _ } :: rest ->
         List.map
 #if OCAML_VERSION < (4,3,0)

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -59,7 +59,8 @@ type tag =
     * nestable_block_element with_location list
   | `Since of string
   | `Before of string * nestable_block_element with_location list
-  | `Version of string ]
+  | `Version of string
+  | `Alert of string * string option ]
 
 type heading_level =
   [ `Title

--- a/src/model/semantics.mli
+++ b/src/model/semantics.mli
@@ -8,11 +8,15 @@ type _ handle_internal_tags =
 
 type sections_allowed = [ `All | `No_titles | `None ]
 
+type alerts =
+  [ `Tag of [ `Alert of string * string option ] ] Location_.with_location list
+
 val ast_to_comment :
   internal_tags:'tags handle_internal_tags ->
   sections_allowed:sections_allowed ->
   parent_of_sections:Paths.Identifier.LabelParent.t ->
   Odoc_parser.Ast.t ->
+  alerts ->
   (Comment.docs * 'tags) Error.with_warnings
 
 val parse_comment :

--- a/src/model_desc/comment_desc.ml
+++ b/src/model_desc/comment_desc.ml
@@ -36,7 +36,8 @@ and general_tag =
   | `See of [ `Url | `File | `Document ] * string * general_docs
   | `Since of string
   | `Before of string * general_docs
-  | `Version of string ]
+  | `Version of string
+  | `Alert of string * string option ]
 
 and general_docs = general_block_element with_location list
 
@@ -124,7 +125,8 @@ and tag : general_tag t =
         C ("`See", (x1, x2, x3), Triple (url_kind, string, docs))
     | `Since x -> C ("`Since", x, string)
     | `Before (x1, x2) -> C ("`Before", (x1, x2), Pair (string, docs))
-    | `Version x -> C ("`Version", x, string))
+    | `Version x -> C ("`Version", x, string)
+    | `Alert (x1, x2) -> C ("`Alert", (x1, x2), Pair (string, Option string)))
 
 and docs : general_docs t = List (Indirect (ignore_loc, block_element))
 

--- a/test/generators/cases/alerts.mli
+++ b/test/generators/cases/alerts.mli
@@ -27,3 +27,22 @@ module Top2 : sig
 
   (** Top-comment. *)
 end
+
+(* Deprecated alert tag. *)
+
+val d : int
+[@@alert deprecated "A deprecated alert d"]
+
+val d2 : int
+[@@alert deprecated]
+
+(* Custom alert tag. *)
+
+val e : int
+[@@alert e "an alert"]
+
+(* Custom alert tag without payload. *)
+
+val f : int
+[@@alert f]
+

--- a/test/generators/cases/alerts.mli
+++ b/test/generators/cases/alerts.mli
@@ -1,0 +1,29 @@
+(* Deprecated tag. *)
+
+val a : int
+[@@deprecated "a"]
+
+(* Both attribute and tag. *)
+
+val b : int
+[@@deprecated "Shouldn't be rendered"]
+(** @deprecated b. *)
+
+(* No payload *)
+
+val c : int
+[@@deprecated]
+
+(* At the top-level of a module. *)
+
+module Top1 : sig
+  [@@@deprecated "A"]
+
+  (** Top-comment. *)
+end
+
+module Top2 : sig
+  [@@@deprecated "A"]
+
+  (** Top-comment. *)
+end

--- a/test/generators/html/Alerts-Top1.html
+++ b/test/generators/html/Alerts-Top1.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Top1 (Alerts.Top1)</title>
+  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Alerts.html">Up</a> – 
+   <a href="Alerts.html">Alerts</a> &#x00BB; Top1
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Alerts.Top1</span></code></h1><p>Top-comment.</p>
+   <ul class="at-tags">
+    <li class="deprecated"><span class="at-tag">deprecated</span> A</li>
+   </ul>
+  </header><div class="odoc-content"></div>
+ </body>
+</html>

--- a/test/generators/html/Alerts-Top2.html
+++ b/test/generators/html/Alerts-Top2.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Top2 (Alerts.Top2)</title>
+  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Alerts.html">Up</a> – 
+   <a href="Alerts.html">Alerts</a> &#x00BB; Top2
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Alerts.Top2</span></code></h1><p>Top-comment.</p>
+   <ul class="at-tags">
+    <li class="deprecated"><span class="at-tag">deprecated</span> A</li>
+   </ul>
+  </header><div class="odoc-content"></div>
+ </body>
+</html>

--- a/test/generators/html/Alerts.html
+++ b/test/generators/html/Alerts.html
@@ -71,6 +71,52 @@
      </code>
     </div><div class="spec-doc"><p>Top-comment.</p></div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-d" class="anchored">
+     <a href="#val-d" class="anchor"></a>
+     <code><span><span class="keyword">val</span> d : int</span></code>
+    </div>
+    <div class="spec-doc">
+     <ul class="at-tags">
+      <li class="deprecated"><span class="at-tag">deprecated</span> 
+       A deprecated alert d
+      </li>
+     </ul>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-d2" class="anchored">
+     <a href="#val-d2" class="anchor"></a>
+     <code><span><span class="keyword">val</span> d2 : int</span></code>
+    </div>
+    <div class="spec-doc">
+     <ul class="at-tags">
+      <li class="deprecated"><span class="at-tag">deprecated</span> </li>
+     </ul>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-e" class="anchored">
+     <a href="#val-e" class="anchor"></a>
+     <code><span><span class="keyword">val</span> e : int</span></code>
+    </div>
+    <div class="spec-doc">
+     <ul class="at-tags">
+      <li class="alert"><span class="at-tag">alert</span> e an alert</li>
+     </ul>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-f" class="anchored">
+     <a href="#val-f" class="anchor"></a>
+     <code><span><span class="keyword">val</span> f : int</span></code>
+    </div>
+    <div class="spec-doc">
+     <ul class="at-tags">
+      <li class="alert"><span class="at-tag">alert</span> f</li>
+     </ul>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Alerts.html
+++ b/test/generators/html/Alerts.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Alerts (Alerts)</title><link rel="stylesheet" href="odoc.css"/>
+  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Alerts</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec value" id="val-a" class="anchored">
+     <a href="#val-a" class="anchor"></a>
+     <code><span><span class="keyword">val</span> a : int</span></code>
+    </div>
+    <div class="spec-doc">
+     <ul class="at-tags">
+      <li class="deprecated"><span class="at-tag">deprecated</span> a</li>
+     </ul>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-b" class="anchored">
+     <a href="#val-b" class="anchor"></a>
+     <code><span><span class="keyword">val</span> b : int</span></code>
+    </div>
+    <div class="spec-doc">
+     <ul class="at-tags">
+      <li class="deprecated"><span class="at-tag">deprecated</span> <p>b.</p>
+      </li>
+     </ul>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value" id="val-c" class="anchored">
+     <a href="#val-c" class="anchor"></a>
+     <code><span><span class="keyword">val</span> c : int</span></code>
+    </div>
+    <div class="spec-doc">
+     <ul class="at-tags">
+      <li class="deprecated"><span class="at-tag">deprecated</span> </li>
+     </ul>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Top1" class="anchored">
+     <a href="#module-Top1" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Alerts-Top1.html">Top1</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div><div class="spec-doc"><p>Top-comment.</p></div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-Top2" class="anchored">
+     <a href="#module-Top2" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Alerts-Top2.html">Top2</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div><div class="spec-doc"><p>Top-comment.</p></div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/alerts.targets
+++ b/test/generators/html/alerts.targets
@@ -1,0 +1,3 @@
+Alerts.html
+Alerts-Top1.html
+Alerts-Top2.html

--- a/test/generators/latex/Alerts.tex
+++ b/test/generators/latex/Alerts.tex
@@ -1,0 +1,24 @@
+\section{Module \ocamlinlinecode{Alerts}}\label{module-Alerts}%
+\label{module-Alerts-val-a}\ocamlcodefragment{\ocamltag{keyword}{val} a : int}\begin{ocamlindent}\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{deprecated}]{a}\end{description}%
+\end{ocamlindent}%
+\medbreak
+\label{module-Alerts-val-b}\ocamlcodefragment{\ocamltag{keyword}{val} b : int}\begin{ocamlindent}\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{deprecated}]{b.}\end{description}%
+\end{ocamlindent}%
+\medbreak
+\label{module-Alerts-val-c}\ocamlcodefragment{\ocamltag{keyword}{val} c : int}\begin{ocamlindent}\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{deprecated}]{}\end{description}%
+\end{ocamlindent}%
+\medbreak
+\label{module-Alerts-module-Top1}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Alerts-module-Top1]{\ocamlinlinecode{Top1}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Top-comment.\end{ocamlindent}%
+\medbreak
+\label{module-Alerts-module-Top2}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Alerts-module-Top2]{\ocamlinlinecode{Top2}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Top-comment.\end{ocamlindent}%
+\medbreak
+
+

--- a/test/generators/latex/Alerts.tex
+++ b/test/generators/latex/Alerts.tex
@@ -20,5 +20,25 @@
 \label{module-Alerts-module-Top2}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Alerts-module-Top2]{\ocamlinlinecode{Top2}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Top-comment.\end{ocamlindent}%
 \medbreak
+\label{module-Alerts-val-d}\ocamlcodefragment{\ocamltag{keyword}{val} d : int}\begin{ocamlindent}\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{deprecated}]{A deprecated alert d}\end{description}%
+\end{ocamlindent}%
+\medbreak
+\label{module-Alerts-val-d2}\ocamlcodefragment{\ocamltag{keyword}{val} d2 : int}\begin{ocamlindent}\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{deprecated}]{}\end{description}%
+\end{ocamlindent}%
+\medbreak
+\label{module-Alerts-val-e}\ocamlcodefragment{\ocamltag{keyword}{val} e : int}\begin{ocamlindent}\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{alert}]{e an alert}\end{description}%
+\end{ocamlindent}%
+\medbreak
+\label{module-Alerts-val-f}\ocamlcodefragment{\ocamltag{keyword}{val} f : int}\begin{ocamlindent}\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{alert}]{f}\end{description}%
+\end{ocamlindent}%
+\medbreak
 
 

--- a/test/generators/latex/alerts.targets
+++ b/test/generators/latex/alerts.targets
@@ -1,0 +1,1 @@
+Alerts.tex

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -1,4 +1,19 @@
 (rule
+ (target alerts.cmti)
+ (action
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/alerts.mli})))
+
+(rule
+ (target alerts.odoc)
+ (action
+  (run odoc compile -o %{target} %{dep:alerts.cmti})))
+
+(rule
+ (target alerts.odocl)
+ (action
+  (run odoc link -o %{target} %{dep:alerts.odoc})))
+
+(rule
  (target alias.cmt)
  (action
   (run ocamlc -c -bin-annot -o %{target} %{dep:cases/alias.ml})))
@@ -460,6 +475,100 @@
  (target val.odocl)
  (action
   (run odoc link -o %{target} %{dep:val.odoc})))
+
+(subdir
+ html
+ (rule
+  (targets Alerts.html.gen Alerts-Top1.html.gen Alerts-Top2.html.gen)
+  (action
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../alerts.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alerts.html Alerts.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alerts-Top1.html Alerts-Top1.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alerts-Top2.html Alerts-Top2.html.gen))))
+
+(subdir
+ html
+ (rule
+  (action
+   (with-outputs-to
+    alerts.targets.gen
+    (run odoc html-targets -o . %{dep:../alerts.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff alerts.targets alerts.targets.gen))))
+
+(subdir
+ latex
+ (rule
+  (targets Alerts.tex.gen)
+  (action
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../alerts.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alerts.tex Alerts.tex.gen))))
+
+(subdir
+ latex
+ (rule
+  (action
+   (with-outputs-to
+    alerts.targets.gen
+    (run odoc latex-targets -o . %{dep:../alerts.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff alerts.targets alerts.targets.gen))))
+
+(subdir
+ man
+ (rule
+  (targets Alerts.3o.gen Alerts.Top1.3o.gen Alerts.Top2.3o.gen)
+  (action
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../alerts.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alerts.3o Alerts.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alerts.Top1.3o Alerts.Top1.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Alerts.Top2.3o Alerts.Top2.3o.gen))))
+
+(subdir
+ man
+ (rule
+  (action
+   (with-outputs-to
+    alerts.targets.gen
+    (run odoc man-targets -o . %{dep:../alerts.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff alerts.targets alerts.targets.gen))))
 
 (subdir
  html

--- a/test/generators/man/Alerts.3o
+++ b/test/generators/man/Alerts.3o
@@ -45,4 +45,32 @@ Top-comment\.
 .ti +2
 Top-comment\.
 .nf 
+.sp 
+\f[CB]val\fR d : int
+.fi 
+.br 
+.ti +2
+@deprecated: A deprecated alert d
+.nf 
+.sp 
+\f[CB]val\fR d2 : int
+.fi 
+.br 
+.ti +2
+@deprecated: 
+.nf 
+.sp 
+\f[CB]val\fR e : int
+.fi 
+.br 
+.ti +2
+@alert: e an alert
+.nf 
+.sp 
+\f[CB]val\fR f : int
+.fi 
+.br 
+.ti +2
+@alert: f
+.nf 
 

--- a/test/generators/man/Alerts.3o
+++ b/test/generators/man/Alerts.3o
@@ -1,0 +1,48 @@
+
+.TH Alerts 3 "" "Odoc" "OCaml Library"
+.SH Name
+Alerts
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Alerts\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]val\fR a : int
+.fi 
+.br 
+.ti +2
+@deprecated: a
+.nf 
+.sp 
+\f[CB]val\fR b : int
+.fi 
+.br 
+.ti +2
+@deprecated: b\.
+.nf 
+.sp 
+\f[CB]val\fR c : int
+.fi 
+.br 
+.ti +2
+@deprecated: 
+.nf 
+.sp 
+\f[CB]module\fR Top1 : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.fi 
+.br 
+.ti +2
+Top-comment\.
+.nf 
+.sp 
+\f[CB]module\fR Top2 : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.fi 
+.br 
+.ti +2
+Top-comment\.
+.nf 
+

--- a/test/generators/man/Alerts.Top1.3o
+++ b/test/generators/man/Alerts.Top1.3o
@@ -1,0 +1,21 @@
+
+.TH Top1 3 "" "Odoc" "OCaml Library"
+.SH Name
+Alerts\.Top1
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Alerts\.Top1\fR
+.in 
+.sp 
+.fi 
+Top-comment\.
+.nf 
+.sp 
+.fi 
+@deprecated: A
+.nf 
+.SH Documentation
+.sp 
+.nf 
+

--- a/test/generators/man/Alerts.Top2.3o
+++ b/test/generators/man/Alerts.Top2.3o
@@ -1,0 +1,21 @@
+
+.TH Top2 3 "" "Odoc" "OCaml Library"
+.SH Name
+Alerts\.Top2
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Alerts\.Top2\fR
+.in 
+.sp 
+.fi 
+Top-comment\.
+.nf 
+.sp 
+.fi 
+@deprecated: A
+.nf 
+.SH Documentation
+.sp 
+.nf 
+

--- a/test/generators/man/alerts.targets
+++ b/test/generators/man/alerts.targets
@@ -1,0 +1,3 @@
+Alerts.3o
+Alerts.Top1.3o
+Alerts.Top2.3o


### PR DESCRIPTION
This PR lifts `deprecated` and [alerts](https://ocaml.org/manual/alerts.html) into `odoc` tags.

`[@@deprecated]` and `[@@alert deprecated]` are handled internally the same way. and rendered similarly to the existing `@deprecated` odoc tag. Alerts are rendered as `alert alert_name` followed by the possible payload.

![image](https://user-images.githubusercontent.com/34110029/154049865-8ac0a46c-4a7e-4fbe-bb92-e877e9c06e19.png)
![image](https://user-images.githubusercontent.com/34110029/154049118-ebfd6c48-21d4-46bb-a455-6aa9f037dc17.png)

When an item contains both a `deprecated` attribute and an attached comment with a `deprecated` `odoc` tag, only the `odoc` tag is kept. This allows to use references in `@deprecated` message, as payloads from alerts or attribute are not parsed by odoc.

This PR closes #406 