### PR TITLE
Improve and simplify the layout for datatypes, with css

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -249,29 +249,21 @@ let rec documentedSrc ~resolve (t : DocumentedSrc.t) : item Html.elt list =
             match doc with
             | [] -> []
             | doc ->
-                let opening, closing = markers in
-                [
-                  Html.td
-                    ~a:(class_ [ "def-doc" ])
-                    (Html.span
-                       ~a:(class_ [ "comment-delim" ])
-                       [ Html.txt opening ]
-                     :: block ~resolve doc
-                    @ [
-                        Html.span
-                          ~a:(class_ [ "comment-delim" ])
-                          [ Html.txt closing ];
-                      ]);
-                ]
+              let opening, closing = markers in
+              let delim s =
+                [Html.span ~a:(class_ [ "comment-delim" ]) [Html.txt s]]
+              in
+              [ Html.div ~a:(class_ [ "def-doc" ]) (
+                  delim opening
+                  @ block ~resolve doc
+                  @ delim closing
+                )]
           in
           let a, link = mk_anchor anchor in
-          let content =
-            let c = link @ content in
-            Html.td ~a:(class_ attrs) (c :> any Html.elt list)
-          in
-          Html.tr ~a (content :: doc)
+          let content = (content :> any Html.elt list) in
+          Html.li ~a:(a @ class_ attrs) (link @ content @ doc)
         in
-        Html.table (List.map one l) :: to_html rest
+        Html.ol (List.map one l) :: to_html rest
   in
   to_html t
 

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -33,11 +33,12 @@ let mk_anchor_link id =
 
 let mk_anchor anchor =
   match anchor with
-  | None -> ([], [])
+  | None -> ([], [], [])
   | Some { Odoc_document.Url.Anchor.anchor; _ } ->
       let link = mk_anchor_link anchor in
-      let attrib = [ Html.a_id anchor; Html.a_class [ "anchored" ] ] in
-      (attrib, link)
+      let extra_attr = [ Html.a_id anchor ] in
+      let extra_class = [ "anchored" ] in
+      (extra_attr, extra_class, link)
 
 let class_ (l : Class.t) = if l = [] then [] else [ Html.a_class l ]
 
@@ -204,7 +205,7 @@ let div : ([< Html_types.div_attrib ], [< item ], [> Html_types.div ]) Html.star
     =
   Html.Unsafe.node "div"
 
-let spec_class = function [] -> [] | attr -> class_ ("spec" :: attr)
+let spec_class attr = class_ ("spec" :: attr)
 
 let spec_doc_div ~resolve = function
   | [] -> []
@@ -249,19 +250,21 @@ let rec documentedSrc ~resolve (t : DocumentedSrc.t) : item Html.elt list =
             match doc with
             | [] -> []
             | doc ->
-              let opening, closing = markers in
-              let delim s =
-                [Html.span ~a:(class_ [ "comment-delim" ]) [Html.txt s]]
-              in
-              [ Html.div ~a:(class_ [ "def-doc" ]) (
-                  delim opening
-                  @ block ~resolve doc
-                  @ delim closing
-                )]
+                let opening, closing = markers in
+                let delim s =
+                  [ Html.span ~a:(class_ [ "comment-delim" ]) [ Html.txt s ] ]
+                in
+                [
+                  Html.div
+                    ~a:(class_ [ "def-doc" ])
+                    (delim opening @ block ~resolve doc @ delim closing);
+                ]
           in
-          let a, link = mk_anchor anchor in
+          let extra_attr, extra_class, link = mk_anchor anchor in
           let content = (content :> any Html.elt list) in
-          Html.li ~a:(a @ class_ attrs) (link @ content @ doc)
+          Html.li
+            ~a:(extra_attr @ class_ (attrs @ extra_class))
+            (link @ content @ doc)
         in
         Html.ol (List.map one l) :: to_html rest
   in
@@ -299,8 +302,8 @@ and items ~resolve l : item Html.elt list =
           let details ~open' =
             let open' = if open' then [ Html.a_open () ] else [] in
             let summary =
-              let anchor_attrib, anchor_link = mk_anchor anchor in
-              let a = spec_class attr @ anchor_attrib in
+              let extra_attr, extra_class, anchor_link = mk_anchor anchor in
+              let a = spec_class (attr @ extra_class) @ extra_attr in
               Html.summary ~a @@ anchor_link @ source (inline ~resolve) summary
             in
             [ Html.details ~a:open' summary included_html ]
@@ -314,8 +317,8 @@ and items ~resolve l : item Html.elt list =
         let inc = [ Html.div ~a:[ Html.a_class a_class ] (doc @ content) ] in
         (continue_with [@tailcall]) rest inc
     | Declaration { Item.attr; anchor; content; doc } :: rest ->
-        let anchor_attrib, anchor_link = mk_anchor anchor in
-        let a = spec_class attr @ anchor_attrib in
+        let extra_attr, extra_class, anchor_link = mk_anchor anchor in
+        let a = spec_class (attr @ extra_class) @ extra_attr in
         let content = anchor_link @ documentedSrc ~resolve content in
         let spec =
           let doc = spec_doc_div ~resolve doc in

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -419,8 +419,8 @@ pre code {
   padding: 0.35em 0.5em;
 }
 
-.def-doc {
-  margin-bottom: 10px;
+li:not(:last-child) > .def-doc {
+  margin-bottom: 15px;
 }
 
 /* Spacing between items */
@@ -428,30 +428,40 @@ div.odoc-spec,.odoc-include {
   margin-bottom: 2em;
 }
 
-.spec.type .variant {
+.spec.type .variant p, .spec.type .record p {
+  margin: 5px;
+}
+
+.spec.type .variant, .spec.type .record {
   margin-left: 2ch;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: 4px;
 }
-.spec.type .variant p {
-  margin: 0;
-  font-style: italic;
+
+.spec.type .record > code, .spec.type .variant > code {
+  min-width: 40%;
 }
-.spec.type .record {
-  margin-left: 2ch;
+
+.spec.type > ol {
+  margin-top: 0;
+  margin-bottom: 0;
 }
-.spec.type .record p {
-  margin: 0;
-  font-style: italic;
+
+.spec.type .record > .def-doc, .spec.type .variant > .def-doc {
+  min-width:50%;
+  padding-left: 22px;
+  margin-left: 10%;
+  border-radius: 3px;
+  flex-grow:1;
+  border-left: 0.1em solid var(--spec-summary-border-color);
 }
 
 div.def {
   margin-top: 0;
   text-indent: -2ex;
   padding-left: 2ex;
-}
-
-div.def+div.def-doc {
-  margin-left: 1ex;
-  margin-top: 2.5px
 }
 
 div.def-doc>*:first-child {

--- a/test/generators/html/Alias-X.html
+++ b/test/generators/html/Alias-X.html
@@ -15,7 +15,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = int</span>

--- a/test/generators/html/Alias.html
+++ b/test/generators/html/Alias.html
@@ -12,7 +12,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Alias-X.html">X</a>

--- a/test/generators/html/Bugs.html
+++ b/test/generators/html/Bugs.html
@@ -12,7 +12,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-opt" class="anchored">
+    <div class="spec type anchored" id="type-opt">
      <a href="#type-opt" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a opt</span></span>
       <span> = <span><span class="type-var">'a</span> option</span></span>
@@ -20,7 +20,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo" class="anchored">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> foo : 

--- a/test/generators/html/Bugs_post_406.html
+++ b/test/generators/html/Bugs_post_406.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec class-type" id="class-type-let_open" class="anchored">
+    <div class="spec class-type anchored" id="class-type-let_open">
      <a href="#class-type-let_open" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 
@@ -31,7 +31,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-let_open'" class="anchored">
+    <div class="spec class anchored" id="class-let_open'">
      <a href="#class-let_open'" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Bugs_post_406-class-let_open'.html">let_open'</a></span>

--- a/test/generators/html/Bugs_pre_410.html
+++ b/test/generators/html/Bugs_pre_410.html
@@ -13,7 +13,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-opt'" class="anchored">
+    <div class="spec type anchored" id="type-opt'">
      <a href="#type-opt'" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a opt'</span></span>
@@ -22,7 +22,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo'" class="anchored">
+    <div class="spec value anchored" id="val-foo'">
      <a href="#val-foo'" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> foo' : 

--- a/test/generators/html/Class.html
+++ b/test/generators/html/Class.html
@@ -12,7 +12,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec class-type" id="class-type-empty" class="anchored">
+    <div class="spec class-type anchored" id="class-type-empty">
      <a href="#class-type-empty" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 
@@ -25,7 +25,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class-type" id="class-type-mutually" class="anchored">
+    <div class="spec class-type anchored" id="class-type-mutually">
      <a href="#class-type-mutually" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 
@@ -39,7 +39,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class-type" id="class-type-recursive" class="anchored">
+    <div class="spec class-type anchored" id="class-type-recursive">
      <a href="#class-type-recursive" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 
@@ -53,7 +53,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-mutually'" class="anchored">
+    <div class="spec class anchored" id="class-mutually'">
      <a href="#class-mutually'" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Class-class-mutually'.html">mutually'</a></span>
@@ -62,7 +62,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-recursive'" class="anchored">
+    <div class="spec class anchored" id="class-recursive'">
      <a href="#class-recursive'" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Class-class-recursive'.html">recursive'</a></span>
@@ -71,8 +71,8 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class-type" id="class-type-empty_virtual"
-     class="anchored"><a href="#class-type-empty_virtual" class="anchor"></a>
+    <div class="spec class-type anchored" id="class-type-empty_virtual">
+     <a href="#class-type-empty_virtual" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 
        <span class="keyword">type</span> <span class="keyword">virtual</span>
@@ -87,7 +87,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-empty_virtual'" class="anchored">
+    <div class="spec class anchored" id="class-empty_virtual'">
      <a href="#class-empty_virtual'" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 
@@ -99,7 +99,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class-type" id="class-type-polymorphic" class="anchored">
+    <div class="spec class-type anchored" id="class-type-polymorphic">
      <a href="#class-type-polymorphic" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 
@@ -114,7 +114,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-polymorphic'" class="anchored">
+    <div class="spec class anchored" id="class-polymorphic'">
      <a href="#class-polymorphic'" class="anchor"></a>
      <code><span><span class="keyword">class</span> 'a </span>
       <span><a href="Class-class-polymorphic'.html">polymorphic'</a></span>

--- a/test/generators/html/External.html
+++ b/test/generators/html/External.html
@@ -13,7 +13,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value external" id="val-foo" class="anchored">
+    <div class="spec value external anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> foo : 

--- a/test/generators/html/Functor-F1-argument-1-Arg.html
+++ b/test/generators/html/Functor-F1-argument-1-Arg.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor-F1.html
+++ b/test/generators/html/Functor-F1.html
@@ -22,7 +22,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Arg" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Arg">
      <a href="#argument-1-Arg" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Functor-F1-argument-1-Arg.html">Arg</a></span>
@@ -32,7 +32,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor-F2-argument-1-Arg.html
+++ b/test/generators/html/Functor-F2-argument-1-Arg.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor-F2.html
+++ b/test/generators/html/Functor-F2.html
@@ -22,7 +22,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Arg" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Arg">
      <a href="#argument-1-Arg" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Functor-F2-argument-1-Arg.html">Arg</a></span>
@@ -32,7 +32,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = <a href="Functor-F2-argument-1-Arg.html#type-t">Arg.t</a>

--- a/test/generators/html/Functor-F3-argument-1-Arg.html
+++ b/test/generators/html/Functor-F3-argument-1-Arg.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor-F3.html
+++ b/test/generators/html/Functor-F3.html
@@ -22,7 +22,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Arg" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Arg">
      <a href="#argument-1-Arg" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Functor-F3-argument-1-Arg.html">Arg</a></span>
@@ -32,7 +32,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = <a href="Functor-F3-argument-1-Arg.html#type-t">Arg.t</a>

--- a/test/generators/html/Functor-F4-argument-1-Arg.html
+++ b/test/generators/html/Functor-F4-argument-1-Arg.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor-F4.html
+++ b/test/generators/html/Functor-F4.html
@@ -22,7 +22,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Arg" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Arg">
      <a href="#argument-1-Arg" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Functor-F4-argument-1-Arg.html">Arg</a></span>
@@ -32,7 +32,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor-F5.html
+++ b/test/generators/html/Functor-F5.html
@@ -23,7 +23,7 @@
    </h2>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor-module-type-S.html
+++ b/test/generators/html/Functor-module-type-S.html
@@ -15,7 +15,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor-module-type-S1-argument-1-_.html
+++ b/test/generators/html/Functor-module-type-S1-argument-1-_.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor-module-type-S1.html
+++ b/test/generators/html/Functor-module-type-S1.html
@@ -22,7 +22,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-_" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-_">
      <a href="#argument-1-_" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Functor-module-type-S1-argument-1-_.html">_</a></span>
@@ -32,7 +32,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor.html
+++ b/test/generators/html/Functor.html
@@ -13,7 +13,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -27,7 +27,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S1" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S1">
      <a href="#module-type-S1" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -44,7 +44,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-F1" class="anchored">
+    <div class="spec module anchored" id="module-F1">
      <a href="#module-F1" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -58,7 +58,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-F2" class="anchored">
+    <div class="spec module anchored" id="module-F2">
      <a href="#module-F2" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -77,7 +77,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-F3" class="anchored">
+    <div class="spec module anchored" id="module-F3">
      <a href="#module-F3" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -91,7 +91,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-F4" class="anchored">
+    <div class="spec module anchored" id="module-F4">
      <a href="#module-F4" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -105,7 +105,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-F5" class="anchored">
+    <div class="spec module anchored" id="module-F5">
      <a href="#module-F5" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Functor2-X-argument-1-Y.html
+++ b/test/generators/html/Functor2-X-argument-1-Y.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor2-X-argument-2-Z.html
+++ b/test/generators/html/Functor2-X-argument-2-Z.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor2-X.html
+++ b/test/generators/html/Functor2-X.html
@@ -22,7 +22,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Y" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Y">
      <a href="#argument-1-Y" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Functor2-X-argument-1-Y.html">Y</a></span>
@@ -31,7 +31,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-2-Z" class="anchored">
+    <div class="spec parameter anchored" id="argument-2-Z">
      <a href="#argument-2-Z" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Functor2-X-argument-2-Z.html">Z</a></span>
@@ -41,7 +41,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-y_t" class="anchored">
+    <div class="spec type anchored" id="type-y_t">
      <a href="#type-y_t" class="anchor"></a>
      <code><span><span class="keyword">type</span> y_t</span>
       <span> = <a href="Functor2-X-argument-1-Y.html#type-t">Y.t</a></span>
@@ -49,7 +49,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-z_t" class="anchored">
+    <div class="spec type anchored" id="type-z_t">
      <a href="#type-z_t" class="anchor"></a>
      <code><span><span class="keyword">type</span> z_t</span>
       <span> = <a href="Functor2-X-argument-2-Z.html#type-t">Z.t</a></span>
@@ -57,7 +57,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-x_t" class="anchored">
+    <div class="spec type anchored" id="type-x_t">
      <a href="#type-x_t" class="anchor"></a>
      <code><span><span class="keyword">type</span> x_t</span>
       <span> = <a href="#type-y_t">y_t</a></span>

--- a/test/generators/html/Functor2-module-type-S.html
+++ b/test/generators/html/Functor2-module-type-S.html
@@ -15,7 +15,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor2-module-type-XF-argument-1-Y.html
+++ b/test/generators/html/Functor2-module-type-XF-argument-1-Y.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor2-module-type-XF-argument-2-Z.html
+++ b/test/generators/html/Functor2-module-type-XF-argument-2-Z.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Functor2-module-type-XF.html
+++ b/test/generators/html/Functor2-module-type-XF.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Y" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Y">
      <a href="#argument-1-Y" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Functor2-module-type-XF-argument-1-Y.html">Y</a></span>
@@ -32,7 +32,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-2-Z" class="anchored">
+    <div class="spec parameter anchored" id="argument-2-Z">
      <a href="#argument-2-Z" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Functor2-module-type-XF-argument-2-Z.html">Z</a></span>
@@ -42,7 +42,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-y_t" class="anchored">
+    <div class="spec type anchored" id="type-y_t">
      <a href="#type-y_t" class="anchor"></a>
      <code><span><span class="keyword">type</span> y_t</span>
       <span> = 
@@ -52,7 +52,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-z_t" class="anchored">
+    <div class="spec type anchored" id="type-z_t">
      <a href="#type-z_t" class="anchor"></a>
      <code><span><span class="keyword">type</span> z_t</span>
       <span> = 
@@ -62,7 +62,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-x_t" class="anchored">
+    <div class="spec type anchored" id="type-x_t">
      <a href="#type-x_t" class="anchor"></a>
      <code><span><span class="keyword">type</span> x_t</span>
       <span> = <a href="#type-y_t">y_t</a></span>

--- a/test/generators/html/Functor2.html
+++ b/test/generators/html/Functor2.html
@@ -13,7 +13,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -27,7 +27,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -43,7 +43,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-XF" class="anchored">
+    <div class="spec module-type anchored" id="module-type-XF">
      <a href="#module-type-XF" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Include-module-type-Dorminant_Module.html
+++ b/test/generators/html/Include-module-type-Dorminant_Module.html
@@ -28,7 +28,7 @@
     </details>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-a" class="anchored">
+    <div class="spec value anchored" id="val-a">
      <a href="#val-a" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> a : 

--- a/test/generators/html/Include-module-type-Inherent_Module.html
+++ b/test/generators/html/Include-module-type-Inherent_Module.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value" id="val-a" class="anchored">
+    <div class="spec value anchored" id="val-a">
      <a href="#val-a" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> a : 

--- a/test/generators/html/Include-module-type-Inlined.html
+++ b/test/generators/html/Include-module-type-Inlined.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span></code>
     </div>

--- a/test/generators/html/Include-module-type-Not_inlined.html
+++ b/test/generators/html/Include-module-type-Not_inlined.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Include-module-type-Not_inlined_and_closed.html
+++ b/test/generators/html/Include-module-type-Not_inlined_and_closed.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-v" class="anchored">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a>
      <code><span><span class="keyword">type</span> v</span></code>
     </div>

--- a/test/generators/html/Include-module-type-Not_inlined_and_opened.html
+++ b/test/generators/html/Include-module-type-Not_inlined_and_opened.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-w" class="anchored">
+    <div class="spec type anchored" id="type-w">
      <a href="#type-w" class="anchor"></a>
      <code><span><span class="keyword">type</span> w</span></code>
     </div>

--- a/test/generators/html/Include.html
+++ b/test/generators/html/Include.html
@@ -13,8 +13,8 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Not_inlined"
-     class="anchored"><a href="#module-type-Not_inlined" class="anchor"></a>
+    <div class="spec module-type anchored" id="module-type-Not_inlined">
+     <a href="#module-type-Not_inlined" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
        <span class="keyword">type</span> 
@@ -36,7 +36,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec type" id="type-t" class="anchored">
+      <div class="spec type anchored" id="type-t">
        <a href="#type-t" class="anchor"></a>
        <code><span><span class="keyword">type</span> t</span></code>
       </div>
@@ -44,7 +44,7 @@
     </details>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Inlined" class="anchored">
+    <div class="spec module-type anchored" id="module-type-Inlined">
      <a href="#module-type-Inlined" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -59,15 +59,15 @@
    </div>
    <div class="odoc-include">
     <div class="odoc-spec">
-     <div class="spec type" id="type-u" class="anchored">
+     <div class="spec type anchored" id="type-u">
       <a href="#type-u" class="anchor"></a>
       <code><span><span class="keyword">type</span> u</span></code>
      </div>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Not_inlined_and_closed"
-     class="anchored">
+    <div class="spec module-type anchored"
+     id="module-type-Not_inlined_and_closed">
      <a href="#module-type-Not_inlined_and_closed" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -94,7 +94,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec type" id="type-v" class="anchored">
+      <div class="spec type anchored" id="type-v">
        <a href="#type-v" class="anchor"></a>
        <code><span><span class="keyword">type</span> v</span></code>
       </div>
@@ -102,8 +102,8 @@
     </details>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Not_inlined_and_opened"
-     class="anchored">
+    <div class="spec module-type anchored"
+     id="module-type-Not_inlined_and_opened">
      <a href="#module-type-Not_inlined_and_opened" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -130,7 +130,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec type" id="type-w" class="anchored">
+      <div class="spec type anchored" id="type-w">
        <a href="#type-w" class="anchor"></a>
        <code><span><span class="keyword">type</span> w</span></code>
       </div>
@@ -138,8 +138,7 @@
     </details>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Inherent_Module"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-Inherent_Module">
      <a href="#module-type-Inherent_Module" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -165,8 +164,7 @@
     </details>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Dorminant_Module"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-Dorminant_Module">
      <a href="#module-type-Dorminant_Module" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -203,7 +201,7 @@
       </details>
      </div>
      <div class="odoc-spec">
-      <div class="spec value" id="val-a" class="anchored">
+      <div class="spec value anchored" id="val-a">
        <a href="#val-a" class="anchor"></a>
        <code>
         <span><span class="keyword">val</span> a : <a href="#type-u">u</a>

--- a/test/generators/html/Include2-X.html
+++ b/test/generators/html/Include2-X.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = int</span>

--- a/test/generators/html/Include2-Y.html
+++ b/test/generators/html/Include2-Y.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Include2-Y_include_doc.html
+++ b/test/generators/html/Include2-Y_include_doc.html
@@ -33,7 +33,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec type" id="type-t" class="anchored">
+      <div class="spec type anchored" id="type-t">
        <a href="#type-t" class="anchor"></a>
        <code><span><span class="keyword">type</span> t</span>
         <span> = <a href="Include2-Y.html#type-t">Y.t</a></span>

--- a/test/generators/html/Include2-Y_include_synopsis.html
+++ b/test/generators/html/Include2-Y_include_synopsis.html
@@ -31,7 +31,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec type" id="type-t" class="anchored">
+      <div class="spec type anchored" id="type-t">
        <a href="#type-t" class="anchor"></a>
        <code><span><span class="keyword">type</span> t</span>
         <span> = <a href="Include2-Y.html#type-t">Y.t</a></span>

--- a/test/generators/html/Include2.html
+++ b/test/generators/html/Include2.html
@@ -13,7 +13,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -42,7 +42,7 @@
      </summary>
      <p>Comment about X that should not appear when including X below.</p>
      <div class="odoc-spec">
-      <div class="spec type" id="type-t" class="anchored">
+      <div class="spec type anchored" id="type-t">
        <a href="#type-t" class="anchor"></a>
        <code><span><span class="keyword">type</span> t</span>
         <span> = int</span>
@@ -52,7 +52,7 @@
     </details>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -65,7 +65,7 @@
     </div><div class="spec-doc"><p>Top-comment of Y.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y_include_synopsis" class="anchored">
+    <div class="spec module anchored" id="module-Y_include_synopsis">
      <a href="#module-Y_include_synopsis" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -83,7 +83,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y_include_doc" class="anchored">
+    <div class="spec module anchored" id="module-Y_include_doc">
      <a href="#module-Y_include_doc" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Include_sections-module-type-Something.html
+++ b/test/generators/html/Include_sections-module-type-Something.html
@@ -24,7 +24,7 @@
   </nav>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value" id="val-something" class="anchored">
+    <div class="spec value anchored" id="val-something">
      <a href="#val-something" class="anchor"></a>
      <code><span><span class="keyword">val</span> something : unit</span>
      </code>
@@ -33,7 +33,7 @@
    <h2 id="something-1"><a href="#something-1" class="anchor"></a>Something 1
    </h2><p>foo</p>
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo" class="anchored">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a>
      <code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
@@ -41,7 +41,7 @@
    <h3 id="something-2"><a href="#something-2" class="anchor"></a>Something 2
    </h3>
    <div class="odoc-spec">
-    <div class="spec value" id="val-bar" class="anchored">
+    <div class="spec value anchored" id="val-bar">
      <a href="#val-bar" class="anchor"></a>
      <code><span><span class="keyword">val</span> bar : unit</span></code>
     </div><div class="spec-doc"><p>foo bar</p></div>

--- a/test/generators/html/Include_sections.html
+++ b/test/generators/html/Include_sections.html
@@ -34,7 +34,7 @@
   </nav>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Something" class="anchored">
+    <div class="spec module-type anchored" id="module-type-Something">
      <a href="#module-type-Something" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -109,7 +109,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec value" id="val-something" class="anchored">
+      <div class="spec value anchored" id="val-something">
        <a href="#val-something" class="anchor"></a>
        <code><span><span class="keyword">val</span> something : unit</span>
        </code>
@@ -119,7 +119,7 @@
       Something 1
      </h2><p>foo</p>
      <div class="odoc-spec">
-      <div class="spec value" id="val-foo" class="anchored">
+      <div class="spec value anchored" id="val-foo">
        <a href="#val-foo" class="anchor"></a>
        <code><span><span class="keyword">val</span> foo : unit</span></code>
       </div>
@@ -128,7 +128,7 @@
       Something 2
      </h3>
      <div class="odoc-spec">
-      <div class="spec value" id="val-bar" class="anchored">
+      <div class="spec value anchored" id="val-bar">
        <a href="#val-bar" class="anchor"></a>
        <code><span><span class="keyword">val</span> bar : unit</span></code>
       </div><div class="spec-doc"><p>foo bar</p></div>

--- a/test/generators/html/Interlude.html
+++ b/test/generators/html/Interlude.html
@@ -15,7 +15,7 @@
   <div class="odoc-content">
    <p>Some separate stray text at the top of the module.</p>
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo" class="anchored">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a>
      <code><span><span class="keyword">val</span> foo : unit</span></code>
     </div><div class="spec-doc"><p>Foo.</p></div>
@@ -24,27 +24,27 @@
    <p>It has multiple paragraphs.</p>
    <p>A separate block of stray text, adjacent to the preceding one.</p>
    <div class="odoc-spec">
-    <div class="spec value" id="val-bar" class="anchored">
+    <div class="spec value anchored" id="val-bar">
      <a href="#val-bar" class="anchor"></a>
      <code><span><span class="keyword">val</span> bar : unit</span></code>
     </div><div class="spec-doc"><p>Bar.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-multiple" class="anchored">
+    <div class="spec value anchored" id="val-multiple">
      <a href="#val-multiple" class="anchor"></a>
      <code><span><span class="keyword">val</span> multiple : unit</span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-signature" class="anchored">
+    <div class="spec value anchored" id="val-signature">
      <a href="#val-signature" class="anchor"></a>
      <code><span><span class="keyword">val</span> signature : unit</span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-items" class="anchored">
+    <div class="spec value anchored" id="val-items">
      <a href="#val-items" class="anchor"></a>
      <code><span><span class="keyword">val</span> items : unit</span></code>
     </div>

--- a/test/generators/html/Labels.html
+++ b/test/generators/html/Labels.html
@@ -19,7 +19,7 @@
    <h2 id="L1"><a href="#L1" class="anchor"></a>Attached to unit</h2>
    <h2 id="L2"><a href="#L2" class="anchor"></a>Attached to nothing</h2>
    <div class="odoc-spec">
-    <div class="spec module" id="module-A" class="anchored">
+    <div class="spec module anchored" id="module-A">
      <a href="#module-A" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Labels-A.html">A</a>
@@ -31,13 +31,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div><div class="spec-doc"><p>Attached to type</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-f" class="anchored">
+    <div class="spec value anchored" id="val-f">
      <a href="#val-f" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> f : <a href="#type-t">t</a>
@@ -46,7 +46,7 @@
     </div><div class="spec-doc"><p>Attached to value</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value external" id="val-e" class="anchored">
+    <div class="spec value external anchored" id="val-e">
      <a href="#val-e" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> e : 
@@ -57,7 +57,7 @@
     </div><div class="spec-doc"><p>Attached to external</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -71,7 +71,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-c" class="anchored">
+    <div class="spec class anchored" id="class-c">
      <a href="#class-c" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Labels-class-c.html">c</a></span>
@@ -82,7 +82,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class-type" id="class-type-cs" class="anchored">
+    <div class="spec class-type anchored" id="class-type-cs">
      <a href="#class-type-cs" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 
@@ -95,7 +95,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec exception" id="exception-E" class="anchored">
+    <div class="spec exception anchored" id="exception-E">
      <a href="#exception-E" class="anchor"></a>
      <code><span><span class="keyword">exception</span> </span>
       <span><span class="exception">E</span></span>
@@ -103,7 +103,7 @@
     </div><div class="spec-doc"><p>Attached to exception</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-x" class="anchored">
+    <div class="spec type anchored" id="type-x">
      <a href="#type-x" class="anchor"></a>
      <code><span><span class="keyword">type</span> x</span><span> = </span>
       <span>..</span>
@@ -111,24 +111,23 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-X" class="anchored">
+    <div class="spec type extension anchored" id="extension-decl-X">
      <a href="#extension-decl-X" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <a href="#type-x">x</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-X" class="anchored">
-       <td class="def extension"><a href="#extension-X" class="anchor"></a>
-        <code><span>| </span><span><span class="extension">X</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="extension-X" class="def extension anchored">
+       <a href="#extension-X" class="anchor"></a>
+       <code><span>| </span><span><span class="extension">X</span></span>
+       </code>
+      </li>
+     </ol>
     </div><div class="spec-doc"><p>Attached to extension</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-substitution" id="module-S" class="anchored">
+    <div class="spec module-substitution anchored" id="module-S">
      <a href="#module-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> S := 
@@ -138,7 +137,7 @@
     </div><div class="spec-doc"><p>Attached to module subst</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type subst" id="type-s" class="anchored">
+    <div class="spec type subst anchored" id="type-s">
      <a href="#type-s" class="anchor"></a>
      <code><span><span class="keyword">type</span> s</span>
       <span> := <a href="#type-t">t</a></span>
@@ -146,40 +145,37 @@
     </div><div class="spec-doc"><p>Attached to type subst</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span><span> = </span>
      </code>
-     <table>
-      <tr id="type-u.A'" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-u.A'" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">A'</span></span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="type-u.A'" class="def variant constructor anchored">
+       <a href="#type-u.A'" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">A'</span></span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>Attached to constructor</p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-v" class="anchored">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a>
      <code><span><span class="keyword">type</span> v</span><span> = </span>
       <span>{</span>
      </code>
-     <table>
-      <tr id="type-v.f" class="anchored">
-       <td class="def record field"><a href="#type-v.f" class="anchor"></a>
-        <code><span>f : <a href="#type-t">t</a>;</span></code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="type-v.f" class="def record field anchored">
+       <a href="#type-v.f" class="anchor"></a>
+       <code><span>f : <a href="#type-t">t</a>;</span></code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>Attached to field</p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table><code><span>}</span></code>
+       </div>
+      </li>
+     </ol><code><span>}</span></code>
     </div>
    </div><p>Testing that labels can be referenced</p>
    <ul><li><a href="#L1">Attached to unit</a></li>

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -235,7 +235,7 @@
     <li class="version"><span class="at-tag">version</span> -1</li>
    </ul>
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo" class="anchored">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a>
      <code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
@@ -246,7 +246,7 @@
     </div>
    </div><p>Some modules to support references.</p>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Markup-X.html">X</a>
@@ -258,7 +258,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Markup-Y.html">Y</a>

--- a/test/generators/html/Module-module-type-S.html
+++ b/test/generators/html/Module-module-type-S.html
@@ -15,26 +15,26 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-v" class="anchored">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a v</span></span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-w" class="anchored">
+    <div class="spec type anchored" id="type-w">
      <a href="#type-w" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
@@ -42,7 +42,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module-module-type-S3.html
+++ b/test/generators/html/Module-module-type-S3.html
@@ -15,7 +15,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = int</span>
@@ -23,7 +23,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span>
       <span> = string</span>
@@ -31,14 +31,14 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-v" class="anchored">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a v</span></span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-w" class="anchored">
+    <div class="spec type anchored" id="type-w">
      <a href="#type-w" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
@@ -46,7 +46,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module-module-type-S4.html
+++ b/test/generators/html/Module-module-type-S4.html
@@ -15,20 +15,20 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-v" class="anchored">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a v</span></span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-w" class="anchored">
+    <div class="spec type anchored" id="type-w">
      <a href="#type-w" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
@@ -36,7 +36,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module-module-type-S5.html
+++ b/test/generators/html/Module-module-type-S5.html
@@ -15,19 +15,19 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-w" class="anchored">
+    <div class="spec type anchored" id="type-w">
      <a href="#type-w" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
@@ -35,7 +35,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module-module-type-S6.html
+++ b/test/generators/html/Module-module-type-S6.html
@@ -15,26 +15,26 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-v" class="anchored">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a v</span></span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module-module-type-S7.html
+++ b/test/generators/html/Module-module-type-S7.html
@@ -15,26 +15,26 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-v" class="anchored">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a v</span></span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-w" class="anchored">
+    <div class="spec type anchored" id="type-w">
      <a href="#type-w" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
@@ -42,7 +42,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code><span><span class="keyword">module</span> M</span>
       <span> = <a href="Module-M'.html">M'</a></span>

--- a/test/generators/html/Module-module-type-S8.html
+++ b/test/generators/html/Module-module-type-S8.html
@@ -15,26 +15,26 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-v" class="anchored">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a v</span></span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-w" class="anchored">
+    <div class="spec type anchored" id="type-w">
      <a href="#type-w" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>

--- a/test/generators/html/Module.html
+++ b/test/generators/html/Module.html
@@ -12,7 +12,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo" class="anchored">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a>
      <code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
@@ -26,7 +26,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -40,7 +40,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S1" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S1">
      <a href="#module-type-S1" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -50,7 +50,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S2" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S2">
      <a href="#module-type-S2" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -60,7 +60,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S3" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S3">
      <a href="#module-type-S3" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -80,7 +80,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S4" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S4">
      <a href="#module-type-S4" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -97,7 +97,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S5" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S5">
      <a href="#module-type-S5" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -115,7 +115,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-result" class="anchored">
+    <div class="spec type anchored" id="type-result">
      <a href="#type-result" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>('a, 'b) result</span>
@@ -124,7 +124,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S6" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S6">
      <a href="#module-type-S6" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -147,7 +147,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M'" class="anchored">
+    <div class="spec module anchored" id="module-M'">
      <a href="#module-M'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -160,7 +160,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S7" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S7">
      <a href="#module-type-S7" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -178,7 +178,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S8" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S8">
      <a href="#module-type-S8" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -196,7 +196,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S9" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S9">
      <a href="#module-type-S9" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -211,7 +211,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Mutually" class="anchored">
+    <div class="spec module anchored" id="module-Mutually">
      <a href="#module-Mutually" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -224,7 +224,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Recursive" class="anchored">
+    <div class="spec module anchored" id="module-Recursive">
      <a href="#module-Recursive" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_alias-module-type-A.html
+++ b/test/generators/html/Module_type_alias-module-type-A.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-a" class="anchored">
+    <div class="spec type anchored" id="type-a">
      <a href="#type-a" class="anchor"></a>
      <code><span><span class="keyword">type</span> a</span></code>
     </div>

--- a/test/generators/html/Module_type_alias-module-type-B-argument-1-C.html
+++ b/test/generators/html/Module_type_alias-module-type-B-argument-1-C.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-c" class="anchored">
+    <div class="spec type anchored" id="type-c">
      <a href="#type-c" class="anchor"></a>
      <code><span><span class="keyword">type</span> c</span></code>
     </div>

--- a/test/generators/html/Module_type_alias-module-type-B.html
+++ b/test/generators/html/Module_type_alias-module-type-B.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-C" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-C">
      <a href="#argument-1-C" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Module_type_alias-module-type-B-argument-1-C.html">C</a>
@@ -36,7 +36,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-b" class="anchored">
+    <div class="spec type anchored" id="type-b">
      <a href="#type-b" class="anchor"></a>
      <code><span><span class="keyword">type</span> b</span></code>
     </div>

--- a/test/generators/html/Module_type_alias-module-type-E-argument-1-F.html
+++ b/test/generators/html/Module_type_alias-module-type-E-argument-1-F.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-f" class="anchored">
+    <div class="spec type anchored" id="type-f">
      <a href="#type-f" class="anchor"></a>
      <code><span><span class="keyword">type</span> f</span></code>
     </div>

--- a/test/generators/html/Module_type_alias-module-type-E-argument-2-C.html
+++ b/test/generators/html/Module_type_alias-module-type-E-argument-2-C.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-c" class="anchored">
+    <div class="spec type anchored" id="type-c">
      <a href="#type-c" class="anchor"></a>
      <code><span><span class="keyword">type</span> c</span></code>
     </div>

--- a/test/generators/html/Module_type_alias-module-type-E.html
+++ b/test/generators/html/Module_type_alias-module-type-E.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-F" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-F">
      <a href="#argument-1-F" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Module_type_alias-module-type-E-argument-1-F.html">F</a>
@@ -35,7 +35,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-2-C" class="anchored">
+    <div class="spec parameter anchored" id="argument-2-C">
      <a href="#argument-2-C" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Module_type_alias-module-type-E-argument-2-C.html">C</a>
@@ -48,7 +48,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-b" class="anchored">
+    <div class="spec type anchored" id="type-b">
      <a href="#type-b" class="anchor"></a>
      <code><span><span class="keyword">type</span> b</span></code>
     </div>

--- a/test/generators/html/Module_type_alias-module-type-G-argument-1-H.html
+++ b/test/generators/html/Module_type_alias-module-type-G-argument-1-H.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-h" class="anchored">
+    <div class="spec type anchored" id="type-h">
      <a href="#type-h" class="anchor"></a>
      <code><span><span class="keyword">type</span> h</span></code>
     </div>

--- a/test/generators/html/Module_type_alias-module-type-G.html
+++ b/test/generators/html/Module_type_alias-module-type-G.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-H" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-H">
      <a href="#argument-1-H" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Module_type_alias-module-type-G-argument-1-H.html">H</a>
@@ -36,7 +36,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-a" class="anchored">
+    <div class="spec type anchored" id="type-a">
      <a href="#type-a" class="anchor"></a>
      <code><span><span class="keyword">type</span> a</span></code>
     </div>

--- a/test/generators/html/Module_type_alias.html
+++ b/test/generators/html/Module_type_alias.html
@@ -14,7 +14,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-A" class="anchored">
+    <div class="spec module-type anchored" id="module-type-A">
      <a href="#module-type-A" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -28,7 +28,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-B" class="anchored">
+    <div class="spec module-type anchored" id="module-type-B">
      <a href="#module-type-B" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -48,7 +48,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-D" class="anchored">
+    <div class="spec module-type anchored" id="module-type-D">
      <a href="#module-type-D" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -59,7 +59,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-E" class="anchored">
+    <div class="spec module-type anchored" id="module-type-E">
      <a href="#module-type-E" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -78,7 +78,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-G" class="anchored">
+    <div class="spec module-type anchored" id="module-type-G">
      <a href="#module-type-G" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -97,7 +97,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-I" class="anchored">
+    <div class="spec module-type anchored" id="module-type-I">
      <a href="#module-type-I" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Basic-module-type-a.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-a.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-b" class="anchored">
+    <div class="spec module-type anchored" id="module-type-b">
      <a href="#module-type-b" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -28,7 +28,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Basic-module-type-c.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-c.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Basic-module-type-u.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Basic-module-type-u2.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u2.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -32,7 +32,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Basic-module-type-with_.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-with_.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Basic-module-type-with_2.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-with_2.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -34,7 +34,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Basic.html
+++ b/test/generators/html/Module_type_subst-Basic.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-u" class="anchored">
+    <div class="spec module-type anchored" id="module-type-u">
      <a href="#module-type-u" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -30,7 +30,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-with_" class="anchored">
+    <div class="spec module-type anchored" id="module-type-with_">
      <a href="#module-type-with_" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -49,7 +49,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-u2" class="anchored">
+    <div class="spec module-type anchored" id="module-type-u2">
      <a href="#module-type-u2" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -63,7 +63,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-with_2" class="anchored">
+    <div class="spec module-type anchored" id="module-type-with_2">
      <a href="#module-type-with_2" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -83,7 +83,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-a" class="anchored">
+    <div class="spec module-type anchored" id="module-type-a">
      <a href="#module-type-a" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -97,7 +97,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-c" class="anchored">
+    <div class="spec module-type anchored" id="module-type-c">
      <a href="#module-type-c" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Local-module-type-local.html
+++ b/test/generators/html/Module_type_subst-Local-module-type-local.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = <a href="Module_type_subst-Local.html#type-local">local</a>

--- a/test/generators/html/Module_type_subst-Local.html
+++ b/test/generators/html/Module_type_subst-Local.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type subst" id="type-local" class="anchored">
+    <div class="spec type subst anchored" id="type-local">
      <a href="#type-local" class="anchor"></a>
      <code><span><span class="keyword">type</span> local</span>
       <span> := int * int</span>
@@ -24,7 +24,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-local" class="anchored">
+    <div class="spec module-type anchored" id="module-type-local">
      <a href="#module-type-local" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -38,7 +38,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-w" class="anchored">
+    <div class="spec module-type anchored" id="module-type-w">
      <a href="#module-type-w" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -51,7 +51,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-s" class="anchored">
+    <div class="spec module-type anchored" id="module-type-s">
      <a href="#module-type-s" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Nested-module-type-nested-N.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-nested-N.html
@@ -20,7 +20,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-t" class="anchored">
+    <div class="spec module-type anchored" id="module-type-t">
      <a href="#module-type-t" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Nested-module-type-nested.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-nested.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_-N.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_-N.html
@@ -20,7 +20,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-t" class="anchored">
+    <div class="spec module-type anchored" id="module-type-t">
      <a href="#module-type-t" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_subst.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_subst.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Nested.html
+++ b/test/generators/html/Module_type_subst-Nested.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-nested" class="anchored">
+    <div class="spec module-type anchored" id="module-type-nested">
      <a href="#module-type-nested" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -30,7 +30,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-with_" class="anchored">
+    <div class="spec module-type anchored" id="module-type-with_">
      <a href="#module-type-with_" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -52,8 +52,8 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-with_subst"
-     class="anchored"><a href="#module-type-with_subst" class="anchor"></a>
+    <div class="spec module-type anchored" id="module-type-with_subst">
+     <a href="#module-type-with_subst" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
        <span class="keyword">type</span> 

--- a/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b-module-type-c.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b-module-type-c.html
@@ -28,22 +28,20 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span><span> = </span>
      </code>
-     <table>
-      <tr id="type-t.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-t.A" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">A</span> 
-          <span class="keyword">of</span> <a href="#type-t">t</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-t.A" class="def variant constructor anchored">
+       <a href="#type-t.A" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">A</span> 
+         <span class="keyword">of</span> <a href="#type-t">t</a>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b.html
@@ -22,7 +22,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-c" class="anchored">
+    <div class="spec module-type anchored" id="module-type-c">
      <a href="#module-type-c" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a.html
@@ -20,7 +20,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-b" class="anchored">
+    <div class="spec module-type anchored" id="module-type-b">
      <a href="#module-type-b" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Structural-module-type-u.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-a" class="anchored">
+    <div class="spec module-type anchored" id="module-type-a">
      <a href="#module-type-a" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b-module-type-c.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b-module-type-c.html
@@ -28,22 +28,20 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span><span> = </span>
      </code>
-     <table>
-      <tr id="type-t.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-t.A" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">A</span> 
-          <span class="keyword">of</span> <a href="#type-t">t</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-t.A" class="def variant constructor anchored">
+       <a href="#type-t.A" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">A</span> 
+         <span class="keyword">of</span> <a href="#type-t">t</a>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b.html
@@ -22,7 +22,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-c" class="anchored">
+    <div class="spec module-type anchored" id="module-type-c">
      <a href="#module-type-c" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a.html
@@ -20,7 +20,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-b" class="anchored">
+    <div class="spec module-type anchored" id="module-type-b">
      <a href="#module-type-b" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Structural-module-type-w.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-a" class="anchored">
+    <div class="spec module-type anchored" id="module-type-a">
      <a href="#module-type-a" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst-Structural.html
+++ b/test/generators/html/Module_type_subst-Structural.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-u" class="anchored">
+    <div class="spec module-type anchored" id="module-type-u">
      <a href="#module-type-u" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -30,7 +30,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-w" class="anchored">
+    <div class="spec module-type anchored" id="module-type-w">
      <a href="#module-type-w" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Module_type_subst.html
+++ b/test/generators/html/Module_type_subst.html
@@ -13,7 +13,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Local" class="anchored">
+    <div class="spec module anchored" id="module-Local">
      <a href="#module-Local" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -26,7 +26,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-s" class="anchored">
+    <div class="spec module-type anchored" id="module-type-s">
      <a href="#module-type-s" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -40,7 +40,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Basic" class="anchored">
+    <div class="spec module anchored" id="module-Basic">
      <a href="#module-Basic" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -53,7 +53,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Nested" class="anchored">
+    <div class="spec module anchored" id="module-Nested">
      <a href="#module-Nested" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -66,7 +66,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Structural" class="anchored">
+    <div class="spec module anchored" id="module-Structural">
      <a href="#module-Structural" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Nested-F-argument-1-Arg1.html
+++ b/test/generators/html/Nested-F-argument-1-Arg1.html
@@ -22,13 +22,13 @@
   <div class="odoc-content">
    <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div><div class="spec-doc"><p>Some type.</p></div>
    </div><h2 id="values"><a href="#values" class="anchor"></a>Values</h2>
    <div class="odoc-spec">
-    <div class="spec value" id="val-y" class="anchored">
+    <div class="spec value anchored" id="val-y">
      <a href="#val-y" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> y : <a href="#type-t">t</a>

--- a/test/generators/html/Nested-F-argument-2-Arg2.html
+++ b/test/generators/html/Nested-F-argument-2-Arg2.html
@@ -19,7 +19,7 @@
   <div class="odoc-content">
    <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div><div class="spec-doc"><p>Some type.</p></div>

--- a/test/generators/html/Nested-F.html
+++ b/test/generators/html/Nested-F.html
@@ -24,7 +24,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Arg1" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Arg1">
      <a href="#argument-1-Arg1" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Nested-F-argument-1-Arg1.html">Arg1</a></span>
@@ -33,7 +33,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-2-Arg2" class="anchored">
+    <div class="spec parameter anchored" id="argument-2-Arg2">
      <a href="#argument-2-Arg2" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Nested-F-argument-2-Arg2.html">Arg2</a></span>
@@ -46,7 +46,7 @@
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <h2 id="type_3"><a href="#type_3" class="anchor"></a>Type</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = <a href="Nested-F-argument-1-Arg1.html#type-t">Arg1.t</a>

--- a/test/generators/html/Nested-X.html
+++ b/test/generators/html/Nested-X.html
@@ -21,13 +21,13 @@
   <div class="odoc-content">
    <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div><div class="spec-doc"><p>Some type.</p></div>
    </div><h2 id="values"><a href="#values" class="anchor"></a>Values</h2>
    <div class="odoc-spec">
-    <div class="spec value" id="val-x" class="anchored">
+    <div class="spec value anchored" id="val-x">
      <a href="#val-x" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> x : <a href="#type-t">t</a>

--- a/test/generators/html/Nested-class-z.html
+++ b/test/generators/html/Nested-class-z.html
@@ -18,13 +18,13 @@
   </nav>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value instance-variable" id="val-y" class="anchored">
+    <div class="spec value instance-variable anchored" id="val-y">
      <a href="#val-y" class="anchor"></a>
      <code><span><span class="keyword">val</span> y : int</span></code>
     </div><div class="spec-doc"><p>Some value.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value instance-variable" id="val-y'" class="anchored">
+    <div class="spec value instance-variable anchored" id="val-y'">
      <a href="#val-y'" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> 
@@ -35,13 +35,13 @@
     </div>
    </div><h2 id="methods"><a href="#methods" class="anchor"></a>Methods</h2>
    <div class="odoc-spec">
-    <div class="spec method" id="method-z" class="anchored">
+    <div class="spec method anchored" id="method-z">
      <a href="#method-z" class="anchor"></a>
      <code><span><span class="keyword">method</span> z : int</span></code>
     </div><div class="spec-doc"><p>Some method.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec method" id="method-z'" class="anchored">
+    <div class="spec method anchored" id="method-z'">
      <a href="#method-z'" class="anchor"></a>
      <code>
       <span><span class="keyword">method</span> 

--- a/test/generators/html/Nested-module-type-Y.html
+++ b/test/generators/html/Nested-module-type-Y.html
@@ -21,13 +21,13 @@
   <div class="odoc-content">
    <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div><div class="spec-doc"><p>Some type.</p></div>
    </div><h2 id="values"><a href="#values" class="anchor"></a>Values</h2>
    <div class="odoc-spec">
-    <div class="spec value" id="val-y" class="anchored">
+    <div class="spec value anchored" id="val-y">
      <a href="#val-y" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> y : <a href="#type-t">t</a>

--- a/test/generators/html/Nested.html
+++ b/test/generators/html/Nested.html
@@ -21,7 +21,7 @@
   <div class="odoc-content">
    <h2 id="module"><a href="#module" class="anchor"></a>Module</h2>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Nested-X.html">X</a>
@@ -35,7 +35,7 @@
    <h2 id="module-type"><a href="#module-type" class="anchor"></a>Module type
    </h2>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Y" class="anchored">
+    <div class="spec module-type anchored" id="module-type-Y">
      <a href="#module-type-Y" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -49,7 +49,7 @@
     </div><div class="spec-doc"><p>This is module type Y.</p></div>
    </div><h2 id="functor"><a href="#functor" class="anchor"></a>Functor</h2>
    <div class="odoc-spec">
-    <div class="spec module" id="module-F" class="anchored">
+    <div class="spec module anchored" id="module-F">
      <a href="#module-F" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Nested-F.html">F</a>
@@ -65,7 +65,7 @@
     </div><div class="spec-doc"><p>This is a functor F.</p></div>
    </div><h2 id="class"><a href="#class" class="anchor"></a>Class</h2>
    <div class="odoc-spec">
-    <div class="spec class" id="class-z" class="anchored">
+    <div class="spec class anchored" id="class-z">
      <a href="#class-z" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 
@@ -78,7 +78,7 @@
     </div><div class="spec-doc"><p>This is class z.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-inherits" class="anchored">
+    <div class="spec class anchored" id="class-inherits">
      <a href="#class-inherits" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 

--- a/test/generators/html/Ocamlary-Aliases-E.html
+++ b/test/generators/html/Ocamlary-Aliases-E.html
@@ -17,13 +17,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-Aliases-Foo-A.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-A.html
@@ -18,13 +18,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-Aliases-Foo-B.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-B.html
@@ -18,13 +18,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-Aliases-Foo-C.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-C.html
@@ -18,13 +18,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-Aliases-Foo-D.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-D.html
@@ -18,13 +18,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-Aliases-Foo-E.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-E.html
@@ -18,13 +18,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-Aliases-Foo.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-A" class="anchored">
+    <div class="spec module anchored" id="module-A">
      <a href="#module-A" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -30,7 +30,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-B" class="anchored">
+    <div class="spec module anchored" id="module-B">
      <a href="#module-B" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -43,7 +43,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-C" class="anchored">
+    <div class="spec module anchored" id="module-C">
      <a href="#module-C" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -56,7 +56,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-D" class="anchored">
+    <div class="spec module anchored" id="module-D">
      <a href="#module-D" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -69,7 +69,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-E" class="anchored">
+    <div class="spec module anchored" id="module-E">
      <a href="#module-E" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Aliases-P1-Y.html
+++ b/test/generators/html/Ocamlary-Aliases-P1-Y.html
@@ -18,13 +18,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-Aliases-P1.html
+++ b/test/generators/html/Ocamlary-Aliases-P1.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Aliases-P2-Z.html
+++ b/test/generators/html/Ocamlary-Aliases-P2-Z.html
@@ -18,13 +18,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-Aliases-P2.html
+++ b/test/generators/html/Ocamlary-Aliases-P2.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Z" class="anchored">
+    <div class="spec module anchored" id="module-Z">
      <a href="#module-Z" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Aliases-Std.html
+++ b/test/generators/html/Ocamlary-Aliases-Std.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-A" class="anchored">
+    <div class="spec module anchored" id="module-A">
      <a href="#module-A" class="anchor"></a>
      <code><span><span class="keyword">module</span> A</span>
       <span> = <a href="Ocamlary-Aliases-Foo-A.html">Foo.A</a></span>
@@ -25,7 +25,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-B" class="anchored">
+    <div class="spec module anchored" id="module-B">
      <a href="#module-B" class="anchor"></a>
      <code><span><span class="keyword">module</span> B</span>
       <span> = <a href="Ocamlary-Aliases-Foo-B.html">Foo.B</a></span>
@@ -33,7 +33,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-C" class="anchored">
+    <div class="spec module anchored" id="module-C">
      <a href="#module-C" class="anchor"></a>
      <code><span><span class="keyword">module</span> C</span>
       <span> = <a href="Ocamlary-Aliases-Foo-C.html">Foo.C</a></span>
@@ -41,7 +41,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-D" class="anchored">
+    <div class="spec module anchored" id="module-D">
      <a href="#module-D" class="anchor"></a>
      <code><span><span class="keyword">module</span> D</span>
       <span> = <a href="Ocamlary-Aliases-Foo-D.html">Foo.D</a></span>
@@ -49,7 +49,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-E" class="anchored">
+    <div class="spec module anchored" id="module-E">
      <a href="#module-E" class="anchor"></a>
      <code><span><span class="keyword">module</span> E</span>
       <span> = <a href="Ocamlary-Aliases-Foo-E.html">Foo.E</a></span>

--- a/test/generators/html/Ocamlary-Aliases.html
+++ b/test/generators/html/Ocamlary-Aliases.html
@@ -19,7 +19,7 @@
   </nav>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Foo" class="anchored">
+    <div class="spec module anchored" id="module-Foo">
      <a href="#module-Foo" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -32,7 +32,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-A'" class="anchored">
+    <div class="spec module anchored" id="module-A'">
      <a href="#module-A'" class="anchor"></a>
      <code><span><span class="keyword">module</span> A'</span>
       <span> = <a href="Ocamlary-Aliases-Foo-A.html">Foo.A</a></span>
@@ -40,7 +40,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-tata" class="anchored">
+    <div class="spec type anchored" id="type-tata">
      <a href="#type-tata" class="anchor"></a>
      <code><span><span class="keyword">type</span> tata</span>
       <span> = <a href="Ocamlary-Aliases-Foo-A.html#type-t">Foo.A.t</a>
@@ -49,7 +49,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-tbtb" class="anchored">
+    <div class="spec type anchored" id="type-tbtb">
      <a href="#type-tbtb" class="anchor"></a>
      <code><span><span class="keyword">type</span> tbtb</span>
       <span> = <a href="Ocamlary-Aliases-Foo-B.html#type-t">Foo.B.t</a>
@@ -58,13 +58,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-tete" class="anchored">
+    <div class="spec type anchored" id="type-tete">
      <a href="#type-tete" class="anchor"></a>
      <code><span><span class="keyword">type</span> tete</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-tata'" class="anchored">
+    <div class="spec type anchored" id="type-tata'">
      <a href="#type-tata'" class="anchor"></a>
      <code><span><span class="keyword">type</span> tata'</span>
       <span> = <a href="Ocamlary-Aliases-Foo-A.html#type-t">A'.t</a></span>
@@ -72,7 +72,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-tete2" class="anchored">
+    <div class="spec type anchored" id="type-tete2">
      <a href="#type-tete2" class="anchor"></a>
      <code><span><span class="keyword">type</span> tete2</span>
       <span> = <a href="Ocamlary-Aliases-Foo-E.html#type-t">Foo.E.t</a>
@@ -81,7 +81,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Std" class="anchored">
+    <div class="spec module anchored" id="module-Std">
      <a href="#module-Std" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -94,7 +94,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-stde" class="anchored">
+    <div class="spec type anchored" id="type-stde">
      <a href="#type-stde" class="anchor"></a>
      <code><span><span class="keyword">type</span> stde</span>
       <span> = <a href="Ocamlary-Aliases-Foo-E.html#type-t">Std.E.t</a>
@@ -117,7 +117,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec module" id="module-A" class="anchored">
+      <div class="spec module anchored" id="module-A">
        <a href="#module-A" class="anchor"></a>
        <code><span><span class="keyword">module</span> A</span>
         <span> = <a href="Ocamlary-Aliases-Foo-A.html">Foo.A</a></span>
@@ -125,7 +125,7 @@
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-B" class="anchored">
+      <div class="spec module anchored" id="module-B">
        <a href="#module-B" class="anchor"></a>
        <code><span><span class="keyword">module</span> B</span>
         <span> = <a href="Ocamlary-Aliases-Foo-B.html">Foo.B</a></span>
@@ -133,7 +133,7 @@
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-C" class="anchored">
+      <div class="spec module anchored" id="module-C">
        <a href="#module-C" class="anchor"></a>
        <code><span><span class="keyword">module</span> C</span>
         <span> = <a href="Ocamlary-Aliases-Foo-C.html">Foo.C</a></span>
@@ -141,7 +141,7 @@
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-D" class="anchored">
+      <div class="spec module anchored" id="module-D">
        <a href="#module-D" class="anchor"></a>
        <code><span><span class="keyword">module</span> D</span>
         <span> = <a href="Ocamlary-Aliases-Foo-D.html">Foo.D</a></span>
@@ -149,7 +149,7 @@
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-E" class="anchored">
+      <div class="spec module anchored" id="module-E">
        <a href="#module-E" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> 
@@ -164,7 +164,7 @@
     </details>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-testa" class="anchored">
+    <div class="spec type anchored" id="type-testa">
      <a href="#type-testa" class="anchor"></a>
      <code><span><span class="keyword">type</span> testa</span>
       <span> = <a href="Ocamlary-Aliases-Foo-A.html#type-t">A.t</a></span>
@@ -177,7 +177,7 @@
     <a href="Ocamlary-Aliases-Foo-B.html#val-id"><code>Foo.B.id</code></a>
    </p>
    <div class="odoc-spec">
-    <div class="spec module" id="module-P1" class="anchored">
+    <div class="spec module anchored" id="module-P1">
      <a href="#module-P1" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -190,7 +190,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-P2" class="anchored">
+    <div class="spec module anchored" id="module-P2">
      <a href="#module-P2" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -203,7 +203,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X1" class="anchored">
+    <div class="spec module anchored" id="module-X1">
      <a href="#module-X1" class="anchor"></a>
      <code><span><span class="keyword">module</span> X1</span>
       <span> = <a href="Ocamlary-Aliases-P2-Z.html">P2.Z</a></span>
@@ -211,7 +211,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X2" class="anchored">
+    <div class="spec module anchored" id="module-X2">
      <a href="#module-X2" class="anchor"></a>
      <code><span><span class="keyword">module</span> X2</span>
       <span> = <a href="Ocamlary-Aliases-P2-Z.html">P2.Z</a></span>
@@ -219,7 +219,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-p1" class="anchored">
+    <div class="spec type anchored" id="type-p1">
      <a href="#type-p1" class="anchor"></a>
      <code><span><span class="keyword">type</span> p1</span>
       <span> = <a href="Ocamlary-Aliases-P2-Z.html#type-t">X1.t</a></span>
@@ -227,7 +227,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-p2" class="anchored">
+    <div class="spec type anchored" id="type-p2">
      <a href="#type-p2" class="anchor"></a>
      <code><span><span class="keyword">type</span> p2</span>
       <span> = <a href="Ocamlary-Aliases-P2-Z.html#type-t">X2.t</a></span>

--- a/test/generators/html/Ocamlary-Buffer.html
+++ b/test/generators/html/Ocamlary-Buffer.html
@@ -19,7 +19,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value" id="val-f" class="anchored">
+    <div class="spec value anchored" id="val-f">
      <a href="#val-f" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> f : 

--- a/test/generators/html/Ocamlary-CanonicalTest-Base-List.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base-List.html
@@ -18,14 +18,14 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a t</span></span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-CanonicalTest-Base.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-List" class="anchored">
+    <div class="spec module anchored" id="module-List">
      <a href="#module-List" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-CanonicalTest-Base_Tests-C.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base_Tests-C.html
@@ -20,14 +20,14 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a t</span></span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-CanonicalTest-Base_Tests.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base_Tests.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-C" class="anchored">
+    <div class="spec module anchored" id="module-C">
      <a href="#module-C" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -32,7 +32,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-L" class="anchored">
+    <div class="spec module anchored" id="module-L">
      <a href="#module-L" class="anchor"></a>
      <code><span><span class="keyword">module</span> L</span>
       <span> = <a href="Ocamlary-CanonicalTest-Base-List.html">Base.List</a>
@@ -41,7 +41,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo" class="anchored">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> foo : 
@@ -58,7 +58,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-bar" class="anchored">
+    <div class="spec value anchored" id="val-bar">
      <a href="#val-bar" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> bar : 
@@ -77,7 +77,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-baz" class="anchored">
+    <div class="spec value anchored" id="val-baz">
      <a href="#val-baz" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> baz : 

--- a/test/generators/html/Ocamlary-CanonicalTest-List_modif.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-List_modif.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'c t</span></span>
       <span> = 
@@ -31,7 +31,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-id" class="anchored">
+    <div class="spec value anchored" id="val-id">
      <a href="#val-id" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> id : 

--- a/test/generators/html/Ocamlary-CanonicalTest.html
+++ b/test/generators/html/Ocamlary-CanonicalTest.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Base" class="anchored">
+    <div class="spec module anchored" id="module-Base">
      <a href="#module-Base" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -29,7 +29,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Base_Tests" class="anchored">
+    <div class="spec module anchored" id="module-Base_Tests">
      <a href="#module-Base_Tests" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -42,7 +42,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-List_modif" class="anchored">
+    <div class="spec module anchored" id="module-List_modif">
      <a href="#module-List_modif" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html
@@ -22,7 +22,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -24,7 +24,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-CollectionModule-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-CollectionModule-InnerModuleA.html
@@ -19,7 +19,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -31,7 +31,7 @@
     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA'" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA'">
      <a href="#module-InnerModuleA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -49,8 +49,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-CollectionModule.html
+++ b/test/generators/html/Ocamlary-CollectionModule.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-collection" class="anchored">
+    <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>
      <code><span><span class="keyword">type</span> collection</span></code>
     </div>
@@ -25,13 +25,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-element" class="anchored">
+    <div class="spec type anchored" id="type-element">
      <a href="#type-element" class="anchor"></a>
      <code><span><span class="keyword">type</span> element</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA">
      <a href="#module-InnerModuleA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -47,8 +47,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep1-X-Y-class-c.html
+++ b/test/generators/html/Ocamlary-Dep1-X-Y-class-c.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec method" id="method-m" class="anchored">
+    <div class="spec method anchored" id="method-m">
      <a href="#method-m" class="anchor"></a>
      <code><span><span class="keyword">method</span> m : int</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep1-X-Y.html
+++ b/test/generators/html/Ocamlary-Dep1-X-Y.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec class" id="class-c" class="anchored">
+    <div class="spec class anchored" id="class-c">
      <a href="#class-c" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Ocamlary-Dep1-X-Y-class-c.html">c</a></span>

--- a/test/generators/html/Ocamlary-Dep1-X.html
+++ b/test/generators/html/Ocamlary-Dep1-X.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep1-module-type-S-class-c.html
+++ b/test/generators/html/Ocamlary-Dep1-module-type-S-class-c.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec method" id="method-m" class="anchored">
+    <div class="spec method anchored" id="method-m">
      <a href="#method-m" class="anchor"></a>
      <code><span><span class="keyword">method</span> m : int</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep1-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep1-module-type-S.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec class" id="class-c" class="anchored">
+    <div class="spec class anchored" id="class-c">
      <a href="#class-c" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Ocamlary-Dep1-module-type-S-class-c.html">c</a></span>

--- a/test/generators/html/Ocamlary-Dep1.html
+++ b/test/generators/html/Ocamlary-Dep1.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -30,7 +30,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep11-module-type-S-class-c.html
+++ b/test/generators/html/Ocamlary-Dep11-module-type-S-class-c.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec method" id="method-m" class="anchored">
+    <div class="spec method anchored" id="method-m">
      <a href="#method-m" class="anchor"></a>
      <code><span><span class="keyword">method</span> m : int</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep11-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep11-module-type-S.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec class" id="class-c" class="anchored">
+    <div class="spec class anchored" id="class-c">
      <a href="#class-c" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Ocamlary-Dep11-module-type-S-class-c.html">c</a></span>

--- a/test/generators/html/Ocamlary-Dep11.html
+++ b/test/generators/html/Ocamlary-Dep11.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep12-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep12-argument-1-Arg.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep12.html
+++ b/test/generators/html/Ocamlary-Dep12.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Arg" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Arg">
      <a href="#argument-1-Arg" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Ocamlary-Dep12-argument-1-Arg.html">Arg</a></span>
@@ -35,7 +35,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep13-class-c.html
+++ b/test/generators/html/Ocamlary-Dep13-class-c.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec method" id="method-m" class="anchored">
+    <div class="spec method anchored" id="method-m">
      <a href="#method-m" class="anchor"></a>
      <code><span><span class="keyword">method</span> m : int</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep13.html
+++ b/test/generators/html/Ocamlary-Dep13.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec class" id="class-c" class="anchored">
+    <div class="spec class anchored" id="class-c">
      <a href="#class-c" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Ocamlary-Dep13-class-c.html">c</a></span>

--- a/test/generators/html/Ocamlary-Dep2-A.html
+++ b/test/generators/html/Ocamlary-Dep2-A.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code><span><span class="keyword">module</span> Y</span>
       <span> : 

--- a/test/generators/html/Ocamlary-Dep2-argument-1-Arg-X.html
+++ b/test/generators/html/Ocamlary-Dep2-argument-1-Arg-X.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code><span><span class="keyword">module</span> Y</span>
       <span> : 

--- a/test/generators/html/Ocamlary-Dep2-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep2-argument-1-Arg.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -27,7 +27,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep2.html
+++ b/test/generators/html/Ocamlary-Dep2.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Arg" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Arg">
      <a href="#argument-1-Arg" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Ocamlary-Dep2-argument-1-Arg.html">Arg</a></span>
@@ -35,7 +35,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec module" id="module-A" class="anchored">
+    <div class="spec module anchored" id="module-A">
      <a href="#module-A" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -48,7 +48,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-B" class="anchored">
+    <div class="spec module anchored" id="module-B">
      <a href="#module-B" class="anchor"></a>
      <code><span><span class="keyword">module</span> B</span>
       <span> = <a href="Ocamlary-Dep2-A.html#module-Y">A.Y</a></span>

--- a/test/generators/html/Ocamlary-Dep3.html
+++ b/test/generators/html/Ocamlary-Dep3.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-a" class="anchored">
+    <div class="spec type anchored" id="type-a">
      <a href="#type-a" class="anchor"></a>
      <code><span><span class="keyword">type</span> a</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep4-X.html
+++ b/test/generators/html/Ocamlary-Dep4-X.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-b" class="anchored">
+    <div class="spec type anchored" id="type-b">
      <a href="#type-b" class="anchor"></a>
      <code><span><span class="keyword">type</span> b</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep4-module-type-S-X.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-S-X.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-b" class="anchored">
+    <div class="spec type anchored" id="type-b">
      <a href="#type-b" class="anchor"></a>
      <code><span><span class="keyword">type</span> b</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep4-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-S.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -27,7 +27,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep4-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-T.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-b" class="anchored">
+    <div class="spec type anchored" id="type-b">
      <a href="#type-b" class="anchor"></a>
      <code><span><span class="keyword">type</span> b</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep4.html
+++ b/test/generators/html/Ocamlary-Dep4.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -30,7 +30,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -44,7 +44,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep5-Z.html
+++ b/test/generators/html/Ocamlary-Dep5-Z.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code><span><span class="keyword">module</span> X</span>
       <span> : 
@@ -27,7 +27,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code><span><span class="keyword">module</span> Y</span>
       <span> = <a href="Ocamlary-Dep3.html">Dep3</a></span>

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code><span><span class="keyword">module</span> X</span>
       <span> : 
@@ -28,7 +28,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -27,7 +27,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -41,7 +41,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code><span><span class="keyword">module</span> X</span>
       <span> : <a href="#module-type-T">T</a></span>

--- a/test/generators/html/Ocamlary-Dep5.html
+++ b/test/generators/html/Ocamlary-Dep5.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Arg" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Arg">
      <a href="#argument-1-Arg" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Ocamlary-Dep5-argument-1-Arg.html">Arg</a></span>
@@ -35,7 +35,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Z" class="anchored">
+    <div class="spec module anchored" id="module-Z">
      <a href="#module-Z" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep6-X-Y.html
+++ b/test/generators/html/Ocamlary-Dep6-X-Y.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-d" class="anchored">
+    <div class="spec type anchored" id="type-d">
      <a href="#type-d" class="anchor"></a>
      <code><span><span class="keyword">type</span> d</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep6-X.html
+++ b/test/generators/html/Ocamlary-Dep6-X.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-R" class="anchored">
+    <div class="spec module-type anchored" id="module-type-R">
      <a href="#module-type-R" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -27,7 +27,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep6-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep6-module-type-S.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-d" class="anchored">
+    <div class="spec type anchored" id="type-d">
      <a href="#type-d" class="anchor"></a>
      <code><span><span class="keyword">type</span> d</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep6-module-type-T-Y.html
+++ b/test/generators/html/Ocamlary-Dep6-module-type-T-Y.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-d" class="anchored">
+    <div class="spec type anchored" id="type-d">
      <a href="#type-d" class="anchor"></a>
      <code><span><span class="keyword">type</span> d</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep6-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep6-module-type-T.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-R" class="anchored">
+    <div class="spec module-type anchored" id="module-type-R">
      <a href="#module-type-R" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -27,7 +27,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep6.html
+++ b/test/generators/html/Ocamlary-Dep6.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -30,7 +30,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -44,7 +44,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep7-M.html
+++ b/test/generators/html/Ocamlary-Dep7-M.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-R" class="anchored">
+    <div class="spec module-type anchored" id="module-type-R">
      <a href="#module-type-R" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -30,7 +30,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code><span><span class="keyword">module</span> Y</span>
       <span> : 

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg-X.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg-X.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-R" class="anchored">
+    <div class="spec module-type anchored" id="module-type-R">
      <a href="#module-type-R" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -31,7 +31,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code><span><span class="keyword">module</span> Y</span>
       <span> : 

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg-module-type-T.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-R" class="anchored">
+    <div class="spec module-type anchored" id="module-type-R">
      <a href="#module-type-R" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -31,7 +31,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code><span><span class="keyword">module</span> Y</span>
       <span> : 

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -27,7 +27,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -41,7 +41,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep7.html
+++ b/test/generators/html/Ocamlary-Dep7.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Arg" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Arg">
      <a href="#argument-1-Arg" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Ocamlary-Dep7-argument-1-Arg.html">Arg</a></span>
@@ -35,7 +35,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep8-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep8-module-type-T.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Dep8.html
+++ b/test/generators/html/Ocamlary-Dep8.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep9-argument-1-X.html
+++ b/test/generators/html/Ocamlary-Dep9-argument-1-X.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Dep9.html
+++ b/test/generators/html/Ocamlary-Dep9.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-X" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-X">
      <a href="#argument-1-X" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Ocamlary-Dep9-argument-1-X.html">X</a></span>
@@ -35,7 +35,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-DoubleInclude1-DoubleInclude2.html
+++ b/test/generators/html/Ocamlary-DoubleInclude1-DoubleInclude2.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-double_include" class="anchored">
+    <div class="spec type anchored" id="type-double_include">
      <a href="#type-double_include" class="anchor"></a>
      <code><span><span class="keyword">type</span> double_include</span>
      </code>

--- a/test/generators/html/Ocamlary-DoubleInclude1.html
+++ b/test/generators/html/Ocamlary-DoubleInclude1.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-DoubleInclude2" class="anchored">
+    <div class="spec module anchored" id="module-DoubleInclude2">
      <a href="#module-DoubleInclude2" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-DoubleInclude3-DoubleInclude2.html
+++ b/test/generators/html/Ocamlary-DoubleInclude3-DoubleInclude2.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-double_include" class="anchored">
+    <div class="spec type anchored" id="type-double_include">
      <a href="#type-double_include" class="anchor"></a>
      <code><span><span class="keyword">type</span> double_include</span>
      </code>

--- a/test/generators/html/Ocamlary-DoubleInclude3.html
+++ b/test/generators/html/Ocamlary-DoubleInclude3.html
@@ -27,7 +27,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec module" id="module-DoubleInclude2" class="anchored">
+      <div class="spec module anchored" id="module-DoubleInclude2">
        <a href="#module-DoubleInclude2" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-ExtMod.html
+++ b/test/generators/html/Ocamlary-ExtMod.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span><span> = </span>
       <span>..</span>
@@ -24,23 +24,21 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-Leisureforce"
-     class="anchored">
+    <div class="spec type extension anchored"
+     id="extension-decl-Leisureforce">
      <a href="#extension-decl-Leisureforce" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <a href="#type-t">t</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-Leisureforce" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Leisureforce" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="extension">Leisureforce</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="extension-Leisureforce" class="def extension anchored">
+       <a href="#extension-Leisureforce" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="extension">Leisureforce</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html
@@ -28,7 +28,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -28,7 +28,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html
@@ -22,7 +22,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -36,7 +36,7 @@
     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA'" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA'">
      <a href="#module-InnerModuleA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -55,8 +55,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
@@ -19,7 +19,7 @@
   <div class="odoc-content">
    <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
-    <div class="spec type" id="type-collection" class="anchored">
+    <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>
      <code><span><span class="keyword">type</span> collection</span></code>
     </div>
@@ -27,13 +27,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-element" class="anchored">
+    <div class="spec type anchored" id="type-element">
      <a href="#type-element" class="anchor"></a>
      <code><span><span class="keyword">type</span> element</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA">
      <a href="#module-InnerModuleA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -52,8 +52,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-FunctorTypeOf.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf.html
@@ -24,7 +24,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-Collection" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-Collection">
      <a href="#argument-1-Collection" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span>
@@ -40,7 +40,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html
+++ b/test/generators/html/Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html
@@ -20,7 +20,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-include_include" class="anchored">
+    <div class="spec type anchored" id="type-include_include">
      <a href="#type-include_include" class="anchor"></a>
      <code><span><span class="keyword">type</span> include_include</span>
      </code>

--- a/test/generators/html/Ocamlary-IncludeInclude1.html
+++ b/test/generators/html/Ocamlary-IncludeInclude1.html
@@ -16,8 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-IncludeInclude2"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-IncludeInclude2">
      <a href="#module-type-IncludeInclude2" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -33,7 +32,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-IncludeInclude2_M" class="anchored">
+    <div class="spec module anchored" id="module-IncludeInclude2_M">
      <a href="#module-IncludeInclude2_M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-IncludedA.html
+++ b/test/generators/html/Ocamlary-IncludedA.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-M.html
+++ b/test/generators/html/Ocamlary-M.html
@@ -15,7 +15,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-One.html
+++ b/test/generators/html/Ocamlary-One.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-one" class="anchored">
+    <div class="spec type anchored" id="type-one">
      <a href="#type-one" class="anchor"></a>
      <code><span><span class="keyword">type</span> one</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Only_a_module.html
+++ b/test/generators/html/Ocamlary-Only_a_module.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html
@@ -22,7 +22,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -23,7 +23,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-Recollection-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-Recollection-InnerModuleA.html
@@ -19,7 +19,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -30,7 +30,7 @@
     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA'" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA'">
      <a href="#module-InnerModuleA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -48,8 +48,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html
@@ -25,7 +25,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -27,7 +27,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA.html
@@ -21,7 +21,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -34,7 +34,7 @@
     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA'" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA'">
      <a href="#module-InnerModuleA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -53,8 +53,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C.html
@@ -18,7 +18,7 @@
   <div class="odoc-content">
    <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
-    <div class="spec type" id="type-collection" class="anchored">
+    <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>
      <code><span><span class="keyword">type</span> collection</span></code>
     </div>
@@ -26,13 +26,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-element" class="anchored">
+    <div class="spec type anchored" id="type-element">
      <a href="#type-element" class="anchor"></a>
      <code><span><span class="keyword">type</span> element</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA">
      <a href="#module-InnerModuleA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -50,8 +50,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-Recollection.html
+++ b/test/generators/html/Ocamlary-Recollection.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-C" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-C">
      <a href="#argument-1-C" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Ocamlary-Recollection-argument-1-C.html">C</a></span>
@@ -35,7 +35,7 @@
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
-    <div class="spec type" id="type-collection" class="anchored">
+    <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>
      <code><span><span class="keyword">type</span> collection</span>
       <span> = 
@@ -51,7 +51,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-element" class="anchored">
+    <div class="spec type anchored" id="type-element">
      <a href="#type-element" class="anchor"></a>
      <code><span><span class="keyword">type</span> element</span>
       <span> = 
@@ -63,7 +63,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA">
      <a href="#module-InnerModuleA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -79,8 +79,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With10-module-type-T-M.html
+++ b/test/generators/html/Ocamlary-With10-module-type-T-M.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With10-module-type-T.html
+++ b/test/generators/html/Ocamlary-With10-module-type-T.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -31,7 +31,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code><span><span class="keyword">module</span> N</span>
       <span> : 

--- a/test/generators/html/Ocamlary-With10.html
+++ b/test/generators/html/Ocamlary-With10.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With2-module-type-S.html
+++ b/test/generators/html/Ocamlary-With2-module-type-S.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-With2.html
+++ b/test/generators/html/Ocamlary-With2.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With3-N.html
+++ b/test/generators/html/Ocamlary-With3-N.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-With3.html
+++ b/test/generators/html/Ocamlary-With3.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code><span><span class="keyword">module</span> M</span>
       <span> = <a href="Ocamlary-With2.html">With2</a></span>
@@ -24,7 +24,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With4-N.html
+++ b/test/generators/html/Ocamlary-With4-N.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-With4.html
+++ b/test/generators/html/Ocamlary-With4.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With5-N.html
+++ b/test/generators/html/Ocamlary-With5-N.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-With5-module-type-S.html
+++ b/test/generators/html/Ocamlary-With5-module-type-S.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-With5.html
+++ b/test/generators/html/Ocamlary-With5.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -30,7 +30,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With6-module-type-T-M.html
+++ b/test/generators/html/Ocamlary-With6-module-type-T-M.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -27,7 +27,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code><span><span class="keyword">module</span> N</span>
       <span> : <a href="#module-type-S">S</a></span>

--- a/test/generators/html/Ocamlary-With6-module-type-T.html
+++ b/test/generators/html/Ocamlary-With6-module-type-T.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With6.html
+++ b/test/generators/html/Ocamlary-With6.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With7-argument-1-X.html
+++ b/test/generators/html/Ocamlary-With7-argument-1-X.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With7.html
+++ b/test/generators/html/Ocamlary-With7.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-X" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-X">
      <a href="#argument-1-X" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Ocamlary-With7-argument-1-X.html">X</a></span>
@@ -35,7 +35,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-With9-module-type-S.html
+++ b/test/generators/html/Ocamlary-With9-module-type-S.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-With9.html
+++ b/test/generators/html/Ocamlary-With9.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-class-one_method_class.html
+++ b/test/generators/html/Ocamlary-class-one_method_class.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec method" id="method-go" class="anchored">
+    <div class="spec method anchored" id="method-go">
      <a href="#method-go" class="anchor"></a>
      <code><span><span class="keyword">method</span> go : unit</span></code>
     </div>

--- a/test/generators/html/Ocamlary-class-param_class.html
+++ b/test/generators/html/Ocamlary-class-param_class.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec method" id="method-v" class="anchored">
+    <div class="spec method anchored" id="method-v">
      <a href="#method-v" class="anchor"></a>
      <code>
       <span><span class="keyword">method</span> v : 

--- a/test/generators/html/Ocamlary-class-two_method_class.html
+++ b/test/generators/html/Ocamlary-class-two_method_class.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec method" id="method-one" class="anchored">
+    <div class="spec method anchored" id="method-one">
      <a href="#method-one" class="anchor"></a>
      <code>
       <span><span class="keyword">method</span> one : 
@@ -26,7 +26,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec method" id="method-undo" class="anchored">
+    <div class="spec method anchored" id="method-undo">
      <a href="#method-undo" class="anchor"></a>
      <code><span><span class="keyword">method</span> undo : unit</span>
      </code>

--- a/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html
@@ -22,7 +22,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -23,7 +23,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA.html
@@ -19,7 +19,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -30,7 +30,7 @@
     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA'" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA'">
      <a href="#module-InnerModuleA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -48,8 +48,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-A-Q.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q.html
@@ -17,7 +17,7 @@
   <div class="odoc-content">
    <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
-    <div class="spec type" id="type-collection" class="anchored">
+    <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>
      <code><span><span class="keyword">type</span> collection</span></code>
     </div>
@@ -25,13 +25,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-element" class="anchored">
+    <div class="spec type anchored" id="type-element">
      <a href="#type-element" class="anchor"></a>
      <code><span><span class="keyword">type</span> element</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA">
      <a href="#module-InnerModuleA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -47,8 +47,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-A.html
+++ b/test/generators/html/Ocamlary-module-type-A.html
@@ -15,13 +15,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Q" class="anchored">
+    <div class="spec module anchored" id="module-Q">
      <a href="#module-Q" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html
@@ -22,7 +22,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -23,7 +23,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA.html
@@ -19,7 +19,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -30,7 +30,7 @@
     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA'" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA'">
      <a href="#module-InnerModuleA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -48,8 +48,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-B-Q.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q.html
@@ -17,7 +17,7 @@
   <div class="odoc-content">
    <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
-    <div class="spec type" id="type-collection" class="anchored">
+    <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>
      <code><span><span class="keyword">type</span> collection</span></code>
     </div>
@@ -25,13 +25,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-element" class="anchored">
+    <div class="spec type anchored" id="type-element">
      <a href="#type-element" class="anchor"></a>
      <code><span><span class="keyword">type</span> element</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA">
      <a href="#module-InnerModuleA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -47,8 +47,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-B.html
+++ b/test/generators/html/Ocamlary-module-type-B.html
@@ -15,13 +15,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Q" class="anchored">
+    <div class="spec module anchored" id="module-Q">
      <a href="#module-Q" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html
@@ -22,7 +22,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -23,7 +23,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA.html
@@ -19,7 +19,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -30,7 +30,7 @@
     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA'" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA'">
      <a href="#module-InnerModuleA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -48,8 +48,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-C-Q.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q.html
@@ -17,7 +17,7 @@
   <div class="odoc-content">
    <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
-    <div class="spec type" id="type-collection" class="anchored">
+    <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>
      <code><span><span class="keyword">type</span> collection</span></code>
     </div>
@@ -25,13 +25,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-element" class="anchored">
+    <div class="spec type anchored" id="type-element">
      <a href="#type-element" class="anchor"></a>
      <code><span><span class="keyword">type</span> element</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA">
      <a href="#module-InnerModuleA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -47,8 +47,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-C.html
+++ b/test/generators/html/Ocamlary-module-type-C.html
@@ -32,13 +32,13 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec type" id="type-t" class="anchored">
+      <div class="spec type anchored" id="type-t">
        <a href="#type-t" class="anchor"></a>
        <code><span><span class="keyword">type</span> t</span></code>
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-Q" class="anchored">
+      <div class="spec module anchored" id="module-Q">
        <a href="#module-Q" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html
@@ -23,7 +23,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -24,7 +24,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA.html
@@ -19,7 +19,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -32,7 +32,7 @@
     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA'" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA'">
      <a href="#module-InnerModuleA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -51,8 +51,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-COLLECTION.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION.html
@@ -18,7 +18,7 @@
   <div class="odoc-content">
    <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
-    <div class="spec type" id="type-collection" class="anchored">
+    <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>
      <code><span><span class="keyword">type</span> collection</span></code>
     </div>
@@ -26,13 +26,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-element" class="anchored">
+    <div class="spec type anchored" id="type-element">
      <a href="#type-element" class="anchor"></a>
      <code><span><span class="keyword">type</span> element</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA">
      <a href="#module-InnerModuleA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -50,8 +50,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-Dep10.html
+++ b/test/generators/html/Ocamlary-module-type-Dep10.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = int</span>

--- a/test/generators/html/Ocamlary-module-type-Empty.html
+++ b/test/generators/html/Ocamlary-module-type-Empty.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-module-type-IncludeInclude2.html
+++ b/test/generators/html/Ocamlary-module-type-IncludeInclude2.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-include_include" class="anchored">
+    <div class="spec type anchored" id="type-include_include">
      <a href="#type-include_include" class="anchor"></a>
      <code><span><span class="keyword">type</span> include_include</span>
      </code>

--- a/test/generators/html/Ocamlary-module-type-IncludedB.html
+++ b/test/generators/html/Ocamlary-module-type-IncludedB.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-s" class="anchored">
+    <div class="spec type anchored" id="type-s">
      <a href="#type-s" class="anchor"></a>
      <code><span><span class="keyword">type</span> s</span></code>
     </div>

--- a/test/generators/html/Ocamlary-module-type-M.html
+++ b/test/generators/html/Ocamlary-module-type-M.html
@@ -15,7 +15,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html
@@ -23,7 +23,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -23,7 +23,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA.html
@@ -19,7 +19,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -31,7 +31,7 @@
     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA'" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA'">
      <a href="#module-InnerModuleA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -49,8 +49,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-MMM-C.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C.html
@@ -18,7 +18,7 @@
   <div class="odoc-content">
    <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
-    <div class="spec type" id="type-collection" class="anchored">
+    <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>
      <code><span><span class="keyword">type</span> collection</span></code>
     </div>
@@ -26,13 +26,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-element" class="anchored">
+    <div class="spec type anchored" id="type-element">
      <a href="#type-element" class="anchor"></a>
      <code><span><span class="keyword">type</span> element</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA">
      <a href="#module-InnerModuleA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -49,8 +49,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-MMM.html
+++ b/test/generators/html/Ocamlary-module-type-MMM.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-C" class="anchored">
+    <div class="spec module anchored" id="module-C">
      <a href="#module-C" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-MissingComment.html
+++ b/test/generators/html/Ocamlary-module-type-MissingComment.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html
+++ b/test/generators/html/Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html
@@ -20,7 +20,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-nested_include" class="anchored">
+    <div class="spec type anchored" id="type-nested_include">
      <a href="#type-nested_include" class="anchor"></a>
      <code><span><span class="keyword">type</span> nested_include</span>
      </code>

--- a/test/generators/html/Ocamlary-module-type-NestedInclude1.html
+++ b/test/generators/html/Ocamlary-module-type-NestedInclude1.html
@@ -16,8 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-NestedInclude2"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-NestedInclude2">
      <a href="#module-type-NestedInclude2" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-NestedInclude2.html
+++ b/test/generators/html/Ocamlary-module-type-NestedInclude2.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-nested_include" class="anchored">
+    <div class="spec type anchored" id="type-nested_include">
      <a href="#type-nested_include" class="anchor"></a>
      <code><span><span class="keyword">type</span> nested_include</span>
      </code>

--- a/test/generators/html/Ocamlary-module-type-RECOLLECTION.html
+++ b/test/generators/html/Ocamlary-module-type-RECOLLECTION.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-C" class="anchored">
+    <div class="spec module anchored" id="module-C">
      <a href="#module-C" class="anchor"></a>
      <code><span><span class="keyword">module</span> C</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html
@@ -25,7 +25,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -26,7 +26,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA.html
@@ -20,7 +20,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -33,7 +33,7 @@
     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA'" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA'">
      <a href="#module-InnerModuleA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -52,8 +52,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-collection" class="anchored">
+    <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>
      <code><span><span class="keyword">type</span> collection</span>
       <span> = 
@@ -30,7 +30,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-element" class="anchored">
+    <div class="spec type anchored" id="type-element">
      <a href="#type-element" class="anchor"></a>
      <code><span><span class="keyword">type</span> element</span>
       <span> = 
@@ -42,7 +42,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-InnerModuleA" class="anchored">
+    <div class="spec module anchored" id="module-InnerModuleA">
      <a href="#module-InnerModuleA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -60,8 +60,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-InnerModuleTypeA"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-SigForMod-Inner.html
+++ b/test/generators/html/Ocamlary-module-type-SigForMod-Inner.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Empty" class="anchored">
+    <div class="spec module-type anchored" id="module-type-Empty">
      <a href="#module-type-Empty" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-SigForMod.html
+++ b/test/generators/html/Ocamlary-module-type-SigForMod.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Inner" class="anchored">
+    <div class="spec module anchored" id="module-Inner">
      <a href="#module-Inner" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-EmptySig.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-EmptySig.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-not_actually_empty" class="anchored">
+    <div class="spec type anchored" id="type-not_actually_empty">
      <a href="#type-not_actually_empty" class="anchor"></a>
      <code><span><span class="keyword">type</span> not_actually_empty</span>
      </code>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-One.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-One.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-two" class="anchored">
+    <div class="spec type anchored" id="type-two">
      <a href="#type-two" class="anchor"></a>
      <code><span><span class="keyword">type</span> two</span></code>
     </div>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html
@@ -21,7 +21,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-sub_sig_a_mod" class="anchored">
+    <div class="spec type anchored" id="type-sub_sig_a_mod">
      <a href="#type-sub_sig_a_mod" class="anchor"></a>
      <code><span><span class="keyword">type</span> sub_sig_a_mod</span>
      </code>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA.html
@@ -27,13 +27,13 @@
      Header Inside of a Signature
    </h4>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-SubSigAMod" class="anchored">
+    <div class="spec module anchored" id="module-SubSigAMod">
      <a href="#module-SubSigAMod" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigB.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigB.html
@@ -29,7 +29,7 @@
      Section Header Inside of a Signature
    </h4>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-module-type-SuperSig.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-SubSigA" class="anchored">
+    <div class="spec module-type anchored" id="module-type-SubSigA">
      <a href="#module-type-SubSigA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -32,7 +32,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-SubSigB" class="anchored">
+    <div class="spec module-type anchored" id="module-type-SubSigB">
      <a href="#module-type-SubSigB" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -48,7 +48,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-EmptySig" class="anchored">
+    <div class="spec module-type anchored" id="module-type-EmptySig">
      <a href="#module-type-EmptySig" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -64,7 +64,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-One" class="anchored">
+    <div class="spec module-type anchored" id="module-type-One">
      <a href="#module-type-One" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -78,7 +78,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-SuperSig" class="anchored">
+    <div class="spec module-type anchored" id="module-type-SuperSig">
      <a href="#module-type-SuperSig" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-ToInclude-IncludedA.html
+++ b/test/generators/html/Ocamlary-module-type-ToInclude-IncludedA.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Ocamlary-module-type-ToInclude-module-type-IncludedB.html
+++ b/test/generators/html/Ocamlary-module-type-ToInclude-module-type-IncludedB.html
@@ -18,7 +18,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-s" class="anchored">
+    <div class="spec type anchored" id="type-s">
      <a href="#type-s" class="anchor"></a>
      <code><span><span class="keyword">type</span> s</span></code>
     </div>

--- a/test/generators/html/Ocamlary-module-type-ToInclude.html
+++ b/test/generators/html/Ocamlary-module-type-ToInclude.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-IncludedA" class="anchored">
+    <div class="spec module anchored" id="module-IncludedA">
      <a href="#module-IncludedA" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -29,7 +29,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-IncludedB" class="anchored">
+    <div class="spec module-type anchored" id="module-type-IncludedB">
      <a href="#module-type-IncludedB" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-TypeExt.html
+++ b/test/generators/html/Ocamlary-module-type-TypeExt.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span><span> = </span>
       <span>..</span>
@@ -24,24 +24,23 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-C" class="anchored">
+    <div class="spec type extension anchored" id="extension-decl-C">
      <a href="#extension-decl-C" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <a href="#type-t">t</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-C" class="anchored">
-       <td class="def extension"><a href="#extension-C" class="anchor"></a>
-        <code><span>| </span><span><span class="extension">C</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="extension-C" class="def extension anchored">
+       <a href="#extension-C" class="anchor"></a>
+       <code><span>| </span><span><span class="extension">C</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-f" class="anchored">
+    <div class="spec value anchored" id="val-f">
      <a href="#val-f" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> f : 

--- a/test/generators/html/Ocamlary-module-type-TypeExtPruned.html
+++ b/test/generators/html/Ocamlary-module-type-TypeExtPruned.html
@@ -16,25 +16,24 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-C" class="anchored">
+    <div class="spec type extension anchored" id="extension-decl-C">
      <a href="#extension-decl-C" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
        <a href="Ocamlary.html#type-new_t">new_t</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-C" class="anchored">
-       <td class="def extension"><a href="#extension-C" class="anchor"></a>
-        <code><span>| </span><span><span class="extension">C</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="extension-C" class="def extension anchored">
+       <a href="#extension-C" class="anchor"></a>
+       <code><span>| </span><span><span class="extension">C</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-f" class="anchored">
+    <div class="spec value anchored" id="val-f">
      <a href="#val-f" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> f : 

--- a/test/generators/html/Ocamlary-module-type-With1-M.html
+++ b/test/generators/html/Ocamlary-module-type-With1-M.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-With1.html
+++ b/test/generators/html/Ocamlary-module-type-With1.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -29,7 +29,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code><span><span class="keyword">module</span> N</span>
       <span> : 

--- a/test/generators/html/Ocamlary-module-type-With11-N.html
+++ b/test/generators/html/Ocamlary-module-type-With11-N.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = int</span>

--- a/test/generators/html/Ocamlary-module-type-With11.html
+++ b/test/generators/html/Ocamlary-module-type-With11.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code><span><span class="keyword">module</span> M</span>
       <span> = <a href="Ocamlary-With9.html">With9</a></span>
@@ -24,7 +24,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-With8-M-N.html
+++ b/test/generators/html/Ocamlary-module-type-With8-M-N.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = <a href="Ocamlary-With5-N.html#type-t">With5.N.t</a></span>

--- a/test/generators/html/Ocamlary-module-type-With8-M.html
+++ b/test/generators/html/Ocamlary-module-type-With8-M.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -28,7 +28,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary-module-type-With8.html
+++ b/test/generators/html/Ocamlary-module-type-With8.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -99,7 +99,7 @@
     <a href="#basic-module-stuff" class="anchor"></a>Basic module stuff
    </h4>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Empty" class="anchored">
+    <div class="spec module anchored" id="module-Empty">
      <a href="#module-Empty" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -112,7 +112,7 @@
     </div><div class="spec-doc"><p>A plain, empty module</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Empty" class="anchored">
+    <div class="spec module-type anchored" id="module-type-Empty">
      <a href="#module-type-Empty" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -127,8 +127,7 @@
     <div class="spec-doc"><p>An ambiguous, misnamed module type</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-MissingComment"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-MissingComment">
      <a href="#module-type-MissingComment" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -143,7 +142,7 @@
     <div class="spec-doc"><p>An ambiguous, misnamed module type</p></div>
    </div><h2 id="s9000"><a href="#s9000" class="anchor"></a>Section 9000</h2>
    <div class="odoc-spec">
-    <div class="spec module" id="module-EmptyAlias" class="anchored">
+    <div class="spec module anchored" id="module-EmptyAlias">
      <a href="#module-EmptyAlias" class="anchor"></a>
      <code><span><span class="keyword">module</span> EmptyAlias</span>
       <span> = <a href="Ocamlary-Empty.html">Empty</a></span>
@@ -154,7 +153,7 @@
    </div>
    <h4 id="emptySig"><a href="#emptySig" class="anchor"></a>EmptySig</h4>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-EmptySig" class="anchored">
+    <div class="spec module-type anchored" id="module-type-EmptySig">
      <a href="#module-type-EmptySig" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -168,8 +167,7 @@
     </div><div class="spec-doc"><p>A plain, empty module signature</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-EmptySigAlias"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-EmptySigAlias">
      <a href="#module-type-EmptySigAlias" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -183,7 +181,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-ModuleWithSignature" class="anchored">
+    <div class="spec module anchored" id="module-ModuleWithSignature">
      <a href="#module-ModuleWithSignature" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -201,8 +199,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-ModuleWithSignatureAlias"
-     class="anchored">
+    <div class="spec module anchored" id="module-ModuleWithSignatureAlias">
      <a href="#module-ModuleWithSignatureAlias" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -217,7 +214,7 @@
     <div class="spec-doc"><p>A plain module with an alias signature</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-One" class="anchored">
+    <div class="spec module anchored" id="module-One">
      <a href="#module-One" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -230,7 +227,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-SigForMod" class="anchored">
+    <div class="spec module-type anchored" id="module-type-SigForMod">
      <a href="#module-type-SigForMod" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -247,7 +244,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-SuperSig" class="anchored">
+    <div class="spec module-type anchored" id="module-type-SuperSig">
      <a href="#module-type-SuperSig" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -275,7 +272,7 @@
      is the module signature.
    </p>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Buffer" class="anchored">
+    <div class="spec module anchored" id="module-Buffer">
      <a href="#module-Buffer" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -297,7 +294,7 @@
      stuff
    </h4><p>After exception title.</p>
    <div class="odoc-spec">
-    <div class="spec exception" id="exception-Kaboom" class="anchored">
+    <div class="spec exception anchored" id="exception-Kaboom">
      <a href="#exception-Kaboom" class="anchor"></a>
      <code><span><span class="keyword">exception</span> </span>
       <span><span class="exception">Kaboom</span> 
@@ -307,7 +304,7 @@
     </div><div class="spec-doc"><p>Unary exception constructor</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec exception" id="exception-Kablam" class="anchored">
+    <div class="spec exception anchored" id="exception-Kablam">
      <a href="#exception-Kablam" class="anchor"></a>
      <code><span><span class="keyword">exception</span> </span>
       <span><span class="exception">Kablam</span> 
@@ -317,7 +314,7 @@
     </div><div class="spec-doc"><p>Binary exception constructor</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec exception" id="exception-Kapow" class="anchored">
+    <div class="spec exception anchored" id="exception-Kapow">
      <a href="#exception-Kapow" class="anchor"></a>
      <code><span><span class="keyword">exception</span> </span>
       <span><span class="exception">Kapow</span> 
@@ -330,7 +327,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec exception" id="exception-EmptySig" class="anchored">
+    <div class="spec exception anchored" id="exception-EmptySig">
      <a href="#exception-EmptySig" class="anchor"></a>
      <code><span><span class="keyword">exception</span> </span>
       <span><span class="exception">EmptySig</span></span>
@@ -346,7 +343,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec exception" id="exception-EmptySigAlias" class="anchored">
+    <div class="spec exception anchored" id="exception-EmptySigAlias">
      <a href="#exception-EmptySigAlias" class="anchor"></a>
      <code><span><span class="keyword">exception</span> </span>
       <span><span class="exception">EmptySigAlias</span></span>
@@ -364,7 +361,7 @@
     </a>Basic type and value stuff with advanced doc comments
    </h4>
    <div class="odoc-spec">
-    <div class="spec type" id="type-a_function" class="anchored">
+    <div class="spec type anchored" id="type-a_function">
      <a href="#type-a_function" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -385,7 +382,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-a_function" class="anchored">
+    <div class="spec value anchored" id="val-a_function">
      <a href="#val-a_function" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> a_function : 
@@ -408,7 +405,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-fun_fun_fun" class="anchored">
+    <div class="spec value anchored" id="val-fun_fun_fun">
      <a href="#val-fun_fun_fun" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> fun_fun_fun : 
@@ -427,7 +424,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-fun_maybe" class="anchored">
+    <div class="spec value anchored" id="val-fun_maybe">
      <a href="#val-fun_maybe" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> fun_maybe : 
@@ -438,7 +435,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-not_found" class="anchored">
+    <div class="spec value anchored" id="val-not_found">
      <a href="#val-not_found" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> not_found : 
@@ -455,7 +452,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-ocaml_org" class="anchored">
+    <div class="spec value anchored" id="val-ocaml_org">
      <a href="#val-ocaml_org" class="anchor"></a>
      <code><span><span class="keyword">val</span> ocaml_org : string</span>
      </code>
@@ -470,7 +467,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-some_file" class="anchored">
+    <div class="spec value anchored" id="val-some_file">
      <a href="#val-some_file" class="anchor"></a>
      <code><span><span class="keyword">val</span> some_file : string</span>
      </code>
@@ -485,7 +482,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-some_doc" class="anchored">
+    <div class="spec value anchored" id="val-some_doc">
      <a href="#val-some_doc" class="anchor"></a>
      <code><span><span class="keyword">val</span> some_doc : string</span>
      </code>
@@ -500,7 +497,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-since_mesozoic" class="anchored">
+    <div class="spec value anchored" id="val-since_mesozoic">
      <a href="#val-since_mesozoic" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> since_mesozoic : unit</span>
@@ -514,7 +511,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-changing" class="anchored">
+    <div class="spec value anchored" id="val-changing">
      <a href="#val-changing" class="anchor"></a>
      <code><span><span class="keyword">val</span> changing : unit</span>
      </code>
@@ -540,86 +537,86 @@
     Some Operators
    </h4>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(~-)" class="anchored">
+    <div class="spec value anchored" id="val-(~-)">
      <a href="#val-(~-)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (~-) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(!)" class="anchored">
+    <div class="spec value anchored" id="val-(!)">
      <a href="#val-(!)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (!) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(@)" class="anchored">
+    <div class="spec value anchored" id="val-(@)">
      <a href="#val-(@)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (@) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-($)" class="anchored">
+    <div class="spec value anchored" id="val-($)">
      <a href="#val-($)" class="anchor"></a>
      <code><span><span class="keyword">val</span> ($) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(%)" class="anchored">
+    <div class="spec value anchored" id="val-(%)">
      <a href="#val-(%)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (%) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(&amp;)" class="anchored">
+    <div class="spec value anchored" id="val-(&amp;)">
      <a href="#val-(&amp;)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (&amp;) : unit</span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(*)" class="anchored">
+    <div class="spec value anchored" id="val-(*)">
      <a href="#val-(*)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (*) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(-)" class="anchored">
+    <div class="spec value anchored" id="val-(-)">
      <a href="#val-(-)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (-) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(+)" class="anchored">
+    <div class="spec value anchored" id="val-(+)">
      <a href="#val-(+)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (+) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(-?)" class="anchored">
+    <div class="spec value anchored" id="val-(-?)">
      <a href="#val-(-?)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (-?) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(/)" class="anchored">
+    <div class="spec value anchored" id="val-(/)">
      <a href="#val-(/)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (/) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(:=)" class="anchored">
+    <div class="spec value anchored" id="val-(:=)">
      <a href="#val-(:=)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (:=) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(=)" class="anchored">
+    <div class="spec value anchored" id="val-(=)">
      <a href="#val-(=)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (=) : unit</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-(land)" class="anchored">
+    <div class="spec value anchored" id="val-(land)">
      <a href="#val-(land)" class="anchor"></a>
      <code><span><span class="keyword">val</span> (land) : unit</span></code>
     </div>
@@ -629,7 +626,7 @@
      Stuff
    </h4>
    <div class="odoc-spec">
-    <div class="spec module" id="module-CollectionModule" class="anchored">
+    <div class="spec module anchored" id="module-CollectionModule">
      <a href="#module-CollectionModule" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -645,8 +642,8 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-COLLECTION"
-     class="anchored"><a href="#module-type-COLLECTION" class="anchor"></a>
+    <div class="spec module-type anchored" id="module-type-COLLECTION">
+     <a href="#module-type-COLLECTION" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
        <span class="keyword">type</span> 
@@ -660,7 +657,7 @@
     </div><div class="spec-doc"><p>module type of</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Recollection" class="anchored">
+    <div class="spec module anchored" id="module-Recollection">
      <a href="#module-Recollection" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -699,7 +696,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-MMM" class="anchored">
+    <div class="spec module-type anchored" id="module-type-MMM">
      <a href="#module-type-MMM" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -713,8 +710,8 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-RECOLLECTION"
-     class="anchored"><a href="#module-type-RECOLLECTION" class="anchor"></a>
+    <div class="spec module-type anchored" id="module-type-RECOLLECTION">
+     <a href="#module-type-RECOLLECTION" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
        <span class="keyword">type</span> 
@@ -732,8 +729,8 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-RecollectionModule"
-     class="anchored">
+    <div class="spec module-type anchored"
+     id="module-type-RecollectionModule">
      <a href="#module-type-RecollectionModule" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -749,7 +746,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-A" class="anchored">
+    <div class="spec module-type anchored" id="module-type-A">
      <a href="#module-type-A" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -763,7 +760,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-B" class="anchored">
+    <div class="spec module-type anchored" id="module-type-B">
      <a href="#module-type-B" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -777,7 +774,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-C" class="anchored">
+    <div class="spec module-type anchored" id="module-type-C">
      <a href="#module-type-C" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -793,7 +790,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-FunctorTypeOf" class="anchored">
+    <div class="spec module anchored" id="module-FunctorTypeOf">
      <a href="#module-FunctorTypeOf" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -817,8 +814,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-IncludeModuleType"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-IncludeModuleType">
      <a href="#module-type-IncludeModuleType" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -837,7 +833,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-ToInclude" class="anchored">
+    <div class="spec module-type anchored" id="module-type-ToInclude">
      <a href="#module-type-ToInclude" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -860,7 +856,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec module" id="module-IncludedA" class="anchored">
+      <div class="spec module anchored" id="module-IncludedA">
        <a href="#module-IncludedA" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> 
@@ -873,8 +869,8 @@
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module-type" id="module-type-IncludedB"
-       class="anchored"><a href="#module-type-IncludedB" class="anchor"></a>
+      <div class="spec module-type anchored" id="module-type-IncludedB">
+       <a href="#module-type-IncludedB" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> 
          <span class="keyword">type</span> 
@@ -892,191 +888,166 @@
     <a href="#advanced-type-stuff" class="anchor"></a>Advanced Type Stuff
    </h4>
    <div class="odoc-spec">
-    <div class="spec type" id="type-record" class="anchored">
+    <div class="spec type anchored" id="type-record">
      <a href="#type-record" class="anchor"></a>
      <code><span><span class="keyword">type</span> record</span>
       <span> = </span><span>{</span>
      </code>
-     <table>
-      <tr id="type-record.field1" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.field1" class="anchor"></a>
-        <code><span>field1 : int;</span></code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="type-record.field1" class="def record field anchored">
+       <a href="#type-record.field1" class="anchor"></a>
+       <code><span>field1 : int;</span></code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>This comment is for <code>field1</code>.</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-record.field2" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.field2" class="anchor"></a>
-        <code><span>field2 : int;</span></code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+       </div>
+      </li>
+      <li id="type-record.field2" class="def record field anchored">
+       <a href="#type-record.field2" class="anchor"></a>
+       <code><span>field2 : int;</span></code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>This comment is for <code>field2</code>.</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table><code><span>}</span></code>
+       </div>
+      </li>
+     </ol><code><span>}</span></code>
     </div>
     <div class="spec-doc"><p>This comment is for <code>record</code>.</p>
      <p>This comment is also for <code>record</code>.</p>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-mutable_record" class="anchored">
+    <div class="spec type anchored" id="type-mutable_record">
      <a href="#type-mutable_record" class="anchor"></a>
      <code><span><span class="keyword">type</span> mutable_record</span>
       <span> = </span><span>{</span>
      </code>
-     <table>
-      <tr id="type-mutable_record.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-mutable_record.a" class="anchor"></a>
-        <code><span><span class="keyword">mutable</span> a : int;</span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="type-mutable_record.a" class="def record field anchored">
+       <a href="#type-mutable_record.a" class="anchor"></a>
+       <code><span><span class="keyword">mutable</span> a : int;</span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p><code>a</code> is first and mutable</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-mutable_record.b" class="anchored">
-       <td class="def record field">
-        <a href="#type-mutable_record.b" class="anchor"></a>
-        <code><span>b : unit;</span></code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+       </div>
+      </li>
+      <li id="type-mutable_record.b" class="def record field anchored">
+       <a href="#type-mutable_record.b" class="anchor"></a>
+       <code><span>b : unit;</span></code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p><code>b</code> is second and immutable</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-mutable_record.c" class="anchored">
-       <td class="def record field">
-        <a href="#type-mutable_record.c" class="anchor"></a>
-        <code><span><span class="keyword">mutable</span> c : int;</span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+       </div>
+      </li>
+      <li id="type-mutable_record.c" class="def record field anchored">
+       <a href="#type-mutable_record.c" class="anchor"></a>
+       <code><span><span class="keyword">mutable</span> c : int;</span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p><code>c</code> is third and mutable</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table><code><span>}</span></code>
+       </div>
+      </li>
+     </ol><code><span>}</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-universe_record" class="anchored">
+    <div class="spec type anchored" id="type-universe_record">
      <a href="#type-universe_record" class="anchor"></a>
      <code><span><span class="keyword">type</span> universe_record</span>
       <span> = </span><span>{</span>
      </code>
-     <table>
-      <tr id="type-universe_record.nihilate" class="anchored">
-       <td class="def record field">
-        <a href="#type-universe_record.nihilate" class="anchor"></a>
-        <code>
-         <span>nihilate : 'a. 
-          <span><span class="type-var">'a</span> 
-           <span class="arrow">&#45;&gt;</span>
-          </span> unit;
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table><code><span>}</span></code>
+     <ol>
+      <li id="type-universe_record.nihilate" class="def record field
+       anchored"><a href="#type-universe_record.nihilate" class="anchor"></a>
+       <code>
+        <span>nihilate : 'a. 
+         <span><span class="type-var">'a</span> 
+          <span class="arrow">&#45;&gt;</span>
+         </span> unit;
+        </span>
+       </code>
+      </li>
+     </ol><code><span>}</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-variant" class="anchored">
+    <div class="spec type anchored" id="type-variant">
      <a href="#type-variant" class="anchor"></a>
      <code><span><span class="keyword">type</span> variant</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-variant.TagA" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.TagA" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">TagA</span></span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="type-variant.TagA" class="def variant constructor anchored">
+       <a href="#type-variant.TagA" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">TagA</span></span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>This comment is for <code>TagA</code>.</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-variant.ConstrB" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.ConstrB" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">ConstrB</span> 
-          <span class="keyword">of</span> int
-         </span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+       </div>
+      </li>
+      <li id="type-variant.ConstrB" class="def variant constructor anchored">
+       <a href="#type-variant.ConstrB" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">ConstrB</span> 
+         <span class="keyword">of</span> int
+        </span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>This comment is for <code>ConstrB</code>.</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-variant.ConstrC" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.ConstrC" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">ConstrC</span> 
-          <span class="keyword">of</span> int * int
-         </span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+       </div>
+      </li>
+      <li id="type-variant.ConstrC" class="def variant constructor anchored">
+       <a href="#type-variant.ConstrC" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">ConstrC</span> 
+         <span class="keyword">of</span> int * int
+        </span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>This comment is for binary <code>ConstrC</code>.</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-variant.ConstrD" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.ConstrD" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">ConstrD</span> 
-          <span class="keyword">of</span> int * int
-         </span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+       </div>
+      </li>
+      <li id="type-variant.ConstrD" class="def variant constructor anchored">
+       <a href="#type-variant.ConstrD" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">ConstrD</span> 
+         <span class="keyword">of</span> int * int
+        </span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>This comment is for unary <code>ConstrD</code> of binary tuple.
         </p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc"><p>This comment is for <code>variant</code>.</p>
      <p>This comment is also for <code>variant</code>.</p>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-poly_variant" class="anchored">
+    <div class="spec type anchored" id="type-poly_variant">
      <a href="#type-poly_variant" class="anchor"></a>
      <code><span><span class="keyword">type</span> poly_variant</span>
       <span> = </span><span>[ </span>
      </code>
-     <table>
-      <tr id="type-poly_variant.TagA" class="anchored">
-       <td class="def constructor">
-        <a href="#type-poly_variant.TagA" class="anchor"></a>
-        <code><span>| </span></code><code><span>`TagA</span></code>
-       </td>
-      </tr>
-      <tr id="type-poly_variant.ConstrB" class="anchored">
-       <td class="def constructor">
-        <a href="#type-poly_variant.ConstrB" class="anchor"></a>
-        <code><span>| </span></code>
-        <code><span>`ConstrB <span class="keyword">of</span> int</span>
-        </code>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+     <ol>
+      <li id="type-poly_variant.TagA" class="def constructor anchored">
+       <a href="#type-poly_variant.TagA" class="anchor"></a>
+       <code><span>| </span></code><code><span>`TagA</span></code>
+      </li>
+      <li id="type-poly_variant.ConstrB" class="def constructor anchored">
+       <a href="#type-poly_variant.ConstrB" class="anchor"></a>
+       <code><span>| </span></code>
+       <code><span>`ConstrB <span class="keyword">of</span> int</span></code>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
     <div class="spec-doc">
      <p>This comment is for <code>poly_variant</code>.</p>
@@ -1084,124 +1055,111 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-full_gadt" class="anchored">
+    <div class="spec type anchored" id="type-full_gadt">
      <a href="#type-full_gadt" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>(_, _) full_gadt</span>
       </span><span> = </span>
      </code>
-     <table>
-      <tr id="type-full_gadt.Tag" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-full_gadt.Tag" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">Tag</span> : 
-          <span><span>(unit, unit)</span> 
-           <a href="#type-full_gadt">full_gadt</a>
-          </span>
+     <ol>
+      <li id="type-full_gadt.Tag" class="def variant constructor anchored">
+       <a href="#type-full_gadt.Tag" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">Tag</span> : 
+         <span><span>(unit, unit)</span> 
+          <a href="#type-full_gadt">full_gadt</a>
          </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-full_gadt.First" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-full_gadt.First" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">First</span> : 
-          <span class="type-var">'a</span> 
+        </span>
+       </code>
+      </li>
+      <li id="type-full_gadt.First" class="def variant constructor anchored">
+       <a href="#type-full_gadt.First" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">First</span> : 
+         <span class="type-var">'a</span> 
+         <span class="arrow">&#45;&gt;</span> 
+         <span><span>(<span class="type-var">'a</span>, unit)</span> 
+          <a href="#type-full_gadt">full_gadt</a>
+         </span>
+        </span>
+       </code>
+      </li>
+      <li id="type-full_gadt.Second" class="def variant constructor anchored">
+       <a href="#type-full_gadt.Second" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">Second</span> : 
+         <span class="type-var">'a</span> 
+         <span class="arrow">&#45;&gt;</span> 
+         <span><span>(unit, <span class="type-var">'a</span>)</span> 
+          <a href="#type-full_gadt">full_gadt</a>
+         </span>
+        </span>
+       </code>
+      </li>
+      <li id="type-full_gadt.Exist" class="def variant constructor anchored">
+       <a href="#type-full_gadt.Exist" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">Exist</span> : 
+         <span class="type-var">'a</span> * <span class="type-var">'b</span>
           <span class="arrow">&#45;&gt;</span> 
-          <span><span>(<span class="type-var">'a</span>, unit)</span>
-            <a href="#type-full_gadt">full_gadt</a>
-          </span>
+         <span><span>(<span class="type-var">'b</span>, unit)</span> 
+          <a href="#type-full_gadt">full_gadt</a>
          </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-full_gadt.Second" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-full_gadt.Second" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">Second</span> : 
-          <span class="type-var">'a</span> 
-          <span class="arrow">&#45;&gt;</span> 
-          <span><span>(unit, <span class="type-var">'a</span>)</span>
-            <a href="#type-full_gadt">full_gadt</a>
-          </span>
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-full_gadt.Exist" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-full_gadt.Exist" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">Exist</span> : 
-          <span class="type-var">'a</span> * <span class="type-var">'b</span>
-           <span class="arrow">&#45;&gt;</span> 
-          <span><span>(<span class="type-var">'b</span>, unit)</span>
-            <a href="#type-full_gadt">full_gadt</a>
-          </span>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc"><p>This comment is for <code>full_gadt</code>.</p>
      <p>Wow! It was a GADT!</p>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-partial_gadt" class="anchored">
+    <div class="spec type anchored" id="type-partial_gadt">
      <a href="#type-partial_gadt" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a partial_gadt</span>
       </span><span> = </span>
      </code>
-     <table>
-      <tr id="type-partial_gadt.AscribeTag" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-partial_gadt.AscribeTag" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">AscribeTag</span> : 
-          <span><span class="type-var">'a</span> 
-           <a href="#type-partial_gadt">partial_gadt</a>
-          </span>
+     <ol>
+      <li id="type-partial_gadt.AscribeTag" class="def variant constructor
+       anchored"><a href="#type-partial_gadt.AscribeTag" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">AscribeTag</span> : 
+         <span><span class="type-var">'a</span> 
+          <a href="#type-partial_gadt">partial_gadt</a>
          </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-partial_gadt.OfTag" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-partial_gadt.OfTag" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">OfTag</span> 
-          <span class="keyword">of</span> 
-          <span><span class="type-var">'a</span> 
-           <a href="#type-partial_gadt">partial_gadt</a>
-          </span>
+        </span>
+       </code>
+      </li>
+      <li id="type-partial_gadt.OfTag" class="def variant constructor
+       anchored"><a href="#type-partial_gadt.OfTag" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">OfTag</span> 
+         <span class="keyword">of</span> 
+         <span><span class="type-var">'a</span> 
+          <a href="#type-partial_gadt">partial_gadt</a>
          </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-partial_gadt.ExistGadtTag" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-partial_gadt.ExistGadtTag" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">ExistGadtTag</span> : 
-          <span>(
-           <span><span class="type-var">'a</span> 
-            <span class="arrow">&#45;&gt;</span>
-           </span> <span class="type-var">'b</span>)
-          </span> <span class="arrow">&#45;&gt;</span> 
+        </span>
+       </code>
+      </li>
+      <li id="type-partial_gadt.ExistGadtTag" class="def variant constructor
+       anchored">
+       <a href="#type-partial_gadt.ExistGadtTag" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">ExistGadtTag</span> : 
+         <span>(
           <span><span class="type-var">'a</span> 
-           <a href="#type-partial_gadt">partial_gadt</a>
-          </span>
+           <span class="arrow">&#45;&gt;</span>
+          </span> <span class="type-var">'b</span>)
+         </span> <span class="arrow">&#45;&gt;</span> 
+         <span><span class="type-var">'a</span> 
+          <a href="#type-partial_gadt">partial_gadt</a>
          </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>This comment is for <code>partial_gadt</code>.</p>
@@ -1209,7 +1167,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-alias" class="anchored">
+    <div class="spec type anchored" id="type-alias">
      <a href="#type-alias" class="anchor"></a>
      <code><span><span class="keyword">type</span> alias</span>
       <span> = <a href="#type-variant">variant</a></span>
@@ -1219,7 +1177,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-tuple" class="anchored">
+    <div class="spec type anchored" id="type-tuple">
      <a href="#type-tuple" class="anchor"></a>
      <code><span><span class="keyword">type</span> tuple</span>
       <span> = 
@@ -1236,168 +1194,148 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-variant_alias" class="anchored">
+    <div class="spec type anchored" id="type-variant_alias">
      <a href="#type-variant_alias" class="anchor"></a>
      <code><span><span class="keyword">type</span> variant_alias</span>
       <span> = <a href="#type-variant">variant</a></span><span> = </span>
      </code>
-     <table>
-      <tr id="type-variant_alias.TagA" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant_alias.TagA" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">TagA</span></span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-variant_alias.ConstrB" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant_alias.ConstrB" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">ConstrB</span> 
-          <span class="keyword">of</span> int
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-variant_alias.ConstrC" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant_alias.ConstrC" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">ConstrC</span> 
-          <span class="keyword">of</span> int * int
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-variant_alias.ConstrD" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant_alias.ConstrD" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">ConstrD</span> 
-          <span class="keyword">of</span> int * int
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-variant_alias.TagA" class="def variant constructor
+       anchored"><a href="#type-variant_alias.TagA" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">TagA</span></span>
+       </code>
+      </li>
+      <li id="type-variant_alias.ConstrB" class="def variant constructor
+       anchored"><a href="#type-variant_alias.ConstrB" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">ConstrB</span> 
+         <span class="keyword">of</span> int
+        </span>
+       </code>
+      </li>
+      <li id="type-variant_alias.ConstrC" class="def variant constructor
+       anchored"><a href="#type-variant_alias.ConstrC" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">ConstrC</span> 
+         <span class="keyword">of</span> int * int
+        </span>
+       </code>
+      </li>
+      <li id="type-variant_alias.ConstrD" class="def variant constructor
+       anchored"><a href="#type-variant_alias.ConstrD" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">ConstrD</span> 
+         <span class="keyword">of</span> int * int
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>This comment is for <code>variant_alias</code>.</p>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-record_alias" class="anchored">
+    <div class="spec type anchored" id="type-record_alias">
      <a href="#type-record_alias" class="anchor"></a>
      <code><span><span class="keyword">type</span> record_alias</span>
       <span> = <a href="#type-record">record</a></span><span> = </span>
       <span>{</span>
      </code>
-     <table>
-      <tr id="type-record_alias.field1" class="anchored">
-       <td class="def record field">
-        <a href="#type-record_alias.field1" class="anchor"></a>
-        <code><span>field1 : int;</span></code>
-       </td>
-      </tr>
-      <tr id="type-record_alias.field2" class="anchored">
-       <td class="def record field">
-        <a href="#type-record_alias.field2" class="anchor"></a>
-        <code><span>field2 : int;</span></code>
-       </td>
-      </tr>
-     </table><code><span>}</span></code>
+     <ol>
+      <li id="type-record_alias.field1" class="def record field anchored">
+       <a href="#type-record_alias.field1" class="anchor"></a>
+       <code><span>field1 : int;</span></code>
+      </li>
+      <li id="type-record_alias.field2" class="def record field anchored">
+       <a href="#type-record_alias.field2" class="anchor"></a>
+       <code><span>field2 : int;</span></code>
+      </li>
+     </ol><code><span>}</span></code>
     </div>
     <div class="spec-doc">
      <p>This comment is for <code>record_alias</code>.</p>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-poly_variant_union" class="anchored">
+    <div class="spec type anchored" id="type-poly_variant_union">
      <a href="#type-poly_variant_union" class="anchor"></a>
      <code><span><span class="keyword">type</span> poly_variant_union</span>
       <span> = </span><span>[ </span>
      </code>
-     <table>
-      <tr id="type-poly_variant_union.poly_variant" class="anchored">
-       <td class="def type">
-        <a href="#type-poly_variant_union.poly_variant" class="anchor"></a>
-        <code><span>| </span></code>
-        <code><span><a href="#type-poly_variant">poly_variant</a></span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-poly_variant_union.TagC" class="anchored">
-       <td class="def constructor">
-        <a href="#type-poly_variant_union.TagC" class="anchor"></a>
-        <code><span>| </span></code><code><span>`TagC</span></code>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+     <ol>
+      <li id="type-poly_variant_union.poly_variant" class="def type anchored">
+       <a href="#type-poly_variant_union.poly_variant" class="anchor"></a>
+       <code><span>| </span></code>
+       <code><span><a href="#type-poly_variant">poly_variant</a></span>
+       </code>
+      </li>
+      <li id="type-poly_variant_union.TagC" class="def constructor anchored">
+       <a href="#type-poly_variant_union.TagC" class="anchor"></a>
+       <code><span>| </span></code><code><span>`TagC</span></code>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
     <div class="spec-doc">
      <p>This comment is for <code>poly_variant_union</code>.</p>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-poly_poly_variant" class="anchored">
+    <div class="spec type anchored" id="type-poly_poly_variant">
      <a href="#type-poly_poly_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
        <span>'a poly_poly_variant</span>
       </span><span> = </span><span>[ </span>
      </code>
-     <table>
-      <tr id="type-poly_poly_variant.TagA" class="anchored">
-       <td class="def constructor">
-        <a href="#type-poly_poly_variant.TagA" class="anchor"></a>
-        <code><span>| </span></code>
-        <code>
-         <span>`TagA <span class="keyword">of</span> 
-          <span class="type-var">'a</span>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+     <ol>
+      <li id="type-poly_poly_variant.TagA" class="def constructor anchored">
+       <a href="#type-poly_poly_variant.TagA" class="anchor"></a>
+       <code><span>| </span></code>
+       <code>
+        <span>`TagA <span class="keyword">of</span> 
+         <span class="type-var">'a</span>
+        </span>
+       </code>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-bin_poly_poly_variant" class="anchored">
+    <div class="spec type anchored" id="type-bin_poly_poly_variant">
      <a href="#type-bin_poly_poly_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
        <span>('a, 'b) bin_poly_poly_variant</span>
       </span><span> = </span><span>[ </span>
      </code>
-     <table>
-      <tr id="type-bin_poly_poly_variant.TagA" class="anchored">
-       <td class="def constructor">
-        <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a>
-        <code><span>| </span></code>
-        <code>
-         <span>`TagA <span class="keyword">of</span> 
-          <span class="type-var">'a</span>
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-bin_poly_poly_variant.ConstrB" class="anchored">
-       <td class="def constructor">
-        <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a>
-        <code><span>| </span></code>
-        <code>
-         <span>`ConstrB <span class="keyword">of</span> 
-          <span class="type-var">'b</span>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+     <ol>
+      <li id="type-bin_poly_poly_variant.TagA" class="def constructor
+       anchored">
+       <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a>
+       <code><span>| </span></code>
+       <code>
+        <span>`TagA <span class="keyword">of</span> 
+         <span class="type-var">'a</span>
+        </span>
+       </code>
+      </li>
+      <li id="type-bin_poly_poly_variant.ConstrB" class="def constructor
+       anchored">
+       <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a>
+       <code><span>| </span></code>
+       <code>
+        <span>`ConstrB <span class="keyword">of</span> 
+         <span class="type-var">'b</span>
+        </span>
+       </code>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-open_poly_variant" class="anchored">
+    <div class="spec type anchored" id="type-open_poly_variant">
      <a href="#type-open_poly_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -1409,7 +1347,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-open_poly_variant2" class="anchored">
+    <div class="spec type anchored" id="type-open_poly_variant2">
      <a href="#type-open_poly_variant2" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -1422,7 +1360,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-open_poly_variant_alias" class="anchored">
+    <div class="spec type anchored" id="type-open_poly_variant_alias">
      <a href="#type-open_poly_variant_alias" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -1439,7 +1377,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-poly_fun" class="anchored">
+    <div class="spec type anchored" id="type-poly_fun">
      <a href="#type-poly_fun" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a poly_fun</span></span>
@@ -1453,7 +1391,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-poly_fun_constraint" class="anchored">
+    <div class="spec type anchored" id="type-poly_fun_constraint">
      <a href="#type-poly_fun_constraint" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -1471,7 +1409,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-closed_poly_variant" class="anchored">
+    <div class="spec type anchored" id="type-closed_poly_variant">
      <a href="#type-closed_poly_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -1484,7 +1422,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-clopen_poly_variant" class="anchored">
+    <div class="spec type anchored" id="type-clopen_poly_variant">
      <a href="#type-clopen_poly_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -1499,51 +1437,43 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-nested_poly_variant" class="anchored">
+    <div class="spec type anchored" id="type-nested_poly_variant">
      <a href="#type-nested_poly_variant" class="anchor"></a>
      <code><span><span class="keyword">type</span> nested_poly_variant</span>
       <span> = </span><span>[ </span>
      </code>
-     <table>
-      <tr id="type-nested_poly_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.A" class="anchor"></a>
-        <code><span>| </span></code><code><span>`A</span></code>
-       </td>
-      </tr>
-      <tr id="type-nested_poly_variant.B" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.B" class="anchor"></a>
-        <code><span>| </span></code>
-        <code>
-         <span>`B <span class="keyword">of</span> 
-          <span>[ `B1 <span>| `B2</span> ]</span>
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-nested_poly_variant.C" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.C" class="anchor"></a>
-        <code><span>| </span></code><code><span>`C</span></code>
-       </td>
-      </tr>
-      <tr id="type-nested_poly_variant.D" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_poly_variant.D" class="anchor"></a>
-        <code><span>| </span></code>
-        <code>
-         <span>`D <span class="keyword">of</span> 
-          <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+     <ol>
+      <li id="type-nested_poly_variant.A" class="def constructor anchored">
+       <a href="#type-nested_poly_variant.A" class="anchor"></a>
+       <code><span>| </span></code><code><span>`A</span></code>
+      </li>
+      <li id="type-nested_poly_variant.B" class="def constructor anchored">
+       <a href="#type-nested_poly_variant.B" class="anchor"></a>
+       <code><span>| </span></code>
+       <code>
+        <span>`B <span class="keyword">of</span> 
+         <span>[ `B1 <span>| `B2</span> ]</span>
+        </span>
+       </code>
+      </li>
+      <li id="type-nested_poly_variant.C" class="def constructor anchored">
+       <a href="#type-nested_poly_variant.C" class="anchor"></a>
+       <code><span>| </span></code><code><span>`C</span></code>
+      </li>
+      <li id="type-nested_poly_variant.D" class="def constructor anchored">
+       <a href="#type-nested_poly_variant.D" class="anchor"></a>
+       <code><span>| </span></code>
+       <code>
+        <span>`D <span class="keyword">of</span> 
+         <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span>
+        </span>
+       </code>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-full_gadt_alias" class="anchored">
+    <div class="spec type anchored" id="type-full_gadt_alias">
      <a href="#type-full_gadt_alias" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -1557,69 +1487,61 @@
        </span>
       </span><span> = </span>
      </code>
-     <table>
-      <tr id="type-full_gadt_alias.Tag" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-full_gadt_alias.Tag" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">Tag</span> : 
-          <span><span>(unit, unit)</span> 
-           <a href="#type-full_gadt_alias">full_gadt_alias</a>
-          </span>
+     <ol>
+      <li id="type-full_gadt_alias.Tag" class="def variant constructor
+       anchored"><a href="#type-full_gadt_alias.Tag" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">Tag</span> : 
+         <span><span>(unit, unit)</span> 
+          <a href="#type-full_gadt_alias">full_gadt_alias</a>
          </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-full_gadt_alias.First" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-full_gadt_alias.First" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">First</span> : 
-          <span class="type-var">'a</span> 
+        </span>
+       </code>
+      </li>
+      <li id="type-full_gadt_alias.First" class="def variant constructor
+       anchored"><a href="#type-full_gadt_alias.First" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">First</span> : 
+         <span class="type-var">'a</span> 
+         <span class="arrow">&#45;&gt;</span> 
+         <span><span>(<span class="type-var">'a</span>, unit)</span> 
+          <a href="#type-full_gadt_alias">full_gadt_alias</a>
+         </span>
+        </span>
+       </code>
+      </li>
+      <li id="type-full_gadt_alias.Second" class="def variant constructor
+       anchored"><a href="#type-full_gadt_alias.Second" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">Second</span> : 
+         <span class="type-var">'a</span> 
+         <span class="arrow">&#45;&gt;</span> 
+         <span><span>(unit, <span class="type-var">'a</span>)</span> 
+          <a href="#type-full_gadt_alias">full_gadt_alias</a>
+         </span>
+        </span>
+       </code>
+      </li>
+      <li id="type-full_gadt_alias.Exist" class="def variant constructor
+       anchored"><a href="#type-full_gadt_alias.Exist" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">Exist</span> : 
+         <span class="type-var">'a</span> * <span class="type-var">'b</span>
           <span class="arrow">&#45;&gt;</span> 
-          <span><span>(<span class="type-var">'a</span>, unit)</span>
-            <a href="#type-full_gadt_alias">full_gadt_alias</a>
-          </span>
+         <span><span>(<span class="type-var">'b</span>, unit)</span> 
+          <a href="#type-full_gadt_alias">full_gadt_alias</a>
          </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-full_gadt_alias.Second" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-full_gadt_alias.Second" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">Second</span> : 
-          <span class="type-var">'a</span> 
-          <span class="arrow">&#45;&gt;</span> 
-          <span><span>(unit, <span class="type-var">'a</span>)</span>
-            <a href="#type-full_gadt_alias">full_gadt_alias</a>
-          </span>
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-full_gadt_alias.Exist" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-full_gadt_alias.Exist" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">Exist</span> : 
-          <span class="type-var">'a</span> * <span class="type-var">'b</span>
-           <span class="arrow">&#45;&gt;</span> 
-          <span><span>(<span class="type-var">'b</span>, unit)</span>
-            <a href="#type-full_gadt_alias">full_gadt_alias</a>
-          </span>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>This comment is for <code>full_gadt_alias</code>.</p>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-partial_gadt_alias" class="anchored">
+    <div class="spec type anchored" id="type-partial_gadt_alias">
      <a href="#type-partial_gadt_alias" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -1631,57 +1553,53 @@
        </span>
       </span><span> = </span>
      </code>
-     <table>
-      <tr id="type-partial_gadt_alias.AscribeTag" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-partial_gadt_alias.AscribeTag" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">AscribeTag</span> : 
-          <span><span class="type-var">'a</span> 
-           <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
-          </span>
+     <ol>
+      <li id="type-partial_gadt_alias.AscribeTag" class="def variant
+       constructor anchored">
+       <a href="#type-partial_gadt_alias.AscribeTag" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">AscribeTag</span> : 
+         <span><span class="type-var">'a</span> 
+          <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
          </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-partial_gadt_alias.OfTag" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-partial_gadt_alias.OfTag" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">OfTag</span> 
-          <span class="keyword">of</span> 
-          <span><span class="type-var">'a</span> 
-           <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
-          </span>
+        </span>
+       </code>
+      </li>
+      <li id="type-partial_gadt_alias.OfTag" class="def variant constructor
+       anchored"><a href="#type-partial_gadt_alias.OfTag" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">OfTag</span> 
+         <span class="keyword">of</span> 
+         <span><span class="type-var">'a</span> 
+          <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
          </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-partial_gadt_alias.ExistGadtTag" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-partial_gadt_alias.ExistGadtTag" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">ExistGadtTag</span> : 
-          <span>(
-           <span><span class="type-var">'a</span> 
-            <span class="arrow">&#45;&gt;</span>
-           </span> <span class="type-var">'b</span>)
-          </span> <span class="arrow">&#45;&gt;</span> 
+        </span>
+       </code>
+      </li>
+      <li id="type-partial_gadt_alias.ExistGadtTag" class="def variant
+       constructor anchored">
+       <a href="#type-partial_gadt_alias.ExistGadtTag" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">ExistGadtTag</span> : 
+         <span>(
           <span><span class="type-var">'a</span> 
-           <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
-          </span>
+           <span class="arrow">&#45;&gt;</span>
+          </span> <span class="type-var">'b</span>)
+         </span> <span class="arrow">&#45;&gt;</span> 
+         <span><span class="type-var">'a</span> 
+          <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
          </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>This comment is for <code>partial_gadt_alias</code>.</p>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec exception" id="exception-Exn_arrow" class="anchored">
+    <div class="spec exception anchored" id="exception-Exn_arrow">
      <a href="#exception-Exn_arrow" class="anchor"></a>
      <code><span><span class="keyword">exception</span> </span>
       <span><span class="exception">Exn_arrow</span> : unit 
@@ -1696,39 +1614,35 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-mutual_constr_a" class="anchored">
+    <div class="spec type anchored" id="type-mutual_constr_a">
      <a href="#type-mutual_constr_a" class="anchor"></a>
      <code><span><span class="keyword">type</span> mutual_constr_a</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-mutual_constr_a.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-mutual_constr_a.A" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">A</span></span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-mutual_constr_a.B_ish" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-mutual_constr_a.B_ish" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">B_ish</span> 
-          <span class="keyword">of</span> 
-          <a href="#type-mutual_constr_b">mutual_constr_b</a>
-         </span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="type-mutual_constr_a.A" class="def variant constructor
+       anchored"><a href="#type-mutual_constr_a.A" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">A</span></span>
+       </code>
+      </li>
+      <li id="type-mutual_constr_a.B_ish" class="def variant constructor
+       anchored"><a href="#type-mutual_constr_a.B_ish" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">B_ish</span> 
+         <span class="keyword">of</span> 
+         <a href="#type-mutual_constr_b">mutual_constr_b</a>
+        </span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>This comment is between 
          <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a>
           and 
          <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>
          .
         </p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>This comment is for 
@@ -1739,35 +1653,31 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-mutual_constr_b" class="anchored">
+    <div class="spec type anchored" id="type-mutual_constr_b">
      <a href="#type-mutual_constr_b" class="anchor"></a>
      <code><span><span class="keyword">and</span> mutual_constr_b</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-mutual_constr_b.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-mutual_constr_b.B" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">B</span></span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-mutual_constr_b.A_ish" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-mutual_constr_b.A_ish" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">A_ish</span> 
-          <span class="keyword">of</span> 
-          <a href="#type-mutual_constr_a">mutual_constr_a</a>
-         </span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="type-mutual_constr_b.B" class="def variant constructor
+       anchored"><a href="#type-mutual_constr_b.B" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">B</span></span>
+       </code>
+      </li>
+      <li id="type-mutual_constr_b.A_ish" class="def variant constructor
+       anchored"><a href="#type-mutual_constr_b.A_ish" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">A_ish</span> 
+         <span class="keyword">of</span> 
+         <a href="#type-mutual_constr_a">mutual_constr_a</a>
+        </span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>This comment must be here for the next to associate correctly.</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+     </ol>
     </div>
     <div class="spec-doc">
      <p>This comment is for 
@@ -1778,7 +1688,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-rec_obj" class="anchored">
+    <div class="spec type anchored" id="type-rec_obj">
      <a href="#type-rec_obj" class="anchor"></a>
      <code><span><span class="keyword">type</span> rec_obj</span>
       <span> = 
@@ -1791,7 +1701,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-open_obj" class="anchored">
+    <div class="spec type anchored" id="type-open_obj">
      <a href="#type-open_obj" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a open_obj</span></span>
@@ -1804,7 +1714,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-oof" class="anchored">
+    <div class="spec type anchored" id="type-oof">
      <a href="#type-oof" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a oof</span></span>
       <span> = 
@@ -1817,7 +1727,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-any_obj" class="anchored">
+    <div class="spec type anchored" id="type-any_obj">
      <a href="#type-any_obj" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a any_obj</span></span>
@@ -1827,7 +1737,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-empty_obj" class="anchored">
+    <div class="spec type anchored" id="type-empty_obj">
      <a href="#type-empty_obj" class="anchor"></a>
      <code><span><span class="keyword">type</span> empty_obj</span>
       <span> = <span>&lt;  &gt;</span></span>
@@ -1835,7 +1745,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-one_meth" class="anchored">
+    <div class="spec type anchored" id="type-one_meth">
      <a href="#type-one_meth" class="anchor"></a>
      <code><span><span class="keyword">type</span> one_meth</span>
       <span> = <span>&lt; meth : unit &gt;</span></span>
@@ -1843,7 +1753,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-ext" class="anchored">
+    <div class="spec type anchored" id="type-ext">
      <a href="#type-ext" class="anchor"></a>
      <code><span><span class="keyword">type</span> ext</span><span> = </span>
       <span>..</span>
@@ -1851,110 +1761,98 @@
     </div><div class="spec-doc"><p>A mystery wrapped in an ellipsis</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-ExtA"
-     class="anchored"><a href="#extension-decl-ExtA" class="anchor"></a>
+    <div class="spec type extension anchored" id="extension-decl-ExtA">
+     <a href="#extension-decl-ExtA" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-ExtA" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtA" class="anchor"></a>
-        <code><span>| </span><span><span class="extension">ExtA</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="extension-ExtA" class="def extension anchored">
+       <a href="#extension-ExtA" class="anchor"></a>
+       <code><span>| </span><span><span class="extension">ExtA</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-ExtB"
-     class="anchored"><a href="#extension-decl-ExtB" class="anchor"></a>
+    <div class="spec type extension anchored" id="extension-decl-ExtB">
+     <a href="#extension-decl-ExtB" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-ExtB" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtB" class="anchor"></a>
-        <code><span>| </span><span><span class="extension">ExtB</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="extension-ExtB" class="def extension anchored">
+       <a href="#extension-ExtB" class="anchor"></a>
+       <code><span>| </span><span><span class="extension">ExtB</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-ExtC"
-     class="anchored"><a href="#extension-decl-ExtC" class="anchor"></a>
+    <div class="spec type extension anchored" id="extension-decl-ExtC">
+     <a href="#extension-decl-ExtC" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-ExtC" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtC" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="extension">ExtC</span> 
-          <span class="keyword">of</span> unit
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="extension-ExtD" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtD" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="extension">ExtD</span> 
-          <span class="keyword">of</span> <a href="#type-ext">ext</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="extension-ExtC" class="def extension anchored">
+       <a href="#extension-ExtC" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="extension">ExtC</span> 
+         <span class="keyword">of</span> unit
+        </span>
+       </code>
+      </li>
+      <li id="extension-ExtD" class="def extension anchored">
+       <a href="#extension-ExtD" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="extension">ExtD</span> 
+         <span class="keyword">of</span> <a href="#type-ext">ext</a>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-ExtE"
-     class="anchored"><a href="#extension-decl-ExtE" class="anchor"></a>
+    <div class="spec type extension anchored" id="extension-decl-ExtE">
+     <a href="#extension-decl-ExtE" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-ExtE" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtE" class="anchor"></a>
-        <code><span>| </span><span><span class="extension">ExtE</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="extension-ExtE" class="def extension anchored">
+       <a href="#extension-ExtE" class="anchor"></a>
+       <code><span>| </span><span><span class="extension">ExtE</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-ExtF"
-     class="anchored"><a href="#extension-decl-ExtF" class="anchor"></a>
+    <div class="spec type extension anchored" id="extension-decl-ExtF">
+     <a href="#extension-decl-ExtF" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-ExtF" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ExtF" class="anchor"></a>
-        <code><span>| </span><span><span class="extension">ExtF</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="extension-ExtF" class="def extension anchored">
+       <a href="#extension-ExtF" class="anchor"></a>
+       <code><span>| </span><span><span class="extension">ExtF</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-poly_ext" class="anchored">
+    <div class="spec type anchored" id="type-poly_ext">
      <a href="#type-poly_ext" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a poly_ext</span></span>
@@ -1963,66 +1861,62 @@
     </div><div class="spec-doc"><p>'a poly_ext</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-Foo" class="anchored">
+    <div class="spec type extension anchored" id="extension-decl-Foo">
      <a href="#extension-decl-Foo" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
        <a href="#type-poly_ext">poly_ext</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-Foo" class="anchored">
-       <td class="def extension"><a href="#extension-Foo" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="extension">Foo</span> 
-          <span class="keyword">of</span> <span class="type-var">'b</span>
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="extension-Bar" class="anchored">
-       <td class="def extension"><a href="#extension-Bar" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="extension">Bar</span> 
-          <span class="keyword">of</span> <span class="type-var">'b</span>
-           * <span class="type-var">'b</span>
-         </span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="extension-Foo" class="def extension anchored">
+       <a href="#extension-Foo" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="extension">Foo</span> 
+         <span class="keyword">of</span> <span class="type-var">'b</span>
+        </span>
+       </code>
+      </li>
+      <li id="extension-Bar" class="def extension anchored">
+       <a href="#extension-Bar" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="extension">Bar</span> 
+         <span class="keyword">of</span> <span class="type-var">'b</span>
+          * <span class="type-var">'b</span>
+        </span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>'b poly_ext</p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-Quux"
-     class="anchored"><a href="#extension-decl-Quux" class="anchor"></a>
+    <div class="spec type extension anchored" id="extension-decl-Quux">
+     <a href="#extension-decl-Quux" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
        <a href="#type-poly_ext">poly_ext</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-Quux" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Quux" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="extension">Quux</span> 
-          <span class="keyword">of</span> <span class="type-var">'c</span>
-         </span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="extension-Quux" class="def extension anchored">
+       <a href="#extension-Quux" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="extension">Quux</span> 
+         <span class="keyword">of</span> <span class="type-var">'c</span>
+        </span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>'c poly_ext</p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-ExtMod" class="anchored">
+    <div class="spec module anchored" id="module-ExtMod">
      <a href="#module-ExtMod" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2035,56 +1929,52 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-ZzzTop0"
-     class="anchored"><a href="#extension-decl-ZzzTop0" class="anchor"></a>
+    <div class="spec type extension anchored" id="extension-decl-ZzzTop0">
+     <a href="#extension-decl-ZzzTop0" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
        <a href="Ocamlary-ExtMod.html#type-t">ExtMod.t</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-ZzzTop0" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ZzzTop0" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="extension">ZzzTop0</span></span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="extension-ZzzTop0" class="def extension anchored">
+       <a href="#extension-ZzzTop0" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="extension">ZzzTop0</span></span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>It's got the rock</p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-ZzzTop"
-     class="anchored"><a href="#extension-decl-ZzzTop" class="anchor"></a>
+    <div class="spec type extension anchored" id="extension-decl-ZzzTop">
+     <a href="#extension-decl-ZzzTop" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
        <a href="Ocamlary-ExtMod.html#type-t">ExtMod.t</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-ZzzTop" class="anchored">
-       <td class="def extension">
-        <a href="#extension-ZzzTop" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="extension">ZzzTop</span> 
-          <span class="keyword">of</span> unit
-         </span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="extension-ZzzTop" class="def extension anchored">
+       <a href="#extension-ZzzTop" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="extension">ZzzTop</span> 
+         <span class="keyword">of</span> unit
+        </span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>and it packs a unit.</p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value external" id="val-launch_missiles"
-     class="anchored"><a href="#val-launch_missiles" class="anchor"></a>
+    <div class="spec value external anchored" id="val-launch_missiles">
+     <a href="#val-launch_missiles" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> launch_missiles : 
        <span>unit <span class="arrow">&#45;&gt;</span></span> unit
@@ -2093,7 +1983,7 @@
     </div><div class="spec-doc"><p>Rotate keys on my mark...</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-my_mod" class="anchored">
+    <div class="spec type anchored" id="type-my_mod">
      <a href="#type-my_mod" class="anchor"></a>
      <code><span><span class="keyword">type</span> my_mod</span>
       <span> = 
@@ -2108,7 +1998,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-empty_class" class="anchored">
+    <div class="spec class anchored" id="class-empty_class">
      <a href="#class-empty_class" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Ocamlary-class-empty_class.html">empty_class</a></span>
@@ -2119,7 +2009,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-one_method_class" class="anchored">
+    <div class="spec class anchored" id="class-one_method_class">
      <a href="#class-one_method_class" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span>
@@ -2132,7 +2022,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-two_method_class" class="anchored">
+    <div class="spec class anchored" id="class-two_method_class">
      <a href="#class-two_method_class" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span>
@@ -2145,7 +2035,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-param_class" class="anchored">
+    <div class="spec class anchored" id="class-param_class">
      <a href="#class-param_class" class="anchor"></a>
      <code><span><span class="keyword">class</span> 'a </span>
       <span><a href="Ocamlary-class-param_class.html">param_class</a></span>
@@ -2159,7 +2049,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-my_unit_object" class="anchored">
+    <div class="spec type anchored" id="type-my_unit_object">
      <a href="#type-my_unit_object" class="anchor"></a>
      <code><span><span class="keyword">type</span> my_unit_object</span>
       <span> = 
@@ -2170,7 +2060,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-my_unit_class" class="anchored">
+    <div class="spec type anchored" id="type-my_unit_class">
      <a href="#type-my_unit_class" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a my_unit_class</span>
@@ -2183,7 +2073,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep1" class="anchored">
+    <div class="spec module anchored" id="module-Dep1">
      <a href="#module-Dep1" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2196,7 +2086,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep2" class="anchored">
+    <div class="spec module anchored" id="module-Dep2">
      <a href="#module-Dep2" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2211,7 +2101,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-dep1" class="anchored">
+    <div class="spec type anchored" id="type-dep1">
      <a href="#type-dep1" class="anchor"></a>
      <code><span><span class="keyword">type</span> dep1</span>
       <span> = 
@@ -2221,7 +2111,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep3" class="anchored">
+    <div class="spec module anchored" id="module-Dep3">
      <a href="#module-Dep3" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2234,7 +2124,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep4" class="anchored">
+    <div class="spec module anchored" id="module-Dep4">
      <a href="#module-Dep4" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2247,7 +2137,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep5" class="anchored">
+    <div class="spec module anchored" id="module-Dep5">
      <a href="#module-Dep5" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2262,7 +2152,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-dep2" class="anchored">
+    <div class="spec type anchored" id="type-dep2">
      <a href="#type-dep2" class="anchor"></a>
      <code><span><span class="keyword">type</span> dep2</span>
       <span> = 
@@ -2272,7 +2162,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-dep3" class="anchored">
+    <div class="spec type anchored" id="type-dep3">
      <a href="#type-dep3" class="anchor"></a>
      <code><span><span class="keyword">type</span> dep3</span>
       <span> = <a href="Ocamlary-Dep3.html#type-a">Dep5(Dep4).Z.Y.a</a>
@@ -2281,7 +2171,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep6" class="anchored">
+    <div class="spec module anchored" id="module-Dep6">
      <a href="#module-Dep6" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2294,7 +2184,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep7" class="anchored">
+    <div class="spec module anchored" id="module-Dep7">
      <a href="#module-Dep7" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2309,7 +2199,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-dep4" class="anchored">
+    <div class="spec type anchored" id="type-dep4">
      <a href="#type-dep4" class="anchor"></a>
      <code><span><span class="keyword">type</span> dep4</span>
       <span> = 
@@ -2320,7 +2210,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep8" class="anchored">
+    <div class="spec module anchored" id="module-Dep8">
      <a href="#module-Dep8" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2333,7 +2223,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep9" class="anchored">
+    <div class="spec module anchored" id="module-Dep9">
      <a href="#module-Dep9" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2348,7 +2238,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Dep10" class="anchored">
+    <div class="spec module-type anchored" id="module-type-Dep10">
      <a href="#module-type-Dep10" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2365,7 +2255,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep11" class="anchored">
+    <div class="spec module anchored" id="module-Dep11">
      <a href="#module-Dep11" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2378,7 +2268,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep12" class="anchored">
+    <div class="spec module anchored" id="module-Dep12">
      <a href="#module-Dep12" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2393,7 +2283,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Dep13" class="anchored">
+    <div class="spec module anchored" id="module-Dep13">
      <a href="#module-Dep13" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2405,7 +2295,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-dep5" class="anchored">
+    <div class="spec type anchored" id="type-dep5">
      <a href="#type-dep5" class="anchor"></a>
      <code><span><span class="keyword">type</span> dep5</span>
       <span> = <a href="Ocamlary-Dep13-class-c.html">Dep13.c</a></span>
@@ -2413,7 +2303,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-With1" class="anchored">
+    <div class="spec module-type anchored" id="module-type-With1">
      <a href="#module-type-With1" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2427,7 +2317,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-With2" class="anchored">
+    <div class="spec module anchored" id="module-With2">
      <a href="#module-With2" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2440,7 +2330,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-With3" class="anchored">
+    <div class="spec module anchored" id="module-With3">
      <a href="#module-With3" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2457,7 +2347,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-with1" class="anchored">
+    <div class="spec type anchored" id="type-with1">
      <a href="#type-with1" class="anchor"></a>
      <code><span><span class="keyword">type</span> with1</span>
       <span> = <a href="Ocamlary-With3-N.html#type-t">With3.N.t</a></span>
@@ -2465,7 +2355,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-With4" class="anchored">
+    <div class="spec module anchored" id="module-With4">
      <a href="#module-With4" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2482,7 +2372,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-with2" class="anchored">
+    <div class="spec type anchored" id="type-with2">
      <a href="#type-with2" class="anchor"></a>
      <code><span><span class="keyword">type</span> with2</span>
       <span> = <a href="Ocamlary-With4-N.html#type-t">With4.N.t</a></span>
@@ -2490,7 +2380,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-With5" class="anchored">
+    <div class="spec module anchored" id="module-With5">
      <a href="#module-With5" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2503,7 +2393,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-With6" class="anchored">
+    <div class="spec module anchored" id="module-With6">
      <a href="#module-With6" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2516,7 +2406,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-With7" class="anchored">
+    <div class="spec module anchored" id="module-With7">
      <a href="#module-With7" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2531,7 +2421,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-With8" class="anchored">
+    <div class="spec module-type anchored" id="module-type-With8">
      <a href="#module-type-With8" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2555,7 +2445,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-With9" class="anchored">
+    <div class="spec module anchored" id="module-With9">
      <a href="#module-With9" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2568,7 +2458,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-With10" class="anchored">
+    <div class="spec module anchored" id="module-With10">
      <a href="#module-With10" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2581,7 +2471,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-With11" class="anchored">
+    <div class="spec module-type anchored" id="module-type-With11">
      <a href="#module-type-With11" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2604,8 +2494,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-NestedInclude1"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-NestedInclude1">
      <a href="#module-type-NestedInclude1" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2628,8 +2517,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec module-type" id="module-type-NestedInclude2"
-       class="anchored">
+      <div class="spec module-type anchored" id="module-type-NestedInclude2">
        <a href="#module-type-NestedInclude2" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> 
@@ -2662,7 +2550,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec type" id="type-nested_include" class="anchored">
+      <div class="spec type anchored" id="type-nested_include">
        <a href="#type-nested_include" class="anchor"></a>
        <code><span><span class="keyword">type</span> nested_include</span>
         <span> = int</span>
@@ -2672,7 +2560,7 @@
     </details>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-DoubleInclude1" class="anchored">
+    <div class="spec module anchored" id="module-DoubleInclude1">
      <a href="#module-DoubleInclude1" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2685,7 +2573,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-DoubleInclude3" class="anchored">
+    <div class="spec module anchored" id="module-DoubleInclude3">
      <a href="#module-DoubleInclude3" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2711,7 +2599,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec type" id="type-double_include" class="anchored">
+      <div class="spec type anchored" id="type-double_include">
        <a href="#type-double_include" class="anchor"></a>
        <code><span><span class="keyword">type</span> double_include</span>
        </code>
@@ -2720,7 +2608,7 @@
     </details>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-IncludeInclude1" class="anchored">
+    <div class="spec module anchored" id="module-IncludeInclude1">
      <a href="#module-IncludeInclude1" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2744,8 +2632,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec module-type" id="module-type-IncludeInclude2"
-       class="anchored">
+      <div class="spec module-type anchored" id="module-type-IncludeInclude2">
        <a href="#module-type-IncludeInclude2" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> 
@@ -2760,7 +2647,7 @@
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-IncludeInclude2_M" class="anchored">
+      <div class="spec module anchored" id="module-IncludeInclude2_M">
        <a href="#module-IncludeInclude2_M" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> 
@@ -2785,7 +2672,7 @@
       </code>
      </summary>
      <div class="odoc-spec">
-      <div class="spec type" id="type-include_include" class="anchored">
+      <div class="spec type anchored" id="type-include_include">
        <a href="#type-include_include" class="anchor"></a>
        <code><span><span class="keyword">type</span> include_include</span>
        </code>
@@ -2832,7 +2719,7 @@
      with @canonical paths
    </h2>
    <div class="odoc-spec">
-    <div class="spec module" id="module-CanonicalTest" class="anchored">
+    <div class="spec module anchored" id="module-CanonicalTest">
      <a href="#module-CanonicalTest" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2860,7 +2747,7 @@
    </p>
    <h2 id="aliases"><a href="#aliases" class="anchor"></a>Aliases again</h2>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Aliases" class="anchored">
+    <div class="spec module anchored" id="module-Aliases">
      <a href="#module-Aliases" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2910,7 +2797,7 @@
     syntax
    </h2>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-M" class="anchored">
+    <div class="spec module-type anchored" id="module-type-M">
      <a href="#module-type-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2924,7 +2811,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2945,7 +2832,7 @@
     </li>
    </ul>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Only_a_module" class="anchored">
+    <div class="spec module anchored" id="module-Only_a_module">
      <a href="#module-Only_a_module" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2980,7 +2867,7 @@
     </li>
    </ul>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-TypeExt" class="anchored">
+    <div class="spec module-type anchored" id="module-type-TypeExt">
      <a href="#module-type-TypeExt" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -2994,7 +2881,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-new_t" class="anchored">
+    <div class="spec type anchored" id="type-new_t">
      <a href="#type-new_t" class="anchor"></a>
      <code><span><span class="keyword">type</span> new_t</span>
       <span> = </span><span>..</span>
@@ -3002,26 +2889,24 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-C" class="anchored">
+    <div class="spec type extension anchored" id="extension-decl-C">
      <a href="#extension-decl-C" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <a href="#type-new_t">new_t</a>
         += 
       </span>
      </code>
-     <table>
-      <tr id="extension-C" class="anchored">
-       <td class="def extension"><a href="#extension-C" class="anchor"></a>
-        <code><span>| </span><span><span class="extension">C</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="extension-C" class="def extension anchored">
+       <a href="#extension-C" class="anchor"></a>
+       <code><span>| </span><span><span class="extension">C</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-TypeExtPruned"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-TypeExtPruned">
      <a href="#module-type-TypeExtPruned" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Recent-X.html
+++ b/test/generators/html/Recent-X.html
@@ -15,7 +15,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-substitution" id="module-L" class="anchored">
+    <div class="spec module-substitution anchored" id="module-L">
      <a href="#module-L" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> L := 
@@ -25,7 +25,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span>
       <span> = 
@@ -35,7 +35,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type subst" id="type-u" class="anchored">
+    <div class="spec type subst anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span>
       <span> := int</span>
@@ -43,7 +43,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-v" class="anchored">
+    <div class="spec type anchored" id="type-v">
      <a href="#type-v" class="anchor"></a>
      <code><span><span class="keyword">type</span> v</span>
       <span> = 

--- a/test/generators/html/Recent-Z-Y-X.html
+++ b/test/generators/html/Recent-Z-Y-X.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a t</span></span>
      </code>

--- a/test/generators/html/Recent-Z-Y.html
+++ b/test/generators/html/Recent-Z-Y.html
@@ -15,7 +15,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Recent-Z.html
+++ b/test/generators/html/Recent-Z.html
@@ -15,7 +15,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Y" class="anchored">
+    <div class="spec module anchored" id="module-Y">
      <a href="#module-Y" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Recent-module-type-PolyS.html
+++ b/test/generators/html/Recent-module-type-PolyS.html
@@ -16,23 +16,21 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span><span> = </span>
       <span>[ </span>
      </code>
-     <table>
-      <tr id="type-t.A" class="anchored">
-       <td class="def constructor"><a href="#type-t.A" class="anchor"></a>
-        <code><span>| </span></code><code><span>`A</span></code>
-       </td>
-      </tr>
-      <tr id="type-t.B" class="anchored">
-       <td class="def constructor"><a href="#type-t.B" class="anchor"></a>
-        <code><span>| </span></code><code><span>`B</span></code>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+     <ol>
+      <li id="type-t.A" class="def constructor anchored">
+       <a href="#type-t.A" class="anchor"></a><code><span>| </span></code>
+       <code><span>`A</span></code>
+      </li>
+      <li id="type-t.B" class="def constructor anchored">
+       <a href="#type-t.B" class="anchor"></a><code><span>| </span></code>
+       <code><span>`B</span></code>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent-module-type-S1.html
+++ b/test/generators/html/Recent-module-type-S1.html
@@ -22,7 +22,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-_" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-_">
      <a href="#argument-1-_" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Recent-module-type-S1-argument-1-_.html">_</a></span>

--- a/test/generators/html/Recent.html
+++ b/test/generators/html/Recent.html
@@ -12,7 +12,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -26,7 +26,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S1" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S1">
      <a href="#module-type-S1" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -43,168 +43,140 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-variant" class="anchored">
+    <div class="spec type anchored" id="type-variant">
      <a href="#type-variant" class="anchor"></a>
      <code><span><span class="keyword">type</span> variant</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-variant.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.A" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">A</span></span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-variant.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.B" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">B</span> 
-          <span class="keyword">of</span> int
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-variant.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.C" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">C</span></span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
+     <ol>
+      <li id="type-variant.A" class="def variant constructor anchored">
+       <a href="#type-variant.A" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">A</span></span>
+       </code>
+      </li>
+      <li id="type-variant.B" class="def variant constructor anchored">
+       <a href="#type-variant.B" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">B</span> 
+         <span class="keyword">of</span> int
+        </span>
+       </code>
+      </li>
+      <li id="type-variant.C" class="def variant constructor anchored">
+       <a href="#type-variant.C" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">C</span></span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-variant.D" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.D" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">D</span></span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+       </div>
+      </li>
+      <li id="type-variant.D" class="def variant constructor anchored">
+       <a href="#type-variant.D" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">D</span></span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p><em>bar</em></p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-variant.E" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.E" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">E</span> 
-          <span class="keyword">of</span> 
-         </span><span>{</span>
-        </code>
-        <table>
-         <tr id="type-variant.a" class="anchored">
-          <td class="def record field">
-           <a href="#type-variant.a" class="anchor"></a>
-           <code><span>a : int;</span></code>
-          </td>
-         </tr>
-        </table><code><span>}</span></code>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+      <li id="type-variant.E" class="def variant constructor anchored">
+       <a href="#type-variant.E" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">E</span> 
+         <span class="keyword">of</span> 
+        </span><span>{</span>
+       </code>
+       <ol>
+        <li id="type-variant.a" class="def record field anchored">
+         <a href="#type-variant.a" class="anchor"></a>
+         <code><span>a : int;</span></code>
+        </li>
+       </ol><code><span>}</span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-gadt" class="anchored">
+    <div class="spec type anchored" id="type-gadt">
      <a href="#type-gadt" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>_ gadt</span></span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-gadt.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.A" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">A</span> : 
-          <span>int <a href="#type-gadt">gadt</a></span>
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-gadt.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.B" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">B</span> : int 
-          <span class="arrow">&#45;&gt;</span> 
-          <span>string <a href="#type-gadt">gadt</a></span>
-         </span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
+     <ol>
+      <li id="type-gadt.A" class="def variant constructor anchored">
+       <a href="#type-gadt.A" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">A</span> : 
+         <span>int <a href="#type-gadt">gadt</a></span>
+        </span>
+       </code>
+      </li>
+      <li id="type-gadt.B" class="def variant constructor anchored">
+       <a href="#type-gadt.B" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">B</span> : int 
+         <span class="arrow">&#45;&gt;</span> 
+         <span>string <a href="#type-gadt">gadt</a></span>
+        </span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-gadt.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.C" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">C</span> : </span><span>{</span>
-        </code>
-        <table>
-         <tr id="type-gadt.a" class="anchored">
-          <td class="def record field">
-           <a href="#type-gadt.a" class="anchor"></a>
-           <code><span>a : int;</span></code>
-          </td>
-         </tr>
-        </table>
-        <code><span>}</span>
-         <span> <span class="arrow">&#45;&gt;</span> 
-          <span>unit <a href="#type-gadt">gadt</a></span>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+      <li id="type-gadt.C" class="def variant constructor anchored">
+       <a href="#type-gadt.C" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">C</span> : </span><span>{</span>
+       </code>
+       <ol>
+        <li id="type-gadt.a" class="def record field anchored">
+         <a href="#type-gadt.a" class="anchor"></a>
+         <code><span>a : int;</span></code>
+        </li>
+       </ol>
+       <code><span>}</span>
+        <span> <span class="arrow">&#45;&gt;</span> 
+         <span>unit <a href="#type-gadt">gadt</a></span>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-polymorphic_variant" class="anchored">
+    <div class="spec type anchored" id="type-polymorphic_variant">
      <a href="#type-polymorphic_variant" class="anchor"></a>
      <code><span><span class="keyword">type</span> polymorphic_variant</span>
       <span> = </span><span>[ </span>
      </code>
-     <table>
-      <tr id="type-polymorphic_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.A" class="anchor"></a>
-        <code><span>| </span></code><code><span>`A</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.B" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.B" class="anchor"></a>
-        <code><span>| </span></code>
-        <code><span>`B <span class="keyword">of</span> int</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.C" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.C" class="anchor"></a>
-        <code><span>| </span></code><code><span>`C</span></code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
+     <ol>
+      <li id="type-polymorphic_variant.A" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.A" class="anchor"></a>
+       <code><span>| </span></code><code><span>`A</span></code>
+      </li>
+      <li id="type-polymorphic_variant.B" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.B" class="anchor"></a>
+       <code><span>| </span></code>
+       <code><span>`B <span class="keyword">of</span> int</span></code>
+      </li>
+      <li id="type-polymorphic_variant.C" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.C" class="anchor"></a>
+       <code><span>| </span></code><code><span>`C</span></code>
+       <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.D" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.D" class="anchor"></a>
-        <code><span>| </span></code><code><span>`D</span></code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span><p>bar</p>
+       </div>
+      </li>
+      <li id="type-polymorphic_variant.D" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.D" class="anchor"></a>
+       <code><span>| </span></code><code><span>`D</span></code>
+       <div class="def-doc"><span class="comment-delim">(*</span><p>bar</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+       </div>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-empty_variant" class="anchored">
+    <div class="spec type anchored" id="type-empty_variant">
      <a href="#type-empty_variant" class="anchor"></a>
      <code><span><span class="keyword">type</span> empty_variant</span>
       <span> = </span><span>|</span>
@@ -212,7 +184,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-nonrec_" class="anchored">
+    <div class="spec type anchored" id="type-nonrec_">
      <a href="#type-nonrec_" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -222,57 +194,53 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-empty_conj" class="anchored">
+    <div class="spec type anchored" id="type-empty_conj">
      <a href="#type-empty_conj" class="anchor"></a>
      <code><span><span class="keyword">type</span> empty_conj</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-empty_conj.X" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-empty_conj.X" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">X</span> : 
-          <span>[&lt; 
-           <span>`X of &amp; <span class="type-var">'a</span> &amp; int
-             * float
-           </span> ]
-          </span> <span class="arrow">&#45;&gt;</span> 
-          <a href="#type-empty_conj">empty_conj</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-empty_conj.X" class="def variant constructor anchored">
+       <a href="#type-empty_conj.X" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">X</span> : 
+         <span>[&lt; 
+          <span>`X of &amp; <span class="type-var">'a</span> &amp; int
+            * float
+          </span> ]
+         </span> <span class="arrow">&#45;&gt;</span> 
+         <a href="#type-empty_conj">empty_conj</a>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-conj" class="anchored">
+    <div class="spec type anchored" id="type-conj">
      <a href="#type-conj" class="anchor"></a>
      <code><span><span class="keyword">type</span> conj</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-conj.X" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-conj.X" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">X</span> : 
-          <span>[&lt; 
-           <span>`X of int &amp; 
-            <span>[&lt; <span>`B of int &amp; float</span> ]</span>
-           </span> ]
-          </span> <span class="arrow">&#45;&gt;</span> 
-          <a href="#type-conj">conj</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-conj.X" class="def variant constructor anchored">
+       <a href="#type-conj.X" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">X</span> : 
+         <span>[&lt; 
+          <span>`X of int &amp; 
+           <span>[&lt; <span>`B of int &amp; float</span> ]</span>
+          </span> ]
+         </span> <span class="arrow">&#45;&gt;</span> 
+         <a href="#type-conj">conj</a>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-empty_conj" class="anchored">
+    <div class="spec value anchored" id="val-empty_conj">
      <a href="#val-empty_conj" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> empty_conj : 
@@ -285,7 +253,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-conj" class="anchored">
+    <div class="spec value anchored" id="val-conj">
      <a href="#val-conj" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> conj : 
@@ -299,7 +267,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Z" class="anchored">
+    <div class="spec module anchored" id="module-Z">
      <a href="#module-Z" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Recent-Z.html">Z</a>
@@ -311,7 +279,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Recent-X.html">X</a>
@@ -323,7 +291,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-PolyS" class="anchored">
+    <div class="spec module-type anchored" id="module-type-PolyS">
      <a href="#module-type-PolyS" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Recent_impl-B.html
+++ b/test/generators/html/Recent_impl-B.html
@@ -16,19 +16,17 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span><span> = </span>
      </code>
-     <table>
-      <tr id="type-t.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-t.B" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">B</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-t.B" class="def variant constructor anchored">
+       <a href="#type-t.B" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">B</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent_impl-Foo-A.html
+++ b/test/generators/html/Recent_impl-Foo-A.html
@@ -17,19 +17,17 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span><span> = </span>
      </code>
-     <table>
-      <tr id="type-t.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-t.A" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">A</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-t.A" class="def variant constructor anchored">
+       <a href="#type-t.A" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">A</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent_impl-Foo-B.html
+++ b/test/generators/html/Recent_impl-Foo-B.html
@@ -17,19 +17,17 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span><span> = </span>
      </code>
-     <table>
-      <tr id="type-t.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-t.B" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">B</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-t.B" class="def variant constructor anchored">
+       <a href="#type-t.B" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">B</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent_impl-Foo.html
+++ b/test/generators/html/Recent_impl-Foo.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-A" class="anchored">
+    <div class="spec module anchored" id="module-A">
      <a href="#module-A" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -29,7 +29,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-B" class="anchored">
+    <div class="spec module anchored" id="module-B">
      <a href="#module-B" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Recent_impl-module-type-S-F.html
+++ b/test/generators/html/Recent_impl-module-type-S-F.html
@@ -23,7 +23,7 @@
    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
    </h2>
    <div class="odoc-spec">
-    <div class="spec parameter" id="argument-1-_" class="anchored">
+    <div class="spec parameter anchored" id="argument-1-_">
      <a href="#argument-1-_" class="anchor"></a>
      <code><span><span class="keyword">module</span> </span>
       <span><a href="Recent_impl-module-type-S-F-argument-1-_.html">_</a>
@@ -36,7 +36,7 @@
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Recent_impl-module-type-S.html
+++ b/test/generators/html/Recent_impl-module-type-S.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-F" class="anchored">
+    <div class="spec module anchored" id="module-F">
      <a href="#module-F" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -31,7 +31,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-X" class="anchored">
+    <div class="spec module anchored" id="module-X">
      <a href="#module-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -44,7 +44,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-f" class="anchored">
+    <div class="spec value anchored" id="val-f">
      <a href="#val-f" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> f : 

--- a/test/generators/html/Recent_impl.html
+++ b/test/generators/html/Recent_impl.html
@@ -13,7 +13,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Foo" class="anchored">
+    <div class="spec module anchored" id="module-Foo">
      <a href="#module-Foo" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -26,7 +26,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-B" class="anchored">
+    <div class="spec module anchored" id="module-B">
      <a href="#module-B" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -39,13 +39,13 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-S" class="anchored">
+    <div class="spec module-type anchored" id="module-type-S">
      <a href="#module-type-S" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -59,7 +59,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-B'" class="anchored">
+    <div class="spec module anchored" id="module-B'">
      <a href="#module-B'" class="anchor"></a>
      <code><span><span class="keyword">module</span> B'</span>
       <span> = <a href="Recent_impl-Foo-B.html">Foo.B</a></span>

--- a/test/generators/html/Section.html
+++ b/test/generators/html/Section.html
@@ -46,7 +46,7 @@
    <h2 id="value-only"><a href="#value-only" class="anchor"></a>Value only
    </h2>
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo" class="anchored">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a>
      <code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>

--- a/test/generators/html/Stop-N.html
+++ b/test/generators/html/Stop-N.html
@@ -15,7 +15,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value" id="val-quux" class="anchored">
+    <div class="spec value anchored" id="val-quux">
      <a href="#val-quux" class="anchor"></a>
      <code><span><span class="keyword">val</span> quux : int</span></code>
     </div>

--- a/test/generators/html/Stop.html
+++ b/test/generators/html/Stop.html
@@ -13,7 +13,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value" id="val-foo" class="anchored">
+    <div class="spec value anchored" id="val-foo">
      <a href="#val-foo" class="anchor"></a>
      <code><span><span class="keyword">val</span> foo : int</span></code>
     </div><div class="spec-doc"><p>This is normal commented text.</p></div>
@@ -30,7 +30,7 @@
      only in that module, and not in this outer module.
    </p>
    <div class="odoc-spec">
-    <div class="spec module" id="module-N" class="anchored">
+    <div class="spec module anchored" id="module-N">
      <a href="#module-N" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Stop-N.html">N</a>
@@ -42,7 +42,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-lol" class="anchored">
+    <div class="spec value anchored" id="val-lol">
      <a href="#val-lol" class="anchor"></a>
      <code><span><span class="keyword">val</span> lol : int</span></code>
     </div>

--- a/test/generators/html/Stop_dead_link_doc-Foo.html
+++ b/test/generators/html/Stop_dead_link_doc-Foo.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Stop_dead_link_doc.html
+++ b/test/generators/html/Stop_dead_link_doc.html
@@ -13,7 +13,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-Foo" class="anchored">
+    <div class="spec module anchored" id="module-Foo">
      <a href="#module-Foo" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -26,119 +26,109 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-foo" class="anchored">
+    <div class="spec type anchored" id="type-foo">
      <a href="#type-foo" class="anchor"></a>
      <code><span><span class="keyword">type</span> foo</span><span> = </span>
      </code>
-     <table>
-      <tr id="type-foo.Bar" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-foo.Bar" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">Bar</span> 
-          <span class="keyword">of</span> 
-          <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-foo.Bar" class="def variant constructor anchored">
+       <a href="#type-foo.Bar" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">Bar</span> 
+         <span class="keyword">of</span> 
+         <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-bar" class="anchored">
+    <div class="spec type anchored" id="type-bar">
      <a href="#type-bar" class="anchor"></a>
      <code><span><span class="keyword">type</span> bar</span><span> = </span>
      </code>
-     <table>
-      <tr id="type-bar.Bar" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-bar.Bar" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">Bar</span> 
-          <span class="keyword">of</span> 
-         </span><span>{</span>
-        </code>
-        <table>
-         <tr id="type-bar.field" class="anchored">
-          <td class="def record field">
-           <a href="#type-bar.field" class="anchor"></a>
-           <code>
-            <span>field : 
-             <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a>;
-            </span>
-           </code>
-          </td>
-         </tr>
-        </table><code><span>}</span></code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-bar.Bar" class="def variant constructor anchored">
+       <a href="#type-bar.Bar" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">Bar</span> 
+         <span class="keyword">of</span> 
+        </span><span>{</span>
+       </code>
+       <ol>
+        <li id="type-bar.field" class="def record field anchored">
+         <a href="#type-bar.field" class="anchor"></a>
+         <code>
+          <span>field : 
+           <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a>;
+          </span>
+         </code>
+        </li>
+       </ol><code><span>}</span></code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-foo_" class="anchored">
+    <div class="spec type anchored" id="type-foo_">
      <a href="#type-foo_" class="anchor"></a>
      <code><span><span class="keyword">type</span> foo_</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-foo_.Bar_" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-foo_.Bar_" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">Bar_</span> 
-          <span class="keyword">of</span> int * 
-          <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a> * int
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-foo_.Bar_" class="def variant constructor anchored">
+       <a href="#type-foo_.Bar_" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">Bar_</span> 
+         <span class="keyword">of</span> int * 
+         <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a> * int
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-bar_" class="anchored">
+    <div class="spec type anchored" id="type-bar_">
      <a href="#type-bar_" class="anchor"></a>
      <code><span><span class="keyword">type</span> bar_</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-bar_.Bar__" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-bar_.Bar__" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">Bar__</span> 
-          <span class="keyword">of</span> 
-          <span><a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a> option
-          </span>
+     <ol>
+      <li id="type-bar_.Bar__" class="def variant constructor anchored">
+       <a href="#type-bar_.Bar__" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">Bar__</span> 
+         <span class="keyword">of</span> 
+         <span><a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a> option
          </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-another_foo" class="anchored">
+    <div class="spec type anchored" id="type-another_foo">
      <a href="#type-another_foo" class="anchor"></a>
      <code><span><span class="keyword">type</span> another_foo</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-another_bar" class="anchored">
+    <div class="spec type anchored" id="type-another_bar">
      <a href="#type-another_bar" class="anchor"></a>
      <code><span><span class="keyword">type</span> another_bar</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-another_foo_" class="anchored">
+    <div class="spec type anchored" id="type-another_foo_">
      <a href="#type-another_foo_" class="anchor"></a>
      <code><span><span class="keyword">type</span> another_foo_</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-another_bar_" class="anchored">
+    <div class="spec type anchored" id="type-another_bar_">
      <a href="#type-another_bar_" class="anchor"></a>
      <code><span><span class="keyword">type</span> another_bar_</span></code>
     </div>

--- a/test/generators/html/Toplevel_comments-Alias.html
+++ b/test/generators/html/Toplevel_comments-Alias.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Toplevel_comments-Comments_on_open-M.html
+++ b/test/generators/html/Toplevel_comments-Comments_on_open-M.html
@@ -19,7 +19,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Toplevel_comments-Comments_on_open.html
+++ b/test/generators/html/Toplevel_comments-Comments_on_open.html
@@ -19,7 +19,7 @@
   <nav class="odoc-toc"><ul><li><a href="#sec">Section</a></li></ul></nav>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Toplevel_comments-Include_inline'.html
+++ b/test/generators/html/Toplevel_comments-Include_inline'.html
@@ -20,7 +20,7 @@
   <div class="odoc-content">
    <div class="odoc-include"><div class="spec-doc"><p>part 3</p></div>
     <div class="odoc-spec">
-     <div class="spec type" id="type-t" class="anchored">
+     <div class="spec type anchored" id="type-t">
       <a href="#type-t" class="anchor"></a>
       <code><span><span class="keyword">type</span> t</span></code>
      </div>

--- a/test/generators/html/Toplevel_comments-Include_inline.html
+++ b/test/generators/html/Toplevel_comments-Include_inline.html
@@ -19,7 +19,7 @@
   <div class="odoc-content">
    <div class="odoc-include">
     <div class="odoc-spec">
-     <div class="spec type" id="type-t" class="anchored">
+     <div class="spec type anchored" id="type-t">
       <a href="#type-t" class="anchor"></a>
       <code><span><span class="keyword">type</span> t</span></code>
      </div>

--- a/test/generators/html/Toplevel_comments-Ref_in_synopsis.html
+++ b/test/generators/html/Toplevel_comments-Ref_in_synopsis.html
@@ -21,7 +21,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Toplevel_comments-module-type-Include_inline_T'.html
+++ b/test/generators/html/Toplevel_comments-module-type-Include_inline_T'.html
@@ -21,7 +21,7 @@
   <div class="odoc-content">
    <div class="odoc-include"><div class="spec-doc"><p>part 3</p></div>
     <div class="odoc-spec">
-     <div class="spec type" id="type-t" class="anchored">
+     <div class="spec type anchored" id="type-t">
       <a href="#type-t" class="anchor"></a>
       <code><span><span class="keyword">type</span> t</span></code>
      </div>

--- a/test/generators/html/Toplevel_comments-module-type-Include_inline_T.html
+++ b/test/generators/html/Toplevel_comments-module-type-Include_inline_T.html
@@ -20,7 +20,7 @@
   <div class="odoc-content">
    <div class="odoc-include">
     <div class="odoc-spec">
-     <div class="spec type" id="type-t" class="anchored">
+     <div class="spec type anchored" id="type-t">
       <a href="#type-t" class="anchor"></a>
       <code><span><span class="keyword">type</span> t</span></code>
      </div>

--- a/test/generators/html/Toplevel_comments-module-type-T.html
+++ b/test/generators/html/Toplevel_comments-module-type-T.html
@@ -17,7 +17,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>

--- a/test/generators/html/Toplevel_comments.html
+++ b/test/generators/html/Toplevel_comments.html
@@ -16,7 +16,7 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-T" class="anchored">
+    <div class="spec module-type anchored" id="module-type-T">
      <a href="#module-type-T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -30,7 +30,7 @@
     </div><div class="spec-doc"><p>Doc of <code>T</code>, part 1.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Include_inline" class="anchored">
+    <div class="spec module anchored" id="module-Include_inline">
      <a href="#module-Include_inline" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -43,7 +43,7 @@
     </div><div class="spec-doc"><p>Doc of <code>T</code>, part 2.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Include_inline'" class="anchored">
+    <div class="spec module anchored" id="module-Include_inline'">
      <a href="#module-Include_inline'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -58,8 +58,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Include_inline_T"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-Include_inline_T">
      <a href="#module-type-Include_inline_T" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -75,8 +74,7 @@
     </div><div class="spec-doc"><p>Doc of <code>T</code>, part 2.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-Include_inline_T'"
-     class="anchored">
+    <div class="spec module-type anchored" id="module-type-Include_inline_T'">
      <a href="#module-type-Include_inline_T'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -95,7 +93,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M" class="anchored">
+    <div class="spec module anchored" id="module-M">
      <a href="#module-M" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -108,7 +106,7 @@
     </div><div class="spec-doc"><p>Doc of <code>M</code></p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M'" class="anchored">
+    <div class="spec module anchored" id="module-M'">
      <a href="#module-M'" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -122,7 +120,7 @@
     <div class="spec-doc"><p>Doc of <code>M'</code> from outside</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-M''" class="anchored">
+    <div class="spec module anchored" id="module-M''">
      <a href="#module-M''" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -135,7 +133,7 @@
     </div><div class="spec-doc"><p>Doc of <code>M''</code>, part 1.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Alias" class="anchored">
+    <div class="spec module anchored" id="module-Alias">
      <a href="#module-Alias" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -146,7 +144,7 @@
     </div><div class="spec-doc"><p>Doc of <code>Alias</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-c1" class="anchored">
+    <div class="spec class anchored" id="class-c1">
      <a href="#class-c1" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Toplevel_comments-class-c1.html">c1</a></span>
@@ -158,7 +156,7 @@
     </div><div class="spec-doc"><p>Doc of <code>c1</code>, part 1.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class-type" id="class-type-ct" class="anchored">
+    <div class="spec class-type anchored" id="class-type-ct">
      <a href="#class-type-ct" class="anchor"></a>
      <code>
       <span><span class="keyword">class</span> 
@@ -172,7 +170,7 @@
     </div><div class="spec-doc"><p>Doc of <code>ct</code>, part 1.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec class" id="class-c2" class="anchored">
+    <div class="spec class anchored" id="class-c2">
      <a href="#class-c2" class="anchor"></a>
      <code><span><span class="keyword">class</span>  </span>
       <span><a href="Toplevel_comments-class-c2.html">c2</a></span>
@@ -181,7 +179,7 @@
     </div><div class="spec-doc"><p>Doc of <code>c2</code>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Ref_in_synopsis" class="anchored">
+    <div class="spec module anchored" id="module-Ref_in_synopsis">
      <a href="#module-Ref_in_synopsis" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -200,7 +198,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module" id="module-Comments_on_open" class="anchored">
+    <div class="spec module anchored" id="module-Comments_on_open">
      <a href="#module-Comments_on_open" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 

--- a/test/generators/html/Type-module-type-X.html
+++ b/test/generators/html/Type-module-type-X.html
@@ -15,13 +15,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-t" class="anchored">
+    <div class="spec type anchored" id="type-t">
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-u" class="anchored">
+    <div class="spec type anchored" id="type-u">
      <a href="#type-u" class="anchor"></a>
      <code><span><span class="keyword">type</span> u</span></code>
     </div>

--- a/test/generators/html/Type.html
+++ b/test/generators/html/Type.html
@@ -12,13 +12,13 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec type" id="type-abstract" class="anchored">
+    <div class="spec type anchored" id="type-abstract">
      <a href="#type-abstract" class="anchor"></a>
      <code><span><span class="keyword">type</span> abstract</span></code>
     </div><div class="spec-doc"><p>Some <em>documentation</em>.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-alias" class="anchored">
+    <div class="spec type anchored" id="type-alias">
      <a href="#type-alias" class="anchor"></a>
      <code><span><span class="keyword">type</span> alias</span>
       <span> = int</span>
@@ -26,7 +26,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-private_" class="anchored">
+    <div class="spec type anchored" id="type-private_">
      <a href="#type-private_" class="anchor"></a>
      <code><span><span class="keyword">type</span> private_</span>
       <span> = <span class="keyword">private</span> int</span>
@@ -34,7 +34,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-constructor" class="anchored">
+    <div class="spec type anchored" id="type-constructor">
      <a href="#type-constructor" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a constructor</span>
@@ -43,7 +43,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-arrow" class="anchored">
+    <div class="spec type anchored" id="type-arrow">
      <a href="#type-arrow" class="anchor"></a>
      <code><span><span class="keyword">type</span> arrow</span>
       <span> = <span>int <span class="arrow">&#45;&gt;</span></span> int
@@ -52,7 +52,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-higher_order" class="anchored">
+    <div class="spec type anchored" id="type-higher_order">
      <a href="#type-higher_order" class="anchor"></a>
      <code><span><span class="keyword">type</span> higher_order</span>
       <span> = 
@@ -65,7 +65,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-labeled" class="anchored">
+    <div class="spec type anchored" id="type-labeled">
      <a href="#type-labeled" class="anchor"></a>
      <code><span><span class="keyword">type</span> labeled</span>
       <span> = <span>l:int <span class="arrow">&#45;&gt;</span></span> int
@@ -74,7 +74,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-optional" class="anchored">
+    <div class="spec type anchored" id="type-optional">
      <a href="#type-optional" class="anchor"></a>
      <code><span><span class="keyword">type</span> optional</span>
       <span> = <span>?l:int <span class="arrow">&#45;&gt;</span></span> int
@@ -83,7 +83,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-labeled_higher_order" class="anchored">
+    <div class="spec type anchored" id="type-labeled_higher_order">
      <a href="#type-labeled_higher_order" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> labeled_higher_order</span>
@@ -101,7 +101,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-pair" class="anchored">
+    <div class="spec type anchored" id="type-pair">
      <a href="#type-pair" class="anchor"></a>
      <code><span><span class="keyword">type</span> pair</span>
       <span> = int * int</span>
@@ -109,7 +109,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-parens_dropped" class="anchored">
+    <div class="spec type anchored" id="type-parens_dropped">
      <a href="#type-parens_dropped" class="anchor"></a>
      <code><span><span class="keyword">type</span> parens_dropped</span>
       <span> = int * int</span>
@@ -117,7 +117,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-triple" class="anchored">
+    <div class="spec type anchored" id="type-triple">
      <a href="#type-triple" class="anchor"></a>
      <code><span><span class="keyword">type</span> triple</span>
       <span> = int * int * int</span>
@@ -125,7 +125,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-nested_pair" class="anchored">
+    <div class="spec type anchored" id="type-nested_pair">
      <a href="#type-nested_pair" class="anchor"></a>
      <code><span><span class="keyword">type</span> nested_pair</span>
       <span> = <span>(int * int)</span> * int</span>
@@ -133,7 +133,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-instance" class="anchored">
+    <div class="spec type anchored" id="type-instance">
      <a href="#type-instance" class="anchor"></a>
      <code><span><span class="keyword">type</span> instance</span>
       <span> = <span>int <a href="#type-constructor">constructor</a></span>
@@ -142,7 +142,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-long" class="anchored">
+    <div class="spec type anchored" id="type-long">
      <a href="#type-long" class="anchor"></a>
      <code><span><span class="keyword">type</span> long</span>
       <span> =
@@ -196,314 +196,266 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-variant_e" class="anchored">
+    <div class="spec type anchored" id="type-variant_e">
      <a href="#type-variant_e" class="anchor"></a>
      <code><span><span class="keyword">type</span> variant_e</span>
       <span> = </span><span>{</span>
      </code>
-     <table>
-      <tr id="type-variant_e.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-variant_e.a" class="anchor"></a>
-        <code><span>a : int;</span></code>
-       </td>
-      </tr>
-     </table><code><span>}</span></code>
+     <ol>
+      <li id="type-variant_e.a" class="def record field anchored">
+       <a href="#type-variant_e.a" class="anchor"></a>
+       <code><span>a : int;</span></code>
+      </li>
+     </ol><code><span>}</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-variant" class="anchored">
+    <div class="spec type anchored" id="type-variant">
      <a href="#type-variant" class="anchor"></a>
      <code><span><span class="keyword">type</span> variant</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-variant.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.A" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">A</span></span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-variant.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.B" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">B</span> 
-          <span class="keyword">of</span> int
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-variant.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.C" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">C</span></span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
+     <ol>
+      <li id="type-variant.A" class="def variant constructor anchored">
+       <a href="#type-variant.A" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">A</span></span>
+       </code>
+      </li>
+      <li id="type-variant.B" class="def variant constructor anchored">
+       <a href="#type-variant.B" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">B</span> 
+         <span class="keyword">of</span> int
+        </span>
+       </code>
+      </li>
+      <li id="type-variant.C" class="def variant constructor anchored">
+       <a href="#type-variant.C" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">C</span></span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-variant.D" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.D" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">D</span></span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+       </div>
+      </li>
+      <li id="type-variant.D" class="def variant constructor anchored">
+       <a href="#type-variant.D" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">D</span></span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p><em>bar</em></p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-variant.E" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-variant.E" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">E</span> 
-          <span class="keyword">of</span> 
-          <a href="#type-variant_e">variant_e</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+      <li id="type-variant.E" class="def variant constructor anchored">
+       <a href="#type-variant.E" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">E</span> 
+         <span class="keyword">of</span> 
+         <a href="#type-variant_e">variant_e</a>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-variant_c" class="anchored">
+    <div class="spec type anchored" id="type-variant_c">
      <a href="#type-variant_c" class="anchor"></a>
      <code><span><span class="keyword">type</span> variant_c</span>
       <span> = </span><span>{</span>
      </code>
-     <table>
-      <tr id="type-variant_c.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-variant_c.a" class="anchor"></a>
-        <code><span>a : int;</span></code>
-       </td>
-      </tr>
-     </table><code><span>}</span></code>
+     <ol>
+      <li id="type-variant_c.a" class="def record field anchored">
+       <a href="#type-variant_c.a" class="anchor"></a>
+       <code><span>a : int;</span></code>
+      </li>
+     </ol><code><span>}</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-gadt" class="anchored">
+    <div class="spec type anchored" id="type-gadt">
      <a href="#type-gadt" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>_ gadt</span></span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-gadt.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.A" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">A</span> : 
-          <span>int <a href="#type-gadt">gadt</a></span>
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-gadt.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.B" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">B</span> : int 
-          <span class="arrow">&#45;&gt;</span> 
-          <span>string <a href="#type-gadt">gadt</a></span>
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-gadt.C" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-gadt.C" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">C</span> : 
-          <a href="#type-variant_c">variant_c</a> 
-          <span class="arrow">&#45;&gt;</span> 
-          <span>unit <a href="#type-gadt">gadt</a></span>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-gadt.A" class="def variant constructor anchored">
+       <a href="#type-gadt.A" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">A</span> : 
+         <span>int <a href="#type-gadt">gadt</a></span>
+        </span>
+       </code>
+      </li>
+      <li id="type-gadt.B" class="def variant constructor anchored">
+       <a href="#type-gadt.B" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">B</span> : int 
+         <span class="arrow">&#45;&gt;</span> 
+         <span>string <a href="#type-gadt">gadt</a></span>
+        </span>
+       </code>
+      </li>
+      <li id="type-gadt.C" class="def variant constructor anchored">
+       <a href="#type-gadt.C" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">C</span> : 
+         <a href="#type-variant_c">variant_c</a> 
+         <span class="arrow">&#45;&gt;</span> 
+         <span>unit <a href="#type-gadt">gadt</a></span>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-degenerate_gadt" class="anchored">
+    <div class="spec type anchored" id="type-degenerate_gadt">
      <a href="#type-degenerate_gadt" class="anchor"></a>
      <code><span><span class="keyword">type</span> degenerate_gadt</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-degenerate_gadt.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-degenerate_gadt.A" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">A</span> : 
-          <a href="#type-degenerate_gadt">degenerate_gadt</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-degenerate_gadt.A" class="def variant constructor
+       anchored"><a href="#type-degenerate_gadt.A" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">A</span> : 
+         <a href="#type-degenerate_gadt">degenerate_gadt</a>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-private_variant" class="anchored">
+    <div class="spec type anchored" id="type-private_variant">
      <a href="#type-private_variant" class="anchor"></a>
      <code><span><span class="keyword">type</span> private_variant</span>
       <span> = <span class="keyword">private</span> </span>
      </code>
-     <table>
-      <tr id="type-private_variant.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-private_variant.A" class="anchor"></a>
-        <code><span>| </span><span><span class="constructor">A</span></span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-private_variant.A" class="def variant constructor
+       anchored"><a href="#type-private_variant.A" class="anchor"></a>
+       <code><span>| </span><span><span class="constructor">A</span></span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-record" class="anchored">
+    <div class="spec type anchored" id="type-record">
      <a href="#type-record" class="anchor"></a>
      <code><span><span class="keyword">type</span> record</span>
       <span> = </span><span>{</span>
      </code>
-     <table>
-      <tr id="type-record.a" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.a" class="anchor"></a>
-        <code><span>a : int;</span></code>
-       </td>
-      </tr>
-      <tr id="type-record.b" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.b" class="anchor"></a>
-        <code><span><span class="keyword">mutable</span> b : int;</span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-record.c" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.c" class="anchor"></a>
-        <code><span>c : int;</span></code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
+     <ol>
+      <li id="type-record.a" class="def record field anchored">
+       <a href="#type-record.a" class="anchor"></a>
+       <code><span>a : int;</span></code>
+      </li>
+      <li id="type-record.b" class="def record field anchored">
+       <a href="#type-record.b" class="anchor"></a>
+       <code><span><span class="keyword">mutable</span> b : int;</span>
+       </code>
+      </li>
+      <li id="type-record.c" class="def record field anchored">
+       <a href="#type-record.c" class="anchor"></a>
+       <code><span>c : int;</span></code>
+       <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
         <span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-record.d" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.d" class="anchor"></a>
-        <code><span>d : int;</span></code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+       </div>
+      </li>
+      <li id="type-record.d" class="def record field anchored">
+       <a href="#type-record.d" class="anchor"></a>
+       <code><span>d : int;</span></code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p><em>bar</em></p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="type-record.e" class="anchored">
-       <td class="def record field">
-        <a href="#type-record.e" class="anchor"></a>
-        <code><span>e : 'a. <span class="type-var">'a</span>;</span></code>
-       </td>
-      </tr>
-     </table><code><span>}</span></code>
+       </div>
+      </li>
+      <li id="type-record.e" class="def record field anchored">
+       <a href="#type-record.e" class="anchor"></a>
+       <code><span>e : 'a. <span class="type-var">'a</span>;</span></code>
+      </li>
+     </ol><code><span>}</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-polymorphic_variant" class="anchored">
+    <div class="spec type anchored" id="type-polymorphic_variant">
      <a href="#type-polymorphic_variant" class="anchor"></a>
      <code><span><span class="keyword">type</span> polymorphic_variant</span>
       <span> = </span><span>[ </span>
      </code>
-     <table>
-      <tr id="type-polymorphic_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.A" class="anchor"></a>
-        <code><span>| </span></code><code><span>`A</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.B" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.B" class="anchor"></a>
-        <code><span>| </span></code>
-        <code><span>`B <span class="keyword">of</span> int</span></code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.C" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.C" class="anchor"></a>
-        <code><span>| </span></code>
-        <code><span>`C <span class="keyword">of</span> int * unit</span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant.D" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant.D" class="anchor"></a>
-        <code><span>| </span></code><code><span>`D</span></code>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+     <ol>
+      <li id="type-polymorphic_variant.A" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.A" class="anchor"></a>
+       <code><span>| </span></code><code><span>`A</span></code>
+      </li>
+      <li id="type-polymorphic_variant.B" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.B" class="anchor"></a>
+       <code><span>| </span></code>
+       <code><span>`B <span class="keyword">of</span> int</span></code>
+      </li>
+      <li id="type-polymorphic_variant.C" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.C" class="anchor"></a>
+       <code><span>| </span></code>
+       <code><span>`C <span class="keyword">of</span> int * unit</span>
+       </code>
+      </li>
+      <li id="type-polymorphic_variant.D" class="def constructor anchored">
+       <a href="#type-polymorphic_variant.D" class="anchor"></a>
+       <code><span>| </span></code><code><span>`D</span></code>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-polymorphic_variant_extension"
-     class="anchored">
+    <div class="spec type anchored" id="type-polymorphic_variant_extension">
      <a href="#type-polymorphic_variant_extension" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> polymorphic_variant_extension
       </span><span> = </span><span>[ </span>
      </code>
-     <table>
-      <tr id="type-polymorphic_variant_extension.polymorphic_variant"
-       class="anchored">
-       <td class="def type">
-        <a href="#type-polymorphic_variant_extension.polymorphic_variant"
-         class="anchor">
-        </a><code><span>| </span></code>
-        <code>
-         <span><a href="#type-polymorphic_variant">polymorphic_variant</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-      <tr id="type-polymorphic_variant_extension.E" class="anchored">
-       <td class="def constructor">
-        <a href="#type-polymorphic_variant_extension.E" class="anchor"></a>
-        <code><span>| </span></code><code><span>`E</span></code>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+     <ol>
+      <li id="type-polymorphic_variant_extension.polymorphic_variant"
+       class="def type anchored">
+       <a href="#type-polymorphic_variant_extension.polymorphic_variant"
+        class="anchor">
+       </a><code><span>| </span></code>
+       <code>
+        <span><a href="#type-polymorphic_variant">polymorphic_variant</a>
+        </span>
+       </code>
+      </li>
+      <li id="type-polymorphic_variant_extension.E" class="def constructor
+       anchored">
+       <a href="#type-polymorphic_variant_extension.E" class="anchor"></a>
+       <code><span>| </span></code><code><span>`E</span></code>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-nested_polymorphic_variant"
-     class="anchored">
+    <div class="spec type anchored" id="type-nested_polymorphic_variant">
      <a href="#type-nested_polymorphic_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> nested_polymorphic_variant
       </span><span> = </span><span>[ </span>
      </code>
-     <table>
-      <tr id="type-nested_polymorphic_variant.A" class="anchored">
-       <td class="def constructor">
-        <a href="#type-nested_polymorphic_variant.A" class="anchor"></a>
-        <code><span>| </span></code>
-        <code>
-         <span>`A <span class="keyword">of</span> 
-          <span>[ `B <span>| `C</span> ]</span>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+     <ol>
+      <li id="type-nested_polymorphic_variant.A" class="def constructor
+       anchored">
+       <a href="#type-nested_polymorphic_variant.A" class="anchor"></a>
+       <code><span>| </span></code>
+       <code>
+        <span>`A <span class="keyword">of</span> 
+         <span>[ `B <span>| `C</span> ]</span>
+        </span>
+       </code>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-private_extenion#row" class="anchored">
+    <div class="spec type anchored" id="type-private_extenion#row">
      <a href="#type-private_extenion#row" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> private_extenion#row</span>
@@ -511,28 +463,27 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-private_extenion" class="anchored">
+    <div class="spec type anchored" id="type-private_extenion">
      <a href="#type-private_extenion" class="anchor"></a>
      <code><span><span class="keyword">and</span> private_extenion</span>
       <span> = <span class="keyword">private</span> </span>
       <span>[&gt; </span>
      </code>
-     <table>
-      <tr id="type-private_extenion.polymorphic_variant" class="anchored">
-       <td class="def type">
-        <a href="#type-private_extenion.polymorphic_variant" class="anchor">
-        </a><code><span>| </span></code>
-        <code>
-         <span><a href="#type-polymorphic_variant">polymorphic_variant</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table><code><span> ]</span></code>
+     <ol>
+      <li id="type-private_extenion.polymorphic_variant" class="def type
+       anchored">
+       <a href="#type-private_extenion.polymorphic_variant" class="anchor">
+       </a><code><span>| </span></code>
+       <code>
+        <span><a href="#type-polymorphic_variant">polymorphic_variant</a>
+        </span>
+       </code>
+      </li>
+     </ol><code><span> ]</span></code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-object_" class="anchored">
+    <div class="spec type anchored" id="type-object_">
      <a href="#type-object_" class="anchor"></a>
      <code><span><span class="keyword">type</span> object_</span>
       <span> = <span>&lt; a : int ; b : int ; c : int &gt;</span></span>
@@ -540,7 +491,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec module-type" id="module-type-X" class="anchored">
+    <div class="spec module-type anchored" id="module-type-X">
      <a href="#module-type-X" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> 
@@ -554,7 +505,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-module_" class="anchored">
+    <div class="spec type anchored" id="type-module_">
      <a href="#type-module_" class="anchor"></a>
      <code><span><span class="keyword">type</span> module_</span>
       <span> = 
@@ -566,7 +517,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-module_substitution" class="anchored">
+    <div class="spec type anchored" id="type-module_substitution">
      <a href="#type-module_substitution" class="anchor"></a>
      <code><span><span class="keyword">type</span> module_substitution</span>
       <span> = 
@@ -582,7 +533,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-covariant" class="anchored">
+    <div class="spec type anchored" id="type-covariant">
      <a href="#type-covariant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>+'a covariant</span>
@@ -591,7 +542,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-contravariant" class="anchored">
+    <div class="spec type anchored" id="type-contravariant">
      <a href="#type-contravariant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>-'a contravariant</span>
@@ -600,7 +551,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-bivariant" class="anchored">
+    <div class="spec type anchored" id="type-bivariant">
      <a href="#type-bivariant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>_ bivariant</span></span>
@@ -609,7 +560,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-binary" class="anchored">
+    <div class="spec type anchored" id="type-binary">
      <a href="#type-binary" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>('a, 'b) binary</span>
@@ -618,7 +569,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-using_binary" class="anchored">
+    <div class="spec type anchored" id="type-using_binary">
      <a href="#type-using_binary" class="anchor"></a>
      <code><span><span class="keyword">type</span> using_binary</span>
       <span> = 
@@ -628,7 +579,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-name" class="anchored">
+    <div class="spec type anchored" id="type-name">
      <a href="#type-name" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'custom name</span>
@@ -637,7 +588,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-constrained" class="anchored">
+    <div class="spec type anchored" id="type-constrained">
      <a href="#type-constrained" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a constrained</span>
@@ -649,7 +600,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-exact_variant" class="anchored">
+    <div class="spec type anchored" id="type-exact_variant">
      <a href="#type-exact_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a exact_variant</span>
@@ -662,7 +613,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-lower_variant" class="anchored">
+    <div class="spec type anchored" id="type-lower_variant">
      <a href="#type-lower_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a lower_variant</span>
@@ -675,7 +626,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-any_variant" class="anchored">
+    <div class="spec type anchored" id="type-any_variant">
      <a href="#type-any_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a any_variant</span>
@@ -687,7 +638,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-upper_variant" class="anchored">
+    <div class="spec type anchored" id="type-upper_variant">
      <a href="#type-upper_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a upper_variant</span>
@@ -700,7 +651,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-named_variant" class="anchored">
+    <div class="spec type anchored" id="type-named_variant">
      <a href="#type-named_variant" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a named_variant</span>
@@ -715,7 +666,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-exact_object" class="anchored">
+    <div class="spec type anchored" id="type-exact_object">
      <a href="#type-exact_object" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a exact_object</span>
@@ -728,7 +679,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-lower_object" class="anchored">
+    <div class="spec type anchored" id="type-lower_object">
      <a href="#type-lower_object" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a lower_object</span>
@@ -741,7 +692,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-poly_object" class="anchored">
+    <div class="spec type anchored" id="type-poly_object">
      <a href="#type-poly_object" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> <span>'a poly_object</span>
@@ -754,7 +705,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-double_constrained" class="anchored">
+    <div class="spec type anchored" id="type-double_constrained">
      <a href="#type-double_constrained" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
@@ -772,7 +723,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-as_" class="anchored">
+    <div class="spec type anchored" id="type-as_">
      <a href="#type-as_" class="anchor"></a>
      <code><span><span class="keyword">type</span> as_</span>
       <span> = int <span class="keyword">as</span> 'a * 
@@ -782,7 +733,7 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-extensible" class="anchored">
+    <div class="spec type anchored" id="type-extensible">
      <a href="#type-extensible" class="anchor"></a>
      <code><span><span class="keyword">type</span> extensible</span>
       <span> = </span><span>..</span>
@@ -790,89 +741,81 @@
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type extension" id="extension-decl-Extension"
-     class="anchored"><a href="#extension-decl-Extension" class="anchor"></a>
+    <div class="spec type extension anchored" id="extension-decl-Extension">
+     <a href="#extension-decl-Extension" class="anchor"></a>
      <code>
       <span><span class="keyword">type</span> 
        <a href="#type-extensible">extensible</a> += 
       </span>
      </code>
-     <table>
-      <tr id="extension-Extension" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Extension" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="extension">Extension</span></span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+     <ol>
+      <li id="extension-Extension" class="def extension anchored">
+       <a href="#extension-Extension" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="extension">Extension</span></span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>Documentation for 
          <a href="#extension-Extension"><code>Extension</code></a>.
         </p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-      <tr id="extension-Another_extension" class="anchored">
-       <td class="def extension">
-        <a href="#extension-Another_extension" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="extension">Another_extension</span></span>
-        </code>
-       </td>
-       <td class="def-doc"><span class="comment-delim">(*</span>
+       </div>
+      </li>
+      <li id="extension-Another_extension" class="def extension anchored">
+       <a href="#extension-Another_extension" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="extension">Another_extension</span></span>
+       </code>
+       <div class="def-doc"><span class="comment-delim">(*</span>
         <p>Documentation for 
          <a href="#extension-Another_extension">
           <code>Another_extension</code>
          </a>.
         </p><span class="comment-delim">*)</span>
-       </td>
-      </tr>
-     </table>
+       </div>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-mutually" class="anchored">
+    <div class="spec type anchored" id="type-mutually">
      <a href="#type-mutually" class="anchor"></a>
      <code><span><span class="keyword">type</span> mutually</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-mutually.A" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-mutually.A" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">A</span> 
-          <span class="keyword">of</span> 
-          <a href="#type-recursive">recursive</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-mutually.A" class="def variant constructor anchored">
+       <a href="#type-mutually.A" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">A</span> 
+         <span class="keyword">of</span> 
+         <a href="#type-recursive">recursive</a>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec type" id="type-recursive" class="anchored">
+    <div class="spec type anchored" id="type-recursive">
      <a href="#type-recursive" class="anchor"></a>
      <code><span><span class="keyword">and</span> recursive</span>
       <span> = </span>
      </code>
-     <table>
-      <tr id="type-recursive.B" class="anchored">
-       <td class="def variant constructor">
-        <a href="#type-recursive.B" class="anchor"></a>
-        <code><span>| </span>
-         <span><span class="constructor">B</span> 
-          <span class="keyword">of</span> 
-          <a href="#type-mutually">mutually</a>
-         </span>
-        </code>
-       </td>
-      </tr>
-     </table>
+     <ol>
+      <li id="type-recursive.B" class="def variant constructor anchored">
+       <a href="#type-recursive.B" class="anchor"></a>
+       <code><span>| </span>
+        <span><span class="constructor">B</span> 
+         <span class="keyword">of</span> 
+         <a href="#type-mutually">mutually</a>
+        </span>
+       </code>
+      </li>
+     </ol>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec exception" id="exception-Foo" class="anchored">
+    <div class="spec exception anchored" id="exception-Foo">
      <a href="#exception-Foo" class="anchor"></a>
      <code><span><span class="keyword">exception</span> </span>
       <span><span class="exception">Foo</span> 

--- a/test/generators/html/Val.html
+++ b/test/generators/html/Val.html
@@ -11,21 +11,21 @@
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">
-    <div class="spec value" id="val-documented" class="anchored">
+    <div class="spec value anchored" id="val-documented">
      <a href="#val-documented" class="anchor"></a>
      <code><span><span class="keyword">val</span> documented : unit</span>
      </code>
     </div><div class="spec-doc"><p>Foo.</p></div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-undocumented" class="anchored">
+    <div class="spec value anchored" id="val-undocumented">
      <a href="#val-undocumented" class="anchor"></a>
      <code><span><span class="keyword">val</span> undocumented : unit</span>
      </code>
     </div>
    </div>
    <div class="odoc-spec">
-    <div class="spec value" id="val-documented_above" class="anchored">
+    <div class="spec value anchored" id="val-documented_above">
      <a href="#val-documented_above" class="anchor"></a>
      <code>
       <span><span class="keyword">val</span> documented_above : unit</span>

--- a/test/xref2/canonical_hidden_module.t/run.t
+++ b/test/xref2/canonical_hidden_module.t/run.t
@@ -83,7 +83,7 @@ See the comments on the types at the end of test.mli for the expectation.
     </header>
     <div class="odoc-content">
      <div class="odoc-spec">
-      <div class="spec module" id="module-A_nonhidden" class="anchored">
+      <div class="spec module anchored" id="module-A_nonhidden">
        <a href="#module-A_nonhidden" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> 
@@ -96,7 +96,7 @@ See the comments on the types at the end of test.mli for the expectation.
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-A" class="anchored">
+      <div class="spec module anchored" id="module-A">
        <a href="#module-A" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> <a href="A/index.html">A</a>
@@ -109,7 +109,7 @@ See the comments on the types at the end of test.mli for the expectation.
       <div class="spec-doc"><p>This should not have an expansion</p></div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-B" class="anchored">
+      <div class="spec module anchored" id="module-B">
        <a href="#module-B" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> <a href="B/index.html">B</a>
@@ -121,7 +121,7 @@ See the comments on the types at the end of test.mli for the expectation.
       </div><div class="spec-doc"><p>This should have an expansion</p></div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-C" class="anchored">
+      <div class="spec module anchored" id="module-C">
        <a href="#module-C" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> <a href="C/index.html">C</a>
@@ -133,7 +133,7 @@ See the comments on the types at the end of test.mli for the expectation.
       </div><div class="spec-doc"><p>This should have an expansion</p></div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-D" class="anchored">
+      <div class="spec module anchored" id="module-D">
        <a href="#module-D" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> <a href="D/index.html">D</a>
@@ -146,7 +146,7 @@ See the comments on the types at the end of test.mli for the expectation.
       <div class="spec-doc"><p>This also should have an expansion</p></div>
      </div>
      <div class="odoc-spec">
-      <div class="spec type" id="type-a" class="anchored">
+      <div class="spec type anchored" id="type-a">
        <a href="#type-a" class="anchor"></a>
        <code><span><span class="keyword">type</span> a</span>
         <span> = <a href="A/index.html#type-t">A.t</a></span>
@@ -159,7 +159,7 @@ See the comments on the types at the end of test.mli for the expectation.
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec type" id="type-b" class="anchored">
+      <div class="spec type anchored" id="type-b">
        <a href="#type-b" class="anchor"></a>
        <code><span><span class="keyword">type</span> b</span></code>
       </div>
@@ -170,7 +170,7 @@ See the comments on the types at the end of test.mli for the expectation.
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec type" id="type-c" class="anchored">
+      <div class="spec type anchored" id="type-c">
        <a href="#type-c" class="anchor"></a>
        <code><span><span class="keyword">type</span> c</span>
         <span> = <a href="C/index.html#type-t">C.t</a></span>
@@ -181,7 +181,7 @@ See the comments on the types at the end of test.mli for the expectation.
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec type" id="type-d" class="anchored">
+      <div class="spec type anchored" id="type-d">
        <a href="#type-d" class="anchor"></a>
        <code><span><span class="keyword">type</span> d</span>
         <span> = <a href="D/index.html#type-t">D.t</a></span>

--- a/test/xref2/labels/labels.t/run.t
+++ b/test/xref2/labels/labels.t/run.t
@@ -100,7 +100,7 @@ The second occurence of 'B' in the main page should be disambiguated
      <h2 id="A"><a href="#A" class="anchor"></a>First label</h2>
      <h2 id="B"><a href="#B" class="anchor"></a>Floating label</h2>
      <div class="odoc-spec">
-      <div class="spec module" id="module-M" class="anchored">
+      <div class="spec module anchored" id="module-M">
        <a href="#module-M" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> <a href="M/index.html">M</a>
@@ -112,7 +112,7 @@ The second occurence of 'B' in the main page should be disambiguated
       </div>
      </div>
      <div class="odoc-spec">
-      <div class="spec module" id="module-N" class="anchored">
+      <div class="spec module anchored" id="module-N">
        <a href="#module-N" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> <a href="N/index.html">N</a>

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -47,7 +47,7 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
     </header>
     <div class="odoc-content">
      <div class="odoc-spec">
-      <div class="spec module" id="module-B" class="anchored">
+      <div class="spec module anchored" id="module-B">
        <a href="#module-B" class="anchor"></a>
        <code>
         <span><span class="keyword">module</span> <a href="B/index.html">B</a>
@@ -95,7 +95,7 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
        the &quot;content&quot;.
      </p>
      <div class="odoc-spec">
-      <div class="spec type" id="type-t" class="anchored">
+      <div class="spec type anchored" id="type-t">
        <a href="#type-t" class="anchor"></a>
        <code><span><span class="keyword">type</span> t</span></code>
       </div>


### PR DESCRIPTION
This is the continuation of #673 by @Drup.

I added css to his modification of the layout. I also dropped the commit making the tag a `div` or a `span` depending on the number of paragraph: There might be single long paragraph, or two very small paragraph.
Instead, this is treated using css only (with `flex-wrap`).

You can find [here](https://choum.net/panglesd/parsetree_test2/ppxlib/Astlib/Ast_413/Parsetree/index.html), as an example, the output on a `Parsetree` doc where comments have been (partly) odocified, as this module contains lots of big variant and product with documentation.

Hopefully, this implements #614.