### PR TITLE
Fix stop-comment when it follows the top-comment

### DIFF
--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -92,6 +92,7 @@ let parse_attribute : Parsetree.attribute -> parsed_attribute option =
       | Some p -> Some (`Text p)
       | None -> None)
   | "doc" | "ocaml.doc" -> (
+      (* We don't expect a stop-comment here. *)
       match load_payload attr_payload with
       | Some p -> Some (`Doc p)
       | None -> None)
@@ -211,8 +212,9 @@ let extract_top_comment internal_tags ~classify parent items =
             let p = match p with Some (p, _) -> Some p | None -> None in
             let attr_loc = read_location attr_loc in
             `Alert (Location_.at attr_loc (`Tag (`Alert (name, p))))
-        | Some (`Stop _) | None -> `Skip)
-    | Some `Open -> `Skip
+        | Some (`Stop _) -> `Return (* Stop at stop-comments. *)
+        | None -> `Skip (* Skip unrecognized attributes. *))
+    | Some `Open -> `Skip (* Skip open statements *)
     | None -> `Return
   in
   let rec extract_tail_alerts acc = function

--- a/test/generators/cases/stop.mli
+++ b/test/generators/cases/stop.mli
@@ -40,3 +40,33 @@ sig
 end
 
 val lol : int
+
+(** The first comment can also be a stop-comment. The test case
+    [stop_first_comment.mli] is testing the same thing but at the toplevel. We
+    should see [bar] inside {!O}. *)
+
+module O :
+sig
+  (**/**)
+
+  val foo : int
+
+  (**/**)
+
+  val bar : int
+end
+
+(** The top-comment computation must not mess with stop comments. *)
+
+module P :
+sig
+  (** Doc. *)
+
+  (**/**)
+
+  val foo : int
+
+  (**/**)
+
+  val bar : int
+end

--- a/test/generators/cases/stop_first_comment.mli
+++ b/test/generators/cases/stop_first_comment.mli
@@ -1,0 +1,9 @@
+(**/**)
+
+(** This should be hidden, we should see [bar] instead. *)
+val foo : int
+
+(**/**)
+
+val bar : int
+

--- a/test/generators/html/Stop-O.html
+++ b/test/generators/html/Stop-O.html
@@ -11,7 +11,15 @@
    <a href="Stop.html">Stop</a> &#x00BB; O
   </nav>
   <header class="odoc-preamble">
-   <h1>Module <code><span>Stop.O</span></code></h1><p>/*</p>
-  </header><div class="odoc-content"></div>
+   <h1>Module <code><span>Stop.O</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-bar">
+     <a href="#val-bar" class="anchor"></a>
+     <code><span><span class="keyword">val</span> bar : int</span></code>
+    </div>
+   </div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Stop-O.html
+++ b/test/generators/html/Stop-O.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>O (Stop.O)</title><link rel="stylesheet" href="odoc.css"/>
+  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Stop.html">Up</a> – 
+   <a href="Stop.html">Stop</a> &#x00BB; O
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Stop.O</span></code></h1><p>/*</p>
+  </header><div class="odoc-content"></div>
+ </body>
+</html>

--- a/test/generators/html/Stop-P.html
+++ b/test/generators/html/Stop-P.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>P (Stop.P)</title><link rel="stylesheet" href="odoc.css"/>
+  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Stop.html">Up</a> – 
+   <a href="Stop.html">Stop</a> &#x00BB; P
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Stop.P</span></code></h1><p>Doc.</p>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec value" id="val-bar" class="anchored">
+     <a href="#val-bar" class="anchor"></a>
+     <code><span><span class="keyword">val</span> bar : int</span></code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Stop-P.html
+++ b/test/generators/html/Stop-P.html
@@ -12,6 +12,14 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Stop.P</span></code></h1><p>Doc.</p>
-  </header><div class="odoc-content"></div>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-bar">
+     <a href="#val-bar" class="anchor"></a>
+     <code><span><span class="keyword">val</span> bar : int</span></code>
+    </div>
+   </div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Stop-P.html
+++ b/test/generators/html/Stop-P.html
@@ -12,14 +12,6 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Stop.P</span></code></h1><p>Doc.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value" id="val-bar" class="anchored">
-     <a href="#val-bar" class="anchor"></a>
-     <code><span><span class="keyword">val</span> bar : int</span></code>
-    </div>
-   </div>
-  </div>
+  </header><div class="odoc-content"></div>
  </body>
 </html>

--- a/test/generators/html/Stop.html
+++ b/test/generators/html/Stop.html
@@ -53,7 +53,7 @@
     <a href="Stop-O.html"><code>O</code></a>.
    </p>
    <div class="odoc-spec">
-    <div class="spec module" id="module-O" class="anchored">
+    <div class="spec module anchored" id="module-O">
      <a href="#module-O" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Stop-O.html">O</a>
@@ -62,10 +62,10 @@
        <span class="keyword">end</span>
       </span>
      </code>
-    </div><div class="spec-doc"><p>/*</p></div>
+    </div>
    </div><p>The top-comment computation must not mess with stop comments.</p>
    <div class="odoc-spec">
-    <div class="spec module" id="module-P" class="anchored">
+    <div class="spec module anchored" id="module-P">
      <a href="#module-P" class="anchor"></a>
      <code>
       <span><span class="keyword">module</span> <a href="Stop-P.html">P</a>

--- a/test/generators/html/Stop.html
+++ b/test/generators/html/Stop.html
@@ -47,6 +47,35 @@
      <code><span><span class="keyword">val</span> lol : int</span></code>
     </div>
    </div>
+   <p>The first comment can also be a stop-comment. The test case 
+    <code>stop_first_comment.mli</code> is testing the same thing but
+     at the toplevel. We should see <code>bar</code> inside 
+    <a href="Stop-O.html"><code>O</code></a>.
+   </p>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-O" class="anchored">
+     <a href="#module-O" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> <a href="Stop-O.html">O</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div><div class="spec-doc"><p>/*</p></div>
+   </div><p>The top-comment computation must not mess with stop comments.</p>
+   <div class="odoc-spec">
+    <div class="spec module" id="module-P" class="anchored">
+     <a href="#module-P" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> <a href="Stop-P.html">P</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div><div class="spec-doc"><p>Doc.</p></div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Stop_first_comment.html
+++ b/test/generators/html/Stop_first_comment.html
@@ -9,7 +9,15 @@
  </head>
  <body class="odoc">
   <header class="odoc-preamble">
-   <h1>Module <code><span>Stop_first_comment</span></code></h1><p>/*</p>
-  </header><div class="odoc-content"></div>
+   <h1>Module <code><span>Stop_first_comment</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-bar">
+     <a href="#val-bar" class="anchor"></a>
+     <code><span><span class="keyword">val</span> bar : int</span></code>
+    </div>
+   </div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Stop_first_comment.html
+++ b/test/generators/html/Stop_first_comment.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Stop_first_comment (Stop_first_comment)</title>
+  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Stop_first_comment</span></code></h1><p>/*</p>
+  </header><div class="odoc-content"></div>
+ </body>
+</html>

--- a/test/generators/html/stop.targets
+++ b/test/generators/html/stop.targets
@@ -1,2 +1,4 @@
 Stop.html
 Stop-N.html
+Stop-O.html
+Stop-P.html

--- a/test/generators/html/stop_first_comment.targets
+++ b/test/generators/html/stop_first_comment.targets
@@ -1,0 +1,1 @@
+Stop_first_comment.html

--- a/test/generators/latex/Stop.tex
+++ b/test/generators/latex/Stop.tex
@@ -13,5 +13,16 @@ Now, we have a nested module, and it has a stop comment between its two items. W
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{module-Stop-val-lol}\ocamlcodefragment{\ocamltag{keyword}{val} lol : int}\\
+The first comment can also be a stop-comment. The test case \ocamlinlinecode{stop\_\allowbreak{}first\_\allowbreak{}comment.\allowbreak{}mli} is testing the same thing but at the toplevel. We should see \ocamlinlinecode{bar} inside \hyperref[module-Stop-module-O]{\ocamlinlinecode{\ocamlinlinecode{O}}[p\pageref*{module-Stop-module-O}]}.
+
+\label{module-Stop-module-O}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Stop-module-O]{\ocamlinlinecode{O}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}/*\end{ocamlindent}%
+\medbreak
+The top-comment computation must not mess with stop comments.
+
+\label{module-Stop-module-P}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Stop-module-P]{\ocamlinlinecode{P}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Stop-module-P-val-bar}\ocamlcodefragment{\ocamltag{keyword}{val} bar : int}\\
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Doc.\end{ocamlindent}%
+\medbreak
 
 

--- a/test/generators/latex/Stop.tex
+++ b/test/generators/latex/Stop.tex
@@ -15,13 +15,12 @@ Now, we have a nested module, and it has a stop comment between its two items. W
 \label{module-Stop-val-lol}\ocamlcodefragment{\ocamltag{keyword}{val} lol : int}\\
 The first comment can also be a stop-comment. The test case \ocamlinlinecode{stop\_\allowbreak{}first\_\allowbreak{}comment.\allowbreak{}mli} is testing the same thing but at the toplevel. We should see \ocamlinlinecode{bar} inside \hyperref[module-Stop-module-O]{\ocamlinlinecode{\ocamlinlinecode{O}}[p\pageref*{module-Stop-module-O}]}.
 
-\label{module-Stop-module-O}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Stop-module-O]{\ocamlinlinecode{O}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
-\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}/*\end{ocamlindent}%
-\medbreak
+\label{module-Stop-module-O}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Stop-module-O]{\ocamlinlinecode{O}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Stop-module-O-val-bar}\ocamlcodefragment{\ocamltag{keyword}{val} bar : int}\\
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
 The top-comment computation must not mess with stop comments.
 
-\label{module-Stop-module-P}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Stop-module-P]{\ocamlinlinecode{P}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Stop-module-P-val-bar}\ocamlcodefragment{\ocamltag{keyword}{val} bar : int}\\
-\end{ocamlindent}%
+\label{module-Stop-module-P}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Stop-module-P]{\ocamlinlinecode{P}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Doc.\end{ocamlindent}%
 \medbreak
 

--- a/test/generators/latex/Stop.tex
+++ b/test/generators/latex/Stop.tex
@@ -20,7 +20,8 @@ The first comment can also be a stop-comment. The test case \ocamlinlinecode{sto
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 The top-comment computation must not mess with stop comments.
 
-\label{module-Stop-module-P}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Stop-module-P]{\ocamlinlinecode{P}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
+\label{module-Stop-module-P}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Stop-module-P]{\ocamlinlinecode{P}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Stop-module-P-val-bar}\ocamlcodefragment{\ocamltag{keyword}{val} bar : int}\\
+\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Doc.\end{ocamlindent}%
 \medbreak
 

--- a/test/generators/latex/Stop_first_comment.tex
+++ b/test/generators/latex/Stop_first_comment.tex
@@ -1,5 +1,4 @@
 \section{Module \ocamlinlinecode{Stop\_\allowbreak{}first\_\allowbreak{}comment}}\label{module-Stop+u+first+u+comment}%
-/*
-
+\label{module-Stop+u+first+u+comment-val-bar}\ocamlcodefragment{\ocamltag{keyword}{val} bar : int}\\
 
 

--- a/test/generators/latex/Stop_first_comment.tex
+++ b/test/generators/latex/Stop_first_comment.tex
@@ -1,0 +1,5 @@
+\section{Module \ocamlinlinecode{Stop\_\allowbreak{}first\_\allowbreak{}comment}}\label{module-Stop+u+first+u+comment}%
+/*
+
+
+

--- a/test/generators/latex/stop_first_comment.targets
+++ b/test/generators/latex/stop_first_comment.targets
@@ -1,0 +1,1 @@
+Stop_first_comment.tex

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -432,6 +432,21 @@
   (>= %{ocaml_version} 4.04)))
 
 (rule
+ (target stop_first_comment.cmti)
+ (action
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/stop_first_comment.mli})))
+
+(rule
+ (target stop_first_comment.odoc)
+ (action
+  (run odoc compile -o %{target} %{dep:stop_first_comment.cmti})))
+
+(rule
+ (target stop_first_comment.odocl)
+ (action
+  (run odoc link -o %{target} %{dep:stop_first_comment.odoc})))
+
+(rule
  (target toplevel_comments.cmti)
  (action
   (run ocamlc -c -bin-annot -o %{target} %{dep:cases/toplevel_comments.mli})))
@@ -6056,7 +6071,7 @@
 (subdir
  html
  (rule
-  (targets Stop.html.gen Stop-N.html.gen)
+  (targets Stop.html.gen Stop-N.html.gen Stop-O.html.gen Stop-P.html.gen)
   (action
    (run
     odoc
@@ -6075,7 +6090,15 @@
  (rule
   (alias runtest)
   (action
-   (diff Stop-N.html Stop-N.html.gen))))
+   (diff Stop-N.html Stop-N.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop-O.html Stop-O.html.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop-P.html Stop-P.html.gen))))
 
 (subdir
  html
@@ -6115,7 +6138,7 @@
 (subdir
  man
  (rule
-  (targets Stop.3o.gen Stop.N.3o.gen)
+  (targets Stop.3o.gen Stop.N.3o.gen Stop.O.3o.gen Stop.P.3o.gen)
   (action
    (run odoc man-generate -o . --extra-suffix gen %{dep:../stop.odocl})))
  (rule
@@ -6125,7 +6148,15 @@
  (rule
   (alias runtest)
   (action
-   (diff Stop.N.3o Stop.N.3o.gen))))
+   (diff Stop.N.3o Stop.N.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop.O.3o Stop.O.3o.gen)))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop.P.3o Stop.P.3o.gen))))
 
 (subdir
  man
@@ -6266,6 +6297,98 @@
    (diff stop_dead_link_doc.targets stop_dead_link_doc.targets.gen))
   (enabled_if
    (>= %{ocaml_version} 4.04))))
+
+(subdir
+ html
+ (rule
+  (targets Stop_first_comment.html.gen)
+  (action
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../stop_first_comment.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop_first_comment.html Stop_first_comment.html.gen))))
+
+(subdir
+ html
+ (rule
+  (action
+   (with-outputs-to
+    stop_first_comment.targets.gen
+    (run odoc html-targets -o . %{dep:../stop_first_comment.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff stop_first_comment.targets stop_first_comment.targets.gen))))
+
+(subdir
+ latex
+ (rule
+  (targets Stop_first_comment.tex.gen)
+  (action
+   (run
+    odoc
+    latex-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../stop_first_comment.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop_first_comment.tex Stop_first_comment.tex.gen))))
+
+(subdir
+ latex
+ (rule
+  (action
+   (with-outputs-to
+    stop_first_comment.targets.gen
+    (run odoc latex-targets -o . %{dep:../stop_first_comment.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff stop_first_comment.targets stop_first_comment.targets.gen))))
+
+(subdir
+ man
+ (rule
+  (targets Stop_first_comment.3o.gen)
+  (action
+   (run
+    odoc
+    man-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../stop_first_comment.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Stop_first_comment.3o Stop_first_comment.3o.gen))))
+
+(subdir
+ man
+ (rule
+  (action
+   (with-outputs-to
+    stop_first_comment.targets.gen
+    (run odoc man-targets -o . %{dep:../stop_first_comment.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff stop_first_comment.targets stop_first_comment.targets.gen))))
 
 (subdir
  html

--- a/test/generators/man/Stop.3o
+++ b/test/generators/man/Stop.3o
@@ -40,11 +40,6 @@ The first comment can also be a stop-comment\. The test case stop_first_comment\
 .nf 
 .sp 
 \f[CB]module\fR O : \f[CB]sig\fR \.\.\. \f[CB]end\fR
-.fi 
-.br 
-.ti +2
-/*
-.nf 
 .sp 
 .fi 
 The top-comment computation must not mess with stop comments\.

--- a/test/generators/man/Stop.3o
+++ b/test/generators/man/Stop.3o
@@ -34,3 +34,26 @@ Now, we have a nested module, and it has a stop comment between its two items\. 
 \f[CB]module\fR N : \f[CB]sig\fR \.\.\. \f[CB]end\fR
 .sp 
 \f[CB]val\fR lol : int
+.sp 
+.fi 
+The first comment can also be a stop-comment\. The test case stop_first_comment\.mli is testing the same thing but at the toplevel\. We should see bar inside \f[CI]O\fR\.
+.nf 
+.sp 
+\f[CB]module\fR O : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.fi 
+.br 
+.ti +2
+/*
+.nf 
+.sp 
+.fi 
+The top-comment computation must not mess with stop comments\.
+.nf 
+.sp 
+\f[CB]module\fR P : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.fi 
+.br 
+.ti +2
+Doc\.
+.nf 
+

--- a/test/generators/man/Stop.O.3o
+++ b/test/generators/man/Stop.O.3o
@@ -1,0 +1,17 @@
+
+.TH O 3 "" "Odoc" "OCaml Library"
+.SH Name
+Stop\.O
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Stop\.O\fR
+.in 
+.sp 
+.fi 
+/*
+.nf 
+.SH Documentation
+.sp 
+.nf 
+

--- a/test/generators/man/Stop.O.3o
+++ b/test/generators/man/Stop.O.3o
@@ -8,10 +8,7 @@ Stop\.O
 \fBModule Stop\.O\fR
 .in 
 .sp 
-.fi 
-/*
-.nf 
 .SH Documentation
 .sp 
 .nf 
-
+\f[CB]val\fR bar : int

--- a/test/generators/man/Stop.P.3o
+++ b/test/generators/man/Stop.P.3o
@@ -1,0 +1,17 @@
+
+.TH P 3 "" "Odoc" "OCaml Library"
+.SH Name
+Stop\.P
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Stop\.P\fR
+.in 
+.sp 
+.fi 
+Doc\.
+.nf 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]val\fR bar : int

--- a/test/generators/man/Stop.P.3o
+++ b/test/generators/man/Stop.P.3o
@@ -14,4 +14,4 @@ Doc\.
 .SH Documentation
 .sp 
 .nf 
-\f[CB]val\fR bar : int
+

--- a/test/generators/man/Stop.P.3o
+++ b/test/generators/man/Stop.P.3o
@@ -14,4 +14,4 @@ Doc\.
 .SH Documentation
 .sp 
 .nf 
-
+\f[CB]val\fR bar : int

--- a/test/generators/man/Stop_first_comment.3o
+++ b/test/generators/man/Stop_first_comment.3o
@@ -1,0 +1,17 @@
+
+.TH Stop_first_comment 3 "" "Odoc" "OCaml Library"
+.SH Name
+Stop_first_comment
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Stop_first_comment\fR
+.in 
+.sp 
+.fi 
+/*
+.nf 
+.SH Documentation
+.sp 
+.nf 
+

--- a/test/generators/man/Stop_first_comment.3o
+++ b/test/generators/man/Stop_first_comment.3o
@@ -8,10 +8,7 @@ Stop_first_comment
 \fBModule Stop_first_comment\fR
 .in 
 .sp 
-.fi 
-/*
-.nf 
 .SH Documentation
 .sp 
 .nf 
-
+\f[CB]val\fR bar : int

--- a/test/generators/man/stop.targets
+++ b/test/generators/man/stop.targets
@@ -1,2 +1,4 @@
 Stop.3o
 Stop.N.3o
+Stop.O.3o
+Stop.P.3o

--- a/test/generators/man/stop_first_comment.targets
+++ b/test/generators/man/stop_first_comment.targets
@@ -1,0 +1,1 @@
+Stop_first_comment.3o


### PR DESCRIPTION
The commit ae62263a914d fixed the handling of stop-comments when it is at the beginning of a signature. For example, it's no longer needed to add an empty comment in https://github.com/dbuenzli/affect/blob/815b99ebf9d4f0c2921886fab76d275f982c0340/src/fiber.mli#L121

But it also added a new bug when the stop-comment follows a top-comment. Both `foo` and `bar` were hidden in this example:

```ocaml
(** Top-comment *)

(**/**)

val foo : int

(**/**)

val bar : int

(**/**)

val baz : int
```

This PR fixes that and adds tests.