### PR TITLE
Fix css of layout for datatypes

### DIFF
--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -451,11 +451,12 @@ div.odoc-spec,.odoc-include {
 
 .spec.type .record > .def-doc, .spec.type .variant > .def-doc {
   min-width:50%;
-  padding-left: 22px;
+  padding: 0.25em 0.5em;
   margin-left: 10%;
   border-radius: 3px;
   flex-grow:1;
-  border-left: 0.1em solid var(--spec-summary-border-color);
+  background: var(--main-background);
+  box-shadow: 2px 2px 4px lightgrey;
 }
 
 div.def {


### PR DESCRIPTION
This PR fixes the css introduced in #830:

It find it more logical that odoc comments always have a `--main-background` color, even if they are inside a `spec` (with background `--spec-summary-background`).

I think it makes it easier to read large record fields with many comments attached to fields.

Compare the two images:
![image](https://user-images.githubusercontent.com/34110029/157723805-6eb39da9-eb82-4571-a497-902d23317d10.png)
with
![image](https://user-images.githubusercontent.com/34110029/157723891-4608b88a-8aed-48c9-8357-f8be7e204aaf.png)

You can find complete examples of the [old style](https://choum.net/panglesd/parsetree_with_comments_old/html/compilerlibref/Parsetree/index.html) and [new style](https://choum.net/panglesd/parsetree_with_comments/html/compilerlibref/Parsetree/index.html) for this file.

(Maybe the thin blue bar could be removed now that the background is white... what do you think?)