### PR TITLE
Handle language tag on code blocks

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -25,7 +25,7 @@ delimited with `(** ... *)`, and outputs HTML.
 """
 
 depends: [
-  "odoc-parser" {>= "0.9.0"}
+  "odoc-parser" {>= "1.0.0"}
   "astring"
   "cmdliner" {>= "1.0.0"}
   "cppo" {build & >= "1.1.0"}

--- a/src/document/codefmt.ml
+++ b/src/document/codefmt.ml
@@ -222,7 +222,7 @@ let code ?attr f = [ inline ?attr @@ Inline.Source (render f) ]
 
 let documentedSrc f = [ DocumentedSrc.Code (render f) ]
 
-let codeblock ?attr f = [ block ?attr @@ Block.Source (render f) ]
+let codeblock ?attr f = [ block ?attr @@ Block.Source (None, render f) ]
 
 let keyword keyword ppf = pf ppf "@{<keyword>%s@}" keyword
 

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -196,8 +196,9 @@ let rec nestable_block_element : Comment.nestable_block_element -> Block.one =
  fun content ->
   match content with
   | `Paragraph p -> paragraph p
-  | `Code_block code ->
-      block @@ Source (source_of_code (Odoc_model.Location_.value code))
+  | `Code_block (lang_tag, code) ->
+      block
+      @@ Source (lang_tag, source_of_code (Odoc_model.Location_.value code))
   | `Verbatim s -> block @@ Verbatim s
   | `Modules ms -> module_references ms
   | `List (kind, items) ->

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -64,6 +64,8 @@ end =
   Heading
 
 and Block : sig
+  type lang_tag = string option
+
   type t = one list
 
   and one = { attr : Class.t; desc : desc }
@@ -73,7 +75,7 @@ and Block : sig
     | Paragraph of Inline.t
     | List of list_type * t list
     | Description of Description.t
-    | Source of Source.t
+    | Source of lang_tag * Source.t
     | Verbatim of string
     | Raw_markup of Raw_markup.t
 

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -308,7 +308,7 @@ let rec block ~in_source (l : Block.t) =
         ]
     | Raw_markup r -> raw_markup r
     | Verbatim s -> [ Verbatim s ]
-    | Source c -> non_empty_block_code c
+    | Source (_, c) -> non_empty_block_code c
   in
   list_concat_map l ~f:one
 

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -331,7 +331,7 @@ let rec block (l : Block.t) =
             indent 2 (str "@" ++ key ++ str ":" ++ sp ++ def)
           in
           list ~sep:break (List.map f descrs) ++ continue rest
-      | Source content ->
+      | Source (_, content) ->
           env "EX" "EE" "" (source_code content) ++ continue rest
       | Verbatim content -> env "EX" "EE" "" (str "%s" content) ++ continue rest
       | Raw_markup t -> raw_markup t ++ continue rest)

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -40,7 +40,7 @@ type module_reference = {
 
 type nestable_block_element =
   [ `Paragraph of paragraph
-  | `Code_block of string with_location
+  | `Code_block of string option * string with_location
   | `Verbatim of string
   | `Modules of module_reference list
   | `List of

--- a/src/model/semantics.ml
+++ b/src/model/semantics.ml
@@ -227,8 +227,13 @@ let rec nestable_block_element :
   match element with
   | { value = `Paragraph content; location } ->
       Location.at location (`Paragraph (inline_elements status content))
-  | { value = `Code_block (_, code); _ } ->
-      Location.same element (`Code_block code)
+  | { value = `Code_block (metadata, code); location } ->
+      let lang_tag =
+        match metadata with
+        | Some ({ Location.value; _ }, _) -> Some value
+        | None -> None
+      in
+      Location.at location (`Code_block (lang_tag, code))
   | { value = `Verbatim _; _ } as element -> element
   | { value = `Modules modules; location } ->
       let modules =

--- a/src/model_desc/comment_desc.ml
+++ b/src/model_desc/comment_desc.ml
@@ -18,7 +18,7 @@ and general_link_content = general_inline_element with_location list
 
 type general_block_element =
   [ `Paragraph of general_link_content
-  | `Code_block of string with_location
+  | `Code_block of string option * string with_location
   | `Verbatim of string
   | `Modules of Comment.module_reference list
   | `List of
@@ -100,7 +100,8 @@ let rec block_element : general_block_element t =
   Variant
     (function
     | `Paragraph x -> C ("`Paragraph", x, link_content)
-    | `Code_block x -> C ("`Code_block", ignore_loc x, string)
+    | `Code_block (x1, x2) ->
+        C ("`Code_block", (x1, ignore_loc x2), Pair (Option string, string))
     | `Verbatim x -> C ("`Verbatim", x, string)
     | `Modules x -> C ("`Modules", x, List module_reference)
     | `List (x1, x2) ->

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -1989,7 +1989,10 @@ let%expect_test _ =
       [%expect
         {|
         {
-          "value": [ { "`Tag": { "`Author": "Foo" } }, { "`Code_block": "bar" } ],
+          "value": [
+            { "`Tag": { "`Author": "Foo" } },
+            { "`Code_block": [ "None", "bar" ] }
+          ],
           "warnings": [
             "File \"f.ml\", line 2, characters 0-7:\n'{[...]}' (code block) is not allowed in the tags section.\nSuggestion: move '{[...]}' (code block) before any tags."
           ]
@@ -2376,7 +2379,7 @@ let%expect_test _ =
       test "{[@author Foo]}";
       [%expect
         {|
-          { "value": [ { "`Code_block": "@author Foo" } ], "warnings": [] } |}]
+          { "value": [ { "`Code_block": [ "None", "@author Foo" ] } ], "warnings": [] } |}]
 
     let in_verbatim =
       test "{v @author Foo v}";
@@ -2389,7 +2392,10 @@ let%expect_test _ =
       [%expect
         {|
         {
-          "value": [ { "`Code_block": "foo" }, { "`Tag": { "`Author": "Bar" } } ],
+          "value": [
+            { "`Code_block": [ "None", "foo" ] },
+            { "`Tag": { "`Author": "Bar" } }
+          ],
           "warnings": [
             "File \"f.ml\", line 1, characters 8-19:\n'@author' should begin on its own line."
           ]


### PR DESCRIPTION
Pass the language tag through the model and to highlightjs in the html generator. The value is ignored in other backends.
Code blocks with no language specified are rendered as before (highlighted).

Highlightjs should recognize `plain`, `plaintext` and `text` to disable highlighting but perhaps we should have a string specific to Odoc that we can document and handle specifically ?

The version of highlightjs vendored only support one language (OCaml) and is not updated in this PR.