### PR TITLE
Upgrade to ocamlformat 0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,2 @@
-version=0.19.0
+module-item-spacing=preserve
+version=0.21.0

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -255,8 +255,7 @@ let rec documentedSrc ~resolve (t : DocumentedSrc.t) : item Html.elt list =
                   [ Html.span ~a:(class_ [ "comment-delim" ]) [ Html.txt s ] ]
                 in
                 [
-                  Html.div
-                    ~a:(class_ [ "def-doc" ])
+                  Html.div ~a:(class_ [ "def-doc" ])
                     (delim opening @ block ~resolve doc @ delim closing);
                 ]
           in


### PR DESCRIPTION
In order to minimise problems with current PRs, this enables the
deprecated 'module-item-spacing=preserve'.