### PR TITLE
Stale issue bot: Don't close issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,6 +30,6 @@ jobs:
             for open issues. They will be given the same review attention, and
             any other help.
           days-before-stale: 365
-          days-before-close: 30
+          days-before-close: -1
           exempt-issue-labels: "bug,not stale"
           stale-issue-label: "stale"


### PR DESCRIPTION
Monitoring what the bot does is a lot of work.

See for example: https://github.com/ocaml/odoc/issues/574