### PR TITLE
Annotate code that is following or followed by other code

### DIFF
--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -166,6 +166,9 @@ let rec last = function
   | [ x ] -> x
   | _ :: xs -> last xs
 
+(* Checking whether an Inline.desc starts with or ends with preformatted text.
+   This is only an approximation as we did not check whether the text is empty
+   [Text ""] or the styled inline is empty [Style (_, [])]. *)
 let rec is_inline_preformatted =
   let open Inline in
   function

--- a/src/odoc/etc/odoc.css
+++ b/src/odoc/etc/odoc.css
@@ -387,6 +387,20 @@ li code {
   padding: 0 0.3ex;
 }
 
+p code.followed-by-code,
+li code.followed-by-code {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+  padding-right: 0px;
+}
+
+p code.following-code,
+li code.following-code {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+  padding-left: 0px;
+}
+
 p a > code {
   color: var(--link-color);
 }

--- a/test/generators/cases/markup.mli
+++ b/test/generators/cases/markup.mli
@@ -47,8 +47,9 @@
     [code] is a different kind of markup that doesn't allow nested markup.
 
     It's possible for two markup elements to appear {b next} {i to} each other
-    and have a space, and appear {b next}{i to} each other with no space. It
-    doesn't matter {b how}  {i much} space it was in the source: in this
+    and have a space, and appear {b next}{i to} each other with no space.
+    This also applies to consecutive code phrases [f][ ][x].
+    It doesn't matter {b how}  {i much} space it was in the source: in this
     sentence, it was two space characters. And in this one, there is {b a}
     {i newline}.
 

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -88,9 +88,13 @@
    </p>
    <p>It's possible for two markup elements to appear <b>next</b> <i>to</i>
      each other and have a space, and appear <b>next</b><i>to</i> each
-     other with no space. It doesn't matter <b>how</b> <i>much</i> space
-     it was in the source: in this sentence, it was two space characters.
-     And in this one, there is <b>a</b> <i>newline</i>.
+     other with no space. This also applies to consecutive code phrases
+     <code class="followed-by-code">f</code>
+    <code class="following-code followed-by-code"> </code>
+    <code class="following-code">x</code>. It doesn't matter <b>how</b>
+     <i>much</i> space it was in the source: in this sentence, it was
+     two space characters. And in this one, there is <b>a</b> <i>newline</i>
+    .
    </p>
    <p>This is also true between <em>non-</em><code>code</code> markup
      <em>and</em> <code>code</code>.

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -1040,12 +1040,15 @@
      <ol>
       <li id="type-poly_variant.TagA" class="def constructor anchored">
        <a href="#type-poly_variant.TagA" class="anchor"></a>
-       <code><span>| </span></code><code><span>`TagA</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`TagA</span></code>
       </li>
       <li id="type-poly_variant.ConstrB" class="def constructor anchored">
        <a href="#type-poly_variant.ConstrB" class="anchor"></a>
-       <code><span>| </span></code>
-       <code><span>`ConstrB <span class="keyword">of</span> int</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
+        <span>`ConstrB <span class="keyword">of</span> int</span>
+       </code>
       </li>
      </ol><code><span> ]</span></code>
     </div>
@@ -1267,13 +1270,15 @@
      <ol>
       <li id="type-poly_variant_union.poly_variant" class="def type anchored">
        <a href="#type-poly_variant_union.poly_variant" class="anchor"></a>
-       <code><span>| </span></code>
-       <code><span><a href="#type-poly_variant">poly_variant</a></span>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
+        <span><a href="#type-poly_variant">poly_variant</a></span>
        </code>
       </li>
       <li id="type-poly_variant_union.TagC" class="def constructor anchored">
        <a href="#type-poly_variant_union.TagC" class="anchor"></a>
-       <code><span>| </span></code><code><span>`TagC</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`TagC</span></code>
       </li>
      </ol><code><span> ]</span></code>
     </div>
@@ -1292,8 +1297,8 @@
      <ol>
       <li id="type-poly_poly_variant.TagA" class="def constructor anchored">
        <a href="#type-poly_poly_variant.TagA" class="anchor"></a>
-       <code><span>| </span></code>
-       <code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
         <span>`TagA <span class="keyword">of</span> 
          <span class="type-var">'a</span>
         </span>
@@ -1314,8 +1319,8 @@
       <li id="type-bin_poly_poly_variant.TagA" class="def constructor
        anchored">
        <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a>
-       <code><span>| </span></code>
-       <code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
         <span>`TagA <span class="keyword">of</span> 
          <span class="type-var">'a</span>
         </span>
@@ -1324,8 +1329,8 @@
       <li id="type-bin_poly_poly_variant.ConstrB" class="def constructor
        anchored">
        <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a>
-       <code><span>| </span></code>
-       <code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
         <span>`ConstrB <span class="keyword">of</span> 
          <span class="type-var">'b</span>
         </span>
@@ -1445,12 +1450,13 @@
      <ol>
       <li id="type-nested_poly_variant.A" class="def constructor anchored">
        <a href="#type-nested_poly_variant.A" class="anchor"></a>
-       <code><span>| </span></code><code><span>`A</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`A</span></code>
       </li>
       <li id="type-nested_poly_variant.B" class="def constructor anchored">
        <a href="#type-nested_poly_variant.B" class="anchor"></a>
-       <code><span>| </span></code>
-       <code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
         <span>`B <span class="keyword">of</span> 
          <span>[ `B1 <span>| `B2</span> ]</span>
         </span>
@@ -1458,12 +1464,13 @@
       </li>
       <li id="type-nested_poly_variant.C" class="def constructor anchored">
        <a href="#type-nested_poly_variant.C" class="anchor"></a>
-       <code><span>| </span></code><code><span>`C</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`C</span></code>
       </li>
       <li id="type-nested_poly_variant.D" class="def constructor anchored">
        <a href="#type-nested_poly_variant.D" class="anchor"></a>
-       <code><span>| </span></code>
-       <code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
         <span>`D <span class="keyword">of</span> 
          <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span>
         </span>

--- a/test/generators/html/Recent-module-type-PolyS.html
+++ b/test/generators/html/Recent-module-type-PolyS.html
@@ -23,12 +23,14 @@
      </code>
      <ol>
       <li id="type-t.A" class="def constructor anchored">
-       <a href="#type-t.A" class="anchor"></a><code><span>| </span></code>
-       <code><span>`A</span></code>
+       <a href="#type-t.A" class="anchor"></a>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`A</span></code>
       </li>
       <li id="type-t.B" class="def constructor anchored">
-       <a href="#type-t.B" class="anchor"></a><code><span>| </span></code>
-       <code><span>`B</span></code>
+       <a href="#type-t.B" class="anchor"></a>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`B</span></code>
       </li>
      </ol><code><span> ]</span></code>
     </div>

--- a/test/generators/html/Recent.html
+++ b/test/generators/html/Recent.html
@@ -151,23 +151,28 @@
      <ol>
       <li id="type-polymorphic_variant.A" class="def constructor anchored">
        <a href="#type-polymorphic_variant.A" class="anchor"></a>
-       <code><span>| </span></code><code><span>`A</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`A</span></code>
       </li>
       <li id="type-polymorphic_variant.B" class="def constructor anchored">
        <a href="#type-polymorphic_variant.B" class="anchor"></a>
-       <code><span>| </span></code>
-       <code><span>`B <span class="keyword">of</span> int</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
+        <span>`B <span class="keyword">of</span> int</span>
+       </code>
       </li>
       <li id="type-polymorphic_variant.C" class="def constructor anchored">
        <a href="#type-polymorphic_variant.C" class="anchor"></a>
-       <code><span>| </span></code><code><span>`C</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`C</span></code>
        <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
         <span class="comment-delim">*)</span>
        </div>
       </li>
       <li id="type-polymorphic_variant.D" class="def constructor anchored">
        <a href="#type-polymorphic_variant.D" class="anchor"></a>
-       <code><span>| </span></code><code><span>`D</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`D</span></code>
        <div class="def-doc"><span class="comment-delim">(*</span><p>bar</p>
         <span class="comment-delim">*)</span>
        </div>

--- a/test/generators/html/Type.html
+++ b/test/generators/html/Type.html
@@ -387,22 +387,27 @@
      <ol>
       <li id="type-polymorphic_variant.A" class="def constructor anchored">
        <a href="#type-polymorphic_variant.A" class="anchor"></a>
-       <code><span>| </span></code><code><span>`A</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`A</span></code>
       </li>
       <li id="type-polymorphic_variant.B" class="def constructor anchored">
        <a href="#type-polymorphic_variant.B" class="anchor"></a>
-       <code><span>| </span></code>
-       <code><span>`B <span class="keyword">of</span> int</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
+        <span>`B <span class="keyword">of</span> int</span>
+       </code>
       </li>
       <li id="type-polymorphic_variant.C" class="def constructor anchored">
        <a href="#type-polymorphic_variant.C" class="anchor"></a>
-       <code><span>| </span></code>
-       <code><span>`C <span class="keyword">of</span> int * unit</span>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
+        <span>`C <span class="keyword">of</span> int * unit</span>
        </code>
       </li>
       <li id="type-polymorphic_variant.D" class="def constructor anchored">
        <a href="#type-polymorphic_variant.D" class="anchor"></a>
-       <code><span>| </span></code><code><span>`D</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`D</span></code>
       </li>
      </ol><code><span> ]</span></code>
     </div>
@@ -419,8 +424,8 @@
        class="def type anchored">
        <a href="#type-polymorphic_variant_extension.polymorphic_variant"
         class="anchor">
-       </a><code><span>| </span></code>
-       <code>
+       </a><code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
         <span><a href="#type-polymorphic_variant">polymorphic_variant</a>
         </span>
        </code>
@@ -428,7 +433,8 @@
       <li id="type-polymorphic_variant_extension.E" class="def constructor
        anchored">
        <a href="#type-polymorphic_variant_extension.E" class="anchor"></a>
-       <code><span>| </span></code><code><span>`E</span></code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code"><span>`E</span></code>
       </li>
      </ol><code><span> ]</span></code>
     </div>
@@ -444,8 +450,8 @@
       <li id="type-nested_polymorphic_variant.A" class="def constructor
        anchored">
        <a href="#type-nested_polymorphic_variant.A" class="anchor"></a>
-       <code><span>| </span></code>
-       <code>
+       <code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
         <span>`A <span class="keyword">of</span> 
          <span>[ `B <span>| `C</span> ]</span>
         </span>
@@ -473,8 +479,8 @@
       <li id="type-private_extenion.polymorphic_variant" class="def type
        anchored">
        <a href="#type-private_extenion.polymorphic_variant" class="anchor">
-       </a><code><span>| </span></code>
-       <code>
+       </a><code class="followed-by-code"><span>| </span></code>
+       <code class="following-code">
         <span><a href="#type-polymorphic_variant">polymorphic_variant</a>
         </span>
        </code>

--- a/test/generators/latex/Markup.tex
+++ b/test/generators/latex/Markup.tex
@@ -28,7 +28,7 @@ Note: \emph{In italics \emph{emphasis} is rendered as normal text while \emph{em
 
 \ocamlinlinecode{code} is a different kind of markup that doesn't allow nested markup.
 
-It's possible for two markup elements to appear \bold{next} \emph{to} each other and have a space, and appear \bold{next}\emph{to} each other with no space. It doesn't matter \bold{how} \emph{much} space it was in the source: in this sentence, it was two space characters. And in this one, there is \bold{a} \emph{newline}.
+It's possible for two markup elements to appear \bold{next} \emph{to} each other and have a space, and appear \bold{next}\emph{to} each other with no space. This also applies to consecutive code phrases \ocamlinlinecode{f}\ocamlinlinecode{ }\ocamlinlinecode{x}. It doesn't matter \bold{how} \emph{much} space it was in the source: in this sentence, it was two space characters. And in this one, there is \bold{a} \emph{newline}.
 
 This is also true between \emph{non-}\ocamlinlinecode{code} markup \emph{and} \ocamlinlinecode{code}.
 

--- a/test/generators/man/Markup.3o
+++ b/test/generators/man/Markup.3o
@@ -80,7 +80,7 @@ links in italics with emphasis in emphasis\.
 .sp 
 code is a different kind of markup that doesn't allow nested markup\.
 .sp 
-It's possible for two markup elements to appear \fBnext\fR \fIto\fR each other and have a space, and appear \fBnext\fR\fIto\fR each other with no space\. It doesn't matter \fBhow\fR \fImuch\fR space it was in the source: in this sentence, it was two space characters\. And in this one, there is \fBa\fR \fInewline\fR\.
+It's possible for two markup elements to appear \fBnext\fR \fIto\fR each other and have a space, and appear \fBnext\fR\fIto\fR each other with no space\. This also applies to consecutive code phrases f x\. It doesn't matter \fBhow\fR \fImuch\fR space it was in the source: in this sentence, it was two space characters\. And in this one, there is \fBa\fR \fInewline\fR\.
 .sp 
 This is also true between non-code markup and code\.
 .sp 


### PR DESCRIPTION
Closes #696. The goal of this PR is to make
```ocaml
(** [f][ ][x] *)
```
look like
```ocaml
(** [f x] *)
```
with the default theme. The motivation is to write `{!val:f}[ x]` so that `f` is linked but the text still looks like `[f x]`.

## Technical details

This PR annotates adjacent `<code>` phrases with CSS classes `following-code` and `followed-by-code` so that one can turn off the padding between `<code>` via CSS.  The comment `[f][ ][x]` will generate something like this:
```html
<code class="followed-by-code">f</code><code class="following-code followed-by-code"> </code><code class="following-code">x</code>
```
and then the padding can be turned off using the CSS selectors `code.following-code` and `code.followed-by-code`. See the changes to `src/odoc/etc/odoc.css`. The annotation algorithm does not change the asymptotic complexity and I did not notice obvious slowdown. However, a serious benchmarking might still be useful.

## Caveats

1. Due to https://github.com/ocsigen/tyxml/issues/287, `tyxml` would insert spaces when `indent` is true, but it's no longer `odoc`'s fault.
2. I did not check how other backends can benefit from the new annotations, but at very least it would not be worse. The LaTeX backend, for example, could benefit from them.