### PR TITLE
No dev deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ the docs locally yourself from the `odoc` directory:
 git clone https://github.com/ocaml/odoc.git
 cd odoc
 opam pin add . -n
-opam install mdx bos
 opam install --deps-only -t odoc
 dune build @docgen
 ```

--- a/doc/contributing.mld
+++ b/doc/contributing.mld
@@ -42,7 +42,6 @@ git clone https://github.com/ocaml/odoc.git
 cd odoc
 opam pin add --no-action odoc .
 opam install --with-test --deps-only odoc
-opam install mdx
 ]}}
 {- Make changes to the code. To compile it,
 {[

--- a/odoc.opam
+++ b/odoc.opam
@@ -44,8 +44,8 @@ depends: [
   "ppx_expect" {with-test}
   "bos" {with-test}
 
-  ("ocaml" {< "4.07.0" & dev} | "bisect_ppx" {dev & > "2.5.0"})
-  ("ocaml" {< "4.03.0" & dev} | "mdx" {dev})
+  ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
+  ("ocaml" {< "4.03.0" & with-test} | "mdx" {with-test})
 ]
 
 build: [


### PR DESCRIPTION
This moves `dev` deps to `with-test` deps. 

This makes release deps the same as `dev` deps and makes it easier to ask users to try `master` with `opam pin --dev odoc` without disturbing their `opam` switch too much.

