### PR TITLE
Add tag content linking

### DIFF
--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -224,13 +224,7 @@ and comment_nestable_block_element env parent ~loc:_
   | `List (x, ys) ->
       `List
         ( x,
-          List.rev_map
-            (fun x ->
-              List.rev_map
-                (with_location (comment_nestable_block_element env parent))
-                x
-              |> List.rev)
-            ys
+          List.rev_map (comment_nestable_block_element_list env parent) ys
           |> List.rev )
   | `Modules refs ->
       let refs =
@@ -259,7 +253,8 @@ and comment_nestable_block_element env parent ~loc:_
 
 and comment_nestable_block_element_list env parent
     (xs : Comment.nestable_block_element Comment.with_location list) =
-  List.map (with_location (comment_nestable_block_element env parent)) xs
+  List.rev_map (with_location (comment_nestable_block_element env parent)) xs
+  |> List.rev
 
 and comment_tag env parent ~loc:_ (x : Comment.tag) =
   match x with

--- a/test/generators/cases/tag_link.ml
+++ b/test/generators/cases/tag_link.ml
@@ -1,0 +1,8 @@
+let foo = ()
+
+(** @deprecated {!foo}
+    @param foo {!foo}
+    @raise Foo {!foo}
+    @return {!foo}
+    @see "foo" {!foo}
+    @before 0.0.1 {!foo} *)

--- a/test/generators/html/Tag_link.html
+++ b/test/generators/html/Tag_link.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Tag_link (Tag_link)</title>
+  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Tag_link</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-foo">
+     <a href="#val-foo" class="anchor"></a>
+     <code><span><span class="keyword">val</span> foo : unit</span></code>
+    </div>
+   </div>
+   <ul class="at-tags">
+    <li class="deprecated"><span class="at-tag">deprecated</span> 
+     <p><a href="#val-foo"><code>foo</code></a></p>
+    </li>
+   </ul>
+   <ul class="at-tags">
+    <li class="parameter"><span class="at-tag">parameter</span> 
+     <span class="value">foo</span> 
+     <p><a href="#val-foo"><code>foo</code></a></p>
+    </li>
+   </ul>
+   <ul class="at-tags">
+    <li class="raises"><span class="at-tag">raises</span> 
+     <span class="value">Foo</span> 
+     <p><a href="#val-foo"><code>foo</code></a></p>
+    </li>
+   </ul>
+   <ul class="at-tags">
+    <li class="returns"><span class="at-tag">returns</span> 
+     <p><a href="#val-foo"><code>foo</code></a></p>
+    </li>
+   </ul>
+   <ul class="at-tags">
+    <li class="see"><span class="at-tag">see</span> 
+     <span class="value">foo</span> 
+     <p><a href="#val-foo"><code>foo</code></a></p>
+    </li>
+   </ul>
+   <ul class="at-tags">
+    <li class="before"><span class="at-tag">before</span> 
+     <span class="value">0.0.1</span> 
+     <p><a href="#val-foo"><code>foo</code></a></p>
+    </li>
+   </ul>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/tag_link.targets
+++ b/test/generators/html/tag_link.targets
@@ -1,0 +1,1 @@
+Tag_link.html

--- a/test/generators/latex/Tag_link.tex
+++ b/test/generators/latex/Tag_link.tex
@@ -1,0 +1,34 @@
+\section{Module \ocamlinlinecode{Tag\_\allowbreak{}link}}\label{module-Tag+u+link}%
+\label{module-Tag+u+link-val-foo}\ocamlcodefragment{\ocamltag{keyword}{val} foo : unit}\\
+\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{deprecated}]{\hyperref[module-Tag+u+link-val-foo]{\ocamlinlinecode{\ocamlinlinecode{foo}}[p\pageref*{module-Tag+u+link-val-foo}]}
+
+}\end{description}%
+\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{parameter foo}]{\hyperref[module-Tag+u+link-val-foo]{\ocamlinlinecode{\ocamlinlinecode{foo}}[p\pageref*{module-Tag+u+link-val-foo}]}
+
+}\end{description}%
+\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{raises Foo}]{\hyperref[module-Tag+u+link-val-foo]{\ocamlinlinecode{\ocamlinlinecode{foo}}[p\pageref*{module-Tag+u+link-val-foo}]}
+
+}\end{description}%
+\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{returns}]{\hyperref[module-Tag+u+link-val-foo]{\ocamlinlinecode{\ocamlinlinecode{foo}}[p\pageref*{module-Tag+u+link-val-foo}]}
+
+}\end{description}%
+\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{see foo}]{\hyperref[module-Tag+u+link-val-foo]{\ocamlinlinecode{\ocamlinlinecode{foo}}[p\pageref*{module-Tag+u+link-val-foo}]}
+
+}\end{description}%
+\begin{description}\kern-\topsep
+\makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
+\item[{before 0.0.1}]{\hyperref[module-Tag+u+link-val-foo]{\ocamlinlinecode{\ocamlinlinecode{foo}}[p\pageref*{module-Tag+u+link-val-foo}]}
+
+}\end{description}%
+
+

--- a/test/generators/latex/tag_link.targets
+++ b/test/generators/latex/tag_link.targets
@@ -1,0 +1,1 @@
+Tag_link.tex

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -468,6 +468,21 @@
   (run odoc link -o %{target} %{dep:stop_first_comment.odoc})))
 
 (rule
+ (target tag_link.cmt)
+ (action
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/tag_link.ml})))
+
+(rule
+ (target tag_link.odoc)
+ (action
+  (run odoc compile -o %{target} %{dep:tag_link.cmt})))
+
+(rule
+ (target tag_link.odocl)
+ (action
+  (run odoc link -o %{target} %{dep:tag_link.odoc})))
+
+(rule
  (target toplevel_comments.cmti)
  (action
   (run ocamlc -c -bin-annot -o %{target} %{dep:cases/toplevel_comments.mli})))
@@ -6571,6 +6586,84 @@
   (alias runtest)
   (action
    (diff stop_first_comment.targets stop_first_comment.targets.gen))))
+
+(subdir
+ html
+ (rule
+  (targets Tag_link.html.gen)
+  (action
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../tag_link.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Tag_link.html Tag_link.html.gen))))
+
+(subdir
+ html
+ (rule
+  (action
+   (with-outputs-to
+    tag_link.targets.gen
+    (run odoc html-targets -o . %{dep:../tag_link.odocl} --flat))))
+ (rule
+  (alias runtest)
+  (action
+   (diff tag_link.targets tag_link.targets.gen))))
+
+(subdir
+ latex
+ (rule
+  (targets Tag_link.tex.gen)
+  (action
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../tag_link.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Tag_link.tex Tag_link.tex.gen))))
+
+(subdir
+ latex
+ (rule
+  (action
+   (with-outputs-to
+    tag_link.targets.gen
+    (run odoc latex-targets -o . %{dep:../tag_link.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff tag_link.targets tag_link.targets.gen))))
+
+(subdir
+ man
+ (rule
+  (targets Tag_link.3o.gen)
+  (action
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../tag_link.odocl})))
+ (rule
+  (alias runtest)
+  (action
+   (diff Tag_link.3o Tag_link.3o.gen))))
+
+(subdir
+ man
+ (rule
+  (action
+   (with-outputs-to
+    tag_link.targets.gen
+    (run odoc man-targets -o . %{dep:../tag_link.odocl}))))
+ (rule
+  (alias runtest)
+  (action
+   (diff tag_link.targets tag_link.targets.gen))))
 
 (subdir
  html

--- a/test/generators/man/Tag_link.3o
+++ b/test/generators/man/Tag_link.3o
@@ -1,0 +1,29 @@
+
+.TH Tag_link 3 "" "Odoc" "OCaml Library"
+.SH Name
+Tag_link
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Tag_link\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]val\fR foo : unit
+.sp 
+.fi 
+@deprecated: \f[CI]foo\fR
+.br 
+@parameter foo: \f[CI]foo\fR
+.br 
+@raises Foo: \f[CI]foo\fR
+.br 
+@returns: \f[CI]foo\fR
+.br 
+@see foo: \f[CI]foo\fR
+.br 
+@before 0\.0\.1: \f[CI]foo\fR
+.nf 
+

--- a/test/generators/man/tag_link.targets
+++ b/test/generators/man/tag_link.targets
@@ -1,0 +1,1 @@
+Tag_link.3o


### PR DESCRIPTION
Closes #827.

I noticed that the similar `List` case in `comment_nestable_block_element` uses `List.rev_map ... |> List.rev` instead though. Should it be done here as well?