### PR TITLE
Render unresolved reference fields in `Source`

### DIFF
--- a/src/ocamlary/ocamlary.mli
+++ b/src/ocamlary/ocamlary.mli
@@ -1067,3 +1067,10 @@ type new_t = ..
 type new_t += C
 
 module type TypeExtPruned = TypeExt with type t := new_t
+
+(** {1 Unresolved references} *)
+
+(** - {!Stdlib.Invalid_argument}
+    - {!Hashtbl.t}
+    - {!Set.S.empty}
+    - {!CollectionModule.InnerModuleA.foo} *)

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -2926,9 +2926,9 @@
    <h2 id="unresolved-references">
     <a href="#unresolved-references" class="anchor"></a>Unresolved references
    </h2>
-   <ul><li><code>Stdlib</code>.Invalid_argument</li>
-    <li><code>Hashtbl</code>.t</li><li><code>Set</code>.S.empty</li>
-    <li><code>CollectionModule</code>.InnerModuleA.foo</li>
+   <ul><li><code>Stdlib.Invalid_argument</code></li>
+    <li><code>Hashtbl.t</code></li><li><code>Set.S.empty</code></li>
+    <li><code>CollectionModule.InnerModuleA.foo</code></li>
    </ul>
   </div>
  </body>

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -67,6 +67,7 @@
     </li><li><a href="#aliases">Aliases again</a></li>
     <li><a href="#section-title-splicing">Section title splicing</a></li>
     <li><a href="#new-reference-syntax">New reference syntax</a></li>
+    <li><a href="#unresolved-references">Unresolved references</a></li>
    </ul>
   </nav>
   <div class="odoc-content">
@@ -2922,6 +2923,13 @@
      </code>
     </div>
    </div>
+   <h2 id="unresolved-references">
+    <a href="#unresolved-references" class="anchor"></a>Unresolved references
+   </h2>
+   <ul><li><code>Stdlib</code>.Invalid_argument</li>
+    <li><code>Hashtbl</code>.t</li><li><code>Set</code>.S.empty</li>
+    <li><code>CollectionModule</code>.InnerModuleA.foo</li>
+   </ul>
   </div>
  </body>
 </html>

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -895,6 +895,11 @@ Here goes:
 \label{module-Ocamlary-module-type-TypeExtPruned-val-f}\ocamlcodefragment{\ocamltag{keyword}{val} f : \hyperref[module-Ocamlary-type-new+u+t]{\ocamlinlinecode{new\_\allowbreak{}t}} \ocamltag{arrow}{$\rightarrow$} unit}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\subsection{Unresolved references\label{unresolved-references}}%
+\begin{itemize}\item{\ocamlinlinecode{Stdlib}.Invalid\_argument}%
+\item{\ocamlinlinecode{Hashtbl}.t}%
+\item{\ocamlinlinecode{Set}.S.empty}%
+\item{\ocamlinlinecode{CollectionModule}.InnerModuleA.foo}\end{itemize}%
 
 \input{Ocamlary.ModuleWithSignature.tex}
 \input{Ocamlary.ModuleWithSignatureAlias.tex}

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -896,10 +896,10 @@ Here goes:
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \subsection{Unresolved references\label{unresolved-references}}%
-\begin{itemize}\item{\ocamlinlinecode{Stdlib}.Invalid\_argument}%
-\item{\ocamlinlinecode{Hashtbl}.t}%
-\item{\ocamlinlinecode{Set}.S.empty}%
-\item{\ocamlinlinecode{CollectionModule}.InnerModuleA.foo}\end{itemize}%
+\begin{itemize}\item{\ocamlinlinecode{Stdlib.\allowbreak{}Invalid\_\allowbreak{}argument}}%
+\item{\ocamlinlinecode{Hashtbl.\allowbreak{}t}}%
+\item{\ocamlinlinecode{Set.\allowbreak{}S.\allowbreak{}empty}}%
+\item{\ocamlinlinecode{CollectionModule.\allowbreak{}InnerModuleA.\allowbreak{}foo}}\end{itemize}%
 
 \input{Ocamlary.ModuleWithSignature.tex}
 \input{Ocamlary.ModuleWithSignatureAlias.tex}

--- a/test/generators/man/Ocamlary.3o
+++ b/test/generators/man/Ocamlary.3o
@@ -1892,3 +1892,18 @@ Here goes:
 \f[CB]val\fR f : new_t \f[CB]\->\fR unit
 .br 
 \f[CB]end\fR
+.sp 
+.in 3
+\fB8 Unresolved references\fR
+.in 
+.sp 
+.fi 
+\(bu Stdlib\.Invalid_argument
+.br 
+\(bu Hashtbl\.t
+.br 
+\(bu Set\.S\.empty
+.br 
+\(bu CollectionModule\.InnerModuleA\.foo
+.nf 
+


### PR DESCRIPTION
Closes #816.

### TODO
- [ ] Fix warnings on `dune build`:
    ```
    File "cases/ocamlary.mli", line 1076, characters 6-42:
    Warning: Failed to resolve reference unresolvedroot(CollectionModule).InnerModuleA.foo Couldn't find "foo"
    File "cases/ocamlary.mli", line 1075, characters 6-20:
    Warning: Failed to resolve reference unresolvedroot(Set).S.empty Couldn't find "Set"
    File "cases/ocamlary.mli", line 1074, characters 6-18:
    Warning: Failed to resolve reference unresolvedroot(Hashtbl).t Couldn't find "Hashtbl"
    File "cases/ocamlary.mli", line 1073, characters 6-32:
    Warning: Failed to resolve reference unresolvedroot(Stdlib).Invalid_argument Couldn't find "Stdlib"
    ```
    Not sure what to do about it though.
- [ ] #613 as suggested in #816?