### PR TITLE
title formatting is now a renderer decision

### DIFF
--- a/src/document/doctree.ml
+++ b/src/document/doctree.ml
@@ -296,20 +296,19 @@ end = struct
     in
     match kind with
     | `Module -> prefix "Module"
-    | `Argument -> prefix "Parameter"
+    | `Parameter -> prefix "Parameter"
     | `ModuleType -> prefix "Module type"
     | `ClassType -> prefix "Class type"
     | `Class -> prefix "Class"
-    | `Page -> []
+    | `Page | `LeafPage | `File -> []
 
-  let make_name_from_path { Url.Path.name; parent; _ } =
+  let make_name_from_path { Url.Path.path_fragment; parent; _ } =
     match parent with
-    | None | Some { kind = `Page; _ } -> name
-    | Some p -> Printf.sprintf "%s.%s" p.name name
+    | None | Some { kind = `Page; _ } -> path_fragment
+    | Some p -> Printf.sprintf "%s.%s" p.path_fragment path_fragment
 
   let render_title (p : Page.t) =
-    format_title p.kind
-      (make_name_from_path p.url)
+    format_title p.url.kind (make_name_from_path p.url)
 end
 
 module Math : sig

--- a/src/document/doctree.ml
+++ b/src/document/doctree.ml
@@ -296,16 +296,16 @@ end = struct
     in
     match kind with
     | `Module -> prefix "Module"
-    | `Parameter -> prefix "Parameter"
+    | `Parameter _ -> prefix "Parameter"
     | `ModuleType -> prefix "Module type"
     | `ClassType -> prefix "Class type"
     | `Class -> prefix "Class"
     | `Page | `LeafPage | `File -> []
 
-  let make_name_from_path { Url.Path.path_fragment; parent; _ } =
+  let make_name_from_path { Url.Path.name; parent; _ } =
     match parent with
-    | None | Some { kind = `Page; _ } -> path_fragment
-    | Some p -> Printf.sprintf "%s.%s" p.path_fragment path_fragment
+    | None | Some { kind = `Page; _ } -> name
+    | Some p -> Printf.sprintf "%s.%s" p.name name
 
   let render_title (p : Page.t) =
     format_title p.url.kind (make_name_from_path p.url)

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -72,10 +72,10 @@ let prepare_preamble comment items =
   in
   (Comment.standalone preamble, Comment.standalone first_comment @ items)
 
-let make_expansion_page title kind url comments items =
+let make_expansion_page url comments items =
   let comment = List.concat comments in
   let preamble, items = prepare_preamble comment items in
-  { Page.title; kind; preamble; items; url }
+  { Page.preamble; items; url }
 
 include Generator_signatures
 
@@ -1009,9 +1009,7 @@ module Make (Syntax : SYNTAX) = struct
         | Some csig ->
             let expansion_doc, items = class_signature csig in
             let url = Url.Path.from_identifier t.id in
-            let page =
-              make_expansion_page name `Class url [ t.doc; expansion_doc ] items
-            in
+            let page = make_expansion_page url [ t.doc; expansion_doc ] items in
             ( O.documentedSrc @@ path url [ inline @@ Text name ],
               Some page,
               Some expansion_doc )
@@ -1046,10 +1044,7 @@ module Make (Syntax : SYNTAX) = struct
         | Some csig ->
             let url = Url.Path.from_identifier t.id in
             let expansion_doc, items = class_signature csig in
-            let page =
-              make_expansion_page name `ClassType url [ t.doc; expansion_doc ]
-                items
-            in
+            let page = make_expansion_page url [ t.doc; expansion_doc ] items in
             ( O.documentedSrc @@ path url [ inline @@ Text name ],
               Some page,
               Some expansion_doc )
@@ -1173,9 +1168,7 @@ module Make (Syntax : SYNTAX) = struct
             let url = Url.Path.from_identifier arg.id in
             let modname = path url [ inline @@ Text name ] in
             let type_with_expansion =
-              let content =
-                make_expansion_page name `Argument url [ expansion_doc ] items
-              in
+              let content = make_expansion_page url [ expansion_doc ] items in
               let summary = O.render modtyp in
               let status = `Default in
               let expansion =
@@ -1323,10 +1316,7 @@ module Make (Syntax : SYNTAX) = struct
             in
             let url = Url.Path.from_identifier t.id in
             let link = path url [ inline @@ Text modname ] in
-            let page =
-              make_expansion_page modname `Module url [ t.doc; expansion_doc ]
-                items
-            in
+            let page = make_expansion_page url [ t.doc; expansion_doc ] items in
             (link, status, Some page, Some expansion_doc)
       in
       let intro = O.keyword "module" ++ O.txt " " ++ modname in
@@ -1382,10 +1372,7 @@ module Make (Syntax : SYNTAX) = struct
         | Some (expansion_doc, items) ->
             let url = Url.Path.from_identifier id in
             let link = path url [ inline @@ Text modname ] in
-            let page =
-              make_expansion_page modname `ModuleType url [ doc; expansion_doc ]
-                items
-            in
+            let page = make_expansion_page url [ doc; expansion_doc ] items in
             (link, Some page, Some expansion_doc)
       in
       let summary =
@@ -1659,24 +1646,22 @@ module Make (Syntax : SYNTAX) = struct
       List.map f t
 
     let compilation_unit (t : Odoc_model.Lang.Compilation_unit.t) : Page.t =
-      let title = Paths.Identifier.name t.id in
       let url = Url.Path.from_identifier t.id in
       let unit_doc, items =
         match t.content with
         | Module sign -> signature sign
         | Pack packed -> ([], pack packed)
       in
-      make_expansion_page title `Module url [ unit_doc ] items
+      make_expansion_page url [ unit_doc ] items
 
     let page (t : Odoc_model.Lang.Page.t) : Page.t =
-      let name =
-        match t.name.iv with `Page (_, name) | `LeafPage (_, name) -> name
-      in
-      let title = Odoc_model.Names.PageName.to_string name in
+      (*let name =
+          match t.name.iv with `Page (_, name) | `LeafPage (_, name) -> name
+        in*)
+      (*let title = Odoc_model.Names.PageName.to_string name in*)
       let url = Url.Path.from_identifier t.name in
       let preamble, items = Sectioning.docs t.content in
-      let kind = `Page in
-      { Page.title; kind; preamble; items; url }
+      { Page.preamble; items; url }
   end
 
   include Page

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -157,9 +157,18 @@ end =
   Item
 
 and Page : sig
+  type kind =
+    [ `Module
+    | `Argument
+    | `ModuleType
+    | `ClassType
+    | `Class
+    | `Page ]
+
   type t = {
     title : string;
-    header : Item.t list;
+    kind : kind;
+    preamble : Item.t list;
     items : Item.t list;
     url : Url.Path.t;
   }

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -157,21 +157,7 @@ end =
   Item
 
 and Page : sig
-  type kind =
-    [ `Module
-    | `Argument
-    | `ModuleType
-    | `ClassType
-    | `Class
-    | `Page ]
-
-  type t = {
-    title : string;
-    kind : kind;
-    preamble : Item.t list;
-    items : Item.t list;
-    url : Url.Path.t;
-  }
+  type t = { preamble : Item.t list; items : Item.t list; url : Url.Path.t }
 end =
   Page
 

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -98,7 +98,7 @@ module Path = struct
     | `Page
     | `LeafPage
     | `ModuleType
-    | `Parameter
+    | `Parameter of int
     | `Class
     | `ClassType
     | `File ]
@@ -108,16 +108,16 @@ module Path = struct
     | `Module -> "module"
     | `LeafPage -> "leaf-page"
     | `ModuleType -> "module-type"
-    | `Parameter -> "argument"
+    | `Parameter arg_num -> Printf.sprintf "argument-%d" arg_num
     | `Class -> "class"
     | `ClassType -> "class-type"
     | `File -> "file"
 
   let pp_kind fmt kind = Format.fprintf fmt "%s" (string_of_kind kind)
 
-  type t = { kind : kind; parent : t option; path_fragment : string }
+  type t = { kind : kind; parent : t option; name : string }
 
-  let mk ?parent kind path_fragment = { kind; parent; path_fragment }
+  let mk ?parent kind name = { kind; parent; name }
 
   let rec from_identifier : source -> t =
    fun x ->
@@ -129,8 +129,8 @@ module Path = struct
           | None -> None
         in
         let kind = `Module in
-        let path_fragment = ModuleName.to_string unit_name in
-        mk ?parent kind path_fragment
+        let name = ModuleName.to_string unit_name in
+        mk ?parent kind name
     | { iv = `Page (parent, page_name); _ } ->
         let parent =
           match parent with
@@ -138,8 +138,8 @@ module Path = struct
           | None -> None
         in
         let kind = `Page in
-        let path_fragment = PageName.to_string page_name in
-        mk ?parent kind path_fragment
+        let name = PageName.to_string page_name in
+        mk ?parent kind name
     | { iv = `LeafPage (parent, page_name); _ } ->
         let parent =
           match parent with
@@ -147,36 +147,34 @@ module Path = struct
           | None -> None
         in
         let kind = `LeafPage in
-        let path_fragment = PageName.to_string page_name in
-        mk ?parent kind path_fragment
+        let name = PageName.to_string page_name in
+        mk ?parent kind name
     | { iv = `Module (parent, mod_name); _ } ->
         let parent = from_identifier (parent :> source) in
         let kind = `Module in
-        let path_fragment = ModuleName.to_string mod_name in
-        mk ~parent kind path_fragment
+        let name = ModuleName.to_string mod_name in
+        mk ~parent kind name
     | { iv = `Parameter (functor_id, arg_name); _ } as p ->
         let parent = from_identifier (functor_id :> source) in
-        let kind = `Parameter in
         let arg_num = functor_arg_pos p in
-        let path_fragment =
-          Printf.sprintf "%d-%s" arg_num (ModuleName.to_string arg_name)
-        in
-        mk ~parent kind path_fragment
+        let kind = `Parameter arg_num in
+        let name = ModuleName.to_string arg_name in
+        mk ~parent kind name
     | { iv = `ModuleType (parent, modt_name); _ } ->
         let parent = from_identifier (parent :> source) in
         let kind = `ModuleType in
-        let path_fragment = ModuleTypeName.to_string modt_name in
-        mk ~parent kind path_fragment
+        let name = ModuleTypeName.to_string modt_name in
+        mk ~parent kind name
     | { iv = `Class (parent, name); _ } ->
         let parent = from_identifier (parent :> source) in
         let kind = `Class in
-        let path_fragment = ClassName.to_string name in
-        mk ~parent kind path_fragment
+        let name = ClassName.to_string name in
+        mk ~parent kind name
     | { iv = `ClassType (parent, name); _ } ->
         let parent = from_identifier (parent :> source) in
         let kind = `ClassType in
-        let path_fragment = ClassTypeName.to_string name in
-        mk ~parent kind path_fragment
+        let name = ClassTypeName.to_string name in
+        mk ~parent kind name
     | { iv = `Result p; _ } -> from_identifier (p :> source)
 
   let from_identifier p =
@@ -184,18 +182,17 @@ module Path = struct
       (p : [< source_pv ] Odoc_model.Paths.Identifier.id :> source)
 
   let to_list url =
-    let rec loop acc { parent; path_fragment; kind } =
+    let rec loop acc { parent; name; kind } =
       match parent with
-      | None -> (kind, path_fragment) :: acc
-      | Some p -> loop ((kind, path_fragment) :: acc) p
+      | None -> (kind, name) :: acc
+      | Some p -> loop ((kind, name) :: acc) p
     in
     loop [] url
 
   let of_list l =
     let rec inner parent = function
       | [] -> parent
-      | (kind, path_fragment) :: xs ->
-          inner (Some { parent; path_fragment; kind }) xs
+      | (kind, name) :: xs -> inner (Some { parent; name; kind }) xs
     in
     inner None l
 
@@ -243,13 +240,11 @@ module Anchor = struct
 
   type t = { page : Path.t; anchor : string; kind : kind }
 
-  let anchorify_path { Path.parent; path_fragment; kind } =
+  let anchorify_path { Path.parent; name; kind } =
     match parent with
     | None -> assert false (* We got a root, should never happen *)
     | Some page ->
-        let anchor =
-          Printf.sprintf "%s-%s" (Path.string_of_kind kind) path_fragment
-        in
+        let anchor = Printf.sprintf "%s-%s" (Path.string_of_kind kind) name in
         { page; anchor; kind = (kind :> kind) }
 
   let add_suffix ~kind { page; anchor; _ } suffix =

--- a/src/document/url.mli
+++ b/src/document/url.mli
@@ -17,7 +17,7 @@ module Path : sig
     | `Page
     | `LeafPage
     | `ModuleType
-    | `Parameter
+    | `Parameter of int
     | `Class
     | `ClassType
     | `File ]
@@ -26,7 +26,7 @@ module Path : sig
 
   val string_of_kind : kind -> string
 
-  type t = { kind : kind; parent : t option; path_fragment : string }
+  type t = { kind : kind; parent : t option; name : string }
 
   type source_pv =
     [ Identifier.Page.t_pv

--- a/src/document/url.mli
+++ b/src/document/url.mli
@@ -17,7 +17,7 @@ module Path : sig
     | `Page
     | `LeafPage
     | `ModuleType
-    | `Argument
+    | `Parameter
     | `Class
     | `ClassType
     | `File ]
@@ -26,7 +26,7 @@ module Path : sig
 
   val string_of_kind : kind -> string
 
-  type t = { kind : kind; parent : t option; name : string }
+  type t = { kind : kind; parent : t option; path_fragment : string }
 
   type source_pv =
     [ Identifier.Page.t_pv

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -403,20 +403,7 @@ module Page = struct
       items ~config ~resolve (Doctree.PageTitle.render_title p @ preamble)
     in
     let content = (items ~config ~resolve i :> any Html.elt list) in
-    let name =
-      match url.kind with
-      | `Parameter ->
-          let i =
-            try String.index url.path_fragment '-'
-            with Not_found ->
-              print_endline url.path_fragment;
-              0
-          in
-          String.sub url.path_fragment (i + 1)
-            (String.length url.path_fragment - i - 1)
-      | _ -> url.path_fragment
-    in
-    Tree.make ~config ~header ~toc ~url ~uses_katex name content subpages
+    Tree.make ~config ~header ~toc ~url ~uses_katex url.name content subpages
 end
 
 let render ~config page = Page.page ~config page

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -367,7 +367,7 @@ module Toc = struct
       in
       let title_str =
         List.map (Format.asprintf "%a" (Tyxml.Html.pp_elt ())) text
-        |> String.concat " "
+        |> String.concat ""
       in
       let href = Link.href ~config ~resolve url in
       { title; title_str; href; children = List.map section children }
@@ -389,7 +389,7 @@ module Page = struct
     Utils.list_concat_map ~f:(include_ ~config) subpages
 
   and page ~config p : Odoc_document.Renderer.page list =
-    let { Page.title; header; items = i; url } =
+    let { Page.title; kind = _; preamble; items = i; url } =
       Doctree.Labels.disambiguate_page p
     and subpages =
       (* Don't use the output of [disambiguate_page] to avoid unecessarily
@@ -400,7 +400,9 @@ module Page = struct
     let i = Doctree.Shift.compute ~on_sub i in
     let uses_katex = Doctree.Math.has_math_elements p in
     let toc = Toc.gen_toc ~config ~resolve ~path:url i in
-    let header = items ~config ~resolve header in
+    let header =
+      items ~config ~resolve (Doctree.PageTitle.render_title p @ preamble)
+    in
     let content = (items ~config ~resolve i :> any Html.elt list) in
     Tree.make ~config ~header ~toc ~url ~uses_katex title content subpages
 end

--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -43,8 +43,7 @@ let page_creator ~config ~url ~uses_katex name header toc content =
       | Types.Absolute uri -> uri ^ "/" ^ file
       | Relative uri ->
           let page =
-            Odoc_document.Url.Path.
-              { kind = `File; parent = uri; path_fragment = file }
+            Odoc_document.Url.Path.{ kind = `File; parent = uri; name = file }
           in
           Link.href ~config ~resolve:(Current url)
             (Odoc_document.Url.from_path page)
@@ -128,12 +127,12 @@ let page_creator ~config ~url ~uses_katex name header toc content =
     match parents with
     | [] -> [] (* Can't happen - Url.Path.to_list returns a non-empty list *)
     | [ _ ] -> [] (* No parents *)
-    | [ x; { path_fragment = "index"; _ } ] ->
+    | [ x; { name = "index"; _ } ] ->
         (* Special case leaf pages called 'index' with one parent. This is for files called
            index.mld that would otherwise clash with their parent. In particular,
            dune and odig both cause this situation right now. *)
         let up_url = "../index.html" in
-        let parent_name = x.path_fragment in
+        let parent_name = x.name in
         make_navigation ~up_url [ Html.txt parent_name ]
     | _ ->
         let up_url = href ~config (List.hd (List.tl (List.rev parents))) in
@@ -146,11 +145,11 @@ let page_creator ~config ~url ~uses_katex name header toc content =
                ~f:(fun url' ->
                  [
                    [
-                     (if url = url' then Html.txt url.path_fragment
+                     (if url = url' then Html.txt url.name
                      else
                        Html.a
                          ~a:[ Html.a_href (href ~config url') ]
-                         [ Html.txt url'.path_fragment ]);
+                         [ Html.txt url'.name ]);
                    ];
                  ])
           |> List.flatten

--- a/src/html/tree.ml
+++ b/src/html/tree.ml
@@ -43,7 +43,8 @@ let page_creator ~config ~url ~uses_katex name header toc content =
       | Types.Absolute uri -> uri ^ "/" ^ file
       | Relative uri ->
           let page =
-            Odoc_document.Url.Path.{ kind = `File; parent = uri; name = file }
+            Odoc_document.Url.Path.
+              { kind = `File; parent = uri; path_fragment = file }
           in
           Link.href ~config ~resolve:(Current url)
             (Odoc_document.Url.from_path page)
@@ -127,12 +128,12 @@ let page_creator ~config ~url ~uses_katex name header toc content =
     match parents with
     | [] -> [] (* Can't happen - Url.Path.to_list returns a non-empty list *)
     | [ _ ] -> [] (* No parents *)
-    | [ x; { name = "index"; _ } ] ->
+    | [ x; { path_fragment = "index"; _ } ] ->
         (* Special case leaf pages called 'index' with one parent. This is for files called
            index.mld that would otherwise clash with their parent. In particular,
            dune and odig both cause this situation right now. *)
         let up_url = "../index.html" in
-        let parent_name = x.name in
+        let parent_name = x.path_fragment in
         make_navigation ~up_url [ Html.txt parent_name ]
     | _ ->
         let up_url = href ~config (List.hd (List.tl (List.rev parents))) in
@@ -145,11 +146,11 @@ let page_creator ~config ~url ~uses_katex name header toc content =
                ~f:(fun url' ->
                  [
                    [
-                     (if url = url' then Html.txt url.name
+                     (if url = url' then Html.txt url.path_fragment
                      else
                        Html.a
                          ~a:[ Html.a_href (href ~config url') ]
-                         [ Html.txt url'.name ]);
+                         [ Html.txt url'.path_fragment ]);
                    ];
                  ])
           |> List.flatten

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -15,8 +15,9 @@ module Link = struct
     match x.parent with
     | Some p ->
         Fmt.pf ppf "%a-%a-%s" flatten_path p Odoc_document.Url.Path.pp_kind
-          x.kind x.name
-    | None -> Fmt.pf ppf "%a-%s" Odoc_document.Url.Path.pp_kind x.kind x.name
+          x.kind x.path_fragment
+    | None ->
+        Fmt.pf ppf "%a-%s" Odoc_document.Url.Path.pp_kind x.kind x.path_fragment
 
   let page p = Format.asprintf "%a" flatten_path p
 
@@ -459,8 +460,7 @@ module Page = struct
     List.flatten @@ List.map (subpage ~with_children) subpages
 
   and page ~with_children p =
-    let { Page.title = _; kind = _; preamble; items = i; url } =
-      Doctree.Labels.disambiguate_page p
+    let { Page.preamble; items = i; url } = Doctree.Labels.disambiguate_page p
     and subpages = subpages ~with_children @@ Doctree.Subpages.compute p in
     let i = Doctree.Shift.compute ~on_sub i in
     let header = items (Doctree.PageTitle.render_title p @ preamble) in

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -459,11 +459,11 @@ module Page = struct
     List.flatten @@ List.map (subpage ~with_children) subpages
 
   and page ~with_children p =
-    let { Page.title = _; header; items = i; url } =
+    let { Page.title = _; kind = _; preamble; items = i; url } =
       Doctree.Labels.disambiguate_page p
     and subpages = subpages ~with_children @@ Doctree.Subpages.compute p in
     let i = Doctree.Shift.compute ~on_sub i in
-    let header = items header in
+    let header = items (Doctree.PageTitle.render_title p @ preamble) in
     let content = items i in
     let page = Doc.make ~with_children url (header @ content) subpages in
     page

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -15,9 +15,8 @@ module Link = struct
     match x.parent with
     | Some p ->
         Fmt.pf ppf "%a-%a-%s" flatten_path p Odoc_document.Url.Path.pp_kind
-          x.kind x.path_fragment
-    | None ->
-        Fmt.pf ppf "%a-%s" Odoc_document.Url.Path.pp_kind x.kind x.path_fragment
+          x.kind x.name
+    | None -> Fmt.pf ppf "%a-%s" Odoc_document.Url.Path.pp_kind x.kind x.name
 
   let page p = Format.asprintf "%a" flatten_path p
 

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -431,7 +431,7 @@ let rec documentedSrc (l : DocumentedSrc.t) =
           let l = list ~sep:break (List.map f lines) in
           indent 2 (break ++ l) ++ break_if_nonempty rest ++ continue rest)
 
-and subpage { title = _; kind = _; preamble = _; items; url = _ } =
+and subpage { preamble = _; items; url = _ } =
   let content = items in
   let surround body =
     if content = [] then sp else indent 2 (break ++ body) ++ break
@@ -482,7 +482,7 @@ let page p =
     Doctree.PageTitle.render_title p @ Shift.compute ~on_sub p.preamble
   in
   let i = Shift.compute ~on_sub p.items in
-  macro "TH" {|%s 3 "" "Odoc" "OCaml Library"|} p.title
+  macro "TH" {|%s 3 "" "Odoc" "OCaml Library"|} p.url.path_fragment
   ++ macro "SH" "Name"
   ++ str "%s" (String.concat "." @@ Link.for_printing p.url)
   ++ macro "SH" "Synopsis" ++ vspace ++ item ~nested:false header

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -431,7 +431,7 @@ let rec documentedSrc (l : DocumentedSrc.t) =
           let l = list ~sep:break (List.map f lines) in
           indent 2 (break ++ l) ++ break_if_nonempty rest ++ continue rest)
 
-and subpage { title = _; header = _; items; url = _ } =
+and subpage { title = _; kind = _; preamble = _; items; url = _ } =
   let content = items in
   let surround body =
     if content = [] then sp else indent 2 (break ++ body) ++ break
@@ -476,13 +476,15 @@ let on_sub subp =
   | `Page p -> if Link.should_inline p.Subpage.content.url then Some 1 else None
   | `Include incl -> if inline_subpage incl.Include.status then Some 0 else None
 
-let page { Page.title; header; items = i; url } =
+let page p =
   reset_heading ();
-  let header = Shift.compute ~on_sub header in
-  let i = Shift.compute ~on_sub i in
-  macro "TH" {|%s 3 "" "Odoc" "OCaml Library"|} title
+  let header =
+    Doctree.PageTitle.render_title p @ Shift.compute ~on_sub p.preamble
+  in
+  let i = Shift.compute ~on_sub p.items in
+  macro "TH" {|%s 3 "" "Odoc" "OCaml Library"|} p.title
   ++ macro "SH" "Name"
-  ++ str "%s" (String.concat "." @@ Link.for_printing url)
+  ++ str "%s" (String.concat "." @@ Link.for_printing p.url)
   ++ macro "SH" "Synopsis" ++ vspace ++ item ~nested:false header
   ++ macro "SH" "Documentation" ++ vspace ++ macro "nf" ""
   ++ item ~nested:false i

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -482,7 +482,7 @@ let page p =
     Doctree.PageTitle.render_title p @ Shift.compute ~on_sub p.preamble
   in
   let i = Shift.compute ~on_sub p.items in
-  macro "TH" {|%s 3 "" "Odoc" "OCaml Library"|} p.url.path_fragment
+  macro "TH" {|%s 3 "" "Odoc" "OCaml Library"|} p.url.name
   ++ macro "SH" "Name"
   ++ str "%s" (String.concat "." @@ Link.for_printing p.url)
   ++ macro "SH" "Synopsis" ++ vspace ++ item ~nested:false header

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -477,7 +477,7 @@ module Odoc_html_args = struct
             ~f:(fun acc seg ->
               Some
                 Odoc_document.Url.Path.
-                  { kind = `Page; parent = acc; path_fragment = seg })
+                  { kind = `Page; parent = acc; name = seg })
             l ~init:None
         in
         `Ok

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -477,7 +477,7 @@ module Odoc_html_args = struct
             ~f:(fun acc seg ->
               Some
                 Odoc_document.Url.Path.
-                  { kind = `Page; parent = acc; name = seg })
+                  { kind = `Page; parent = acc; path_fragment = seg })
             l ~init:None
         in
         `Ok

--- a/test/generators/html/Functor-F1-argument-1-Arg.html
+++ b/test/generators/html/Functor-F1-argument-1-Arg.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Functor.F1.1-Arg)</title>
+ <head><title>Arg (Functor.F1.Arg)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Functor-F1.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; 
-   <a href="Functor-F1.html">F1</a> &#x00BB; 1-Arg
+   <a href="Functor-F1.html">F1</a> &#x00BB; Arg
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>F1.1-Arg</span></code></h1>
+   <h1>Parameter <code><span>F1.Arg</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Functor-F2-argument-1-Arg.html
+++ b/test/generators/html/Functor-F2-argument-1-Arg.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Functor.F2.1-Arg)</title>
+ <head><title>Arg (Functor.F2.Arg)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Functor-F2.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; 
-   <a href="Functor-F2.html">F2</a> &#x00BB; 1-Arg
+   <a href="Functor-F2.html">F2</a> &#x00BB; Arg
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>F2.1-Arg</span></code></h1>
+   <h1>Parameter <code><span>F2.Arg</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Functor-F3-argument-1-Arg.html
+++ b/test/generators/html/Functor-F3-argument-1-Arg.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Functor.F3.1-Arg)</title>
+ <head><title>Arg (Functor.F3.Arg)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Functor-F3.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; 
-   <a href="Functor-F3.html">F3</a> &#x00BB; 1-Arg
+   <a href="Functor-F3.html">F3</a> &#x00BB; Arg
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>F3.1-Arg</span></code></h1>
+   <h1>Parameter <code><span>F3.Arg</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Functor-F4-argument-1-Arg.html
+++ b/test/generators/html/Functor-F4-argument-1-Arg.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Functor.F4.1-Arg)</title>
+ <head><title>Arg (Functor.F4.Arg)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Functor-F4.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; 
-   <a href="Functor-F4.html">F4</a> &#x00BB; 1-Arg
+   <a href="Functor-F4.html">F4</a> &#x00BB; Arg
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>F4.1-Arg</span></code></h1>
+   <h1>Parameter <code><span>F4.Arg</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Functor-module-type-S1-argument-1-_.html
+++ b/test/generators/html/Functor-module-type-S1-argument-1-_.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>_ (Functor.S1.1-_)</title>
+ <head><title>_ (Functor.S1._)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Functor-module-type-S1.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; 
-   <a href="Functor-module-type-S1.html">S1</a> &#x00BB; 1-_
+   <a href="Functor-module-type-S1.html">S1</a> &#x00BB; _
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>S1.1-_</span></code></h1>
+   <h1>Parameter <code><span>S1._</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Functor2-X-argument-1-Y.html
+++ b/test/generators/html/Functor2-X-argument-1-Y.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Functor2.X.1-Y)</title>
+ <head><title>Y (Functor2.X.Y)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Functor2-X.html">Up</a> – 
    <a href="Functor2.html">Functor2</a> &#x00BB; 
-   <a href="Functor2-X.html">X</a> &#x00BB; 1-Y
+   <a href="Functor2-X.html">X</a> &#x00BB; Y
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>X.1-Y</span></code></h1>
+   <h1>Parameter <code><span>X.Y</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Functor2-X-argument-2-Z.html
+++ b/test/generators/html/Functor2-X-argument-2-Z.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Z (Functor2.X.2-Z)</title>
+ <head><title>Z (Functor2.X.Z)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Functor2-X.html">Up</a> – 
    <a href="Functor2.html">Functor2</a> &#x00BB; 
-   <a href="Functor2-X.html">X</a> &#x00BB; 2-Z
+   <a href="Functor2-X.html">X</a> &#x00BB; Z
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>X.2-Z</span></code></h1>
+   <h1>Parameter <code><span>X.Z</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Functor2-module-type-XF-argument-1-Y.html
+++ b/test/generators/html/Functor2-module-type-XF-argument-1-Y.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Functor2.XF.1-Y)</title>
+ <head><title>Y (Functor2.XF.Y)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Functor2-module-type-XF.html">Up</a>
     – <a href="Functor2.html">Functor2</a> &#x00BB; 
-   <a href="Functor2-module-type-XF.html">XF</a> &#x00BB; 1-Y
+   <a href="Functor2-module-type-XF.html">XF</a> &#x00BB; Y
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>XF.1-Y</span></code></h1>
+   <h1>Parameter <code><span>XF.Y</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Functor2-module-type-XF-argument-2-Z.html
+++ b/test/generators/html/Functor2-module-type-XF-argument-2-Z.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Z (Functor2.XF.2-Z)</title>
+ <head><title>Z (Functor2.XF.Z)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Functor2-module-type-XF.html">Up</a>
     – <a href="Functor2.html">Functor2</a> &#x00BB; 
-   <a href="Functor2-module-type-XF.html">XF</a> &#x00BB; 2-Z
+   <a href="Functor2-module-type-XF.html">XF</a> &#x00BB; Z
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>XF.2-Z</span></code></h1>
+   <h1>Parameter <code><span>XF.Z</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Module_type_alias-module-type-B-argument-1-C.html
+++ b/test/generators/html/Module_type_alias-module-type-B-argument-1-C.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>C (Module_type_alias.B.1-C)</title>
+ <head><title>C (Module_type_alias.B.C)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Module_type_alias-module-type-B.html">Up</a>
     – <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB;
-    <a href="Module_type_alias-module-type-B.html">B</a> &#x00BB; 1-C
+    <a href="Module_type_alias-module-type-B.html">B</a> &#x00BB; C
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>B.1-C</span></code></h1>
+   <h1>Parameter <code><span>B.C</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Module_type_alias-module-type-E-argument-1-F.html
+++ b/test/generators/html/Module_type_alias-module-type-E-argument-1-F.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>F (Module_type_alias.E.1-F)</title>
+ <head><title>F (Module_type_alias.E.F)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Module_type_alias-module-type-E.html">Up</a>
     – <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB;
-    <a href="Module_type_alias-module-type-E.html">E</a> &#x00BB; 1-F
+    <a href="Module_type_alias-module-type-E.html">E</a> &#x00BB; F
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>E.1-F</span></code></h1>
+   <h1>Parameter <code><span>E.F</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Module_type_alias-module-type-E-argument-2-C.html
+++ b/test/generators/html/Module_type_alias-module-type-E-argument-2-C.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>C (Module_type_alias.E.2-C)</title>
+ <head><title>C (Module_type_alias.E.C)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Module_type_alias-module-type-E.html">Up</a>
     – <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB;
-    <a href="Module_type_alias-module-type-E.html">E</a> &#x00BB; 2-C
+    <a href="Module_type_alias-module-type-E.html">E</a> &#x00BB; C
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>E.2-C</span></code></h1>
+   <h1>Parameter <code><span>E.C</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Module_type_alias-module-type-G-argument-1-H.html
+++ b/test/generators/html/Module_type_alias-module-type-G-argument-1-H.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>H (Module_type_alias.G.1-H)</title>
+ <head><title>H (Module_type_alias.G.H)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Module_type_alias-module-type-G.html">Up</a>
     – <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB;
-    <a href="Module_type_alias-module-type-G.html">G</a> &#x00BB; 1-H
+    <a href="Module_type_alias-module-type-G.html">G</a> &#x00BB; H
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>G.1-H</span></code></h1>
+   <h1>Parameter <code><span>G.H</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Nested-F-argument-1-Arg1.html
+++ b/test/generators/html/Nested-F-argument-1-Arg1.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg1 (Nested.F.1-Arg1)</title>
+ <head><title>Arg1 (Nested.F.Arg1)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Nested-F.html">Up</a> – 
    <a href="Nested.html">Nested</a> &#x00BB; <a href="Nested-F.html">F</a>
-    &#x00BB; 1-Arg1
+    &#x00BB; Arg1
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>F.1-Arg1</span></code></h1>
+   <h1>Parameter <code><span>F.Arg1</span></code></h1>
   </header>
   <nav class="odoc-toc">
    <ul><li><a href="#type">Type</a></li><li><a href="#values">Values</a></li>

--- a/test/generators/html/Nested-F-argument-2-Arg2.html
+++ b/test/generators/html/Nested-F-argument-2-Arg2.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg2 (Nested.F.2-Arg2)</title>
+ <head><title>Arg2 (Nested.F.Arg2)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Nested-F.html">Up</a> – 
    <a href="Nested.html">Nested</a> &#x00BB; <a href="Nested-F.html">F</a>
-    &#x00BB; 2-Arg2
+    &#x00BB; Arg2
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>F.2-Arg2</span></code></h1>
+   <h1>Parameter <code><span>F.Arg2</span></code></h1>
   </header>
   <nav class="odoc-toc"><ul><li><a href="#type">Type</a></li></ul></nav>
   <div class="odoc-content">

--- a/test/generators/html/Ocamlary-Dep12-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep12-argument-1-Arg.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Ocamlary.Dep12.1-Arg)</title>
+ <head><title>Arg (Ocamlary.Dep12.Arg)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Ocamlary-Dep12.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
-   <a href="Ocamlary-Dep12.html">Dep12</a> &#x00BB; 1-Arg
+   <a href="Ocamlary-Dep12.html">Dep12</a> &#x00BB; Arg
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>Dep12.1-Arg</span></code></h1>
+   <h1>Parameter <code><span>Dep12.Arg</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Ocamlary-Dep2-argument-1-Arg-X.html
+++ b/test/generators/html/Ocamlary-Dep2-argument-1-Arg-X.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.Dep2.1-Arg.X)</title>
+ <head><title>X (Ocamlary.Dep2.Arg.X)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -11,10 +11,10 @@
   <nav class="odoc-nav"><a href="Ocamlary-Dep2-argument-1-Arg.html">Up</a>
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep2.html">Dep2</a> &#x00BB; 
-   <a href="Ocamlary-Dep2-argument-1-Arg.html">1-Arg</a> &#x00BB; X
+   <a href="Ocamlary-Dep2-argument-1-Arg.html">Arg</a> &#x00BB; X
   </nav>
   <header class="odoc-preamble">
-   <h1>Module <code><span>1-Arg.X</span></code></h1>
+   <h1>Module <code><span>Arg.X</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Ocamlary-Dep2-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep2-argument-1-Arg.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Ocamlary.Dep2.1-Arg)</title>
+ <head><title>Arg (Ocamlary.Dep2.Arg)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Ocamlary-Dep2.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
-   <a href="Ocamlary-Dep2.html">Dep2</a> &#x00BB; 1-Arg
+   <a href="Ocamlary-Dep2.html">Dep2</a> &#x00BB; Arg
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>Dep2.1-Arg</span></code></h1>
+   <h1>Parameter <code><span>Dep2.Arg</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Ocamlary.Dep5.1-Arg.S.Y)</title>
+ <head><title>Y (Ocamlary.Dep5.Arg.S.Y)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -12,7 +12,7 @@
    <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep5.html">Dep5</a> &#x00BB; 
-   <a href="Ocamlary-Dep5-argument-1-Arg.html">1-Arg</a> &#x00BB; 
+   <a href="Ocamlary-Dep5-argument-1-Arg.html">Arg</a> &#x00BB; 
    <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S.html">S</a> &#x00BB;
     Y
   </nav>

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Ocamlary.Dep5.1-Arg.S)</title>
+ <head><title>S (Ocamlary.Dep5.Arg.S)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -11,10 +11,10 @@
   <nav class="odoc-nav"><a href="Ocamlary-Dep5-argument-1-Arg.html">Up</a>
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep5.html">Dep5</a> &#x00BB; 
-   <a href="Ocamlary-Dep5-argument-1-Arg.html">1-Arg</a> &#x00BB; S
+   <a href="Ocamlary-Dep5-argument-1-Arg.html">Arg</a> &#x00BB; S
   </nav>
   <header class="odoc-preamble">
-   <h1>Module type <code><span>1-Arg.S</span></code></h1>
+   <h1>Module type <code><span>Arg.S</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Ocamlary.Dep5.1-Arg)</title>
+ <head><title>Arg (Ocamlary.Dep5.Arg)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Ocamlary-Dep5.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
-   <a href="Ocamlary-Dep5.html">Dep5</a> &#x00BB; 1-Arg
+   <a href="Ocamlary-Dep5.html">Dep5</a> &#x00BB; Arg
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>Dep5.1-Arg</span></code></h1>
+   <h1>Parameter <code><span>Dep5.Arg</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg-X.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg-X.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.Dep7.1-Arg.X)</title>
+ <head><title>X (Ocamlary.Dep7.Arg.X)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -11,10 +11,10 @@
   <nav class="odoc-nav"><a href="Ocamlary-Dep7-argument-1-Arg.html">Up</a>
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep7.html">Dep7</a> &#x00BB; 
-   <a href="Ocamlary-Dep7-argument-1-Arg.html">1-Arg</a> &#x00BB; X
+   <a href="Ocamlary-Dep7-argument-1-Arg.html">Arg</a> &#x00BB; X
   </nav>
   <header class="odoc-preamble">
-   <h1>Module <code><span>1-Arg.X</span></code></h1>
+   <h1>Module <code><span>Arg.X</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg-module-type-T.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>T (Ocamlary.Dep7.1-Arg.T)</title>
+ <head><title>T (Ocamlary.Dep7.Arg.T)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -11,10 +11,10 @@
   <nav class="odoc-nav"><a href="Ocamlary-Dep7-argument-1-Arg.html">Up</a>
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep7.html">Dep7</a> &#x00BB; 
-   <a href="Ocamlary-Dep7-argument-1-Arg.html">1-Arg</a> &#x00BB; T
+   <a href="Ocamlary-Dep7-argument-1-Arg.html">Arg</a> &#x00BB; T
   </nav>
   <header class="odoc-preamble">
-   <h1>Module type <code><span>1-Arg.T</span></code></h1>
+   <h1>Module type <code><span>Arg.T</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Ocamlary.Dep7.1-Arg)</title>
+ <head><title>Arg (Ocamlary.Dep7.Arg)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Ocamlary-Dep7.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
-   <a href="Ocamlary-Dep7.html">Dep7</a> &#x00BB; 1-Arg
+   <a href="Ocamlary-Dep7.html">Dep7</a> &#x00BB; Arg
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>Dep7.1-Arg</span></code></h1>
+   <h1>Parameter <code><span>Dep7.Arg</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Ocamlary-Dep9-argument-1-X.html
+++ b/test/generators/html/Ocamlary-Dep9-argument-1-X.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.Dep9.1-X)</title>
+ <head><title>X (Ocamlary.Dep9.X)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Ocamlary-Dep9.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
-   <a href="Ocamlary-Dep9.html">Dep9</a> &#x00BB; 1-X
+   <a href="Ocamlary-Dep9.html">Dep9</a> &#x00BB; X
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>Dep9.1-X</span></code></h1>
+   <h1>Parameter <code><span>Dep9.X</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html
@@ -3,7 +3,7 @@
  <head>
   <title>
    InnerModuleA'
-   (Ocamlary.FunctorTypeOf.1-Collection.InnerModuleA.InnerModuleA')
+   (Ocamlary.FunctorTypeOf.Collection.InnerModuleA.InnerModuleA')
   </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -16,8 +16,8 @@
     Up
    </a> – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-FunctorTypeOf.html">FunctorTypeOf</a> &#x00BB; 
-   <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">1-Collection
-   </a> &#x00BB; 
+   <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">Collection</a>
+    &#x00BB; 
    <a href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html">
     InnerModuleA
    </a> &#x00BB; InnerModuleA'

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -3,7 +3,7 @@
  <head>
   <title>
    InnerModuleTypeA'
-   (Ocamlary.FunctorTypeOf.1-Collection.InnerModuleA.InnerModuleTypeA')
+   (Ocamlary.FunctorTypeOf.Collection.InnerModuleA.InnerModuleTypeA')
   </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -16,8 +16,8 @@
     Up
    </a> – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-FunctorTypeOf.html">FunctorTypeOf</a> &#x00BB; 
-   <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">1-Collection
-   </a> &#x00BB; 
+   <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">Collection</a>
+    &#x00BB; 
    <a href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html">
     InnerModuleA
    </a> &#x00BB; InnerModuleTypeA'

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
-  <title>InnerModuleA (Ocamlary.FunctorTypeOf.1-Collection.InnerModuleA)
+  <title>InnerModuleA (Ocamlary.FunctorTypeOf.Collection.InnerModuleA)
   </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -13,11 +13,11 @@
    <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">Up</a>
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-FunctorTypeOf.html">FunctorTypeOf</a> &#x00BB; 
-   <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">1-Collection
-   </a> &#x00BB; InnerModuleA
+   <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">Collection</a>
+    &#x00BB; InnerModuleA
   </nav>
   <header class="odoc-preamble">
-   <h1>Module <code><span>1-Collection.InnerModuleA</span></code></h1>
+   <h1>Module <code><span>Collection.InnerModuleA</span></code></h1>
    <p>This comment is for <code>InnerModuleA</code>.</p>
   </header>
   <div class="odoc-content">

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Collection (Ocamlary.FunctorTypeOf.1-Collection)</title>
+ <head><title>Collection (Ocamlary.FunctorTypeOf.Collection)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -11,10 +11,10 @@
   <nav class="odoc-nav"><a href="Ocamlary-FunctorTypeOf.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-FunctorTypeOf.html">FunctorTypeOf</a> &#x00BB; 
-   1-Collection
+   Collection
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>FunctorTypeOf.1-Collection</span></code></h1>
+   <h1>Parameter <code><span>FunctorTypeOf.Collection</span></code></h1>
   </header>
   <div class="odoc-content">
    <p>This comment is for <code>CollectionModule</code>.</p>

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
-  <title>InnerModuleA' (Ocamlary.Recollection.1-C.InnerModuleA.InnerModuleA')
+  <title>InnerModuleA' (Ocamlary.Recollection.C.InnerModuleA.InnerModuleA')
   </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -13,8 +13,7 @@
    <a href="Ocamlary-Recollection-argument-1-C-InnerModuleA.html">Up</a>
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Recollection.html">Recollection</a> &#x00BB; 
-   <a href="Ocamlary-Recollection-argument-1-C.html">1-C</a> &#x00BB;
-    
+   <a href="Ocamlary-Recollection-argument-1-C.html">C</a> &#x00BB; 
    <a href="Ocamlary-Recollection-argument-1-C-InnerModuleA.html">
     InnerModuleA
    </a> &#x00BB; InnerModuleA'

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -2,8 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>
-   InnerModuleTypeA'
-   (Ocamlary.Recollection.1-C.InnerModuleA.InnerModuleTypeA')
+   InnerModuleTypeA' (Ocamlary.Recollection.C.InnerModuleA.InnerModuleTypeA')
   </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -15,8 +14,7 @@
    <a href="Ocamlary-Recollection-argument-1-C-InnerModuleA.html">Up</a>
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Recollection.html">Recollection</a> &#x00BB; 
-   <a href="Ocamlary-Recollection-argument-1-C.html">1-C</a> &#x00BB;
-    
+   <a href="Ocamlary-Recollection-argument-1-C.html">C</a> &#x00BB; 
    <a href="Ocamlary-Recollection-argument-1-C-InnerModuleA.html">
     InnerModuleA
    </a> &#x00BB; InnerModuleTypeA'

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>InnerModuleA (Ocamlary.Recollection.1-C.InnerModuleA)</title>
+ <head><title>InnerModuleA (Ocamlary.Recollection.C.InnerModuleA)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -12,11 +12,11 @@
    <a href="Ocamlary-Recollection-argument-1-C.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Recollection.html">Recollection</a> &#x00BB; 
-   <a href="Ocamlary-Recollection-argument-1-C.html">1-C</a> &#x00BB;
-    InnerModuleA
+   <a href="Ocamlary-Recollection-argument-1-C.html">C</a> &#x00BB; 
+   InnerModuleA
   </nav>
   <header class="odoc-preamble">
-   <h1>Module <code><span>1-C.InnerModuleA</span></code></h1>
+   <h1>Module <code><span>C.InnerModuleA</span></code></h1>
    <p>This comment is for <code>InnerModuleA</code>.</p>
   </header>
   <div class="odoc-content">

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>C (Ocamlary.Recollection.1-C)</title>
+ <head><title>C (Ocamlary.Recollection.C)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Ocamlary-Recollection.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
-   <a href="Ocamlary-Recollection.html">Recollection</a> &#x00BB; 1-C
+   <a href="Ocamlary-Recollection.html">Recollection</a> &#x00BB; C
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>Recollection.1-C</span></code></h1>
+   <h1>Parameter <code><span>Recollection.C</span></code></h1>
   </header>
   <div class="odoc-content">
    <p>This comment is for <code>CollectionModule</code>.</p>

--- a/test/generators/html/Ocamlary-With7-argument-1-X.html
+++ b/test/generators/html/Ocamlary-With7-argument-1-X.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.With7.1-X)</title>
+ <head><title>X (Ocamlary.With7.X)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -10,10 +10,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Ocamlary-With7.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
-   <a href="Ocamlary-With7.html">With7</a> &#x00BB; 1-X
+   <a href="Ocamlary-With7.html">With7</a> &#x00BB; X
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>With7.1-X</span></code></h1>
+   <h1>Parameter <code><span>With7.X</span></code></h1>
   </header>
   <div class="odoc-content">
    <div class="odoc-spec">

--- a/test/generators/html/Recent-module-type-S1-argument-1-_.html
+++ b/test/generators/html/Recent-module-type-S1-argument-1-_.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>_ (Recent.S1.1-_)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
-  <meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>_ (Recent.S1._)</title><link rel="stylesheet" href="odoc.css"/>
+  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>
@@ -10,10 +9,10 @@
  <body class="odoc">
   <nav class="odoc-nav"><a href="Recent-module-type-S1.html">Up</a> – 
    <a href="Recent.html">Recent</a> &#x00BB; 
-   <a href="Recent-module-type-S1.html">S1</a> &#x00BB; 1-_
+   <a href="Recent-module-type-S1.html">S1</a> &#x00BB; _
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>S1.1-_</span></code></h1>
+   <h1>Parameter <code><span>S1._</span></code></h1>
   </header><div class="odoc-content"></div>
  </body>
 </html>

--- a/test/generators/html/Recent_impl-module-type-S-F-argument-1-_.html
+++ b/test/generators/html/Recent_impl-module-type-S-F-argument-1-_.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>_ (Recent_impl.S.F.1-_)</title>
+ <head><title>_ (Recent_impl.S.F._)</title>
   <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
@@ -11,10 +11,10 @@
   <nav class="odoc-nav"><a href="Recent_impl-module-type-S-F.html">Up</a>
     – <a href="Recent_impl.html">Recent_impl</a> &#x00BB; 
    <a href="Recent_impl-module-type-S.html">S</a> &#x00BB; 
-   <a href="Recent_impl-module-type-S-F.html">F</a> &#x00BB; 1-_
+   <a href="Recent_impl-module-type-S-F.html">F</a> &#x00BB; _
   </nav>
   <header class="odoc-preamble">
-   <h1>Parameter <code><span>F.1-_</span></code></h1>
+   <h1>Parameter <code><span>F._</span></code></h1>
   </header><div class="odoc-content"></div>
  </body>
 </html>


### PR DESCRIPTION
This patch puts the responsibility of rendering the title (part of the "header" section) on the renderer, as suggested in the comment at https://github.com/ocaml/odoc/blob/a52dd8e960f99b38162d40311a9c4512d5741d43/src/document/generator.ml#L24

This refactoring is a prerequisite for adding more varied renderers, e.g., as requested in https://github.com/ocaml/odoc/issues/374 and as we need for the ocaml.org website's package docs browser.

`Odoc_document.Types.Page.t` now contains `preamble` and `kind` instead of `header` and the decision on whether (and how) to render a title is now made in the respective `Generator.Page.page` function of the corresponding renderer.

As I didn't change anything about the title rendering itself, I put the title rendering code shared between the different renderers in a new module `Doctree.PageTitle`. I am very open to suggestions where else to put it. Also, if there's anything I need to change about this PR, let me know.
