### PR TITLE
Allow to omit parent type in constructor reference.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ Tags:
 ### Added
 - Display 'private' keyword for private type extensions (@gpetiot, #1019)
 - Add support for search (@panglesd, @EmileTrotignon, #972)
+- Allow to omit parent type in constructor reference (@panglesd,
+  @EmileTrotignon, #933)
 
 ### Fixed
 

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -628,7 +628,7 @@ let read_constructor_declaration_arguments env parent arg =
 let read_constructor_declaration env parent cd =
   let open TypeDecl.Constructor in
   let id = Ident_env.find_constructor_identifier env cd.cd_id in
-  let container = (parent : Identifier.DataType.t :> Identifier.LabelParent.t) in
+  let container = (parent :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container cd.cd_attributes in
   let args =
     read_constructor_declaration_arguments env
@@ -713,7 +713,7 @@ let read_type_declaration env parent id decl =
   let params = mark_type_declaration decl in
   let manifest = opt_map (read_type_expr env) decl.type_manifest in
   let constraints = read_type_constraints env params in
-  let representation = read_type_kind env id decl.type_kind in
+  let representation = read_type_kind env (id :> Identifier.Parent.t) decl.type_kind in
   let abstr =
     match decl.type_kind with
       Type_abstract ->

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -713,7 +713,7 @@ let read_type_declaration env parent id decl =
   let params = mark_type_declaration decl in
   let manifest = opt_map (read_type_expr env) decl.type_manifest in
   let constraints = read_type_constraints env params in
-  let representation = read_type_kind env (id :> Identifier.Parent.t) decl.type_kind in
+  let representation = read_type_kind env (id :> Identifier.DataType.t) decl.type_kind in
   let abstr =
     match decl.type_kind with
       Type_abstract ->

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -632,7 +632,7 @@ let read_constructor_declaration env parent cd =
   let doc = Doc_attr.attached_no_tag container cd.cd_attributes in
   let args =
     read_constructor_declaration_arguments env
-      (parent :> Identifier.Parent.t) cd.cd_args
+      (parent :> Identifier.FragmentTypeParent.t) cd.cd_args
   in
   let res = opt_map (read_type_expr env) cd.cd_res in
     {id; doc; args; res}
@@ -652,7 +652,7 @@ let read_type_kind env parent =
     | Type_record(lbls, _) ->
         let lbls =
           List.map
-            (read_label_declaration env (parent :> Identifier.Parent.t))
+            (read_label_declaration env (parent :> Identifier.FragmentTypeParent.t))
             lbls
         in
           Some (Record lbls)
@@ -745,7 +745,7 @@ let read_extension_constructor env parent id ext =
   let doc = Doc_attr.attached_no_tag container ext.ext_attributes in
   let args =
     read_constructor_declaration_arguments env
-      (parent : Identifier.Signature.t :> Identifier.Parent.t) ext.ext_args
+      (parent : Identifier.Signature.t :> Identifier.FragmentTypeParent.t) ext.ext_args
   in
   let res = opt_map (read_type_expr env) ext.ext_ret_type in
   {id; locs; doc; args; res}
@@ -779,7 +779,7 @@ let read_exception env parent id ext =
     mark_exception ext;
     let args =
       read_constructor_declaration_arguments env
-        (parent : Identifier.Signature.t :> Identifier.Parent.t) ext.ext_args
+        (parent : Identifier.Signature.t :> Identifier.FragmentTypeParent.t) ext.ext_args
     in
     let res = opt_map (read_type_expr env) ext.ext_ret_type in
     {id; locs; doc; args; res}

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -632,7 +632,7 @@ let read_constructor_declaration env parent cd =
   let doc = Doc_attr.attached_no_tag container cd.cd_attributes in
   let args =
     read_constructor_declaration_arguments env
-      (parent :> Identifier.FragmentTypeParent.t) cd.cd_args
+      (parent :> Identifier.FieldParent.t) cd.cd_args
   in
   let res = opt_map (read_type_expr env) cd.cd_res in
     {id; doc; args; res}
@@ -652,7 +652,7 @@ let read_type_kind env parent =
     | Type_record(lbls, _) ->
         let lbls =
           List.map
-            (read_label_declaration env (parent :> Identifier.FragmentTypeParent.t))
+            (read_label_declaration env (parent :> Identifier.FieldParent.t))
             lbls
         in
           Some (Record lbls)
@@ -745,7 +745,7 @@ let read_extension_constructor env parent id ext =
   let doc = Doc_attr.attached_no_tag container ext.ext_attributes in
   let args =
     read_constructor_declaration_arguments env
-      (parent : Identifier.Signature.t :> Identifier.FragmentTypeParent.t) ext.ext_args
+      (parent : Identifier.Signature.t :> Identifier.FieldParent.t) ext.ext_args
   in
   let res = opt_map (read_type_expr env) ext.ext_ret_type in
   {id; locs; doc; args; res}
@@ -779,7 +779,7 @@ let read_exception env parent id ext =
     mark_exception ext;
     let args =
       read_constructor_declaration_arguments env
-        (parent : Identifier.Signature.t :> Identifier.FragmentTypeParent.t) ext.ext_args
+        (parent : Identifier.Signature.t :> Identifier.FieldParent.t) ext.ext_args
     in
     let res = opt_map (read_type_expr env) ext.ext_ret_type in
     {id; locs; doc; args; res}

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -214,7 +214,7 @@ let read_constructor_declaration_arguments env parent label_parent arg =
 let read_constructor_declaration env parent cd =
   let open TypeDecl.Constructor in
   let id = Ident_env.find_constructor_identifier env cd.cd_id in
-  let container = parent in
+  let container = (parent :> Identifier.Parent.t) in
   let label_container = (container :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag label_container cd.cd_attributes in
   let args =
@@ -231,7 +231,7 @@ let read_type_kind env parent =
         let cstrs = List.map (read_constructor_declaration env parent) cstrs in
           Some (Variant cstrs)
     | Ttype_record lbls ->
-        let parent = (parent ) in
+        let parent = (parent :> Identifier.Parent.t) in
       let label_parent = (parent :> Identifier.LabelParent.t) in
       let lbls =
         List.map (read_label_declaration env parent label_parent) lbls in
@@ -260,7 +260,7 @@ let read_type_declaration env parent decl =
   let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container decl.typ_attributes in
   let canonical = (canonical :> Path.Type.t option) in
   let equation = read_type_equation env container decl in
-  let representation = read_type_kind env (id :> Identifier.Parent.t) decl.typ_kind in
+  let representation = read_type_kind env id decl.typ_kind in
   {id; locs; doc; canonical; equation; representation}
 
 let read_type_declarations env parent rec_flag decls =

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -214,7 +214,7 @@ let read_constructor_declaration_arguments env parent label_parent arg =
 let read_constructor_declaration env parent cd =
   let open TypeDecl.Constructor in
   let id = Ident_env.find_constructor_identifier env cd.cd_id in
-  let container = (parent :> Identifier.Parent.t) in
+  let container = (parent :> Identifier.FragmentTypeParent.t) in
   let label_container = (container :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag label_container cd.cd_attributes in
   let args =
@@ -231,7 +231,7 @@ let read_type_kind env parent =
         let cstrs = List.map (read_constructor_declaration env parent) cstrs in
           Some (Variant cstrs)
     | Ttype_record lbls ->
-        let parent = (parent :> Identifier.Parent.t) in
+        let parent = (parent :> Identifier.FragmentTypeParent.t) in
       let label_parent = (parent :> Identifier.LabelParent.t) in
       let lbls =
         List.map (read_label_declaration env parent label_parent) lbls in
@@ -292,7 +292,7 @@ let read_extension_constructor env parent ext =
   let open Extension.Constructor in
   let id = Env.find_extension_identifier env ext.ext_id in
   let locs = None in
-  let container = (parent : Identifier.Signature.t :> Identifier.Parent.t) in
+  let container = (parent : Identifier.Signature.t :> Identifier.FragmentTypeParent.t) in
   let label_container = (container :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag label_container ext.ext_attributes in
   match ext.ext_kind with
@@ -325,7 +325,7 @@ let read_exception env parent (ext : extension_constructor) =
   let open Exception in
   let id = Env.find_exception_identifier env ext.ext_id in
   let locs = None in
-  let container = (parent : Identifier.Signature.t :> Identifier.Parent.t) in
+  let container = (parent : Identifier.Signature.t :> Identifier.FragmentTypeParent.t) in
   let label_container = (container :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag label_container ext.ext_attributes in
   match ext.ext_kind with

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -214,7 +214,7 @@ let read_constructor_declaration_arguments env parent label_parent arg =
 let read_constructor_declaration env parent cd =
   let open TypeDecl.Constructor in
   let id = Ident_env.find_constructor_identifier env cd.cd_id in
-  let container = (parent : Identifier.DataType.t :> Identifier.Parent.t) in
+  let container = parent in
   let label_container = (container :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag label_container cd.cd_attributes in
   let args =
@@ -231,7 +231,7 @@ let read_type_kind env parent =
         let cstrs = List.map (read_constructor_declaration env parent) cstrs in
           Some (Variant cstrs)
     | Ttype_record lbls ->
-        let parent = (parent : Identifier.DataType.t :> Identifier.Parent.t) in
+        let parent = (parent ) in
       let label_parent = (parent :> Identifier.LabelParent.t) in
       let lbls =
         List.map (read_label_declaration env parent label_parent) lbls in
@@ -260,7 +260,7 @@ let read_type_declaration env parent decl =
   let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container decl.typ_attributes in
   let canonical = (canonical :> Path.Type.t option) in
   let equation = read_type_equation env container decl in
-  let representation = read_type_kind env (id :> Identifier.DataType.t) decl.typ_kind in
+  let representation = read_type_kind env (id :> Identifier.Parent.t) decl.typ_kind in
   {id; locs; doc; canonical; equation; representation}
 
 let read_type_declarations env parent rec_flag decls =

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -214,7 +214,7 @@ let read_constructor_declaration_arguments env parent label_parent arg =
 let read_constructor_declaration env parent cd =
   let open TypeDecl.Constructor in
   let id = Ident_env.find_constructor_identifier env cd.cd_id in
-  let container = (parent :> Identifier.FragmentTypeParent.t) in
+  let container = (parent :> Identifier.FieldParent.t) in
   let label_container = (container :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag label_container cd.cd_attributes in
   let args =
@@ -231,7 +231,7 @@ let read_type_kind env parent =
         let cstrs = List.map (read_constructor_declaration env parent) cstrs in
           Some (Variant cstrs)
     | Ttype_record lbls ->
-        let parent = (parent :> Identifier.FragmentTypeParent.t) in
+      let parent = (parent :> Identifier.FieldParent.t) in
       let label_parent = (parent :> Identifier.LabelParent.t) in
       let lbls =
         List.map (read_label_declaration env parent label_parent) lbls in
@@ -292,7 +292,7 @@ let read_extension_constructor env parent ext =
   let open Extension.Constructor in
   let id = Env.find_extension_identifier env ext.ext_id in
   let locs = None in
-  let container = (parent : Identifier.Signature.t :> Identifier.FragmentTypeParent.t) in
+  let container = (parent : Identifier.Signature.t :> Identifier.FieldParent.t) in
   let label_container = (container :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag label_container ext.ext_attributes in
   match ext.ext_kind with
@@ -325,7 +325,7 @@ let read_exception env parent (ext : extension_constructor) =
   let open Exception in
   let id = Env.find_exception_identifier env ext.ext_id in
   let locs = None in
-  let container = (parent : Identifier.Signature.t :> Identifier.FragmentTypeParent.t) in
+  let container = (parent : Identifier.Signature.t :> Identifier.FieldParent.t) in
   let label_container = (container :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag label_container ext.ext_attributes in
   match ext.ext_kind with

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -166,7 +166,7 @@ module Identifier = struct
       | { iv = `Method (p, _); _ } | { iv = `InstanceVariable (p, _); _ } ->
           (p : class_signature :> label_parent)
       | { iv = `Constructor (p, _); _ } -> (p : datatype :> label_parent)
-      | { iv = `Field (p, _); _ } -> (p : parent :> label_parent)
+      | { iv = `Field (p, _); _ } -> (p : fragment_type_parent :> label_parent)
 
   let label_parent n = label_parent_aux (n :> Id.non_src)
 
@@ -217,9 +217,9 @@ module Identifier = struct
     type t_pv = Id.datatype_pv
   end
 
-  module Parent = struct
-    type t = Id.parent
-    type t_pv = Id.parent_pv
+  module FragmentTypeParent = struct
+    type t = Paths_types.Identifier.fragment_type_parent
+    type t_pv = Paths_types.Identifier.fragment_type_parent_pv
   end
 
   module LabelParent = struct
@@ -578,7 +578,8 @@ module Identifier = struct
           `Constructor (p, n))
 
     let field :
-        Parent.t * FieldName.t -> [> `Field of Parent.t * FieldName.t ] id =
+        FragmentTypeParent.t * FieldName.t ->
+        [> `Field of FragmentTypeParent.t * FieldName.t ] id =
       mk_parent FieldName.to_string "fld" (fun (p, n) -> `Field (p, n))
 
     let extension :
@@ -991,12 +992,14 @@ module Reference = struct
       | `ClassType (sg, s) ->
           Identifier.Mk.class_type (parent_signature_identifier sg, s)
 
-    and parent_identifier : parent -> Identifier.Parent.t = function
+    and parent_identifier :
+        fragment_type_parent -> Identifier.FragmentTypeParent.t = function
       | `Identifier id -> id
       | (`Hidden _ | `Alias _ | `AliasModuleType _ | `Module _ | `ModuleType _)
         as sg ->
-          (parent_signature_identifier sg :> Identifier.Parent.t)
-      | `Type _ as t -> (parent_type_identifier t :> Identifier.Parent.t)
+          (parent_signature_identifier sg :> Identifier.FragmentTypeParent.t)
+      | `Type _ as t ->
+          (parent_type_identifier t :> Identifier.FragmentTypeParent.t)
 
     and label_parent_identifier : label_parent -> Identifier.LabelParent.t =
       function
@@ -1042,8 +1045,8 @@ module Reference = struct
       type t = Paths_types.Resolved_reference.datatype
     end
 
-    module Parent = struct
-      type t = Paths_types.Resolved_reference.parent
+    module FragmentTypeParent = struct
+      type t = Paths_types.Resolved_reference.fragment_type_parent
     end
 
     module LabelParent = struct
@@ -1127,8 +1130,8 @@ module Reference = struct
     type t = Paths_types.Reference.datatype
   end
 
-  module Parent = struct
-    type t = Paths_types.Reference.parent
+  module FragmentTypeParent = struct
+    type t = Paths_types.Reference.fragment_type_parent
   end
 
   module LabelParent = struct

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -165,7 +165,7 @@ module Identifier = struct
       | { iv = `Label (p, _); _ } -> p
       | { iv = `Method (p, _); _ } | { iv = `InstanceVariable (p, _); _ } ->
           (p : class_signature :> label_parent)
-      | { iv = `Constructor (p, _); _ } -> (p : datatype :> label_parent)
+      | { iv = `Constructor (p, _); _ } -> (p : parent :> label_parent)
       | { iv = `Field (p, _); _ } -> (p : parent :> label_parent)
 
   let label_parent n = label_parent_aux (n :> Id.non_src)
@@ -572,8 +572,8 @@ module Identifier = struct
       mk_fresh (fun s -> s) "coret" (fun s -> `CoreType (TypeName.make_std s))
 
     let constructor :
-        Type.t * ConstructorName.t ->
-        [> `Constructor of Type.t * ConstructorName.t ] id =
+        Parent.t * ConstructorName.t ->
+        [> `Constructor of Parent.t * ConstructorName.t ] id =
       mk_parent ConstructorName.to_string "ctor" (fun (p, n) ->
           `Constructor (p, n))
 
@@ -1013,8 +1013,7 @@ module Reference = struct
         | `Class _ | `ClassType _ | `ModuleType _ ) as r ->
           (label_parent_identifier r :> Identifier.t)
       | `Field (p, n) -> Identifier.Mk.field (parent_identifier p, n)
-      | `Constructor (s, n) ->
-          Identifier.Mk.constructor (parent_type_identifier s, n)
+      | `Constructor (s, n) -> Identifier.Mk.constructor (parent_identifier s, n)
       | `Extension (p, q) ->
           Identifier.Mk.extension (parent_signature_identifier p, q)
       | `ExtensionDecl (p, q, r) ->

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -165,7 +165,7 @@ module Identifier = struct
       | { iv = `Label (p, _); _ } -> p
       | { iv = `Method (p, _); _ } | { iv = `InstanceVariable (p, _); _ } ->
           (p : class_signature :> label_parent)
-      | { iv = `Constructor (p, _); _ } -> (p : parent :> label_parent)
+      | { iv = `Constructor (p, _); _ } -> (p : datatype :> label_parent)
       | { iv = `Field (p, _); _ } -> (p : parent :> label_parent)
 
   let label_parent n = label_parent_aux (n :> Id.non_src)
@@ -572,8 +572,8 @@ module Identifier = struct
       mk_fresh (fun s -> s) "coret" (fun s -> `CoreType (TypeName.make_std s))
 
     let constructor :
-        Parent.t * ConstructorName.t ->
-        [> `Constructor of Parent.t * ConstructorName.t ] id =
+        DataType.t * ConstructorName.t ->
+        [> `Constructor of DataType.t * ConstructorName.t ] id =
       mk_parent ConstructorName.to_string "ctor" (fun (p, n) ->
           `Constructor (p, n))
 
@@ -1013,7 +1013,9 @@ module Reference = struct
         | `Class _ | `ClassType _ | `ModuleType _ ) as r ->
           (label_parent_identifier r :> Identifier.t)
       | `Field (p, n) -> Identifier.Mk.field (parent_identifier p, n)
-      | `Constructor (s, n) -> Identifier.Mk.constructor (parent_identifier s, n)
+      | `Constructor (s, n) ->
+          Identifier.Mk.constructor
+            ((parent_type_identifier s :> Identifier.DataType.t), n)
       | `Extension (p, q) ->
           Identifier.Mk.extension (parent_signature_identifier p, q)
       | `ExtensionDecl (p, q, r) ->

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -997,14 +997,14 @@ module Reference = struct
         as sg ->
           (parent_signature_identifier sg :> Identifier.Parent.t)
       | `Type _ as t -> (parent_type_identifier t :> Identifier.Parent.t)
-      | (`Class _ | `ClassType _) as c ->
-          (parent_class_signature_identifier c :> Identifier.Parent.t)
 
     and label_parent_identifier : label_parent -> Identifier.LabelParent.t =
       function
       | `Identifier id -> id
+      | (`Class _ | `ClassType _) as c ->
+          (parent_class_signature_identifier c :> Identifier.LabelParent.t)
       | ( `Hidden _ | `Alias _ | `AliasModuleType _ | `Module _ | `ModuleType _
-        | `Type _ | `Class _ | `ClassType _ ) as r ->
+        | `Type _ ) as r ->
           (parent_identifier r :> Identifier.LabelParent.t)
 
     and identifier : t -> Identifier.t = function

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -166,7 +166,7 @@ module Identifier = struct
       | { iv = `Method (p, _); _ } | { iv = `InstanceVariable (p, _); _ } ->
           (p : class_signature :> label_parent)
       | { iv = `Constructor (p, _); _ } -> (p : datatype :> label_parent)
-      | { iv = `Field (p, _); _ } -> (p : fragment_type_parent :> label_parent)
+      | { iv = `Field (p, _); _ } -> (p : field_parent :> label_parent)
 
   let label_parent n = label_parent_aux (n :> Id.non_src)
 
@@ -217,9 +217,9 @@ module Identifier = struct
     type t_pv = Id.datatype_pv
   end
 
-  module FragmentTypeParent = struct
-    type t = Paths_types.Identifier.fragment_type_parent
-    type t_pv = Paths_types.Identifier.fragment_type_parent_pv
+  module FieldParent = struct
+    type t = Paths_types.Identifier.field_parent
+    type t_pv = Paths_types.Identifier.field_parent_pv
   end
 
   module LabelParent = struct
@@ -578,8 +578,8 @@ module Identifier = struct
           `Constructor (p, n))
 
     let field :
-        FragmentTypeParent.t * FieldName.t ->
-        [> `Field of FragmentTypeParent.t * FieldName.t ] id =
+        FieldParent.t * FieldName.t ->
+        [> `Field of FieldParent.t * FieldName.t ] id =
       mk_parent FieldName.to_string "fld" (fun (p, n) -> `Field (p, n))
 
     let extension :
@@ -992,14 +992,13 @@ module Reference = struct
       | `ClassType (sg, s) ->
           Identifier.Mk.class_type (parent_signature_identifier sg, s)
 
-    and parent_identifier :
-        fragment_type_parent -> Identifier.FragmentTypeParent.t = function
+    and field_parent_identifier : field_parent -> Identifier.FieldParent.t =
+      function
       | `Identifier id -> id
       | (`Hidden _ | `Alias _ | `AliasModuleType _ | `Module _ | `ModuleType _)
         as sg ->
-          (parent_signature_identifier sg :> Identifier.FragmentTypeParent.t)
-      | `Type _ as t ->
-          (parent_type_identifier t :> Identifier.FragmentTypeParent.t)
+          (parent_signature_identifier sg :> Identifier.FieldParent.t)
+      | `Type _ as t -> (parent_type_identifier t :> Identifier.FieldParent.t)
 
     and label_parent_identifier : label_parent -> Identifier.LabelParent.t =
       function
@@ -1008,14 +1007,14 @@ module Reference = struct
           (parent_class_signature_identifier c :> Identifier.LabelParent.t)
       | ( `Hidden _ | `Alias _ | `AliasModuleType _ | `Module _ | `ModuleType _
         | `Type _ ) as r ->
-          (parent_identifier r :> Identifier.LabelParent.t)
+          (field_parent_identifier r :> Identifier.LabelParent.t)
 
     and identifier : t -> Identifier.t = function
       | `Identifier id -> id
       | ( `Alias _ | `AliasModuleType _ | `Module _ | `Hidden _ | `Type _
         | `Class _ | `ClassType _ | `ModuleType _ ) as r ->
           (label_parent_identifier r :> Identifier.t)
-      | `Field (p, n) -> Identifier.Mk.field (parent_identifier p, n)
+      | `Field (p, n) -> Identifier.Mk.field (field_parent_identifier p, n)
       | `Constructor (s, n) ->
           Identifier.Mk.constructor
             ((parent_type_identifier s :> Identifier.DataType.t), n)
@@ -1045,8 +1044,8 @@ module Reference = struct
       type t = Paths_types.Resolved_reference.datatype
     end
 
-    module FragmentTypeParent = struct
-      type t = Paths_types.Resolved_reference.fragment_type_parent
+    module FieldParent = struct
+      type t = Paths_types.Resolved_reference.field_parent
     end
 
     module LabelParent = struct

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -79,9 +79,9 @@ module Identifier : sig
     type t = Id.datatype
     type t_pv = Id.datatype_pv
   end
-  module FragmentTypeParent : sig
-    type t = Id.fragment_type_parent
-    type t_pv = Id.fragment_type_parent_pv
+  module FieldParent : sig
+    type t = Id.field_parent
+    type t_pv = Id.field_parent_pv
   end
 
   module FunctorResult : sig
@@ -294,8 +294,8 @@ module Identifier : sig
       [> `Constructor of DataType.t * ConstructorName.t ] id
 
     val field :
-      FragmentTypeParent.t * FieldName.t ->
-      [> `Field of FragmentTypeParent.t * FieldName.t ] id
+      FieldParent.t * FieldName.t ->
+      [> `Field of FieldParent.t * FieldName.t ] id
 
     val extension :
       Signature.t * ExtensionName.t ->
@@ -508,8 +508,8 @@ module rec Reference : sig
       type t = Paths_types.Resolved_reference.datatype
     end
 
-    module FragmentTypeParent : sig
-      type t = Paths_types.Resolved_reference.fragment_type_parent
+    module FieldParent : sig
+      type t = Paths_types.Resolved_reference.field_parent
     end
 
     module LabelParent : sig

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -290,8 +290,8 @@ module Identifier : sig
     val core_type : string -> [> `CoreType of TypeName.t ] id
 
     val constructor :
-      Parent.t * ConstructorName.t ->
-      [> `Constructor of Parent.t * ConstructorName.t ] id
+      DataType.t * ConstructorName.t ->
+      [> `Constructor of DataType.t * ConstructorName.t ] id
 
     val field :
       Parent.t * FieldName.t -> [> `Field of Parent.t * FieldName.t ] id

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -79,9 +79,9 @@ module Identifier : sig
     type t = Id.datatype
     type t_pv = Id.datatype_pv
   end
-  module Parent : sig
-    type t = Id.parent
-    type t_pv = Id.parent_pv
+  module FragmentTypeParent : sig
+    type t = Id.fragment_type_parent
+    type t_pv = Id.fragment_type_parent_pv
   end
 
   module FunctorResult : sig
@@ -294,7 +294,8 @@ module Identifier : sig
       [> `Constructor of DataType.t * ConstructorName.t ] id
 
     val field :
-      Parent.t * FieldName.t -> [> `Field of Parent.t * FieldName.t ] id
+      FragmentTypeParent.t * FieldName.t ->
+      [> `Field of FragmentTypeParent.t * FieldName.t ] id
 
     val extension :
       Signature.t * ExtensionName.t ->
@@ -507,8 +508,8 @@ module rec Reference : sig
       type t = Paths_types.Resolved_reference.datatype
     end
 
-    module Parent : sig
-      type t = Paths_types.Resolved_reference.parent
+    module FragmentTypeParent : sig
+      type t = Paths_types.Resolved_reference.fragment_type_parent
     end
 
     module LabelParent : sig
@@ -592,8 +593,8 @@ module rec Reference : sig
     type t = Paths_types.Reference.datatype
   end
 
-  module Parent : sig
-    type t = Paths_types.Reference.parent
+  module FragmentTypeParent : sig
+    type t = Paths_types.Reference.fragment_type_parent
   end
 
   module LabelParent : sig

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -290,8 +290,8 @@ module Identifier : sig
     val core_type : string -> [> `CoreType of TypeName.t ] id
 
     val constructor :
-      Type.t * ConstructorName.t ->
-      [> `Constructor of Type.t * ConstructorName.t ] id
+      Parent.t * ConstructorName.t ->
+      [> `Constructor of Parent.t * ConstructorName.t ] id
 
     val field :
       Parent.t * FieldName.t -> [> `Field of Parent.t * FieldName.t ] id

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -132,7 +132,7 @@ module Identifier = struct
   and type_ = type_pv id
   (** @canonical Odoc_model.Paths.Identifier.Type.t *)
 
-  type constructor_pv = [ `Constructor of type_ * ConstructorName.t ]
+  type constructor_pv = [ `Constructor of parent * ConstructorName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Constructor.t_pv *)
 
   and constructor = constructor_pv id
@@ -666,7 +666,7 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.constructor
     | `Root of string * [ `TConstructor | `TExtension | `TException | `TUnknown ]
     | `Dot of label_parent * string
-    | `Constructor of datatype * ConstructorName.t
+    | `Constructor of parent * ConstructorName.t
     | `Extension of signature * ExtensionName.t
     | `Exception of signature * ExceptionName.t ]
   (** @canonical Odoc_model.Paths.Reference.Constructor.t *)
@@ -756,7 +756,7 @@ module rec Reference : sig
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t
-    | `Constructor of datatype * ConstructorName.t
+    | `Constructor of parent * ConstructorName.t
     | `Field of parent * FieldName.t
     | `Extension of signature * ExtensionName.t
     | `ExtensionDecl of signature * ExtensionName.t
@@ -847,7 +847,7 @@ and Resolved_reference : sig
 
   type constructor =
     [ `Identifier of Identifier.reference_constructor
-    | `Constructor of datatype * ConstructorName.t
+    | `Constructor of parent * ConstructorName.t
     | `Extension of signature * ExtensionName.t
     | `Exception of signature * ExceptionName.t ]
   (** @canonical Odoc_model.Paths.Reference.Resolved.Constructor.t *)
@@ -920,7 +920,7 @@ and Resolved_reference : sig
     | `Hidden of module_
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t
-    | `Constructor of datatype * ConstructorName.t
+    | `Constructor of parent * ConstructorName.t
     | `Field of parent * FieldName.t
     | `Extension of signature * ExtensionName.t
     | `ExtensionDecl of signature * ExtensionName.t * ExtensionName.t

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -583,8 +583,7 @@ module rec Reference : sig
 
   type tag_datatype = [ `TUnknown | `TType ]
 
-  type tag_parent =
-    [ `TUnknown | `TModule | `TModuleType | `TClass | `TClassType | `TType ]
+  type tag_parent = [ `TUnknown | `TModule | `TModuleType | `TType ]
 
   type tag_label_parent =
     [ `TUnknown

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -132,7 +132,7 @@ module Identifier = struct
   and type_ = type_pv id
   (** @canonical Odoc_model.Paths.Identifier.Type.t *)
 
-  type constructor_pv = [ `Constructor of parent * ConstructorName.t ]
+  type constructor_pv = [ `Constructor of datatype * ConstructorName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Constructor.t_pv *)
 
   and constructor = constructor_pv id
@@ -843,7 +843,7 @@ and Resolved_reference : sig
 
   type constructor =
     [ `Identifier of Identifier.reference_constructor
-    | `Constructor of parent * ConstructorName.t
+    | `Constructor of datatype * ConstructorName.t
     | `Extension of signature * ExtensionName.t
     | `Exception of signature * ExceptionName.t ]
   (** @canonical Odoc_model.Paths.Reference.Resolved.Constructor.t *)
@@ -916,7 +916,7 @@ and Resolved_reference : sig
     | `Hidden of module_
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t
-    | `Constructor of parent * ConstructorName.t
+    | `Constructor of datatype * ConstructorName.t
     | `Field of parent * FieldName.t
     | `Extension of signature * ExtensionName.t
     | `ExtensionDecl of signature * ExtensionName.t * ExtensionName.t

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -81,13 +81,13 @@ module Identifier = struct
   and datatype = datatype_pv id
   (** @canonical Odoc_model.Paths.Identifier.DataType.t *)
 
-  type parent_pv = [ signature_pv | datatype_pv | class_signature_pv ]
+  type parent_pv = [ signature_pv | datatype_pv ]
   (** @canonical Odoc_model.Paths.Identifier.Parent.t_pv *)
 
   and parent = parent_pv id
   (** @canonical Odoc_model.Paths.Identifier.Parent.t *)
 
-  type label_parent_pv = [ parent_pv | page_pv ]
+  type label_parent_pv = [ parent_pv | page_pv | class_signature_pv ]
   (** @canonical Odoc_model.Paths.Identifier.LabelParent.t_pv *)
 
   and label_parent = label_parent_pv id
@@ -623,8 +623,6 @@ module rec Reference : sig
     | `Dot of label_parent * string
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
-    | `Class of signature * ClassName.t
-    | `ClassType of signature * ClassTypeName.t
     | `Type of signature * TypeName.t ]
   (** @canonical Odoc_model.Paths.Reference.Parent.t *)
 
@@ -813,8 +811,6 @@ and Resolved_reference : sig
     | `Module of signature * ModuleName.t
     | `Hidden of module_
     | `ModuleType of signature * ModuleTypeName.t
-    | `Class of signature * ClassName.t
-    | `ClassType of signature * ClassTypeName.t
     | `Type of signature * TypeName.t ]
   (** @canonical Odoc_model.Paths.Reference.Resolved.Parent.t *)
 

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -81,13 +81,17 @@ module Identifier = struct
   and datatype = datatype_pv id
   (** @canonical Odoc_model.Paths.Identifier.DataType.t *)
 
-  type parent_pv = [ signature_pv | datatype_pv ]
-  (** @canonical Odoc_model.Paths.Identifier.Parent.t_pv *)
+  type fragment_type_parent_pv = [ signature_pv | datatype_pv ]
+  (** @canonical Odoc_model.Paths.Identifier.FragmentTypeParent.t_pv *)
 
-  and parent = parent_pv id
-  (** @canonical Odoc_model.Paths.Identifier.Parent.t *)
+  (* fragment_type_parent in identifiers is for record fields parent. It’s type
+     (for usual record fields) or [signature] for fields of inline records of
+     extension constructor. *)
+  and fragment_type_parent = fragment_type_parent_pv id
+  (** @canonical Odoc_model.Paths.Identifier.FragmentTypeParent.t *)
 
-  type label_parent_pv = [ parent_pv | page_pv | class_signature_pv ]
+  type label_parent_pv =
+    [ fragment_type_parent_pv | page_pv | class_signature_pv ]
   (** @canonical Odoc_model.Paths.Identifier.LabelParent.t_pv *)
 
   and label_parent = label_parent_pv id
@@ -138,7 +142,7 @@ module Identifier = struct
   and constructor = constructor_pv id
   (** @canonical Odoc_model.Paths.Identifier.Constructor.t *)
 
-  type field_pv = [ `Field of parent * FieldName.t ]
+  type field_pv = [ `Field of fragment_type_parent * FieldName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Field.t_pv *)
 
   and field = field_pv id
@@ -206,7 +210,7 @@ module Identifier = struct
     [ signature_pv
     | class_signature_pv
     | datatype_pv
-    | parent_pv
+    | fragment_type_parent_pv
     | label_parent_pv
     | module_pv
     | functor_parameter_pv
@@ -617,14 +621,15 @@ module rec Reference : sig
     | `Type of signature * TypeName.t ]
   (** @canonical Odoc_model.Paths.Reference.DataType.t *)
 
-  and parent =
-    [ `Resolved of Resolved_reference.parent
+  (* Parent of fields and constructor. Can be either a type or [signature] *)
+  and fragment_type_parent =
+    [ `Resolved of Resolved_reference.fragment_type_parent
     | `Root of string * tag_parent
     | `Dot of label_parent * string
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t ]
-  (** @canonical Odoc_model.Paths.Reference.Parent.t *)
+  (** @canonical Odoc_model.Paths.Reference.FragmentTypeParent.t *)
 
   and label_parent =
     [ `Resolved of Resolved_reference.label_parent
@@ -664,7 +669,7 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.constructor
     | `Root of string * [ `TConstructor | `TExtension | `TException | `TUnknown ]
     | `Dot of label_parent * string
-    | `Constructor of parent * ConstructorName.t
+    | `Constructor of fragment_type_parent * ConstructorName.t
     | `Extension of signature * ExtensionName.t
     | `Exception of signature * ExceptionName.t ]
   (** @canonical Odoc_model.Paths.Reference.Constructor.t *)
@@ -673,7 +678,7 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.field
     | `Root of string * [ `TField | `TUnknown ]
     | `Dot of label_parent * string
-    | `Field of parent * FieldName.t ]
+    | `Field of fragment_type_parent * FieldName.t ]
   (** @canonical Odoc_model.Paths.Reference.Field.t *)
 
   type extension =
@@ -754,8 +759,8 @@ module rec Reference : sig
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t
-    | `Constructor of parent * ConstructorName.t
-    | `Field of parent * FieldName.t
+    | `Constructor of fragment_type_parent * ConstructorName.t
+    | `Field of fragment_type_parent * FieldName.t
     | `Extension of signature * ExtensionName.t
     | `ExtensionDecl of signature * ExtensionName.t
     | `Exception of signature * ExceptionName.t
@@ -803,16 +808,18 @@ and Resolved_reference : sig
     | `ClassType of signature * ClassTypeName.t ]
   (** @canonical Odoc_model.Paths.Reference.Resolved.ClassSignature.t *)
 
-  (* parent is [ signature | class_signature ] *)
-  and parent =
-    [ `Identifier of Identifier.parent
+  (* fragment_type_parent in resolved references is for record fields parent.
+     It’s type (for usual record fields) or [signature] for fields of inline
+     records of extension constructor. *)
+  and fragment_type_parent =
+    [ `Identifier of Identifier.fragment_type_parent
     | `Alias of Resolved_path.module_ * module_
     | `AliasModuleType of Resolved_path.module_type * module_type
     | `Module of signature * ModuleName.t
     | `Hidden of module_
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t ]
-  (** @canonical Odoc_model.Paths.Reference.Resolved.Parent.t *)
+  (** @canonical Odoc_model.Paths.Reference.Resolved.FragmentTypeParent.t *)
 
   (* The only difference between parent and label_parent
      is that the Identifier allows more types *)
@@ -850,7 +857,7 @@ and Resolved_reference : sig
 
   type field =
     [ `Identifier of Identifier.reference_field
-    | `Field of parent * FieldName.t ]
+    | `Field of fragment_type_parent * FieldName.t ]
   (** @canonical Odoc_model.Paths.Reference.Resolved.Field.t *)
 
   type extension =
@@ -917,7 +924,7 @@ and Resolved_reference : sig
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t
     | `Constructor of datatype * ConstructorName.t
-    | `Field of parent * FieldName.t
+    | `Field of fragment_type_parent * FieldName.t
     | `Extension of signature * ExtensionName.t
     | `ExtensionDecl of signature * ExtensionName.t * ExtensionName.t
     | `Exception of signature * ExceptionName.t

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -81,17 +81,16 @@ module Identifier = struct
   and datatype = datatype_pv id
   (** @canonical Odoc_model.Paths.Identifier.DataType.t *)
 
-  type fragment_type_parent_pv = [ signature_pv | datatype_pv ]
-  (** @canonical Odoc_model.Paths.Identifier.FragmentTypeParent.t_pv *)
+  type field_parent_pv = [ signature_pv | datatype_pv ]
+  (** @canonical Odoc_model.Paths.Identifier.FieldParent.t_pv *)
 
   (* fragment_type_parent in identifiers is for record fields parent. It’s type
      (for usual record fields) or [signature] for fields of inline records of
      extension constructor. *)
-  and fragment_type_parent = fragment_type_parent_pv id
-  (** @canonical Odoc_model.Paths.Identifier.FragmentTypeParent.t *)
+  and field_parent = field_parent_pv id
+  (** @canonical Odoc_model.Paths.Identifier.FieldParent.t *)
 
-  type label_parent_pv =
-    [ fragment_type_parent_pv | page_pv | class_signature_pv ]
+  type label_parent_pv = [ field_parent_pv | page_pv | class_signature_pv ]
   (** @canonical Odoc_model.Paths.Identifier.LabelParent.t_pv *)
 
   and label_parent = label_parent_pv id
@@ -142,7 +141,7 @@ module Identifier = struct
   and constructor = constructor_pv id
   (** @canonical Odoc_model.Paths.Identifier.Constructor.t *)
 
-  type field_pv = [ `Field of fragment_type_parent * FieldName.t ]
+  type field_pv = [ `Field of field_parent * FieldName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Field.t_pv *)
 
   and field = field_pv id
@@ -210,7 +209,7 @@ module Identifier = struct
     [ signature_pv
     | class_signature_pv
     | datatype_pv
-    | fragment_type_parent_pv
+    | field_parent_pv
     | label_parent_pv
     | module_pv
     | functor_parameter_pv
@@ -623,7 +622,7 @@ module rec Reference : sig
 
   (* Parent of fields and constructor. Can be either a type or [signature] *)
   and fragment_type_parent =
-    [ `Resolved of Resolved_reference.fragment_type_parent
+    [ `Resolved of Resolved_reference.field_parent
     | `Root of string * tag_parent
     | `Dot of label_parent * string
     | `Module of signature * ModuleName.t
@@ -811,8 +810,8 @@ and Resolved_reference : sig
   (* fragment_type_parent in resolved references is for record fields parent.
      It’s type (for usual record fields) or [signature] for fields of inline
      records of extension constructor. *)
-  and fragment_type_parent =
-    [ `Identifier of Identifier.fragment_type_parent
+  and field_parent =
+    [ `Identifier of Identifier.field_parent
     | `Alias of Resolved_path.module_ * module_
     | `AliasModuleType of Resolved_path.module_type * module_type
     | `Module of signature * ModuleName.t
@@ -857,7 +856,7 @@ and Resolved_reference : sig
 
   type field =
     [ `Identifier of Identifier.reference_field
-    | `Field of fragment_type_parent * FieldName.t ]
+    | `Field of field_parent * FieldName.t ]
   (** @canonical Odoc_model.Paths.Reference.Resolved.Field.t *)
 
   type extension =
@@ -924,7 +923,7 @@ and Resolved_reference : sig
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t
     | `Constructor of datatype * ConstructorName.t
-    | `Field of fragment_type_parent * FieldName.t
+    | `Field of field_parent * FieldName.t
     | `Extension of signature * ExtensionName.t
     | `ExtensionDecl of signature * ExtensionName.t * ExtensionName.t
     | `Exception of signature * ExceptionName.t

--- a/src/model/reference.ml
+++ b/src/model/reference.ml
@@ -219,13 +219,10 @@ let parse whole_reference_location s :
     match tokens with
     | [] -> (
         match kind with
-        | (`TUnknown | `TModule | `TModuleType | `TType | `TClass | `TClassType)
-          as kind ->
+        | (`TUnknown | `TModule | `TModuleType | `TType) as kind ->
             `Root (identifier, kind)
         | _ ->
-            expected
-              [ "module"; "module-type"; "type"; "class"; "class-type" ]
-              location
+            expected [ "module"; "module-type"; "type" ] location
             |> Error.raise_exception)
     | next_token :: tokens -> (
         match kind with
@@ -238,15 +235,8 @@ let parse whole_reference_location s :
               (signature next_token tokens, ModuleTypeName.make_std identifier)
         | `TType ->
             `Type (signature next_token tokens, TypeName.make_std identifier)
-        | `TClass ->
-            `Class (signature next_token tokens, ClassName.make_std identifier)
-        | `TClassType ->
-            `ClassType
-              (signature next_token tokens, ClassTypeName.make_std identifier)
         | _ ->
-            expected
-              [ "module"; "module-type"; "type"; "class"; "class-type" ]
-              location
+            expected [ "module"; "module-type"; "type" ] location
             |> Error.raise_exception)
   in
 
@@ -271,22 +261,6 @@ let parse whole_reference_location s :
         | _ ->
             expected [ "class"; "class-type" ] location |> Error.raise_exception
         )
-  in
-
-  let datatype (kind, identifier, location) tokens : DataType.t =
-    let kind = match_reference_kind location kind in
-    match tokens with
-    | [] -> (
-        match kind with
-        | (`TUnknown | `TType) as kind -> `Root (identifier, kind)
-        | _ -> expected [ "type" ] location |> Error.raise_exception)
-    | next_token :: tokens -> (
-        match kind with
-        | `TUnknown ->
-            `Dot ((parent next_token tokens :> LabelParent.t), identifier)
-        | `TType ->
-            `Type (signature next_token tokens, TypeName.make_std identifier)
-        | _ -> expected [ "type" ] location |> Error.raise_exception)
   in
 
   let rec label_parent (kind, identifier, location) tokens : LabelParent.t =
@@ -360,7 +334,7 @@ let parse whole_reference_location s :
             `Type (signature next_token tokens, TypeName.make_std identifier)
         | `TConstructor ->
             `Constructor
-              (datatype next_token tokens, ConstructorName.make_std identifier)
+              (parent next_token tokens, ConstructorName.make_std identifier)
         | `TField ->
             `Field (parent next_token tokens, FieldName.make_std identifier)
         | `TExtension ->

--- a/src/model/reference.ml
+++ b/src/model/reference.ml
@@ -214,7 +214,7 @@ let parse whole_reference_location s :
         | _ ->
             expected [ "module"; "module-type" ] location
             |> Error.raise_exception)
-  and parent (kind, identifier, location) tokens : Parent.t =
+  and parent (kind, identifier, location) tokens : FragmentTypeParent.t =
     let kind = match_reference_kind location kind in
     match tokens with
     | [] -> (

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -103,7 +103,7 @@ and content env id =
 
 and value_ env parent t =
   let open Value in
-  let container = (parent :> Id.Parent.t) in
+  let container = (parent :> Id.LabelParent.t) in
   try { t with type_ = type_expression env container t.type_ }
   with _ ->
     Errors.report ~what:(`Value t.id) `Compile;
@@ -111,14 +111,14 @@ and value_ env parent t =
 
 and exception_ env parent e =
   let open Exception in
-  let container = (parent :> Id.Parent.t) in
+  let container = (parent :> Id.LabelParent.t) in
   let res = Opt.map (type_expression env container) e.res in
   let args = type_decl_constructor_argument env container e.args in
   { e with res; args }
 
 and extension env parent t =
   let open Extension in
-  let container = (parent :> Id.Parent.t) in
+  let container = (parent :> Id.LabelParent.t) in
   let constructor c =
     let open Constructor in
     {
@@ -133,7 +133,7 @@ and extension env parent t =
 
 and class_type_expr env parent =
   let open ClassType in
-  let container = (parent :> Id.Parent.t) in
+  let container = (parent :> Id.LabelParent.t) in
   function
   | Constr (path, texps) ->
       Constr
@@ -169,7 +169,7 @@ and class_type env c =
 
 and class_signature env parent c =
   let open ClassSignature in
-  let container = (parent : Id.ClassSignature.t :> Id.Parent.t) in
+  let container = (parent : Id.ClassSignature.t :> Id.LabelParent.t) in
   let env = Env.open_class_signature c env in
   let map_item = function
     | Method m -> Method (method_ env parent m)
@@ -186,12 +186,12 @@ and class_signature env parent c =
 
 and method_ env parent m =
   let open Method in
-  let container = (parent :> Id.Parent.t) in
+  let container = (parent :> Id.LabelParent.t) in
   { m with type_ = type_expression env container m.type_ }
 
 and instance_variable env parent i =
   let open InstanceVariable in
-  let container = (parent :> Id.Parent.t) in
+  let container = (parent :> Id.LabelParent.t) in
   { i with type_ = type_expression env container i.type_ }
 
 and class_constraint env parent cst =
@@ -208,7 +208,7 @@ and inherit_ env parent ih =
 
 and class_ env parent c =
   let open Class in
-  let container = (parent :> Id.Parent.t) in
+  let container = (parent :> Id.LabelParent.t) in
   let expansion =
     match
       let open Utils.OptionMonad in
@@ -513,7 +513,7 @@ and module_type_expr_sub id ~fragment_root (sg_res, env, subs) lsub =
                   Errors.report ~what:(`With_type cfrag) `Compile;
                   (cfrag, frag)
             in
-            let eqn' = type_decl_equation env (id :> Id.Parent.t) eqn in
+            let eqn' = type_decl_equation env (id :> Id.LabelParent.t) eqn in
             let ceqn' = Component.Of_Lang.(type_equation (empty ()) eqn') in
             Tools.fragmap ~mark_substituted:true env
               (Component.ModuleType.TypeEq (cfrag', ceqn'))
@@ -556,7 +556,7 @@ and module_type_expr_sub id ~fragment_root (sg_res, env, subs) lsub =
                   Errors.report ~what:(`With_type cfrag) `Compile;
                   (cfrag, frag)
             in
-            let eqn' = type_decl_equation env (id :> Id.Parent.t) eqn in
+            let eqn' = type_decl_equation env (id :> Id.LabelParent.t) eqn in
             let ceqn' = Component.Of_Lang.(type_equation (empty ()) eqn') in
             Tools.fragmap ~mark_substituted:true env
               (Component.ModuleType.TypeSubst (cfrag', ceqn'))
@@ -739,7 +739,7 @@ and type_decl : Env.t -> TypeDecl.t -> TypeDecl.t =
   let open TypeDecl in
   let container =
     match t.id.iv with
-    | `Type (parent, _) -> (parent :> Id.Parent.t)
+    | `Type (parent, _) -> (parent :> Id.LabelParent.t)
     | `CoreType _ -> assert false
   in
   let equation = type_decl_equation env container t.equation in
@@ -749,7 +749,7 @@ and type_decl : Env.t -> TypeDecl.t -> TypeDecl.t =
   { t with equation; representation }
 
 and type_decl_equation :
-    Env.t -> Id.Parent.t -> TypeDecl.Equation.t -> TypeDecl.Equation.t =
+    Env.t -> Id.LabelParent.t -> TypeDecl.Equation.t -> TypeDecl.Equation.t =
  fun env parent t ->
   let open TypeDecl.Equation in
   let manifest = Opt.map (type_expression env parent) t.manifest in
@@ -763,7 +763,7 @@ and type_decl_equation :
 
 and type_decl_representation :
     Env.t ->
-    Id.Parent.t ->
+    Id.LabelParent.t ->
     TypeDecl.Representation.t ->
     TypeDecl.Representation.t =
  fun env parent r ->
@@ -784,7 +784,10 @@ and type_decl_constructor_argument env parent c =
   | Record fs -> Record (List.map (type_decl_field env parent) fs)
 
 and type_decl_constructor :
-    Env.t -> Id.Parent.t -> TypeDecl.Constructor.t -> TypeDecl.Constructor.t =
+    Env.t ->
+    Id.LabelParent.t ->
+    TypeDecl.Constructor.t ->
+    TypeDecl.Constructor.t =
  fun env parent c ->
   let open TypeDecl.Constructor in
   let args = type_decl_constructor_argument env parent c.args in
@@ -853,7 +856,7 @@ and type_expression_package env parent p =
               }))
   | Error _ -> { p with path = Lang_of.(Path.module_type (empty ()) cp) }
 
-and type_expression : Env.t -> Id.Parent.t -> _ -> _ =
+and type_expression : Env.t -> Id.LabelParent.t -> _ -> _ =
  fun env parent texpr ->
   let open TypeExpr in
   match texpr with

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -496,7 +496,7 @@ module Element = struct
 
   type module_type = [ `ModuleType of Identifier.ModuleType.t * ModuleType.t ]
 
-  type type_ = [ `Type of Identifier.Type.t * TypeDecl.t ]
+  type datatype = [ `Type of Identifier.Type.t * TypeDecl.t ]
 
   type value = [ `Value of Identifier.Value.t * Value.t ]
 
@@ -506,7 +506,7 @@ module Element = struct
 
   type class_type = [ `ClassType of Identifier.ClassType.t * ClassType.t ]
 
-  type datatype = [ type_ | class_ | class_type ]
+  type type_ = [ datatype | class_ | class_type ]
 
   type signature = [ module_ | module_type ]
 
@@ -527,12 +527,12 @@ module Element = struct
   (* No component for pages yet *)
   type page = [ `Page of Identifier.Page.t * Odoc_model.Lang.Page.t ]
 
-  type label_parent = [ signature | datatype | page ]
+  type label_parent = [ signature | type_ | page ]
 
   type any =
     [ signature
     | value
-    | type_
+    | datatype
     | label
     | class_
     | class_type

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -529,6 +529,8 @@ module Element = struct
 
   type label_parent = [ signature | type_ | page ]
 
+  type fragment_type_parent = [ signature | datatype ]
+
   type any =
     [ signature
     | value

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -493,6 +493,8 @@ module Element : sig
 
   type label_parent = [ signature | type_ | page ]
 
+  type fragment_type_parent = [ signature | datatype ]
+
   type any =
     [ signature
     | value

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -460,7 +460,7 @@ module Element : sig
 
   type module_type = [ `ModuleType of Identifier.ModuleType.t * ModuleType.t ]
 
-  type type_ = [ `Type of Identifier.Type.t * TypeDecl.t ]
+  type datatype = [ `Type of Identifier.Type.t * TypeDecl.t ]
 
   type value = [ `Value of Identifier.Value.t * Value.t ]
 
@@ -470,7 +470,7 @@ module Element : sig
 
   type class_type = [ `ClassType of Identifier.ClassType.t * ClassType.t ]
 
-  type datatype = [ type_ | class_ | class_type ]
+  type type_ = [ datatype | class_ | class_type ]
 
   type signature = [ module_ | module_type ]
 
@@ -491,12 +491,12 @@ module Element : sig
   (* No component for pages yet *)
   type page = [ `Page of Identifier.Page.t * Odoc_model.Lang.Page.t ]
 
-  type label_parent = [ signature | datatype | page ]
+  type label_parent = [ signature | type_ | page ]
 
   type any =
     [ signature
     | value
-    | type_
+    | datatype
     | label
     | class_
     | class_type

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -592,6 +592,11 @@ let s_label_parent : Component.Element.label_parent scope =
     | #Component.Element.label_parent as r -> Some r
     | _ -> None)
 
+let s_fragment_type_parent : Component.Element.fragment_type_parent scope =
+  make_scope ~root:lookup_root_module_fallback (function
+    | #Component.Element.fragment_type_parent as r -> Some r
+    | _ -> None)
+
 let len = ref 0
 
 let n = ref 0

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -543,11 +543,11 @@ let s_module_type : Component.Element.module_type scope =
     | #Component.Element.module_type as r -> Some r
     | _ -> None)
 
-let s_datatype : Component.Element.datatype scope =
-  make_scope (function #Component.Element.datatype as r -> Some r | _ -> None)
-
 let s_type : Component.Element.type_ scope =
   make_scope (function #Component.Element.type_ as r -> Some r | _ -> None)
+
+let s_datatype : Component.Element.datatype scope =
+  make_scope (function #Component.Element.datatype as r -> Some r | _ -> None)
 
 let s_class : Component.Element.class_ scope =
   make_scope (function #Component.Element.class_ as r -> Some r | _ -> None)

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -288,13 +288,14 @@ let add_module identifier m docs env =
   let env' = add_to_elts Kind_Module identifier (`Module (identifier, m)) env in
   if env.linking then add_cdocs identifier docs env' else env'
 
-let add_type identifier t env =
+let add_type (identifier : Identifier.Type.t) t env =
   let open Component in
   let open_typedecl cs =
     let add_cons env (cons : TypeDecl.Constructor.t) =
       let ident =
         Paths.Identifier.Mk.constructor
-          (identifier, ConstructorName.make_std cons.name)
+          ( (identifier :> Identifier.Parent.t),
+            ConstructorName.make_std cons.name )
       in
       add_to_elts Kind_Constructor ident (`Constructor (ident, cons)) env
     and add_field env (field : TypeDecl.Field.t) =

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -301,7 +301,7 @@ let add_type (identifier : Identifier.Type.t) t env =
     and add_field env (field : TypeDecl.Field.t) =
       let ident =
         Paths.Identifier.Mk.field
-          ( (identifier :> Paths.Identifier.Parent.t),
+          ( (identifier :> Paths.Identifier.FragmentTypeParent.t),
             FieldName.make_std field.name )
       in
       add_to_elts Kind_Field ident (`Field (ident, field)) env

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -301,7 +301,7 @@ let add_type (identifier : Identifier.Type.t) t env =
     and add_field env (field : TypeDecl.Field.t) =
       let ident =
         Paths.Identifier.Mk.field
-          ( (identifier :> Paths.Identifier.FragmentTypeParent.t),
+          ( (identifier :> Paths.Identifier.FieldParent.t),
             FieldName.make_std field.name )
       in
       add_to_elts Kind_Field ident (`Field (ident, field)) env

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -294,7 +294,7 @@ let add_type (identifier : Identifier.Type.t) t env =
     let add_cons env (cons : TypeDecl.Constructor.t) =
       let ident =
         Paths.Identifier.Mk.constructor
-          ( (identifier :> Identifier.Parent.t),
+          ( (identifier :> Identifier.DataType.t),
             ConstructorName.make_std cons.name )
       in
       add_to_elts Kind_Constructor ident (`Constructor (ident, cons)) env

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -144,6 +144,8 @@ val s_field : Component.Element.field scope
 
 val s_label_parent : Component.Element.label_parent scope
 
+val s_fragment_type_parent : Component.Element.fragment_type_parent scope
+
 (* val open_component_signature :
    Paths_types.Identifier.signature -> Component.Signature.t -> t -> t *)
 

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -122,9 +122,9 @@ val s_module : Component.Element.module_ scope
 
 val s_module_type : Component.Element.module_type scope
 
-val s_datatype : Component.Element.datatype scope
-
 val s_type : Component.Element.type_ scope
+
+val s_datatype : Component.Element.datatype scope
 
 val s_class : Component.Element.class_ scope
 

--- a/src/xref2/ident.ml
+++ b/src/xref2/ident.ml
@@ -16,10 +16,13 @@ type class_signature =
 
 type datatype = [ `LType of TypeName.t * int ]
 
-type parent = [ signature | datatype | class_signature ]
+type parent = [ signature | datatype ]
 
 type label_parent =
-  [ parent | `LPage of PageName.t * int | `LLeafPage of PageName.t * int ]
+  [ parent
+  | `LPage of PageName.t * int
+  | `LLeafPage of PageName.t * int
+  | class_signature ]
 
 type module_ =
   [ `LRoot of ModuleName.t * int
@@ -143,11 +146,12 @@ module Of_Identifier = struct
     match p with
     | { iv = #Signature.t_pv; _ } as s -> (signature s :> parent)
     | { iv = #DataType.t_pv; _ } as s -> (datatype s :> parent)
-    | { iv = #ClassSignature.t_pv; _ } as s -> (class_signature s :> parent)
 
   let label_parent : LabelParent.t -> label_parent =
    fun p ->
     match p with
+    | { iv = #ClassSignature.t_pv; _ } as s ->
+        (class_signature s :> label_parent)
     | { iv = #Parent.t_pv; _ } as s -> (parent s :> label_parent)
     | { iv = `Page (_, n); _ } -> `LPage (n, fresh_int ())
     | { iv = `LeafPage (_, n); _ } -> `LLeafPage (n, fresh_int ())

--- a/src/xref2/ident.ml
+++ b/src/xref2/ident.ml
@@ -141,7 +141,7 @@ module Of_Identifier = struct
     | `Type (_, n) -> `LType (n, i)
     | `CoreType _n -> failwith "Bad"
 
-  let parent : FragmentTypeParent.t -> parent =
+  let field_parent : FieldParent.t -> parent =
    fun p ->
     match p with
     | { iv = #Signature.t_pv; _ } as s -> (signature s :> parent)
@@ -152,7 +152,7 @@ module Of_Identifier = struct
     match p with
     | { iv = #ClassSignature.t_pv; _ } as s ->
         (class_signature s :> label_parent)
-    | { iv = #FragmentTypeParent.t_pv; _ } as s -> (parent s :> label_parent)
+    | { iv = #FieldParent.t_pv; _ } as s -> (field_parent s :> label_parent)
     | { iv = `Page (_, n); _ } -> `LPage (n, fresh_int ())
     | { iv = `LeafPage (_, n); _ } -> `LLeafPage (n, fresh_int ())
 

--- a/src/xref2/ident.ml
+++ b/src/xref2/ident.ml
@@ -141,7 +141,7 @@ module Of_Identifier = struct
     | `Type (_, n) -> `LType (n, i)
     | `CoreType _n -> failwith "Bad"
 
-  let parent : Parent.t -> parent =
+  let parent : FragmentTypeParent.t -> parent =
    fun p ->
     match p with
     | { iv = #Signature.t_pv; _ } as s -> (signature s :> parent)
@@ -152,7 +152,7 @@ module Of_Identifier = struct
     match p with
     | { iv = #ClassSignature.t_pv; _ } as s ->
         (class_signature s :> label_parent)
-    | { iv = #Parent.t_pv; _ } as s -> (parent s :> label_parent)
+    | { iv = #FragmentTypeParent.t_pv; _ } as s -> (parent s :> label_parent)
     | { iv = `Page (_, n); _ } -> `LPage (n, fresh_int ())
     | { iv = `LeafPage (_, n); _ } -> `LLeafPage (n, fresh_int ())
 

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -895,7 +895,8 @@ and type_decl_constructor_argument :
   match a with
   | Tuple ls ->
       Tuple (List.map (type_expr map (parent :> Identifier.LabelParent.t)) ls)
-  | Record fs -> Record (List.map (type_decl_field map parent) fs)
+  | Record fs ->
+      Record (List.map (type_decl_field map (parent :> Identifier.Parent.t)) fs)
 
 and type_decl_field :
     maps ->
@@ -942,9 +943,7 @@ and type_decl_representation map id (t : Component.TypeDecl.Representation.t) :
     Odoc_model.Lang.TypeDecl.Representation.t =
   match t with
   | Extensible -> Extensible
-  | Variant cs ->
-      Variant
-        (List.map (type_decl_constructor map (id :> Identifier.Parent.t)) cs)
+  | Variant cs -> Variant (List.map (type_decl_constructor map id) cs)
   | Record fs ->
       Record
         (List.map
@@ -953,7 +952,7 @@ and type_decl_representation map id (t : Component.TypeDecl.Representation.t) :
 
 and type_decl_constructor :
     maps ->
-    Odoc_model.Paths.Identifier.Parent.t ->
+    Odoc_model.Paths.Identifier.DataType.t ->
     Component.TypeDecl.Constructor.t ->
     Odoc_model.Lang.TypeDecl.Constructor.t =
  fun map id t ->
@@ -963,8 +962,8 @@ and type_decl_constructor :
   let parent = (id :> Identifier.LabelParent.t) in
   {
     id = identifier;
-    doc = docs (id :> Identifier.LabelParent.t) t.doc;
-    args = type_decl_constructor_argument map id t.args;
+    doc = docs parent t.doc;
+    args = type_decl_constructor_argument map (id :> Identifier.Parent.t) t.args;
     res = Opt.map (type_expr map parent) t.res;
   }
 

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -940,7 +940,9 @@ and type_decl_representation map id (t : Component.TypeDecl.Representation.t) :
     Odoc_model.Lang.TypeDecl.Representation.t =
   match t with
   | Extensible -> Extensible
-  | Variant cs -> Variant (List.map (type_decl_constructor map id) cs)
+  | Variant cs ->
+      Variant
+        (List.map (type_decl_constructor map (id :> Identifier.Parent.t)) cs)
   | Record fs ->
       Record
         (List.map
@@ -949,7 +951,7 @@ and type_decl_representation map id (t : Component.TypeDecl.Representation.t) :
 
 and type_decl_constructor :
     maps ->
-    Odoc_model.Paths.Identifier.Type.t ->
+    Odoc_model.Paths.Identifier.Parent.t ->
     Component.TypeDecl.Constructor.t ->
     Odoc_model.Lang.TypeDecl.Constructor.t =
  fun map id t ->
@@ -959,11 +961,8 @@ and type_decl_constructor :
   {
     id = identifier;
     doc = docs (id :> Identifier.LabelParent.t) t.doc;
-    args =
-      type_decl_constructor_argument map
-        (id :> Odoc_model.Paths.Identifier.Parent.t)
-        t.args;
-    res = Opt.map (type_expr map (id :> Identifier.Parent.t)) t.res;
+    args = type_decl_constructor_argument map id t.args;
+    res = Opt.map (type_expr map id) t.res;
   }
 
 and type_expr_package map parent t =

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -711,7 +711,9 @@ and extension_constructor map parent c =
     locs = c.locs;
     doc = docs (parent :> Identifier.LabelParent.t) c.doc;
     args =
-      type_decl_constructor_argument map (parent :> Identifier.Parent.t) c.args;
+      type_decl_constructor_argument map
+        (parent :> Identifier.FragmentTypeParent.t)
+        c.args;
     res = Opt.map (type_expr map (parent :> Identifier.LabelParent.t)) c.res;
   }
 
@@ -767,11 +769,15 @@ and mty_substitution map identifier = function
   | TypeEq (frag, eqn) ->
       TypeEq
         ( Path.type_fragment map frag,
-          type_decl_equation map (identifier :> Identifier.Parent.t) eqn )
+          type_decl_equation map
+            (identifier :> Identifier.FragmentTypeParent.t)
+            eqn )
   | TypeSubst (frag, eqn) ->
       TypeSubst
         ( Path.type_fragment map frag,
-          type_decl_equation map (identifier :> Identifier.Parent.t) eqn )
+          type_decl_equation map
+            (identifier :> Identifier.FragmentTypeParent.t)
+            eqn )
   | ModuleTypeEq (frag, eqn) ->
       ModuleTypeEq
         (Path.module_type_fragment map frag, module_type_expr map identifier eqn)
@@ -888,7 +894,7 @@ and module_type_substitution :
 
 and type_decl_constructor_argument :
     maps ->
-    Paths.Identifier.Parent.t ->
+    Paths.Identifier.FragmentTypeParent.t ->
     Component.TypeDecl.Constructor.argument ->
     Odoc_model.Lang.TypeDecl.Constructor.argument =
  fun map parent a ->
@@ -896,11 +902,14 @@ and type_decl_constructor_argument :
   | Tuple ls ->
       Tuple (List.map (type_expr map (parent :> Identifier.LabelParent.t)) ls)
   | Record fs ->
-      Record (List.map (type_decl_field map (parent :> Identifier.Parent.t)) fs)
+      Record
+        (List.map
+           (type_decl_field map (parent :> Identifier.FragmentTypeParent.t))
+           fs)
 
 and type_decl_field :
     maps ->
-    Identifier.Parent.t ->
+    Identifier.FragmentTypeParent.t ->
     Component.TypeDecl.Field.t ->
     Odoc_model.Lang.TypeDecl.Field.t =
  fun map parent f ->
@@ -912,7 +921,7 @@ and type_decl_field :
     type_ = type_expr map (parent :> Identifier.LabelParent.t) f.type_;
   }
 
-and type_decl_equation map (parent : Identifier.Parent.t)
+and type_decl_equation map (parent : Identifier.FragmentTypeParent.t)
     (eqn : Component.TypeDecl.Equation.t) : Odoc_model.Lang.TypeDecl.Equation.t
     =
   let parent = (parent :> Identifier.LabelParent.t) in
@@ -932,7 +941,10 @@ and type_decl map parent id (t : Component.TypeDecl.t) :
   {
     id = identifier;
     locs = t.locs;
-    equation = type_decl_equation map (parent :> Identifier.Parent.t) t.equation;
+    equation =
+      type_decl_equation map
+        (parent :> Identifier.FragmentTypeParent.t)
+        t.equation;
     doc = docs (parent :> Identifier.LabelParent.t) t.doc;
     canonical = t.canonical;
     representation =
@@ -947,7 +959,8 @@ and type_decl_representation map id (t : Component.TypeDecl.Representation.t) :
   | Record fs ->
       Record
         (List.map
-           (type_decl_field map (id :> Odoc_model.Paths.Identifier.Parent.t))
+           (type_decl_field map
+              (id :> Odoc_model.Paths.Identifier.FragmentTypeParent.t))
            fs)
 
 and type_decl_constructor :
@@ -963,7 +976,10 @@ and type_decl_constructor :
   {
     id = identifier;
     doc = docs parent t.doc;
-    args = type_decl_constructor_argument map (id :> Identifier.Parent.t) t.args;
+    args =
+      type_decl_constructor_argument map
+        (id :> Identifier.FragmentTypeParent.t)
+        t.args;
     res = Opt.map (type_expr map parent) t.res;
   }
 
@@ -1055,7 +1071,9 @@ and exception_ map parent id (e : Component.Exception.t) :
     locs = e.locs;
     doc = docs (parent :> Identifier.LabelParent.t) e.doc;
     args =
-      type_decl_constructor_argument map (parent :> Identifier.Parent.t) e.args;
+      type_decl_constructor_argument map
+        (parent :> Identifier.FragmentTypeParent.t)
+        e.args;
     res = Opt.map (type_expr map (parent :> Identifier.LabelParent.t)) e.res;
   }
 

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -712,7 +712,7 @@ and extension_constructor map parent c =
     doc = docs (parent :> Identifier.LabelParent.t) c.doc;
     args =
       type_decl_constructor_argument map
-        (parent :> Identifier.FragmentTypeParent.t)
+        (parent :> Identifier.FieldParent.t)
         c.args;
     res = Opt.map (type_expr map (parent :> Identifier.LabelParent.t)) c.res;
   }
@@ -769,15 +769,11 @@ and mty_substitution map identifier = function
   | TypeEq (frag, eqn) ->
       TypeEq
         ( Path.type_fragment map frag,
-          type_decl_equation map
-            (identifier :> Identifier.FragmentTypeParent.t)
-            eqn )
+          type_decl_equation map (identifier :> Identifier.FieldParent.t) eqn )
   | TypeSubst (frag, eqn) ->
       TypeSubst
         ( Path.type_fragment map frag,
-          type_decl_equation map
-            (identifier :> Identifier.FragmentTypeParent.t)
-            eqn )
+          type_decl_equation map (identifier :> Identifier.FieldParent.t) eqn )
   | ModuleTypeEq (frag, eqn) ->
       ModuleTypeEq
         (Path.module_type_fragment map frag, module_type_expr map identifier eqn)
@@ -894,7 +890,7 @@ and module_type_substitution :
 
 and type_decl_constructor_argument :
     maps ->
-    Paths.Identifier.FragmentTypeParent.t ->
+    Paths.Identifier.FieldParent.t ->
     Component.TypeDecl.Constructor.argument ->
     Odoc_model.Lang.TypeDecl.Constructor.argument =
  fun map parent a ->
@@ -903,13 +899,11 @@ and type_decl_constructor_argument :
       Tuple (List.map (type_expr map (parent :> Identifier.LabelParent.t)) ls)
   | Record fs ->
       Record
-        (List.map
-           (type_decl_field map (parent :> Identifier.FragmentTypeParent.t))
-           fs)
+        (List.map (type_decl_field map (parent :> Identifier.FieldParent.t)) fs)
 
 and type_decl_field :
     maps ->
-    Identifier.FragmentTypeParent.t ->
+    Identifier.FieldParent.t ->
     Component.TypeDecl.Field.t ->
     Odoc_model.Lang.TypeDecl.Field.t =
  fun map parent f ->
@@ -921,7 +915,7 @@ and type_decl_field :
     type_ = type_expr map (parent :> Identifier.LabelParent.t) f.type_;
   }
 
-and type_decl_equation map (parent : Identifier.FragmentTypeParent.t)
+and type_decl_equation map (parent : Identifier.FieldParent.t)
     (eqn : Component.TypeDecl.Equation.t) : Odoc_model.Lang.TypeDecl.Equation.t
     =
   let parent = (parent :> Identifier.LabelParent.t) in
@@ -942,9 +936,7 @@ and type_decl map parent id (t : Component.TypeDecl.t) :
     id = identifier;
     locs = t.locs;
     equation =
-      type_decl_equation map
-        (parent :> Identifier.FragmentTypeParent.t)
-        t.equation;
+      type_decl_equation map (parent :> Identifier.FieldParent.t) t.equation;
     doc = docs (parent :> Identifier.LabelParent.t) t.doc;
     canonical = t.canonical;
     representation =
@@ -960,7 +952,7 @@ and type_decl_representation map id (t : Component.TypeDecl.Representation.t) :
       Record
         (List.map
            (type_decl_field map
-              (id :> Odoc_model.Paths.Identifier.FragmentTypeParent.t))
+              (id :> Odoc_model.Paths.Identifier.FieldParent.t))
            fs)
 
 and type_decl_constructor :
@@ -977,9 +969,7 @@ and type_decl_constructor :
     id = identifier;
     doc = docs parent t.doc;
     args =
-      type_decl_constructor_argument map
-        (id :> Identifier.FragmentTypeParent.t)
-        t.args;
+      type_decl_constructor_argument map (id :> Identifier.FieldParent.t) t.args;
     res = Opt.map (type_expr map parent) t.res;
   }
 
@@ -1072,7 +1062,7 @@ and exception_ map parent id (e : Component.Exception.t) :
     doc = docs (parent :> Identifier.LabelParent.t) e.doc;
     args =
       type_decl_constructor_argument map
-        (parent :> Identifier.FragmentTypeParent.t)
+        (parent :> Identifier.FieldParent.t)
         e.args;
     res = Opt.map (type_expr map (parent :> Identifier.LabelParent.t)) e.res;
   }

--- a/src/xref2/lang_of.mli
+++ b/src/xref2/lang_of.mli
@@ -217,7 +217,7 @@ val type_decl_representation :
 
 val type_decl_constructor :
   maps ->
-  Identifier.Parent.t ->
+  Identifier.DataType.t ->
   Component.TypeDecl.Constructor.t ->
   Odoc_model.Lang.TypeDecl.Constructor.t
 

--- a/src/xref2/lang_of.mli
+++ b/src/xref2/lang_of.mli
@@ -223,25 +223,25 @@ val type_decl_constructor :
 
 val type_expr_package :
   maps ->
-  Identifier.Parent.t ->
+  Identifier.LabelParent.t ->
   Component.TypeExpr.Package.t ->
   Odoc_model.Lang.TypeExpr.Package.t
 
 val type_expr :
   maps ->
-  Identifier.Parent.t ->
+  Identifier.LabelParent.t ->
   Component.TypeExpr.t ->
   Odoc_model.Lang.TypeExpr.t
 
 val type_expr_polyvar :
   maps ->
-  Identifier.Parent.t ->
+  Identifier.LabelParent.t ->
   Component.TypeExpr.Polymorphic_variant.t ->
   Odoc_model.Lang.TypeExpr.Polymorphic_variant.t
 
 val type_expr_object :
   maps ->
-  Identifier.Parent.t ->
+  Identifier.LabelParent.t ->
   Component.TypeExpr.Object.t ->
   Odoc_model.Lang.TypeExpr.Object.t
 

--- a/src/xref2/lang_of.mli
+++ b/src/xref2/lang_of.mli
@@ -217,7 +217,7 @@ val type_decl_representation :
 
 val type_decl_constructor :
   maps ->
-  Identifier.Type.t ->
+  Identifier.Parent.t ->
   Component.TypeDecl.Constructor.t ->
   Odoc_model.Lang.TypeDecl.Constructor.t
 

--- a/src/xref2/lang_of.mli
+++ b/src/xref2/lang_of.mli
@@ -186,19 +186,19 @@ val simple_expansion :
 
 val type_decl_constructor_argument :
   maps ->
-  Identifier.FragmentTypeParent.t ->
+  Identifier.FieldParent.t ->
   Component.TypeDecl.Constructor.argument ->
   Odoc_model.Lang.TypeDecl.Constructor.argument
 
 val type_decl_field :
   maps ->
-  Identifier.FragmentTypeParent.t ->
+  Identifier.FieldParent.t ->
   Component.TypeDecl.Field.t ->
   Odoc_model.Lang.TypeDecl.Field.t
 
 val type_decl_equation :
   maps ->
-  Identifier.FragmentTypeParent.t ->
+  Identifier.FieldParent.t ->
   Component.TypeDecl.Equation.t ->
   Odoc_model.Lang.TypeDecl.Equation.t
 

--- a/src/xref2/lang_of.mli
+++ b/src/xref2/lang_of.mli
@@ -186,19 +186,19 @@ val simple_expansion :
 
 val type_decl_constructor_argument :
   maps ->
-  Identifier.Parent.t ->
+  Identifier.FragmentTypeParent.t ->
   Component.TypeDecl.Constructor.argument ->
   Odoc_model.Lang.TypeDecl.Constructor.argument
 
 val type_decl_field :
   maps ->
-  Identifier.Parent.t ->
+  Identifier.FragmentTypeParent.t ->
   Component.TypeDecl.Field.t ->
   Odoc_model.Lang.TypeDecl.Field.t
 
 val type_decl_equation :
   maps ->
-  Identifier.Parent.t ->
+  Identifier.FragmentTypeParent.t ->
   Component.TypeDecl.Equation.t ->
   Odoc_model.Lang.TypeDecl.Equation.t
 

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -1047,7 +1047,7 @@ and type_expression : Env.t -> Id.Signature.t -> _ -> _ =
                     let t' =
                       Expand_tools.type_expr map
                         Lang_of.(
-                          type_expr (empty ()) (parent :> Id.Parent.t) expr)
+                          type_expr (empty ()) (parent :> Id.LabelParent.t) expr)
                     in
                     type_expression env parent (p :: visited) t'
                   with
@@ -1066,7 +1066,7 @@ and type_expression : Env.t -> Id.Signature.t -> _ -> _ =
             Constr (`Resolved p, ts)
         | Ok (_cp, `FType_removed (_, x, _eq)) ->
             (* Type variables ? *)
-            Lang_of.(type_expr (empty ()) (parent :> Id.Parent.t) x)
+            Lang_of.(type_expr (empty ()) (parent :> Id.LabelParent.t) x)
         | Error _ -> Constr (path', ts))
   | Polymorphic_variant v ->
       Polymorphic_variant (type_expression_polyvar env parent visited v)

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -921,7 +921,7 @@ and type_decl : Env.t -> Id.Signature.t -> TypeDecl.t -> TypeDecl.t =
             try
               Expand_tools.collapse_eqns default.equation
                 (Lang_of.type_decl_equation (Lang_of.empty ())
-                   (parent :> Id.Parent.t)
+                   (parent :> Id.FragmentTypeParent.t)
                    t'.equation)
                 params
             with _ -> default.equation

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -921,7 +921,7 @@ and type_decl : Env.t -> Id.Signature.t -> TypeDecl.t -> TypeDecl.t =
             try
               Expand_tools.collapse_eqns default.equation
                 (Lang_of.type_decl_equation (Lang_of.empty ())
-                   (parent :> Id.FragmentTypeParent.t)
+                   (parent :> Id.FieldParent.t)
                    t'.equation)
                 params
             with _ -> default.equation

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -292,8 +292,7 @@ module T = struct
     | `ClassType _ as e -> `CT (CT.of_element env e)
 
   let in_env env name =
-    env_lookup_by_name Env.s_datatype name env >>= fun e ->
-    Ok (of_element env e)
+    env_lookup_by_name Env.s_type name env >>= fun e -> Ok (of_element env e)
 
   (* Don't handle name collisions between class, class types and type decls *)
   let in_signature _env ((parent', parent_cp, sg) : signature_lookup_result)

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -456,16 +456,13 @@ module CS = struct
         find Find.any_in_type t name_s >>= function
         | `FField _ -> got_a_field name_s
         | `FConstructor _ ->
-            Ok
-              (`Constructor
-                ((parent' : Resolved.DataType.t :> Resolved.Parent.t), name)))
+            Ok (`Constructor ((parent' : Resolved.DataType.t), name)))
     | (`C _ | `CT _ | `P _) as r -> wrong_kind_error [ `S; `T ] r
 
   let of_component _env parent name =
     Ok
       (`Constructor
-        ( (parent : Resolved.DataType.t :> Resolved.Parent.t),
-          ConstructorName.make_std name ))
+        ((parent : Resolved.DataType.t), ConstructorName.make_std name))
 end
 
 module F = struct

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -486,18 +486,21 @@ module F = struct
         find_ambiguous Find.any_in_type_in_sig sg name_s >>= function
         | `In_type (_, _, `FConstructor _) -> got_a_constructor name_s
         | `In_type (typ_name, _, `FField _) ->
-            Ok (`Field ((`Type (parent', typ_name) :> Resolved.Parent.t), name))
-        )
+            Ok
+              (`Field
+                ( (`Type (parent', typ_name) :> Resolved.FragmentTypeParent.t),
+                  name )))
     | `T (parent', t) -> (
         find Find.any_in_type t name_s >>= function
         | `FConstructor _ -> got_a_constructor name_s
-        | `FField _ -> Ok (`Field ((parent' :> Resolved.Parent.t), name)))
+        | `FField _ ->
+            Ok (`Field ((parent' :> Resolved.FragmentTypeParent.t), name)))
     | (`C _ | `CT _ | `P _) as r -> wrong_kind_error [ `S; `T ] r
 
   let of_component _env parent name =
     Ok
       (`Field
-        ( (parent : Resolved.DataType.t :> Resolved.Parent.t),
+        ( (parent : Resolved.DataType.t :> Resolved.FragmentTypeParent.t),
           FieldName.make_std name ))
 end
 
@@ -812,7 +815,8 @@ let resolve_reference =
     | `Dot (parent, name) -> resolve_reference_dot env parent name
     | `Root (name, `TConstructor) -> CS.in_env env name >>= resolved1
     | `Constructor (parent, name) ->
-        resolve_label_parent_reference env (parent : Parent.t :> LabelParent.t)
+        resolve_label_parent_reference env
+          (parent : FragmentTypeParent.t :> LabelParent.t)
         >>= fun p -> CS.in_parent env p name >>= resolved1
     | `Root (name, `TException) -> EX.in_env env name >>= resolved1
     | `Exception (parent, name) ->
@@ -828,7 +832,8 @@ let resolve_reference =
         ED.in_signature env p name >>= resolved1
     | `Root (name, `TField) -> F.in_env env name >>= resolved1
     | `Field (parent, name) ->
-        resolve_label_parent_reference env (parent : Parent.t :> LabelParent.t)
+        resolve_label_parent_reference env
+          (parent : FragmentTypeParent.t :> LabelParent.t)
         >>= fun p -> F.in_parent env p name >>= resolved1
     | `Root (name, `TMethod) -> MM.in_env env name >>= resolved1
     | `Method (parent, name) ->

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -488,19 +488,17 @@ module F = struct
         | `In_type (typ_name, _, `FField _) ->
             Ok
               (`Field
-                ( (`Type (parent', typ_name) :> Resolved.FragmentTypeParent.t),
-                  name )))
+                ((`Type (parent', typ_name) :> Resolved.FieldParent.t), name)))
     | `T (parent', t) -> (
         find Find.any_in_type t name_s >>= function
         | `FConstructor _ -> got_a_constructor name_s
-        | `FField _ ->
-            Ok (`Field ((parent' :> Resolved.FragmentTypeParent.t), name)))
+        | `FField _ -> Ok (`Field ((parent' :> Resolved.FieldParent.t), name)))
     | (`C _ | `CT _ | `P _) as r -> wrong_kind_error [ `S; `T ] r
 
   let of_component _env parent name =
     Ok
       (`Field
-        ( (parent : Resolved.DataType.t :> Resolved.FragmentTypeParent.t),
+        ( (parent : Resolved.DataType.t :> Resolved.FieldParent.t),
           FieldName.make_std name ))
 end
 

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -52,7 +52,7 @@ let c_ty_poss env p =
   match p with
   | `Dot (p, n) -> (
       let rest = List.map (fun p -> `Dot (p, n)) (c_mod_poss env p) in
-      match Env.lookup_by_name Env.s_type n env with
+      match Env.lookup_by_name Env.s_datatype n env with
       | Ok (`Type (id, _)) ->
           `Identifier ((id :> Odoc_model.Paths.Identifier.Path.Type.t), false)
           :: rest
@@ -64,7 +64,7 @@ let c_daty_poss env p =
   match p with
   | `Dot (p, n) -> (
       let rest = List.map (fun p -> `Dot (p, n)) (c_mod_poss env p) in
-      match Env.lookup_by_name Env.s_type n env with
+      match Env.lookup_by_name Env.s_datatype n env with
       | Ok (`Type (id, _)) ->
           `Identifier
             ((id :> Odoc_model.Paths.Identifier.Path.DataType.t), false)
@@ -436,7 +436,7 @@ let simplify_type : Env.t -> Cpath.Resolved.type_ -> Cpath.Resolved.type_ =
   match m with
   | `Type (`Module (`Gpath (`Identifier p)), name) -> (
       let ident = (Mk.type_ ((p :> Signature.t), name) : Path.Type.t) in
-      match Env.(lookup_by_id s_type (ident :> Path.Type.t) env) with
+      match Env.(lookup_by_id s_datatype (ident :> Path.Type.t) env) with
       | Some _ -> `Gpath (`Identifier ident)
       | None -> m)
   | _ -> m
@@ -858,7 +858,8 @@ and lookup_type_gpath :
               next clause. We just look them up here in the list of core types *)
         Ok (`FType (name, List.assoc (TypeName.to_string name) core_types))
     | `Identifier ({ iv = `Type _; _ } as i) ->
-        of_option ~error:(`Lookup_failureT i) (Env.(lookup_by_id s_type) i env)
+        of_option ~error:(`Lookup_failureT i)
+          (Env.(lookup_by_id s_datatype) i env)
         >>= fun (`Type ({ iv = `CoreType name | `Type (_, name); _ }, t)) ->
         Ok (`FType (name, t))
     | `Identifier ({ iv = `Class _; _ } as i) ->
@@ -899,7 +900,8 @@ and lookup_datatype_gpath :
               next clause. We just look them up here in the list of core types *)
         Ok (`FType (name, List.assoc (TypeName.to_string name) core_types))
     | `Identifier ({ iv = `Type _; _ } as i) ->
-        of_option ~error:(`Lookup_failureT i) (Env.(lookup_by_id s_type) i env)
+        of_option ~error:(`Lookup_failureT i)
+          (Env.(lookup_by_id s_datatype) i env)
         >>= fun (`Type ({ iv = `CoreType name | `Type (_, name); _ }, t)) ->
         Ok (`FType (name, t))
     | `CanonicalDataType (t1, _) -> lookup_datatype_gpath env t1

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -1645,79 +1645,79 @@ let%expect_test _ =
       test "{!class-foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_class_type =
       test "{!class-type-foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-type-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-16:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-type-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-16:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_constructor =
       test "{!constructor-Foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"constructor-Foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-17:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"constructor-Foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-17:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_exception =
       test "{!exception-Foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"exception-Foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"exception-Foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_extension =
       test "{!extension-Foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"extension-Foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"extension-Foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_field =
       test "{!field-foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"field-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"field-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_section =
       test "{!section-foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"section-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-13:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"section-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-13:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_instance_variable =
       test "{!instance-variable-foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"instance-variable-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-23:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"instance-variable-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-23:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_method =
       test "{!method-foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"method-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-12:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"method-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-12:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_module =
       test "{!module-Foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"module-Foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-12:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Reference":[{"`Constructor":[{"`Root":["Foo","`TModule"]},"Bar"]},[]]}]}],"warnings":[]} |}]
 
     let constructor_in_module_type =
       test "{!module-type-Foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"module-type-Foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-17:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Reference":[{"`Constructor":[{"`Root":["Foo","`TModuleType"]},"Bar"]},[]]}]}],"warnings":[]} |}]
 
     let constructor_in_page =
       test "{!page-foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_val =
       test "{!val-foo.constructor-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"val-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-9:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"val-foo.constructor-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-9:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_something_nested =
       test "{!foo.bar.constructor-Baz}";
@@ -1735,79 +1735,79 @@ let%expect_test _ =
       test "{!Foo.class-bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.class-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.class-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_class_type_nested =
       test "{!Foo.class-type-bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.class-type-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-20:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.class-type-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-20:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_constructor_nested =
       test "{!Foo.constructor-Bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.constructor-Bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-21:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.constructor-Bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-21:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_exception_nested =
       test "{!Foo.exception-Bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.exception-Bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.exception-Bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_extension_nested =
       test "{!Foo.extension-Bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.extension-Bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.extension-Bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_field_nested =
       test "{!foo.field-bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.field-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.field-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_section_nested =
       test "{!foo.section-bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.section-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-17:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.section-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-17:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_instance_variable_nested =
       test "{!foo.instance-variable-bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.instance-variable-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-27:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.instance-variable-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-27:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_method_nested =
       test "{!foo.method-bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.method-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-16:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.method-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-16:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_module_nested =
       test "{!Foo.module-Bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.module-Bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-16:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Reference":[{"`Constructor":[{"`Module":[{"`Root":["Foo","`TUnknown"]},"Bar"]},"Baz"]},[]]}]}],"warnings":[]} |}]
 
     let constructor_in_module_type_nested =
       test "{!Foo.module-type-Bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.module-type-Bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-21:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Reference":[{"`Constructor":[{"`ModuleType":[{"`Root":["Foo","`TUnknown"]},"Bar"]},"Baz"]},[]]}]}],"warnings":[]} |}]
 
     let constructor_in_page_nested =
       test "{!foo.page-bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let constructor_in_val_nested =
       test "{!Foo.val-bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.val-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-13:\nExpected 'type-' or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.val-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-13:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_empty =
       test "{!.field-foo}";
@@ -1843,67 +1843,67 @@ let%expect_test _ =
       test "{!class-foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Reference":[{"`Field":[{"`Root":["foo","`TClass"]},"bar"]},[]]}]}],"warnings":[]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_class_type =
       test "{!class-type-foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Reference":[{"`Field":[{"`Root":["foo","`TClassType"]},"bar"]},[]]}]}],"warnings":[]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-type-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-16:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_constructor =
       test "{!constructor-Foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"constructor-Foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-17:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"constructor-Foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-17:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_exception =
       test "{!exception-Foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"exception-Foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"exception-Foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_extension =
       test "{!extension-Foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"extension-Foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"extension-Foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_field =
       test "{!field-foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"field-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"field-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_section =
       test "{!section-foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"section-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-13:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"section-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-13:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_instance_variable =
       test "{!instance-variable-foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"instance-variable-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-23:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"instance-variable-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-23:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_method =
       test "{!method-foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"method-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-12:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"method-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-12:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_page =
       test "{!page-foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_val =
       test "{!val-foo.field-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"val-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-9:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"val-foo.field-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-9:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_something_nested =
       test "{!foo.bar.field-baz}";
@@ -1933,67 +1933,67 @@ let%expect_test _ =
       test "{!Foo.class-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Reference":[{"`Field":[{"`Class":[{"`Root":["Foo","`TUnknown"]},"bar"]},"baz"]},[]]}]}],"warnings":[]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.class-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_class_type_nested =
       test "{!Foo.class-type-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Reference":[{"`Field":[{"`ClassType":[{"`Root":["Foo","`TUnknown"]},"bar"]},"baz"]},[]]}]}],"warnings":[]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.class-type-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-20:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_constructor_nested =
       test "{!Foo.constructor-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.constructor-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-21:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.constructor-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-21:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_exception_nested =
       test "{!Foo.exception-Bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.exception-Bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.exception-Bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_extension_nested =
       test "{!Foo.extension-Bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.extension-Bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.extension-Bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_field_nested =
       test "{!Foo.field-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.field-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.field-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_section_nested =
       test "{!foo.section-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.section-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-17:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.section-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-17:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_instance_variable_nested =
       test "{!foo.instance-variable-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.instance-variable-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-27:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.instance-variable-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-27:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_method_nested =
       test "{!foo.method-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.method-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-16:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.method-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-16:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_page_nested =
       test "{!foo.page-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let field_in_val_nested =
       test "{!Foo.val-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.val-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-13:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.val-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-13:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let exception_in_something =
       test "{!Foo.exception-Bar}";
@@ -2371,13 +2371,13 @@ let%expect_test _ =
       test "{!class-foo.bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Reference":[{"`Field":[{"`Dot":[{"`Root":["foo","`TClass"]},"bar"]},"baz"]},[]]}]}],"warnings":[]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let inner_parent_something_in_page =
       test "{!page-foo.bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let inner_parent_module_in_module =
       test "{!module-Foo.module-Bar.field-baz}";
@@ -2419,25 +2419,25 @@ let%expect_test _ =
       test "{!module-Foo.class-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Reference":[{"`Field":[{"`Class":[{"`Root":["Foo","`TModule"]},"bar"]},"baz"]},[]]}]}],"warnings":[]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"module-Foo.class-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 13-22:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let inner_parent_class_in_class =
       test "{!class-foo.class-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 12-21:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let inner_parent_class_type_in_module =
       test "{!module-Foo.class-type-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Reference":[{"`Field":[{"`ClassType":[{"`Root":["Foo","`TModule"]},"bar"]},"baz"]},[]]}]}],"warnings":[]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"module-Foo.class-type-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 13-27:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let inner_parent_class_type_in_class =
       test "{!class-foo.class-type-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-type-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-type-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 12-26:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let inner_label_parent_something_in_something =
       test "{!foo.bar.baz}";
@@ -2527,7 +2527,7 @@ let%expect_test _ =
       test "{!page-foo.bar.method-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.bar.method-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.bar.method-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let inner_class_signature_class_in_module =
       test "{!module-Foo.class-bar.method-baz}";
@@ -2563,7 +2563,7 @@ let%expect_test _ =
       test "{!page-foo.bar.type-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.bar.type-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.bar.type-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let inner_signature_module_in_module =
       test "{!module-Foo.module-Bar.type-baz}";
@@ -2599,7 +2599,7 @@ let%expect_test _ =
       test "{!page-foo.bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', 'type-', or an unqualified reference."]} |}]
 
     let inner_datatype_type_in_module =
       test "{!module-Foo.type-bar.constructor-Baz}";

--- a/test/xref2/github_issue_447.t/a.mli
+++ b/test/xref2/github_issue_447.t/a.mli
@@ -1,6 +1,6 @@
-type u = Bar
+type u = Foo
 
-(** {!constructor-Bar} {!u.constructor-Bar} *)
+(** {!constructor-Foo} {!u.constructor-Foo} *)
 
 module M : sig
   type t = Foo

--- a/test/xref2/github_issue_447.t/a.mli
+++ b/test/xref2/github_issue_447.t/a.mli
@@ -1,0 +1,15 @@
+type u = Bar
+
+(** {!constructor-Bar} {!u.constructor-Bar} *)
+
+module M : sig
+  type t = Foo
+end
+
+(** {!M.constructor-Foo} and {!M.Foo}
+
+    {!M.t.constructor-Foo} and {!M.t.Foo} *)
+
+class t : object end
+
+(** {!t.constructor-A} *)

--- a/test/xref2/github_issue_447.t/a.mli
+++ b/test/xref2/github_issue_447.t/a.mli
@@ -1,6 +1,6 @@
 type u = Foo
 
-(** {!constructor-Foo} {!u.constructor-Foo} *)
+(** {!constructor-Foo} {!u.constructor-Foo} {!Foo} *)
 
 module M : sig
   type t = Foo

--- a/test/xref2/github_issue_447.t/run.t
+++ b/test/xref2/github_issue_447.t/run.t
@@ -10,7 +10,7 @@ faulty reference.
 
   $ odoc link a.odoc
   File "a.mli", line 15, characters 4-22:
-  Warning: Failed to resolve reference unresolvedroot(t).A is of kind class but expected signature or type
+  Warning: Failed to resolve reference unresolvedroot(t).A Couldn't find "t"
 
 Let's now check that the reference point to the right page/anchor:
 

--- a/test/xref2/github_issue_447.t/run.t
+++ b/test/xref2/github_issue_447.t/run.t
@@ -1,0 +1,15 @@
+This test tests the ability to reference constructors, omitting the type they
+are coming from.
+
+  $ ocamlc -c -bin-annot a.mli
+  $ odoc compile --warn-error -I . a.cmti
+
+Currently, it is only possible to omit the parent type of the constructor in the
+toplevel: only [{!M.constructor-Foo}] does not resolve, as it cannot find a type
+named [M].
+
+  $ odoc link a.odoc
+  File "a.mli", line 15, characters 4-22:
+  Warning: Failed to resolve reference unresolvedroot(t).A Couldn't find "t"
+  File "a.mli", line 9, characters 4-24:
+  Warning: Failed to resolve reference unresolvedroot(M).Foo Couldn't find "M"

--- a/test/xref2/github_issue_447.t/run.t
+++ b/test/xref2/github_issue_447.t/run.t
@@ -4,12 +4,22 @@ are coming from.
   $ ocamlc -c -bin-annot a.mli
   $ odoc compile --warn-error -I . a.cmti
 
-Currently, it is only possible to omit the parent type of the constructor in the
-toplevel: only [{!M.constructor-Foo}] does not resolve, as it cannot find a type
-named [M].
+It is possible to omit type parent in constructor reference, and use directly
+the parent module. All references in [a.mli] resolve without warning, except the
+faulty reference.
 
   $ odoc link a.odoc
   File "a.mli", line 15, characters 4-22:
-  Warning: Failed to resolve reference unresolvedroot(t).A Couldn't find "t"
-  File "a.mli", line 9, characters 4-24:
-  Warning: Failed to resolve reference unresolvedroot(M).Foo Couldn't find "M"
+  Warning: Failed to resolve reference unresolvedroot(t).A is of kind class but expected signature or type
+
+Let's now check that the reference point to the right page/anchor:
+
+  $ odoc html-generate --output-dir html --indent a.odocl
+
+  $ cat html/A/index.html | grep \# | grep Foo | grep -v anchor
+     <p><a href="#type-u.Foo"><code>Foo</code></a> 
+      <a href="#type-u.Foo"><code>u.Foo</code></a>
+     <p><a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a> and 
+      <a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a>
+     <p><a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a> and 
+      <a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a>

--- a/test/xref2/github_issue_447.t/run.t
+++ b/test/xref2/github_issue_447.t/run.t
@@ -18,7 +18,8 @@ Let's now check that the reference point to the right page/anchor:
 
   $ cat html/A/index.html | grep \# | grep Foo | grep -v anchor
      <p><a href="#type-u.Foo"><code>Foo</code></a> 
-      <a href="#type-u.Foo"><code>u.Foo</code></a>
+      <a href="#type-u.Foo"><code>u.Foo</code></a> 
+      <a href="#type-u.Foo"><code>Foo</code></a>
      <p><a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a> and 
       <a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a>
      <p><a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a> and 

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -448,8 +448,24 @@ Explicit, in sig:
           M);
       ihash = 716453475; ikey = "m_M.r_Root.p_None"},
    E2)
-# resolve_ref "constructor:M.C2" (* Not allowed by types *) ;;
-Exception: Failure "resolve_reference: Couldn't find \"M\"".
+# resolve_ref "constructor:M.C2" ;;
+- : ref =
+`Constructor
+  (`Type
+     (`Identifier
+        {Odoc_model__Paths_types.iv =
+          `Module
+            ({Odoc_model__Paths_types.iv =
+               `Root
+                 (Some
+                   {Odoc_model__Paths_types.iv = `Page (None, None);
+                    ihash = 236059787; ikey = "p_None"},
+                  Root);
+              ihash = 818126955; ikey = "r_Root.p_None"},
+             M);
+         ihash = 716453475; ikey = "m_M.r_Root.p_None"},
+      t2),
+   C2)
 # resolve_ref "val:M.e2" ;;
 - : ref =
 `Value
@@ -515,7 +531,7 @@ Exception: Failure "resolve_reference: Couldn't find \"M\"".
       ihash = 716453475; ikey = "m_M.r_Root.p_None"},
    x2)
 # resolve_ref "constructor:M.X2" (* X2 is an extension constructor *) ;;
-Exception: Failure "resolve_reference: Couldn't find \"M\"".
+Exception: Failure "resolve_reference: Couldn't find \"X2\"".
 # resolve_ref "extension:M.X2" ;;
 - : ref =
 `Extension
@@ -2634,7 +2650,7 @@ Exception: Failure "resolve_reference: Couldn't find field \"C\"".
 Exception: Failure "resolve_reference: is of kind type but expected class".
 # (* Lookup a constructor but find a field *)
   resolve_ref "M.constructor-f" ;;
-Exception: Failure "resolve_reference: Couldn't find \"M\"".
+Exception: Failure "resolve_reference: Couldn't find constructor \"f\"".
 # resolve_ref "M.u.constructor-f" ;;
 Exception: Failure "resolve_reference: Couldn't find constructor \"f\"".
 ```
@@ -2666,8 +2682,9 @@ Failure
 # resolve_ref "M.t.method-m" ;;
 Exception:
 Failure "resolve_reference: is of kind type but expected class or class type".
-# resolve_ref "c.constructor-C" (* Type in env but find class (parent of constructor is "datatype") *) ;;
-Exception: Failure "resolve_reference: Couldn't find \"c\"".
+# resolve_ref "c.constructor-C" (* Type in env but find class (parent of constructor is "parent") *) ;;
+Exception:
+Failure "resolve_reference: is of kind class but expected signature or type".
 # resolve_ref "c.field-f" (* Field in class (parent of field is "label_parent") *) ;;
 Exception:
 Failure "resolve_reference: is of kind class but expected signature or type".
@@ -2922,7 +2939,23 @@ Unambiguous:
       ihash = 895481052; ikey = "m_X.r_Root.p_None"},
    u)
 # resolve_ref "X.constructor-Y" ;;
-Exception: Failure "resolve_reference: Couldn't find \"X\"".
+- : ref =
+`Constructor
+  (`Type
+     (`Identifier
+        {Odoc_model__Paths_types.iv =
+          `Module
+            ({Odoc_model__Paths_types.iv =
+               `Root
+                 (Some
+                   {Odoc_model__Paths_types.iv = `Page (None, None);
+                    ihash = 236059787; ikey = "p_None"},
+                  Root);
+              ihash = 818126955; ikey = "r_Root.p_None"},
+             X);
+         ihash = 895481052; ikey = "m_X.r_Root.p_None"},
+      u),
+   Y)
 # resolve_ref "X.module-Y" ;;
 - : ref =
 `Module
@@ -3037,7 +3070,23 @@ Unambiguous 2:
       ihash = 895481052; ikey = "m_X.r_Root.p_None"},
    u)
 # resolve_ref "constructor:X.Y" ;;
-Exception: Failure "resolve_reference: Couldn't find \"X\"".
+- : ref =
+`Constructor
+  (`Type
+     (`Identifier
+        {Odoc_model__Paths_types.iv =
+          `Module
+            ({Odoc_model__Paths_types.iv =
+               `Root
+                 (Some
+                   {Odoc_model__Paths_types.iv = `Page (None, None);
+                    ihash = 236059787; ikey = "p_None"},
+                  Root);
+              ihash = 818126955; ikey = "r_Root.p_None"},
+             X);
+         ihash = 895481052; ikey = "m_X.r_Root.p_None"},
+      u),
+   Y)
 # resolve_ref "module:X.Y" ;;
 - : ref =
 `Module

--- a/test/xref2/refs/refs.md
+++ b/test/xref2/refs/refs.md
@@ -2683,11 +2683,9 @@ Failure
 Exception:
 Failure "resolve_reference: is of kind type but expected class or class type".
 # resolve_ref "c.constructor-C" (* Type in env but find class (parent of constructor is "parent") *) ;;
-Exception:
-Failure "resolve_reference: is of kind class but expected signature or type".
+Exception: Failure "resolve_reference: Couldn't find \"c\"".
 # resolve_ref "c.field-f" (* Field in class (parent of field is "label_parent") *) ;;
-Exception:
-Failure "resolve_reference: is of kind class but expected signature or type".
+Exception: Failure "resolve_reference: Couldn't find \"c\"".
 ```
 
 ## Ambiguous references


### PR DESCRIPTION
Fix #447.

Currently, it is not possible to refer to constructors without specifying the parent type, except if they are in scope.

This PR fixes this by extending parents of constructor references to signatures.

The first commit adds the test. The second fixes the issue similarly to what it is done with `field` (which already allows omitting the type parent). The last two commits are refactoring that improve the guarantee given by the subtyping.

(Made with @EmileTrotignon)