### PR TITLE
Treat *.ml{i} in Linguist as OCaml, mark *.t as undetectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ml linguist-language=OCaml
+*.mli linguist-language=OCaml

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.ml linguist-language=OCaml
 *.mli linguist-language=OCaml
+*.t -linguist-detectable


### PR DESCRIPTION
The Linguist stats on the bottom-right of the main page are incorrectly recognizing some files as SML; this fixes them to be OCaml instead.