### PR TITLE
Fix hidden flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ UNRELEASED
 Additions
 - Source code rendering (@Julow, @panglesd, #909)
 
+Bugfixes
+- Fix `--hidden` not always taken into account (@panglesd, #940)
+
 2.2.0
 -----
 

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -107,7 +107,7 @@ let resolve_imports resolver imports =
     imports
 
 (** Raises warnings and errors. *)
-let resolve_and_substitute ~resolver ~make_root ~source
+let resolve_and_substitute ~resolver ~make_root ~source ~hidden
     (parent : Paths.Identifier.ContainerPage.t option) input_file input_type =
   let filename = Fs.File.to_string input_file in
   (* [impl_shape] is used to lookup locations in the implementation. It is
@@ -135,6 +135,7 @@ let resolve_and_substitute ~resolver ~make_root ~source
         in
         (unit, None)
   in
+  let unit = { unit with hidden = hidden || unit.hidden } in
   let impl_shape =
     match cmt_infos with Some (shape, _) -> Some shape | None -> None
   in
@@ -330,8 +331,8 @@ let compile ~resolver ~parent_cli_spec ~hidden ~children ~output
     let make_root = root_of_compilation_unit ~parent_spec ~hidden ~output in
     let result =
       Error.catch_errors_and_warnings (fun () ->
-          resolve_and_substitute ~resolver ~make_root ~source parent input
-            input_type)
+          resolve_and_substitute ~resolver ~make_root ~hidden ~source parent
+            input input_type)
     in
     (* Extract warnings to write them into the output file *)
     let _, warnings = Error.unpack_warnings result in

--- a/test/sources/single_mli.t/run.t
+++ b/test/sources/single_mli.t/run.t
@@ -15,13 +15,6 @@ Similar to Astring library.
   $ odoc link -I . a_x.odoc
   $ odoc link -I . a.odoc
 
-TODO: It seems that --hidden do not work:
-  $ odoc_print a_x.odoc | grep hidden
-    "hidden": "false",
-                "hidden": "false"
-  $ odoc_print a_x.odocl | grep hidden
-    "hidden": "false",
-
   $ odoc html-generate --source a_x.ml --indent -o html a_x.odocl
   $ odoc html-generate --source a.ml --indent -o html a.odocl
 
@@ -35,18 +28,14 @@ Look if all the source files are generated:
   html/A/X/Y/index.html
   html/A/X/index.html
   html/A/index.html
-  html/A_x
-  html/A_x/index.html
   html/root
   html/root/source
   html/root/source/a.ml.html
   html/root/source/a_x.ml.html
 
-Documentation for `A_x` is not generated for hidden modules, but --hidden do not
-work right now:
+Documentation for `A_x` is not generated for hidden modules:
 
   $ ! [ -f html/A_x/index.html ]
-  [1]
 
 Code source for `A_x` is wanted:
 


### PR DESCRIPTION
Previously, the `--hidden` flag was used to set only the `Root.Odoc_file.compilation_unit` `hidden` field value.

Now, we also use it to set the `Lang.compilation_unit` `hidden` field value, so that they are in sync.

This allows to use the `--hidden` flag to not generate documentation, for instance when compiling a module solely to render its source (which happens for instance in the `single_mli` test, or in real life, `Astring` mli).