### PR TITLE
Fix #342

### DIFF
--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -332,7 +332,7 @@ let block_element : Comment.block_element -> Block.t = function
   | `Heading (_, _, text) ->
       (* We are not supposed to receive Heading in this context.
          TODO: Remove heading in attached documentation in the model *)
-      [ block @@ Paragraph (non_link_inline_element_list text) ]
+      [ block @@ Paragraph (inline_element_list text) ]
 
 let heading_level_to_int = function
   | `Title -> 0
@@ -345,7 +345,7 @@ let heading_level_to_int = function
 let heading
     (attrs, { Odoc_model.Paths.Identifier.iv = `Label (_, label); _ }, text) =
   let label = Odoc_model.Names.LabelName.to_string label in
-  let title = non_link_inline_element_list text in
+  let title = inline_element_list text in
   let level = heading_level_to_int attrs.Comment.heading_level in
   let label = Some label in
   let source_anchor = None in

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -477,7 +477,7 @@ and Label : sig
   type t = {
     attrs : Odoc_model.Comment.heading_attrs;
     label : Ident.label;
-    text : Odoc_model.Comment.link_content;
+    text : Odoc_model.Comment.paragraph;
     location : Odoc_model.Location_.span;
   }
 end =

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -446,7 +446,7 @@ and Label : sig
   type t = {
     attrs : Odoc_model.Comment.heading_attrs;
     label : Ident.label;
-    text : Odoc_model.Comment.link_content;
+    text : Odoc_model.Comment.paragraph;
     location : Odoc_model.Location_.span;
   }
 end

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -1823,13 +1823,11 @@ let%expect_test _ =
               "`Heading": [
                 { "heading_level": "`Subsection", "heading_label_explicit": "false" },
                 { "`Label": [ { "`Page": [ "None", "f.ml" ] }, "" ] },
-                [ { "`Styled": [ "`Emphasis", [] ] } ]
+                [ { "`Link": [ "foo", [] ] } ]
               ]
             }
           ],
-          "warnings": [
-            "File \"f.ml\", line 1, characters 3-11:\n'{{:...} ...}' (external link) is not allowed in '{2 ...}' (section heading)."
-          ]
+          "warnings": []
         } |}]
 
     let reference_in_markup =
@@ -1842,13 +1840,11 @@ let%expect_test _ =
               "`Heading": [
                 { "heading_level": "`Subsection", "heading_label_explicit": "false" },
                 { "`Label": [ { "`Page": [ "None", "f.ml" ] }, "" ] },
-                [ { "`Styled": [ "`Emphasis", [] ] } ]
+                [ { "`Reference": [ { "`Root": [ "foo", "`TUnknown" ] }, [] ] } ]
               ]
             }
           ],
-          "warnings": [
-            "File \"f.ml\", line 1, characters 3-9:\n'{!...}' (cross-reference) is not allowed in '{2 ...}' (section heading)."
-          ]
+          "warnings": []
         } |}]
 
     let two =

--- a/test/xref2/github_issue_342.t/foo.mli
+++ b/test/xref2/github_issue_342.t/foo.mli
@@ -1,0 +1,8 @@
+module A : sig end
+
+(**  {1 References {!A} and {{!A}with text} in title}
+
+{1 An url {:http://ocaml.org} and {{:http://ocaml.org}with text} in a title}
+
+*)
+

--- a/test/xref2/github_issue_342.t/run.t
+++ b/test/xref2/github_issue_342.t/run.t
@@ -1,0 +1,36 @@
+A quick test to repro the issue found in #342
+
+  $ ocamlc -bin-annot -c foo.mli
+
+  $ odoc compile foo.cmti
+  $ odoc link foo.odoc
+
+  $ odoc html-generate --indent -o html/ foo.odocl
+
+The table of content:
+
+  $ cat html/Foo/index.html | grep "odoc-toc" -A 9
+    <nav class="odoc-toc">
+     <ul>
+      <li>
+       <a href="#references--and-with-text-in-title">References <code>A</code>
+         and with text in title
+       </a>
+      </li>
+      <li>
+       <a href="#an-url--and-with-text-in-a-title">An url http://ocaml.org
+         and with text in a title
+
+The rendered headings
+
+  $ cat html/Foo/index.html | grep "<h2" -A 3
+     <h2 id="references--and-with-text-in-title">
+      <a href="#references--and-with-text-in-title" class="anchor"></a>
+      References <a href="A/index.html"><code>A</code></a> and 
+      <a href="A/index.html" title="A">with text</a> in title
+  --
+     <h2 id="an-url--and-with-text-in-a-title">
+      <a href="#an-url--and-with-text-in-a-title" class="anchor"></a>An
+       url <a href="http://ocaml.org">http://ocaml.org</a> and 
+      <a href="http://ocaml.org">with text</a> in a title
+


### PR DESCRIPTION
Fixes issue #342 : links and references are now allowed in headings.

They are displayed as regular text inside the table of content, as the headings here are already links, and nesting links is a bad idea.