### PR TITLE
Fix rendering of references to label

### DIFF
--- a/test/xref2/github_issue_941.t/foo.mli
+++ b/test/xref2/github_issue_941.t/foo.mli
@@ -1,0 +1,5 @@
+(** {2:splice_me Splice me}
+
+    This is correct {!splice_me}.
+
+    This is incorrect {!Foo.splice_me}. *)

--- a/test/xref2/github_issue_941.t/foo.mli
+++ b/test/xref2/github_issue_941.t/foo.mli
@@ -1,5 +1,6 @@
 (** {2:splice_me Splice me}
 
-    This is correct {!splice_me}.
-
-    This is incorrect {!Foo.splice_me}. *)
+    Should output only the heading's text:
+    {!splice_me}
+    {!Foo.splice_me}
+    {!page.splice_me} *)

--- a/test/xref2/github_issue_941.t/page.mld
+++ b/test/xref2/github_issue_941.t/page.mld
@@ -1,0 +1,3 @@
+{0 Page}
+
+{1:splice_me Splice me}

--- a/test/xref2/github_issue_941.t/run.t
+++ b/test/xref2/github_issue_941.t/run.t
@@ -1,0 +1,16 @@
+A quick test to repro the issue found in #941
+
+  $ ocamlc -bin-annot -c foo.mli
+
+  $ odoc compile foo.cmti
+  $ odoc link foo.odoc
+
+  $ odoc html-generate --indent -o html/ foo.odocl
+
+The rendered html
+
+  $ cat html/Foo/index.html | grep "<h3" -A 3
+     <h3 id="splice_me"><a href="#splice_me" class="anchor"></a>Splice me</h3>
+     <p>This is correct <a href="#splice_me">Splice me</a>.</p>
+     <p>This is incorrect <a href="#splice_me"><code>splice_me</code></a>.</p>
+    </div>

--- a/test/xref2/github_issue_941.t/run.t
+++ b/test/xref2/github_issue_941.t/run.t
@@ -3,14 +3,24 @@ A quick test to repro the issue found in #941
   $ ocamlc -bin-annot -c foo.mli
 
   $ odoc compile foo.cmti
-  $ odoc link foo.odoc
+  $ odoc compile page.mld
+  $ odoc link -I . foo.odoc
+  $ odoc link -I . page-page.odoc
 
   $ odoc html-generate --indent -o html/ foo.odocl
+  $ odoc html-generate --indent -o html/ page-page.odocl
 
 The rendered html
 
-  $ cat html/Foo/index.html | grep "<h3" -A 3
+  $ cat html/Foo/index.html | grep "splice_me" -A 3
+    <nav class="odoc-toc"><ul><li><a href="#splice_me">Splice me</a></li></ul>
+    </nav>
+    <div class="odoc-content">
      <h3 id="splice_me"><a href="#splice_me" class="anchor"></a>Splice me</h3>
-     <p>This is correct <a href="#splice_me">Splice me</a>.</p>
-     <p>This is incorrect <a href="#splice_me"><code>splice_me</code></a>.</p>
+     <p>Should output only the heading's text: 
+      <a href="#splice_me" title="splice_me">Splice me</a> 
+      <a href="#splice_me"><code>splice_me</code></a> 
+      <a href="../page.html#splice_me"><code>splice_me</code></a>
+     </p>
     </div>
+   </body>


### PR DESCRIPTION
First draft to fix #941

Apparently the reference is parsed and built correctly so I only patched the rendering.

This is the first time I'm touching this part of the code so I'm not sure if this is the right fix, let me know what you think.