### PR TITLE
Add a tooltip to references with text

### DIFF
--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -57,6 +57,34 @@ module Reference = struct
         render_resolved (r :> t) ^ "." ^ InstanceVariableName.to_string s
     | `Label (_, s) -> LabelName.to_string s
 
+  let rec render_unresolved : Reference.t -> string =
+    let open Reference in
+    function
+    | `Resolved r -> render_resolved r
+    | `Root (n, _) -> n
+    | `Dot (p, f) -> render_unresolved (p :> t) ^ "." ^ f
+    | `Module (p, f) ->
+        render_unresolved (p :> t) ^ "." ^ ModuleName.to_string f
+    | `ModuleType (p, f) ->
+        render_unresolved (p :> t) ^ "." ^ ModuleTypeName.to_string f
+    | `Type (p, f) -> render_unresolved (p :> t) ^ "." ^ TypeName.to_string f
+    | `Constructor (p, f) ->
+        render_unresolved (p :> t) ^ "." ^ ConstructorName.to_string f
+    | `Field (p, f) -> render_unresolved (p :> t) ^ "." ^ FieldName.to_string f
+    | `Extension (p, f) ->
+        render_unresolved (p :> t) ^ "." ^ ExtensionName.to_string f
+    | `Exception (p, f) ->
+        render_unresolved (p :> t) ^ "." ^ ExceptionName.to_string f
+    | `Value (p, f) -> render_unresolved (p :> t) ^ "." ^ ValueName.to_string f
+    | `Class (p, f) -> render_unresolved (p :> t) ^ "." ^ ClassName.to_string f
+    | `ClassType (p, f) ->
+        render_unresolved (p :> t) ^ "." ^ ClassTypeName.to_string f
+    | `Method (p, f) ->
+        render_unresolved (p :> t) ^ "." ^ MethodName.to_string f
+    | `InstanceVariable (p, f) ->
+        render_unresolved (p :> t) ^ "." ^ InstanceVariableName.to_string f
+    | `Label (p, f) -> render_unresolved (p :> t) ^ "." ^ LabelName.to_string f
+
   (* This is the entry point. stop_before is false on entry, true on recursive
      call. *)
   let rec to_ir : ?text:Inline.t -> stop_before:bool -> Reference.t -> Inline.t
@@ -70,7 +98,9 @@ module Reference = struct
             let s = source_of_code s in
             [ inline @@ Inline.Source s ]
         | Some content ->
-            let link = { InternalLink.target = Unresolved; content } in
+            let link =
+              { InternalLink.target = Unresolved; content; tooltip = Some s }
+            in
             [ inline @@ Inline.InternalLink link ])
     | `Dot (parent, s) -> unresolved ?text (parent :> t) s
     | `Module (parent, s) ->
@@ -101,16 +131,20 @@ module Reference = struct
     | `Resolved r -> (
         (* IDENTIFIER MUST BE RENAMED TO DEFINITION. *)
         let id = Reference.Resolved.identifier r in
+        let rendered = render_resolved r in
         let content =
           match text with
-          | None ->
-              [ inline @@ Inline.Source (source_of_code (render_resolved r)) ]
+          | None -> [ inline @@ Inline.Source (source_of_code rendered) ]
           | Some s -> s
+        and tooltip =
+          (* Add a tooltip if the content is not the rendered reference. *)
+          match text with None -> None | Some _ -> Some rendered
         in
         match Url.from_identifier ~stop_before id with
         | Ok url ->
             let target = InternalLink.Resolved url in
-            [ inline @@ Inline.InternalLink { InternalLink.target; content } ]
+            let link = { InternalLink.target; content; tooltip } in
+            [ inline @@ Inline.InternalLink link ]
         | Error (Not_linkable _) -> content
         | Error exn ->
             (* FIXME: better error message *)
@@ -121,7 +155,8 @@ module Reference = struct
    fun ?text parent field ->
     match text with
     | Some content ->
-        let link = { InternalLink.target = Unresolved; content } in
+        let tooltip = Some (render_unresolved parent ^ "." ^ field) in
+        let link = { InternalLink.target = Unresolved; content; tooltip } in
         [ inline @@ InternalLink link ]
     | None ->
         let tail = [ inline @@ Text ("." ^ field) ] in

--- a/src/document/doctree.ml
+++ b/src/document/doctree.ml
@@ -377,15 +377,11 @@ end = struct
       match x.desc with
       | Styled (_, x) -> inline x
       | Link (_, x) -> inline x
-      | InternalLink x -> internallink x
+      | InternalLink x -> inline x.content
       | Math _ -> true
       | Text _ | Entity _ | Linebreak | Source _ | Raw_markup _ -> false
     in
     List.exists inline_ x
-
-  and internallink : InternalLink.t -> bool = function
-    | Resolved (_, x) -> inline x
-    | Unresolved x -> inline x
 
   and description : Description.t -> bool =
    fun x ->

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -32,15 +32,15 @@ let type_var tv = tag "type-var" (O.txt tv)
 
 let enclose ~l ~r x = O.span (O.txt l ++ x ++ O.txt r)
 
-let path p txt =
-  O.elt
-    [ inline @@ InternalLink (InternalLink.Resolved (Url.from_path p, txt)) ]
+let resolved p content =
+  let link = { InternalLink.target = Resolved p; content } in
+  O.elt [ inline @@ InternalLink link ]
 
-let resolved p txt =
-  O.elt [ inline @@ InternalLink (InternalLink.Resolved (p, txt)) ]
+let path p content = resolved (Url.from_path p) content
 
-let unresolved txt =
-  O.elt [ inline @@ InternalLink (InternalLink.Unresolved txt) ]
+let unresolved content =
+  let link = { InternalLink.target = Unresolved; content } in
+  O.elt [ inline @@ InternalLink link ]
 
 let path_to_id path =
   match Url.Anchor.from_identifier (path :> Paths.Identifier.t) with
@@ -1814,8 +1814,8 @@ module Make (Syntax : SYNTAX) = struct
         in
         let li ?(attr = []) name url =
           let link url desc =
-            Inline.InternalLink
-              InternalLink.(Resolved (url, [ Inline.{ attr = []; desc } ]))
+            let content = [ Inline.{ attr = []; desc } ] in
+            Inline.InternalLink { InternalLink.target = Resolved url; content }
           in
           [ block ~attr @@ Block.Inline (inline @@ link url (Text name)) ]
         in

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -33,13 +33,13 @@ let type_var tv = tag "type-var" (O.txt tv)
 let enclose ~l ~r x = O.span (O.txt l ++ x ++ O.txt r)
 
 let resolved p content =
-  let link = { InternalLink.target = Resolved p; content } in
+  let link = { InternalLink.target = Resolved p; content; tooltip = None } in
   O.elt [ inline @@ InternalLink link ]
 
 let path p content = resolved (Url.from_path p) content
 
 let unresolved content =
-  let link = { InternalLink.target = Unresolved; content } in
+  let link = { InternalLink.target = Unresolved; content; tooltip = None } in
   O.elt [ inline @@ InternalLink link ]
 
 let path_to_id path =
@@ -1814,8 +1814,9 @@ module Make (Syntax : SYNTAX) = struct
         in
         let li ?(attr = []) name url =
           let link url desc =
-            let content = [ Inline.{ attr = []; desc } ] in
-            Inline.InternalLink { InternalLink.target = Resolved url; content }
+            let content = [ Inline.{ attr = []; desc } ] and tooltip = None in
+            Inline.InternalLink
+              { InternalLink.target = Resolved url; content; tooltip }
           in
           [ block ~attr @@ Block.Inline (inline @@ link url (Text name)) ]
         in

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -6,11 +6,9 @@ end =
   Class
 
 and InternalLink : sig
-  type resolved = Url.t * Inline.t
+  type target = Resolved of Url.t | Unresolved
 
-  type unresolved = Inline.t
-
-  type t = Resolved of resolved | Unresolved of Inline.t
+  type t = { target : target; content : Inline.t }
 end =
   InternalLink
 

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -8,7 +8,7 @@ end =
 and InternalLink : sig
   type target = Resolved of Url.t | Unresolved
 
-  type t = { target : target; content : Inline.t }
+  type t = { target : target; content : Inline.t; tooltip : string option }
 end =
   InternalLink
 

--- a/src/document/utils.ml
+++ b/src/document/utils.ml
@@ -33,10 +33,7 @@ and compute_length_inline (t : Types.Inline.t) : int =
     | Text s -> acc + String.length s
     | Entity _e -> acc + 1
     | Linebreak -> 0 (* TODO *)
-    | Styled (_, t)
-    | Link (_, t)
-    | InternalLink (Resolved (_, t))
-    | InternalLink (Unresolved t) ->
+    | Styled (_, t) | Link (_, t) | InternalLink { content = t; _ } ->
         acc + compute_length_inline t
     | Source s -> acc + compute_length_source s
     | Math _ -> assert false

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -92,21 +92,22 @@ and styled style ~emph_level =
   | `Superscript -> (emph_level, Html.sup ~a:[])
   | `Subscript -> (emph_level, Html.sub ~a:[])
 
-let rec internallink ~config ~emph_level ~resolve ?(a = []) (t : InternalLink.t)
-    =
+let rec internallink ~config ~emph_level ~resolve ?(a = [])
+    { InternalLink.target; content; tooltip } =
+  let a = match tooltip with Some s -> Html.a_title s :: a | None -> a in
   let elt =
-    match t.target with
+    match target with
     | Resolved uri ->
         let href = Link.href ~config ~resolve uri in
         let a = (a :> Html_types.a_attrib Html.attrib list) in
-        Html.a ~a:(Html.a_href href :: a) (inline_nolink ~emph_level t.content)
+        Html.a ~a:(Html.a_href href :: a) (inline_nolink ~emph_level content)
     | Unresolved ->
         (* let title =
          *   Html.a_title (Printf.sprintf "unresolved reference to %S"
          *       (ref_to_string ref)
          * in *)
         let a = Html.a_class [ "xref-unresolved" ] :: a in
-        Html.span ~a (inline ~config ~emph_level ~resolve t.content)
+        Html.span ~a (inline ~config ~emph_level ~resolve content)
   in
   [ (elt :> phrasing Html.elt) ]
 

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -94,24 +94,21 @@ and styled style ~emph_level =
 
 let rec internallink ~config ~emph_level ~resolve ?(a = []) (t : InternalLink.t)
     =
-  match t with
-  | Resolved (uri, content) ->
-      let href = Link.href ~config ~resolve uri in
-      let a = (a :> Html_types.a_attrib Html.attrib list) in
-      let elt =
-        Html.a ~a:(Html.a_href href :: a) (inline_nolink ~emph_level content)
-      in
-      let elt = (elt :> phrasing Html.elt) in
-      [ elt ]
-  | Unresolved content ->
-      (* let title =
-       *   Html.a_title (Printf.sprintf "unresolved reference to %S"
-       *       (ref_to_string ref)
-       * in *)
-      let a = Html.a_class [ "xref-unresolved" ] :: a in
-      let elt = Html.span ~a (inline ~config ~emph_level ~resolve content) in
-      let elt = (elt :> phrasing Html.elt) in
-      [ elt ]
+  let elt =
+    match t.target with
+    | Resolved uri ->
+        let href = Link.href ~config ~resolve uri in
+        let a = (a :> Html_types.a_attrib Html.attrib list) in
+        Html.a ~a:(Html.a_href href :: a) (inline_nolink ~emph_level t.content)
+    | Unresolved ->
+        (* let title =
+         *   Html.a_title (Printf.sprintf "unresolved reference to %S"
+         *       (ref_to_string ref)
+         * in *)
+        let a = Html.a_class [ "xref-unresolved" ] :: a in
+        Html.span ~a (inline ~config ~emph_level ~resolve t.content)
+  in
+  [ (elt :> phrasing Html.elt) ]
 
 and inline ~config ?(emph_level = 0) ~resolve (l : Inline.t) :
     phrasing Html.elt list =

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -231,17 +231,14 @@ let source k (t : Source.t) =
   tokens t
 
 let rec internalref ~verbatim ~in_source (t : InternalLink.t) =
-  match t with
-  | Resolved (uri, content) ->
-      let target = Link.label uri in
-      let text = Some (inline ~verbatim ~in_source content) in
-      let short = in_source in
-      Internal_ref { short; text; target }
-  | Unresolved content ->
-      let target = "xref-unresolved" in
-      let text = Some (inline ~verbatim ~in_source content) in
-      let short = in_source in
-      Internal_ref { short; target; text }
+  let target =
+    match t.target with
+    | InternalLink.Resolved uri -> Link.label uri
+    | Unresolved -> "xref-unresolved"
+  in
+  let text = Some (inline ~verbatim ~in_source t.content) in
+  let short = in_source in
+  Internal_ref { short; target; text }
 
 and inline ~in_source ~verbatim (l : Inline.t) =
   let one (t : Inline.one) =

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -238,9 +238,7 @@ let strip l =
               { h with desc = Styled (sty, List.rev @@ loop [] content) }
             in
             loop (h :: acc) t
-        | Link (_, content)
-        | InternalLink (Resolved (_, content))
-        | InternalLink (Unresolved content) ->
+        | Link (_, content) | InternalLink { content; _ } ->
             let acc = loop acc content in
             loop acc t
         | Source code ->
@@ -298,7 +296,7 @@ and inline (l : Inline.t) =
       | Styled (sty, content) -> style sty (inline content) ++ inline rest
       | Link (href, content) ->
           env "UR" "UE" href (inline @@ strip content) ++ inline rest
-      | InternalLink (Resolved (_, content) | Unresolved content) ->
+      | InternalLink { content; _ } ->
           font "CI" (inline @@ strip content) ++ inline rest
       | Source content -> source_code content ++ inline rest
       | Math s -> math s ++ inline rest

--- a/test/generators/html/Labels.html
+++ b/test/generators/html/Labels.html
@@ -178,20 +178,20 @@
      </ol><code><span>}</span></code>
     </div>
    </div><p>Testing that labels can be referenced</p>
-   <ul><li><a href="#L1">Attached to unit</a></li>
-    <li><a href="#L2">Attached to nothing</a></li>
-    <li><a href="#L3">Attached to module</a></li>
-    <li><a href="#L4">Attached to type</a></li>
-    <li><a href="#L5">Attached to value</a></li>
-    <li><a href="#L6">Attached to module type</a></li>
-    <li><a href="#L7">Attached to class</a></li>
-    <li><a href="#L8">Attached to class type</a></li>
-    <li><a href="#L9">Attached to exception</a></li>
-    <li><a href="#L10">Attached to extension</a></li>
-    <li><a href="#L11">Attached to module subst</a></li>
-    <li><a href="#L12">Attached to type subst</a></li>
-    <li><a href="#L13">Attached to constructor</a></li>
-    <li><a href="#L14">Attached to field</a></li>
+   <ul><li><a href="#L1" title="L1">Attached to unit</a></li>
+    <li><a href="#L2" title="L2">Attached to nothing</a></li>
+    <li><a href="#L3" title="L3">Attached to module</a></li>
+    <li><a href="#L4" title="L4">Attached to type</a></li>
+    <li><a href="#L5" title="L5">Attached to value</a></li>
+    <li><a href="#L6" title="L6">Attached to module type</a></li>
+    <li><a href="#L7" title="L7">Attached to class</a></li>
+    <li><a href="#L8" title="L8">Attached to class type</a></li>
+    <li><a href="#L9" title="L9">Attached to exception</a></li>
+    <li><a href="#L10" title="L10">Attached to extension</a></li>
+    <li><a href="#L11" title="L11">Attached to module subst</a></li>
+    <li><a href="#L12" title="L12">Attached to type subst</a></li>
+    <li><a href="#L13" title="L13">Attached to constructor</a></li>
+    <li><a href="#L14" title="L14">Attached to field</a></li>
    </ul>
   </div>
  </body>

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -76,9 +76,10 @@
    <p>but odoc has banned deeper headings. There are also title headings,
      but they are only allowed in mld files.
    </p><h4 id="anchors"><a href="#anchors" class="anchor"></a>Anchors</h4>
-   <p>Sections can have attached <a href="#anchors">Anchors</a>, and 
-    it is possible to <a href="#anchors">link</a> to them. Links to section
-     headers should not be set in source code style.
+   <p>Sections can have attached 
+    <a href="#anchors" title="anchors">Anchors</a>, and it is possible
+     to <a href="#anchors" title="anchors">link</a> to them. Links to
+     section headers should not be set in source code style.
    </p>
    <h5 id="paragraph"><a href="#paragraph" class="anchor"></a>Paragraph</h5>
    <p>Individual paragraphs can have a heading.</p>
@@ -137,17 +138,19 @@
    </p>
    <p>This is a reference to <a href="#val-foo"><code>foo</code></a>.
      References can have replacement text: 
-    <a href="#val-foo">the value foo</a>. Except for the special lookup
-     support, references are pretty much just like links. The replacement
-     text can have nested styles: <a href="#val-foo"><b>bold</b></a>,
-     <a href="#val-foo"><i>italic</i></a>, 
-    <a href="#val-foo"><em>emphasis</em></a>, 
-    <a href="#val-foo">super<sup>script</sup></a>, 
-    <a href="#val-foo">sub<sub>script</sub></a>, and 
-    <a href="#val-foo"><code>code</code></a>. It's also possible to surround
-     a reference in a style: <b><a href="#val-foo"><code>foo</code></a></b>
-    . References can't be nested inside references, and links and references
-     can't be nested inside each other.
+    <a href="#val-foo" title="foo">the value foo</a>. Except for the 
+    special lookup support, references are pretty much just like links.
+     The replacement text can have nested styles: 
+    <a href="#val-foo" title="foo"><b>bold</b></a>, 
+    <a href="#val-foo" title="foo"><i>italic</i></a>, 
+    <a href="#val-foo" title="foo"><em>emphasis</em></a>, 
+    <a href="#val-foo" title="foo">super<sup>script</sup></a>, 
+    <a href="#val-foo" title="foo">sub<sub>script</sub></a>, and 
+    <a href="#val-foo" title="foo"><code>code</code></a>. It's also possible
+     to surround a reference in a style: 
+    <b><a href="#val-foo"><code>foo</code></a></b>. References can't 
+    be nested inside references, and links and references can't be nested
+     inside each other.
    </p>
    <h2 id="preformatted-text">
     <a href="#preformatted-text" class="anchor"></a>Preformatted text

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -266,8 +266,9 @@
     </a> or 
     <a href="Ocamlary-module-type-SuperSig-module-type-EmptySig.html">
      <code>SuperSig.EmptySig</code>
-    </a>. Section <a href="#s9000">Section 9000</a> is also interesting.
-     <a href="#emptySig">EmptySig</a> is the section and 
+    </a>. Section <a href="#s9000" title="s9000">Section 9000</a> is 
+    also interesting. <a href="#emptySig" title="emptySig">EmptySig</a>
+     is the section and 
     <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
      is the module signature.
    </p>
@@ -2764,9 +2765,13 @@
    </h2><p>I can refer to</p>
    <ul>
     <li><code>{!section:indexmodules}</code> : 
-     <a href="#indexmodules">Trying the {!modules: ...} command.</a>
+     <a href="#indexmodules" title="indexmodules">Trying the {!modules:
+       ...} command.
+     </a>
     </li>
-    <li><code>{!aliases}</code> : <a href="#aliases">Aliases again</a></li>
+    <li><code>{!aliases}</code> : 
+     <a href="#aliases" title="aliases">Aliases again</a>
+    </li>
    </ul><p>But also to things in submodules:</p>
    <ul>
     <li><code>{!section:SuperSig.SubSigA.subSig}</code> : 
@@ -2780,15 +2785,17 @@
    </ul><p>And just to make sure we do not mess up:</p>
    <ul>
     <li><code>{{!section:indexmodules}A}</code> : 
-     <a href="#indexmodules">A</a>
-    </li><li><code>{{!aliases}B}</code> : <a href="#aliases">B</a></li>
+     <a href="#indexmodules" title="indexmodules">A</a>
+    </li>
+    <li><code>{{!aliases}B}</code> : <a href="#aliases" title="aliases">B</a>
+    </li>
     <li><code>{{!section:SuperSig.SubSigA.subSig}C}</code> : 
-     <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig">
-      C
+     <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig"
+      title="subSig">C
      </a>
     </li>
     <li><code>{{!Aliases.incl}D}</code> : 
-     <a href="Ocamlary-Aliases.html#incl">D</a>
+     <a href="Ocamlary-Aliases.html#incl" title="incl">D</a>
     </li>
    </ul>
    <h2 id="new-reference-syntax">

--- a/test/generators/html/Toplevel_comments-Comments_on_open.html
+++ b/test/generators/html/Toplevel_comments-Comments_on_open.html
@@ -32,7 +32,7 @@
     </div>
    </div><h3 id="sec"><a href="#sec" class="anchor"></a>Section</h3>
    <p>Comments attached to open are treated as floating comments. Referencing
-     <a href="#sec">Section</a> 
+     <a href="#sec" title="sec">Section</a> 
     <a href="Toplevel_comments-Comments_on_open-M.html#type-t">
      <code>M.t</code>
     </a> works

--- a/test/xref2/labels/labels.t/run.t
+++ b/test/xref2/labels/labels.t/run.t
@@ -63,7 +63,7 @@ There are two references in N, one should point to a local label and the other t
     </nav>
     <div class="odoc-content">
      <h2 id="B"><a href="#B" class="anchor"></a>An other conflicting label</h2>
-     <p><a href="#B">An other conflicting label</a> 
+     <p><a href="#B" title="B">An other conflicting label</a> 
       <a href="../M/index.html#B"><code>B</code></a>
      </p>
     </div>
@@ -125,7 +125,8 @@ The second occurence of 'B' in the main page should be disambiguated
      </div><h2 id="B_2"><a href="#B_2" class="anchor"></a>Dupplicate B</h2>
      <p>Define <code>B</code> again in the same scope.</p>
      <p>References to the labels:</p>
-     <p><a href="#A">First label</a> <a href="#B">Dupplicate B</a> 
+     <p><a href="#A" title="A">First label</a> 
+      <a href="#B" title="B">Dupplicate B</a> 
       <a href="M/index.html#C"><code>C</code></a> 
       <a href="M/index.html#D"><code>D</code></a> 
       <a href="M/index.html#B"><code>B</code></a> 


### PR DESCRIPTION
Fix https://github.com/ocaml/odoc/issues/613

The tooltip shows what would be rendered instead if no text was written. This is currently the original reference.
This is most useful for references that do not resolve, because the original reference is not visible at all.

The tooltip is generally easier to read than the target URL shown by the browser on hover and might benefit from smarter rendering of references in the future (eg. https://github.com/ocaml/odoc/issues/372)
