### PR TITLE
Warn against tags in pages

### DIFF
--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -113,7 +113,7 @@ let pad_loc loc =
 
 let ast_to_comment ~internal_tags parent ast_docs alerts =
   Odoc_model.Semantics.ast_to_comment ~internal_tags ~sections_allowed:`All
-    ~parent_of_sections:parent ast_docs alerts
+    ~tags_allowed:true ~parent_of_sections:parent ast_docs alerts
   |> Error.raise_warnings
 
 let mk_alert_payload ~loc name p =
@@ -145,21 +145,22 @@ let attached_no_tag parent attrs =
   let x, () = attached Semantics.Expect_none parent attrs in
   x
 
-let read_string internal_tags parent location str =
+let read_string ~tags_allowed internal_tags parent location str =
   Odoc_model.Semantics.parse_comment
     ~internal_tags
     ~sections_allowed:`All
+    ~tags_allowed
     ~containing_definition:parent
     ~location
     ~text:str
   |> Odoc_model.Error.raise_warnings
 
 let read_string_comment internal_tags parent loc str =
-  read_string internal_tags parent (pad_loc loc) str
+  read_string ~tags_allowed:true internal_tags parent (pad_loc loc) str
 
 let page parent loc str =
   let doc, () =
-    read_string Odoc_model.Semantics.Expect_none parent loc.Location.loc_start
+    read_string ~tags_allowed:false Odoc_model.Semantics.Expect_none parent loc.Location.loc_start
       str
   in
   `Docs doc

--- a/src/model/semantics.mli
+++ b/src/model/semantics.mli
@@ -14,6 +14,7 @@ type alerts =
 val ast_to_comment :
   internal_tags:'tags handle_internal_tags ->
   sections_allowed:sections_allowed ->
+  tags_allowed:bool ->
   parent_of_sections:Paths.Identifier.LabelParent.t ->
   Odoc_parser.Ast.t ->
   alerts ->
@@ -22,6 +23,7 @@ val ast_to_comment :
 val parse_comment :
   internal_tags:'tags handle_internal_tags ->
   sections_allowed:sections_allowed ->
+  tags_allowed:bool ->
   containing_definition:Paths.Identifier.LabelParent.t ->
   location:Lexing.position ->
   text:string ->

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -15,7 +15,7 @@ let parser_output_desc =
           F ("warnings", snd, List warning_desc);
         ] )
 
-let test ?(sections_allowed = `No_titles)
+let test ?(sections_allowed = `No_titles) ?(tags_allowed = true)
     ?(location = { Location_.line = 1; column = 0 }) str =
   let dummy_filename = "f.ml" in
   let dummy_page =
@@ -31,7 +31,8 @@ let test ?(sections_allowed = `No_titles)
   in
   let parser_output =
     Semantics.parse_comment ~internal_tags:Odoc_model.Semantics.Expect_none
-      ~sections_allowed ~containing_definition:dummy_page ~location ~text:str
+      ~sections_allowed ~tags_allowed ~containing_definition:dummy_page
+      ~location ~text:str
   in
   let print_json_desc desc t =
     let yojson = Type_desc_to_yojson.to_yojson desc t in
@@ -2479,6 +2480,17 @@ let%expect_test _ =
           "value": [ { "`Paragraph": [ { "`Word": "@authorfoo" } ] } ],
           "warnings": [
             "File \"f.ml\", line 1, characters 0-10:\nUnknown tag '@authorfoo'."
+          ]
+        } |}]
+
+    let not_allowed =
+      test ~tags_allowed:false "@author Foo bar";
+      [%expect
+        {|
+        {
+          "value": [ { "`Tag": { "`Author": "Foo bar" } } ],
+          "warnings": [
+            "File \"f.ml\", line 1, characters 0-15:\nTags are not allowed in pages."
           ]
         } |}]
   end in


### PR DESCRIPTION
Related issue: https://github.com/ocaml/odoc/issues/814

Most tags don't make sense in a page (deprecated, param, raise, ...) and the syntax prevents tags from being added in the middle of a page.

This adds a warning but do not disallow tags. It is important to not remove any text from pages and turning tags into paragraphs would not add anything interesting.