### PR TITLE
Fix references to extension declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,11 @@ Tags:
 
 ### Added
 - Display 'private' keyword for private type extensions (@gpetiot, #1019)
+
+### Fixed
+
 - Fix rendering of polymorphic variants (@wikku, @panglesd, #971)
+- Add references to extension declarations (@gpetiot, @panglesd, #949)
 
 # 2.3.0
 

--- a/doc/ocamldoc_differences.mld
+++ b/doc/ocamldoc_differences.mld
@@ -51,6 +51,7 @@ Additionally we support extra annotations:
 - [class-type] is a replacement for [classtype]
 - [exn] is recognised as [exception]
 - [extension] refers to a type extension
+- [extension-decl] refers to the declaration point of an extension constructor
 - [field] is a replacement for [recfield]
 - [instance-variable] refers to instance variables
 - [label] refers to labels introduced in anchors

--- a/doc/odoc_for_authors.mld
+++ b/doc/odoc_for_authors.mld
@@ -388,6 +388,7 @@ The prefixes supported are:
 - [method]
 - [constructor] (and the equivalent deprecated prefix [const])
 - [extension]
+- [extension-decl] for refering to the declaration point of an extension constructor
 - [field] (and the equivalent deprecated prefix [recfield])
 - [instance-variable]
 - [section] (and the equivalent deprecated prefix [label]) - for referring to headings

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -43,6 +43,8 @@ module Reference = struct
     | `Field (r, s) -> render_resolved (r :> t) ^ "." ^ FieldName.to_string s
     | `Extension (r, s) ->
         render_resolved (r :> t) ^ "." ^ ExtensionName.to_string s
+    | `ExtensionDecl (r, _, s) ->
+        render_resolved (r :> t) ^ "." ^ ExtensionName.to_string s
     | `Exception (r, s) ->
         render_resolved (r :> t) ^ "." ^ ExceptionName.to_string s
     | `Value (r, s) -> render_resolved (r :> t) ^ "." ^ ValueName.to_string s
@@ -72,6 +74,8 @@ module Reference = struct
         render_unresolved (p :> t) ^ "." ^ ConstructorName.to_string f
     | `Field (p, f) -> render_unresolved (p :> t) ^ "." ^ FieldName.to_string f
     | `Extension (p, f) ->
+        render_unresolved (p :> t) ^ "." ^ ExtensionName.to_string f
+    | `ExtensionDecl (p, f) ->
         render_unresolved (p :> t) ^ "." ^ ExtensionName.to_string f
     | `Exception (p, f) ->
         render_unresolved (p :> t) ^ "." ^ ExceptionName.to_string f

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -312,6 +312,17 @@ module Anchor = struct
                 (ExtensionName.to_string name);
             kind;
           }
+    | { iv = `ExtensionDecl (parent, name, _); _ } ->
+        let page = Path.from_identifier (parent :> Path.any) in
+        let kind = `ExtensionDecl in
+        Ok
+          {
+            page;
+            anchor =
+              Format.asprintf "%a-%s" pp_kind kind
+                (ExtensionName.to_string name);
+            kind;
+          }
     | { iv = `Exception (parent, name); _ } ->
         let page = Path.from_identifier (parent :> Path.any) in
         let kind = `Exception in

--- a/src/loader/implementation.ml
+++ b/src/loader/implementation.ml
@@ -451,6 +451,9 @@ let anchor_of_identifier id =
     | `Extension (parent, name) ->
         let anchor = anchor `Extension (ExtensionName.to_string name) in
         continue anchor parent
+    | `ExtensionDecl (parent, name, _) ->
+        let anchor = anchor `ExtensionDecl (ExtensionName.to_string name) in
+        continue anchor parent
   in
   anchor_of_identifier [] id |> String.concat "."
 

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -43,6 +43,7 @@ module Identifier = struct
     | `Constructor (_, name) -> ConstructorName.to_string name
     | `Field (_, name) -> FieldName.to_string name
     | `Extension (_, name) -> ExtensionName.to_string name
+    | `ExtensionDecl (_, _, name) -> ExtensionName.to_string name
     | `Exception (_, name) -> ExceptionName.to_string name
     | `CoreException name -> ExceptionName.to_string name
     | `Value (_, name) -> ValueName.to_string name
@@ -80,6 +81,7 @@ module Identifier = struct
       | { iv = `ClassType (p, _); _ }
       | { iv = `Type (p, _); _ }
       | { iv = `Extension (p, _); _ }
+      | { iv = `ExtensionDecl (p, _, _); _ }
       | { iv = `Exception (p, _); _ }
       | { iv = `Value (p, _); _ } ->
           (p : signature :> label_parent)
@@ -216,6 +218,18 @@ module Identifier = struct
   module Extension = struct
     type t = Id.extension
     type t_pv = Id.extension_pv
+  end
+
+  module ExtensionDecl = struct
+    type t = Paths_types.Identifier.extension_decl
+
+    type t_pv = Paths_types.Identifier.extension_decl_pv
+
+    let equal = equal
+
+    let hash = hash
+
+    let compare = compare
   end
 
   module Exception = struct
@@ -470,6 +484,16 @@ module Identifier = struct
         Signature.t * ExtensionName.t ->
         [> `Extension of Signature.t * ExtensionName.t ] id =
       mk_parent ExtensionName.to_string "extn" (fun (p, n) -> `Extension (p, n))
+
+    let extension_decl :
+        Signature.t * (ExtensionName.t * ExtensionName.t) ->
+        [> `ExtensionDecl of Signature.t * ExtensionName.t * ExtensionName.t ]
+        id =
+      mk_parent
+        (fun (n, m) ->
+          ExtensionName.to_string n ^ "." ^ ExtensionName.to_string m)
+        "extn-decl"
+        (fun (p, (n, m)) -> `ExtensionDecl (p, n, m))
 
     let exception_ :
         Signature.t * ExceptionName.t ->
@@ -850,6 +874,8 @@ module Reference = struct
           Identifier.Mk.constructor (parent_type_identifier s, n)
       | `Extension (p, q) ->
           Identifier.Mk.extension (parent_signature_identifier p, q)
+      | `ExtensionDecl (p, q, r) ->
+          Identifier.Mk.extension_decl (parent_signature_identifier p, (q, r))
       | `Exception (p, q) ->
           Identifier.Mk.exception_ (parent_signature_identifier p, q)
       | `Value (p, q) -> Identifier.Mk.value (parent_signature_identifier p, q)
@@ -902,6 +928,10 @@ module Reference = struct
 
     module Extension = struct
       type t = Paths_types.Resolved_reference.extension
+    end
+
+    module ExtensionDecl = struct
+      type t = Paths_types.Resolved_reference.extension_decl
     end
 
     module Exception = struct
@@ -983,6 +1013,10 @@ module Reference = struct
 
   module Extension = struct
     type t = Paths_types.Reference.extension
+  end
+
+  module ExtensionDecl = struct
+    type t = Paths_types.Reference.extension_decl
   end
 
   module Exception = struct

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -104,6 +104,18 @@ module Identifier : sig
     type t_pv = Id.extension_pv
   end
 
+  module ExtensionDecl : sig
+    type t = Paths_types.Identifier.extension_decl
+
+    type t_pv = Paths_types.Identifier.extension_decl_pv
+
+    val equal : t -> t -> bool
+
+    val hash : t -> int
+
+    val compare : t -> t -> int
+  end
+
   module Exception : sig
     type t = Id.exception_
     type t_pv = Id.exception_pv
@@ -273,6 +285,14 @@ module Identifier : sig
     val extension :
       Signature.t * ExtensionName.t ->
       [> `Extension of Signature.t * ExtensionName.t ] id
+
+    val extension_decl :
+      Signature.t * (ExtensionName.t * ExtensionName.t) ->
+      [> `ExtensionDecl of Signature.t * ExtensionName.t * ExtensionName.t ] id
+    (** [extension_decl (sg, e1, eN)] defines an extension declaration where [sg] is the parent,
+        [e1] is the first constructor of the extension, and [eN] is the constructor the Id is created for.
+        [e1] will be used for the url, and [eN] will be the one displayed.
+        The first constructor of the extension will always be used to reference the extension point. *)
 
     val exception_ :
       Signature.t * ExceptionName.t ->
@@ -475,6 +495,10 @@ module rec Reference : sig
       type t = Paths_types.Resolved_reference.extension
     end
 
+    module ExtensionDecl : sig
+      type t = Paths_types.Resolved_reference.extension_decl
+    end
+
     module Exception : sig
       type t = Paths_types.Resolved_reference.exception_
     end
@@ -554,6 +578,10 @@ module rec Reference : sig
 
   module Extension : sig
     type t = Paths_types.Reference.extension
+  end
+
+  module ExtensionDecl : sig
+    type t = Paths_types.Reference.extension_decl
   end
 
   module Exception : sig

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -147,8 +147,15 @@ module Identifier = struct
   type extension_pv = [ `Extension of signature * ExtensionName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Extension.t_pv *)
 
+  type extension_decl_pv =
+    [ `ExtensionDecl of signature * ExtensionName.t * ExtensionName.t ]
+  (** @canonical Odoc_model.Paths.Identifier.ExtensionDecl.t_pv *)
+
   and extension = extension_pv id
   (** @canonical Odoc_model.Paths.Identifier.Extension.t *)
+
+  and extension_decl = extension_decl_pv id
+  (** @canonical Odoc_model.Paths.Identifier.ExtensionDecl.t *)
 
   type exception_pv =
     [ `Exception of signature * ExceptionName.t
@@ -209,6 +216,7 @@ module Identifier = struct
     | constructor_pv
     | field_pv
     | extension_pv
+    | extension_decl_pv
     | exception_pv
     | value_pv
     | class_pv
@@ -274,6 +282,8 @@ module Identifier = struct
   type reference_field = field
 
   type reference_extension = [ extension_pv | exception_pv ] id
+
+  type reference_extension_decl = extension_decl
 
   type reference_exception = exception_
 
@@ -508,6 +518,7 @@ module rec Reference : sig
     | `TConstructor
     | `TField
     | `TExtension
+    | `TExtensionDecl
     | `TException
     | `TValue
     | `TClass
@@ -632,6 +643,13 @@ module rec Reference : sig
     | `Exception of signature * ExceptionName.t ]
   (** @canonical Odoc_model.Paths.Reference.Extension.t *)
 
+  type extension_decl =
+    [ `Resolved of Resolved_reference.extension_decl
+    | `Root of string * [ `TExtension | `TException | `TUnknown ]
+    | `Dot of label_parent * string
+    | `ExtensionDecl of signature * ExtensionName.t ]
+  (** @canonical Odoc_model.Paths.Reference.ExtensionDecl.t *)
+
   type exception_ =
     [ `Resolved of Resolved_reference.exception_
     | `Root of string * [ `TException | `TUnknown ]
@@ -698,6 +716,7 @@ module rec Reference : sig
     | `Constructor of datatype * ConstructorName.t
     | `Field of parent * FieldName.t
     | `Extension of signature * ExtensionName.t
+    | `ExtensionDecl of signature * ExtensionName.t
     | `Exception of signature * ExceptionName.t
     | `Value of signature * ValueName.t
     | `Class of signature * ClassName.t
@@ -801,6 +820,16 @@ and Resolved_reference : sig
     | `Exception of signature * ExceptionName.t ]
   (** @canonical Odoc_model.Paths.Reference.Resolved.Extension.t *)
 
+  type extension_decl =
+    [ `Identifier of Identifier.reference_extension_decl
+    | `ExtensionDecl of
+      signature
+      * ExtensionName.t
+        (* The extension_name used in the url.
+           It is the extension_name of the first constructor of the extension (there is always at least 1). *)
+      * ExtensionName.t (* displayed *) ]
+  (** @canonical Odoc_model.Paths.Reference.Resolved.Extension.t *)
+
   type exception_ =
     [ `Identifier of Identifier.reference_exception
     | `Exception of signature * ExceptionName.t ]
@@ -851,6 +880,7 @@ and Resolved_reference : sig
     | `Constructor of datatype * ConstructorName.t
     | `Field of parent * FieldName.t
     | `Extension of signature * ExtensionName.t
+    | `ExtensionDecl of signature * ExtensionName.t * ExtensionName.t
     | `Exception of signature * ExceptionName.t
     | `Value of signature * ValueName.t
     | `Class of signature * ClassName.t

--- a/src/model/reference.ml
+++ b/src/model/reference.ml
@@ -68,6 +68,7 @@ let match_extra_odoc_reference_kind (_location as loc) s :
       d loc "exn" "exception";
       Some `TException
   | Some "extension" -> Some `TExtension
+  | Some "extension-decl" -> Some `TExtensionDecl
   | Some "field" -> Some `TField
   | Some "instance-variable" -> Some `TInstanceVariable
   | Some "label" ->
@@ -364,6 +365,9 @@ let parse whole_reference_location s :
             `Field (parent next_token tokens, FieldName.make_std identifier)
         | `TExtension ->
             `Extension
+              (signature next_token tokens, ExtensionName.make_std identifier)
+        | `TExtensionDecl ->
+            `ExtensionDecl
               (signature next_token tokens, ExtensionName.make_std identifier)
         | `TException ->
             `Exception

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -130,6 +130,11 @@ module General_paths = struct
               ( "`Extension",
                 ((parent :> id_t), name),
                 Pair (identifier, Names.extensionname) )
+        | `ExtensionDecl (parent, name, name') ->
+            C
+              ( "`ExtensionDecl",
+                ((parent :> id_t), name, name'),
+                Triple (identifier, Names.extensionname, Names.extensionname) )
         | `Exception (parent, name) ->
             C
               ( "`Exception",
@@ -184,6 +189,7 @@ module General_paths = struct
       | `TConstructor -> C0 "`TConstructor"
       | `TException -> C0 "`TException"
       | `TExtension -> C0 "`TExtension"
+      | `TExtensionDecl -> C0 "`TExtensionDecl"
       | `TField -> C0 "`TField"
       | `TInstanceVariable -> C0 "`TInstanceVariable"
       | `TLabel -> C0 "`TLabel"
@@ -294,6 +300,11 @@ module General_paths = struct
             ( "`Extension",
               ((x1 :> r), x2),
               Pair (reference, Names.extensionname) )
+      | `ExtensionDecl (x1, x2) ->
+          C
+            ( "`ExtensionDecl",
+              ((x1 :> r), x2),
+              Pair (reference, Names.extensionname) )
       | `Exception (x1, x2) ->
           C
             ( "`Exception",
@@ -346,6 +357,13 @@ module General_paths = struct
             ( "`Extension",
               ((x1 :> rr), x2),
               Pair (resolved_reference, Names.extensionname) )
+      | `ExtensionDecl (x1, x2, x3) ->
+          C
+            ( "`ExtensionDecl",
+              ((x1 :> rr), x2, x3),
+              Triple
+                (resolved_reference, Names.extensionname, Names.extensionname)
+            )
       | `Field (x1, x2) ->
           C
             ( "`Field",

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -510,7 +510,11 @@ module Element = struct
   type exception_ = [ `Exception of Identifier.Exception.t * Exception.t ]
 
   type extension =
-    [ `Extension of Identifier.Extension.t * Extension.Constructor.t ]
+    [ `Extension of
+      Identifier.Extension.t * Extension.Constructor.t * Extension.t ]
+
+  type extension_decl =
+    [ `ExtensionDecl of Identifier.Extension.t * Extension.Constructor.t ]
 
   type field = [ `Field of Identifier.Field.t * TypeDecl.Field.t ]
 
@@ -529,6 +533,7 @@ module Element = struct
     | constructor
     | exception_
     | extension
+    | extension_decl
     | field
     | page ]
 
@@ -545,7 +550,8 @@ module Element = struct
     | `Constructor (id, _) -> (id :> t)
     | `Exception (id, _) -> (id :> t)
     | `Field (id, _) -> (id :> t)
-    | `Extension (id, _) -> (id :> t)
+    | `Extension (id, _, _) -> (id :> t)
+    | `ExtensionDecl (id, _) -> (id :> t)
     | `Page (id, _) -> (id :> t)
 end
 
@@ -1245,6 +1251,10 @@ module Fmt = struct
         Format.fprintf ppf "%a.%s" model_identifier
           (p :> Odoc_model.Paths.Identifier.t)
           (ExtensionName.to_string name)
+    | `ExtensionDecl (p, _, name) ->
+        Format.fprintf ppf "%a.%s" model_identifier
+          (p :> Odoc_model.Paths.Identifier.t)
+          (ExtensionName.to_string name)
     | `Page (_, name) | `LeafPage (_, name) ->
         Format.fprintf ppf "%s" (PageName.to_string name)
     | `SourcePage (p, name) | `SourceDir (p, name) ->
@@ -1411,6 +1421,10 @@ module Fmt = struct
         Format.fprintf ppf "%a.%s" model_resolved_reference
           (parent :> t)
           (ExtensionName.to_string name)
+    | `ExtensionDecl (parent, name, _) ->
+        Format.fprintf ppf "%a.%s" model_resolved_reference
+          (parent :> t)
+          (ExtensionName.to_string name)
     | `Exception (parent, name) ->
         Format.fprintf ppf "%a.%s" model_resolved_reference
           (parent :> t)
@@ -1478,6 +1492,10 @@ module Fmt = struct
           (parent :> t)
           (FieldName.to_string name)
     | `Extension (parent, name) ->
+        Format.fprintf ppf "%a.%s" model_reference
+          (parent :> t)
+          (ExtensionName.to_string name)
+    | `ExtensionDecl (parent, name) ->
         Format.fprintf ppf "%a.%s" model_reference
           (parent :> t)
           (ExtensionName.to_string name)

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -478,7 +478,11 @@ module Element : sig
   type exception_ = [ `Exception of Identifier.Exception.t * Exception.t ]
 
   type extension =
-    [ `Extension of Identifier.Extension.t * Extension.Constructor.t ]
+    [ `Extension of
+      Identifier.Extension.t * Extension.Constructor.t * Extension.t ]
+
+  type extension_decl =
+    [ `ExtensionDecl of Identifier.Extension.t * Extension.Constructor.t ]
 
   type field = [ `Field of Identifier.Field.t * TypeDecl.Field.t ]
 
@@ -497,6 +501,7 @@ module Element : sig
     | constructor
     | exception_
     | extension
+    | extension_decl
     | field
     | page ]
 

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -531,7 +531,11 @@ let s_any : Component.Element.any scope =
                   :> Component.Element.any amb_err)
             with Not_found -> None)
         | _ -> None)
-    (fun r -> Some r)
+    (function
+      (* Reference to [A] could refer to [extension-A] or [extension-decl-A].
+         The legacy behavior refers to the constructor [extension-A]. *)
+      | #Component.Element.extension_decl -> None
+      | r -> Some r)
 
 let s_module_type : Component.Element.module_type scope =
   make_scope (function

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -351,8 +351,8 @@ let add_exception identifier (e : Component.Exception.t) env =
   |> add_cdocs identifier e.doc
 
 let add_extension_constructor identifier
-    (ec : Component.Extension.Constructor.t) env =
-  add_to_elts Kind_Extension identifier (`Extension (identifier, ec)) env
+    (ec : Component.Extension.Constructor.t) te env =
+  add_to_elts Kind_Extension identifier (`Extension (identifier, ec, te)) env
   |> add_cdocs identifier ec.doc
 
 let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
@@ -722,10 +722,12 @@ let rec open_signature : Lang.Signature.t -> t -> t =
         | Comment c, true -> add_comment c env
         | TypExt te, true ->
             let doc = docs ident_map te.doc in
+            let te' = extension ident_map te in
             List.fold_left
               (fun env tec ->
                 let ty = extension_constructor ident_map tec in
-                add_extension_constructor tec.L.Extension.Constructor.id ty env)
+                add_extension_constructor tec.L.Extension.Constructor.id ty te'
+                  env)
               env te.L.Extension.constructors
             |> add_cdocs te.L.Extension.parent doc
         | Exception e, true ->

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -71,7 +71,11 @@ val add_class_type : Identifier.ClassType.t -> Component.ClassType.t -> t -> t
 val add_exception : Identifier.Exception.t -> Component.Exception.t -> t -> t
 
 val add_extension_constructor :
-  Identifier.Extension.t -> Component.Extension.Constructor.t -> t -> t
+  Identifier.Extension.t ->
+  Component.Extension.Constructor.t ->
+  Component.Extension.t ->
+  t ->
+  t
 
 val add_docs : Comment.docs -> t -> t
 

--- a/src/xref2/shape_tools.ml
+++ b/src/xref2/shape_tools.ml
@@ -40,6 +40,8 @@ let rec shape_of_id env :
     | `Value (parent, name) -> proj parent Kind.Value (ValueName.to_string name)
     | `Extension (parent, name) ->
         proj parent Kind.Extension_constructor (ExtensionName.to_string name)
+    | `ExtensionDecl (parent, name, _) ->
+        proj parent Kind.Extension_constructor (ExtensionName.to_string name)
     | `Exception (parent, name) ->
         proj parent Kind.Extension_constructor (ExceptionName.to_string name)
     | `Class (parent, name) -> proj parent Kind.Class (ClassName.to_string name)

--- a/test/xref2/github_issue_932.t/foo.mli
+++ b/test/xref2/github_issue_932.t/foo.mli
@@ -1,0 +1,12 @@
+(* Consider this extensible type *)
+
+type t = ..
+
+type t +=
+| A
+| B
+
+(** - {!t}
+    - {!extension-decl-A}
+    - {!extension-A}
+    - {!extension-B} *)

--- a/test/xref2/github_issue_932.t/foo.mli
+++ b/test/xref2/github_issue_932.t/foo.mli
@@ -6,7 +6,27 @@ type t +=
 | A
 | B
 
-(** - {!t}
-    - {!extension-decl-A}
-    - {!extension-A}
-    - {!extension-B} *)
+module M : sig
+  type t = ..
+
+  type t +=
+  | A
+  | B
+end
+
+type M.t += C
+
+(** - t : {!t}
+    - extension-decl-A : {!extension-decl-A}
+    - extension-decl-B : {!extension-decl-B}
+    - extension-A : {!extension-A}
+    - extension-B : {!extension-B}
+    - A : {!A}
+
+    - M.t : {!M.t}
+    - M.extension-decl-A : {!M.extension-decl-A}
+    - M.extension-decl-B : {!M.extension-decl-B}
+    - M.extension-A : {!M.extension-A}
+    - M.extension-B : {!M.extension-B}
+    - M.A : {!M.A}
+ *)

--- a/test/xref2/github_issue_932.t/run.t
+++ b/test/xref2/github_issue_932.t/run.t
@@ -1,0 +1,38 @@
+A quick test to repro the issue found in #941
+
+  $ ocamlc -bin-annot -c foo.mli
+
+  $ odoc compile foo.cmti
+  File "foo.mli", line 10, characters 8-24:
+  Warning: Unknown reference qualifier 'extension-decl'.
+  $ odoc link foo.odoc
+
+  $ odoc html-generate --indent -o html/ foo.odocl
+
+The rendered html
+
+  $ cat html/Foo/index.html | grep "extension" -A 3
+      <div class="spec type extension anchored" id="extension-decl-A">
+       <a href="#extension-decl-A" class="anchor"></a>
+       <code>
+        <span><span class="keyword">type</span> <a href="#type-t">t</a> += 
+        </span>
+  --
+        <li id="extension-A" class="def extension anchored">
+         <a href="#extension-A" class="anchor"></a>
+         <code><span>| </span><span><span class="extension">A</span></span>
+         </code>
+        </li>
+        <li id="extension-B" class="def extension anchored">
+         <a href="#extension-B" class="anchor"></a>
+         <code><span>| </span><span><span class="extension">B</span></span>
+         </code>
+        </li>
+       </ol>
+  --
+      <li><code>extension-decl-A</code></li>
+      <li><a href="#extension-A"><code>A</code></a></li>
+      <li><a href="#extension-B"><code>B</code></a></li>
+     </ul>
+    </div>
+   </body>

--- a/test/xref2/github_issue_932.t/run.t
+++ b/test/xref2/github_issue_932.t/run.t
@@ -4,6 +4,10 @@ A quick test to repro the issue found in #941
 
   $ odoc compile foo.cmti
   $ odoc link foo.odoc
+  File "foo.mli", line 24, characters 10-14:
+  Warning: Reference to 'A' is ambiguous. Please specify its kind: extension-A, extension-decl-A.
+  File "foo.mli", line 21, characters 25-44:
+  Warning: Failed to resolve reference unresolvedroot(B) Couldn't find "B"
 
   $ odoc html-generate --indent -o html/ foo.odocl
 

--- a/test/xref2/github_issue_932.t/run.t
+++ b/test/xref2/github_issue_932.t/run.t
@@ -4,10 +4,6 @@ A quick test to repro the issue found in #941
 
   $ odoc compile foo.cmti
   $ odoc link foo.odoc
-  File "foo.mli", line 24, characters 10-14:
-  Warning: Reference to 'A' is ambiguous. Please specify its kind: extension-A, extension-decl-A.
-  File "foo.mli", line 21, characters 25-44:
-  Warning: Failed to resolve reference unresolvedroot(B) Couldn't find "B"
 
   $ odoc html-generate --indent -o html/ foo.odocl
 

--- a/test/xref2/github_issue_932.t/run.t
+++ b/test/xref2/github_issue_932.t/run.t
@@ -3,8 +3,6 @@ A quick test to repro the issue found in #941
   $ ocamlc -bin-annot -c foo.mli
 
   $ odoc compile foo.cmti
-  File "foo.mli", line 10, characters 8-24:
-  Warning: Unknown reference qualifier 'extension-decl'.
   $ odoc link foo.odoc
 
   $ odoc html-generate --indent -o html/ foo.odocl
@@ -18,21 +16,52 @@ The rendered html
         <span><span class="keyword">type</span> <a href="#type-t">t</a> += 
         </span>
   --
-        <li id="extension-A" class="def extension anchored">
+        <li id="extension-A" class="def variant extension anchored">
          <a href="#extension-A" class="anchor"></a>
          <code><span>| </span><span><span class="extension">A</span></span>
          </code>
         </li>
-        <li id="extension-B" class="def extension anchored">
+        <li id="extension-B" class="def variant extension anchored">
          <a href="#extension-B" class="anchor"></a>
          <code><span>| </span><span><span class="extension">B</span></span>
          </code>
         </li>
        </ol>
   --
-      <li><code>extension-decl-A</code></li>
-      <li><a href="#extension-A"><code>A</code></a></li>
-      <li><a href="#extension-B"><code>B</code></a></li>
+      <div class="spec type extension anchored" id="extension-decl-C">
+       <a href="#extension-decl-C" class="anchor"></a>
+       <code>
+        <span><span class="keyword">type</span> 
+         <a href="M/index.html#type-t">M.t</a> += 
+  --
+        <li id="extension-C" class="def variant extension anchored">
+         <a href="#extension-C" class="anchor"></a>
+         <code><span>| </span><span><span class="extension">C</span></span>
+         </code>
+        </li>
+       </ol>
+  --
+      <li>extension-decl-A : <a href="#extension-decl-A"><code>A</code></a>
+      </li>
+      <li>extension-decl-B : <a href="#extension-decl-A"><code>B</code></a>
+      </li><li>extension-A : <a href="#extension-A"><code>A</code></a></li>
+      <li>extension-B : <a href="#extension-B"><code>B</code></a></li>
+      <li>A : <a href="#extension-A"><code>A</code></a></li>
+     </ul>
+     <ul><li>M.t : <a href="M/index.html#type-t"><code>M.t</code></a></li>
+      <li>M.extension-decl-A : 
+       <a href="M/index.html#extension-decl-A"><code>M.A</code></a>
+      </li>
+      <li>M.extension-decl-B : 
+       <a href="M/index.html#extension-decl-A"><code>M.B</code></a>
+      </li>
+      <li>M.extension-A : 
+       <a href="M/index.html#extension-A"><code>M.A</code></a>
+      </li>
+      <li>M.extension-B : 
+       <a href="M/index.html#extension-B"><code>M.B</code></a>
+      </li>
+      <li>M.A : <a href="M/index.html#extension-A"><code>M.A</code></a></li>
      </ul>
     </div>
    </body>


### PR DESCRIPTION
Fix #932

Not working yet, I've written most of the boring code, some tweaking is needed to make it work.
- the `ExtensionDecl` reference is added in Env
- I think the lookup code in Ref_tools is correct
- what is found in the Env is a `Extension` anchor, despite adding an `ExtensionDecl`

I think it's due to using `Extension.t` in the `extension_decl` type in Component:
```
type extension_decl =
  [ `ExtensionDecl of Identifier.Extension.t * Extension.Constructor.t ]
```
but changing everything creates too many changes. On the opposite side, it's probably possible to refactor the types, as maybe the existing `Extension` type might be enough in a lot of places, but I'm not familiar enough with the code to tell.

Ideas are welcome!