### PR TITLE
Fix rendering of unresolved references

### DIFF
--- a/src/ocamlary/ocamlary.mli
+++ b/src/ocamlary/ocamlary.mli
@@ -1070,3 +1070,10 @@ type new_t = ..
 type new_t += C
 
 module type TypeExtPruned = TypeExt with type t := new_t
+
+(** {1 Unresolved references} *)
+
+(** - {!Stdlib.Invalid_argument}
+    - {!Hashtbl.t}
+    - {!Set.S.empty}
+    - {!CollectionModule.InnerModuleA.foo} *)

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -67,6 +67,7 @@
     </li><li><a href="#aliases">Aliases again</a></li>
     <li><a href="#section-title-splicing">Section title splicing</a></li>
     <li><a href="#new-reference-syntax">New reference syntax</a></li>
+    <li><a href="#unresolved-references">Unresolved references</a></li>
    </ul>
   </nav>
   <div class="odoc-content">
@@ -2947,6 +2948,13 @@
      </code>
     </div>
    </div>
+   <h2 id="unresolved-references">
+    <a href="#unresolved-references" class="anchor"></a>Unresolved references
+   </h2>
+   <ul><li><code>Stdlib</code>.Invalid_argument</li>
+    <li><code>Hashtbl</code>.t</li><li><code>Set</code>.S.empty</li>
+    <li><code>CollectionModule</code>.InnerModuleA.foo</li>
+   </ul>
   </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -2951,9 +2951,9 @@
    <h2 id="unresolved-references">
     <a href="#unresolved-references" class="anchor"></a>Unresolved references
    </h2>
-   <ul><li><code>Stdlib</code>.Invalid_argument</li>
-    <li><code>Hashtbl</code>.t</li><li><code>Set</code>.S.empty</li>
-    <li><code>CollectionModule</code>.InnerModuleA.foo</li>
+   <ul><li><code>Stdlib.Invalid_argument</code></li>
+    <li><code>Hashtbl.t</code></li><li><code>Set.S.empty</code></li>
+    <li><code>CollectionModule.InnerModuleA.foo</code></li>
    </ul>
   </div>
  </body>

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -901,10 +901,10 @@ Here goes:
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \subsection{Unresolved references\label{unresolved-references}}%
-\begin{itemize}\item{\ocamlinlinecode{Stdlib}.Invalid\_argument}%
-\item{\ocamlinlinecode{Hashtbl}.t}%
-\item{\ocamlinlinecode{Set}.S.empty}%
-\item{\ocamlinlinecode{CollectionModule}.InnerModuleA.foo}\end{itemize}%
+\begin{itemize}\item{\ocamlinlinecode{Stdlib.\allowbreak{}Invalid\_\allowbreak{}argument}}%
+\item{\ocamlinlinecode{Hashtbl.\allowbreak{}t}}%
+\item{\ocamlinlinecode{Set.\allowbreak{}S.\allowbreak{}empty}}%
+\item{\ocamlinlinecode{CollectionModule.\allowbreak{}InnerModuleA.\allowbreak{}foo}}\end{itemize}%
 
 \input{Ocamlary.ModuleWithSignature.tex}
 \input{Ocamlary.ModuleWithSignatureAlias.tex}

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -900,6 +900,11 @@ Here goes:
 \label{module-Ocamlary-module-type-TypeExtPruned-val-f}\ocamlcodefragment{\ocamltag{keyword}{val} f : \hyperref[module-Ocamlary-type-new_t]{\ocamlinlinecode{new\_\allowbreak{}t}} \ocamltag{arrow}{$\rightarrow$} unit}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\subsection{Unresolved references\label{unresolved-references}}%
+\begin{itemize}\item{\ocamlinlinecode{Stdlib}.Invalid\_argument}%
+\item{\ocamlinlinecode{Hashtbl}.t}%
+\item{\ocamlinlinecode{Set}.S.empty}%
+\item{\ocamlinlinecode{CollectionModule}.InnerModuleA.foo}\end{itemize}%
 
 \input{Ocamlary.ModuleWithSignature.tex}
 \input{Ocamlary.ModuleWithSignatureAlias.tex}

--- a/test/generators/man/Ocamlary.3o
+++ b/test/generators/man/Ocamlary.3o
@@ -1899,3 +1899,18 @@ Here goes:
 \f[CB]val\fR f : new_t \f[CB]\->\fR unit
 .br 
 \f[CB]end\fR
+.sp 
+.in 3
+\fB8 Unresolved references\fR
+.in 
+.sp 
+.fi 
+\(bu Stdlib\.Invalid_argument
+.br 
+\(bu Hashtbl\.t
+.br 
+\(bu Set\.S\.empty
+.br 
+\(bu CollectionModule\.InnerModuleA\.foo
+.nf 
+


### PR DESCRIPTION
Closes https://github.com/ocaml/odoc/issues/816 https://github.com/ocaml/odoc/pull/892

This is an alternative to https://github.com/ocaml/odoc/pull/892, which uses the recent `render_unresolved` function introduced in https://github.com/ocaml/odoc/pull/945.