### PR TITLE
Humanist font fallbacks

### DIFF
--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -260,7 +260,7 @@ header {
 }
 
 nav {
-  font-family: "Fira Sans", Helvetica, Arial, sans-serif;
+  font-family: "Fira Sans", Seravek, "Source Sans Pro", source-sans-pro, sans-serif;
 }
 
 /* Basic markup elements */
@@ -391,7 +391,7 @@ a.anchor {
 a.source_link {
   float: right;
   color: var(--source-color);
-  font-family: "Fira Sans", Helvetica, Arial, sans-serif;
+  font-family: "Fira Sans", Seravek, "Source Sans Pro", source-sans-pro, sans-serif;
   font-size: initial;
 }
 
@@ -400,7 +400,7 @@ a.source_link {
    we restart the sequence there like h2  */
 
 h1, h2, h3, h4, h5, h6, .h7, .h8, .h9, .h10 {
-  font-family: "Fira Sans", Helvetica, Arial, sans-serif;
+  font-family: "Fira Sans", Seravek, "Source Sans Pro", source-sans-pro, sans-serif;
   font-weight: 400;
   padding-top: 0.1em;
   line-height: 1.2;


### PR DESCRIPTION
If Fira Sans is the preferred font, a humanist sans serif, similar humanist sans serifs on OSs should be chosen over a Grotesque like Helvetica and Arial. Seravek is available on macOS/iOS and Source Sans Pro is on Android. Other available options are (subjectively) far enough away from Fira Sans that it would be better to defer to the user agent and user settings than trying to shoehorn in Gill Sans or a common Linux font.