### PR TITLE
Source identifiers

### DIFF
--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -23,20 +23,16 @@ let render_path : Odoc_model.Paths.Path.t -> string =
     | `Subst (_, p) -> render_resolved (p :> t)
     | `SubstT (_, p) -> render_resolved (p :> t)
     | `Alias (dest, `Resolved src) ->
-        if
-          Odoc_model.Paths.Path.Resolved.Module.is_hidden
-            ~weak_canonical_test:false src
-        then render_resolved (dest :> t)
+        if Odoc_model.Paths.Path.Resolved.(is_hidden (src :> t)) then
+          render_resolved (dest :> t)
         else render_resolved (src :> t)
     | `Alias (dest, src) ->
         if Odoc_model.Paths.Path.is_hidden (src :> Path.t) then
           render_resolved (dest :> t)
         else render_path (src :> Path.t)
     | `AliasModuleType (p1, p2) ->
-        if
-          Odoc_model.Paths.Path.Resolved.ModuleType.is_hidden
-            ~weak_canonical_test:false p2
-        then render_resolved (p1 :> t)
+        if Odoc_model.Paths.Path.Resolved.(is_hidden (p2 :> t)) then
+          render_resolved (p1 :> t)
         else render_resolved (p2 :> t)
     | `Hidden p -> render_resolved (p :> t)
     | `Module (p, s) -> render_resolved (p :> t) ^ "." ^ ModuleName.to_string s

--- a/src/document/url.mli
+++ b/src/document/url.mli
@@ -29,21 +29,17 @@ module Path : sig
 
   type t = { kind : kind; parent : t option; name : string }
 
-  type source_pv =
+  type nonsrc_pv =
     [ Identifier.Page.t_pv
     | Identifier.Signature.t_pv
     | Identifier.ClassSignature.t_pv ]
 
+  type source_pv =
+    [ nonsrc_pv | Identifier.SourcePage.t_pv | Identifier.SourceDir.t_pv ]
+
   and source = source_pv Odoc_model.Paths.Identifier.id
 
   val from_identifier : [< source_pv ] Odoc_model.Paths.Identifier.id -> t
-
-  val source_dir_from_identifier : Odoc_model.Paths.Identifier.SourceDir.t -> t
-  (** A path to a source dir. *)
-
-  val source_file_from_identifier :
-    Odoc_model.Paths.Identifier.SourcePage.t -> t
-  (** A path to a source file. *)
 
   val to_list : t -> (kind * string) list
 
@@ -92,9 +88,6 @@ module Anchor : sig
   }
 
   val from_identifier : Identifier.t -> (t, Error.t) result
-
-  val source_file_from_identifier :
-    Odoc_model.Paths.Identifier.SourcePage.t -> anchor:string -> t
 
   val polymorphic_variant :
     type_ident:Identifier.t ->

--- a/src/loader/lookup_def.mli
+++ b/src/loader/lookup_def.mli
@@ -4,8 +4,8 @@ type t
 
 val lookup_def :
   (string -> (Lang.Compilation_unit.t * t) option) ->
-  Identifier.t ->
-  Lang.Locations.t option
+  Identifier.NonSrc.t ->
+  Identifier.SourceLocation.t option
 (** Returns the root module containing the definition of the given identifier
     and the corresponding anchor. *)
 

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -16,16 +16,7 @@
 
 open Paths
 
-module Locations = struct
-  type t = {
-    source_parent : Identifier.SourcePage.t;
-        (** Correspond to where the source code is stored. Might be different
-            from the root component of the identifier inside expansions. *)
-    anchor : string option;
-        (** Location of the definition in the implementation file. *)
-  }
-end
-
+(** {3 Modules} *)
 module Source_info = struct
   type anchor = { anchor : string }
 
@@ -40,8 +31,6 @@ module Source_info = struct
   type t = { id : Identifier.SourcePage.t; infos : infos }
 end
 
-(** {3 Modules} *)
-
 module rec Module : sig
   type decl =
     | Alias of (Path.Module.t * ModuleType.simple_expansion option)
@@ -49,8 +38,8 @@ module rec Module : sig
 
   type t = {
     id : Identifier.Module.t;
-    locs : Locations.t option;
-        (** Locations might not be set when the module is artificially constructed from a functor argument. *)
+    locs : Identifier.SourceLocation.t option;
+        (** Identifier.SourceLocation might not be set when the module is artificially constructed from a functor argument. *)
     doc : Comment.docs;
     type_ : decl;
     canonical : Path.Module.t option;
@@ -127,7 +116,7 @@ and ModuleType : sig
 
   type t = {
     id : Identifier.ModuleType.t;
-    locs : Locations.t option;
+    locs : Identifier.SourceLocation.t option;
         (** Can be [None] for module types created by a type substitution. *)
     doc : Comment.docs;
     canonical : Path.ModuleType.t option;
@@ -268,7 +257,7 @@ and TypeDecl : sig
 
   type t = {
     id : Identifier.Type.t;
-    locs : Locations.t option;
+    locs : Identifier.SourceLocation.t option;
     doc : Comment.docs;
     canonical : Path.Type.t option;
     equation : Equation.t;
@@ -283,7 +272,7 @@ and Extension : sig
   module Constructor : sig
     type t = {
       id : Identifier.Extension.t;
-      locs : Locations.t option;
+      locs : Identifier.SourceLocation.t option;
       doc : Comment.docs;
       args : TypeDecl.Constructor.argument;
       res : TypeExpr.t option;
@@ -305,7 +294,7 @@ end =
 and Exception : sig
   type t = {
     id : Identifier.Exception.t;
-    locs : Locations.t option;
+    locs : Identifier.SourceLocation.t option;
     doc : Comment.docs;
     args : TypeDecl.Constructor.argument;
     res : TypeExpr.t option;
@@ -320,7 +309,7 @@ and Value : sig
 
   type t = {
     id : Identifier.Value.t;
-    locs : Locations.t option;
+    locs : Identifier.SourceLocation.t option;
     value : value;
     doc : Comment.docs;
     type_ : TypeExpr.t;
@@ -337,7 +326,7 @@ and Class : sig
 
   type t = {
     id : Identifier.Class.t;
-    locs : Locations.t option;
+    locs : Identifier.SourceLocation.t option;
     doc : Comment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;
@@ -356,7 +345,7 @@ and ClassType : sig
 
   type t = {
     id : Identifier.ClassType.t;
-    locs : Locations.t option;
+    locs : Identifier.SourceLocation.t option;
     doc : Comment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;

--- a/src/model/names.ml
+++ b/src/model/names.ml
@@ -141,3 +141,4 @@ module MethodName = SimpleName
 module InstanceVariableName = SimpleName
 module LabelName = SimpleName
 module PageName = SimpleName
+module DefName = SimpleName

--- a/src/model/names.mli
+++ b/src/model/names.mli
@@ -95,3 +95,5 @@ module InstanceVariableName : SimpleName
 module LabelName : SimpleName
 
 module PageName : SimpleName
+
+module DefName : SimpleName

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -22,9 +22,11 @@ open Names
 module Identifier = struct
   type 'a id = 'a Paths_types.id = { iv : 'a; ihash : int; ikey : string }
 
-  type t = Paths_types.Identifier.any
+  module Id = Paths_types.Identifier
 
-  type t_pv = Paths_types.Identifier.any_pv
+  type t = Id.any
+
+  type t_pv = Id.any_pv
 
   let rec name_aux : t -> string =
    fun x ->
@@ -52,31 +54,9 @@ module Identifier = struct
 
   let name : [< t_pv ] id -> string = fun n -> name_aux (n :> t)
 
-  let rec root id =
-    match id.iv with
-    | `Root _ as root -> Some { id with iv = root }
-    | `Module (parent, _) -> root (parent :> t)
-    | `Parameter (parent, _) -> root (parent :> t)
-    | `Result x -> root (x :> t)
-    | `ModuleType (parent, _) -> root (parent :> t)
-    | `Type (parent, _) -> root (parent :> t)
-    | `Constructor (parent, _) -> root (parent :> t)
-    | `Field (parent, _) -> root (parent :> t)
-    | `Extension (parent, _) -> root (parent :> t)
-    | `Exception (parent, _) -> root (parent :> t)
-    | `Value (parent, _) -> root (parent :> t)
-    | `Class (parent, _) -> root (parent :> t)
-    | `ClassType (parent, _) -> root (parent :> t)
-    | `Method (parent, _) -> root (parent :> t)
-    | `InstanceVariable (parent, _) -> root (parent :> t)
-    | `Label (parent, _) -> root (parent :> t)
-    | `Page _ | `LeafPage _ | `CoreType _ | `CoreException _ -> None
-
-  let root id = root (id :> t)
-
   let rec label_parent_aux =
-    let open Paths_types.Identifier in
-    fun (n : any) ->
+    let open Id in
+    fun (n : t) ->
       match n with
       | { iv = `Result i; _ } -> label_parent_aux (i :> any)
       | { iv = `CoreType _; _ } | { iv = `CoreException _; _ } -> assert false
@@ -109,313 +89,175 @@ module Identifier = struct
 
   type any = t
 
+  type any_pv = t_pv
+
+  module type IdSig = sig
+    type t
+    type t_pv
+    val equal : t -> t -> bool
+    val hash : t -> int
+    val compare : t -> t -> int
+  end
+
   module Any = struct
     type t = any
-
+    type t_pv = any_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
   end
 
   module Signature = struct
-    type t = Paths_types.Identifier.signature
-
-    type t_pv = Paths_types.Identifier.signature_pv
-
+    type t = Id.signature
+    type t_pv = Id.signature_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
-
-    let rec root = function
-      | { iv = `Root _; _ } as root -> root
-      | {
-          iv =
-            ( `ModuleType (parent, _)
-            | `Module (parent, _)
-            | `Parameter (parent, _) );
-          _;
-        } ->
-          root parent
-      | { iv = `Result x; _ } -> root x
-
-    let root id = root (id :> t)
   end
 
   module ClassSignature = struct
-    type t = Paths_types.Identifier.class_signature
-
-    type t_pv = Paths_types.Identifier.class_signature_pv
-
+    type t = Id.class_signature
+    type t_pv = Id.class_signature_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
   end
 
   module DataType = struct
-    type t = Paths_types.Identifier.datatype
-
-    type t_pv = Paths_types.Identifier.datatype_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.datatype
+    type t_pv = Id.datatype_pv
   end
 
   module Parent = struct
-    type t = Paths_types.Identifier.parent
-
-    type t_pv = Paths_types.Identifier.parent_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.parent
+    type t_pv = Id.parent_pv
   end
 
   module LabelParent = struct
-    type t = Paths_types.Identifier.label_parent
-
-    type t_pv = Paths_types.Identifier.label_parent_pv
-
+    type t = Id.label_parent
+    type t_pv = Id.label_parent_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
   end
 
   module RootModule = struct
-    type t = Paths_types.Identifier.root_module
-
-    type t_pv = Paths_types.Identifier.root_module_pv
-
+    type t = Id.root_module
+    type t_pv = Id.root_module_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
-
-    let name { iv = `Root (_, name); _ } = ModuleName.to_string name
   end
 
   module Module = struct
-    type t = Paths_types.Identifier.module_
-
-    type t_pv = Paths_types.Identifier.module_pv
-
+    type t = Id.module_
+    type t_pv = Id.module_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
-
-    let root id = Signature.root (id :> Signature.t)
   end
 
   module FunctorParameter = struct
-    type t = Paths_types.Identifier.functor_parameter
-
-    type t_pv = Paths_types.Identifier.functor_parameter_pv
-
+    type t = Id.functor_parameter
+    type t_pv = Id.functor_parameter_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
   end
 
   module FunctorResult = struct
-    type t = Paths_types.Identifier.functor_result
-
-    type t_pv = Paths_types.Identifier.functor_result_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.functor_result
+    type t_pv = Id.functor_result_pv
   end
 
   module ModuleType = struct
-    type t = Paths_types.Identifier.module_type
-
-    type t_pv = Paths_types.Identifier.module_type_pv
-
+    type t = Id.module_type
+    type t_pv = Id.module_type_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
   end
 
   module Type = struct
-    type t = Paths_types.Identifier.type_
-
-    type t_pv = Paths_types.Identifier.type_pv
-
+    type t = Id.type_
+    type t_pv = Id.type_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
   end
 
   module Constructor = struct
-    type t = Paths_types.Identifier.constructor
-
-    type t_pv = Paths_types.Identifier.constructor_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.constructor
+    type t_pv = Id.constructor_pv
   end
 
   module Field = struct
-    type t = Paths_types.Identifier.field
-
-    type t_pv = Paths_types.Identifier.field_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.field
+    type t_pv = Id.field_pv
   end
 
   module Extension = struct
-    type t = Paths_types.Identifier.extension
-
-    type t_pv = Paths_types.Identifier.extension_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.extension
+    type t_pv = Id.extension_pv
   end
 
   module Exception = struct
-    type t = Paths_types.Identifier.exception_
-
-    type t_pv = Paths_types.Identifier.exception_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.exception_
+    type t_pv = Id.exception_pv
   end
 
   module Value = struct
-    type t = Paths_types.Identifier.value
-
-    type t_pv = Paths_types.Identifier.value_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.value
+    type t_pv = Id.value_pv
   end
 
   module Class = struct
-    type t = Paths_types.Identifier.class_
-
-    type t_pv = Paths_types.Identifier.class_pv
-
+    type t = Id.class_
+    type t_pv = Id.class_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
   end
 
   module ClassType = struct
-    type t = Paths_types.Identifier.class_type
-
-    type t_pv = Paths_types.Identifier.class_type_pv
-
+    type t = Id.class_type
+    type t_pv = Id.class_type_pv
     let equal = equal
-
     let hash = hash
-
     let compare = compare
   end
 
   module Method = struct
-    type t = Paths_types.Identifier.method_
-
-    type t_pv = Paths_types.Identifier.method_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.method_
+    type t_pv = Id.method_pv
   end
 
   module InstanceVariable = struct
-    type t = Paths_types.Identifier.instance_variable
-
-    type t_pv = Paths_types.Identifier.instance_variable_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.instance_variable
+    type t_pv = Id.instance_variable_pv
   end
 
   module Label = struct
     type t = Paths_types.Identifier.label
-
     type t_pv = Paths_types.Identifier.label_pv
-
     let equal = equal
-
     let hash = hash
-
     let compare = compare
   end
 
   module Page = struct
-    type t = Paths_types.Identifier.page
-
-    type t_pv = Paths_types.Identifier.page_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.page
+    type t_pv = Id.page_pv
   end
 
   module ContainerPage = struct
-    type t = Paths_types.Identifier.container_page
-
-    type t_pv = Paths_types.Identifier.container_page_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.container_page
+    type t_pv = Id.container_page_pv
   end
 
   module SourceDir = struct
-    type t = Paths_types.Identifier.source_dir
-    type t_pv = Paths_types.Identifier.source_dir_pv
+    type t = Id.source_dir
+    type t_pv = Id.source_dir_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -425,76 +267,52 @@ module Identifier = struct
   end
 
   module SourcePage = struct
-    type t = Paths_types.Identifier.source_page
-    type t_pv = Paths_types.Identifier.source_page_pv
+    type t = Id.source_page
+    type t_pv = Id.source_page_pv
     let equal = equal
-    let hash = hash
-    let compare = compare
     let name { iv = `SourcePage (p, name); _ } = SourceDir.name p ^ name
+    
   end
 
   module OdocId = struct
-    type t = Paths_types.Identifier.odoc_id
-
-    type t_pv = Paths_types.Identifier.odoc_id_pv
-
-    let equal = equal
-
-    let hash = hash
-
-    let compare = compare
+    type t = Id.odoc_id
+    type t_pv = Id.odoc_id_pv
   end
 
   module Path = struct
     module Module = struct
-      type t = Paths_types.Identifier.path_module
-
-      type t_pv = Paths_types.Identifier.path_module_pv
-
+      type t = Id.path_module
+      type t_pv = Id.path_module_pv
       let equal = equal
-
       let hash = hash
-
       let compare = compare
-
-      let root id = Signature.root (id :> Signature.t)
     end
 
     module ModuleType = struct
-      type t = Paths_types.Identifier.path_module_type
-
+      type t = Id.path_module_type
+      type t_pv = Id.module_type_pv
       let equal = equal
-
       let hash = hash
-
       let compare = compare
     end
 
     module Type = struct
-      type t = Paths_types.Identifier.path_type
-
-      type t_pv = Paths_types.Identifier.path_type_pv
-
+      type t = Id.path_type
+      type t_pv = Id.path_type_pv
       let equal = equal
-
       let hash = hash
-
       let compare = compare
     end
 
     module ClassType = struct
-      type t = Paths_types.Identifier.path_class_type
-
-      type t_pv = Paths_types.Identifier.path_class_type_pv
-
+      type t = Id.path_class_type
+      type t_pv = Id.path_class_type_pv
       let equal = equal
-
       let hash = hash
-
       let compare = compare
     end
 
-    type t = Paths_types.Identifier.path_any
+    type t = Id.path_any
   end
 
   module Maps = struct
@@ -774,60 +592,18 @@ module Path = struct
 
       let is_hidden m =
         is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
-
-      let rec identifier : t -> Identifier.Path.Module.t =
-       fun x ->
-        let r = identifier in
-        match x with
-        | `Identifier id -> id
-        | `Subst (_, x) -> r x
-        | `Hidden p -> r p
-        | `Module (m, n) -> Identifier.Mk.module_ (parent_module_identifier m, n)
-        | `Canonical (p, _) -> r p
-        | `Apply (m, _) -> r m
-        | `Alias (dest, _src) -> r dest
-        | `OpaqueModule m -> r m
-
-      let rec root : t -> string option = function
-        | `Identifier id -> (
-            match Identifier.root (id :> Identifier.t) with
-            | Some root -> Some (Identifier.name root)
-            | None -> None)
-        | `Subst (_, p)
-        | `Hidden p
-        | `Module (p, _)
-        | `Canonical (p, _)
-        | `Apply (p, _)
-        | `Alias (p, _)
-        | `OpaqueModule p ->
-            root p
     end
 
     module ModuleType = struct
       type t = Paths_types.Resolved_path.module_type
-
-      let is_hidden m =
-        is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
     end
 
     module Type = struct
       type t = Paths_types.Resolved_path.type_
-
-      let of_ident id = `Identifier id
-
-      let is_hidden m =
-        is_resolved_hidden ~weak_canonical_test:false
-          (m : t :> Paths_types.Resolved_path.any)
     end
 
     module ClassType = struct
       type t = Paths_types.Resolved_path.class_type
-
-      let of_ident id = `Identifier id
-
-      let is_hidden m =
-        is_resolved_hidden ~weak_canonical_test:false
-          (m : t :> Paths_types.Resolved_path.any)
     end
 
     let rec identifier : t -> Identifier.t = function
@@ -866,16 +642,6 @@ module Path = struct
 
   module Module = struct
     type t = Paths_types.Path.module_
-
-    let rec root : t -> string option = function
-      | `Resolved r -> Resolved.Module.root r
-      | `Identifier (id, _) -> (
-          match Identifier.root (id :> Identifier.t) with
-          | Some root -> Some (Identifier.name root)
-          | None -> None)
-      | `Root s -> Some s
-      | `Forward _ -> None
-      | `Dot (p, _) | `Apply (p, _) -> root p
   end
 
   module ModuleType = struct
@@ -899,92 +665,28 @@ module Fragment = struct
 
     type root = Paths_types.Resolved_fragment.root
 
-    let sig_of_mod m =
-      let open Paths_types.Resolved_fragment in
-      (m : module_ :> signature)
-
-    type base_name =
-      | Base of root
-      | Branch of ModuleName.t * Paths_types.Resolved_fragment.signature
-
-    let rec split_parent : Paths_types.Resolved_fragment.signature -> base_name
-        = function
-      | `Root i -> Base i
-      | `Subst (_, p) -> split_parent (sig_of_mod p)
-      | `Alias (_, p) -> split_parent (sig_of_mod p)
-      | `OpaqueModule m -> split_parent (sig_of_mod m)
-      | `Module (p, name) -> (
-          match split_parent p with
-          | Base i -> Branch (name, `Root i)
-          | Branch (base, m) -> Branch (base, `Module (m, name)))
-
     module Signature = struct
       type t = Paths_types.Resolved_fragment.signature
 
-      let rec split : t -> string * t option = function
-        | `Root _ -> ("", None)
-        | `Subst (_, p) -> split (sig_of_mod p)
-        | `Alias (_, p) -> split (sig_of_mod p)
-        | `OpaqueModule m -> split (sig_of_mod m)
-        | `Module (m, name) -> (
-            match split_parent m with
-            | Base _ -> (ModuleName.to_string name, None)
-            | Branch (base, m) ->
-                (ModuleName.to_string base, Some (`Module (m, name))))
-
-      let rec identifier : t -> Identifier.Signature.t = function
+      let rec sgidentifier : t -> Identifier.Signature.t = function
         | `Root (`ModuleType i) -> Path.Resolved.parent_module_type_identifier i
         | `Root (`Module i) -> Path.Resolved.parent_module_identifier i
         | `Subst (s, _) -> Path.Resolved.parent_module_type_identifier s
         | `Alias (i, _) -> Path.Resolved.parent_module_identifier i
-        | `Module (m, n) -> Identifier.Mk.module_ (identifier m, n)
-        | `OpaqueModule m -> identifier (sig_of_mod m)
+        | `Module (m, n) -> Identifier.Mk.module_ (sgidentifier m, n)
+        | `OpaqueModule m -> sgidentifier (m :> t)
     end
 
     module Module = struct
       type t = Paths_types.Resolved_fragment.module_
-
-      let rec split : t -> string * t option = function
-        | `Subst (_, p) -> split p
-        | `Alias (_, p) -> split p
-        | `Module (m, name) -> (
-            match split_parent m with
-            | Base _ -> (ModuleName.to_string name, None)
-            | Branch (base, m) ->
-                (ModuleName.to_string base, Some (`Module (m, name))))
-        | `OpaqueModule m -> split m
     end
 
     module ModuleType = struct
       type t = Paths_types.Resolved_fragment.module_type
-
-      let split : t -> string * t option = function
-        | `Module_type (m, name) -> (
-            match split_parent m with
-            | Base _ -> (ModuleTypeName.to_string name, None)
-            | Branch (base, m) ->
-                (ModuleName.to_string base, Some (`Module_type (m, name))))
     end
 
     module Type = struct
       type t = Paths_types.Resolved_fragment.type_
-
-      let split : t -> string * t option = function
-        | `Type (m, name) -> (
-            match split_parent m with
-            | Base _ -> (TypeName.to_string name, None)
-            | Branch (base, m) ->
-                (ModuleName.to_string base, Some (`Type (m, name))))
-        | `Class (m, name) -> (
-            match split_parent m with
-            | Base _ -> (ClassName.to_string name, None)
-            | Branch (base, m) ->
-                (ModuleName.to_string base, Some (`Class (m, name))))
-        | `ClassType (m, name) -> (
-            match split_parent m with
-            | Base _ -> (ClassTypeName.to_string name, None)
-            | Branch (base, m) ->
-                (ModuleName.to_string base, Some (`ClassType (m, name))))
     end
 
     type leaf = Paths_types.Resolved_fragment.leaf
@@ -995,27 +697,20 @@ module Fragment = struct
       | `Subst (s, _) -> Path.Resolved.identifier (s :> Path.Resolved.t)
       | `Alias (p, _) ->
           (Path.Resolved.parent_module_identifier p :> Identifier.t)
-      | `Module (m, n) -> Identifier.Mk.module_ (Signature.identifier m, n)
+      | `Module (m, n) -> Identifier.Mk.module_ (Signature.sgidentifier m, n)
       | `Module_type (m, n) ->
-          Identifier.Mk.module_type (Signature.identifier m, n)
-      | `Type (m, n) -> Identifier.Mk.type_ (Signature.identifier m, n)
-      | `Class (m, n) -> Identifier.Mk.class_ (Signature.identifier m, n)
-      | `ClassType (m, n) -> Identifier.Mk.class_type (Signature.identifier m, n)
+          Identifier.Mk.module_type (Signature.sgidentifier m, n)
+      | `Type (m, n) -> Identifier.Mk.type_ (Signature.sgidentifier m, n)
+      | `Class (m, n) -> Identifier.Mk.class_ (Signature.sgidentifier m, n)
+      | `ClassType (m, n) ->
+          Identifier.Mk.class_type (Signature.sgidentifier m, n)
       | `OpaqueModule m -> identifier (m :> t)
 
     let rec is_hidden : t -> bool = function
-      | `Root (`ModuleType r) ->
-          Path.is_resolved_hidden ~weak_canonical_test:false
-            (r :> Path.Resolved.t)
-      | `Root (`Module r) ->
-          Path.is_resolved_hidden ~weak_canonical_test:false
-            (r :> Path.Resolved.t)
-      | `Subst (s, _) ->
-          Path.is_resolved_hidden ~weak_canonical_test:false
-            (s :> Path.Resolved.t)
-      | `Alias (s, _) ->
-          Path.is_resolved_hidden ~weak_canonical_test:false
-            (s :> Path.Resolved.t)
+      | `Root (`ModuleType r) -> Path.Resolved.(is_hidden (r :> t))
+      | `Root (`Module r) -> Path.Resolved.(is_hidden (r :> t))
+      | `Subst (s, _) -> Path.Resolved.(is_hidden (s :> t))
+      | `Alias (s, _) -> Path.Resolved.(is_hidden (s :> t))
       | `Module (m, _)
       | `Module_type (m, _)
       | `Type (m, _)
@@ -1027,81 +722,20 @@ module Fragment = struct
 
   type t = Paths_types.Fragment.any
 
-  type base_name =
-    | Base of Resolved.root option
-    | Branch of ModuleName.t * Paths_types.Fragment.signature
-
-  let rec split_parent : Paths_types.Fragment.signature -> base_name = function
-    | `Root -> Base None
-    | `Resolved r -> (
-        match Resolved.split_parent r with
-        | Resolved.Base i -> Base (Some i)
-        | Resolved.Branch (base, m) -> Branch (base, `Resolved m))
-    | `Dot (m, name) -> (
-        match split_parent m with
-        | Base None -> Branch (ModuleName.make_std name, `Root)
-        | Base (Some i) -> Branch (ModuleName.make_std name, `Resolved (`Root i))
-        | Branch (base, m) -> Branch (base, `Dot (m, name)))
-
   module Signature = struct
     type t = Paths_types.Fragment.signature
-
-    let split : t -> string * t option = function
-      | `Root -> ("", None)
-      | `Resolved r ->
-          let base, m = Resolved.Signature.split r in
-          let m = match m with None -> None | Some m -> Some (`Resolved m) in
-          (base, m)
-      | `Dot (m, name) -> (
-          match split_parent m with
-          | Base _ -> (name, None)
-          | Branch (base, m) ->
-              (ModuleName.to_string base, Some (`Dot (m, name))))
   end
 
   module Module = struct
     type t = Paths_types.Fragment.module_
-
-    let split : t -> string * t option = function
-      | `Resolved r ->
-          let base, m = Resolved.Module.split r in
-          let m = match m with None -> None | Some m -> Some (`Resolved m) in
-          (base, m)
-      | `Dot (m, name) -> (
-          match split_parent m with
-          | Base _ -> (name, None)
-          | Branch (base, m) ->
-              (ModuleName.to_string base, Some (`Dot (m, name))))
   end
 
   module ModuleType = struct
     type t = Paths_types.Fragment.module_type
-
-    let split : t -> string * t option = function
-      | `Resolved r ->
-          let base, m = Resolved.ModuleType.split r in
-          let m = match m with None -> None | Some m -> Some (`Resolved m) in
-          (base, m)
-      | `Dot (m, name) -> (
-          match split_parent m with
-          | Base _ -> (name, None)
-          | Branch (base, m) ->
-              (ModuleName.to_string base, Some (`Dot (m, name))))
   end
 
   module Type = struct
     type t = Paths_types.Fragment.type_
-
-    let split : t -> string * t option = function
-      | `Resolved r ->
-          let base, m = Resolved.Type.split r in
-          let m = match m with None -> None | Some m -> Some (`Resolved m) in
-          (base, m)
-      | `Dot (m, name) -> (
-          match split_parent m with
-          | Base _ -> (name, None)
-          | Branch (base, m) ->
-              (ModuleName.to_string base, Some (`Dot (m, name))))
   end
 
   type leaf = Paths_types.Fragment.leaf
@@ -1118,14 +752,14 @@ module Reference = struct
       | `Identifier id -> id
       | `Hidden s -> parent_signature_identifier (s :> signature)
       | `Alias (sub, orig) ->
-          if Path.Resolved.Module.is_hidden ~weak_canonical_test:false sub then
+          if Path.Resolved.(is_hidden (sub :> t)) then
             parent_signature_identifier (orig :> signature)
           else
             (Path.Resolved.parent_module_identifier sub
               :> Identifier.Signature.t)
       | `AliasModuleType (sub, orig) ->
-          if Path.Resolved.ModuleType.is_hidden ~weak_canonical_test:false sub
-          then parent_signature_identifier (orig :> signature)
+          if Path.Resolved.(is_hidden (sub :> t)) then
+            parent_signature_identifier (orig :> signature)
           else
             (Path.Resolved.parent_module_type_identifier sub
               :> Identifier.Signature.t)

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -60,11 +60,8 @@ module Identifier : sig
 
   module Type : IdSig with type t = Id.type_ and type t_pv = Id.type_pv
 
-  module SourceDir : sig
-
-    include IdSig with type t = Id.source_dir and type t_pv = Id.source_dir_pv
-    val name : t -> string
-  end
+  module SourceDir :
+    IdSig with type t = Id.source_dir and type t_pv = Id.source_dir_pv
 
   module Class : IdSig with type t = Id.class_ and type t_pv = Id.class_pv
 
@@ -121,8 +118,8 @@ module Identifier : sig
   end
   module Label :
     IdSig
-      with type t = Paths_types.Identifier.label
-       and type t_pv = Paths_types.Identifier.label_pv
+      with type t = Id.label
+       and type t_pv = Id.label_pv
 
   module Page : sig
     type t = Id.page
@@ -134,12 +131,21 @@ module Identifier : sig
     type t_pv = Id.container_page_pv
   end
 
+  module NonSrc : sig
+    type t = Id.non_src
+    type t_pv = Id.non_src_pv
+  end
+
   module SourcePage : sig
     type t = Id.source_page
     type t_pv = Id.source_page_pv
-    val name : t -> string
-    val equal : t -> t -> bool
   end
+
+  module SourceLocation : sig
+    type t = Id.source_location
+    type t_pv = Id.source_location_pv
+  end
+
   module OdocId : sig
     type t = Id.odoc_id
     type t_pv = Id.odoc_id_pv
@@ -177,7 +183,7 @@ module Identifier : sig
 
   val equal : ([< t_pv ] id as 'a) -> 'a -> bool
 
-  val label_parent : [< t_pv ] id -> LabelParent.t
+  val label_parent : [< NonSrc.t_pv ] id -> LabelParent.t
 
   module Maps : sig
     module Any : Map.S with type key = Any.t
@@ -277,6 +283,13 @@ module Identifier : sig
     val label :
       LabelParent.t * LabelName.t ->
       [> `Label of LabelParent.t * LabelName.t ] id
+
+    val source_location :
+      SourcePage.t * DefName.t ->
+      [> `SourceLocation of SourcePage.t * DefName.t ] id
+
+    val source_location_mod :
+      SourcePage.t -> [> `SourceLocationMod of SourcePage.t ] id
   end
 end
 

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -24,389 +24,154 @@ module Identifier : sig
 
   type 'a id = 'a Paths_types.id = { iv : 'a; ihash : int; ikey : string }
 
-  module Any : sig
-    type t = Paths_types.Identifier.any
-
+  module type IdSig = sig
+    type t
+    type t_pv
     val equal : t -> t -> bool
-
     val hash : t -> int
-
     val compare : t -> t -> int
   end
 
-  module RootModule : sig
-    type t = Paths_types.Identifier.root_module
+  module Id = Paths_types.Identifier
 
-    type t_pv = Paths_types.Identifier.root_module_pv
+  module Any : IdSig with type t = Id.any and type t_pv = Id.any_pv
 
-    val equal : t -> t -> bool
+  module RootModule :
+    IdSig with type t = Id.root_module and type t_pv = Id.root_module_pv
 
-    val hash : t -> int
+  module Signature :
+    IdSig with type t = Id.signature and type t_pv = Id.signature_pv
 
-    val compare : t -> t -> int
+  module ClassSignature :
+    IdSig with type t = Id.class_signature and type t_pv = Id.class_signature_pv
 
+  module LabelParent :
+    IdSig with type t = Id.label_parent and type t_pv = Id.label_parent_pv
+
+  module Module : IdSig with type t = Id.module_ and type t_pv = Id.module_pv
+
+  module FunctorParameter :
+    IdSig
+      with type t = Id.functor_parameter
+       and type t_pv = Id.functor_parameter_pv
+
+  module ModuleType :
+    IdSig with type t = Id.module_type and type t_pv = Id.module_type_pv
+
+  module Type : IdSig with type t = Id.type_ and type t_pv = Id.type_pv
+
+  module SourceDir : sig
+
+    include IdSig with type t = Id.source_dir and type t_pv = Id.source_dir_pv
     val name : t -> string
   end
 
-  module Signature : sig
-    type t = Paths_types.Identifier.signature
+  module Class : IdSig with type t = Id.class_ and type t_pv = Id.class_pv
 
-    type t_pv = Paths_types.Identifier.signature_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-
-    val root : [< t_pv ] id -> RootModule.t
-  end
-
-  module ClassSignature : sig
-    type t = Paths_types.Identifier.class_signature
-
-    type t_pv = Paths_types.Identifier.class_signature_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-  end
+  module ClassType :
+    IdSig with type t = Id.class_type and type t_pv = Id.class_type_pv
 
   module DataType : sig
-    type t = Paths_types.Identifier.datatype
-
-    type t_pv = Paths_types.Identifier.datatype_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.datatype
+    type t_pv = Id.datatype_pv
   end
-
   module Parent : sig
-    type t = Paths_types.Identifier.parent
-
-    type t_pv = Paths_types.Identifier.parent_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-  end
-
-  module LabelParent : sig
-    type t = Paths_types.Identifier.label_parent
-
-    type t_pv = Paths_types.Identifier.label_parent_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-  end
-
-  module Module : sig
-    type t = Paths_types.Identifier.module_
-
-    type t_pv = Paths_types.Identifier.module_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-
-    val root : t -> RootModule.t
-  end
-
-  module FunctorParameter : sig
-    type t = Paths_types.Identifier.functor_parameter
-
-    type t_pv = Paths_types.Identifier.functor_parameter_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.parent
+    type t_pv = Id.parent_pv
   end
 
   module FunctorResult : sig
-    type t = Paths_types.Identifier.functor_result
-
-    type t_pv = Paths_types.Identifier.functor_result_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-  end
-
-  module ModuleType : sig
-    type t = Paths_types.Identifier.module_type
-
-    type t_pv = Paths_types.Identifier.module_type_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-  end
-
-  module Type : sig
-    type t = Paths_types.Identifier.type_
-
-    type t_pv = Paths_types.Identifier.type_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.functor_result
+    type t_pv = Id.functor_result_pv
   end
 
   module Constructor : sig
-    type t = Paths_types.Identifier.constructor
-
-    type t_pv = Paths_types.Identifier.constructor_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.constructor
+    type t_pv = Id.constructor_pv
   end
 
   module Field : sig
-    type t = Paths_types.Identifier.field
-
-    type t_pv = Paths_types.Identifier.field_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.field
+    type t_pv = Id.field_pv
   end
 
   module Extension : sig
-    type t = Paths_types.Identifier.extension
-
-    type t_pv = Paths_types.Identifier.extension_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.extension
+    type t_pv = Id.extension_pv
   end
 
   module Exception : sig
-    type t = Paths_types.Identifier.exception_
-
-    type t_pv = Paths_types.Identifier.exception_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.exception_
+    type t_pv = Id.exception_pv
   end
 
   module Value : sig
-    type t = Paths_types.Identifier.value
-
-    type t_pv = Paths_types.Identifier.value_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-  end
-
-  module Class : sig
-    type t = Paths_types.Identifier.class_
-
-    type t_pv = Paths_types.Identifier.class_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-  end
-
-  module ClassType : sig
-    type t = Paths_types.Identifier.class_type
-
-    type t_pv = Paths_types.Identifier.class_type_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.value
+    type t_pv = Id.value_pv
   end
 
   module Method : sig
-    type t = Paths_types.Identifier.method_
-
-    type t_pv = Paths_types.Identifier.method_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.method_
+    type t_pv = Id.method_pv
   end
 
   module InstanceVariable : sig
-    type t = Paths_types.Identifier.instance_variable
-
-    type t_pv = Paths_types.Identifier.instance_variable_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.instance_variable
+    type t_pv = Id.instance_variable_pv
   end
-
-  module Label : sig
-    type t = Paths_types.Identifier.label
-
-    type t_pv = Paths_types.Identifier.label_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-  end
+  module Label :
+    IdSig
+      with type t = Paths_types.Identifier.label
+       and type t_pv = Paths_types.Identifier.label_pv
 
   module Page : sig
-    type t = Paths_types.Identifier.page
-
-    type t_pv = Paths_types.Identifier.page_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+    type t = Id.page
+    type t_pv = Id.page_pv
   end
 
   module ContainerPage : sig
-    type t = Paths_types.Identifier.container_page
-
-    type t_pv = Paths_types.Identifier.container_page_pv
-
-    val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
-  end
-
-  module SourceDir : sig
-    type t = Paths_types.Identifier.source_dir
-    type t_pv = Paths_types.Identifier.source_dir_pv
-    val equal : t -> t -> bool
-    val hash : t -> int
-    val compare : t -> t -> int
-    val name : t -> string
+    type t = Id.container_page
+    type t_pv = Id.container_page_pv
   end
 
   module SourcePage : sig
-    type t = Paths_types.Identifier.source_page
-    type t_pv = Paths_types.Identifier.source_page_pv
-    val equal : t -> t -> bool
-    val hash : t -> int
-    val compare : t -> t -> int
+    type t = Id.source_page
+    type t_pv = Id.source_page_pv
     val name : t -> string
-  end
-
-  module OdocId : sig
-    type t = Paths_types.Identifier.odoc_id
-
-    type t_pv = Paths_types.Identifier.odoc_id_pv
-
     val equal : t -> t -> bool
-
-    val hash : t -> int
-
-    val compare : t -> t -> int
+  end
+  module OdocId : sig
+    type t = Id.odoc_id
+    type t_pv = Id.odoc_id_pv
   end
 
   module Path : sig
-    module Module : sig
-      type t = Paths_types.Identifier.path_module
+    module Module :
+      IdSig with type t = Id.path_module and type t_pv = Id.path_module_pv
 
-      type t_pv = Paths_types.Identifier.path_module_pv
+    module ModuleType :
+      IdSig with type t = Id.path_module_type and type t_pv = Id.module_type_pv
 
-      val equal : t -> t -> bool
+    module Type :
+      IdSig with type t = Id.path_type and type t_pv = Id.path_type_pv
 
-      val hash : t -> int
+    module ClassType :
+      IdSig
+        with type t = Id.path_class_type
+         and type t_pv = Id.path_class_type_pv
 
-      val compare : t -> t -> int
-
-      val root : t -> RootModule.t
-    end
-
-    module ModuleType : sig
-      type t = Paths_types.Identifier.path_module_type
-
-      val equal : t -> t -> bool
-
-      val hash : t -> int
-
-      val compare : t -> t -> int
-    end
-
-    module Type : sig
-      type t = Paths_types.Identifier.path_type
-
-      type t_pv = Paths_types.Identifier.path_type_pv
-
-      val equal : t -> t -> bool
-
-      val hash : t -> int
-
-      val compare : t -> t -> int
-    end
-
-    module ClassType : sig
-      type t = Paths_types.Identifier.path_class_type
-
-      type t_pv = Paths_types.Identifier.path_class_type_pv
-
-      val equal : t -> t -> bool
-
-      val hash : t -> int
-
-      val compare : t -> t -> int
-    end
-
-    type t = Paths_types.Identifier.path_any
+    type t = Id.path_any
   end
 
-  type t_pv = Paths_types.Identifier.any_pv
+  type t = Id.any
 
-  type t = Paths_types.Identifier.any
+  type t_pv = Id.any_pv
 
   val hash : t -> int
 
   val name : [< t_pv ] id -> string
 
-  val root : [< t_pv ] id -> RootModule.t_pv id option
+  (* val root : [< t_pv ] id -> RootModule.t_pv id option *)
 
   val compare : t -> t -> int
 
@@ -523,15 +288,15 @@ module rec Path : sig
 
       val is_hidden : t -> weak_canonical_test:bool -> bool
 
-      val identifier : t -> Identifier.Path.Module.t
+      (* val identifier : t -> Identifier.Path.Module.t *)
 
-      val root : t -> string option
+      (* val root : t -> string option *)
     end
 
     module ModuleType : sig
       type t = Paths_types.Resolved_path.module_type
 
-      val is_hidden : t -> weak_canonical_test:bool -> bool
+      (* val is_hidden : t -> weak_canonical_test:bool -> bool *)
 
       (* val identifier : t -> Identifier.Path.ModuleType.t *)
     end
@@ -539,9 +304,9 @@ module rec Path : sig
     module Type : sig
       type t = Paths_types.Resolved_path.type_
 
-      val of_ident : Identifier.Path.Type.t -> t
+      (* val of_ident : Identifier.Path.Type.t -> t *)
 
-      val is_hidden : t -> bool
+      (* val is_hidden : t -> bool *)
 
       (* val identifier : t -> Identifier.Path.Type.t *)
     end
@@ -549,9 +314,9 @@ module rec Path : sig
     module ClassType : sig
       type t = Paths_types.Resolved_path.class_type
 
-      val of_ident : Identifier.Path.ClassType.t -> t
+      (* val of_ident : Identifier.Path.ClassType.t -> t *)
 
-      val is_hidden : t -> bool
+      (* val is_hidden : t -> bool *)
     end
 
     type t = Paths_types.Resolved_path.any
@@ -564,7 +329,7 @@ module rec Path : sig
   module Module : sig
     type t = Paths_types.Path.module_
 
-    val root : t -> string option
+    (* val root : t -> string option *)
   end
 
   module ModuleType : sig
@@ -589,26 +354,18 @@ module Fragment : sig
   module Resolved : sig
     module Signature : sig
       type t = Paths_types.Resolved_fragment.signature
-
-      val split : t -> string * t option
     end
 
     module Module : sig
       type t = Paths_types.Resolved_fragment.module_
-
-      val split : t -> string * t option
     end
 
     module ModuleType : sig
       type t = Paths_types.Resolved_fragment.module_type
-
-      val split : t -> string * t option
     end
 
     module Type : sig
       type t = Paths_types.Resolved_fragment.type_
-
-      val split : t -> string * t option
     end
 
     type leaf = Paths_types.Resolved_fragment.leaf
@@ -624,26 +381,18 @@ module Fragment : sig
 
   module Signature : sig
     type t = Paths_types.Fragment.signature
-
-    val split : t -> string * t option
   end
 
   module Module : sig
     type t = Paths_types.Fragment.module_
-
-    val split : t -> string * t option
   end
 
   module ModuleType : sig
     type t = Paths_types.Fragment.module_type
-
-    val split : t -> string * t option
   end
 
   module Type : sig
     type t = Paths_types.Fragment.type_
-
-    val split : t -> string * t option
   end
 
   type leaf = Paths_types.Fragment.leaf

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -18,10 +18,11 @@ module Identifier = struct
   and page = page_pv id
   (** @canonical Odoc_model.Paths.Identifier.Page.t *)
 
-  type source_dir_pv =
-    [ `SourceRoot of container_page | `SourceDir of source_dir * string ]
+  type source_dir_pv = [ container_page_pv | `SourceDir of source_dir * string ]
+  (** @canonical Odoc_model.Paths.Identifier.SourceDir.t_pv *)
 
   and source_dir = source_dir_pv id
+  (** @canonical Odoc_model.Paths.Identifier.SourceDir.t *)
 
   type source_page_pv = [ `SourcePage of source_dir * string ]
   (** The second argument is the filename.
@@ -30,6 +31,14 @@ module Identifier = struct
 
   type source_page = source_page_pv id
   (** @canonical Odoc_model.Paths.Identifier.SourcePage.t *)
+
+  type source_location_pv =
+    [ `SourceLocationMod of source_page
+    | `SourceLocation of source_page * DefName.t ]
+  (** @canonical Odoc_model.Paths.Identifier.SourceLocation.t *)
+
+  and source_location = source_location_pv id
+  (** @canonical Odoc_model.Paths.Identifier.SourceLocation.t_pv *)
 
   type odoc_id_pv = [ page_pv | `Root of container_page option * ModuleName.t ]
   (** @canonical Odoc_model.Paths.Identifier.OdocId.t_pv *)
@@ -177,7 +186,7 @@ module Identifier = struct
   and label = label_pv id
   (** @canonical Odoc_model.Paths.Identifier.Label.t *)
 
-  type any_pv =
+  type non_src_pv =
     [ signature_pv
     | class_signature_pv
     | datatype_pv
@@ -199,6 +208,16 @@ module Identifier = struct
     | instance_variable_pv
     | label_pv
     | page_pv ]
+  (** @canonical Odoc_model.Paths.Identifier.NonSrc.t_pv *)
+
+  and non_src = non_src_pv id
+  (** @canonical Odoc_model.Paths.Identifier.NonSrc.t *)
+
+  type any_pv =
+    [ non_src_pv
+    | source_page_pv
+    | source_dir_pv
+    | source_location_pv ]
   (** @canonical Odoc_model.Paths.Identifier.t_pv *)
 
   and any = any_pv id

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -16,17 +16,9 @@ let inline_status =
     | `Closed -> C0 "`Closed"
     | `Inline -> C0 "`Inline")
 
-let locations =
-  let open Lang.Locations in
-  Record
-    [
-      F ("source_parent", (fun t -> t.source_parent), sourcepage_identifier);
-      F ("anchor", (fun t -> t.anchor), Option string);
-    ]
-
 let source_info =
   let open Lang.Source_info in
-  Record [ F ("id", (fun t -> t.id), sourcepage_identifier) ]
+  Record [ F ("id", (fun t -> t.id), identifier) ]
 
 (** {3 Module} *)
 
@@ -46,7 +38,7 @@ and module_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option locations);
+      F ("locs", (fun t -> t.locs), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("type_", (fun t -> t.type_), module_decl);
       F
@@ -180,7 +172,7 @@ and moduletype_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option locations);
+      F ("locs", (fun t -> t.locs), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F
         ( "canonical",
@@ -370,7 +362,7 @@ and typedecl_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option locations);
+      F ("locs", (fun t -> t.locs), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("equation", (fun t -> t.equation), typedecl_equation);
       F
@@ -385,7 +377,7 @@ and extension_constructor =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option locations);
+      F ("locs", (fun t -> t.locs), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("args", (fun t -> t.args), typedecl_constructor_argument);
       F ("res", (fun t -> t.res), Option typeexpr_t);
@@ -409,7 +401,7 @@ and exception_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option locations);
+      F ("locs", (fun t -> t.locs), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("args", (fun t -> t.args), typedecl_constructor_argument);
       F ("res", (fun t -> t.res), Option typeexpr_t);
@@ -427,7 +419,7 @@ and value_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option locations);
+      F ("locs", (fun t -> t.locs), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("type_", (fun t -> t.type_), typeexpr_t);
       F ("value", (fun t -> t.value), value_value_t);
@@ -451,7 +443,7 @@ and class_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option locations);
+      F ("locs", (fun t -> t.locs), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("virtual_", (fun t -> t.virtual_), bool);
       F ("params", (fun t -> t.params), List typedecl_param);
@@ -474,7 +466,7 @@ and classtype_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option locations);
+      F ("locs", (fun t -> t.locs), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("virtual_", (fun t -> t.virtual_), bool);
       F ("params", (fun t -> t.params), List typedecl_param);
@@ -712,8 +704,5 @@ and source_tree_page_t =
       F ("name", (fun t -> t.name), identifier);
       F ("root", (fun t -> t.root), root);
       F ("digest", (fun t -> t.digest), Digest.t);
-      F
-        ( "source_children",
-          (fun t -> t.source_children),
-          List sourcepage_identifier );
+      F ("source_children", (fun t -> t.source_children), List identifier);
     ]

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -37,6 +37,8 @@ module Names = struct
   let pagename = To_string PageName.to_string
 
   let parametername = To_string ModuleName.to_string
+
+  let defname = To_string DefName.to_string
 end
 
 module General_paths = struct
@@ -149,7 +151,21 @@ module General_paths = struct
             C
               ( "`Label",
                 ((parent :> id_t), name),
-                Pair (identifier, Names.labelname) ))
+                Pair (identifier, Names.labelname) )
+        | `SourceDir (parent, name) ->
+            C ("`SourceDir", ((parent :> id_t), name), Pair (identifier, string))
+        | `SourcePage (parent, name) ->
+            C
+              ( "`SourcePage",
+                ((parent :> id_t), name),
+                Pair (identifier, string) )
+        | `SourceLocation (parent, name) ->
+            C
+              ( "`SourceLocation",
+                ((parent :> id_t), name),
+                Pair (identifier, Names.defname) )
+        | `SourceLocationMod parent ->
+            C ("`SourceLocationMod", (parent :> id_t), identifier))
 
   let reference_tag : tag t =
     Variant
@@ -433,25 +449,6 @@ let modulename = Names.modulename
 (* Indirection seems to be required to make the type open. *)
 let identifier : [< Paths.Identifier.t_pv ] Paths.Identifier.id Type_desc.t =
   Indirect ((fun n -> (n :> Paths.Identifier.t)), General_paths.identifier)
-
-let rec sourcedir_identifier : Paths.Identifier.SourceDir.t Type_desc.t =
-  Variant
-    (fun id ->
-      match id.iv with
-      | `SourceDir (parent, name) ->
-          C ("`SourceDir", (parent, name), Pair (sourcedir_identifier, string))
-      | `SourceRoot parent ->
-          C
-            ( "`SourceRoot",
-              (parent :> Paths.Identifier.t),
-              General_paths.identifier ))
-
-let sourcepage_identifier : Paths.Identifier.SourcePage.t Type_desc.t =
-  Indirect
-    ( (fun id ->
-        let (`SourcePage (parent, name)) = id.iv in
-        (parent, name)),
-      Pair (sourcedir_identifier, string) )
 
 let resolved_path : [< Paths.Path.Resolved.t ] Type_desc.t =
   Indirect ((fun n -> (n :> General_paths.rp)), General_paths.resolved_path)

--- a/src/model_desc/paths_desc.mli
+++ b/src/model_desc/paths_desc.mli
@@ -6,8 +6,6 @@ val modulename : Odoc_model.Names.ModuleName.t Type_desc.t
 
 val identifier : [< Identifier.t_pv ] Odoc_model.Paths.Identifier.id Type_desc.t
 
-val sourcepage_identifier : Odoc_model.Paths.Identifier.SourcePage.t Type_desc.t
-
 val resolved_path : [< Path.Resolved.t ] Type_desc.t
 
 val path : [< Path.t ] Type_desc.t

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -309,9 +309,7 @@ let compile ~resolver ~parent_cli_spec ~hidden ~children ~output
             | { Paths.Identifier.iv = `Page _; _ } as parent_id ->
                 let name = Paths.Identifier.Mk.source_page (parent_id, name) in
                 if
-                  List.exists
-                    (Paths.Identifier.SourcePage.equal name)
-                    page.source_children
+                  List.exists (Paths.Identifier.SourcePage.equal name) page.source_children
                 then Ok (Some name)
                 else err_not_parent ()
             | { iv = `LeafPage _; _ } -> err_not_parent ())

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -309,7 +309,9 @@ let compile ~resolver ~parent_cli_spec ~hidden ~children ~output
             | { Paths.Identifier.iv = `Page _; _ } as parent_id ->
                 let name = Paths.Identifier.Mk.source_page (parent_id, name) in
                 if
-                  List.exists (Paths.Identifier.SourcePage.equal name) page.source_children
+                  List.exists
+                    (Paths.Identifier.equal name)
+                    page.source_children
                 then Ok (Some name)
                 else err_not_parent ()
             | { iv = `LeafPage _; _ } -> err_not_parent ())

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -37,7 +37,7 @@ let extra_documents args unit ~syntax =
               source_code;
           ])
   | Some { id; _ }, None ->
-      let filename = Paths.Identifier.SourcePage.name id in
+      let filename = Paths.Identifier.name id in
       Error.raise_warning
         (Error.filename_only
            "The --source should be passed when generating documents from \

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -76,7 +76,7 @@ module rec Module : sig
     | ModuleType of ModuleType.expr
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     type_ : decl;
     canonical : Odoc_model.Paths.Path.Module.t option;
@@ -148,7 +148,7 @@ and Extension : sig
   module Constructor : sig
     type t = {
       name : string;
-      locs : Odoc_model.Lang.Locations.t option;
+      locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
       doc : CComment.docs;
       args : TypeDecl.Constructor.argument;
       res : TypeExpr.t option;
@@ -167,7 +167,7 @@ end =
 
 and Exception : sig
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     args : TypeDecl.Constructor.argument;
     res : TypeExpr.t option;
@@ -231,7 +231,7 @@ and ModuleType : sig
     | TypeOf of typeof_t
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     canonical : Odoc_model.Paths.Path.ModuleType.t option;
     expr : expr option;
@@ -279,7 +279,7 @@ and TypeDecl : sig
   end
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     canonical : Odoc_model.Paths.Path.Type.t option;
     equation : Equation.t;
@@ -292,7 +292,7 @@ and Value : sig
   type value = Odoc_model.Lang.Value.value
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     type_ : TypeExpr.t;
     value : value;
@@ -363,7 +363,7 @@ and Class : sig
     | Arrow of TypeExpr.label option * TypeExpr.t * decl
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;
@@ -379,7 +379,7 @@ and ClassType : sig
     | Signature of ClassSignature.t
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;
@@ -1247,6 +1247,17 @@ module Fmt = struct
           (ExtensionName.to_string name)
     | `Page (_, name) | `LeafPage (_, name) ->
         Format.fprintf ppf "%s" (PageName.to_string name)
+    | `SourcePage (p, name) | `SourceDir (p, name) ->
+        Format.fprintf ppf "%a/%s" model_identifier
+          (p :> Odoc_model.Paths.Identifier.t)
+          name
+    | `SourceLocation (p, def) ->
+        Format.fprintf ppf "%a#%s" model_identifier
+          (p :> Odoc_model.Paths.Identifier.t)
+          (DefName.to_string def)
+    | `SourceLocationMod p ->
+        Format.fprintf ppf "%a#" model_identifier
+          (p :> Odoc_model.Paths.Identifier.t)
 
   and model_fragment ppf (f : Odoc_model.Paths.Fragment.t) =
     match f with

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -66,7 +66,7 @@ module rec Module : sig
     | ModuleType of ModuleType.expr
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     type_ : decl;
     canonical : Odoc_model.Paths.Path.Module.t option;
@@ -134,7 +134,7 @@ and Extension : sig
   module Constructor : sig
     type t = {
       name : string;
-      locs : Odoc_model.Lang.Locations.t option;
+      locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
       doc : CComment.docs;
       args : TypeDecl.Constructor.argument;
       res : TypeExpr.t option;
@@ -152,7 +152,7 @@ end
 
 and Exception : sig
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     args : TypeDecl.Constructor.argument;
     res : TypeExpr.t option;
@@ -214,7 +214,7 @@ and ModuleType : sig
     | TypeOf of typeof_t
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     canonical : Odoc_model.Paths.Path.ModuleType.t option;
     expr : expr option;
@@ -261,7 +261,7 @@ and TypeDecl : sig
   end
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     canonical : Odoc_model.Paths.Path.Type.t option;
     equation : Equation.t;
@@ -326,7 +326,7 @@ and Value : sig
   type value = Odoc_model.Lang.Value.value
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     type_ : TypeExpr.t;
     value : value;
@@ -339,7 +339,7 @@ and Class : sig
     | Arrow of TypeExpr.label option * TypeExpr.t * decl
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;
@@ -354,7 +354,7 @@ and ClassType : sig
     | Signature of ClassSignature.t
 
   type t = {
-    locs : Odoc_model.Lang.Locations.t option;
+    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;

--- a/src/xref2/cpath.ml
+++ b/src/xref2/cpath.ml
@@ -219,9 +219,7 @@ and is_module_type_hidden : module_type -> bool = function
 
 and is_resolved_module_type_hidden : Resolved.module_type -> bool = function
   | `Local _ -> false
-  | `Gpath p ->
-      Odoc_model.Paths.Path.Resolved.ModuleType.is_hidden
-        ~weak_canonical_test:false p
+  | `Gpath p -> Odoc_model.Paths.Path.Resolved.(is_hidden (p :> t))
   | `Substituted p -> is_resolved_module_type_hidden p
   | `ModuleType (p, _) -> is_resolved_parent_hidden ~weak_canonical_test:false p
   | `SubstT (p1, p2) ->
@@ -247,7 +245,7 @@ and is_type_hidden : type_ -> bool = function
 
 and is_resolved_type_hidden : Resolved.type_ -> bool = function
   | `Local _ -> false
-  | `Gpath p -> Odoc_model.Paths.Path.Resolved.Type.is_hidden p
+  | `Gpath p -> Odoc_model.Paths.Path.Resolved.(is_hidden (p :> t))
   | `Substituted p -> is_resolved_type_hidden p
   | `CanonicalType (_, `Resolved _) -> false
   | `CanonicalType (p, _) -> is_resolved_type_hidden p
@@ -256,7 +254,7 @@ and is_resolved_type_hidden : Resolved.type_ -> bool = function
 
 and is_resolved_class_type_hidden : Resolved.class_type -> bool = function
   | `Local _ -> false
-  | `Gpath p -> Odoc_model.Paths.Path.Resolved.ClassType.is_hidden p
+  | `Gpath p -> Odoc_model.Paths.Path.Resolved.(is_hidden (p :> t))
   | `Substituted p -> is_resolved_class_type_hidden p
   | `Class (p, _) | `ClassType (p, _) ->
       is_resolved_parent_hidden ~weak_canonical_test:false p

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -18,7 +18,7 @@ type resolver = {
   open_units : string list;
   lookup_unit : string -> lookup_unit_result;
   lookup_page : string -> lookup_page_result;
-  lookup_def : Identifier.t -> Lang.Locations.t option;
+  lookup_def : Identifier.NonSrc.t -> Identifier.SourceLocation.t option;
 }
 
 let unique_id =
@@ -361,7 +361,7 @@ let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
   let id = (unit.id :> Paths.Identifier.Module.t) in
   let locs =
     match unit.source_info with
-    | Some src -> Some { Lang.Locations.source_parent = src.id; anchor = None }
+    | Some src -> Some (Identifier.Mk.source_location_mod src.id)
     | None -> None
   in
   match unit.content with
@@ -425,7 +425,7 @@ let lookup_root_module name env =
   result
 
 let lookup_def id env =
-  let id = (id :> Paths.Identifier.Any.t) in
+  let id = (id :> Paths.Identifier.NonSrc.t) in
   match env.resolver with Some r -> r.lookup_def id | None -> None
 
 let lookup_page name env =

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -19,7 +19,7 @@ type resolver = {
   open_units : string list;
   lookup_unit : string -> lookup_unit_result;
   lookup_page : string -> lookup_page_result;
-  lookup_def : Identifier.t -> Lang.Locations.t option;
+  lookup_def : Identifier.NonSrc.t -> Identifier.SourceLocation.t option;
       (** Lookup the source code location from an identifier. Returns
           [Some (source_parent, anchor)] when definition is found. *)
 }
@@ -98,8 +98,7 @@ val module_of_unit : Lang.Compilation_unit.t -> Component.Module.t
 
 val lookup_root_module : string -> t -> root option
 
-val lookup_def :
-  [< Identifier.t_pv ] Paths.Identifier.id -> t -> Lang.Locations.t option
+val lookup_def : Identifier.NonSrc.t -> t -> Identifier.SourceLocation.t option
 (** Lookup the definition of the given identifier. Returns the root module and
     the anchor. *)
 

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -8,6 +8,7 @@ module Opt = struct
 end
 
 let locations env id locs =
+  let id = (id :> Id.NonSrc.t) in
   match locs with Some _ as locs -> locs | None -> Env.lookup_def id env
 
 (** Equivalent to {!Comment.synopsis}. *)
@@ -360,7 +361,7 @@ and value_ env parent t =
   let open Value in
   {
     t with
-    locs = locations env (t.id :> Id.t) t.locs;
+    locs = locations env t.id t.locs;
     doc = comment_docs env parent t.doc;
     type_ = type_expression env parent [] t.type_;
   }
@@ -541,7 +542,7 @@ and module_ : Env.t -> Module.t -> Module.t =
           else type_
       | Alias _ | ModuleType _ -> type_
     in
-    let locs = (locations env (m.id :> Id.t)) m.locs in
+    let locs = locations env m.id m.locs in
     let doc = comment_docs env sg_id m.doc in
     { m with locs; doc; type_ }
 

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -847,7 +847,7 @@ and type_decl : Env.t -> Id.Signature.t -> TypeDecl.t -> TypeDecl.t =
   let hidden_path =
     match equation.Equation.manifest with
     | Some (Constr (`Resolved path, params))
-      when Paths.Path.Resolved.Type.is_hidden path
+      when Paths.Path.Resolved.(is_hidden (path :> t))
            || Paths.Path.Resolved.(identifier (path :> t))
               = (t.id :> Paths.Identifier.t) ->
         Some (path, params)


### PR DESCRIPTION
The `Lang.Locations` module seems to be better represented as an identifier than a separate thing. This PR fixes that and also cleans up the paths interface and removes a bunch of dead code.