### PR TITLE
Rudimentary support for assets

### DIFF
--- a/src/document/renderer.ml
+++ b/src/document/renderer.ml
@@ -17,14 +17,14 @@ let traverse ~f t =
   in
   List.iter aux t
 
+type input =
+  | CU of Odoc_model.Lang.Compilation_unit.t
+  | Page of Odoc_model.Lang.Page.t
+
 type 'a t = {
   name : string;
   render : 'a -> Types.Document.t -> page list;
-  extra_documents :
-    'a ->
-    Odoc_model.Lang.Compilation_unit.t ->
-    syntax:syntax ->
-    Types.Document.t list;
+  extra_documents : 'a -> input -> syntax:syntax -> Types.Document.t list;
 }
 
 let document_of_page ~syntax v =

--- a/src/document/types.ml
+++ b/src/document/types.ml
@@ -192,8 +192,13 @@ and Source_page : sig
 end =
   Source_page
 
+and Asset : sig
+  type t = { url : Url.Path.t; src : Fpath.t }
+end =
+  Asset
+
 module Document = struct
-  type t = Page of Page.t | Source_page of Source_page.t
+  type t = Page of Page.t | Source_page of Source_page.t | Asset of Asset.t
 end
 
 let inline ?(attr = []) desc = Inline.{ attr; desc }

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -380,10 +380,10 @@ module Anchor = struct
     | { iv = `SourceLocationMod parent; _ } ->
         let page = Path.from_identifier (parent :> Path.any) in
         Ok { page; kind = `SourceAnchor; anchor = "" }
-    | { iv = `SourcePage (p, _name); _ } | { iv = `SourceDir (p, _name); _ } ->
+    | { iv = `SourcePage _ | `SourceDir _; _ } as p ->
         let page = Path.from_identifier (p :> Path.any) in
         Ok { page; kind = `Page; anchor = "" }
-    | { iv = `AssetFile (p, _name); _ } ->
+    | { iv = `AssetFile _; _ } as p ->
         let page = Path.from_identifier p in
         Ok { page; kind = `File; anchor = "" }
 

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -88,7 +88,10 @@ module Path = struct
     | Identifier.ClassSignature.t_pv ]
 
   type source_pv =
-    [ nonsrc_pv | Identifier.SourcePage.t_pv | Identifier.SourceDir.t_pv ]
+    [ nonsrc_pv
+    | Identifier.SourcePage.t_pv
+    | Identifier.SourceDir.t_pv
+    | Identifier.AssetFile.t_pv ]
 
   and source = source_pv Odoc_model.Paths.Identifier.id
 
@@ -181,6 +184,10 @@ module Path = struct
     | { iv = `SourcePage (parent, name); _ } ->
         let parent = from_identifier (parent :> source) in
         let kind = `Page in
+        mk ~parent kind name
+    | { iv = `AssetFile (parent, name); _ } ->
+        let parent = from_identifier (parent :> source) in
+        let kind = `File in
         mk ~parent kind name
 
   let from_identifier p =
@@ -377,6 +384,9 @@ module Anchor = struct
     | { iv = `SourcePage (p, _name); _ } | { iv = `SourceDir (p, _name); _ } ->
         let page = Path.from_identifier (p :> Path.source) in
         Ok { page; kind = `Page; anchor = "" }
+    | { iv = `AssetFile (p, _name); _ } ->
+        let page = Path.from_identifier p in
+        Ok { page; kind = `File; anchor = "" }
 
   let polymorphic_variant ~type_ident elt =
     let name_of_type_constr te =

--- a/src/document/url.mli
+++ b/src/document/url.mli
@@ -35,7 +35,10 @@ module Path : sig
     | Identifier.ClassSignature.t_pv ]
 
   type source_pv =
-    [ nonsrc_pv | Identifier.SourcePage.t_pv | Identifier.SourceDir.t_pv ]
+    [ nonsrc_pv
+    | Identifier.SourcePage.t_pv
+    | Identifier.SourceDir.t_pv
+    | Identifier.AssetFile.t_pv ]
 
   and source = source_pv Odoc_model.Paths.Identifier.id
 

--- a/src/document/url.mli
+++ b/src/document/url.mli
@@ -29,20 +29,17 @@ module Path : sig
 
   type t = { kind : kind; parent : t option; name : string }
 
-  type nonsrc_pv =
+  type any_pv =
     [ Identifier.Page.t_pv
     | Identifier.Signature.t_pv
-    | Identifier.ClassSignature.t_pv ]
-
-  type source_pv =
-    [ nonsrc_pv
+    | Identifier.ClassSignature.t_pv
     | Identifier.SourcePage.t_pv
     | Identifier.SourceDir.t_pv
     | Identifier.AssetFile.t_pv ]
 
-  and source = source_pv Odoc_model.Paths.Identifier.id
+  and any = any_pv Odoc_model.Paths.Identifier.id
 
-  val from_identifier : [< source_pv ] Odoc_model.Paths.Identifier.id -> t
+  val from_identifier : [< any_pv ] Odoc_model.Paths.Identifier.id -> t
 
   val to_list : t -> (kind * string) list
 

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -489,4 +489,4 @@ end
 
 let render ~with_children = function
   | Document.Page page -> [ Page.page ~with_children page ]
-  | Source_page _ -> []
+  | Source_page _ | Asset _ -> []

--- a/src/manpage/generator.ml
+++ b/src/manpage/generator.ml
@@ -562,4 +562,4 @@ and render_page (p : Page.t) =
 
 let render = function
   | Document.Page page -> [ render_page page ]
-  | Source_page _ -> []
+  | Source_page _ | Asset _ -> []

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -497,6 +497,7 @@ module rec Page : sig
     | Page_child of string
     | Module_child of string
     | Source_tree_child of string
+    | Asset_child of string
 
   type t = {
     name : Identifier.Page.t;

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -55,6 +55,7 @@ module Identifier = struct
     | `SourceDir (_, name) -> name
     | `SourceLocation (_, anchor) -> DefName.to_string anchor
     | `SourceLocationMod x -> name_aux (x :> t)
+    | `AssetFile (_, name) -> name
 
   let name : [< t_pv ] id -> string = fun n -> name_aux (n :> t)
 
@@ -282,6 +283,11 @@ module Identifier = struct
     type t_pv = Paths_types.Identifier.source_location_pv
   end
 
+  module AssetFile = struct
+    type t = Id.asset_file
+    type t_pv = Id.asset_file_pv
+  end
+
   module OdocId = struct
     type t = Id.odoc_id
     type t_pv = Id.odoc_id_pv
@@ -371,6 +377,9 @@ module Identifier = struct
         ContainerPage.t option * PageName.t ->
         [> `LeafPage of ContainerPage.t option * PageName.t ] id =
       mk_parent_opt PageName.to_string "lp" (fun (p, n) -> `LeafPage (p, n))
+
+    let asset_file : Page.t * string -> AssetFile.t =
+      mk_parent (fun k -> k) "asset" (fun (p, n) -> `AssetFile (p, n))
 
     let source_page (container_page, path) =
       let rec source_dir dir =

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -143,6 +143,11 @@ module Identifier : sig
     type t_pv = Id.source_location_pv
   end
 
+  module AssetFile : sig
+    type t = Id.asset_file
+    type t_pv = Id.asset_file_pv
+  end
+
   module OdocId : sig
     type t = Id.odoc_id
     type t_pv = Id.odoc_id_pv
@@ -218,6 +223,8 @@ module Identifier : sig
       [> `LeafPage of ContainerPage.t option * PageName.t ] id
 
     val source_page : ContainerPage.t * string list -> SourcePage.t
+
+    val asset_file : Page.t * string -> AssetFile.t
 
     val root :
       ContainerPage.t option * ModuleName.t ->

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -32,6 +32,14 @@ module Identifier = struct
   type source_page = source_page_pv id
   (** @canonical Odoc_model.Paths.Identifier.SourcePage.t *)
 
+  type asset_file_pv = [ `AssetFile of page * string ]
+  (** The second argument is the filename.
+
+    @canonical Odoc_model.Paths.Identifier.AssetFile.t_pv *)
+
+  type asset_file = asset_file_pv id
+  (** @canonical Odoc_model.Paths.Identifier.AssetFile.t *)
+
   type source_location_pv =
     [ `SourceLocationMod of source_page
     | `SourceLocation of source_page * DefName.t ]
@@ -214,7 +222,11 @@ module Identifier = struct
   (** @canonical Odoc_model.Paths.Identifier.NonSrc.t *)
 
   type any_pv =
-    [ non_src_pv | source_page_pv | source_dir_pv | source_location_pv ]
+    [ non_src_pv
+    | source_page_pv
+    | source_dir_pv
+    | source_location_pv
+    | asset_file_pv ]
   (** @canonical Odoc_model.Paths.Identifier.t_pv *)
 
   and any = any_pv id

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -74,6 +74,8 @@ module General_paths = struct
               ( "`LeafPage",
                 ((parent :> id_t option), name),
                 Pair (Option identifier, Names.pagename) )
+        | `AssetFile (parent, name) ->
+            C ("`AssetFile", ((parent :> id_t), name), Pair (identifier, string))
         | `Root (parent, name) ->
             C
               ( "`Root",

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -706,19 +706,27 @@ module Odoc_html_args = struct
       & opt (some convert_fpath) None
       & info [ "source" ] ~doc ~docv:"file.ml")
 
+  let assets =
+    let doc =
+      "Assets files. These must match the assets listed as children during the \
+       compile phase."
+    in
+    Arg.(
+      value & opt_all convert_fpath [] & info [ "asset" ] ~doc ~docv:"file.ext")
+
   let extra_args =
     let config semantic_uris closed_details indent theme_uri support_uri flat
-        as_json source_file =
+        as_json source_file assets =
       let open_details = not closed_details in
       let html_config =
         Odoc_html.Config.v ~theme_uri ~support_uri ~semantic_uris ~indent ~flat
           ~open_details ~as_json ()
       in
-      { Html_page.html_config; source_file }
+      { Html_page.html_config; source_file; assets }
     in
     Term.(
       const config $ semantic_uris $ closed_details $ indent $ theme_uri
-      $ support_uri $ flat $ as_json $ source_file)
+      $ support_uri $ flat $ as_json $ source_file $ assets)
 end
 
 module Odoc_html = Make_renderer (Odoc_html_args)

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -16,13 +16,17 @@
 
 open Odoc_model
 
-type args = { html_config : Odoc_html.Config.t; source_file : Fpath.t option }
+type args = {
+  html_config : Odoc_html.Config.t;
+  source_file : Fpath.t option;
+  assets : Fpath.t list;
+}
 
-let render { html_config; source_file = _ } page =
+let render { html_config; source_file = _; assets = _ } page =
   Odoc_html.Generator.render ~config:html_config page
 
-let extra_documents args unit ~syntax =
-  match (unit.Lang.Compilation_unit.source_info, args.source_file) with
+let source_documents source_info source_file ~syntax =
+  match (source_info, source_file) with
   | Some { Lang.Source_info.id; infos }, Some src -> (
       match Fs.File.read src with
       | Error (`Msg msg) ->
@@ -53,5 +57,47 @@ let extra_documents args unit ~syntax =
            (Fs.File.to_string src));
       []
   | None, None -> []
+
+exception Missing_asset of string
+
+let asset_documents parent_id children asset_paths =
+  let asset_names =
+    List.filter_map
+      (function Lang.Page.Asset_child name -> Some name | _ -> None)
+      children
+  in
+  let rec extract paths name =
+    match paths with
+    | [] -> raise (Missing_asset name)
+    | x :: xs when Fpath.basename x = name -> (xs, (name, x))
+    | x :: xs ->
+        let rest, elt = extract xs name in
+        (x :: rest, elt)
+  in
+  match List.fold_left_map extract asset_paths asset_names with
+  | unmatched, paired ->
+      List.iter
+        (fun asset ->
+          Error.raise_warning
+            (Error.filename_only "this asset was not declared as a child of %s"
+               (Paths.Identifier.name parent_id)
+               (Fs.File.to_string asset)))
+        unmatched;
+      List.map
+        (fun (name, path) ->
+          let asset_id = Paths.Identifier.Mk.asset_file (parent_id, name) in
+          let url = Odoc_document.Url.Path.from_identifier asset_id in
+          Odoc_document.Types.Document.Asset { url; src = path })
+        paired
+  | exception Missing_asset name ->
+      Error.raise_warning (Error.filename_only "asset is missing." name);
+      []
+
+let extra_documents args input ~syntax =
+  match input with
+  | Odoc_document.Renderer.CU unit ->
+      source_documents unit.Lang.Compilation_unit.source_info args.source_file
+        ~syntax
+  | Page page -> asset_documents page.Lang.Page.name page.children args.assets
 
 let renderer = { Odoc_document.Renderer.name = "html"; render; extra_documents }

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -16,6 +16,10 @@
 
 open Odoc_document
 
-type args = { html_config : Odoc_html.Config.t; source_file : Fpath.t option }
+type args = {
+  html_config : Odoc_html.Config.t;
+  source_file : Fpath.t option;
+  assets : Fpath.t list;
+}
 
 val renderer : args Renderer.t

--- a/src/odoc/source_tree.ml
+++ b/src/odoc/source_tree.ml
@@ -7,7 +7,7 @@ module Id = Paths.Identifier
 let check_is_child_of_parent siblings root_name =
   let check_child = function
     | Lang.Page.Source_tree_child n -> root_name = n
-    | Page_child _ | Module_child _ -> false
+    | Page_child _ | Asset_child _ | Module_child _ -> false
   in
   if List.exists check_child siblings then Ok ()
   else Error (`Msg "Specified parent is not a parent of this file")

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -1258,6 +1258,10 @@ module Fmt = struct
     | `SourceLocationMod p ->
         Format.fprintf ppf "%a#" model_identifier
           (p :> Odoc_model.Paths.Identifier.t)
+    | `AssetFile (p, name) ->
+        Format.fprintf ppf "%a/%s" model_identifier
+          (p :> Odoc_model.Paths.Identifier.t)
+          name
 
   and model_fragment ppf (f : Odoc_model.Paths.Fragment.t) =
     match f with

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -1046,6 +1046,7 @@ let page env page =
           | None -> Errors.report ~what `Lookup
         in
         match child with
+        | Page.Asset_child _
         | Page.Source_tree_child _ -> ()
         | Page.Page_child page ->
             check_resolves ~what:(`Child_page page) Env.lookup_page page

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -1046,8 +1046,7 @@ let page env page =
           | None -> Errors.report ~what `Lookup
         in
         match child with
-        | Page.Asset_child _
-        | Page.Source_tree_child _ -> ()
+        | Page.Asset_child _ | Page.Source_tree_child _ -> ()
         | Page.Page_child page ->
             check_resolves ~what:(`Child_page page) Env.lookup_page page
         | Page.Module_child mod_ ->

--- a/test/pages/assets.t/index.mld
+++ b/test/pages/assets.t/index.mld
@@ -1,0 +1,4 @@
+{0 Package page}
+
+Some image:
+{%html: <img src="img.jpg" />%}

--- a/test/pages/assets.t/run.t
+++ b/test/pages/assets.t/run.t
@@ -49,12 +49,13 @@ Which matches the output of the targets command (which emits no warning):
   html/index/index.html
 
 Trying to pass an asset which doesn't exist:
+(also: some sed magic due to cmdliner output changing based on the version)
 
-  $ odoc html-generate page-index.odocl --asset img.jpg -o html
+  $ odoc html-generate page-index.odocl --asset img.jpg -o html 2>&1 | \
+  > sed 's/…/.../' | sed "s/\`/'/g"
   odoc: option '--asset': no 'img.jpg' file or directory
-  Usage: odoc html-generate [OPTION]… FILE.odocl
+  Usage: odoc html-generate [OPTION]... FILE.odocl
   Try 'odoc html-generate --help' or 'odoc --help' for more information.
-  [2]
 
 Creating then passing the asset alongside an incorrect one:
 

--- a/test/pages/assets.t/run.t
+++ b/test/pages/assets.t/run.t
@@ -1,0 +1,91 @@
+Blablabla
+
+  $ cat index.mld
+  {0 Package page}
+  
+  Some image:
+  {%html: <img src="img.jpg" />%}
+
+And we'll have a module that we'll put underneath this package page.
+
+  $ cat test.mli 
+  (** Humpf, let's try accessing the asset:
+    {%html: <img src="../img.jpg" />%}
+    *)
+  
+  (** Nevermind *)
+  type t
+  
+
+Compile the module first
+
+  $ ocamlc -c -bin-annot test.mli
+
+Then we need to odoc-compile the package mld file, listing its children
+
+  $ odoc compile index.mld --child module-test --child asset-img.jpg
+
+This will have produced a file called 'page-index.odoc'.
+Now we can odoc-compile the module odoc file passing that file as parent.
+
+  $ odoc compile test.cmti -I . --parent index
+
+Link and generate the HTML (forgetting the asset!):
+
+  $ for i in *.odoc; do odoc link -I . $i; done
+  $ for i in *.odocl; do odoc html-generate $i -o html; done
+  File "img.jpg":
+  Warning: asset is missing.
+
+Note that the html was generated despite the missing asset (there might be dead refs!)
+
+  $ find html -type f | sort
+  html/index/Test/index.html
+  html/index/index.html
+
+Which matches the output of the targets command (which emits no warning):
+
+  $ odoc html-targets page-index.odocl -o html
+  html/index/index.html
+
+Trying to pass an asset which doesn't exist:
+
+  $ odoc html-generate page-index.odocl --asset img.jpg -o html
+  odoc: option '--asset': no 'img.jpg' file or directory
+  Usage: odoc html-generate [OPTION]… FILE.odocl
+  Try 'odoc html-generate --help' or 'odoc --help' for more information.
+  [2]
+
+Creating then passing the asset alongside an incorrect one:
+
+  $ touch img.jpg
+  $ odoc html-generate page-index.odocl --asset img.jpg --asset test.mli -o html
+  File "test.mli":
+  Warning: this asset was not declared as a child of index
+
+This time, the asset should have been copied at the right place:
+
+  $ find html -type f | sort
+  html/index/Test/index.html
+  html/index/img.jpg
+  html/index/index.html
+
+Which once again matches the output of the targets command (still no warning!):
+
+  $ odoc html-targets page-index.odocl --asset img.jpg --asset test.mli -o html
+  html/index/index.html
+  html/index/img.jpg
+
+Let's make sure the manpage and latex renderers "work" too
+
+  $ for i in *.odocl; do odoc man-generate $i -o man; odoc latex-generate $i -o latex; done
+
+  $ find man -type f | sort
+  man/index.3o
+  man/index/Test.3o
+
+  $ find latex -type f | sort
+  latex/index.tex
+  latex/index/Test.tex
+
+Notice that the assets are *not* there. This should probably be fixed for the latex backend.

--- a/test/pages/assets.t/test.mli
+++ b/test/pages/assets.t/test.mli
@@ -1,0 +1,7 @@
+(** Humpf, let's try accessing the asset:
+  {%html: <img src="../img.jpg" />%}
+  *)
+
+(** Nevermind *)
+type t
+


### PR DESCRIPTION
Context: #59 , #972

**No support for referring to assets yet.**
This only provides a way to get odoc to place them "in the right place" in the directory structure; so it's only marginally useful.

Current interface:
- children given to `odoc compile` can now be of the form `asset-filename`
- `html-generate` and `html-targets` commands now accept `--asset FILE` arguments, which are paired (based on filename) with the relevant child asset. Warnings are emitted for unknown and missing assets.
- files passed to `html-generate` through `--asset` are copied in the directory of their parent; would it be better to put them in an `_assets` subdirectory?

This is illustrated in `test/pages/assets.t/run.t`