### PR TITLE
Create .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# ocamlformat 0.17.0
+b0c03d1b76f7da7d88d40bbc5029accfa9228112
+# ocamlformat 0.19.0
+c5b7900eb40a48e2877db4994a2b2f8d755531e4
+# ocamlformat 0.22.4
+8b4a11d74af7dd4de0ae9463af3c9d563d758cfc
+# ocamlformat 0.25.1
+0f01f32f3b3adc849bc7cc859776763a9139da19


### PR DESCRIPTION
Ignore all ocamlformat commits for `git blame`.

For reference: [Ignore commits in the blame view](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)