### PR TITLE
Update version constraint on Yojson

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -51,7 +51,7 @@ depends: [
   "fmt"
 
   "ocamlfind" {with-test}
-  "yojson" {with-test}
+  "yojson" {>= "1.6.0" & with-test}
   ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
   "conf-jq" {with-test}
 


### PR DESCRIPTION
The version 1.6.0 contains a breaking change that we rely on.
This was caught by ocaml-ci's lower-bound check.