### PR TITLE
Creates a dedicated rule to generate support files

### DIFF
--- a/src/html_support_files/dune
+++ b/src/html_support_files/dune
@@ -2,7 +2,7 @@
 ; of the vendored projects.
 
 (rule
- (aliases runtest html-support-files)
+ (aliases runtest support-files)
  (enabled_if
   (> %{ocaml_version} 4.08))
  (deps

--- a/src/html_support_files/dune
+++ b/src/html_support_files/dune
@@ -2,7 +2,7 @@
 ; of the vendored projects.
 
 (rule
- (alias html-support-files)
+ (aliases runtest html-support-files)
  (enabled_if
   (> %{ocaml_version} 4.08))
  (deps

--- a/src/html_support_files/dune
+++ b/src/html_support_files/dune
@@ -2,7 +2,7 @@
 ; of the vendored projects.
 
 (rule
- (alias runtest)
+ (alias html-support-files)
  (enabled_if
   (> %{ocaml_version} 4.08))
  (deps


### PR DESCRIPTION
Currently, regenerating support files requires using the test rule, which feels weird because changing the css has very little to do with tests. It also allows to generate the support files without running the test more easily.