### PR TITLE
Improvements to benchmarks and profiling

### DIFF
--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -793,7 +793,7 @@ If needed, the list of the slowest commands for each subcommands can be shown by
 (for the record, these commands are run from directory `_build/default/doc`)
 
 {[
-# List.iter print_cmd (k_longest_commands "compile" 5)
+# (* List.iter print_cmd (k_longest_commands "compile" 5) *)
 # (* List.iter print_cmd (k_longest_commands "link" 5) *)
 # (* List.iter print_cmd (k_longest_commands "html-generate" 5) *)
 ]}

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -891,11 +891,32 @@ let compute_produced_cmd cmd =
           ];
       ]
 
+(** Analyze the size of files produced by a command. *)
+let compute_longest_cmd cmd =
+  match k_longest_commands cmd 1 with
+  | hd :: _ ->
+      [
+        `Assoc
+          [
+            ("name", `String ("longest-" ^ cmd));
+            ("value", `Float hd.time);
+            ("units", `String "s");
+            ( "description",
+              `String
+                ("Time taken by the longest invokation of 'odoc " ^ cmd ^ "'")
+            );
+            ("trend", `String "lower-is-better");
+          ];
+      ]
+  | [] -> []
+
 let metrics =
   compute_metric_cmd "compile"
   @ compute_metric_cmd "compile-deps"
   @ compute_metric_cmd "link"
   @ compute_metric_cmd "html-generate"
+  @ compute_longest_cmd "compile"
+  @ compute_longest_cmd "link"
   @ compute_produced_cmd "compile"
   @ compute_produced_cmd "link"
 

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -169,23 +169,34 @@ type executed_command = {
    the produced file. *)
 let commands = ref [ ]
 
+let instrument_dir =
+  lazy (
+    let dir = Fpath.v "landmarks" in
+    OS.Dir.delete dir |> get_ok;
+    OS.Dir.create dir |> get_ok |> ignore;
+    dir
+  )
+
 (* Environment variables passed to commands. *)
-let env =
-  let env = OS.Env.current () |> get_ok in
-  let env =
-    if instrument then (
-      let instrument_dir = Fpath.v "landmarks" in
-      OS.Dir.delete instrument_dir |> get_ok;
-      OS.Dir.create instrument_dir |> get_ok |> ignore;
-      Astring.String.Map.add "OCAML_LANDMARKS"
-        ("time,allocation,format=json,output=temporary:" ^ Fpath.to_string instrument_dir)
-        env
-    ) else env
-  in
-  env
+let env = OS.Env.current () |> get_ok
 
 let run ?output_file cmd =
   let t_start = Unix.gettimeofday () in
+  let env =
+    if instrument then
+      let lazy instrument_dir = instrument_dir in
+      let instrument_out =
+        match output_file with
+        | Some outf ->
+            Fpath.(/) instrument_dir (Fpath.basename outf ^ ".json")
+            |> Fpath.to_string
+        | None -> "temporary:" ^ Fpath.to_string instrument_dir
+      in
+      Astring.String.Map.add "OCAML_LANDMARKS"
+        ("time,allocation,format=json,output=" ^ instrument_out)
+        env
+    else env
+  in
   let r = OS.Cmd.(run_out ~env ~err:OS.Cmd.err_run_out cmd |> to_lines) |> get_ok in
   let t_end = Unix.gettimeofday () in
   let time = t_end -. t_start in


### PR DESCRIPTION
The first commit comment-out a command that should have been.

The second commit gives predictable and useful names to landmarks output files. Previously, names contained random numbers.

The third commit adds a benchmarks: The time spent running the slowest command. This metric might help recognize large performance regressions in rare cases that we might have missed otherwise.