### PR TITLE
Micro-optimize Ident.compare

### DIFF
--- a/src/xref2/ident.ml
+++ b/src/xref2/ident.ml
@@ -363,8 +363,7 @@ end
 
 let hash : any -> int = Hashtbl.hash
 
-let compare : any -> any -> int =
- fun a b -> compare (int_of_any a) (int_of_any b)
+let compare : any -> any -> int = fun a b -> int_of_any a - int_of_any b
 
 module Maps = struct
   module Module = Map.Make (struct


### PR DESCRIPTION
This function is called a very large amount of times. Surprisingly, it was calling the generic compare function.

This has a very small impact.