### PR TITLE
Reference driver: Generate docs for the parser module

### DIFF
--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -318,7 +318,7 @@ let dep_libraries =
 let odoc_libraries = [
     "odoc_xref_test"; "odoc_xref2"; "odoc_odoc"; "odoc_html_support_files";
     "odoc_model_desc"; "odoc_model"; "odoc_manpage"; "odoc_loader";
-    "odoc_latex"; "odoc_html"; "odoc_document"; "odoc_examples" ];;
+    "odoc_latex"; "odoc_html"; "odoc_document"; "odoc_examples"; "odoc_parser" ];;
 
 let all_libraries = dep_libraries @ odoc_libraries;;
 

--- a/doc/library_mlds/odoc_parser.mld
+++ b/doc/library_mlds/odoc_parser.mld
@@ -1,0 +1,3 @@
+{0 Odoc's parser}
+
+{!childmodule-Odoc_parser}


### PR DESCRIPTION
The parser's doc were not included anywhere since the remerge.

This PR simply includes the parser in the list of modules built by the driver.