### PR TITLE
Update odoc-parser's constraint on dune

### DIFF
--- a/odoc-parser.opam
+++ b/odoc-parser.opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/ocaml/odoc/issues"
 dev-repo: "git+https://github.com/ocaml/odoc.git"
 doc: "https://ocaml-doc.github.io/odoc-parser/"
 depends: [
-  "dune" {>= "2.8"}
+  "dune" {>= "3.7"}
   "ocaml" {>= "4.02.0"}
   "astring"
   "result"


### PR DESCRIPTION
Since the `dune-project` file now has

```
(lang dune 3.7)
```

it generates a warning to build the odoc parser with a too old version of dune.