### PR TITLE
Handle differences in sig_class for OCaml 5.1. (to master branch)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ Tags:
 ### Added
 - Display 'private' keyword for private type extensions (@gpetiot, #1019)
 
+### Fixed
+- Fix 5.1 support (@tmcgilchrist, #1018)
+
 # 2.3.0
 
 ### Added

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -1041,8 +1041,13 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
             else shadowed
           in
             loop (ModuleType mtd :: acc, shadowed) rest
+#if OCAML_VERSION < (5,1,0)
     | Sig_class(id, cl, rec_status, _) :: Sig_class_type _
       :: Sig_type _ :: Sig_type _ :: rest ->
+#else
+    | Sig_class(id, cl, rec_status, _) :: Sig_class_type _
+      :: Sig_type _ :: rest ->
+#endif
           let cl = read_class_declaration env parent id cl in
           let shadowed =
             if Env.is_shadowed env id
@@ -1050,7 +1055,11 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
             else shadowed
           in
             loop (Class (read_type_rec_status rec_status, cl)::acc, shadowed) rest
+#if OCAML_VERSION < (5,1,0)
     | Sig_class_type(id, cltyp, rec_status, _)::Sig_type _::Sig_type _::rest ->
+#else
+    | Sig_class_type(id, cltyp, rec_status, _)::Sig_type _::rest ->
+#endif
         let cltyp = read_class_type_declaration env parent id cltyp in
         let shadowed =
           if Env.is_shadowed env id


### PR DESCRIPTION
Cherry pick changes from #1018.

Is everyone happy with me not picking the rename from `cmi.ml` to `cmi.cppo.ml`?