### PR TITLE
Handle differences in sig_class for OCaml 5.1. (to `v2.3` branch)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,11 @@ Tags:
 - Internal
 -->
 
-# 2.3.0 (Unreleased)
+# 2.3.1 (Unreleased)
+
+- Fix 5.1 support (@tmcgilchrist, #1018)
+
+# 2.3.0
 
 ### Added
 - Source code rendering (@Julow, @panglesd, @jonludlam #909, #996, #993, #982)

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -1041,8 +1041,13 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
             else shadowed
           in
             loop (ModuleType mtd :: acc, shadowed) rest
+#if OCAML_VERSION < (5,1,0)
     | Sig_class(id, cl, rec_status, _) :: Sig_class_type _
       :: Sig_type _ :: Sig_type _ :: rest ->
+#else
+    | Sig_class(id, cl, rec_status, _) :: Sig_class_type _
+      :: Sig_type _ :: rest ->
+#endif
           let cl = read_class_declaration env parent id cl in
           let shadowed =
             if Env.is_shadowed env id
@@ -1050,7 +1055,11 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
             else shadowed
           in
             loop (Class (read_type_rec_status rec_status, cl)::acc, shadowed) rest
+#if OCAML_VERSION < (5,1,0)
     | Sig_class_type(id, cltyp, rec_status, _)::Sig_type _::Sig_type _::rest ->
+#else
+    | Sig_class_type(id, cltyp, rec_status, _)::Sig_type _::rest ->
+#endif
         let cltyp = read_class_type_declaration env parent id cltyp in
         let shadowed =
           if Env.is_shadowed env id


### PR DESCRIPTION
Cherry pick changes from https://github.com/ocaml/odoc/pull/1018, without the file rename.