### PR TITLE
Update tyxml constraint

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -47,7 +47,7 @@ depends: [
   "fpath"
   "ocaml" {>= "4.02.0"}
   "result"
-  "tyxml" {>= "4.3.0"}
+  "tyxml" {>= "4.4.0"}
   "fmt"
 
   "ocamlfind" {with-test}


### PR DESCRIPTION
Since table support, odoc is incompatible with tyxml 4.3.0.

See https://github.com/ocaml/opam-repository/pull/24686.