### PR TITLE
Improve performances of Find functions

### DIFF
--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -758,37 +758,7 @@ Let's see if there was any output from the [odoc] invocations:
 {[
 # !compile_output;;
 - : string list = [""]
-# !link_output;;
-- : string list =
-["";
- "'../src/odoc/bin/main.exe' 'link' 'odoc_html_frontend.odoc' '-o' 'odoc_html_frontend.odocl' '-I' '.'";
- "odoc_html_frontend.odoc: File \"src/search/odoc_html_frontend.mli\", line 3, characters 15-25:";
- "odoc_html_frontend.odoc: Warning: Failed to resolve reference unresolvedroot(Entry).t Couldn't find \"Entry\"";
- "'../src/odoc/bin/main.exe' 'link' 'page-deps.odoc' '-o' 'page-deps.odocl' '-I' '.'";
- "page-deps.odoc: File \"src/fmt.mli\", line 6, characters 4-13:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Format) Couldn't find \"Format\"";
- "page-deps.odoc: File \"deps.mld\", line 27, characters 0-79:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Bi_vint) Parent_module: Lookup failure (root module): Bi_vint";
- "page-deps.odoc: File \"deps.mld\", line 27, characters 0-79:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Bi_util) Parent_module: Lookup failure (root module): Bi_util";
- "page-deps.odoc: File \"deps.mld\", line 27, characters 0-79:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Bi_stream) Parent_module: Lookup failure (root module): Bi_stream";
- "page-deps.odoc: File \"deps.mld\", line 27, characters 0-79:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Bi_share) Parent_module: Lookup failure (root module): Bi_share";
- "page-deps.odoc: File \"deps.mld\", line 27, characters 0-79:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Bi_outbuf) Parent_module: Lookup failure (root module): Bi_outbuf";
- "page-deps.odoc: File \"deps.mld\", line 27, characters 0-79:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Bi_io) Parent_module: Lookup failure (root module): Bi_io";
- "page-deps.odoc: File \"deps.mld\", line 27, characters 0-79:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Bi_inbuf) Parent_module: Lookup failure (root module): Bi_inbuf";
- "page-deps.odoc: File \"deps.mld\", line 27, characters 0-79:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Bi_dump) Parent_module: Lookup failure (root module): Bi_dump";
- "page-deps.odoc: File \"src/fpath.mli\", line 8, characters 8-20:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Map) Couldn't find \"Map\"";
- "page-deps.odoc: File \"src/fpath.mli\", line 7, characters 59-71:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(Set) Couldn't find \"Set\"";
- "page-deps.odoc: File \"src/fpath.mli\", line 7, characters 28-52:";
- "page-deps.odoc: Warning: Failed to resolve reference unresolvedroot(file_exts) Couldn't find \"file_exts\""]
+# (* Not showing output from 'odoc link' as it is unstable. !link_output *);;
 # !source_tree_output;;
 - : string list = [""]
 # !generate_output;;
@@ -809,6 +779,7 @@ index.html
 interface.html
 katex.min.css
 katex.min.js
+ocamlary
 ocamldoc_differences.html
 odoc.css
 odoc_document
@@ -831,38 +802,6 @@ odoc_xref2
 odoc_xref_test
 parent_child_spec.html
 source
-$ ls html/odoc/deps
-astring
-cmdliner
-fmt
-fpath
-index.html
-odoc-parser
-result
-stdlib
-tyxml
-yojson
-$ find html/odoc/deps | sort | tail -n 20
-html/odoc/deps/tyxml/Xml_wrap/NoWrap
-html/odoc/deps/tyxml/Xml_wrap/NoWrap/index.html
-html/odoc/deps/yojson
-html/odoc/deps/yojson/index.html
-html/odoc/deps/yojson/Yojson
-html/odoc/deps/yojson/Yojson/Basic
-html/odoc/deps/yojson/Yojson/Basic/index.html
-html/odoc/deps/yojson/Yojson/Basic/Util
-html/odoc/deps/yojson/Yojson/Basic/Util/index.html
-html/odoc/deps/yojson/Yojson/index.html
-html/odoc/deps/yojson/Yojson/Lexer_state
-html/odoc/deps/yojson/Yojson/Lexer_state/index.html
-html/odoc/deps/yojson/Yojson/Raw
-html/odoc/deps/yojson/Yojson/Raw/index.html
-html/odoc/deps/yojson/Yojson/Raw/Util
-html/odoc/deps/yojson/Yojson/Raw/Util/index.html
-html/odoc/deps/yojson/Yojson/Safe
-html/odoc/deps/yojson/Yojson/Safe/index.html
-html/odoc/deps/yojson/Yojson/Safe/Util
-html/odoc/deps/yojson/Yojson/Safe/Util/index.html
 $ find html/odoc/odoc_html | sort
 html/odoc/odoc_html
 html/odoc/odoc_html/index.html

--- a/dune
+++ b/dune
@@ -12,4 +12,6 @@
 (rule
  (alias bench)
  (action
-  (cat doc/driver-benchmarks.json)))
+  (progn
+   (bash "diff doc/driver.mld doc/driver.mld.corrected >&2 || true")
+   (cat doc/driver-benchmarks.json))))

--- a/odoc-bench.opam
+++ b/odoc-bench.opam
@@ -41,5 +41,6 @@ depends: [
   "bos"
   "yojson" {>= "1.6.0"}
   "mdx" {>= "2.3.0"}
-  "core"
+  "core" {= "v0.16.2"}
+  "core_kernel" {= "v0.16.0"}
 ]

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -70,6 +70,8 @@ module Delayed = struct
     else { v = None; get = Some f }
 
   let put_val : 'a -> 'a t = fun v -> { v = Some v; get = None }
+
+  let map f t = put (fun () -> f (get t))
 end
 
 module Opt = struct

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -31,6 +31,8 @@ module Delayed : sig
   val put : (unit -> 'a) -> 'a t
 
   val put_val : 'a -> 'a t
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
 end
 
 module Opt : sig

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -55,6 +55,16 @@ type method_ = [ `FMethod of MethodName.t * Method.t ]
 
 type any_in_class_sig = [ instance_variable | method_ ]
 
+type sig_ctx = Signature.t
+type type_ctx = TypeDecl.t
+type typext_ctx = Extension.t
+type class_sig_ctx = ClassSignature.t
+
+let context_of_sig sg = sg
+let context_of_type typ = typ
+let context_of_typext ext = ext
+let context_of_class_sig csig = csig
+
 module N = Ident.Name
 
 let rec find_map f = function

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -1,9 +1,9 @@
 open Odoc_model.Names
 open Component
 
-type module_ = [ `FModule of ModuleName.t * Module.t ]
+type module_ = [ `FModule of ModuleName.t * Module.t Delayed.t ]
 
-type module_type = [ `FModuleType of ModuleTypeName.t * ModuleType.t ]
+type module_type = [ `FModuleType of ModuleTypeName.t * ModuleType.t Delayed.t ]
 
 type datatype = [ `FType of TypeName.t * TypeDecl.t ]
 
@@ -11,7 +11,7 @@ type class_ =
   [ `FClass of ClassName.t * Class.t
   | `FClassType of ClassTypeName.t * ClassType.t ]
 
-type value = [ `FValue of ValueName.t * Value.t ]
+type value = [ `FValue of ValueName.t * Value.t Delayed.t ]
 
 type label = [ `FLabel of Label.t ]
 
@@ -102,13 +102,13 @@ let rec disambiguate = function
 let module_in_sig sg name =
   find_in_sig sg (function
     | Signature.Module (id, _, m) when N.module_ id = name ->
-        Some (`FModule (N.typed_module id, Delayed.get m))
+        Some (`FModule (N.typed_module id, m))
     | _ -> None)
 
 let module_type_in_sig sg name =
   find_in_sig sg (function
     | Signature.ModuleType (id, mt) when N.module_type id = name ->
-        Some (`FModuleType (N.typed_module_type id, Delayed.get mt))
+        Some (`FModuleType (N.typed_module_type id, mt))
     | _ -> None)
 
 let type_in_sig sg name =
@@ -250,18 +250,18 @@ let any_in_comment d name =
 let any_in_sig sg name =
   filter_in_sig sg (function
     | Signature.Module (id, _, m) when N.module_ id = name ->
-        Some (`FModule (N.typed_module id, Delayed.get m))
+        Some (`FModule (N.typed_module id, m))
     | ModuleSubstitution (id, ms) when N.module_ id = name ->
         Some (`FModule_subst ms)
     | ModuleType (id, mt) when N.module_type id = name ->
-        Some (`FModuleType (N.typed_module_type id, Delayed.get mt))
+        Some (`FModuleType (N.typed_module_type id, mt))
     | Type (id, _, t) when N.type_ id = name ->
         Some (`FType (N.type' id, Delayed.get t))
     | TypeSubstitution (id, ts) when N.type_ id = name -> Some (`FType_subst ts)
     | Exception (id, exc) when N.exception_ id = name ->
         Some (`FExn (N.typed_exception id, exc))
     | Value (id, v) when N.value id = name ->
-        Some (`FValue (N.typed_value id, Delayed.get v))
+        Some (`FValue (N.typed_value id, v))
     | Class (id, _, c) when N.class_ id = name ->
         Some (`FClass (N.class' id, c))
     | ClassType (id, _, ct) when N.class_type id = name ->
@@ -278,21 +278,21 @@ let any_in_sig sg name =
 let signature_in_sig sg name =
   filter_in_sig sg (function
     | Signature.Module (id, _, m) when N.module_ id = name ->
-        Some (`FModule (N.typed_module id, Delayed.get m))
+        Some (`FModule (N.typed_module id, m))
     | ModuleType (id, mt) when N.module_type id = name ->
-        Some (`FModuleType (N.typed_module_type id, Delayed.get mt))
+        Some (`FModuleType (N.typed_module_type id, mt))
     | _ -> None)
 
 let module_type_in_sig sg name =
   find_in_sig sg (function
     | Signature.ModuleType (id, m) when N.module_type id = name ->
-        Some (`FModuleType (N.typed_module_type id, Delayed.get m))
+        Some (`FModuleType (N.typed_module_type id, m))
     | _ -> None)
 
 let value_in_sig sg name =
   filter_in_sig sg (function
     | Signature.Value (id, m) when N.value id = name ->
-        Some (`FValue (N.typed_value id, Delayed.get m))
+        Some (`FValue (N.typed_value id, m))
     | _ -> None)
 
 let value_in_sig_unambiguous sg name = disambiguate (value_in_sig sg name)
@@ -321,9 +321,9 @@ let extension_in_sig sg name =
 let label_parent_in_sig sg name =
   filter_in_sig sg (function
     | Signature.Module (id, _, m) when N.module_ id = name ->
-        Some (`FModule (N.typed_module id, Component.Delayed.get m))
+        Some (`FModule (N.typed_module id, m))
     | ModuleType (id, mt) when N.module_type id = name ->
-        Some (`FModuleType (N.typed_module_type id, Component.Delayed.get mt))
+        Some (`FModuleType (N.typed_module_type id, mt))
     | Type (id, _, t) when N.type_ id = name ->
         Some (`FType (N.type' id, Component.Delayed.get t))
     | Class (id, _, c) when N.class_ id = name ->

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -15,9 +15,9 @@ val context_of_type : TypeDecl.t -> type_ctx
 val context_of_typext : Extension.t -> typext_ctx
 val context_of_class_sig : ClassSignature.t -> class_sig_ctx
 
-type module_ = [ `FModule of ModuleName.t * Module.t ]
+type module_ = [ `FModule of ModuleName.t * Module.t Delayed.t ]
 
-type module_type = [ `FModuleType of ModuleTypeName.t * ModuleType.t ]
+type module_type = [ `FModuleType of ModuleTypeName.t * ModuleType.t Delayed.t ]
 
 type datatype = [ `FType of TypeName.t * TypeDecl.t ]
 
@@ -25,7 +25,7 @@ type class_ =
   [ `FClass of ClassName.t * Class.t
   | `FClassType of ClassTypeName.t * ClassType.t ]
 
-type value = [ `FValue of ValueName.t * Value.t ]
+type value = [ `FValue of ValueName.t * Value.t Delayed.t ]
 
 type label = [ `FLabel of Label.t ]
 

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -2,6 +2,19 @@
 open Odoc_model.Names
 open Component
 
+(** Context in which to perform search. Every search operation needs a context.
+    The context can be expensive to compute. *)
+
+type sig_ctx
+type type_ctx
+type typext_ctx
+type class_sig_ctx
+
+val context_of_sig : Signature.t -> sig_ctx
+val context_of_type : TypeDecl.t -> type_ctx
+val context_of_typext : Extension.t -> typext_ctx
+val context_of_class_sig : ClassSignature.t -> class_sig_ctx
+
 type module_ = [ `FModule of ModuleName.t * Module.t ]
 
 type module_type = [ `FModuleType of ModuleTypeName.t * ModuleType.t ]
@@ -57,52 +70,52 @@ type any_in_class_sig = [ instance_variable | method_ ]
 
 (** Lookup by name, unambiguous *)
 
-val module_in_sig : Signature.t -> string -> module_ option
+val module_in_sig : sig_ctx -> string -> module_ option
 
-val type_in_sig : Signature.t -> string -> type_ option
+val type_in_sig : sig_ctx -> string -> type_ option
 
-val datatype_in_sig : Signature.t -> string -> datatype option
+val datatype_in_sig : sig_ctx -> string -> datatype option
 
-val module_type_in_sig : Signature.t -> string -> module_type option
+val module_type_in_sig : sig_ctx -> string -> module_type option
 
-val exception_in_sig : Signature.t -> string -> exception_ option
+val exception_in_sig : sig_ctx -> string -> exception_ option
 
-val extension_in_sig : Signature.t -> string -> extension option
+val extension_in_sig : sig_ctx -> string -> extension option
 
-val any_in_type : TypeDecl.t -> string -> any_in_type option
+val any_in_type : type_ctx -> string -> any_in_type option
 
-val constructor_in_type : TypeDecl.t -> string -> constructor option
+val constructor_in_type : type_ctx -> string -> constructor option
 
-val any_in_typext : Extension.t -> string -> extension option
+val any_in_typext : typext_ctx -> string -> extension option
 
-val method_in_class_signature : ClassSignature.t -> string -> method_ option
+val method_in_class_signature : class_sig_ctx -> string -> method_ option
 
 val instance_variable_in_class_signature :
-  ClassSignature.t -> string -> instance_variable option
+  class_sig_ctx -> string -> instance_variable option
 
 (** Maybe ambiguous *)
 
-val class_in_sig : Signature.t -> string -> class_ list
+val class_in_sig : sig_ctx -> string -> class_ list
 
-val signature_in_sig : Signature.t -> string -> signature list
+val signature_in_sig : sig_ctx -> string -> signature list
 
-val value_in_sig : Signature.t -> string -> value list
+val value_in_sig : sig_ctx -> string -> value list
 
-val label_in_sig : Signature.t -> string -> label list
+val label_in_sig : sig_ctx -> string -> label list
 
-val label_parent_in_sig : Signature.t -> string -> label_parent list
+val label_parent_in_sig : sig_ctx -> string -> label_parent list
 
-val any_in_sig : Signature.t -> string -> any_in_sig list
+val any_in_sig : sig_ctx -> string -> any_in_sig list
 
-val any_in_type_in_sig : Signature.t -> string -> any_in_type_in_sig list
+val any_in_type_in_sig : sig_ctx -> string -> any_in_type_in_sig list
 
-val any_in_class_signature : ClassSignature.t -> string -> any_in_class_sig list
+val any_in_class_signature : class_sig_ctx -> string -> any_in_class_sig list
 
 (** Disambiguated lookups, returns the last match. *)
 
-val class_in_sig_unambiguous : Signature.t -> string -> class_ option
+val class_in_sig_unambiguous : sig_ctx -> string -> class_ option
 
-val value_in_sig_unambiguous : Signature.t -> string -> value option
+val value_in_sig_unambiguous : sig_ctx -> string -> value option
 
 (** Lookup removed items *)
 
@@ -120,13 +133,12 @@ type careful_datatype = [ datatype | removed_type ]
 
 type careful_class = [ class_ | removed_type ]
 
-val careful_module_in_sig : Signature.t -> string -> careful_module option
+val careful_module_in_sig : sig_ctx -> string -> careful_module option
 
-val careful_module_type_in_sig :
-  Signature.t -> string -> careful_module_type option
+val careful_module_type_in_sig : sig_ctx -> string -> careful_module_type option
 
-val careful_type_in_sig : Signature.t -> string -> careful_type option
+val careful_type_in_sig : sig_ctx -> string -> careful_type option
 
-val careful_datatype_in_sig : Signature.t -> string -> careful_datatype option
+val careful_datatype_in_sig : sig_ctx -> string -> careful_datatype option
 
-val careful_class_in_sig : Signature.t -> string -> careful_class option
+val careful_class_in_sig : sig_ctx -> string -> careful_class option

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -202,6 +202,7 @@ module M = struct
     let sg = Tools.prefix_signature (parent_cp, sg) in
     find Find.module_in_sig (Find.context_of_sig sg) name
     >>= fun (`FModule (name, m)) ->
+    let m = Component.Delayed.get m in
     Ok (of_component env m (`Module (parent_cp, name)) (`Module (parent, name)))
 
   let of_element env (`Module (id, m)) : t =
@@ -234,7 +235,7 @@ module MT = struct
     find Find.module_type_in_sig (Find.context_of_sig sg) name
     >>= fun (`FModuleType (name, mt)) ->
     Ok
-      (of_component env mt
+      (of_component env (Component.Delayed.get mt)
          (`ModuleType (parent_cp, name))
          (`ModuleType (parent', name)))
 
@@ -572,13 +573,13 @@ module LP = struct
     >>= function
     | `FModule (name, m) ->
         module_lookup_to_signature_lookup env
-          (M.of_component env m
+          (M.of_component env (Component.Delayed.get m)
              (`Module (parent_cp, name))
              (`Module (parent', name)))
         >>= fun s -> Ok (`S s)
     | `FModuleType (name, mt) ->
         module_type_lookup_to_signature_lookup env
-          (MT.of_component env mt
+          (MT.of_component env (Component.Delayed.get mt)
              (`ModuleType (parent_cp, name))
              (`ModuleType (parent', name)))
         >>= fun s -> Ok (`S s)
@@ -664,12 +665,12 @@ and resolve_signature_reference :
         >>= function
         | `FModule (name, m) ->
             module_lookup_to_signature_lookup env
-              (M.of_component env m
+              (M.of_component env (Component.Delayed.get m)
                  (`Module (parent_cp, name))
                  (`Module (parent, name)))
         | `FModuleType (name, mt) ->
             module_type_lookup_to_signature_lookup env
-              (MT.of_component env mt
+              (MT.of_component env (Component.Delayed.get mt)
                  (`ModuleType (parent_cp, name))
                  (`ModuleType (parent, name))))
   in
@@ -729,12 +730,12 @@ let resolve_reference_dot_sg env ~parent_path ~parent_ref ~parent_sg name =
   >>= function
   | `FModule (name, m) ->
       resolved3
-        (M.of_component env m
+        (M.of_component env (Component.Delayed.get m)
            (`Module (parent_path, name))
            (`Module (parent_ref, name)))
   | `FModuleType (name, mt) ->
       resolved3
-        (MT.of_component env mt
+        (MT.of_component env (Component.Delayed.get mt)
            (`ModuleType (parent_path, name))
            (`ModuleType (parent_ref, name)))
   | `FType (name, t) -> DT.of_component env t ~parent_ref name >>= resolved2

--- a/src/xref2/tools.mli
+++ b/src/xref2/tools.mli
@@ -194,15 +194,6 @@ val reresolve_class_type :
 
 val reresolve_parent : Env.t -> Cpath.Resolved.parent -> Cpath.Resolved.parent
 
-val handle_module_type_lookup :
-  Env.t ->
-  add_canonical:bool ->
-  string ->
-  Cpath.Resolved.parent ->
-  Component.Signature.t ->
-  Component.Substitution.t ->
-  (Cpath.Resolved.module_type * Component.ModuleType.t) option
-
 type module_modifiers =
   [ `Aliased of Cpath.Resolved.module_ | `SubstMT of Cpath.Resolved.module_type ]
 
@@ -344,15 +335,6 @@ val fragmap :
     and signature [sg], and a fragment substitution (e.g.
     [ModuleSubst] to destructively substitute a module), and returns the substituted
     signature. *)
-
-val handle_signature_with_subs :
-  mark_substituted:bool ->
-  Env.t ->
-  Component.Signature.t ->
-  Component.ModuleType.substitution list ->
-  (Component.Signature.t, expansion_of_module_error) Result.result
-(** [handle_signature_with_subs ~mark_substituted env sg subs] applies the
-    fragment modifiers [subs], in order, to the supplied signature [sg]. *)
 
 (** {2 Cache handling} *)
 

--- a/test/xref2/labels/ambiguous_label.t/run.t
+++ b/test/xref2/labels/ambiguous_label.t/run.t
@@ -10,6 +10,8 @@ Labels don't follow OCaml's scoping rules:
     File "test.ml", line 3, character 4
     File "test.ml", line 18, character 4
     File "test.ml", line 9, character 4
+  File "test_2.ml", line 1, characters 4-55:
+  Warning: Reference to 'example' is ambiguous. Please specify its kind: section-example, section-example, section-example.
 
 Contains some ambiguous labels:
 


### PR DESCRIPTION
This is a work in progress. I'm opening a PR to use ocaml-benchmarks.

Swap the implementation of `Find` for one that first index the entire signature using a Hashtbl. These linear search functions perform poorly on some modules containing a large amount of items (for example, `Html_sigs` in tyxml).

The datastructure construction is cached with hopefully a large rate of cache hit. This also removes the large amount of code duplication in the find functions.