### PR TITLE
fixes anchor appearing bellow search bar

### DIFF
--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -95,7 +95,10 @@
 
 :root,
 .light:root {
-   --main-background: #FFFFFF;
+
+  scroll-padding-top: 100px;
+
+  --main-background: #FFFFFF;
 
   --color: #333333;
   --link-color: #2C94BD;

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -96,7 +96,7 @@
 :root,
 .light:root {
 
-  scroll-padding-top: 100px;
+  scroll-padding-top: calc(var(--search-bar-height) + var(--search-padding-top) + 1em);
 
   --main-background: #FFFFFF;
 


### PR DESCRIPTION
It used to be that the when following a link to an anchor, the anchor would appear a the top of the view, which was under the new search bar. This adds a margin of a 100px to such jumps. 