### PR TITLE
Avoid running the reference when running `dune build` at the root of the project.

### DIFF
--- a/dune
+++ b/dune
@@ -9,6 +9,14 @@
   (flags
    (:standard -g -w -18-53))))
 
+; Note: We exclude any other directory from the default alias, to avoid building
+; docs targets when running `dune build` in the root directory.
+
+(alias
+ (name default)
+ (deps
+  (alias_rec src/default)))
+
 (rule
  (alias bench)
  (action


### PR DESCRIPTION
The default alias will build every target known to dune. Since the addition of benchmarking, the rule running the reference driver does have a target, and was runned at each invokation of `dune build` in the root of the project.

This makes the default rules of the root directory an alias for the default rule of the `src` directory, avoiding running the reference driver too often (it also removes some rules in test from the root default alias).