### PR TITLE
tells if a search entry is child of a module type

### DIFF
--- a/src/search/entry.ml
+++ b/src/search/entry.ml
@@ -72,6 +72,67 @@ type t = {
   kind : kind;
 }
 
+let rec is_from_module_type (id : Odoc_model.Paths.Identifier.Any.t) =
+  match id.iv with
+  | `InstanceVariable (parent, _name) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Parameter (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Module (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `SourceDir (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `ModuleType _ -> true
+  | `Method (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `AssetFile (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Field (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `SourceLocationMod parent ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Result parent ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Type (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Label (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Exception (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Class (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Page (parent, _) -> (
+      match parent with
+      | None -> false
+      | Some parent ->
+          is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t))
+  | `LeafPage (parent, _) -> (
+      match parent with
+      | None -> false
+      | Some parent ->
+          is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t))
+  | `CoreType _ -> false
+  | `SourceLocation (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `ClassType (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `SourcePage (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Value (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `CoreException _ -> false
+  | `Constructor (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `Root _ -> false
+  | `Extension (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `ExtensionDecl (parent, _, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+  | `SourceLocationInternal (parent, _) ->
+      is_from_module_type (parent :> Odoc_model.Paths.Identifier.Any.t)
+
+let is_from_module_type { id; _ } = is_from_module_type id
+
 let entry ~id ~doc ~kind =
   let id = (id :> Odoc_model.Paths.Identifier.Any.t) in
   { id; kind; doc }

--- a/src/search/entry.mli
+++ b/src/search/entry.mli
@@ -61,5 +61,11 @@ type t = {
   kind : kind;
 }
 
+val is_from_module_type : t -> bool
+(** [is_from_module_type e] is true if the entry [e] is the child of a module
+    type. This information can be important because such entries do not have
+    implementations and tend to have very generic names like [compare], so a
+    search engine might want to rank them lower. *)
+
 val entries_of_item :
   Odoc_model.Paths.Identifier.Any.t -> Odoc_model.Fold.item -> t list


### PR DESCRIPTION
Adds a function that tells if an entry is the child of a module type
this is useful because search entry from module types might be given a different priority in search results