### PR TITLE
html: Output meta charset before any stylesheet

### DIFF
--- a/src/html/html_page.ml
+++ b/src/html/html_page.ml
@@ -93,8 +93,8 @@ let default_meta_elements ~config ~url =
   let theme_uri = Config.theme_uri config in
   let odoc_css_uri = file_uri ~config ~url theme_uri "odoc.css" in
   [
-    Html.link ~rel:[ `Stylesheet ] ~href:odoc_css_uri ();
     Html.meta ~a:[ Html.a_charset "utf-8" ] ();
+    Html.link ~rel:[ `Stylesheet ] ~href:odoc_css_uri ();
     Html.meta
       ~a:[ Html.a_name "generator"; Html.a_content "odoc %%VERSION%%" ]
       ();

--- a/test/generators/html/Alerts-Top1.html
+++ b/test/generators/html/Alerts-Top1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Top1 (Alerts.Top1)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Top1 (Alerts.Top1)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Alerts-Top2.html
+++ b/test/generators/html/Alerts-Top2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Top2 (Alerts.Top2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Top2 (Alerts.Top2)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Alerts.html
+++ b/test/generators/html/Alerts.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Alerts (Alerts)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Alerts (Alerts)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Alias-X.html
+++ b/test/generators/html/Alias-X.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Alias.X)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>X (Alias.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Alias.html
+++ b/test/generators/html/Alias.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Alias (Alias)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Alias (Alias)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Bugs.html
+++ b/test/generators/html/Bugs.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Bugs (Bugs)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Bugs (Bugs)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Bugs_post_406-class-let_open'.html
+++ b/test/generators/html/Bugs_post_406-class-let_open'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>let_open' (Bugs_post_406.let_open')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Bugs_post_406-class-type-let_open.html
+++ b/test/generators/html/Bugs_post_406-class-type-let_open.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>let_open (Bugs_post_406.let_open)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Bugs_post_406.html
+++ b/test/generators/html/Bugs_post_406.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Bugs_post_406 (Bugs_post_406)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Bugs_post_406 (Bugs_post_406)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class-class-empty_virtual'.html
+++ b/test/generators/html/Class-class-empty_virtual'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>empty_virtual' (Class.empty_virtual')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class-class-mutually'.html
+++ b/test/generators/html/Class-class-mutually'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>mutually' (Class.mutually')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>mutually' (Class.mutually')</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class-class-polymorphic'.html
+++ b/test/generators/html/Class-class-polymorphic'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>polymorphic' (Class.polymorphic')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class-class-recursive'.html
+++ b/test/generators/html/Class-class-recursive'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>recursive' (Class.recursive')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>recursive' (Class.recursive')</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class-class-type-empty.html
+++ b/test/generators/html/Class-class-type-empty.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>empty (Class.empty)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>empty (Class.empty)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class-class-type-empty_virtual.html
+++ b/test/generators/html/Class-class-type-empty_virtual.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>empty_virtual (Class.empty_virtual)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class-class-type-mutually.html
+++ b/test/generators/html/Class-class-type-mutually.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>mutually (Class.mutually)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>mutually (Class.mutually)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class-class-type-polymorphic.html
+++ b/test/generators/html/Class-class-type-polymorphic.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>polymorphic (Class.polymorphic)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>polymorphic (Class.polymorphic)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class-class-type-recursive.html
+++ b/test/generators/html/Class-class-type-recursive.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>recursive (Class.recursive)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>recursive (Class.recursive)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class.html
+++ b/test/generators/html/Class.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Class (Class)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Class (Class)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Class_comments-class-c.html
+++ b/test/generators/html/Class_comments-class-c.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>c (Class_comments.c)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>c (Class_comments.c)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class_comments-class-x.html
+++ b/test/generators/html/Class_comments-class-x.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>x (Class_comments.x)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>x (Class_comments.x)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Class_comments.html
+++ b/test/generators/html/Class_comments.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Class_comments (Class_comments)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Class_comments (Class_comments)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/External.html
+++ b/test/generators/html/External.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>External (External)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>External (External)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor-F1-argument-1-Arg.html
+++ b/test/generators/html/Functor-F1-argument-1-Arg.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Functor.F1.Arg)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Arg (Functor.F1.Arg)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor-F1.html
+++ b/test/generators/html/Functor-F1.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>F1 (Functor.F1)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>F1 (Functor.F1)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Functor-F2-argument-1-Arg.html
+++ b/test/generators/html/Functor-F2-argument-1-Arg.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Functor.F2.Arg)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Arg (Functor.F2.Arg)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor-F2.html
+++ b/test/generators/html/Functor-F2.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>F2 (Functor.F2)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>F2 (Functor.F2)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Functor-F3-argument-1-Arg.html
+++ b/test/generators/html/Functor-F3-argument-1-Arg.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Functor.F3.Arg)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Arg (Functor.F3.Arg)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor-F3.html
+++ b/test/generators/html/Functor-F3.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>F3 (Functor.F3)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>F3 (Functor.F3)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Functor-F4-argument-1-Arg.html
+++ b/test/generators/html/Functor-F4-argument-1-Arg.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Functor.F4.Arg)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Arg (Functor.F4.Arg)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor-F4.html
+++ b/test/generators/html/Functor-F4.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>F4 (Functor.F4)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>F4 (Functor.F4)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Functor-F5.html
+++ b/test/generators/html/Functor-F5.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>F5 (Functor.F5)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>F5 (Functor.F5)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Functor-module-type-S.html
+++ b/test/generators/html/Functor-module-type-S.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Functor.S)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S (Functor.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Functor-module-type-S1-argument-1-_.html
+++ b/test/generators/html/Functor-module-type-S1-argument-1-_.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>_ (Functor.S1._)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>_ (Functor.S1._)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor-module-type-S1.html
+++ b/test/generators/html/Functor-module-type-S1.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S1 (Functor.S1)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S1 (Functor.S1)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Functor.html
+++ b/test/generators/html/Functor.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Functor (Functor)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Functor (Functor)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor2-X-argument-1-Y.html
+++ b/test/generators/html/Functor2-X-argument-1-Y.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Functor2.X.Y)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Y (Functor2.X.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor2-X-argument-2-Z.html
+++ b/test/generators/html/Functor2-X-argument-2-Z.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Z (Functor2.X.Z)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Z (Functor2.X.Z)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor2-X.html
+++ b/test/generators/html/Functor2-X.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Functor2.X)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>X (Functor2.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Functor2-module-type-S.html
+++ b/test/generators/html/Functor2-module-type-S.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Functor2.S)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S (Functor2.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Functor2-module-type-XF-argument-1-Y.html
+++ b/test/generators/html/Functor2-module-type-XF-argument-1-Y.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Functor2.XF.Y)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Y (Functor2.XF.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor2-module-type-XF-argument-2-Z.html
+++ b/test/generators/html/Functor2-module-type-XF-argument-2-Z.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Z (Functor2.XF.Z)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Z (Functor2.XF.Z)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor2-module-type-XF.html
+++ b/test/generators/html/Functor2-module-type-XF.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>XF (Functor2.XF)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>XF (Functor2.XF)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor2.html
+++ b/test/generators/html/Functor2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Functor2 (Functor2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Functor2 (Functor2)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor_ml-Bar.html
+++ b/test/generators/html/Functor_ml-Bar.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Bar (Functor_ml.Bar)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Bar (Functor_ml.Bar)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor_ml-Foo'-argument-1-X.html
+++ b/test/generators/html/Functor_ml-Foo'-argument-1-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Functor_ml.Foo'.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Functor_ml.Foo'.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor_ml-Foo'.html
+++ b/test/generators/html/Functor_ml-Foo'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Foo' (Functor_ml.Foo')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Foo' (Functor_ml.Foo')</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Functor_ml.html
+++ b/test/generators/html/Functor_ml.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Functor_ml (Functor_ml)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Functor_ml (Functor_ml)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include-module-type-Dorminant_Module.html
+++ b/test/generators/html/Include-module-type-Dorminant_Module.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Dorminant_Module (Include.Dorminant_Module)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include-module-type-Inherent_Module.html
+++ b/test/generators/html/Include-module-type-Inherent_Module.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Inherent_Module (Include.Inherent_Module)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include-module-type-Inlined.html
+++ b/test/generators/html/Include-module-type-Inlined.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Inlined (Include.Inlined)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Inlined (Include.Inlined)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include-module-type-Not_inlined.html
+++ b/test/generators/html/Include-module-type-Not_inlined.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Not_inlined (Include.Not_inlined)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include-module-type-Not_inlined_and_closed.html
+++ b/test/generators/html/Include-module-type-Not_inlined_and_closed.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Not_inlined_and_closed (Include.Not_inlined_and_closed)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include-module-type-Not_inlined_and_opened.html
+++ b/test/generators/html/Include-module-type-Not_inlined_and_opened.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Not_inlined_and_opened (Include.Not_inlined_and_opened)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include.html
+++ b/test/generators/html/Include.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Include (Include)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Include (Include)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include2-X.html
+++ b/test/generators/html/Include2-X.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Include2.X)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>X (Include2.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Include2-Y.html
+++ b/test/generators/html/Include2-Y.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Include2.Y)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Y (Include2.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Include2-Y_include_doc.html
+++ b/test/generators/html/Include2-Y_include_doc.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Y_include_doc (Include2.Y_include_doc)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include2-Y_include_synopsis.html
+++ b/test/generators/html/Include2-Y_include_synopsis.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Y_include_synopsis (Include2.Y_include_synopsis)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include2.html
+++ b/test/generators/html/Include2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Include2 (Include2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Include2 (Include2)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include_sections-module-type-Something.html
+++ b/test/generators/html/Include_sections-module-type-Something.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Something (Include_sections.Something)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Include_sections.html
+++ b/test/generators/html/Include_sections.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Include_sections (Include_sections)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Interlude.html
+++ b/test/generators/html/Interlude.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Interlude (Interlude)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Interlude (Interlude)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Labels-A.html
+++ b/test/generators/html/Labels-A.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>A (Labels.A)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>A (Labels.A)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Labels-class-c.html
+++ b/test/generators/html/Labels-class-c.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>c (Labels.c)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>c (Labels.c)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Labels-class-type-cs.html
+++ b/test/generators/html/Labels-class-type-cs.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>cs (Labels.cs)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>cs (Labels.cs)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Labels-module-type-S.html
+++ b/test/generators/html/Labels-module-type-S.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Labels.S)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S (Labels.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Labels.html
+++ b/test/generators/html/Labels.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Labels (Labels)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Labels (Labels)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Markup-X.html
+++ b/test/generators/html/Markup-X.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Markup.X)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>X (Markup.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Markup-Y.html
+++ b/test/generators/html/Markup-Y.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Markup.Y)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Y (Markup.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Markup (Markup)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Markup (Markup)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-M'.html
+++ b/test/generators/html/Module-M'.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M' (Module.M')</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>M' (Module.M')</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-Mutually.html
+++ b/test/generators/html/Module-Mutually.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Mutually (Module.Mutually)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Mutually (Module.Mutually)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module-Recursive.html
+++ b/test/generators/html/Module-Recursive.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Recursive (Module.Recursive)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Recursive (Module.Recursive)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module-module-type-S-M.html
+++ b/test/generators/html/Module-module-type-S-M.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Module.S.M)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>M (Module.S.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S.html
+++ b/test/generators/html/Module-module-type-S.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Module.S)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S (Module.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S3-M.html
+++ b/test/generators/html/Module-module-type-S3-M.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Module.S3.M)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>M (Module.S3.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S3.html
+++ b/test/generators/html/Module-module-type-S3.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S3 (Module.S3)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S3 (Module.S3)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S4-M.html
+++ b/test/generators/html/Module-module-type-S4-M.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Module.S4.M)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>M (Module.S4.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S4.html
+++ b/test/generators/html/Module-module-type-S4.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S4 (Module.S4)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S4 (Module.S4)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S5-M.html
+++ b/test/generators/html/Module-module-type-S5-M.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Module.S5.M)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>M (Module.S5.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S5.html
+++ b/test/generators/html/Module-module-type-S5.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S5 (Module.S5)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S5 (Module.S5)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S6-M.html
+++ b/test/generators/html/Module-module-type-S6-M.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Module.S6.M)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>M (Module.S6.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S6.html
+++ b/test/generators/html/Module-module-type-S6.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S6 (Module.S6)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S6 (Module.S6)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S7.html
+++ b/test/generators/html/Module-module-type-S7.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S7 (Module.S7)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S7 (Module.S7)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S8.html
+++ b/test/generators/html/Module-module-type-S8.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S8 (Module.S8)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S8 (Module.S8)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module-module-type-S9.html
+++ b/test/generators/html/Module-module-type-S9.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S9 (Module.S9)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S9 (Module.S9)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module.html
+++ b/test/generators/html/Module.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Module (Module)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Module (Module)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Module_type_alias-module-type-A.html
+++ b/test/generators/html/Module_type_alias-module-type-A.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>A (Module_type_alias.A)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>A (Module_type_alias.A)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_alias-module-type-B-argument-1-C.html
+++ b/test/generators/html/Module_type_alias-module-type-B-argument-1-C.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>C (Module_type_alias.B.C)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>C (Module_type_alias.B.C)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_alias-module-type-B.html
+++ b/test/generators/html/Module_type_alias-module-type-B.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>B (Module_type_alias.B)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>B (Module_type_alias.B)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_alias-module-type-E-argument-1-F.html
+++ b/test/generators/html/Module_type_alias-module-type-E-argument-1-F.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>F (Module_type_alias.E.F)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>F (Module_type_alias.E.F)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_alias-module-type-E-argument-2-C.html
+++ b/test/generators/html/Module_type_alias-module-type-E-argument-2-C.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>C (Module_type_alias.E.C)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>C (Module_type_alias.E.C)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_alias-module-type-E.html
+++ b/test/generators/html/Module_type_alias-module-type-E.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>E (Module_type_alias.E)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>E (Module_type_alias.E)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_alias-module-type-G-argument-1-H.html
+++ b/test/generators/html/Module_type_alias-module-type-G-argument-1-H.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>H (Module_type_alias.G.H)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>H (Module_type_alias.G.H)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_alias-module-type-G.html
+++ b/test/generators/html/Module_type_alias-module-type-G.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>G (Module_type_alias.G)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>G (Module_type_alias.G)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_alias.html
+++ b/test/generators/html/Module_type_alias.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Module_type_alias (Module_type_alias)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-a-M.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-a-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Module_type_subst.Basic.a.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M (Module_type_subst.Basic.a.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-a.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-a.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>a (Module_type_subst.Basic.a)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>a (Module_type_subst.Basic.a)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-c-M.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-c-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Module_type_subst.Basic.c.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M (Module_type_subst.Basic.c.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-c.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-c.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>c (Module_type_subst.Basic.c)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>c (Module_type_subst.Basic.c)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-u-module-type-T.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u-module-type-T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>T (Module_type_subst.Basic.u.T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>T (Module_type_subst.Basic.u.T)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-u.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>u (Module_type_subst.Basic.u)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>u (Module_type_subst.Basic.u)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-u2-M.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u2-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Module_type_subst.Basic.u2.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M (Module_type_subst.Basic.u2.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-u2-module-type-T.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u2-module-type-T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>T (Module_type_subst.Basic.u2.T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>T (Module_type_subst.Basic.u2.T)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-u2.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>u2 (Module_type_subst.Basic.u2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>u2 (Module_type_subst.Basic.u2)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-with_.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-with_.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>with_ (Module_type_subst.Basic.with_)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-with_2-M.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-with_2-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>M (Module_type_subst.Basic.with_2.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-with_2-module-type-T.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-with_2-module-type-T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>T (Module_type_subst.Basic.with_2.T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic-module-type-with_2.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-with_2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>with_2 (Module_type_subst.Basic.with_2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Basic.html
+++ b/test/generators/html/Module_type_subst-Basic.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Basic (Module_type_subst.Basic)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Basic (Module_type_subst.Basic)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Local-module-type-local.html
+++ b/test/generators/html/Module_type_subst-Local-module-type-local.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>local (Module_type_subst.Local.local)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Local-module-type-s.html
+++ b/test/generators/html/Module_type_subst-Local-module-type-s.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>s (Module_type_subst.Local.s)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>s (Module_type_subst.Local.s)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Local.html
+++ b/test/generators/html/Module_type_subst-Local.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Local (Module_type_subst.Local)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Local (Module_type_subst.Local)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Nested-module-type-nested-N-module-type-t.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-nested-N-module-type-t.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>t (Module_type_subst.Nested.nested.N.t)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Nested-module-type-nested-N.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-nested-N.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>N (Module_type_subst.Nested.nested.N)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Nested-module-type-nested.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-nested.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>nested (Module_type_subst.Nested.nested)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_-N.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_-N.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>N (Module_type_subst.Nested.with_.N)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>with_ (Module_type_subst.Nested.with_)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_subst-N.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_subst-N.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>N (Module_type_subst.Nested.with_subst.N)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_subst.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_subst.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>with_subst (Module_type_subst.Nested.with_subst)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Nested.html
+++ b/test/generators/html/Module_type_subst-Nested.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Nested (Module_type_subst.Nested)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b-module-type-c.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b-module-type-c.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>c (Module_type_subst.Structural.u.a.b.c)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>b (Module_type_subst.Structural.u.a.b)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>a (Module_type_subst.Structural.u.a)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Structural-module-type-u.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>u (Module_type_subst.Structural.u)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b-module-type-c.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b-module-type-c.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>c (Module_type_subst.Structural.w.a.b.c)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>b (Module_type_subst.Structural.w.a.b)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>a (Module_type_subst.Structural.w.a)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Structural-module-type-w.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>w (Module_type_subst.Structural.w)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-Structural.html
+++ b/test/generators/html/Module_type_subst-Structural.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Structural (Module_type_subst.Structural)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst-module-type-s.html
+++ b/test/generators/html/Module_type_subst-module-type-s.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>s (Module_type_subst.s)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>s (Module_type_subst.s)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Module_type_subst.html
+++ b/test/generators/html/Module_type_subst.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Module_type_subst (Module_type_subst)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Nested-F-argument-1-Arg1.html
+++ b/test/generators/html/Nested-F-argument-1-Arg1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg1 (Nested.F.Arg1)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Arg1 (Nested.F.Arg1)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Nested-F-argument-2-Arg2.html
+++ b/test/generators/html/Nested-F-argument-2-Arg2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg2 (Nested.F.Arg2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Arg2 (Nested.F.Arg2)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Nested-F.html
+++ b/test/generators/html/Nested-F.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>F (Nested.F)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>F (Nested.F)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Nested-X.html
+++ b/test/generators/html/Nested-X.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Nested.X)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>X (Nested.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Nested-class-inherits.html
+++ b/test/generators/html/Nested-class-inherits.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>inherits (Nested.inherits)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>inherits (Nested.inherits)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Nested-class-z.html
+++ b/test/generators/html/Nested-class-z.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>z (Nested.z)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>z (Nested.z)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Nested-module-type-Y.html
+++ b/test/generators/html/Nested-module-type-Y.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Nested.Y)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Y (Nested.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Nested.html
+++ b/test/generators/html/Nested.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Nested (Nested)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Nested (Nested)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Ocamlary-Aliases-E.html
+++ b/test/generators/html/Ocamlary-Aliases-E.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>E (Ocamlary.Aliases.E)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>E (Ocamlary.Aliases.E)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-Foo-A.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-A.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>A (Ocamlary.Aliases.Foo.A)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>A (Ocamlary.Aliases.Foo.A)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-Foo-B.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-B.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>B (Ocamlary.Aliases.Foo.B)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>B (Ocamlary.Aliases.Foo.B)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-Foo-C.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-C.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>C (Ocamlary.Aliases.Foo.C)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>C (Ocamlary.Aliases.Foo.C)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-Foo-D.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-D.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>D (Ocamlary.Aliases.Foo.D)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>D (Ocamlary.Aliases.Foo.D)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-Foo-E.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-E.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>E (Ocamlary.Aliases.Foo.E)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>E (Ocamlary.Aliases.Foo.E)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-Foo.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Foo (Ocamlary.Aliases.Foo)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Foo (Ocamlary.Aliases.Foo)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-P1-Y.html
+++ b/test/generators/html/Ocamlary-Aliases-P1-Y.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Ocamlary.Aliases.P1.Y)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Y (Ocamlary.Aliases.P1.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-P1.html
+++ b/test/generators/html/Ocamlary-Aliases-P1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>P1 (Ocamlary.Aliases.P1)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>P1 (Ocamlary.Aliases.P1)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-P2-Z.html
+++ b/test/generators/html/Ocamlary-Aliases-P2-Z.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Z (Ocamlary.Aliases.P2.Z)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Z (Ocamlary.Aliases.P2.Z)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-P2.html
+++ b/test/generators/html/Ocamlary-Aliases-P2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>P2 (Ocamlary.Aliases.P2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>P2 (Ocamlary.Aliases.P2)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases-Std.html
+++ b/test/generators/html/Ocamlary-Aliases-Std.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Std (Ocamlary.Aliases.Std)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Std (Ocamlary.Aliases.Std)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Aliases.html
+++ b/test/generators/html/Ocamlary-Aliases.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Aliases (Ocamlary.Aliases)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Aliases (Ocamlary.Aliases)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Buffer.html
+++ b/test/generators/html/Ocamlary-Buffer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Buffer (Ocamlary.Buffer)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Buffer (Ocamlary.Buffer)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-CanonicalTest-Base-List.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base-List.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>List (Ocamlary.CanonicalTest.Base.List)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-CanonicalTest-Base.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Base (Ocamlary.CanonicalTest.Base)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-CanonicalTest-Base_Tests-C.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base_Tests-C.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>C (Ocamlary.CanonicalTest.Base_Tests.C)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-CanonicalTest-Base_Tests.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base_Tests.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Base_Tests (Ocamlary.CanonicalTest.Base_Tests)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-CanonicalTest-List_modif.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-List_modif.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>List_modif (Ocamlary.CanonicalTest.List_modif)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-CanonicalTest.html
+++ b/test/generators/html/Ocamlary-CanonicalTest.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>CanonicalTest (Ocamlary.CanonicalTest)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>InnerModuleA' (Ocamlary.CollectionModule.InnerModuleA.InnerModuleA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -4,7 +4,7 @@
   <title>
    InnerModuleTypeA'
    (Ocamlary.CollectionModule.InnerModuleA.InnerModuleTypeA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-CollectionModule-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-CollectionModule-InnerModuleA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA (Ocamlary.CollectionModule.InnerModuleA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-CollectionModule.html
+++ b/test/generators/html/Ocamlary-CollectionModule.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>CollectionModule (Ocamlary.CollectionModule)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep1-X-Y-class-c.html
+++ b/test/generators/html/Ocamlary-Dep1-X-Y-class-c.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>c (Ocamlary.Dep1.X.Y.c)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>c (Ocamlary.Dep1.X.Y.c)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep1-X-Y.html
+++ b/test/generators/html/Ocamlary-Dep1-X-Y.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Ocamlary.Dep1.X.Y)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Y (Ocamlary.Dep1.X.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep1-X.html
+++ b/test/generators/html/Ocamlary-Dep1-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.Dep1.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Ocamlary.Dep1.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep1-module-type-S-class-c.html
+++ b/test/generators/html/Ocamlary-Dep1-module-type-S-class-c.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>c (Ocamlary.Dep1.S.c)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>c (Ocamlary.Dep1.S.c)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep1-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep1-module-type-S.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Ocamlary.Dep1.S)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>S (Ocamlary.Dep1.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep1.html
+++ b/test/generators/html/Ocamlary-Dep1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep1 (Ocamlary.Dep1)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep1 (Ocamlary.Dep1)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep11-module-type-S-class-c.html
+++ b/test/generators/html/Ocamlary-Dep11-module-type-S-class-c.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>c (Ocamlary.Dep11.S.c)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>c (Ocamlary.Dep11.S.c)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep11-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep11-module-type-S.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Ocamlary.Dep11.S)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>S (Ocamlary.Dep11.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep11.html
+++ b/test/generators/html/Ocamlary-Dep11.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep11 (Ocamlary.Dep11)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep11 (Ocamlary.Dep11)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep12-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep12-argument-1-Arg.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Ocamlary.Dep12.Arg)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Arg (Ocamlary.Dep12.Arg)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep12.html
+++ b/test/generators/html/Ocamlary-Dep12.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep12 (Ocamlary.Dep12)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep12 (Ocamlary.Dep12)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep13-class-c.html
+++ b/test/generators/html/Ocamlary-Dep13-class-c.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>c (Ocamlary.Dep13.c)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>c (Ocamlary.Dep13.c)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep13.html
+++ b/test/generators/html/Ocamlary-Dep13.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep13 (Ocamlary.Dep13)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep13 (Ocamlary.Dep13)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep2-A.html
+++ b/test/generators/html/Ocamlary-Dep2-A.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>A (Ocamlary.Dep2.A)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>A (Ocamlary.Dep2.A)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep2-argument-1-Arg-X.html
+++ b/test/generators/html/Ocamlary-Dep2-argument-1-Arg-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.Dep2.Arg.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Ocamlary.Dep2.Arg.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep2-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep2-argument-1-Arg.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Ocamlary.Dep2.Arg)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Arg (Ocamlary.Dep2.Arg)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep2.html
+++ b/test/generators/html/Ocamlary-Dep2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep2 (Ocamlary.Dep2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep2 (Ocamlary.Dep2)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep3.html
+++ b/test/generators/html/Ocamlary-Dep3.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep3 (Ocamlary.Dep3)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep3 (Ocamlary.Dep3)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep4-X.html
+++ b/test/generators/html/Ocamlary-Dep4-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.Dep4.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Ocamlary.Dep4.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep4-module-type-S-X.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-S-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.Dep4.S.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Ocamlary.Dep4.S.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep4-module-type-S-Y.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-S-Y.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Ocamlary.Dep4.S.Y)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Y (Ocamlary.Dep4.S.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep4-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-S.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Ocamlary.Dep4.S)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>S (Ocamlary.Dep4.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep4-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>T (Ocamlary.Dep4.T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>T (Ocamlary.Dep4.T)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep4.html
+++ b/test/generators/html/Ocamlary-Dep4.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep4 (Ocamlary.Dep4)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep4 (Ocamlary.Dep4)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep5-Z.html
+++ b/test/generators/html/Ocamlary-Dep5-Z.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Z (Ocamlary.Dep5.Z)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Z (Ocamlary.Dep5.Z)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Ocamlary.Dep5.Arg.S.Y)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Y (Ocamlary.Dep5.Arg.S.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Ocamlary.Dep5.Arg.S)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>S (Ocamlary.Dep5.Arg.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Ocamlary.Dep5.Arg)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Arg (Ocamlary.Dep5.Arg)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep5.html
+++ b/test/generators/html/Ocamlary-Dep5.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep5 (Ocamlary.Dep5)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep5 (Ocamlary.Dep5)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep6-X-Y.html
+++ b/test/generators/html/Ocamlary-Dep6-X-Y.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Ocamlary.Dep6.X.Y)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Y (Ocamlary.Dep6.X.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep6-X.html
+++ b/test/generators/html/Ocamlary-Dep6-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.Dep6.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Ocamlary.Dep6.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep6-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep6-module-type-S.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Ocamlary.Dep6.S)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>S (Ocamlary.Dep6.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep6-module-type-T-Y.html
+++ b/test/generators/html/Ocamlary-Dep6-module-type-T-Y.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Ocamlary.Dep6.T.Y)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Y (Ocamlary.Dep6.T.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep6-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep6-module-type-T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>T (Ocamlary.Dep6.T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>T (Ocamlary.Dep6.T)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep6.html
+++ b/test/generators/html/Ocamlary-Dep6.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep6 (Ocamlary.Dep6)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep6 (Ocamlary.Dep6)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep7-M.html
+++ b/test/generators/html/Ocamlary-Dep7-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Ocamlary.Dep7.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M (Ocamlary.Dep7.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg-X.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.Dep7.Arg.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Ocamlary.Dep7.Arg.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg-module-type-T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>T (Ocamlary.Dep7.Arg.T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>T (Ocamlary.Dep7.Arg.T)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Arg (Ocamlary.Dep7.Arg)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Arg (Ocamlary.Dep7.Arg)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep7.html
+++ b/test/generators/html/Ocamlary-Dep7.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep7 (Ocamlary.Dep7)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep7 (Ocamlary.Dep7)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep8-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep8-module-type-T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>T (Ocamlary.Dep8.T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>T (Ocamlary.Dep8.T)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep8.html
+++ b/test/generators/html/Ocamlary-Dep8.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep8 (Ocamlary.Dep8)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep8 (Ocamlary.Dep8)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep9-argument-1-X.html
+++ b/test/generators/html/Ocamlary-Dep9-argument-1-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.Dep9.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Ocamlary.Dep9.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Dep9.html
+++ b/test/generators/html/Ocamlary-Dep9.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep9 (Ocamlary.Dep9)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep9 (Ocamlary.Dep9)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-DoubleInclude1-DoubleInclude2.html
+++ b/test/generators/html/Ocamlary-DoubleInclude1-DoubleInclude2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>DoubleInclude2 (Ocamlary.DoubleInclude1.DoubleInclude2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-DoubleInclude1.html
+++ b/test/generators/html/Ocamlary-DoubleInclude1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>DoubleInclude1 (Ocamlary.DoubleInclude1)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-DoubleInclude3-DoubleInclude2.html
+++ b/test/generators/html/Ocamlary-DoubleInclude3-DoubleInclude2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>DoubleInclude2 (Ocamlary.DoubleInclude3.DoubleInclude2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-DoubleInclude3.html
+++ b/test/generators/html/Ocamlary-DoubleInclude3.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>DoubleInclude3 (Ocamlary.DoubleInclude3)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Empty.html
+++ b/test/generators/html/Ocamlary-Empty.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Empty (Ocamlary.Empty)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Empty (Ocamlary.Empty)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-ExtMod.html
+++ b/test/generators/html/Ocamlary-ExtMod.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>ExtMod (Ocamlary.ExtMod)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>ExtMod (Ocamlary.ExtMod)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html
@@ -4,7 +4,7 @@
   <title>
    InnerModuleA'
    (Ocamlary.FunctorTypeOf.Collection.InnerModuleA.InnerModuleA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -4,7 +4,7 @@
   <title>
    InnerModuleTypeA'
    (Ocamlary.FunctorTypeOf.Collection.InnerModuleA.InnerModuleTypeA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>InnerModuleA (Ocamlary.FunctorTypeOf.Collection.InnerModuleA)
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Collection (Ocamlary.FunctorTypeOf.Collection)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-FunctorTypeOf.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>FunctorTypeOf (Ocamlary.FunctorTypeOf)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-IncludeInclude1-IncludeInclude2_M.html
+++ b/test/generators/html/Ocamlary-IncludeInclude1-IncludeInclude2_M.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>IncludeInclude2_M (Ocamlary.IncludeInclude1.IncludeInclude2_M)
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html
+++ b/test/generators/html/Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>IncludeInclude2 (Ocamlary.IncludeInclude1.IncludeInclude2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-IncludeInclude1.html
+++ b/test/generators/html/Ocamlary-IncludeInclude1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>IncludeInclude1 (Ocamlary.IncludeInclude1)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-IncludeInclude2_M.html
+++ b/test/generators/html/Ocamlary-IncludeInclude2_M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>IncludeInclude2_M (Ocamlary.IncludeInclude2_M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-IncludedA.html
+++ b/test/generators/html/Ocamlary-IncludedA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>IncludedA (Ocamlary.IncludedA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>IncludedA (Ocamlary.IncludedA)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-M.html
+++ b/test/generators/html/Ocamlary-M.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Ocamlary.M)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>M (Ocamlary.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Ocamlary-ModuleWithSignature.html
+++ b/test/generators/html/Ocamlary-ModuleWithSignature.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>ModuleWithSignature (Ocamlary.ModuleWithSignature)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-ModuleWithSignatureAlias.html
+++ b/test/generators/html/Ocamlary-ModuleWithSignatureAlias.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>ModuleWithSignatureAlias (Ocamlary.ModuleWithSignatureAlias)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-One.html
+++ b/test/generators/html/Ocamlary-One.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>One (Ocamlary.One)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>One (Ocamlary.One)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Only_a_module.html
+++ b/test/generators/html/Ocamlary-Only_a_module.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Only_a_module (Ocamlary.Only_a_module)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>InnerModuleA' (Ocamlary.Recollection.InnerModuleA.InnerModuleA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -3,7 +3,7 @@
  <head>
   <title>
    InnerModuleTypeA' (Ocamlary.Recollection.InnerModuleA.InnerModuleTypeA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Recollection-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-Recollection-InnerModuleA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA (Ocamlary.Recollection.InnerModuleA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>InnerModuleA' (Ocamlary.Recollection.C.InnerModuleA.InnerModuleA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -3,7 +3,7 @@
  <head>
   <title>
    InnerModuleTypeA' (Ocamlary.Recollection.C.InnerModuleA.InnerModuleTypeA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA (Ocamlary.Recollection.C.InnerModuleA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>C (Ocamlary.Recollection.C)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>C (Ocamlary.Recollection.C)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-Recollection.html
+++ b/test/generators/html/Ocamlary-Recollection.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Recollection (Ocamlary.Recollection)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With10-module-type-T-M.html
+++ b/test/generators/html/Ocamlary-With10-module-type-T-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Ocamlary.With10.T.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M (Ocamlary.With10.T.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With10-module-type-T.html
+++ b/test/generators/html/Ocamlary-With10-module-type-T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>T (Ocamlary.With10.T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>T (Ocamlary.With10.T)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With10.html
+++ b/test/generators/html/Ocamlary-With10.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With10 (Ocamlary.With10)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With10 (Ocamlary.With10)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With2-module-type-S.html
+++ b/test/generators/html/Ocamlary-With2-module-type-S.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Ocamlary.With2.S)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>S (Ocamlary.With2.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With2.html
+++ b/test/generators/html/Ocamlary-With2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With2 (Ocamlary.With2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With2 (Ocamlary.With2)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With3-N.html
+++ b/test/generators/html/Ocamlary-With3-N.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>N (Ocamlary.With3.N)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>N (Ocamlary.With3.N)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With3.html
+++ b/test/generators/html/Ocamlary-With3.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With3 (Ocamlary.With3)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With3 (Ocamlary.With3)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With4-N.html
+++ b/test/generators/html/Ocamlary-With4-N.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>N (Ocamlary.With4.N)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>N (Ocamlary.With4.N)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With4.html
+++ b/test/generators/html/Ocamlary-With4.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With4 (Ocamlary.With4)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With4 (Ocamlary.With4)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With5-N.html
+++ b/test/generators/html/Ocamlary-With5-N.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>N (Ocamlary.With5.N)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>N (Ocamlary.With5.N)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With5-module-type-S.html
+++ b/test/generators/html/Ocamlary-With5-module-type-S.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Ocamlary.With5.S)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>S (Ocamlary.With5.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With5.html
+++ b/test/generators/html/Ocamlary-With5.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With5 (Ocamlary.With5)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With5 (Ocamlary.With5)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With6-module-type-T-M.html
+++ b/test/generators/html/Ocamlary-With6-module-type-T-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Ocamlary.With6.T.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M (Ocamlary.With6.T.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With6-module-type-T.html
+++ b/test/generators/html/Ocamlary-With6-module-type-T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>T (Ocamlary.With6.T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>T (Ocamlary.With6.T)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With6.html
+++ b/test/generators/html/Ocamlary-With6.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With6 (Ocamlary.With6)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With6 (Ocamlary.With6)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With7-argument-1-X.html
+++ b/test/generators/html/Ocamlary-With7-argument-1-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Ocamlary.With7.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Ocamlary.With7.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With7.html
+++ b/test/generators/html/Ocamlary-With7.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With7 (Ocamlary.With7)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With7 (Ocamlary.With7)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With9-module-type-S.html
+++ b/test/generators/html/Ocamlary-With9-module-type-S.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Ocamlary.With9.S)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>S (Ocamlary.With9.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-With9.html
+++ b/test/generators/html/Ocamlary-With9.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With9 (Ocamlary.With9)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With9 (Ocamlary.With9)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-class-empty_class.html
+++ b/test/generators/html/Ocamlary-class-empty_class.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>empty_class (Ocamlary.empty_class)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-class-one_method_class.html
+++ b/test/generators/html/Ocamlary-class-one_method_class.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>one_method_class (Ocamlary.one_method_class)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-class-param_class.html
+++ b/test/generators/html/Ocamlary-class-param_class.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>param_class (Ocamlary.param_class)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-class-two_method_class.html
+++ b/test/generators/html/Ocamlary-class-two_method_class.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>two_method_class (Ocamlary.two_method_class)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA' (Ocamlary.A.Q.InnerModuleA.InnerModuleA')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>InnerModuleTypeA' (Ocamlary.A.Q.InnerModuleA.InnerModuleTypeA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA (Ocamlary.A.Q.InnerModuleA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-A-Q.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Q (Ocamlary.A.Q)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Q (Ocamlary.A.Q)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-A.html
+++ b/test/generators/html/Ocamlary-module-type-A.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>A (Ocamlary.A)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>A (Ocamlary.A)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA' (Ocamlary.B.Q.InnerModuleA.InnerModuleA')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>InnerModuleTypeA' (Ocamlary.B.Q.InnerModuleA.InnerModuleTypeA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA (Ocamlary.B.Q.InnerModuleA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-B-Q.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Q (Ocamlary.B.Q)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Q (Ocamlary.B.Q)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-B.html
+++ b/test/generators/html/Ocamlary-module-type-B.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>B (Ocamlary.B)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>B (Ocamlary.B)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA' (Ocamlary.C.Q.InnerModuleA.InnerModuleA')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>InnerModuleTypeA' (Ocamlary.C.Q.InnerModuleA.InnerModuleTypeA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA (Ocamlary.C.Q.InnerModuleA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-C-Q.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Q (Ocamlary.C.Q)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Q (Ocamlary.C.Q)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-C.html
+++ b/test/generators/html/Ocamlary-module-type-C.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>C (Ocamlary.C)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>C (Ocamlary.C)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>InnerModuleA' (Ocamlary.COLLECTION.InnerModuleA.InnerModuleA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -3,7 +3,7 @@
  <head>
   <title>
    InnerModuleTypeA' (Ocamlary.COLLECTION.InnerModuleA.InnerModuleTypeA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA (Ocamlary.COLLECTION.InnerModuleA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-COLLECTION.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>COLLECTION (Ocamlary.COLLECTION)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>COLLECTION (Ocamlary.COLLECTION)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-Dep10.html
+++ b/test/generators/html/Ocamlary-module-type-Dep10.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Dep10 (Ocamlary.Dep10)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Dep10 (Ocamlary.Dep10)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-Empty.html
+++ b/test/generators/html/Ocamlary-module-type-Empty.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Empty (Ocamlary.Empty)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Empty (Ocamlary.Empty)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-EmptySig.html
+++ b/test/generators/html/Ocamlary-module-type-EmptySig.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>EmptySig (Ocamlary.EmptySig)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>EmptySig (Ocamlary.EmptySig)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-IncludeInclude2.html
+++ b/test/generators/html/Ocamlary-module-type-IncludeInclude2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>IncludeInclude2 (Ocamlary.IncludeInclude2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-IncludeModuleType.html
+++ b/test/generators/html/Ocamlary-module-type-IncludeModuleType.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>IncludeModuleType (Ocamlary.IncludeModuleType)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-IncludedB.html
+++ b/test/generators/html/Ocamlary-module-type-IncludedB.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>IncludedB (Ocamlary.IncludedB)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>IncludedB (Ocamlary.IncludedB)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-M.html
+++ b/test/generators/html/Ocamlary-module-type-M.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Ocamlary.M)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>M (Ocamlary.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>InnerModuleA' (Ocamlary.MMM.C.InnerModuleA.InnerModuleA')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>InnerModuleTypeA' (Ocamlary.MMM.C.InnerModuleA.InnerModuleTypeA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA (Ocamlary.MMM.C.InnerModuleA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-MMM-C.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>C (Ocamlary.MMM.C)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>C (Ocamlary.MMM.C)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-MMM.html
+++ b/test/generators/html/Ocamlary-module-type-MMM.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>MMM (Ocamlary.MMM)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>MMM (Ocamlary.MMM)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-MissingComment.html
+++ b/test/generators/html/Ocamlary-module-type-MissingComment.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>MissingComment (Ocamlary.MissingComment)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html
+++ b/test/generators/html/Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>NestedInclude2 (Ocamlary.NestedInclude1.NestedInclude2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-NestedInclude1.html
+++ b/test/generators/html/Ocamlary-module-type-NestedInclude1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>NestedInclude1 (Ocamlary.NestedInclude1)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-NestedInclude2.html
+++ b/test/generators/html/Ocamlary-module-type-NestedInclude2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>NestedInclude2 (Ocamlary.NestedInclude2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-RECOLLECTION.html
+++ b/test/generators/html/Ocamlary-module-type-RECOLLECTION.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>RECOLLECTION (Ocamlary.RECOLLECTION)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html
@@ -3,7 +3,7 @@
  <head>
   <title>
    InnerModuleA' (Ocamlary.RecollectionModule.InnerModuleA.InnerModuleA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -4,7 +4,7 @@
   <title>
    InnerModuleTypeA'
    (Ocamlary.RecollectionModule.InnerModuleA.InnerModuleTypeA')
-  </title><link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  </title><meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>InnerModuleA (Ocamlary.RecollectionModule.InnerModuleA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>RecollectionModule (Ocamlary.RecollectionModule)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-SigForMod-Inner-module-type-Empty.html
+++ b/test/generators/html/Ocamlary-module-type-SigForMod-Inner-module-type-Empty.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Empty (Ocamlary.SigForMod.Inner.Empty)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-SigForMod-Inner.html
+++ b/test/generators/html/Ocamlary-module-type-SigForMod-Inner.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Inner (Ocamlary.SigForMod.Inner)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Inner (Ocamlary.SigForMod.Inner)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-SigForMod.html
+++ b/test/generators/html/Ocamlary-module-type-SigForMod.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>SigForMod (Ocamlary.SigForMod)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>SigForMod (Ocamlary.SigForMod)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-EmptySig.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-EmptySig.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>EmptySig (Ocamlary.SuperSig.EmptySig)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-One.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-One.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>One (Ocamlary.SuperSig.One)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>One (Ocamlary.SuperSig.One)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>SubSigAMod (Ocamlary.SuperSig.SubSigA.SubSigAMod)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>SubSigA (Ocamlary.SuperSig.SubSigA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigB.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigB.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>SubSigB (Ocamlary.SuperSig.SubSigB)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SuperSig.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SuperSig.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>SuperSig (Ocamlary.SuperSig.SuperSig)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-SuperSig.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>SuperSig (Ocamlary.SuperSig)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>SuperSig (Ocamlary.SuperSig)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-ToInclude-IncludedA.html
+++ b/test/generators/html/Ocamlary-module-type-ToInclude-IncludedA.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>IncludedA (Ocamlary.ToInclude.IncludedA)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-ToInclude-module-type-IncludedB.html
+++ b/test/generators/html/Ocamlary-module-type-ToInclude-module-type-IncludedB.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>IncludedB (Ocamlary.ToInclude.IncludedB)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-ToInclude.html
+++ b/test/generators/html/Ocamlary-module-type-ToInclude.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>ToInclude (Ocamlary.ToInclude)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>ToInclude (Ocamlary.ToInclude)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-TypeExt.html
+++ b/test/generators/html/Ocamlary-module-type-TypeExt.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>TypeExt (Ocamlary.TypeExt)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>TypeExt (Ocamlary.TypeExt)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-TypeExtPruned.html
+++ b/test/generators/html/Ocamlary-module-type-TypeExtPruned.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>TypeExtPruned (Ocamlary.TypeExtPruned)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-With1-M.html
+++ b/test/generators/html/Ocamlary-module-type-With1-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Ocamlary.With1.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M (Ocamlary.With1.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-With1.html
+++ b/test/generators/html/Ocamlary-module-type-With1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With1 (Ocamlary.With1)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With1 (Ocamlary.With1)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-With11-N.html
+++ b/test/generators/html/Ocamlary-module-type-With11-N.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>N (Ocamlary.With11.N)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>N (Ocamlary.With11.N)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-With11.html
+++ b/test/generators/html/Ocamlary-module-type-With11.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With11 (Ocamlary.With11)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With11 (Ocamlary.With11)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-With8-M-N.html
+++ b/test/generators/html/Ocamlary-module-type-With8-M-N.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>N (Ocamlary.With8.M.N)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>N (Ocamlary.With8.M.N)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-With8-M.html
+++ b/test/generators/html/Ocamlary-module-type-With8-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Ocamlary.With8.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M (Ocamlary.With8.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary-module-type-With8.html
+++ b/test/generators/html/Ocamlary-module-type-With8.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>With8 (Ocamlary.With8)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>With8 (Ocamlary.With8)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Ocamlary (Ocamlary)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Ocamlary (Ocamlary)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent-X.html
+++ b/test/generators/html/Recent-X.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Recent.X)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>X (Recent.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Recent-Z-Y-X.html
+++ b/test/generators/html/Recent-Z-Y-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Recent.Z.Y.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Recent.Z.Y.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent-Z-Y.html
+++ b/test/generators/html/Recent-Z-Y.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Y (Recent.Z.Y)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Y (Recent.Z.Y)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Recent-Z.html
+++ b/test/generators/html/Recent-Z.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Z (Recent.Z)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Z (Recent.Z)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Recent-module-type-PolyS.html
+++ b/test/generators/html/Recent-module-type-PolyS.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>PolyS (Recent.PolyS)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>PolyS (Recent.PolyS)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent-module-type-S.html
+++ b/test/generators/html/Recent-module-type-S.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Recent.S)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S (Recent.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Recent-module-type-S1-argument-1-_.html
+++ b/test/generators/html/Recent-module-type-S1-argument-1-_.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>_ (Recent.S1._)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>_ (Recent.S1._)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Recent-module-type-S1.html
+++ b/test/generators/html/Recent-module-type-S1.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S1 (Recent.S1)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>S1 (Recent.S1)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Recent.html
+++ b/test/generators/html/Recent.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Recent (Recent)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Recent (Recent)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Recent_impl-B.html
+++ b/test/generators/html/Recent_impl-B.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>B (Recent_impl.B)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>B (Recent_impl.B)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent_impl-Foo-A.html
+++ b/test/generators/html/Recent_impl-Foo-A.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>A (Recent_impl.Foo.A)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>A (Recent_impl.Foo.A)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent_impl-Foo-B.html
+++ b/test/generators/html/Recent_impl-Foo-B.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>B (Recent_impl.Foo.B)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>B (Recent_impl.Foo.B)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent_impl-Foo.html
+++ b/test/generators/html/Recent_impl-Foo.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Foo (Recent_impl.Foo)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Foo (Recent_impl.Foo)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent_impl-module-type-S-F-argument-1-_.html
+++ b/test/generators/html/Recent_impl-module-type-S-F-argument-1-_.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>_ (Recent_impl.S.F._)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>_ (Recent_impl.S.F._)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent_impl-module-type-S-F.html
+++ b/test/generators/html/Recent_impl-module-type-S-F.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>F (Recent_impl.S.F)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>F (Recent_impl.S.F)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent_impl-module-type-S-X.html
+++ b/test/generators/html/Recent_impl-module-type-S-X.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Recent_impl.S.X)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>X (Recent_impl.S.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent_impl-module-type-S.html
+++ b/test/generators/html/Recent_impl-module-type-S.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>S (Recent_impl.S)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>S (Recent_impl.S)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Recent_impl.html
+++ b/test/generators/html/Recent_impl.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Recent_impl (Recent_impl)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Recent_impl (Recent_impl)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Section.html
+++ b/test/generators/html/Section.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Section (Section)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Section (Section)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Stop-N.html
+++ b/test/generators/html/Stop-N.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>N (Stop.N)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>N (Stop.N)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Stop-O.html
+++ b/test/generators/html/Stop-O.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>O (Stop.O)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>O (Stop.O)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Stop-P.html
+++ b/test/generators/html/Stop-P.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>P (Stop.P)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>P (Stop.P)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Stop.html
+++ b/test/generators/html/Stop.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Stop (Stop)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Stop (Stop)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Stop_dead_link_doc-Foo.html
+++ b/test/generators/html/Stop_dead_link_doc-Foo.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Foo (Stop_dead_link_doc.Foo)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Foo (Stop_dead_link_doc.Foo)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Stop_dead_link_doc.html
+++ b/test/generators/html/Stop_dead_link_doc.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Stop_dead_link_doc (Stop_dead_link_doc)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Stop_first_comment.html
+++ b/test/generators/html/Stop_first_comment.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Stop_first_comment (Stop_first_comment)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Tag_link.html
+++ b/test/generators/html/Tag_link.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Tag_link (Tag_link)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Tag_link (Tag_link)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-Alias.html
+++ b/test/generators/html/Toplevel_comments-Alias.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Alias (Toplevel_comments.Alias)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>Alias (Toplevel_comments.Alias)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-Comments_on_open-M.html
+++ b/test/generators/html/Toplevel_comments-Comments_on_open-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>M (Toplevel_comments.Comments_on_open.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-Comments_on_open.html
+++ b/test/generators/html/Toplevel_comments-Comments_on_open.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Comments_on_open (Toplevel_comments.Comments_on_open)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-Include_inline'.html
+++ b/test/generators/html/Toplevel_comments-Include_inline'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Include_inline' (Toplevel_comments.Include_inline')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-Include_inline.html
+++ b/test/generators/html/Toplevel_comments-Include_inline.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Include_inline (Toplevel_comments.Include_inline)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-M''.html
+++ b/test/generators/html/Toplevel_comments-M''.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M'' (Toplevel_comments.M'')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M'' (Toplevel_comments.M'')</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-M'.html
+++ b/test/generators/html/Toplevel_comments-M'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M' (Toplevel_comments.M')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M' (Toplevel_comments.M')</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-M.html
+++ b/test/generators/html/Toplevel_comments-M.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>M (Toplevel_comments.M)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>M (Toplevel_comments.M)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-Ref_in_synopsis.html
+++ b/test/generators/html/Toplevel_comments-Ref_in_synopsis.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Ref_in_synopsis (Toplevel_comments.Ref_in_synopsis)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-class-c1.html
+++ b/test/generators/html/Toplevel_comments-class-c1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>c1 (Toplevel_comments.c1)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>c1 (Toplevel_comments.c1)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-class-c2.html
+++ b/test/generators/html/Toplevel_comments-class-c2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>c2 (Toplevel_comments.c2)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>c2 (Toplevel_comments.c2)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-class-type-ct.html
+++ b/test/generators/html/Toplevel_comments-class-type-ct.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>ct (Toplevel_comments.ct)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>ct (Toplevel_comments.ct)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-module-type-Include_inline_T'.html
+++ b/test/generators/html/Toplevel_comments-module-type-Include_inline_T'.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Include_inline_T' (Toplevel_comments.Include_inline_T')</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-module-type-Include_inline_T.html
+++ b/test/generators/html/Toplevel_comments-module-type-Include_inline_T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Include_inline_T (Toplevel_comments.Include_inline_T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments-module-type-T.html
+++ b/test/generators/html/Toplevel_comments-module-type-T.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>T (Toplevel_comments.T)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+ <head><title>T (Toplevel_comments.T)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Toplevel_comments.html
+++ b/test/generators/html/Toplevel_comments.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head><title>Toplevel_comments (Toplevel_comments)</title>
-  <link rel="stylesheet" href="odoc.css"/><meta charset="utf-8"/>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
   <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>

--- a/test/generators/html/Type-module-type-X.html
+++ b/test/generators/html/Type-module-type-X.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>X (Type.X)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>X (Type.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Type.html
+++ b/test/generators/html/Type.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Type (Type)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Type (Type)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/Val.html
+++ b/test/generators/html/Val.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>Val (Val)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>Val (Val)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/generators/html/mld.html
+++ b/test/generators/html/mld.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head><title>mld (mld)</title><link rel="stylesheet" href="odoc.css"/>
-  <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+ <head><title>mld (mld)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="highlight.pack.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>

--- a/test/sources/double_wrapped.t/run.t
+++ b/test/sources/double_wrapped.t/run.t
@@ -38,8 +38,8 @@ Look if all the source files are generated:
   $ cat html/Main/A/index.html
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">
-   <head><title>A (Main.A)</title>
-    <link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/>
+   <head><title>A (Main.A)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../odoc.css"/>
     <meta name="generator" content="odoc %%VERSION%%"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <script src="../../highlight.pack.js"></script>

--- a/test/sources/lookup_def_wrapped.t/run.t
+++ b/test/sources/lookup_def_wrapped.t/run.t
@@ -42,8 +42,8 @@ Look if all the source files are generated:
   $ cat html/Main/A/index.html
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">
-   <head><title>A (Main.A)</title>
-    <link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/>
+   <head><title>A (Main.A)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../odoc.css"/>
     <meta name="generator" content="odoc %%VERSION%%"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <script src="../../highlight.pack.js"></script>

--- a/test/sources/source_hierarchy.t/run.t
+++ b/test/sources/source_hierarchy.t/run.t
@@ -56,8 +56,8 @@ A directory simply list its children:
   $ cat html/root/source/lib/index.html
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">
-   <head><title>lib (root.source.lib)</title>
-    <link rel="stylesheet" href="../../../odoc.css"/><meta charset="utf-8"/>
+   <head><title>lib (root.source.lib)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../../odoc.css"/>
     <meta name="generator" content="odoc %%VERSION%%"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <script src="../../../highlight.pack.js"></script>

--- a/test/sources/source_hierarchy_source_root.t/run.t
+++ b/test/sources/source_hierarchy_source_root.t/run.t
@@ -56,8 +56,8 @@ A directory simply list its children:
   $ cat html/root/source/lib/index.html
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">
-   <head><title>lib (root.source.lib)</title>
-    <link rel="stylesheet" href="../../../odoc.css"/><meta charset="utf-8"/>
+   <head><title>lib (root.source.lib)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../../odoc.css"/>
     <meta name="generator" content="odoc %%VERSION%%"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <script src="../../../highlight.pack.js"></script>

--- a/test/xref2/canonical_hidden_module.t/run.t
+++ b/test/xref2/canonical_hidden_module.t/run.t
@@ -71,8 +71,9 @@ See the comments on the types at the end of test.mli for the expectation.
   $ cat Test/index.html
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">
-   <head><title>Test (Test)</title><link rel="stylesheet" href="../odoc.css"/>
-    <meta charset="utf-8"/><meta name="generator" content="odoc %%VERSION%%"/>
+   <head><title>Test (Test)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../odoc.css"/>
+    <meta name="generator" content="odoc %%VERSION%%"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <script src="../highlight.pack.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>

--- a/test/xref2/labels/labels.t/run.t
+++ b/test/xref2/labels/labels.t/run.t
@@ -43,8 +43,8 @@ There are two references in N, one should point to a local label and the other t
   $ cat html/test/Test/N/index.html
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">
-   <head><title>N (test.Test.N)</title>
-    <link rel="stylesheet" href="../../../odoc.css"/><meta charset="utf-8"/>
+   <head><title>N (test.Test.N)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../../odoc.css"/>
     <meta name="generator" content="odoc %%VERSION%%"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <script src="../../../highlight.pack.js"></script>
@@ -76,8 +76,8 @@ The second occurence of 'B' in the main page should be disambiguated
   $ cat html/test/Test/index.html
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">
-   <head><title>Test (test.Test)</title>
-    <link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/>
+   <head><title>Test (test.Test)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../odoc.css"/>
     <meta name="generator" content="odoc %%VERSION%%"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <script src="../../highlight.pack.js"></script>

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -30,8 +30,8 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
   $ cat html/test/A/index.html
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">
-   <head><title>A (test.A)</title>
-    <link rel="stylesheet" href="../../odoc.css"/><meta charset="utf-8"/>
+   <head><title>A (test.A)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../odoc.css"/>
     <meta name="generator" content="odoc %%VERSION%%"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <script src="../../highlight.pack.js"></script>
@@ -68,8 +68,8 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
   $ cat html/test/A/B/index.html
   <!DOCTYPE html>
   <html xmlns="http://www.w3.org/1999/xhtml">
-   <head><title>B (test.A.B)</title>
-    <link rel="stylesheet" href="../../../odoc.css"/><meta charset="utf-8"/>
+   <head><title>B (test.A.B)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../../odoc.css"/>
     <meta name="generator" content="odoc %%VERSION%%"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <script src="../../../highlight.pack.js"></script>


### PR DESCRIPTION
This is a dirty fix for a problem affecting the release.

The generator meta element has a variable length due to the `%%VERSION%%` watermarking and that makes the test fail after a `dune subst`.
The generator meta and the charset meta elements are sometimes formatted on the same line, depending on the length of the version string. This do not happen anymore.

The first commit is refactoring.
