### PR TITLE
Don't make parser tests installable

### DIFF
--- a/src/parser/test/dune
+++ b/src/parser/test/dune
@@ -1,6 +1,5 @@
 (library
  (name odoc_parser_test)
- (package odoc-parser)
  (inline_tests)
  (enabled_if
   (>= %{ocaml_version} 4.04.1))


### PR DESCRIPTION
This is broken since https://github.com/ocaml/odoc/pull/1061 as I focused on tests and forgot to try building without.
Related dune issue: https://github.com/ocaml/dune/issues/4738
