### PR TITLE
Separate implementation and interface in different (odoc) compilation units

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Improve jump to implementation in rendered source code, and add a
   `count-occurrences` flag and command to count occurrences of every identifiers
   (@panglesd, #976)
+- Separate compilation of interface and implementation files, using a new
+  `compile-src` command (@panglesd, #1067).
 
 ### Changed
 

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -132,25 +132,25 @@ In this section [odoc] is used to generate the documentation of [odoc] and some 
 Let's start with some functions to execute the three phases of [odoc].
 
 Compiling a file with [odoc] requires a few arguments: the file to compile, an
-optional parent, a list of include paths, a list of children for [.mld] files,
-optional parent and name for source implementation, and an output path. Include
-paths can be just ['.'], and we can calculate the output file from the input
-because all of the files are going into the same directory. If we wish to count
-occurrences of each identifier, we need to pass the [--count-occurrences] flag.
+optional parent, a list of include paths, a list of children for [.mld] files
+and an output path. Include paths can be just ['.'], and we can calculate the
+output file from the input because all of the files are going into the same
+directory.
+
+Odoc supports compiling {i implementations}. This can be useful to render source
+code, generate links from and to source code, and count occurrences of
+identifiers. The [compile-src] command takes a source-tree parent file, and a
+source path which has to be in the source tree.
 
 Linking a file with [odoc] requires the input file and a list of include paths. As
 for compile, we will hard-code the include path.
 
-Generating the HTML requires the input [odocl] file, an optional implementation
-source file (passed via the [--source] argument), and an output path. We will
-hard-code the output path to be [html/].
-
-Using the [--source] argument with an [.odocl] file that was not compiled with
-[--source-parent-file] and [--source-name] will result in an error, as will omitting [--source] when generating HTML of an [odocl] that was
-compiled with [--source-parent-file] and [--source-name].
+Generating the HTML requires the input [odocl] file, and an output path. We will
+hard-code the output path to be [html/]. In the case of implementations, a
+source file (passed via the [--source] argument) is required.
 
 To get the number of uses of each identifier, we can use the [count-occurrences]
-command.
+command on the "implementation" units.
 
 In all of these, we'll capture [stdout] and [stderr] so we can check it later.
 
@@ -158,6 +158,8 @@ In all of these, we'll capture [stdout] and [stderr] so we can check it later.
 let odoc = Cmd.v "../src/odoc/bin/main.exe" (* This is the just-built odoc binary *)
 
 let compile_output = ref [ "" ]
+
+let compile_src_output = ref [ "" ]
 
 let link_output = ref [ "" ]
 
@@ -213,8 +215,8 @@ let add_prefixed_output cmd list prefix lines =
       !list
       @ Bos.Cmd.to_string cmd :: List.map (fun l -> prefix ^ ": " ^ l) lines
 
-let compile file ?(count_occurrences = true) ?parent ?(output_dir = Fpath.v "./")
-    ?(ignore_output = false) ?source_args children =
+let compile file ?parent ?(output_dir = Fpath.v "./") ?(ignore_output = false)
+    children =
   let output_basename =
     let ext = Fpath.get_ext file in
     let basename = Fpath.basename (Fpath.rem_ext file) in
@@ -223,28 +225,10 @@ let compile file ?(count_occurrences = true) ?parent ?(output_dir = Fpath.v "./"
     | ".cmt" | ".cmti" | ".cmi" -> basename ^ ".odoc"
     | _ -> failwith ("bad extension: " ^ ext)
   in
-  let output_file = Fpath.(/) output_dir output_basename in
+  let output_file = Fpath.( / ) output_dir output_basename in
   let open Cmd in
-  let source_args =
-    match source_args with
-    | None -> Cmd.empty
-    | Some (source_name, source_parent_file) ->
-        Cmd.(
-          v "--source-name" % p source_name % "--source-parent-file"
-          % p source_parent_file)
-  in
-  let cmt_arg =
-    let cmt_file = Fpath.set_ext ".cmt" file in
-    if Fpath.get_ext file = ".cmti" then
-    match Bos.OS.File.exists cmt_file with
-    | Ok true -> Cmd.(v "--cmt" % p cmt_file)
-    | _ -> Cmd.empty
-    else Cmd.empty
-  in
-  let occ = if count_occurrences then Cmd.v "--count-occurrences" else Cmd.empty in
   let cmd =
-    odoc % "compile" % Fpath.to_string file %% source_args %% occ %% cmt_arg
-    % "-I" % "." % "-o" % p output_file
+    odoc % "compile" % Fpath.to_string file % "-I" % "." % "-o" % p output_file
     |> List.fold_right (fun child cmd -> cmd % "--child" % child) children
   in
   let cmd =
@@ -256,35 +240,58 @@ let compile file ?(count_occurrences = true) ?parent ?(output_dir = Fpath.v "./"
   if not ignore_output then
     add_prefixed_output cmd compile_output (Fpath.to_string file) lines
 
+let compile_src file ?(output_dir = Fpath.v "./") ?(ignore_output = false)
+    ~source_name ~source_parent_file () =
+  let output_basename =
+    let ext = Fpath.get_ext file in
+    let basename = Fpath.basename (Fpath.rem_ext file) in
+    match ext with
+    | ".cmt" -> "src-" ^ basename ^ ".odoc"
+    | _ -> failwith ("bad extension: " ^ ext)
+  in
+  let output_file = Fpath.( / ) output_dir output_basename in
+  let open Cmd in
+  let source_args =
+    Cmd.(
+      v "--source-path" % p source_name % "--source-parent-file"
+      % p source_parent_file)
+  in
+  let cmd =
+    odoc % "compile-src" % Fpath.to_string file %% source_args % "-I" % "."
+    % "-o" % p output_file
+  in
+  let lines = run ~output_file cmd in
+  if not ignore_output then
+    add_prefixed_output cmd compile_src_output (Fpath.to_string file) lines
+
 let link ?(ignore_output = false) file =
   let open Cmd in
   let output_file = Fpath.set_ext "odocl" file in
   let cmd = odoc % "link" % p file % "-o" % p output_file % "-I" % "." in
-  let cmd = if Fpath.to_string file = "stdlib.odoc" then cmd % "--open=\"\"" else cmd in
+  let cmd =
+    if Fpath.to_string file = "stdlib.odoc" then cmd % "--open=\"\"" else cmd
+  in
   let lines = run ~output_file cmd in
   if not ignore_output then
     add_prefixed_output cmd link_output (Fpath.to_string file) lines
 
-let html_generate ?(ignore_output = false) ?(assets = []) ?(search_uris = []) file source =
+let html_generate ?(ignore_output = false) ?(assets = []) ?(search_uris = [])
+    file source =
   let open Cmd in
   let source =
     match source with None -> empty | Some source -> v "--source" % p source
   in
   let assets =
-    List.fold_left
-      (fun acc filename -> acc % "--asset" % filename)
-      empty
-      assets
+    List.fold_left (fun acc filename -> acc % "--asset" % filename) empty assets
   in
   let search_uris =
     List.fold_left
       (fun acc filename -> acc % "--search-uri" % p filename)
-      empty
-      search_uris
+      empty search_uris
   in
   let cmd =
-    odoc % "html-generate" %% source % p file %% assets %% search_uris % "-o" % "html"
-    % "--theme-uri" % "odoc" % "--support-uri" % "odoc"
+    odoc % "html-generate" %% source % p file %% assets %% search_uris % "-o"
+    % "html" % "--theme-uri" % "odoc" % "--support-uri" % "odoc"
   in
   let lines = run cmd in
   if not ignore_output then
@@ -488,10 +495,9 @@ let compile_deps f =
   | _ -> Error (`Msg "odd")
 ]}
 
-For each compiled odoc file, we'll need to remember some options given at
-[odoc compile]-time. An example of this is the source code rendering: when we
-enable the feature at compile time, we need to provide the source file at html
-generation.
+For each compiled odoc file, we'll need to remember some options given at [odoc
+compile]-time. An example of this is the source code rendering: when we compile
+an implementation unit, we need to provide the source file at html generation.
 
 {[
 type unit = {
@@ -521,7 +527,7 @@ let source_tree ?(ignore_output = false) ~parent ~output file =
   if not ignore_output then
     add_prefixed_output cmd source_tree_output (Fpath.to_string file) lines
 
-let odoc_source_tree = Fpath.v "src-source.odoc"
+let odoc_source_tree = Fpath.v "srctree-source.odoc"
 
 let source_dir_of_odoc_lib lib =
   match String.split_on_char '_' lib with
@@ -554,7 +560,7 @@ let source_files_of_odoc_module lib module_ =
         |> List.map (fun ext -> add_filename path ext)
         |> List.find_opt (fun f -> Bos.OS.File.exists (relativize f) |> get_ok)
       in
-      find_by_extension relpath [ "pp.ml"; "ml" ]
+      find_by_extension relpath [ "pp.ml"; "ml"; "ml-gen" ]
 
 let compile_source_tree units =
   let sources =
@@ -638,7 +644,7 @@ let compile_mlds () =
   in
   ignore
     (compile (mkmld "odoc")
-       ("src-source" :: "page-deps" :: List.map mkpage (odoc_libraries @ extra_docs)));
+       ("srctree-source" :: "page-deps" :: List.map mkpage (odoc_libraries @ extra_docs)));
   ignore (compile (mkmld "deps") ~parent:"odoc" (List.map mkpage dep_libraries));
   let extra_odocs =
     List.map
@@ -674,8 +680,12 @@ Now we get to the compilation phase. For each unit, we query its dependencies, t
 let compile_all () =
   let mld_odocs = compile_mlds () in
   let source_tree = compile_source_tree all_units in
-  let source_args =
-    Option.map (fun source_relpath -> (source_relpath, odoc_source_tree))
+  let compile_src file ~ignore_output source_args () =
+    match source_args with
+    | None -> ()
+    | Some source_name ->
+        compile_src (Fpath.set_ext "cmt" file) ~source_name ~ignore_output
+          ~source_parent_file:odoc_source_tree ()
   in
   let rec rec_compile ?impl parent lib file =
     let output = Fpath.(base (set_ext "odoc" file)) in
@@ -698,24 +708,30 @@ let compile_all () =
           [] deps.deps
       in
       let ignore_output = parent = "deps" in
-      let source_args = source_args impl in
-      compile file ~parent:lib ?source_args ~ignore_output [];
-      { file = output ; ignore_output ; source = impl; assets = [] } :: files
+      compile_src file impl ~ignore_output ();
+      compile file ~parent:lib ~ignore_output [];
+      { file = output; ignore_output; source = impl; assets = [] } :: files
   in
   source_tree
   :: List.fold_left
-    (fun acc (parent, lib, dep, impl) ->
-      acc @ rec_compile ?impl parent lib (best_file dep))
-      [] all_units
-   @ mld_odocs
+       (fun acc (parent, lib, dep, impl) ->
+         acc @ rec_compile ?impl parent lib (best_file dep))
+       [] all_units
+  @ mld_odocs
 ]}
 
 Linking is now straightforward. We link all [odoc] files.
 
 {[
+let src_file file =
+  let fdir, fname = Fpath.split_base file in
+  let fname = Fpath.v ("src-" ^ Fpath.to_string fname) in
+  Fpath.( // ) fdir fname
+
 let link_all odoc_files =
   List.map
-    (fun ({ file = odoc_file ; ignore_output ; _ } as unit) ->
+    (fun ({ file = odoc_file; ignore_output; source; _ } as unit) ->
+      if Option.is_some source then ignore (link ~ignore_output (src_file odoc_file));
       ignore (link ~ignore_output odoc_file);
       { unit with file = Fpath.set_ext "odocl" odoc_file })
     odoc_files
@@ -727,12 +743,15 @@ We notify the generator that the javascript file to use for search is [index.js]
 
 {[
 let generate_all odocl_files =
-  let relativize_opt = function None -> None | Some file -> Some (relativize file) in
-  let search_uris = [Fpath.v "minisearch.js"; Fpath.v "index.js"] in
+  let search_uris = [ Fpath.v "minisearch.js"; Fpath.v "index.js" ] in
   List.iter
-     (fun ({file = f ; ignore_output = _ ; source ; assets}) ->
-     ignore(html_generate ~assets ~search_uris f (relativize_opt source)))
-     odocl_files;
+    (fun { file; ignore_output = _; source; assets } ->
+      ignore (html_generate ~assets ~search_uris file None);
+      match source with
+      | None -> ()
+      | Some source ->
+          ignore (html_generate (src_file file) (Some (relativize source))))
+    odocl_files;
   support_files ()
 ]}
 
@@ -765,8 +784,8 @@ let index_generate ?(ignore_output = false) () =
     OS.Dir.contents (Fpath.v ".")
     |> get_ok
     |> List.filter (Fpath.has_ext "odocl")
-    |> List.filter (fun p -> not (String.equal "src-source.odocl" (Fpath.filename p)))
-    |> List.filter (fun p -> not (is_hidden p))
+    |> List.filter (fun p ->
+           String.starts_with ~prefix:"src-" (Fpath.filename p))
     |> List.map Fpath.to_string
   in
   let index_map = Fpath.v "index.map" in
@@ -833,7 +852,7 @@ let compiled = compile_all () in
 let linked = link_all compiled in
 let () = index_generate () in
 let _ = js_index () in
-let _ = count_occurrences (Fpath.v "occurrences-odoc_and_deps.odoc") in
+let _ = count_occurrences (Fpath.v "occurrences-from-odoc.odoc") in
 generate_all linked
 ]}
 
@@ -841,6 +860,8 @@ Let's see if there was any output from the [odoc] invocations:
 
 {[
 # !compile_output;;
+- : string list = [""]
+# !compile_src_output;;
 - : string list = [""]
 # (* Not showing output from 'odoc link' as it is unstable. !link_output *);;
 # !source_tree_output;;

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -253,7 +253,7 @@ let compile_src file ?(output_dir = Fpath.v "./") ?(ignore_output = false)
   let open Cmd in
   let source_args =
     Cmd.(
-      v "--source-path" % p source_name % "--source-parent-file"
+      v "--source-path" % p source_name % "--parent"
       % p source_parent_file)
   in
   let cmd =

--- a/src/.ocamlformat-ignore
+++ b/src/.ocamlformat-ignore
@@ -9,7 +9,6 @@ loader/implementation.ml
 loader/typedtree_traverse.ml
 loader/lookup_def.ml
 loader/lookup_def.mli
-loader/odoc_loader.ml
 syntax_highlighter/syntax_highlighter.ml
 model/*.cppo.ml
 html_support_files/*.ml

--- a/src/document/ML.mli
+++ b/src/document/ML.mli
@@ -15,7 +15,6 @@
  *)
 
 open Odoc_model
-open Odoc_model.Paths
 
 val compilation_unit : Lang.Compilation_unit.t -> Types.Document.t
 
@@ -25,11 +24,7 @@ val page : Lang.Page.t -> Types.Document.t
 val source_tree : Lang.SourceTree.t -> Types.Document.t list
 
 val source_page :
-  Identifier.SourcePage.t ->
-  Syntax_highlighter.infos ->
-  Lang.Source_info.infos ->
-  string ->
-  Types.Document.t
+  Lang.Source_page.t -> Syntax_highlighter.infos -> string -> Types.Document.t
 
 val type_expr : ?needs_parentheses:bool -> Lang.TypeExpr.t -> Codefmt.t
 

--- a/src/document/ML.mli
+++ b/src/document/ML.mli
@@ -23,8 +23,11 @@ val page : Lang.Page.t -> Types.Document.t
 
 val source_tree : Lang.SourceTree.t -> Types.Document.t list
 
-val source_page :
-  Lang.Source_page.t -> Syntax_highlighter.infos -> string -> Types.Document.t
+val implementation :
+  Lang.Implementation.t ->
+  Syntax_highlighter.infos ->
+  string ->
+  Types.Document.t
 
 val type_expr : ?needs_parentheses:bool -> Lang.TypeExpr.t -> Codefmt.t
 

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1774,6 +1774,9 @@ module Make (Syntax : SYNTAX) = struct
     val page : Lang.Page.t -> Document.t
 
     val source_tree : Lang.SourceTree.t -> Document.t list
+
+    val implementation :
+      Lang.Implementation.t -> Syntax_highlighter.infos -> string -> Document.t
   end = struct
     let pack : Lang.Compilation_unit.Packed.t -> Item.t list =
      fun t ->
@@ -1903,6 +1906,11 @@ module Make (Syntax : SYNTAX) = struct
           { Types.Page.preamble = []; items; url; source_anchor = None }
       in
       M.fold (fun dir children acc -> page_of_dir dir children :: acc) mmap []
+
+    let implementation (v : Odoc_model.Lang.Implementation.t) syntax_info
+        source_code =
+      Document.Source_page
+        (Source_page.source v.id syntax_info v.source_info source_code)
   end
 
   include Page
@@ -1910,8 +1918,4 @@ module Make (Syntax : SYNTAX) = struct
   let type_expr = type_expr
 
   let record = record
-
-  let source_page (v : Odoc_model.Lang.Source_page.t) syntax_info source_code =
-    Document.Source_page
-      (Source_page.source v.id syntax_info v.source_info source_code)
 end

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -53,10 +53,10 @@ let path_to_id path =
   | Error _ -> None
   | Ok url -> Some url
 
-let source_anchor locs =
+let source_anchor source_loc =
   (* Remove when dropping support for OCaml < 4.08 *)
   let to_option = function Result.Ok x -> Some x | Result.Error _ -> None in
-  match locs with
+  match source_loc with
   | Some id ->
       Url.Anchor.from_identifier
         (id : Paths.Identifier.SourceLocation.t :> Paths.Identifier.t)
@@ -690,7 +690,7 @@ module Make (Syntax : SYNTAX) = struct
         (* Take the anchor from the first constructor only for consistency with
            regular variants. *)
         match t.constructors with
-        | hd :: _ -> source_anchor hd.locs
+        | hd :: _ -> source_anchor hd.source_loc
         | [] -> None
       in
       Item.Declaration { attr; anchor; doc; content; source_anchor }
@@ -706,7 +706,7 @@ module Make (Syntax : SYNTAX) = struct
       let attr = [ "exception" ] in
       let anchor = path_to_id t.id in
       let doc = Comment.to_ir t.doc in
-      let source_anchor = source_anchor t.locs in
+      let source_anchor = source_anchor t.source_loc in
       Item.Declaration { attr; anchor; doc; content; source_anchor }
 
     let polymorphic_variant ~type_ident
@@ -919,7 +919,7 @@ module Make (Syntax : SYNTAX) = struct
       let attr = "type" :: (if is_substitution then [ "subst" ] else []) in
       let anchor = path_to_id t.id in
       let doc = Comment.to_ir t.doc in
-      let source_anchor = source_anchor t.locs in
+      let source_anchor = source_anchor t.source_loc in
       Item.Declaration { attr; anchor; doc; content; source_anchor }
   end
 
@@ -947,7 +947,7 @@ module Make (Syntax : SYNTAX) = struct
       let attr = [ "value" ] @ extra_attr in
       let anchor = path_to_id t.id in
       let doc = Comment.to_ir t.doc in
-      let source_anchor = source_anchor t.locs in
+      let source_anchor = source_anchor t.source_loc in
       Item.Declaration { attr; anchor; doc; content; source_anchor }
   end
 
@@ -1144,7 +1144,7 @@ module Make (Syntax : SYNTAX) = struct
         if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop
       in
 
-      let source_anchor = source_anchor t.locs in
+      let source_anchor = source_anchor t.source_loc in
       let cname, expansion, expansion_doc =
         match t.expansion with
         | None -> (O.documentedSrc @@ O.txt name, None, None)
@@ -1182,7 +1182,7 @@ module Make (Syntax : SYNTAX) = struct
       let virtual_ =
         if t.virtual_ then O.keyword "virtual" ++ O.txt " " else O.noop
       in
-      let source_anchor = source_anchor t.locs in
+      let source_anchor = source_anchor t.source_loc in
       let cname, expansion, expansion_doc =
         match t.expansion with
         | None -> (O.documentedSrc @@ O.txt name, None, None)
@@ -1445,7 +1445,7 @@ module Make (Syntax : SYNTAX) = struct
         | Alias (_, None) -> None
         | ModuleType e -> expansion_of_module_type_expr e
       in
-      let source_anchor = source_anchor t.locs in
+      let source_anchor = source_anchor t.source_loc in
       let modname, status, expansion, expansion_doc =
         match expansion with
         | None -> (O.txt modname, `Default, None, None)
@@ -1540,7 +1540,7 @@ module Make (Syntax : SYNTAX) = struct
         O.keyword "module" ++ O.txt " " ++ O.keyword "type" ++ O.txt " "
       in
       let modname = Paths.Identifier.name t.id in
-      let source_anchor = source_anchor t.locs in
+      let source_anchor = source_anchor t.source_loc in
       let modname, expansion_doc, mty =
         module_type_manifest ~subst:false ~source_anchor modname t.id t.doc
           t.expr prefix
@@ -1806,7 +1806,7 @@ module Make (Syntax : SYNTAX) = struct
         | Module sign -> signature sign
         | Pack packed -> ([], pack packed)
       in
-      let source_anchor = source_anchor t.locs in
+      let source_anchor = source_anchor t.source_loc in
       let page = make_expansion_page ~source_anchor url [ unit_doc ] items in
       Document.Page page
 

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -241,16 +241,14 @@ module Make (Syntax : SYNTAX) = struct
   end
 
   module Source_page : sig
-    val url : Paths.Identifier.SourcePage.t -> Url.t
     val source :
       Paths.Identifier.SourcePage.t ->
       Syntax_highlighter.infos ->
-      Lang.Source_info.infos ->
+      Lang.Source_info.t ->
       string ->
       Source_page.t
   end = struct
     let path id = Url.Path.from_identifier id
-    let url id = Url.from_path (path id)
 
     let to_link { Lang.Source_info.documentation; implementation } =
       let documentation =
@@ -936,7 +934,6 @@ module Make (Syntax : SYNTAX) = struct
         | Abstract -> ([], Syntax.Value.semicolon)
         | External _ -> ([ "external" ], Syntax.Type.External.semicolon)
       in
-      (* TODO: link to source *)
       let name = Paths.Identifier.name t.id in
       let content =
         O.documentedSrc
@@ -1466,7 +1463,6 @@ module Make (Syntax : SYNTAX) = struct
             in
             (link, status, Some page, Some expansion_doc)
       in
-      (* TODO: link to source *)
       let intro = O.keyword "module" ++ O.txt " " ++ modname in
       let summary = O.ignore intro ++ mdexpr_in_decl t.id t.type_ in
       let modexpr =
@@ -1807,11 +1803,7 @@ module Make (Syntax : SYNTAX) = struct
         | Module sign -> signature sign
         | Pack packed -> ([], pack packed)
       in
-      let source_anchor =
-        match t.source_info with
-        | Some { id = Some id; _ } -> Some (Source_page.url id)
-        | _ -> None
-      in
+      let source_anchor = source_anchor t.locs in
       let page = make_expansion_page ~source_anchor url [ unit_doc ] items in
       Document.Page page
 
@@ -1919,6 +1911,7 @@ module Make (Syntax : SYNTAX) = struct
 
   let record = record
 
-  let source_page id syntax_info infos source_code =
-    Document.Source_page (Source_page.source id syntax_info infos source_code)
+  let source_page (v : Odoc_model.Lang.Source_page.t) syntax_info source_code =
+    Document.Source_page
+      (Source_page.source v.id syntax_info v.source_info source_code)
 end

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -109,9 +109,8 @@ module type GENERATOR = sig
   val source_tree : Lang.SourceTree.t -> Document.t list
 
   val source_page :
-    Odoc_model.Paths.Identifier.SourcePage.t ->
+    Odoc_model.Lang.Source_page.t ->
     Syntax_highlighter.infos ->
-    Lang.Source_info.infos ->
     string ->
     Document.t
 

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -108,8 +108,8 @@ module type GENERATOR = sig
 
   val source_tree : Lang.SourceTree.t -> Document.t list
 
-  val source_page :
-    Odoc_model.Lang.Source_page.t ->
+  val implementation :
+    Odoc_model.Lang.Implementation.t ->
     Syntax_highlighter.infos ->
     string ->
     Document.t

--- a/src/document/reason.mli
+++ b/src/document/reason.mli
@@ -15,7 +15,6 @@
  *)
 
 open Odoc_model
-open Odoc_model.Paths
 
 val compilation_unit : Lang.Compilation_unit.t -> Types.Document.t
 
@@ -25,9 +24,5 @@ val page : Lang.Page.t -> Types.Document.t
 val source_tree : Lang.SourceTree.t -> Types.Document.t list
 
 val source_page :
-  Identifier.SourcePage.t ->
-  Syntax_highlighter.infos ->
-  Lang.Source_info.infos ->
-  string ->
-  Types.Document.t
+  Lang.Source_page.t -> Syntax_highlighter.infos -> string -> Types.Document.t
 (** Highlight the source as OCaml syntax *)

--- a/src/document/reason.mli
+++ b/src/document/reason.mli
@@ -23,6 +23,9 @@ val page : Lang.Page.t -> Types.Document.t
 
 val source_tree : Lang.SourceTree.t -> Types.Document.t list
 
-val source_page :
-  Lang.Source_page.t -> Syntax_highlighter.infos -> string -> Types.Document.t
+val implementation :
+  Lang.Implementation.t ->
+  Syntax_highlighter.infos ->
+  string ->
+  Types.Document.t
 (** Highlight the source as OCaml syntax *)

--- a/src/document/renderer.ml
+++ b/src/document/renderer.ml
@@ -34,14 +34,11 @@ let documents_of_source_tree ~syntax v =
   match syntax with Reason -> Reason.source_tree v | OCaml -> ML.source_tree v
 
 let documents_of_implementation ~syntax v =
-  match syntax with Reason -> Reason.source_page v | OCaml -> ML.source_page v
+  match syntax with
+  | Reason -> Reason.implementation v
+  | OCaml -> ML.implementation v
 
 let document_of_compilation_unit ~syntax v =
   match syntax with
   | Reason -> Reason.compilation_unit v
   | OCaml -> ML.compilation_unit v
-
-let document_of_source ~syntax =
-  match syntax with
-  | Reason -> Reason.source_page (* Currently, both functions are equivalent *)
-  | OCaml -> ML.source_page

--- a/src/document/renderer.ml
+++ b/src/document/renderer.ml
@@ -24,7 +24,7 @@ type input =
 type 'a t = {
   name : string;
   render : 'a -> Types.Document.t -> page list;
-  extra_documents : 'a -> input -> syntax:syntax -> Types.Document.t list;
+  extra_documents : 'a -> input -> Types.Document.t list;
 }
 
 let document_of_page ~syntax v =

--- a/src/document/renderer.ml
+++ b/src/document/renderer.ml
@@ -33,6 +33,9 @@ let document_of_page ~syntax v =
 let documents_of_source_tree ~syntax v =
   match syntax with Reason -> Reason.source_tree v | OCaml -> ML.source_tree v
 
+let documents_of_implementation ~syntax v =
+  match syntax with Reason -> Reason.source_page v | OCaml -> ML.source_page v
+
 let document_of_compilation_unit ~syntax v =
   match syntax with
   | Reason -> Reason.compilation_unit v

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -578,7 +578,7 @@ and read_object env fi nm =
 let read_value_description env parent id vd =
   let open Signature in
   let id = Env.find_value_identifier env id in
-  let locs = None in
+  let source_loc = None in
   let container =
     (parent : Identifier.Signature.t :> Identifier.LabelParent.t)
   in
@@ -597,7 +597,7 @@ let read_value_description env parent id vd =
         External primitives
     | _ -> assert false
   in
-  Value { Value.id; locs; doc; type_; value }
+  Value { Value.id; source_loc; doc; type_; value }
 
 let read_label_declaration env parent ld =
   let open TypeDecl.Field in
@@ -704,7 +704,7 @@ let read_class_constraints env params =
 let read_type_declaration env parent id decl =
   let open TypeDecl in
   let id = Env.find_type_identifier env id in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, canonical =
     Doc_attr.attached Odoc_model.Semantics.Expect_canonical container decl.type_attributes
@@ -735,12 +735,12 @@ let read_type_declaration env parent id decl =
   in
   let private_ = (decl.type_private = Private) in
   let equation = Equation.{params; manifest; constraints; private_} in
-  {id; locs; doc; canonical; equation; representation}
+  {id; source_loc; doc; canonical; equation; representation}
 
 let read_extension_constructor env parent id ext =
   let open Extension.Constructor in
   let id = Env.find_extension_identifier env id in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container ext.ext_attributes in
   let args =
@@ -748,7 +748,7 @@ let read_extension_constructor env parent id ext =
       (parent : Identifier.Signature.t :> Identifier.FieldParent.t) ext.ext_args
   in
   let res = opt_map (read_type_expr env) ext.ext_ret_type in
-  {id; locs; doc; args; res}
+  {id; source_loc; doc; args; res}
 
 let read_type_extension env parent id ext rest =
   let open Extension in
@@ -773,7 +773,7 @@ let read_type_extension env parent id ext rest =
 let read_exception env parent id ext =
   let open Exception in
   let id = Env.find_exception_identifier env id in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container ext.ext_attributes in
     mark_exception ext;
@@ -782,7 +782,7 @@ let read_exception env parent id ext =
         (parent : Identifier.Signature.t :> Identifier.FieldParent.t) ext.ext_args
     in
     let res = opt_map (read_type_expr env) ext.ext_ret_type in
-    {id; locs; doc; args; res}
+    {id; source_loc; doc; args; res}
 
 let read_method env parent concrete (name, kind, typ) =
   let open Method in
@@ -867,7 +867,7 @@ let rec read_virtual = function
 let read_class_type_declaration env parent id cltd =
   let open ClassType in
   let id = Env.find_class_type_identifier env id in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container cltd.clty_attributes in
     mark_class_type_declaration cltd;
@@ -880,7 +880,7 @@ let read_class_type_declaration env parent id cltd =
       read_class_signature env (id :> Identifier.ClassSignature.t) cltd.clty_params cltd.clty_type
     in
     let virtual_ = read_virtual cltd.clty_type in
-    { id; locs; doc; virtual_; params; expr; expansion = None }
+    { id; source_loc; doc; virtual_; params; expr; expansion = None }
 
 let rec read_class_type env parent params =
   let open Class in function
@@ -903,7 +903,7 @@ let rec read_class_type env parent params =
 let read_class_declaration env parent id cld =
   let open Class in
   let id = Env.find_class_identifier env id in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container cld.cty_attributes in
     mark_class_declaration cld;
@@ -916,7 +916,7 @@ let read_class_declaration env parent id cld =
       read_class_type env (id :> Identifier.ClassSignature.t) cld.cty_params cld.cty_type
     in
     let virtual_ = cld.cty_new = None in
-    { id; locs; doc; virtual_; params; type_; expansion = None }
+    { id; source_loc; doc; virtual_; params; type_; expansion = None }
 
 let rec read_module_type env parent (mty : Odoc_model.Compat.module_type) =
   let open ModuleType in
@@ -945,17 +945,17 @@ let rec read_module_type env parent (mty : Odoc_model.Compat.module_type) =
 and read_module_type_declaration env parent id (mtd : Odoc_model.Compat.modtype_declaration) =
   let open ModuleType in
   let id = Env.find_module_type env id in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container mtd.mtd_attributes in
   let canonical = (canonical :> Path.ModuleType.t option) in
   let expr = opt_map (read_module_type env (id :> Identifier.Signature.t)) mtd.mtd_type in
-  {id; locs; doc; canonical; expr }
+  {id; source_loc; doc; canonical; expr }
 
 and read_module_declaration env parent ident (md : Odoc_model.Compat.module_declaration) =
   let open Module in
   let id = (Env.find_module_identifier env ident :> Identifier.Module.t) in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container md.md_attributes in
   let canonical = (canonical :> Path.Module.t option) in
@@ -969,7 +969,7 @@ and read_module_declaration env parent ident (md : Odoc_model.Compat.module_decl
     | Some _ -> false
     | None -> Odoc_model.Names.contains_double_underscore (Ident.name ident)
   in
-  {id; locs; doc; type_; canonical; hidden }
+  {id; source_loc; doc; type_; canonical; hidden }
 
 and read_type_rec_status rec_status =
   let open Signature in

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -29,7 +29,7 @@ let read_core_type env ctyp =
   Cmi.read_type_expr env ctyp.ctyp_type
 
 let rec read_pattern env parent doc pat =
-  let locs _id = None in
+  let source_loc = None in
   let open Signature in
     match pat.pat_desc with
     | Tpat_any -> []
@@ -39,14 +39,14 @@ let rec read_pattern env parent doc pat =
           Cmi.mark_type_expr pat.pat_type;
           let type_ = Cmi.read_type_expr env pat.pat_type in
           let value = Abstract in
-          [Value {id; locs = locs id; doc; type_; value}]
+          [Value {id; source_loc; doc; type_; value}]
     | Tpat_alias(pat, id, _) ->
         let open Value in
         let id = Env.find_value_identifier env id in
           Cmi.mark_type_expr pat.pat_type;
           let type_ = Cmi.read_type_expr env pat.pat_type in
           let value = Abstract in
-          Value {id; locs = locs id; doc; type_; value} :: read_pattern env parent doc pat
+          Value {id; source_loc; doc; type_; value} :: read_pattern env parent doc pat
     | Tpat_constant _ -> []
     | Tpat_tuple pats ->
         List.concat (List.map (read_pattern env parent doc) pats)
@@ -324,7 +324,7 @@ let rec read_class_expr env parent params cl =
 let read_class_declaration env parent cld =
   let open Class in
   let id = Env.find_class_identifier env cld.ci_id_class in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container cld.ci_attributes in
     Cmi.mark_class_declaration cld.ci_decl;
@@ -338,7 +338,7 @@ let read_class_declaration env parent cld =
         clparams
     in
     let type_ = read_class_expr env (id :> Identifier.ClassSignature.t) clparams cld.ci_expr in
-    { id; locs; doc; virtual_; params; type_; expansion = None }
+    { id; source_loc; doc; virtual_; params; type_; expansion = None }
 
 let read_class_declarations env parent clds =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
@@ -432,7 +432,7 @@ and read_module_binding env parent mb =
   let id = Env.find_module_identifier env mb.mb_id in
 #endif
   let id = (id :> Identifier.Module.t) in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container mb.mb_attributes in
   let type_, canonical =
@@ -457,7 +457,7 @@ and read_module_binding env parent mb =
     | _ -> false
 #endif
   in
-  Some {id; locs; doc; type_; canonical; hidden; }
+  Some {id; source_loc; doc; type_; canonical; hidden; }
 
 and read_module_bindings env parent mbs =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t)

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -146,7 +146,7 @@ let rec read_core_type env container ctyp =
 let read_value_description env parent vd =
   let open Signature in
   let id = Env.find_value_identifier env vd.val_id in
-  let locs = None in
+  let source_loc = None in
   let container =
     (parent : Identifier.Signature.t :> Identifier.LabelParent.t)
   in
@@ -157,7 +157,7 @@ let read_value_description env parent vd =
     | [] -> Value.Abstract
     | primitives -> External primitives
   in
-  Value { Value.id; locs; doc; type_; value }
+  Value { Value.id; source_loc; doc; type_; value }
 
 let read_type_parameter (ctyp, var_and_injectivity)  =
   let open TypeDecl in
@@ -255,13 +255,13 @@ let read_type_equation env container decl =
 let read_type_declaration env parent decl =
   let open TypeDecl in
   let id = Env.find_type_identifier env decl.typ_id in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container decl.typ_attributes in
   let canonical = (canonical :> Path.Type.t option) in
   let equation = read_type_equation env container decl in
   let representation = read_type_kind env id decl.typ_kind in
-  {id; locs; doc; canonical; equation; representation}
+  {id; source_loc; doc; canonical; equation; representation}
 
 let read_type_declarations env parent rec_flag decls =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
@@ -291,7 +291,7 @@ let read_type_substitutions env parent decls =
 let read_extension_constructor env parent ext =
   let open Extension.Constructor in
   let id = Env.find_extension_identifier env ext.ext_id in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.FieldParent.t) in
   let label_container = (container :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag label_container ext.ext_attributes in
@@ -307,7 +307,7 @@ let read_extension_constructor env parent ext =
         env container label_container args
     in
     let res = opt_map (read_core_type env label_container) res in
-    {id; locs; doc; args; res}
+    {id; source_loc; doc; args; res}
 
 let read_type_extension env parent tyext =
   let open Extension in
@@ -324,7 +324,7 @@ let read_type_extension env parent tyext =
 let read_exception env parent (ext : extension_constructor) =
   let open Exception in
   let id = Env.find_exception_identifier env ext.ext_id in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.FieldParent.t) in
   let label_container = (container :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag label_container ext.ext_attributes in
@@ -340,7 +340,7 @@ let read_exception env parent (ext : extension_constructor) =
         env container label_container args
     in
     let res = opt_map (read_core_type env label_container) res in
-    {id; locs; doc; args; res}
+    {id; source_loc; doc; args; res}
 
 let rec read_class_type_field env parent ctf =
   let open ClassSignature in
@@ -414,13 +414,13 @@ and read_class_signature env parent label_parent cltyp =
 let read_class_type_declaration env parent cltd =
   let open ClassType in
   let id = Env.find_class_type_identifier env cltd.ci_id_class_type in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container cltd.ci_attributes in
   let virtual_ = (cltd.ci_virt = Virtual) in
   let params = List.map read_type_parameter cltd.ci_params in
   let expr = read_class_signature env (id :> Identifier.ClassSignature.t) container cltd.ci_expr in
-  { id; locs; doc; virtual_; params; expr; expansion = None }
+  { id; source_loc; doc; virtual_; params; expr; expansion = None }
 
 let read_class_type_declarations env parent cltds =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
@@ -453,13 +453,13 @@ let rec read_class_type env parent label_parent cty =
 let read_class_description env parent cld =
   let open Class in
   let id = Env.find_class_identifier env cld.ci_id_class in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container cld.ci_attributes in
   let virtual_ = (cld.ci_virt = Virtual) in
   let params = List.map read_type_parameter cld.ci_params in
   let type_ = read_class_type env (id :> Identifier.ClassSignature.t) container cld.ci_expr in
-  { id; locs; doc; virtual_; params; type_; expansion = None }
+  { id; source_loc; doc; virtual_; params; type_; expansion = None }
 
 let read_class_descriptions env parent clds =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
@@ -582,7 +582,7 @@ and read_module_type_maybe_canonical env parent container ~canonical mty =
 and read_module_type_declaration env parent mtd =
   let open ModuleType in
   let id = Env.find_module_type env mtd.mtd_id in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container mtd.mtd_attributes in
   let expr, canonical =
@@ -597,7 +597,7 @@ and read_module_type_declaration env parent mtd =
     | None -> (None, canonical)
   in
   let canonical = (canonical :> Path.ModuleType.t option) in
-  { id; locs; doc; canonical; expr }
+  { id; source_loc; doc; canonical; expr }
 
 and read_module_declaration env parent md =
   let open Module in
@@ -610,7 +610,7 @@ and read_module_declaration env parent md =
   let id = Env.find_module_identifier env md.md_id in
 #endif
   let id = (id :> Identifier.Module.t) in
-  let locs = None in
+  let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container md.md_attributes in
   let type_, canonical =
@@ -636,7 +636,7 @@ and read_module_declaration env parent md =
     | _ -> false
 #endif
   in
-  Some {id; locs; doc; type_; canonical; hidden}
+  Some {id; source_loc; doc; type_; canonical; hidden}
 
 and read_module_declarations env parent mds =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in

--- a/src/loader/implementation.ml
+++ b/src/loader/implementation.ml
@@ -369,7 +369,7 @@ let read_cmt_infos source_id shape_info impl digest root imports =
       in
       let shape_info = Some (shape, Shape.Uid.Tbl.to_map uid_to_id) in
       {
-        Odoc_model.Lang.Source_page.id = source_id;
+        Odoc_model.Lang.Implementation.id = source_id;
         source_info = source_infos;
         digest;
         root;
@@ -378,7 +378,7 @@ let read_cmt_infos source_id shape_info impl digest root imports =
         imports;
       }
   | None as shape_info -> {
-        Odoc_model.Lang.Source_page.id = source_id;
+        Odoc_model.Lang.Implementation.id = source_id;
         source_info = [];
         digest;
         root;
@@ -392,7 +392,7 @@ let read_cmt_infos source_id shape_info impl digest root imports =
 
 let read_cmt_infos source_id shape_info _impl digest root imports =
   {
-    Odoc_model.Lang.Source_page.id = source_id;
+    Odoc_model.Lang.Implementation.id = source_id;
     source_info = [];
     digest;
     root;

--- a/src/loader/implementation.mli
+++ b/src/loader/implementation.mli
@@ -1,13 +1,13 @@
+open Odoc_model
+
 val read_cmt_infos :
-  Odoc_model.Paths.Identifier.Id.source_page option ->
-  Odoc_model.Paths.Identifier.Id.root_module ->
-  Cmt_format.cmt_infos ->
-  count_occurrences:bool ->
-  (Odoc_model.Compat.shape
-  * Odoc_model.Paths.Identifier.Id.source_location
-    Odoc_model.Compat.shape_uid_map)
-  option
-  * Odoc_model.Lang.Source_info.t option
+  Paths.Identifier.Id.source_page ->
+  (Compat.shape * Compat.uid_to_loc) option ->
+  Typedtree.structure ->
+  string ->
+  Root.t ->
+  Lang.Compilation_unit.Import.t list ->
+  Lang.Source_page.t
 (** Extract all implementation information from a [cmt]: the shape, and the
     {{!Odoc_model.Lang.Source_info.infos}source infos} (local and global
     definitions and occurrences).

--- a/src/loader/implementation.mli
+++ b/src/loader/implementation.mli
@@ -7,7 +7,7 @@ val read_cmt_infos :
   string ->
   Root.t ->
   Lang.Compilation_unit.Import.t list ->
-  Lang.Source_page.t
+  Lang.Implementation.t
 (** Extract all implementation information from a [cmt]: the shape, and the
     {{!Odoc_model.Lang.Source_info.infos}source infos} (local and global
     definitions and occurrences).

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -42,17 +42,21 @@ exception Not_an_interface
 
 exception Make_root_error of string
 
-let read_cmt_infos source_id_opt id ~filename ~count_occurrences () =
+let read_cmt_infos source_id ~filename root digest imports () =
   match Cmt_format.read_cmt filename with
   | exception Cmi_format.Error _ -> raise Corrupted
   | cmt_info -> (
       match cmt_info.cmt_annots with
-      | Implementation _ -> Implementation.read_cmt_infos source_id_opt id cmt_info ~count_occurrences
+      | Implementation impl ->
+          let shape_infos =
+            Odoc_model.Compat.shape_info_of_cmt_infos cmt_info
+          in
+          Implementation.read_cmt_infos source_id shape_infos impl digest root
+            imports
       | _ -> raise Not_an_implementation)
 
-
 let make_compilation_unit ~make_root ~imports ~interface ?sourcefile ~name ~id
-    ?canonical ?shape_info ~source_info content =
+    ?canonical content =
   let open Odoc_model.Lang.Compilation_unit in
   let interface, digest =
     match interface with
@@ -88,18 +92,16 @@ let make_compilation_unit ~make_root ~imports ~interface ?sourcefile ~name ~id
     expansion = None;
     linked = false;
     canonical;
-    source_info;
-    shape_info;
+    locs = None;
   }
 
-
 let compilation_unit_of_sig ~make_root ~imports ~interface ?sourcefile ~name ~id
-    ?canonical ?shape_info sg =
+    ?canonical sg =
   let content = Odoc_model.Lang.Compilation_unit.Module sg in
   make_compilation_unit ~make_root ~imports ~interface ?sourcefile ~name ~id
-    ?canonical ?shape_info content
+    ?canonical content
 
-let read_cmti ~make_root ~parent ~filename ~cmt_filename_opt ~source_id_opt ~count_occurrences () =
+let read_cmti ~make_root ~parent ~filename () =
   let cmt_info = Cmt_format.read_cmt filename in
   match cmt_info.cmt_annots with
   | Interface intf -> (
@@ -113,19 +115,11 @@ let read_cmti ~make_root ~parent ~filename ~cmt_filename_opt ~source_id_opt ~cou
               cmt_info.cmt_builddir )
           in
           let id, sg, canonical = Cmti.read_interface parent name intf in
-          let shape_info, source_info =
-            match cmt_filename_opt with
-            | Some cmt_filename ->
-                read_cmt_infos source_id_opt id ~filename:cmt_filename ~count_occurrences ()
-            | None ->
-               (None, None)
-          in
           compilation_unit_of_sig ~make_root ~imports:cmt_info.cmt_imports
-            ~interface ~sourcefile ~name ~id ?shape_info ~source_info
-            ?canonical sg)
+            ~interface ~sourcefile ~name ~id ?canonical sg)
   | _ -> raise Not_an_interface
 
-let read_cmt ~make_root ~parent ~filename ~source_id_opt ~count_occurrences () =
+let read_cmt ~make_root ~parent ~filename () =
   match Cmt_format.read_cmt filename with
   | exception Cmi_format.Error (Not_an_interface _) ->
       raise Not_an_implementation
@@ -165,14 +159,11 @@ let read_cmt ~make_root ~parent ~filename ~source_id_opt ~count_occurrences () =
           in
           let content = Odoc_model.Lang.Compilation_unit.Pack items in
           make_compilation_unit ~make_root ~imports ~interface ~sourcefile ~name
-            ~id ~source_info:None content
+            ~id content
       | Implementation impl ->
           let id, sg, canonical = Cmt.read_implementation parent name impl in
-          let shape_info, source_info =
-            read_cmt_infos source_id_opt id ~filename ~count_occurrences ()
-          in
           compilation_unit_of_sig ~make_root ~imports ~interface ~sourcefile
-            ~name ~id ?canonical ?shape_info ~source_info sg
+            ~name ~id ?canonical sg
       | _ -> raise Not_an_implementation)
 
 let read_cmi ~make_root ~parent ~filename () =
@@ -183,9 +174,47 @@ let read_cmi ~make_root ~parent ~filename () =
         Cmi.read_interface parent name
           (Odoc_model.Compat.signature cmi_info.cmi_sign)
       in
-      compilation_unit_of_sig ~make_root ~imports ~interface ~name ~id
-        ~source_info:None sg
+      compilation_unit_of_sig ~make_root ~imports ~interface ~name ~id sg
   | _ -> raise Corrupted
+
+let read_impl ~make_root ~filename ~source_id () =
+  match Cmt_format.read_cmt filename with
+  | exception Cmi_format.Error (Not_an_interface _) ->
+      raise Not_an_implementation
+  | cmt_info -> (
+      let name = cmt_info.cmt_modname in
+      let _sourcefile =
+        ( cmt_info.cmt_sourcefile,
+          cmt_info.cmt_source_digest,
+          cmt_info.cmt_builddir )
+      in
+      let interface = cmt_info.cmt_interface_digest in
+      let imports = cmt_info.cmt_imports in
+      match cmt_info.cmt_annots with
+      | Implementation _impl ->
+          let digest =
+            match interface with
+            | Some digest -> digest
+            | None -> (
+                match List.assoc name imports with
+                | Some digest -> digest
+                | None -> raise Corrupted
+                | exception Not_found -> raise Corrupted)
+          in
+          let root =
+            match make_root ~module_name:name ~digest with
+            | Ok root -> root
+            | Error (`Msg m) -> raise (Make_root_error m)
+          in
+          let imports = List.filter (fun (name', _) -> name <> name') imports in
+          let imports =
+            List.map
+              (fun (s, d) ->
+                Odoc_model.Lang.Compilation_unit.Import.Unresolved (s, d))
+              imports
+          in
+          read_cmt_infos source_id ~filename root digest imports ()
+      | _ -> raise Not_an_implementation)
 
 (** Catch errors from reading the object files and some internal errors *)
 let wrap_errors ~filename f =
@@ -200,12 +229,14 @@ let wrap_errors ~filename f =
       | Not_an_interface -> not_an_interface filename
       | Make_root_error m -> error_msg filename m)
 
-let read_cmti ~make_root ~parent ~filename ~source_id_opt ~cmt_filename_opt ~count_occurrences =
-  wrap_errors ~filename
-    (read_cmti ~make_root ~parent ~filename ~source_id_opt ~cmt_filename_opt ~count_occurrences)
+let read_cmti ~make_root ~parent ~filename =
+  wrap_errors ~filename (read_cmti ~make_root ~parent ~filename)
 
-let read_cmt ~make_root ~parent ~filename ~source_id_opt ~count_occurrences =
-  wrap_errors ~filename (read_cmt ~make_root ~parent ~filename ~source_id_opt ~count_occurrences)
+let read_cmt ~make_root ~parent ~filename =
+  wrap_errors ~filename (read_cmt ~make_root ~parent ~filename)
+
+let read_impl ~make_root ~filename ~source_id =
+  wrap_errors ~filename (read_impl ~make_root ~source_id ~filename)
 
 let read_cmi ~make_root ~parent ~filename =
   wrap_errors ~filename (read_cmi ~make_root ~parent ~filename)

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -92,7 +92,7 @@ let make_compilation_unit ~make_root ~imports ~interface ?sourcefile ~name ~id
     expansion = None;
     linked = false;
     canonical;
-    locs = None;
+    source_loc = None;
   }
 
 let compilation_unit_of_sig ~make_root ~imports ~interface ?sourcefile ~name ~id

--- a/src/loader/odoc_loader.mli
+++ b/src/loader/odoc_loader.mli
@@ -29,7 +29,7 @@ val read_impl :
   make_root:make_root ->
   filename:string ->
   source_id:Identifier.SourcePage.t ->
-  (Lang.Source_page.t, Error.t) result Error.with_warnings
+  (Lang.Implementation.t, Error.t) result Error.with_warnings
 
 val read_cmi :
   make_root:make_root ->

--- a/src/loader/odoc_loader.mli
+++ b/src/loader/odoc_loader.mli
@@ -17,18 +17,19 @@ val read_cmti :
   make_root:make_root ->
   parent:Identifier.ContainerPage.t option ->
   filename:string ->
-  source_id_opt:Identifier.SourcePage.t option ->
-  cmt_filename_opt:string option ->
-  count_occurrences:bool ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_cmt :
   make_root:make_root ->
   parent:Identifier.ContainerPage.t option ->
   filename:string ->
-  source_id_opt:Identifier.SourcePage.t option ->
-  count_occurrences:bool ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
+
+val read_impl :
+  make_root:make_root ->
+  filename:string ->
+  source_id:Identifier.SourcePage.t ->
+  (Lang.Source_page.t, Error.t) result Error.with_warnings
 
 val read_cmi :
   make_root:make_root ->

--- a/src/model/compat.cppo.ml
+++ b/src/model/compat.cppo.ml
@@ -235,7 +235,8 @@ type 'a shape_uid_map = 'a Shape.Uid.Map.t
 type uid_to_loc = Warnings.loc Types.Uid.Tbl.t
 let empty_map = Shape.Uid.Map.empty
 
-let shape_of_cmt_infos : Cmt_format.cmt_infos -> shape option = fun x -> x.cmt_impl_shape
+let shape_info_of_cmt_infos : Cmt_format.cmt_infos -> (shape * uid_to_loc) option =
+ fun x -> Option.map (fun s -> (s, x.cmt_uid_to_loc)) x.cmt_impl_shape
 
 #else
 
@@ -246,6 +247,6 @@ type 'a shape_uid_map = unit
 type uid_to_loc = unit
 let empty_map = ()
 
-let shape_of_cmt_infos : Cmt_format.cmt_infos -> shape option = fun _ -> None
+let shape_info_of_cmt_infos : Cmt_format.cmt_infos -> (shape * uid_to_loc) option = fun _ -> None
 
 #endif

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -25,7 +25,7 @@ module rec Module : sig
 
   type t = {
     id : Identifier.Module.t;
-    locs : Identifier.SourceLocation.t option;
+    source_loc : Identifier.SourceLocation.t option;
         (** Identifier.SourceLocation might not be set when the module is artificially constructed from a functor argument. *)
     doc : Comment.docs;
     type_ : decl;
@@ -103,7 +103,7 @@ and ModuleType : sig
 
   type t = {
     id : Identifier.ModuleType.t;
-    locs : Identifier.SourceLocation.t option;
+    source_loc : Identifier.SourceLocation.t option;
         (** Can be [None] for module types created by a type substitution. *)
     doc : Comment.docs;
     canonical : Path.ModuleType.t option;
@@ -244,7 +244,7 @@ and TypeDecl : sig
 
   type t = {
     id : Identifier.Type.t;
-    locs : Identifier.SourceLocation.t option;
+    source_loc : Identifier.SourceLocation.t option;
     doc : Comment.docs;
     canonical : Path.Type.t option;
     equation : Equation.t;
@@ -259,7 +259,7 @@ and Extension : sig
   module Constructor : sig
     type t = {
       id : Identifier.Extension.t;
-      locs : Identifier.SourceLocation.t option;
+      source_loc : Identifier.SourceLocation.t option;
       doc : Comment.docs;
       args : TypeDecl.Constructor.argument;
       res : TypeExpr.t option;
@@ -281,7 +281,7 @@ end =
 and Exception : sig
   type t = {
     id : Identifier.Exception.t;
-    locs : Identifier.SourceLocation.t option;
+    source_loc : Identifier.SourceLocation.t option;
     doc : Comment.docs;
     args : TypeDecl.Constructor.argument;
     res : TypeExpr.t option;
@@ -296,7 +296,7 @@ and Value : sig
 
   type t = {
     id : Identifier.Value.t;
-    locs : Identifier.SourceLocation.t option;
+    source_loc : Identifier.SourceLocation.t option;
     value : value;
     doc : Comment.docs;
     type_ : TypeExpr.t;
@@ -313,7 +313,7 @@ and Class : sig
 
   type t = {
     id : Identifier.Class.t;
-    locs : Identifier.SourceLocation.t option;
+    source_loc : Identifier.SourceLocation.t option;
     doc : Comment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;
@@ -332,7 +332,7 @@ and ClassType : sig
 
   type t = {
     id : Identifier.ClassType.t;
-    locs : Identifier.SourceLocation.t option;
+    source_loc : Identifier.SourceLocation.t option;
     doc : Comment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;
@@ -473,7 +473,7 @@ module rec Compilation_unit : sig
     content : content;
     expansion : Signature.t option;
     linked : bool;  (** Whether this unit has been linked. *)
-    locs : Identifier.SourceLocation.t option;
+    source_loc : Identifier.SourceLocation.t option;
     canonical : Path.Module.t option;
   }
 end =

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -17,29 +17,6 @@
 open Paths
 
 (** {3 Modules} *)
-module Source_info = struct
-  type 'a jump_to_impl =
-    | Unresolved of 'a
-    | Resolved of Identifier.SourceLocation.t
-
-  type 'a jump_to = {
-    documentation : 'a option;
-    implementation : 'a jump_to_impl option;
-  }
-
-  type annotation =
-    | Definition of Paths.Identifier.SourceLocation.t
-    | Value of Path.Value.t jump_to
-    | Module of Path.Module.t jump_to
-    | ModuleType of Path.ModuleType.t jump_to
-    | Type of Path.Type.t jump_to
-
-  type 'a with_pos = 'a * (int * int)
-
-  type infos = annotation with_pos list
-
-  type t = { id : Identifier.SourcePage.t option; infos : infos }
-end
 
 module rec Module : sig
   type decl =
@@ -496,14 +473,49 @@ module rec Compilation_unit : sig
     content : content;
     expansion : Signature.t option;
     linked : bool;  (** Whether this unit has been linked. *)
+    locs : Identifier.SourceLocation.t option;
     canonical : Path.Module.t option;
-    source_info : Source_info.t option;
+  }
+end =
+  Compilation_unit
+
+module rec Source_info : sig
+  type 'a jump_to_impl =
+    | Unresolved of 'a
+    | Resolved of Identifier.SourceLocation.t
+
+  type 'a jump_to = {
+    documentation : 'a option;
+    implementation : 'a jump_to_impl option;
+  }
+
+  type annotation =
+    | Definition of Paths.Identifier.SourceLocation.t
+    | Value of Path.Value.t jump_to
+    | Module of Path.Module.t jump_to
+    | ModuleType of Path.ModuleType.t jump_to
+    | Type of Path.Type.t jump_to
+
+  type 'a with_pos = 'a * (int * int)
+
+  type t = annotation with_pos list
+end =
+  Source_info
+
+module rec Source_page : sig
+  type t = {
+    id : Identifier.SourcePage.t;
+    digest : Digest.t;
+    root : Root.t;
+    linked : bool;  (** Whether this unit has been linked. *)
+    imports : Compilation_unit.Import.t list;
+    source_info : Source_info.t;
     shape_info :
       (Compat.shape * Paths.Identifier.SourceLocation.t Compat.shape_uid_map)
       option;
   }
 end =
-  Compilation_unit
+  Source_page
 
 module rec Page : sig
   type child =

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -502,7 +502,7 @@ module rec Source_info : sig
 end =
   Source_info
 
-module rec Source_page : sig
+module rec Implementation : sig
   type t = {
     id : Identifier.SourcePage.t;
     digest : Digest.t;
@@ -515,7 +515,7 @@ module rec Source_page : sig
       option;
   }
 end =
-  Source_page
+  Implementation
 
 module rec Page : sig
   type child =

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -49,7 +49,8 @@ module Identifier = struct
   and source_location = source_location_pv id
   (** @canonical Odoc_model.Paths.Identifier.SourceLocation.t_pv *)
 
-  type odoc_id_pv = [ page_pv | `Root of container_page option * ModuleName.t ]
+  type odoc_id_pv =
+    [ page_pv | source_page_pv | `Root of container_page option * ModuleName.t ]
   (** @canonical Odoc_model.Paths.Identifier.OdocId.t_pv *)
 
   and odoc_id = odoc_id_pv id

--- a/src/model/predefined.ml
+++ b/src/model/predefined.ml
@@ -33,11 +33,18 @@ let covariant_equation =
 let invariant_equation =
   mk_equation [ { desc = Var "'a"; variance = None; injectivity = true } ]
 
-let locations = None
+let source_loc = None
 
 let mk_type ?(doc = empty_doc) ?(eq = nullary_equation) ?repr id =
-  let locs = locations and canonical = None in
-  { TypeDecl.id; locs; doc; canonical; equation = eq; representation = repr }
+  let canonical = None in
+  {
+    TypeDecl.id;
+    source_loc;
+    doc;
+    canonical;
+    equation = eq;
+    representation = repr;
+  }
 
 let mk_constr ?(args = TypeDecl.Constructor.Tuple []) id =
   { TypeDecl.Constructor.id; doc = empty_doc; args; res = None }

--- a/src/model/root.mli
+++ b/src/model/root.mli
@@ -28,11 +28,16 @@ end
 module Odoc_file : sig
   type compilation_unit = { name : string; hidden : bool }
 
-  type t = Page of string | Compilation_unit of compilation_unit
+  type t =
+    | Page of string
+    | Compilation_unit of compilation_unit
+    | Impl of string
 
   val create_unit : force_hidden:bool -> string -> t
 
   val create_page : string -> t
+
+  val create_impl : string -> t
 
   val name : t -> string
 

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -692,8 +692,8 @@ and page_t =
       F ("digest", (fun t -> t.digest), Digest.t);
     ]
 
-and source_page_t =
-  let open Lang.Source_page in
+and implementation_t =
+  let open Lang.Implementation in
   Record
     [
       F ("id", (fun t -> t.id), identifier);

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -16,10 +16,6 @@ let inline_status =
     | `Closed -> C0 "`Closed"
     | `Inline -> C0 "`Inline")
 
-let source_info =
-  let open Lang.Source_info in
-  Record [ F ("id", (fun t -> t.id), Option identifier) ]
-
 (** {3 Module} *)
 
 let rec module_decl =
@@ -682,7 +678,6 @@ and compilation_unit_t =
         ( "canonical",
           (fun t -> (t.canonical :> Paths.Path.t option)),
           Option path );
-      F ("sources", (fun t -> t.source_info), Option source_info);
     ]
 
 (** {3 Page} *)
@@ -695,6 +690,15 @@ and page_t =
       F ("root", (fun t -> t.root), root);
       F ("content", (fun t -> t.content), docs);
       F ("digest", (fun t -> t.digest), Digest.t);
+    ]
+
+and source_page_t =
+  let open Lang.Source_page in
+  Record
+    [
+      F ("id", (fun t -> t.id), identifier);
+      F ("digest", (fun t -> t.digest), Digest.t);
+      F ("root", (fun t -> t.root), root);
     ]
 
 and source_tree_page_t =

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -34,7 +34,7 @@ and module_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option identifier);
+      F ("source_loc", (fun t -> t.source_loc), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("type_", (fun t -> t.type_), module_decl);
       F
@@ -168,7 +168,7 @@ and moduletype_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option identifier);
+      F ("source_loc", (fun t -> t.source_loc), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F
         ( "canonical",
@@ -358,7 +358,7 @@ and typedecl_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option identifier);
+      F ("source_loc", (fun t -> t.source_loc), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("equation", (fun t -> t.equation), typedecl_equation);
       F
@@ -373,7 +373,7 @@ and extension_constructor =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option identifier);
+      F ("source_loc", (fun t -> t.source_loc), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("args", (fun t -> t.args), typedecl_constructor_argument);
       F ("res", (fun t -> t.res), Option typeexpr_t);
@@ -397,7 +397,7 @@ and exception_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option identifier);
+      F ("source_loc", (fun t -> t.source_loc), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("args", (fun t -> t.args), typedecl_constructor_argument);
       F ("res", (fun t -> t.res), Option typeexpr_t);
@@ -415,7 +415,7 @@ and value_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option identifier);
+      F ("source_loc", (fun t -> t.source_loc), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("type_", (fun t -> t.type_), typeexpr_t);
       F ("value", (fun t -> t.value), value_value_t);
@@ -439,7 +439,7 @@ and class_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option identifier);
+      F ("source_loc", (fun t -> t.source_loc), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("virtual_", (fun t -> t.virtual_), bool);
       F ("params", (fun t -> t.params), List typedecl_param);
@@ -462,7 +462,7 @@ and classtype_t =
   Record
     [
       F ("id", (fun t -> t.id), identifier);
-      F ("locs", (fun t -> t.locs), Option identifier);
+      F ("source_loc", (fun t -> t.source_loc), Option identifier);
       F ("doc", (fun t -> t.doc), docs);
       F ("virtual_", (fun t -> t.virtual_), bool);
       F ("params", (fun t -> t.params), List typedecl_param);

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -430,7 +430,7 @@ module Compile_src = struct
       Arg.(
         required
         & opt (some convert_fpath) None
-        & info [ "source-parent-file" ] ~doc ~docv:"srctree-PARENT.odoc")
+        & info [ "parent" ] ~doc ~docv:(Source_tree.prefix ^ "PARENT.odoc"))
     in
     let source_path =
       let doc =

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -351,9 +351,9 @@ module Source_tree = struct
 
   let info ~docs =
     let doc =
-      "Compile a source tree into a page. Expect a text file containing the \
-       relative paths to every source files in the source tree. The paths \
-       should be the same as the one passed to $(i,odoc compile \
+      "(EXPERIMENTAL) Compile a source tree into a page. Expect a text file \
+       containing the relative paths to every source files in the source tree. \
+       The paths should be the same as the one passed to $(i,odoc compile \
        --source-name)."
     in
     Term.info "source-tree" ~docs ~doc
@@ -449,8 +449,9 @@ module Compile_src = struct
 
   let info ~docs =
     let doc =
-      "Compile a $(i,NAME.cmt) file to a $(i,src-NAME.odoc) containing the \
-       implementation information needed by odoc for the compilation unit."
+      "(EXPERIMENTAL) Compile a $(i,NAME.cmt) file to a $(i,src-NAME.odoc) \
+       containing the implementation information needed by odoc for the \
+       compilation unit."
     in
     Term.info "compile-src" ~docs ~doc
 end
@@ -671,8 +672,8 @@ end = struct
 
     let source_file =
       let doc =
-        "Source code for the compilation unit. It must have been compiled with \
-         --source-parent passed."
+        "(EXPERIMENTAL) Source code for the compilation unit. It must have \
+         been compiled with --source-parent passed."
       in
       Arg.(
         value
@@ -681,9 +682,9 @@ end = struct
 
     let source_root =
       let doc =
-        "Source code root for the compilation unit. Used to find the source \
-         file from the value of --source-name it was compiled with. \
-         Incompatible with --source-file."
+        "(EXPERIMENTAL) Source code root for the compilation unit. Used to \
+         find the source file from the value of --source-name it was compiled \
+         with. Incompatible with --source-file."
       in
       Arg.(
         value

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -40,7 +40,7 @@ let is_module_name n = String.length n > 0 && Char.Ascii.is_upper n.[0]
     - [module-Foo] child is a module.
     - [module-foo], [Foo] child is a module, for backward compatibility.
     - [page-foo] child is a container or leaf page.
-    - [src-foo] child is a source tree
+    - [srctree-foo] child is a source tree
 
   Parses [...-"foo"] as [...-foo] for backward compatibility. *)
 let parse_parent_child_reference s =
@@ -56,6 +56,7 @@ let parse_parent_child_reference s =
   | Some ("asset", n) -> Ok (Asset_child (unquote n))
   | Some ("module", n) ->
       Ok (Module_child (unquote (String.Ascii.capitalize n)))
+  | Some ("src", _) -> Error (`Msg "Implementation unexpected")
   | Some (k, _) -> Error (`Msg ("Unrecognized kind: " ^ k))
   | None -> if is_module_name s then Ok (Module_child s) else Ok (Page_child s)
 

--- a/src/odoc/compile.mli
+++ b/src/odoc/compile.mli
@@ -41,9 +41,6 @@ val compile :
   children:string list ->
   output:Fs.File.t ->
   warnings_options:Odoc_model.Error.warnings_options ->
-  source:(Fpath.t * string list) option ->
-  cmt_filename_opt:string option ->
-  count_occurrences:bool ->
   Fs.File.t ->
   (unit, [> msg ]) result
 (** Produces .odoc files out of [.cm{i,t,ti}] or .mld files. *)

--- a/src/odoc/compile.mli
+++ b/src/odoc/compile.mli
@@ -27,6 +27,11 @@ val name_of_output : prefix:string -> Fs.File.t -> string
 (** Compute the name of the page from the output file. Prefix is the prefix to
     remove from the filename. *)
 
+val resolve_imports :
+  Resolver.t ->
+  Lang.Compilation_unit.Import.t list ->
+  Lang.Compilation_unit.Import.t list
+
 val resolve_parent_page :
   Resolver.t ->
   string ->

--- a/src/odoc/depends.ml
+++ b/src/odoc/depends.ml
@@ -82,6 +82,13 @@ let deps_of_odoc_file ~deps input =
   match unit.content with
   | Page_content _ | Source_tree_content _ ->
       Ok () (* XXX something should certainly be done here *)
+  | Impl_content impl ->
+      List.iter impl.Odoc_model.Lang.Source_page.imports ~f:(fun import ->
+          match import with
+          | Odoc_model.Lang.Compilation_unit.Import.Unresolved _ -> ()
+          | Odoc_model.Lang.Compilation_unit.Import.Resolved (root, _) ->
+              Hash_set.add deps root);
+      Ok ()
   | Unit_content unit ->
       List.iter unit.Odoc_model.Lang.Compilation_unit.imports ~f:(fun import ->
           match import with

--- a/src/odoc/depends.ml
+++ b/src/odoc/depends.ml
@@ -77,25 +77,23 @@ end = struct
     Odoc_model.Root.Hash_table.fold (fun s () acc -> s :: acc) t []
 end
 
+let deps_of_imports ~deps imports =
+  List.iter imports ~f:(fun import ->
+      match import with
+      | Odoc_model.Lang.Compilation_unit.Import.Unresolved _ -> ()
+      | Odoc_model.Lang.Compilation_unit.Import.Resolved (root, _) ->
+          Hash_set.add deps root);
+  Ok ()
+
 let deps_of_odoc_file ~deps input =
   Odoc_file.load input >>= fun unit ->
   match unit.content with
   | Page_content _ | Source_tree_content _ ->
       Ok () (* XXX something should certainly be done here *)
   | Impl_content impl ->
-      List.iter impl.Odoc_model.Lang.Implementation.imports ~f:(fun import ->
-          match import with
-          | Odoc_model.Lang.Compilation_unit.Import.Unresolved _ -> ()
-          | Odoc_model.Lang.Compilation_unit.Import.Resolved (root, _) ->
-              Hash_set.add deps root);
-      Ok ()
+      deps_of_imports ~deps impl.Odoc_model.Lang.Implementation.imports
   | Unit_content unit ->
-      List.iter unit.Odoc_model.Lang.Compilation_unit.imports ~f:(fun import ->
-          match import with
-          | Odoc_model.Lang.Compilation_unit.Import.Unresolved _ -> ()
-          | Odoc_model.Lang.Compilation_unit.Import.Resolved (root, _) ->
-              Hash_set.add deps root);
-      Ok ()
+      deps_of_imports ~deps unit.Odoc_model.Lang.Compilation_unit.imports
 
 let for_rendering_step pkg_dir =
   let deps = Hash_set.create () in

--- a/src/odoc/depends.ml
+++ b/src/odoc/depends.ml
@@ -83,7 +83,7 @@ let deps_of_odoc_file ~deps input =
   | Page_content _ | Source_tree_content _ ->
       Ok () (* XXX something should certainly be done here *)
   | Impl_content impl ->
-      List.iter impl.Odoc_model.Lang.Source_page.imports ~f:(fun import ->
+      List.iter impl.Odoc_model.Lang.Implementation.imports ~f:(fun import ->
           match import with
           | Odoc_model.Lang.Compilation_unit.Import.Unresolved _ -> ()
           | Odoc_model.Lang.Compilation_unit.Import.Resolved (root, _) ->

--- a/src/odoc/html_page.ml
+++ b/src/odoc/html_page.ml
@@ -69,7 +69,7 @@ let asset_documents parent_id children asset_paths =
           Some (Odoc_document.Types.Document.Asset { url; src = path }))
     paired_or_missing
 
-let extra_documents args input ~syntax:_ =
+let extra_documents args input =
   match input with
   | Odoc_document.Renderer.CU _unit ->
       (* Remove assets from [Document.t] and move their rendering in the main

--- a/src/odoc/html_page.mli
+++ b/src/odoc/html_page.mli
@@ -16,18 +16,6 @@
 
 open Odoc_document
 
-module Source : sig
-  type t = File of Fpath.t | Root of Fpath.t
-
-  val pp : Format.formatter -> t -> unit
-end
-
-type source = Source.t
-
-type args = {
-  html_config : Odoc_html.Config.t;
-  source : source option;
-  assets : Fpath.t list;
-}
+type args = { html_config : Odoc_html.Config.t; assets : Fpath.t list }
 
 val renderer : args Renderer.t

--- a/src/odoc/latex.ml
+++ b/src/odoc/latex.ml
@@ -5,6 +5,6 @@ type args = { with_children : bool }
 let render args page =
   Odoc_latex.Generator.render ~with_children:args.with_children page
 
-let extra_documents _args _unit ~syntax:_ = []
+let extra_documents _args _unit = []
 
 let renderer = { Renderer.name = "latex"; render; extra_documents }

--- a/src/odoc/man_page.ml
+++ b/src/odoc/man_page.ml
@@ -2,6 +2,6 @@ open Odoc_document
 
 let render _ page = Odoc_manpage.Generator.render page
 
-let extra_documents _args _unit ~syntax:_ = []
+let extra_documents _args _unit = []
 
 let renderer = { Renderer.name = "man"; render; extra_documents }

--- a/src/odoc/occurrences.ml
+++ b/src/odoc/occurrences.ml
@@ -5,7 +5,7 @@ let handle_file file ~f =
   | Error _ as e -> e
   | Ok unit' -> (
       match unit' with
-      | { Odoc_file.content = Unit_content unit; _ } -> Ok (Some (f unit))
+      | { Odoc_file.content = Impl_content impl; _ } -> Ok (Some (f impl))
       | _ -> Ok None)
 
 let fold_dirs ~dirs ~f ~init =
@@ -123,7 +123,7 @@ end
 
 let count ~dst ~warnings_options:_ directories include_hidden =
   let htbl = H.create 100 in
-  let f () (unit : Odoc_model.Lang.Compilation_unit.t) =
+  let f () (unit : Odoc_model.Lang.Source_page.t) =
     let incr tbl p =
       let p = (p :> Odoc_model.Paths.Path.Resolved.t) in
       let id = Odoc_model.Paths.Path.Resolved.identifier p in
@@ -142,7 +142,7 @@ let count ~dst ~warnings_options:_ directories include_hidden =
               incr htbl p
           | Type { documentation = Some (`Resolved p); _ }, _ -> incr htbl p
           | _ -> ())
-        (match unit.source_info with None -> [] | Some i -> i.infos)
+        unit.source_info
     in
     ()
   in

--- a/src/odoc/occurrences.ml
+++ b/src/odoc/occurrences.ml
@@ -123,7 +123,7 @@ end
 
 let count ~dst ~warnings_options:_ directories include_hidden =
   let htbl = H.create 100 in
-  let f () (unit : Odoc_model.Lang.Source_page.t) =
+  let f () (unit : Odoc_model.Lang.Implementation.t) =
     let incr tbl p =
       let p = (p :> Odoc_model.Paths.Path.Resolved.t) in
       let id = Odoc_model.Paths.Path.Resolved.identifier p in

--- a/src/odoc/occurrences.ml
+++ b/src/odoc/occurrences.ml
@@ -1,12 +1,25 @@
 open Or_error
 
+(* Copied from ocaml 5.0 String module *)
+let string_starts_with ~prefix s =
+  let open String in
+  let len_s = length s and len_pre = length prefix in
+  let rec aux i =
+    if i = len_pre then true
+    else if unsafe_get s i <> unsafe_get prefix i then false
+    else aux (i + 1)
+  in
+  len_s >= len_pre && aux 0
+
 let handle_file file ~f =
-  Odoc_file.load file |> function
-  | Error _ as e -> e
-  | Ok unit' -> (
-      match unit' with
-      | { Odoc_file.content = Impl_content impl; _ } -> Ok (Some (f impl))
-      | _ -> Ok None)
+  if string_starts_with ~prefix:"src-" (Fpath.filename file) then
+    Odoc_file.load file |> function
+    | Error _ as e -> e
+    | Ok unit' -> (
+        match unit' with
+        | { Odoc_file.content = Impl_content impl; _ } -> Ok (Some (f impl))
+        | _ -> Ok None)
+  else Ok None
 
 let fold_dirs ~dirs ~f ~init =
   dirs

--- a/src/odoc/odoc_file.ml
+++ b/src/odoc/odoc_file.ml
@@ -22,6 +22,7 @@ type unit_content = Lang.Compilation_unit.t
 type content =
   | Page_content of Lang.Page.t
   | Source_tree_content of Lang.SourceTree.t
+  | Impl_content of Lang.Source_page.t
   | Unit_content of unit_content
 
 type t = { content : content; warnings : Odoc_model.Error.t list }
@@ -51,11 +52,21 @@ let save_source_tree file ~warnings src_page =
   let dir = Fs.File.dirname file in
   let base = Fs.File.(to_string @@ basename file) in
   let file =
-    if Astring.String.is_prefix ~affix:"src-" base then file
-    else Fs.File.create ~directory:dir ~name:("src-" ^ base)
+    if Astring.String.is_prefix ~affix:"srctree-" base then file
+    else Fs.File.create ~directory:dir ~name:("srctree-" ^ base)
   in
   save_unit file src_page.Lang.SourceTree.root
     { content = Source_tree_content src_page; warnings }
+
+let save_impl file ~warnings impl =
+  let dir = Fs.File.dirname file in
+  let base = Fs.File.(to_string @@ basename file) in
+  let file =
+    if Astring.String.is_prefix ~affix:"src-" base then file
+    else Fs.File.create ~directory:dir ~name:("src-" ^ base)
+  in
+  save_unit file impl.Lang.Source_page.root
+    { content = Impl_content impl; warnings }
 
 let save_unit file ~warnings m =
   save_unit file m.Lang.Compilation_unit.root

--- a/src/odoc/odoc_file.ml
+++ b/src/odoc/odoc_file.ml
@@ -22,7 +22,7 @@ type unit_content = Lang.Compilation_unit.t
 type content =
   | Page_content of Lang.Page.t
   | Source_tree_content of Lang.SourceTree.t
-  | Impl_content of Lang.Source_page.t
+  | Impl_content of Lang.Implementation.t
   | Unit_content of unit_content
 
 type t = { content : content; warnings : Odoc_model.Error.t list }
@@ -65,7 +65,7 @@ let save_impl file ~warnings impl =
     if Astring.String.is_prefix ~affix:"src-" base then file
     else Fs.File.create ~directory:dir ~name:("src-" ^ base)
   in
-  save_unit file impl.Lang.Source_page.root
+  save_unit file impl.Lang.Implementation.root
     { content = Impl_content impl; warnings }
 
 let save_unit file ~warnings m =

--- a/src/odoc/odoc_file.mli
+++ b/src/odoc/odoc_file.mli
@@ -25,7 +25,7 @@ type unit_content = Lang.Compilation_unit.t
 type content =
   | Page_content of Lang.Page.t
   | Source_tree_content of Lang.SourceTree.t
-  | Impl_content of Lang.Source_page.t
+  | Impl_content of Lang.Implementation.t
   | Unit_content of unit_content
 
 type t = { content : content; warnings : Error.t list }
@@ -43,7 +43,8 @@ val save_source_tree :
 val save_unit : Fs.File.t -> warnings:Error.t list -> unit_content -> unit
 (** Save a module. *)
 
-val save_impl : Fs.File.t -> warnings:Error.t list -> Lang.Source_page.t -> unit
+val save_impl :
+  Fs.File.t -> warnings:Error.t list -> Lang.Implementation.t -> unit
 (** Save an implementation. The [src-] prefix is added to the file name if
     missing. *)
 

--- a/src/odoc/odoc_file.mli
+++ b/src/odoc/odoc_file.mli
@@ -25,6 +25,7 @@ type unit_content = Lang.Compilation_unit.t
 type content =
   | Page_content of Lang.Page.t
   | Source_tree_content of Lang.SourceTree.t
+  | Impl_content of Lang.Source_page.t
   | Unit_content of unit_content
 
 type t = { content : content; warnings : Error.t list }
@@ -36,11 +37,15 @@ val save_page : Fs.File.t -> warnings:Error.t list -> Lang.Page.t -> unit
 
 val save_source_tree :
   Fs.File.t -> warnings:Error.t list -> Lang.SourceTree.t -> unit
-(** Save a source tree page. The [src-] prefix is added to the file name if
+(** Save a source tree page. The [srctree] prefix is added to the file name if
     missing. *)
 
 val save_unit : Fs.File.t -> warnings:Error.t list -> unit_content -> unit
 (** Save a module. *)
+
+val save_impl : Fs.File.t -> warnings:Error.t list -> Lang.Source_page.t -> unit
+(** Save an implementation. The [src-] prefix is added to the file name if
+    missing. *)
 
 (** {2 Deserialization} *)
 

--- a/src/odoc/rendering.ml
+++ b/src/odoc/rendering.ml
@@ -53,7 +53,7 @@ let documents_of_implementation ~warnings_options:_ ~syntax impl source =
             let get_path : SourcePage.t -> Fpath.t = function
               | { iv = `SourcePage (d, f); _ } -> Fpath.(get_path_dir d / f)
             in
-            get_path impl.Odoc_model.Lang.Source_page.id
+            get_path impl.Odoc_model.Lang.Implementation.id
       in
       match Fs.File.read source_file with
       | Error (`Msg msg) ->
@@ -64,8 +64,8 @@ let documents_of_implementation ~warnings_options:_ ~syntax impl source =
           in
           Ok
             [
-              Odoc_document.Renderer.document_of_source ~syntax impl syntax_info
-                source_code;
+              Odoc_document.Renderer.documents_of_implementation ~syntax impl
+                syntax_info source_code;
             ])
   | None ->
       Error

--- a/src/odoc/rendering.ml
+++ b/src/odoc/rendering.ml
@@ -25,7 +25,7 @@ let documents_of_unit ~warnings_options ~syntax ~source ~renderer ~extra
     ~filename unit =
   Odoc_model.Error.catch_warnings (fun () ->
       check_empty_source_arg source filename;
-      renderer.Renderer.extra_documents ~syntax extra (CU unit))
+      renderer.Renderer.extra_documents extra (CU unit))
   |> Odoc_model.Error.handle_warnings ~warnings_options
   >>= fun extra_docs ->
   Ok (Renderer.document_of_compilation_unit ~syntax unit :: extra_docs)
@@ -34,7 +34,7 @@ let documents_of_page ~warnings_options ~syntax ~source ~renderer ~extra
     ~filename page =
   Odoc_model.Error.catch_warnings (fun () ->
       check_empty_source_arg source filename;
-      renderer.Renderer.extra_documents ~syntax extra (Page page))
+      renderer.Renderer.extra_documents extra (Page page))
   |> Odoc_model.Error.handle_warnings ~warnings_options
   >>= fun extra_docs -> Ok (Renderer.document_of_page ~syntax page :: extra_docs)
 
@@ -73,6 +73,13 @@ let documents_of_implementation ~warnings_options:_ ~syntax impl source =
           "--source or --source-root should be passed when generating \
            documents for an implementation.")
 
+let documents_of_source_tree ~warnings_options ~syntax ~source ~filename srctree
+    =
+  Odoc_model.Error.catch_warnings (fun () ->
+      check_empty_source_arg source filename)
+  |> Odoc_model.Error.handle_warnings ~warnings_options
+  >>= fun () -> Ok (Renderer.documents_of_source_tree ~syntax srctree)
+
 let documents_of_odocl ~warnings_options ~renderer ~extra ~source ~syntax input
     =
   Odoc_file.load input >>= fun unit ->
@@ -82,7 +89,8 @@ let documents_of_odocl ~warnings_options ~renderer ~extra ~source ~syntax input
       documents_of_page ~warnings_options ~syntax ~source ~renderer ~extra
         ~filename odoctree
   | Source_tree_content srctree ->
-      Ok (Renderer.documents_of_source_tree ~syntax srctree)
+      documents_of_source_tree ~warnings_options ~syntax ~source ~filename
+        srctree
   | Impl_content impl ->
       documents_of_implementation ~warnings_options ~syntax impl source
   | Unit_content odoctree ->

--- a/src/odoc/rendering.ml
+++ b/src/odoc/rendering.ml
@@ -1,28 +1,93 @@
 open Odoc_document
 open Or_error
 
-let documents_of_unit ~warnings_options ~syntax ~renderer ~extra unit =
+module Source = struct
+  type t = File of Fpath.t | Root of Fpath.t
+
+  let pp fmt = function
+    | File f -> Format.fprintf fmt "File: %a" Fpath.pp f
+    | Root f -> Format.fprintf fmt "File: %a" Fpath.pp f
+
+  let to_string f = Format.asprintf "%a" pp f
+end
+
+type source = Source.t
+
+let check_empty_source_arg source filename =
+  if source <> None then
+    Odoc_model.Error.raise_warning
+    @@ Odoc_model.Error.filename_only
+         "--source and --source-root only have an effect when generating from \
+          an implementation"
+         filename
+
+let documents_of_unit ~warnings_options ~syntax ~source ~renderer ~extra
+    ~filename unit =
   Odoc_model.Error.catch_warnings (fun () ->
+      check_empty_source_arg source filename;
       renderer.Renderer.extra_documents ~syntax extra (CU unit))
   |> Odoc_model.Error.handle_warnings ~warnings_options
   >>= fun extra_docs ->
   Ok (Renderer.document_of_compilation_unit ~syntax unit :: extra_docs)
 
-let documents_of_page ~warnings_options ~syntax ~renderer ~extra page =
+let documents_of_page ~warnings_options ~syntax ~source ~renderer ~extra
+    ~filename page =
   Odoc_model.Error.catch_warnings (fun () ->
+      check_empty_source_arg source filename;
       renderer.Renderer.extra_documents ~syntax extra (Page page))
   |> Odoc_model.Error.handle_warnings ~warnings_options
   >>= fun extra_docs -> Ok (Renderer.document_of_page ~syntax page :: extra_docs)
 
-let documents_of_odocl ~warnings_options ~renderer ~extra ~syntax input =
+let documents_of_implementation ~warnings_options:_ ~syntax impl source =
+  match source with
+  | Some source -> (
+      let source_file =
+        match source with
+        | Source.File f -> f
+        | Root f ->
+            let open Odoc_model.Paths.Identifier in
+            let rec get_path_dir : SourceDir.t -> Fpath.t = function
+              | { iv = `SourceDir (d, f); _ } -> Fpath.(get_path_dir d / f)
+              | { iv = `Page _; _ } -> f
+            in
+            let get_path : SourcePage.t -> Fpath.t = function
+              | { iv = `SourcePage (d, f); _ } -> Fpath.(get_path_dir d / f)
+            in
+            get_path impl.Odoc_model.Lang.Source_page.id
+      in
+      match Fs.File.read source_file with
+      | Error (`Msg msg) ->
+          Error (`Msg (Format.sprintf "Couldn't load source file: %s" msg))
+      | Ok source_code ->
+          let syntax_info =
+            Syntax_highlighter.syntax_highlighting_locs source_code
+          in
+          Ok
+            [
+              Odoc_document.Renderer.document_of_source ~syntax impl syntax_info
+                source_code;
+            ])
+  | None ->
+      Error
+        (`Msg
+          "--source or --source-root should be passed when generating \
+           documents for an implementation.")
+
+let documents_of_odocl ~warnings_options ~renderer ~extra ~source ~syntax input
+    =
   Odoc_file.load input >>= fun unit ->
+  let filename = Fpath.to_string input in
   match unit.content with
   | Odoc_file.Page_content odoctree ->
-      documents_of_page ~warnings_options ~syntax ~renderer ~extra odoctree
+      documents_of_page ~warnings_options ~syntax ~source ~renderer ~extra
+        ~filename odoctree
   | Source_tree_content srctree ->
       Ok (Renderer.documents_of_source_tree ~syntax srctree)
+  | Impl_content impl ->
+      documents_of_implementation ~warnings_options ~syntax impl source
   | Unit_content odoctree ->
-      documents_of_unit ~warnings_options ~syntax ~renderer ~extra odoctree
+      documents_of_unit ~warnings_options ~source ~syntax ~renderer ~extra
+        ~filename odoctree
 
 let documents_of_input ~renderer ~extra ~resolver ~warnings_options ~syntax
     input =
@@ -30,7 +95,10 @@ let documents_of_input ~renderer ~extra ~resolver ~warnings_options ~syntax
   Odoc_link.from_odoc ~resolver ~warnings_options input output >>= function
   | `Source_tree st -> Ok (Renderer.documents_of_source_tree ~syntax st)
   | `Page page -> Ok [ Renderer.document_of_page ~syntax page ]
-  | `Module m -> documents_of_unit ~warnings_options ~syntax ~renderer ~extra m
+  | `Impl impl -> Ok [ Renderer.documents_of_implementation ~syntax impl [] "" ]
+  | `Module m ->
+      documents_of_unit ~warnings_options ~source:None ~filename:"" ~syntax
+        ~renderer ~extra m
 
 let render_document renderer ~output:root_dir ~extra_suffix ~extra doc =
   let pages = renderer.Renderer.render extra doc in
@@ -57,19 +125,21 @@ let render_odoc ~resolver ~warnings_options ~syntax ~renderer ~output extra file
   Ok ()
 
 let generate_odoc ~syntax ~warnings_options ~renderer ~output ~extra_suffix
-    extra file =
-  documents_of_odocl ~warnings_options ~renderer ~extra ~syntax file
+    ~source extra file =
+  documents_of_odocl ~warnings_options ~renderer ~source ~extra ~syntax file
   >>= fun docs ->
   List.iter (render_document renderer ~output ~extra_suffix ~extra) docs;
   Ok ()
 
 let targets_odoc ~resolver ~warnings_options ~syntax ~renderer ~output:root_dir
-    ~extra odoctree =
+    ~extra ~source odoctree =
   let docs =
     if Fpath.get_ext odoctree = ".odoc" then
       documents_of_input ~renderer ~extra ~resolver ~warnings_options ~syntax
         odoctree
-    else documents_of_odocl ~warnings_options ~renderer ~extra ~syntax odoctree
+    else
+      documents_of_odocl ~warnings_options ~renderer ~extra ~syntax ~source
+        odoctree
   in
   docs >>= fun docs ->
   List.iter

--- a/src/odoc/rendering.mli
+++ b/src/odoc/rendering.mli
@@ -1,6 +1,16 @@
 open Odoc_document
 open Or_error
 
+module Source : sig
+  type t = File of Fpath.t | Root of Fpath.t
+
+  val pp : Format.formatter -> t -> unit
+
+  val to_string : t -> string
+end
+
+type source = Source.t
+
 val render_odoc :
   resolver:Resolver.t ->
   warnings_options:Odoc_model.Error.warnings_options ->
@@ -17,6 +27,7 @@ val generate_odoc :
   renderer:'a Renderer.t ->
   output:Fs.directory ->
   extra_suffix:string option ->
+  source:source option ->
   'a ->
   Fpath.t ->
   (unit, [> msg ]) result
@@ -28,5 +39,6 @@ val targets_odoc :
   renderer:'a Renderer.t ->
   output:Fs.directory ->
   extra:'a ->
+  source:source option ->
   Fpath.t ->
   (unit, [> msg ]) result

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -261,7 +261,9 @@ let build ?(imports_map = StringMap.empty)
   { Env.open_units; lookup_unit; lookup_page; lookup_impl }
 
 let build_compile_env_for_impl t i =
-  let imports_map = build_imports_map i.Odoc_model.Lang.Source_page.imports in
+  let imports_map =
+    build_imports_map i.Odoc_model.Lang.Implementation.imports
+  in
   let resolver = build ~imports_map t in
   Env.env_of_impl i resolver
 
@@ -272,7 +274,9 @@ let build_link_env_for_unit t m =
   Env.env_of_unit m ~linking:true resolver
 
 let build_link_env_for_impl t i =
-  let imports_map = build_imports_map i.Odoc_model.Lang.Source_page.imports in
+  let imports_map =
+    build_imports_map i.Odoc_model.Lang.Implementation.imports
+  in
   let resolver = build ~imports_map t in
   Env.env_of_impl i resolver
 

--- a/src/odoc/resolver.mli
+++ b/src/odoc/resolver.mli
@@ -47,6 +47,14 @@ val build_link_env_for_unit :
 val build_env_for_page : t -> Odoc_model.Lang.Page.t -> Odoc_xref2.Env.t
 (** Initialize the environment for the given page. *)
 
+val build_compile_env_for_impl :
+  t -> Odoc_model.Lang.Source_page.t -> Odoc_xref2.Env.t
+(** Initialize the environment for the given implementation. *)
+
+val build_link_env_for_impl :
+  t -> Odoc_model.Lang.Source_page.t -> Odoc_xref2.Env.t
+(** Initialize the environment for the given implementation. *)
+
 val build_env_for_reference : t -> Odoc_xref2.Env.t
 (** Initialize the environment for a reference. *)
 

--- a/src/odoc/resolver.mli
+++ b/src/odoc/resolver.mli
@@ -48,11 +48,11 @@ val build_env_for_page : t -> Odoc_model.Lang.Page.t -> Odoc_xref2.Env.t
 (** Initialize the environment for the given page. *)
 
 val build_compile_env_for_impl :
-  t -> Odoc_model.Lang.Source_page.t -> Odoc_xref2.Env.t
+  t -> Odoc_model.Lang.Implementation.t -> Odoc_xref2.Env.t
 (** Initialize the environment for the given implementation. *)
 
 val build_link_env_for_impl :
-  t -> Odoc_model.Lang.Source_page.t -> Odoc_xref2.Env.t
+  t -> Odoc_model.Lang.Implementation.t -> Odoc_xref2.Env.t
 (** Initialize the environment for the given implementation. *)
 
 val build_env_for_reference : t -> Odoc_xref2.Env.t

--- a/src/odoc/source.ml
+++ b/src/odoc/source.ml
@@ -1,0 +1,61 @@
+open Odoc_model
+open Or_error
+
+let resolve_imports resolver imports =
+  List.map
+    (function
+      | Lang.Compilation_unit.Import.Resolved _ as resolved -> resolved
+      | Unresolved (name, _) as unresolved -> (
+          match Resolver.resolve_import resolver name with
+          | Some root -> Resolved (root, Names.ModuleName.make_std name)
+          | None -> unresolved))
+    imports
+
+let resolve_and_substitute ~resolver ~make_root ~source_id input_file =
+  let filename = Fs.File.to_string input_file in
+  let impl =
+    Odoc_loader.read_impl ~make_root ~filename ~source_id
+    |> Error.raise_errors_and_warnings
+  in
+  let impl = { impl with imports = resolve_imports resolver impl.imports } in
+  let env = Resolver.build_compile_env_for_impl resolver impl in
+  Odoc_xref2.Compile.compile_impl ~filename env impl |> Error.raise_warnings
+
+let root_of_implementation ~source_id ~module_name ~digest =
+  let open Root in
+  let result =
+    let file = Odoc_file.create_impl module_name in
+    let id :> Paths.Identifier.OdocId.t = source_id in
+    Ok { id; file; digest }
+  in
+  result
+
+let compile ~resolver ~output ~warnings_options ~source_path ~source_parent_file
+    input =
+  ( Odoc_file.load source_parent_file >>= fun parent ->
+    let err_not_parent () =
+      Error (`Msg "Specified source-parent is not a parent of the source.")
+    in
+    match parent.Odoc_file.content with
+    | Odoc_file.Source_tree_content page -> (
+        match page.Lang.SourceTree.name with
+        | { Paths.Identifier.iv = `Page _; _ } as parent_id ->
+            let id = Paths.Identifier.Mk.source_page (parent_id, source_path) in
+            if List.exists (Paths.Identifier.equal id) page.source_children then
+              Ok id
+            else err_not_parent ()
+        | { iv = `LeafPage _; _ } -> err_not_parent ())
+    | Unit_content _ | Page_content _ | Impl_content _ ->
+        Error (`Msg "Specified source-parent should be a page but is a module.")
+  )
+  >>= fun source_id ->
+  let make_root = root_of_implementation ~source_id in
+  let result =
+    Error.catch_errors_and_warnings (fun () ->
+        resolve_and_substitute ~resolver ~make_root ~source_id input)
+  in
+  (* Extract warnings to write them into the output file *)
+  let _, warnings = Error.unpack_warnings result in
+  Error.handle_errors_and_warnings ~warnings_options result >>= fun impl ->
+  Odoc_file.save_impl output ~warnings impl;
+  Ok ()

--- a/src/odoc/source_tree.ml
+++ b/src/odoc/source_tree.ml
@@ -24,7 +24,7 @@ let parse_input_file input =
 let source_child_id parent segs = Id.Mk.source_page (parent, segs)
 
 let compile ~resolver ~parent ~output ~warnings_options:_ input =
-  let root_name = Compile.name_of_output ~prefix:"src-" output in
+  let root_name = Compile.name_of_output ~prefix:"srctree-" output in
   let page_name = PageName.make_std root_name in
   Compile.resolve_parent_page resolver parent >>= fun (parent, siblings) ->
   let id = Id.Mk.page (Some parent, page_name) in

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -65,14 +65,11 @@ and class_type_path : Env.t -> Paths.Path.ClassType.t -> Paths.Path.ClassType.t
 
 let rec unit env t =
   let open Compilation_unit in
-  let source_info =
-    match t.source_info with
-    | Some si -> Some (source_info env si)
-    | None -> None
-  in
-  { t with content = content env t.id t.content; source_info }
+  { t with content = content env t.id t.content }
 
-and source_info env si = { si with infos = source_info_infos env si.infos }
+and source_page env sp =
+  let open Source_page in
+  { sp with source_info = source_info_infos env sp.source_info }
 
 and source_info_infos env infos =
   let open Source_info in
@@ -896,5 +893,8 @@ and type_expression : Env.t -> Id.LabelParent.t -> _ -> _ =
 
 let compile ~filename env compilation_unit =
   Lookup_failures.catch_failures ~filename (fun () -> unit env compilation_unit)
+
+let compile_impl ~filename env i =
+  Lookup_failures.catch_failures ~filename (fun () -> source_page env i)
 
 let resolve_page _resolver y = y

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -67,8 +67,8 @@ let rec unit env t =
   let open Compilation_unit in
   { t with content = content env t.id t.content }
 
-and source_page env sp =
-  let open Source_page in
+and implementation env sp =
+  let open Implementation in
   { sp with source_info = source_info_infos env sp.source_info }
 
 and source_info_infos env infos =
@@ -895,6 +895,6 @@ let compile ~filename env compilation_unit =
   Lookup_failures.catch_failures ~filename (fun () -> unit env compilation_unit)
 
 let compile_impl ~filename env i =
-  Lookup_failures.catch_failures ~filename (fun () -> source_page env i)
+  Lookup_failures.catch_failures ~filename (fun () -> implementation env i)
 
 let resolve_page _resolver y = y

--- a/src/xref2/compile.mli
+++ b/src/xref2/compile.mli
@@ -13,4 +13,11 @@ val compile :
   Lang.Compilation_unit.t Error.with_warnings
 (** [filename] is used for generating warnings. *)
 
+val compile_impl :
+  filename:string ->
+  Env.t ->
+  Lang.Source_page.t ->
+  Lang.Source_page.t Error.with_warnings
+(** [filename] is used for generating warnings. *)
+
 val resolve_page : 'a -> 'b -> 'b

--- a/src/xref2/compile.mli
+++ b/src/xref2/compile.mli
@@ -16,8 +16,8 @@ val compile :
 val compile_impl :
   filename:string ->
   Env.t ->
-  Lang.Source_page.t ->
-  Lang.Source_page.t Error.with_warnings
+  Lang.Implementation.t ->
+  Lang.Implementation.t Error.with_warnings
 (** [filename] is used for generating warnings. *)
 
 val resolve_page : 'a -> 'b -> 'b

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -82,7 +82,7 @@ module rec Module : sig
     | ModuleType of ModuleType.expr
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     type_ : decl;
     canonical : Odoc_model.Paths.Path.Module.t option;
@@ -154,7 +154,7 @@ and Extension : sig
   module Constructor : sig
     type t = {
       name : string;
-      locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+      source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
       doc : CComment.docs;
       args : TypeDecl.Constructor.argument;
       res : TypeExpr.t option;
@@ -173,7 +173,7 @@ end =
 
 and Exception : sig
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     args : TypeDecl.Constructor.argument;
     res : TypeExpr.t option;
@@ -237,7 +237,7 @@ and ModuleType : sig
     | TypeOf of typeof_t
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     canonical : Odoc_model.Paths.Path.ModuleType.t option;
     expr : expr option;
@@ -285,7 +285,7 @@ and TypeDecl : sig
   end
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     canonical : Odoc_model.Paths.Path.Type.t option;
     equation : Equation.t;
@@ -298,7 +298,7 @@ and Value : sig
   type value = Odoc_model.Lang.Value.value
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     type_ : TypeExpr.t;
     value : value;
@@ -369,7 +369,7 @@ and Class : sig
     | Arrow of TypeExpr.label option * TypeExpr.t * decl
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;
@@ -385,7 +385,7 @@ and ClassType : sig
     | Signature of ClassSignature.t
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;
@@ -1963,7 +1963,7 @@ module Of_Lang = struct
   let rec type_decl ident_map ty =
     let open Odoc_model.Lang.TypeDecl in
     {
-      TypeDecl.locs = ty.locs;
+      TypeDecl.source_loc = ty.source_loc;
       doc = docs ident_map ty.doc;
       canonical = ty.canonical;
       equation = type_equation ident_map ty.equation;
@@ -2129,7 +2129,7 @@ module Of_Lang = struct
     let type_ = module_decl ident_map m.Odoc_model.Lang.Module.type_ in
     let canonical = m.Odoc_model.Lang.Module.canonical in
     {
-      Module.locs = m.locs;
+      Module.source_loc = m.source_loc;
       doc = docs ident_map m.doc;
       type_;
       canonical;
@@ -2184,7 +2184,7 @@ module Of_Lang = struct
     let res = Opt.map (type_expression ident_map) c.res in
     {
       Extension.Constructor.name = Paths.Identifier.name c.id;
-      locs = c.locs;
+      source_loc = c.source_loc;
       doc = docs ident_map c.doc;
       args;
       res;
@@ -2194,7 +2194,12 @@ module Of_Lang = struct
     let open Odoc_model.Lang.Exception in
     let args = type_decl_constructor_argument ident_map e.args in
     let res = Opt.map (type_expression ident_map) e.res in
-    { Exception.locs = e.locs; doc = docs ident_map e.doc; args; res }
+    {
+      Exception.source_loc = e.source_loc;
+      doc = docs ident_map e.doc;
+      args;
+      res;
+    }
 
   and u_module_type_expr ident_map m =
     let open Odoc_model in
@@ -2277,7 +2282,7 @@ module Of_Lang = struct
       Opt.map (module_type_expr ident_map) m.Odoc_model.Lang.ModuleType.expr
     in
     {
-      ModuleType.locs = m.locs;
+      ModuleType.source_loc = m.source_loc;
       doc = docs ident_map m.doc;
       canonical = m.canonical;
       expr;
@@ -2285,7 +2290,12 @@ module Of_Lang = struct
 
   and value ident_map v =
     let type_ = type_expression ident_map v.Lang.Value.type_ in
-    { Value.type_; doc = docs ident_map v.doc; value = v.value; locs = v.locs }
+    {
+      Value.type_;
+      doc = docs ident_map v.doc;
+      value = v.value;
+      source_loc = v.source_loc;
+    }
 
   and include_ ident_map i =
     let open Odoc_model.Lang.Include in
@@ -2305,7 +2315,7 @@ module Of_Lang = struct
     let open Odoc_model.Lang.Class in
     let expansion = Opt.map (class_signature ident_map) c.expansion in
     {
-      Class.locs = c.locs;
+      Class.source_loc = c.source_loc;
       doc = docs ident_map c.doc;
       virtual_ = c.virtual_;
       params = c.params;
@@ -2332,7 +2342,7 @@ module Of_Lang = struct
     let open Odoc_model.Lang.ClassType in
     let expansion = Opt.map (class_signature ident_map) t.expansion in
     {
-      ClassType.locs = t.locs;
+      ClassType.source_loc = t.source_loc;
       doc = docs ident_map t.doc;
       virtual_ = t.virtual_;
       params = t.params;
@@ -2411,7 +2421,7 @@ module Of_Lang = struct
       (t : Odoc_model.Lang.ModuleSubstitution.t) =
     let manifest = module_path ident_map t.manifest in
     {
-      Module.locs = None;
+      Module.source_loc = None;
       doc = docs ident_map t.doc;
       type_ = Alias (manifest, None);
       canonical = None;
@@ -2519,7 +2529,7 @@ end
 
 let module_of_functor_argument (arg : FunctorParameter.parameter) =
   {
-    Module.locs = None;
+    Module.source_loc = None;
     doc = [];
     type_ = ModuleType arg.expr;
     canonical = None;

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -68,7 +68,7 @@ module rec Module : sig
     | ModuleType of ModuleType.expr
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     type_ : decl;
     canonical : Odoc_model.Paths.Path.Module.t option;
@@ -136,7 +136,7 @@ and Extension : sig
   module Constructor : sig
     type t = {
       name : string;
-      locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+      source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
       doc : CComment.docs;
       args : TypeDecl.Constructor.argument;
       res : TypeExpr.t option;
@@ -154,7 +154,7 @@ end
 
 and Exception : sig
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     args : TypeDecl.Constructor.argument;
     res : TypeExpr.t option;
@@ -216,7 +216,7 @@ and ModuleType : sig
     | TypeOf of typeof_t
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     canonical : Odoc_model.Paths.Path.ModuleType.t option;
     expr : expr option;
@@ -263,7 +263,7 @@ and TypeDecl : sig
   end
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     canonical : Odoc_model.Paths.Path.Type.t option;
     equation : Equation.t;
@@ -328,7 +328,7 @@ and Value : sig
   type value = Odoc_model.Lang.Value.value
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     type_ : TypeExpr.t;
     value : value;
@@ -341,7 +341,7 @@ and Class : sig
     | Arrow of TypeExpr.label option * TypeExpr.t * decl
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;
@@ -356,7 +356,7 @@ and ClassType : sig
     | Signature of ClassSignature.t
 
   type t = {
-    locs : Odoc_model.Paths.Identifier.SourceLocation.t option;
+    source_loc : Odoc_model.Paths.Identifier.SourceLocation.t option;
     doc : CComment.docs;
     virtual_ : bool;
     params : TypeDecl.param list;

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -10,6 +10,8 @@ type lookup_unit_result =
 
 type lookup_page_result = Lang.Page.t option
 
+type lookup_impl_result = Lang.Source_page.t option
+
 type root =
   | Resolved of (Odoc_model.Root.t * Identifier.Module.t * Component.Module.t)
   | Forward
@@ -17,6 +19,7 @@ type root =
 type resolver = {
   open_units : string list;
   lookup_unit : string -> lookup_unit_result;
+  lookup_impl : string -> lookup_impl_result;
   lookup_page : string -> lookup_page_result;
 }
 
@@ -359,11 +362,7 @@ let add_extension_constructor identifier
 let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
  fun unit ->
   let id = (unit.id :> Paths.Identifier.Module.t) in
-  let locs =
-    match unit.source_info with
-    | Some { id = Some id; _ } -> Some (Identifier.Mk.source_location_mod id)
-    | _ -> None
-  in
+  let locs = None in
   match unit.content with
   | Module s ->
       let m =
@@ -429,6 +428,9 @@ let lookup_page name env =
 
 let lookup_unit name env =
   match env.resolver with None -> None | Some r -> Some (r.lookup_unit name)
+
+let lookup_impl name env =
+  match env.resolver with None -> None | Some r -> r.lookup_impl name
 
 type 'a scope = {
   filter : Component.Element.any -> ([< Component.Element.any ] as 'a) option;
@@ -819,6 +821,9 @@ let open_page page env = add_docs page.Lang.Page.content env
 let env_of_page page resolver =
   let initial_env = open_page page empty in
   set_resolver initial_env resolver |> open_units resolver
+
+let env_of_impl _impl resolver =
+  set_resolver empty resolver |> open_units resolver
 
 let env_for_reference resolver =
   set_resolver empty resolver |> open_units resolver

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -362,14 +362,13 @@ let add_extension_constructor identifier
 let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
  fun unit ->
   let id = (unit.id :> Paths.Identifier.Module.t) in
-  let locs = None in
   match unit.content with
   | Module s ->
       let m =
         Lang.Module.
           {
             id;
-            locs;
+            source_loc = None;
             doc = [];
             type_ = ModuleType (Signature s);
             canonical = unit.canonical;
@@ -383,7 +382,7 @@ let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
         Lang.Module.
           {
             id;
-            locs;
+            source_loc = None;
             doc = [];
             type_ =
               ModuleType (Signature { items = []; compiled = true; doc = [] });
@@ -616,7 +615,7 @@ let lookup_fragment_root env =
 let mk_functor_parameter module_type =
   let type_ = Component.Module.ModuleType module_type in
   Component.Module.
-    { locs = None; doc = []; type_; canonical = None; hidden = false }
+    { source_loc = None; doc = []; type_; canonical = None; hidden = false }
 
 let add_functor_parameter : Lang.FunctorParameter.t -> t -> t =
  fun p t ->
@@ -784,7 +783,7 @@ let open_module_type_substitution : Lang.ModuleTypeSubstitution.t -> t -> t =
     module_type (empty ())
       {
         id = t.id;
-        locs = None;
+        source_loc = None;
         doc = t.doc;
         expr = Some t.manifest;
         canonical = None;

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -10,7 +10,7 @@ type lookup_unit_result =
 
 type lookup_page_result = Lang.Page.t option
 
-type lookup_impl_result = Lang.Source_page.t option
+type lookup_impl_result = Lang.Implementation.t option
 
 type root =
   | Resolved of (Odoc_model.Root.t * Identifier.Module.t * Component.Module.t)

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -10,6 +10,8 @@ type lookup_unit_result =
 
 type lookup_page_result = Lang.Page.t option
 
+type lookup_impl_result = Lang.Source_page.t option
+
 type root =
   | Resolved of
       (Root.t * Odoc_model.Paths.Identifier.Module.t * Component.Module.t)
@@ -18,6 +20,7 @@ type root =
 type resolver = {
   open_units : string list;
   lookup_unit : string -> lookup_unit_result;
+  lookup_impl : string -> lookup_impl_result;
   lookup_page : string -> lookup_page_result;
 }
 
@@ -92,6 +95,8 @@ val add_module_type_functor_args :
 val lookup_fragment_root : t -> (int * Component.Signature.t) option
 
 val lookup_page : string -> t -> Lang.Page.t option
+
+val lookup_impl : string -> t -> Lang.Source_page.t option
 
 val lookup_unit : string -> t -> lookup_unit_result option
 
@@ -169,6 +174,9 @@ val env_of_unit : Lang.Compilation_unit.t -> linking:bool -> resolver -> t
 
 val env_of_page : Lang.Page.t -> resolver -> t
 (** Create a new env for a page. *)
+
+val env_of_impl : Lang.Source_page.t -> resolver -> t
+(** Create a new env for an implementation. *)
 
 val env_for_reference : resolver -> t
 (** Create a new env for a reference. *)

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -10,7 +10,7 @@ type lookup_unit_result =
 
 type lookup_page_result = Lang.Page.t option
 
-type lookup_impl_result = Lang.Source_page.t option
+type lookup_impl_result = Lang.Implementation.t option
 
 type root =
   | Resolved of
@@ -96,7 +96,7 @@ val lookup_fragment_root : t -> (int * Component.Signature.t) option
 
 val lookup_page : string -> t -> Lang.Page.t option
 
-val lookup_impl : string -> t -> Lang.Source_page.t option
+val lookup_impl : string -> t -> Lang.Implementation.t option
 
 val lookup_unit : string -> t -> lookup_unit_result option
 
@@ -175,7 +175,7 @@ val env_of_unit : Lang.Compilation_unit.t -> linking:bool -> resolver -> t
 val env_of_page : Lang.Page.t -> resolver -> t
 (** Create a new env for a page. *)
 
-val env_of_impl : Lang.Source_page.t -> resolver -> t
+val env_of_impl : Lang.Implementation.t -> resolver -> t
 (** Create a new env for an implementation. *)
 
 val env_for_reference : resolver -> t

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -484,7 +484,7 @@ and class_ map parent id c =
   in
   {
     id = identifier;
-    locs = c.locs;
+    source_loc = c.source_loc;
     doc = docs (parent :> Identifier.LabelParent.t) c.doc;
     virtual_ = c.virtual_;
     params = c.params;
@@ -522,7 +522,7 @@ and class_type map parent id c =
   in
   {
     Odoc_model.Lang.ClassType.id = identifier;
-    locs = c.locs;
+    source_loc = c.source_loc;
     doc = docs (parent :> Identifier.LabelParent.t) c.doc;
     virtual_ = c.virtual_;
     params = c.params;
@@ -671,7 +671,7 @@ and value_ map parent id v =
   let identifier = Identifier.Mk.value (parent, typed_name) in
   {
     id = identifier;
-    locs = v.locs;
+    source_loc = v.source_loc;
     doc = docs (parent :> Identifier.LabelParent.t) v.doc;
     type_ = type_expr map (parent :> Identifier.LabelParent.t) v.type_;
     value = v.value;
@@ -695,7 +695,7 @@ and extension_constructor map parent c =
   in
   {
     id = identifier;
-    locs = c.locs;
+    source_loc = c.source_loc;
     doc = docs (parent :> Identifier.LabelParent.t) c.doc;
     args =
       type_decl_constructor_argument map
@@ -714,7 +714,7 @@ and module_ map parent id m =
     let map = { map with shadowed = empty_shadow } in
     {
       Odoc_model.Lang.Module.id;
-      locs = m.locs;
+      source_loc = m.source_loc;
       doc = docs (parent :> Identifier.LabelParent.t) m.doc;
       type_ = module_decl map identifier m.type_;
       canonical = m.canonical;
@@ -853,7 +853,7 @@ and module_type :
   let map = { map with shadowed = empty_shadow } in
   {
     Odoc_model.Lang.ModuleType.id = identifier;
-    locs = mty.locs;
+    source_loc = mty.source_loc;
     doc = docs (parent :> Identifier.LabelParent.t) mty.doc;
     canonical = mty.canonical;
     expr = Opt.map (module_type_expr map sig_id) mty.expr;
@@ -921,7 +921,7 @@ and type_decl map parent id (t : Component.TypeDecl.t) :
   let identifier = Component.TypeMap.find id map.type_ in
   {
     id = identifier;
-    locs = t.locs;
+    source_loc = t.source_loc;
     equation =
       type_decl_equation map (parent :> Identifier.FieldParent.t) t.equation;
     doc = docs (parent :> Identifier.LabelParent.t) t.doc;
@@ -1045,7 +1045,7 @@ and exception_ map parent id (e : Component.Exception.t) :
   in
   {
     id = identifier;
-    locs = e.locs;
+    source_loc = e.source_loc;
     doc = docs (parent :> Identifier.LabelParent.t) e.doc;
     args =
       type_decl_constructor_argument map

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -378,58 +378,9 @@ let rec unit env t =
           Module sg
       | Pack _ as p -> p
   in
-  let source_info =
-    let open Source_info in
-    match t.source_info with
-    | Some inf ->
-        let jump_to v f_impl f_doc =
-          let documentation =
-            match v.documentation with Some p -> Some (f_doc p) | None -> None
-          in
-          let implementation =
-            match v.implementation with
-            | Some (Unresolved p) -> (
-                match f_impl p with
-                | Some x -> Some (Resolved x)
-                | None -> v.implementation)
-            | x -> x
-          in
-          { documentation; implementation }
-        in
-        let infos =
-          List.map
-            (fun (i, pos) ->
-              let info =
-                match i with
-                | Value v ->
-                    Value
-                      (jump_to v
-                         (Shape_tools.lookup_value_path env)
-                         (value_path env))
-                | Module v ->
-                    Module
-                      (jump_to v
-                         (Shape_tools.lookup_module_path env)
-                         (module_path env))
-                | ModuleType v ->
-                    ModuleType
-                      (jump_to v
-                         (Shape_tools.lookup_module_type_path env)
-                         (module_type_path env))
-                | Type v ->
-                    Type
-                      (jump_to v
-                         (Shape_tools.lookup_type_path env)
-                         (type_path env))
-                | i -> i
-              in
-              (info, pos))
-            inf.infos
-        in
-        Some { inf with infos }
-    | None -> None
-  in
-  { t with content; linked = true; source_info }
+  let locs = locations env t.id t.locs in
+
+  { t with content; linked = true; locs }
 
 and value_ env parent t =
   let open Value in
@@ -1134,6 +1085,52 @@ let page env page =
     linked = true;
   }
 
+let source_info env infos =
+  let open Source_info in
+  let jump_to v f_impl f_doc =
+    let documentation =
+      match v.documentation with Some p -> Some (f_doc p) | None -> None
+    in
+    let implementation =
+      match v.implementation with
+      | Some (Unresolved p) -> (
+          match f_impl p with
+          | Some x -> Some (Resolved x)
+          | None -> v.implementation)
+      | x -> x
+    in
+    { documentation; implementation }
+  in
+  List.map
+    (fun (i, pos) ->
+      let info =
+        match i with
+        | Value v ->
+            Value
+              (jump_to v (Shape_tools.lookup_value_path env) (value_path env))
+        | Module v ->
+            Module
+              (jump_to v (Shape_tools.lookup_module_path env) (module_path env))
+        | ModuleType v ->
+            ModuleType
+              (jump_to v
+                 (Shape_tools.lookup_module_type_path env)
+                 (module_type_path env))
+        | Type v ->
+            Type (jump_to v (Shape_tools.lookup_type_path env) (type_path env))
+        | i -> i
+      in
+      (info, pos))
+    infos
+
+let impl env i =
+  let open Source_page in
+  { i with source_info = source_info env i.source_info; linked = true }
+
 let resolve_page ~filename env p =
   Lookup_failures.catch_failures ~filename (fun () ->
       if p.Lang.Page.linked then p else page env p)
+
+let resolve_impl ~filename env i =
+  Lookup_failures.catch_failures ~filename (fun () ->
+      if i.Lang.Source_page.linked then i else impl env i)

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -1124,7 +1124,7 @@ let source_info env infos =
     infos
 
 let impl env i =
-  let open Source_page in
+  let open Implementation in
   { i with source_info = source_info env i.source_info; linked = true }
 
 let resolve_page ~filename env p =
@@ -1133,4 +1133,4 @@ let resolve_page ~filename env p =
 
 let resolve_impl ~filename env i =
   Lookup_failures.catch_failures ~filename (fun () ->
-      if i.Lang.Source_page.linked then i else impl env i)
+      if i.Lang.Implementation.linked then i else impl env i)

--- a/src/xref2/link.mli
+++ b/src/xref2/link.mli
@@ -14,3 +14,9 @@ val link :
 
 val resolve_page :
   filename:string -> Env.t -> Lang.Page.t -> Lang.Page.t Error.with_warnings
+
+val resolve_impl :
+  filename:string ->
+  Env.t ->
+  Lang.Source_page.t ->
+  Lang.Source_page.t Error.with_warnings

--- a/src/xref2/link.mli
+++ b/src/xref2/link.mli
@@ -18,5 +18,5 @@ val resolve_page :
 val resolve_impl :
   filename:string ->
   Env.t ->
-  Lang.Source_page.t ->
-  Lang.Source_page.t Error.with_warnings
+  Lang.Implementation.t ->
+  Lang.Implementation.t Error.with_warnings

--- a/src/xref2/paths.md
+++ b/src/xref2/paths.md
@@ -434,7 +434,7 @@ val sg : Odoc_model.Lang.Signature.t =
               ihash = 818126955; ikey = "r_Root.p_None"},
              ARG);
          ihash = 379411454; ikey = "mt_ARG.r_Root.p_None"};
-       locs = None; doc = []; canonical = None;
+       source_loc = None; doc = []; canonical = None;
        expr =
         Some
          (Odoc_model.Lang.ModuleType.Signature
@@ -457,7 +457,7 @@ val sg : Odoc_model.Lang.Signature.t =
                        ihash = 379411454; ikey = "mt_ARG.r_Root.p_None"},
                       S);
                   ihash = 208722936; ikey = "mt_S.mt_ARG.r_Root.p_None"};
-                locs = None; doc = []; canonical = None; expr = None}];
+                source_loc = None; doc = []; canonical = None; expr = None}];
             compiled = true; doc = []})};
      Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
       {Odoc_model.Lang.Module.id =
@@ -472,7 +472,7 @@ val sg : Odoc_model.Lang.Signature.t =
               ihash = 818126955; ikey = "r_Root.p_None"},
              F);
          ihash = 748202139; ikey = "m_F.r_Root.p_None"};
-       locs = None; doc = [];
+       source_loc = None; doc = [];
        type_ =
         Odoc_model.Lang.Module.ModuleType
          (Odoc_model.Lang.ModuleType.Functor
@@ -527,7 +527,7 @@ val sg : Odoc_model.Lang.Signature.t =
                                 S);
                             ihash = 313393860;
                             ikey = "mt_S.p_X.m_F.r_Root.p_None"};
-                          locs = None; doc = []; canonical = None;
+                          source_loc = None; doc = []; canonical = None;
                           expr = None}];
                       compiled = true; doc = []});
                  p_path =
@@ -574,7 +574,7 @@ val sg : Odoc_model.Lang.Signature.t =
                        N);
                    ihash = 837385364;
                    ikey = "m_N.___r"... (* string length 33; truncated *)};
-                 locs = None; doc = [];
+                 source_loc = None; doc = [];
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Path

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -613,7 +613,7 @@ and module_type s t =
   let expr =
     match t.expr with Some m -> Some (module_type_expr s m) | None -> None
   in
-  { expr; locs = t.locs; doc = t.doc; canonical = t.canonical }
+  { expr; source_loc = t.source_loc; doc = t.doc; canonical = t.canonical }
 
 and module_type_substitution s t =
   let open Component.ModuleTypeSubstitution in

--- a/src/xref2/test.md
+++ b/src/xref2/test.md
@@ -205,7 +205,7 @@ and so we simply look up the type in the environment, giving a `Component.Type.t
             ihash = 818126955; ikey = "r_Root.p_None"},
            x);
        ihash = 622581103; ikey = "t_x.r_Root.p_None"};
-     locs = None; doc = []; canonical = None;
+     source_loc = None; doc = []; canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest = None; constraints = []};
@@ -223,7 +223,7 @@ and so we simply look up the type in the environment, giving a `Component.Type.t
             ihash = 818126955; ikey = "r_Root.p_None"},
            u);
        ihash = 15973539; ikey = "t_u.r_Root.p_None"};
-     locs = None; doc = []; canonical = None;
+     source_loc = None; doc = []; canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest =
@@ -331,7 +331,7 @@ val path : Cpath.Resolved.module_ =
 val module_ : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
-     {Odoc_xref2.Component.Module.locs = None; doc = [];
+     {Odoc_xref2.Component.Module.source_loc = None; doc = [];
       type_ =
        Odoc_xref2.Component.Module.ModuleType
         (Odoc_xref2.Component.ModuleType.Signature
@@ -340,7 +340,7 @@ val module_ : Component.Module.t Component.Delayed.t =
               Odoc_model.Lang.Signature.Ordinary,
               {Odoc_xref2.Component.Delayed.v =
                 Some
-                 {Odoc_xref2.Component.TypeDecl.locs = None; doc = [];
+                 {Odoc_xref2.Component.TypeDecl.source_loc = None; doc = [];
                   canonical = None;
                   equation =
                    {Odoc_xref2.Component.TypeDecl.Equation.params = [];
@@ -363,7 +363,7 @@ Odoc_xref2.Tools.Signature
      Odoc_model.Lang.Signature.Ordinary,
      {Odoc_xref2.Component.Delayed.v =
        Some
-        {Odoc_xref2.Component.TypeDecl.locs = None; doc = [];
+        {Odoc_xref2.Component.TypeDecl.source_loc = None; doc = [];
          canonical = None;
          equation =
           {Odoc_xref2.Component.TypeDecl.Equation.params = [];
@@ -418,7 +418,7 @@ val path : Cpath.Resolved.module_ =
 val module_ : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
-     {Odoc_xref2.Component.Module.locs = None; doc = [];
+     {Odoc_xref2.Component.Module.source_loc = None; doc = [];
       type_ =
        Odoc_xref2.Component.Module.ModuleType
         (Odoc_xref2.Component.ModuleType.Path
@@ -484,7 +484,7 @@ val m : Component.Element.module_type option =
              ihash = 818126955; ikey = "r_Root.p_None"},
             M);
         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
-       {Odoc_xref2.Component.ModuleType.locs = None; doc = [];
+       {Odoc_xref2.Component.ModuleType.source_loc = None; doc = [];
         canonical = None;
         expr =
          Some
@@ -494,8 +494,8 @@ val m : Component.Element.module_type option =
                 (`LModuleType (N, 1),
                 {Odoc_xref2.Component.Delayed.v =
                   Some
-                   {Odoc_xref2.Component.ModuleType.locs = None; doc = [];
-                    canonical = None;
+                   {Odoc_xref2.Component.ModuleType.source_loc = None;
+                    doc = []; canonical = None;
                     expr =
                      Some
                       (Odoc_xref2.Component.ModuleType.Signature
@@ -505,7 +505,8 @@ val m : Component.Element.module_type option =
                             Odoc_model.Lang.Signature.Ordinary,
                             {Odoc_xref2.Component.Delayed.v =
                               Some
-                               {Odoc_xref2.Component.TypeDecl.locs = None;
+                               {Odoc_xref2.Component.TypeDecl.source_loc =
+                                 None;
                                 doc = []; canonical = None;
                                 equation =
                                  {Odoc_xref2.Component.TypeDecl.Equation.params
@@ -520,7 +521,7 @@ val m : Component.Element.module_type option =
                 Odoc_model.Lang.Signature.Ordinary,
                 {Odoc_xref2.Component.Delayed.v =
                   Some
-                   {Odoc_xref2.Component.Module.locs = None; doc = [];
+                   {Odoc_xref2.Component.Module.source_loc = None; doc = [];
                     type_ =
                      Odoc_xref2.Component.Module.ModuleType
                       (Odoc_xref2.Component.ModuleType.Path
@@ -838,7 +839,7 @@ val module_C_lens :
         ihash = 818126955; ikey = "r_Root.p_None"},
        C);
    ihash = 43786577; ikey = "m_C.r_Root.p_None"};
- locs = None; doc = [];
+ source_loc = None; doc = [];
  type_ =
   Odoc_model.Lang.Module.ModuleType
    (Odoc_model.Lang.ModuleType.With
@@ -886,7 +887,7 @@ of module `C` we see the following:
 val m : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
-     {Odoc_xref2.Component.Module.locs = None; doc = [];
+     {Odoc_xref2.Component.Module.source_loc = None; doc = [];
       type_ =
        Odoc_xref2.Component.Module.ModuleType
         (Odoc_xref2.Component.ModuleType.With
@@ -939,7 +940,7 @@ val sg : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.locs = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
            type_ =
             Odoc_xref2.Component.Module.Alias
              (`Identifier
@@ -962,7 +963,7 @@ val sg : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.locs = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
            type_ =
             Odoc_xref2.Component.Module.ModuleType
              (Odoc_xref2.Component.ModuleType.Path
@@ -982,7 +983,7 @@ look up module `N` from within this and find its signature:
 val m : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
-     {Odoc_xref2.Component.Module.locs = None; doc = [];
+     {Odoc_xref2.Component.Module.source_loc = None; doc = [];
       type_ =
        Odoc_xref2.Component.Module.ModuleType
         (Odoc_xref2.Component.ModuleType.Path
@@ -1017,7 +1018,7 @@ Odoc_xref2.Tools.Signature
      Odoc_model.Lang.Signature.Ordinary,
      {Odoc_xref2.Component.Delayed.v =
        Some
-        {Odoc_xref2.Component.TypeDecl.locs = None; doc = [];
+        {Odoc_xref2.Component.TypeDecl.source_loc = None; doc = [];
          canonical = None;
          equation =
           {Odoc_xref2.Component.TypeDecl.Equation.params = [];
@@ -1507,7 +1508,7 @@ val p : Cpath.Resolved.module_ =
 val m : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
-     {Odoc_xref2.Component.Module.locs = None; doc = [];
+     {Odoc_xref2.Component.Module.source_loc = None; doc = [];
       type_ =
        Odoc_xref2.Component.Module.ModuleType
         (Odoc_xref2.Component.ModuleType.Path
@@ -1559,7 +1560,7 @@ val sg' : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.locs = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
            type_ =
             Odoc_xref2.Component.Module.ModuleType
              (Odoc_xref2.Component.ModuleType.Path
@@ -1596,7 +1597,7 @@ val sg' : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.locs = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
            type_ =
             Odoc_xref2.Component.Module.ModuleType
              (Odoc_xref2.Component.ModuleType.Path
@@ -1633,7 +1634,7 @@ val sg' : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.locs = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
            type_ =
             Odoc_xref2.Component.Module.ModuleType
              (Odoc_xref2.Component.ModuleType.Path
@@ -1670,7 +1671,7 @@ val sg' : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.locs = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
            type_ =
             Odoc_xref2.Component.Module.ModuleType
              (Odoc_xref2.Component.ModuleType.Path
@@ -2439,7 +2440,7 @@ let resolved = Common.compile_signature sg;;
         ihash = 818126955; ikey = "r_Root.p_None"},
        t);
    ihash = 1016576344; ikey = "t_t.r_Root.p_None"};
- locs = None;
+ source_loc = None;
  doc =
   [{Odoc_model__.Location_.location =
      {Odoc_model__.Location_.file = "";
@@ -2503,7 +2504,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 818126955; ikey = "r_Root.p_None"},
            M);
        ihash = 459143770; ikey = "mt_M.r_Root.p_None"};
-     locs = None; doc = []; canonical = None;
+     source_loc = None; doc = []; canonical = None;
      expr =
       Some
        (Odoc_model.Lang.ModuleType.Signature
@@ -2527,7 +2528,7 @@ let sg = Common.signature_of_mli_string test_data;;
                      ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                     t);
                 ihash = 825731485; ikey = "t_t.mt_M.r_Root.p_None"};
-              locs = None; doc = []; canonical = None;
+              source_loc = None; doc = []; canonical = None;
               equation =
                {Odoc_model.Lang.TypeDecl.Equation.params = [];
                 private_ = false; manifest = None; constraints = []};
@@ -2546,7 +2547,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 818126955; ikey = "r_Root.p_None"},
            u);
        ihash = 15973539; ikey = "t_u.r_Root.p_None"};
-     locs = None; doc = []; canonical = None;
+     source_loc = None; doc = []; canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest = None; constraints = []};
@@ -2564,7 +2565,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 818126955; ikey = "r_Root.p_None"},
            M1);
        ihash = 756272831; ikey = "mt_M1.r_Root.p_None"};
-     locs = None; doc = []; canonical = None;
+     source_loc = None; doc = []; canonical = None;
      expr =
       Some
        (Odoc_model.Lang.ModuleType.With
@@ -2654,7 +2655,7 @@ Odoc_model.Lang.ModuleType.Path
                   ihash = 716453475; ikey = "m_M.r_Root.p_None"},
                  s);
              ihash = 395135148; ikey = "t_s.m_M.r_Root.p_None"};
-           locs = None; doc = []; canonical = None;
+           source_loc = None; doc = []; canonical = None;
            equation =
             {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
              manifest = None; constraints = []};
@@ -2809,7 +2810,7 @@ let m_e_i_s_value mod_name n val_name =
         ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
        id);
    ihash = 424389437; ikey = "v_id.m_Foo3.r_Root.p_None"};
- locs = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+ source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
  type_ =
   Odoc_model.Lang.TypeExpr.Constr
    (`Dot
@@ -2846,7 +2847,7 @@ let m_e_i_s_value mod_name n val_name =
         ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
        id2);
    ihash = 412619918; ikey = "v_id2.m_Foo3.r_Root.p_None"};
- locs = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+ source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
  type_ =
   Odoc_model.Lang.TypeExpr.Constr
    (`Identifier
@@ -2917,7 +2918,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            {t}4);
        ihash = 671044364; ikey = "t_{t}4.m_Foo3.r_Root.p_None"};
-     locs = None; doc = []; canonical = None;
+     source_loc = None; doc = []; canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest =
@@ -2958,7 +2959,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            id);
        ihash = 424389437; ikey = "v_id.m_Foo3.r_Root.p_None"};
-     locs = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+     source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
      type_ =
       Odoc_model.Lang.TypeExpr.Constr
        (`Identifier
@@ -3000,7 +3001,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            {t}5);
        ihash = 67089224; ikey = "t_{t}5.m_Foo3.r_Root.p_None"};
-     locs = None; doc = []; canonical = None;
+     source_loc = None; doc = []; canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest =
@@ -3041,7 +3042,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            id2);
        ihash = 412619918; ikey = "v_id2.m_Foo3.r_Root.p_None"};
-     locs = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+     source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
      type_ =
       Odoc_model.Lang.TypeExpr.Constr
        (`Identifier
@@ -3115,7 +3116,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            {t}6);
        ihash = 133032212; ikey = "t_{t}6.m_Foo3.r_Root.p_None"};
-     locs = None; doc = []; canonical = None;
+     source_loc = None; doc = []; canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest =
@@ -3156,7 +3157,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            {x}7);
        ihash = 314949087; ikey = "v_{x}7.m_Foo3.r_Root.p_None"};
-     locs = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+     source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
      type_ =
       Odoc_model.Lang.TypeExpr.Constr
        (`Identifier
@@ -3181,7 +3182,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            id);
        ihash = 424389437; ikey = "v_id.m_Foo3.r_Root.p_None"};
-     locs = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+     source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
      type_ =
       Odoc_model.Lang.TypeExpr.Constr
        (`Identifier
@@ -3254,7 +3255,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            {Bar}9);
        ihash = 658027043; ikey = "m_{Bar}9.m_Foo3.r_Root.p_None"};
-     locs = None; doc = [];
+     source_loc = None; doc = [];
      type_ =
       Odoc_model.Lang.Module.Alias
        (`Dot
@@ -3291,7 +3292,7 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            id);
        ihash = 424389437; ikey = "v_id.m_Foo3.r_Root.p_None"};
-     locs = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+     source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
      type_ =
       Odoc_model.Lang.TypeExpr.Constr
        (`Dot

--- a/test/integration/json_expansion_with_sources.t/run.t
+++ b/test/integration/json_expansion_with_sources.t/run.t
@@ -1,37 +1,47 @@
 Test the JSON output in the presence of expanded modules.
 
-  $ odoc compile --child module-a --child src-source root.mld
+  $ odoc compile --child module-a --child srctree-source root.mld
 
   $ printf "a.ml\nmain.ml\n" > source_tree.map
-  $ odoc source-tree -I . --parent page-root -o src-source.odoc source_tree.map
+  $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
 
   $ ocamlc -c -bin-annot -o main__A.cmo a.ml -I .
   $ ocamlc -c -bin-annot main.ml -I .
-  $ odoc compile --source-name a.ml --source-parent-file src-source.odoc -I . main__A.cmt
-  $ odoc compile --source-name main.ml --source-parent-file src-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . main__A.cmt
+  $ odoc compile -I . main__A.cmt
+  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile -I . main.cmt
+  $ odoc link -I . src-main__A.odoc
+  $ odoc link -I . src-main.odoc
   $ odoc link -I . main__A.odoc
   $ odoc link -I . main.odoc
 
-  $ odoc html-targets --source a.ml -o html main__A.odocl
+  $ odoc html-targets -o html main__A.odocl
   html/Main__A/index.html
-  html/root/source/a.ml.html
-  $ odoc html-targets --source main.ml -o html main.odocl
+  $ odoc html-targets -o html main.odocl
   html/Main/index.html
   html/Main/A/index.html
   html/Main/A/B/index.html
-  html/root/source/main.ml.html
-  $ odoc html-targets --source a.ml --as-json -o html main__A.odocl
+  $ odoc html-targets --as-json -o html main__A.odocl
   html/Main__A/index.html.json
-  html/root/source/a.ml.html.json
-  $ odoc html-targets --source main.ml --as-json -o html main.odocl
+  $ odoc html-targets --as-json -o html main.odocl
   html/Main/index.html.json
   html/Main/A/index.html.json
   html/Main/A/B/index.html.json
+  $ odoc html-targets --source a.ml -o html src-main__A.odocl
+  html/root/source/a.ml.html
+  $ odoc html-targets --source main.ml -o html src-main.odocl
+  html/root/source/main.ml.html
+  $ odoc html-targets --source a.ml --as-json -o html src-main__A.odocl
+  html/root/source/a.ml.html.json
+  $ odoc html-targets --source main.ml --as-json -o html src-main.odocl
   html/root/source/main.ml.html.json
 
-  $ odoc html-generate --source a.ml --as-json -o html main__A.odocl
-  $ odoc html-generate --source main.ml --as-json -o html main.odocl
+  $ odoc html-generate --source a.ml --as-json -o html src-main__A.odocl
+  $ odoc html-generate --as-json -o html main__A.odocl
+  $ odoc html-generate --source main.ml --as-json -o html src-main.odocl
+  $ odoc html-generate --as-json -o html main.odocl
 
   $ cat html/Main/index.html.json
   {"type":"documentation","uses_katex":false,"breadcrumbs":[{"name":"Main","href":"#","kind":"module"}],"toc":[],"source_anchor":"../root/source/main.ml.html","preamble":"","content":"<div class=\"odoc-spec\"><div class=\"spec module anchored\" id=\"module-A\"><a href=\"#module-A\" class=\"anchor\"></a><a href=\"../root/source/a.ml.html\" class=\"source_link\">Source</a><code><span><span class=\"keyword\">module</span> <a href=\"A/index.html\">A</a></span><span> : <span class=\"keyword\">sig</span> ... <span class=\"keyword\">end</span></span></code></div></div>"}

--- a/test/integration/json_expansion_with_sources.t/run.t
+++ b/test/integration/json_expansion_with_sources.t/run.t
@@ -8,9 +8,9 @@ Test the JSON output in the presence of expanded modules.
 
   $ ocamlc -c -bin-annot -o main__A.cmo a.ml -I .
   $ ocamlc -c -bin-annot main.ml -I .
-  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . main__A.cmt
+  $ odoc compile-src --source-path a.ml --parent srctree-source.odoc -I . main__A.cmt
   $ odoc compile -I . main__A.cmt
-  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path main.ml --parent srctree-source.odoc -I . main.cmt
   $ odoc compile -I . main.cmt
   $ odoc link -I . src-main__A.odoc
   $ odoc link -I . src-main.odoc

--- a/test/occurrences/double_wrapped.t/run.t
+++ b/test/occurrences/double_wrapped.t/run.t
@@ -16,11 +16,11 @@ Collecting occurrences is done on implementation files. We thus need a source tr
   $ printf "a.ml\nb.ml\nc.ml\nmain.ml\nmain__.ml\n" > source_tree.map
   $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
-  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . main__A.cmt
-  $ odoc compile-src --source-path c.ml --source-parent-file srctree-source.odoc -I . main__C.cmt
-  $ odoc compile-src --source-path b.ml --source-parent-file srctree-source.odoc -I . main__B.cmt
-  $ odoc compile-src --source-path main__.ml --source-parent-file srctree-source.odoc -I . main__.cmt
-  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path a.ml --parent srctree-source.odoc -I . main__A.cmt
+  $ odoc compile-src --source-path c.ml --parent srctree-source.odoc -I . main__C.cmt
+  $ odoc compile-src --source-path b.ml --parent srctree-source.odoc -I . main__B.cmt
+  $ odoc compile-src --source-path main__.ml --parent srctree-source.odoc -I . main__.cmt
+  $ odoc compile-src --source-path main.ml --parent srctree-source.odoc -I . main.cmt
 
 We need the interface version to resolve the occurrences
 

--- a/test/occurrences/double_wrapped.t/run.t
+++ b/test/occurrences/double_wrapped.t/run.t
@@ -10,20 +10,33 @@ The module B depends on both B and C, the module C only depends on A.
   $ ocamlc -c -open Main__ -o main__B.cmo b.ml -bin-annot -I .
   $ ocamlc -c -open Main__ main.ml -bin-annot -I .
 
-Passing the count-occurrences flag to odoc compile makes it collect the
-occurrences information.
+Collecting occurrences is done on implementation files. We thus need a source tree as a parent.
 
-  $ odoc compile --count-occurrences -I . main__A.cmt
-  $ odoc compile --count-occurrences -I . main__C.cmt
-  $ odoc compile --count-occurrences -I . main__B.cmt
-  $ odoc compile --count-occurrences -I . main__.cmt
-  $ odoc compile --count-occurrences -I . main.cmt
+  $ odoc compile -c srctree-source root.mld
+  $ printf "a.ml\nb.ml\nc.ml\nmain.ml\nmain__.ml\n" > source_tree.map
+  $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
-  $ odoc link -I . main.odoc
-  $ odoc link -I . main__A.odoc
-  $ odoc link -I . main__B.odoc
-  $ odoc link -I . main__C.odoc
-  $ odoc link -I . main__.odoc
+  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . main__A.cmt
+  $ odoc compile-src --source-path c.ml --source-parent-file srctree-source.odoc -I . main__C.cmt
+  $ odoc compile-src --source-path b.ml --source-parent-file srctree-source.odoc -I . main__B.cmt
+  $ odoc compile-src --source-path main__.ml --source-parent-file srctree-source.odoc -I . main__.cmt
+  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+
+We need the interface version to resolve the occurrences
+
+  $ odoc compile -I . main__A.cmt
+  $ odoc compile -I . main__C.cmt
+  $ odoc compile -I . main__B.cmt
+  $ odoc compile -I . main__.cmt
+  $ odoc compile -I . main.cmt
+
+Let's link the implementations
+
+  $ odoc link -I . src-main.odoc
+  $ odoc link -I . src-main__A.odoc
+  $ odoc link -I . src-main__B.odoc
+  $ odoc link -I . src-main__C.odoc
+  $ odoc link -I . src-main__.odoc
 
 The count occurrences command outputs a marshalled hashtable, whose keys are
 odoc identifiers, and whose values are integers corresponding to the number of
@@ -36,11 +49,11 @@ and a hashtable for each compilation unit.
   $ mkdir main__B
   $ mkdir main__C
 
-  $ mv main.odocl main
-  $ mv main__.odocl main__
-  $ mv main__A.odocl main__A
-  $ mv main__B.odocl main__B
-  $ mv main__C.odocl main__C
+  $ mv src-main.odocl main
+  $ mv src-main__.odocl main__
+  $ mv src-main__A.odocl main__A
+  $ mv src-main__B.odocl main__B
+  $ mv src-main__C.odocl main__C
   $ odoc count-occurrences -I main -o occurrences-main.odoc
   $ odoc count-occurrences -I main__ -o occurrences-main__.odoc
   $ odoc count-occurrences -I main__A -o occurrences-main__A.odoc

--- a/test/odoc_print/odoc_print.ml
+++ b/test/odoc_print/odoc_print.ml
@@ -174,7 +174,7 @@ let run inp ref =
       print_json_desc Lang_desc.page_t page;
       Ok ()
   | Odoc_file.Impl_content impl ->
-      print_json_desc Lang_desc.source_page_t impl;
+      print_json_desc Lang_desc.implementation_t impl;
       Ok ()
   | Unit_content u -> (
       match ref with

--- a/test/odoc_print/odoc_print.ml
+++ b/test/odoc_print/odoc_print.ml
@@ -173,6 +173,9 @@ let run inp ref =
   | Odoc_file.Page_content page ->
       print_json_desc Lang_desc.page_t page;
       Ok ()
+  | Odoc_file.Impl_content impl ->
+      print_json_desc Lang_desc.source_page_t impl;
+      Ok ()
   | Unit_content u -> (
       match ref with
       | None ->

--- a/test/search/html_search.t/run.t
+++ b/test/search/html_search.t/run.t
@@ -254,12 +254,12 @@ Passing an inexistent file:
 
 Passing an odoc file which is neither a compilation unit nor a page:
 
-  $ odoc compile -c src-source page.mld
+  $ odoc compile -c srctree-source page.mld
   $ printf "a.ml\n" > source_tree.map
-  $ odoc source-tree -I . --parent page -o src-source.odoc source_tree.map
+  $ odoc source-tree -I . --parent page -o srctree-source.odoc source_tree.map
 
-  $ odoc compile-index src-source.odoc
-  File "src-source.odoc":
+  $ odoc compile-index srctree-source.odoc
+  File "srctree-source.odoc":
   Warning: Only pages and unit are allowed as input when generating an index
 
 Passing a file which is not a correctly marshalled one:

--- a/test/sources/compile_deps.t/a.ml
+++ b/test/sources/compile_deps.t/a.ml
@@ -1,1 +1,1 @@
-include B
+let a = B.a

--- a/test/sources/double_wrapped.t/run.t
+++ b/test/sources/double_wrapped.t/run.t
@@ -1,26 +1,32 @@
 This is what happens when a dune user write a toplevel module.
 Similar to the lookup_def_wrapped test.
 
-  $ odoc compile -c module-a -c src-source root.mld
+  $ odoc compile -c module-a -c srctree-source root.mld
 
-  $ printf "a.ml\nmain.ml\n" > source_tree.map
-  $ odoc source-tree -I . --parent page-root -o src-source.odoc source_tree.map
+  $ printf "a.ml\nmain.ml\nmain__.ml\n" > source_tree.map
+  $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
   $ ocamlc -c -o main__A.cmo a.ml -bin-annot -I .
   $ ocamlc -c -o main__.cmo main__.ml -bin-annot -I .
   $ ocamlc -c -open Main__ main.ml -bin-annot -I .
 
-  $ odoc compile --source-name a.ml --source-parent-file src-source.odoc -I . main__A.cmt
+  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . main__A.cmt
+  $ odoc compile -I . main__A.cmt
+  $ odoc compile-src --source-path main__.ml --source-parent-file srctree-source.odoc -I . main__.cmt
   $ odoc compile -I . main__.cmt
-  $ odoc compile --source-name main.ml --source-parent-file src-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile -I . main.cmt
 
   $ odoc link -I . main.odoc
+  $ odoc link -I . src-main__A.odoc
+  $ odoc link -I . src-main.odoc
+  $ odoc link -I . src-main__.odoc
   $ odoc link -I . main__A.odoc
   $ odoc link -I . main__.odoc
 
-  $ odoc html-generate --source main.ml --indent -o html main.odocl
-  $ odoc html-generate --hidden --indent -o html main__.odocl
-  $ odoc html-generate --source a.ml --hidden --indent -o html main__A.odocl
+  $ odoc html-generate --indent -o html main.odocl
+  $ odoc html-generate --source main.ml --indent -o html src-main.odocl
+  $ odoc html-generate --source a.ml --indent -o html src-main__A.odocl
 
 Look if all the source files are generated:
 
@@ -30,10 +36,6 @@ Look if all the source files are generated:
   html/Main/A
   html/Main/A/index.html
   html/Main/index.html
-  html/Main__
-  html/Main__/index.html
-  html/Main__A
-  html/Main__A/index.html
   html/root
   html/root/source
   html/root/source/a.ml.html

--- a/test/sources/double_wrapped.t/run.t
+++ b/test/sources/double_wrapped.t/run.t
@@ -10,11 +10,11 @@ Similar to the lookup_def_wrapped test.
   $ ocamlc -c -o main__.cmo main__.ml -bin-annot -I .
   $ ocamlc -c -open Main__ main.ml -bin-annot -I .
 
-  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . main__A.cmt
+  $ odoc compile-src --source-path a.ml --parent srctree-source.odoc -I . main__A.cmt
   $ odoc compile -I . main__A.cmt
-  $ odoc compile-src --source-path main__.ml --source-parent-file srctree-source.odoc -I . main__.cmt
+  $ odoc compile-src --source-path main__.ml --parent srctree-source.odoc -I . main__.cmt
   $ odoc compile -I . main__.cmt
-  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path main.ml --parent srctree-source.odoc -I . main.cmt
   $ odoc compile -I . main.cmt
 
   $ odoc link -I . main.odoc

--- a/test/sources/functor.t/run.t
+++ b/test/sources/functor.t/run.t
@@ -8,11 +8,11 @@ Verify the behavior on functors.
   $ ocamlc -c -o s.cmo s.ml -bin-annot -I .
   $ ocamlc -c -o a.cmo a.ml -bin-annot -I .
   $ ocamlc -c -o b.cmo b.ml -bin-annot -I .
-  $ odoc compile-src --source-path s.ml --source-parent-file srctree-source.odoc -I . s.cmt
+  $ odoc compile-src --source-path s.ml --parent srctree-source.odoc -I . s.cmt
   $ odoc compile -I . s.cmt
-  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . a.cmt
+  $ odoc compile-src --source-path a.ml --parent srctree-source.odoc -I . a.cmt
   $ odoc compile -I . a.cmt
-  $ odoc compile-src --source-path b.ml --source-parent-file srctree-source.odoc -I . b.cmt
+  $ odoc compile-src --source-path b.ml --parent srctree-source.odoc -I . b.cmt
   $ odoc compile -I . b.cmt
   $ odoc link -I . s.odoc
   $ odoc link -I . a.odoc

--- a/test/sources/functor.t/run.t
+++ b/test/sources/functor.t/run.t
@@ -1,22 +1,31 @@
 Verify the behavior on functors.
 
-  $ odoc compile -c module-a -c src-source root.mld
+  $ odoc compile -c module-a -c srctree-source root.mld
 
   $ printf "s.ml\na.ml\nb.ml\n" > source_tree.map
-  $ odoc source-tree -I . --parent page-root -o src-source.odoc source_tree.map
+  $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
   $ ocamlc -c -o s.cmo s.ml -bin-annot -I .
   $ ocamlc -c -o a.cmo a.ml -bin-annot -I .
   $ ocamlc -c -o b.cmo b.ml -bin-annot -I .
-  $ odoc compile --source-name s.ml --source-parent-file src-source.odoc -I . s.cmt
-  $ odoc compile --source-name a.ml --source-parent-file src-source.odoc -I . a.cmt
-  $ odoc compile --source-name b.ml --source-parent-file src-source.odoc -I . b.cmt
+  $ odoc compile-src --source-path s.ml --source-parent-file srctree-source.odoc -I . s.cmt
+  $ odoc compile -I . s.cmt
+  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . a.cmt
+  $ odoc compile -I . a.cmt
+  $ odoc compile-src --source-path b.ml --source-parent-file srctree-source.odoc -I . b.cmt
+  $ odoc compile -I . b.cmt
   $ odoc link -I . s.odoc
   $ odoc link -I . a.odoc
   $ odoc link -I . b.odoc
-  $ odoc html-generate --source s.ml --indent -o html s.odocl
-  $ odoc html-generate --source a.ml --indent -o html a.odocl
-  $ odoc html-generate --source b.ml --indent -o html b.odocl
+  $ odoc link -I . src-s.odoc
+  $ odoc link -I . src-a.odoc
+  $ odoc link -I . src-b.odoc
+  $ odoc html-generate --source s.ml --indent -o html src-s.odocl
+  $ odoc html-generate --indent -o html s.odocl
+  $ odoc html-generate --source a.ml --indent -o html src-a.odocl
+  $ odoc html-generate --indent -o html a.odocl
+  $ odoc html-generate --source b.ml --indent -o html src-b.odocl
+  $ odoc html-generate --indent -o html b.odocl
 
   $ find html | sort
   html

--- a/test/sources/include_in_expansion.t/run.t
+++ b/test/sources/include_in_expansion.t/run.t
@@ -9,11 +9,11 @@ Checking that source parents are kept, using include.
   $ ocamlc -c -o main__A.cmo a.ml -bin-annot -I .
   $ ocamlc -c main.ml -bin-annot -I .
 
-  $ odoc compile-src --source-path b.ml --source-parent-file srctree-source.odoc -I . b.cmt
+  $ odoc compile-src --source-path b.ml --parent srctree-source.odoc -I . b.cmt
   $ odoc compile -I . b.cmt
-  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . main__A.cmt
+  $ odoc compile-src --source-path a.ml --parent srctree-source.odoc -I . main__A.cmt
   $ odoc compile -I . main__A.cmt
-  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path main.ml --parent srctree-source.odoc -I . main.cmt
   $ odoc compile -I . main.cmt
 
   $ odoc link -I . main.odoc

--- a/test/sources/include_in_expansion.t/run.t
+++ b/test/sources/include_in_expansion.t/run.t
@@ -1,23 +1,30 @@
 Checking that source parents are kept, using include.
 
-  $ odoc compile -c module-a -c src-source root.mld
+  $ odoc compile -c module-a -c srctree-source root.mld
 
   $ printf "a.ml\nb.ml\nmain.ml\n" > source_tree.map
-  $ odoc source-tree -I . --parent page-root -o src-source.odoc source_tree.map
+  $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
   $ ocamlc -c -o b.cmo b.ml -bin-annot -I .
   $ ocamlc -c -o main__A.cmo a.ml -bin-annot -I .
   $ ocamlc -c main.ml -bin-annot -I .
 
-  $ odoc compile --source-name b.ml --source-parent-file src-source.odoc -I . b.cmt
-  $ odoc compile --source-name a.ml --source-parent-file src-source.odoc -I . main__A.cmt
-  $ odoc compile --source-name main.ml --source-parent-file src-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path b.ml --source-parent-file srctree-source.odoc -I . b.cmt
+  $ odoc compile -I . b.cmt
+  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . main__A.cmt
+  $ odoc compile -I . main__A.cmt
+  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile -I . main.cmt
 
   $ odoc link -I . main.odoc
   $ odoc link -I . main__A.odoc
+  $ odoc link -I . src-main.odoc
+  $ odoc link -I . src-main__A.odoc
 
-  $ odoc html-generate --source main.ml --indent -o html main.odocl
-  $ odoc html-generate --source a.ml --hidden --indent -o html main__A.odocl
+  $ odoc html-generate --source main.ml --indent -o html src-main.odocl
+  $ odoc html-generate --indent -o html main.odocl
+  $ odoc html-generate --source a.ml --hidden --indent -o html src-main__A.odocl
+  $ odoc html-generate --hidden --indent -o html main__A.odocl
 
 In Main.A, the source parent of value x should be to Main__A, while the
 source parent of value y should be left to B.

--- a/test/sources/lookup_def.t/run.t
+++ b/test/sources/lookup_def.t/run.t
@@ -15,7 +15,7 @@ Compile the modules:
 
 Show the locations:
 
-  $ odoc_print a.odocl | jq -c '.. | select(.locs?) | [ .id, .locs ]'
+  $ odoc_print a.odocl | jq -c '.. | select(.source_loc?) | [ .id, .source_loc ]'
   [{"`Module":[{"`Root":["None","A"]},"M"]},{"Some":{"`SourceLocation":[{"`SourcePage":[{"`Page":[{"Some":{"`Page":["None","root"]}},"source"]},"a.ml"]},"module-M"]}}]
   [{"`Module":[{"`Root":["None","A"]},"N"]},{"Some":{"`SourceLocation":[{"`SourcePage":[{"`Page":[{"Some":{"`Page":["None","root"]}},"source"]},"a.ml"]},"module-N"]}}]
   [{"`ModuleType":[{"`Module":[{"`Root":["None","A"]},"N"]},"S"]},{"Some":{"`SourceLocation":[{"`SourcePage":[{"`Page":[{"Some":{"`Page":["None","root"]}},"source"]},"a.ml"]},"module-N.module-type-S"]}}]

--- a/test/sources/lookup_def.t/run.t
+++ b/test/sources/lookup_def.t/run.t
@@ -7,7 +7,7 @@ Compile the modules:
 
   $ ocamlc -c a.mli a.ml -bin-annot
 
-  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . a.cmt
+  $ odoc compile-src --source-path a.ml --parent srctree-source.odoc -I . a.cmt
   $ odoc compile -I . a.cmti
 
   $ odoc link -I . src-a.odoc

--- a/test/sources/lookup_def.t/run.t
+++ b/test/sources/lookup_def.t/run.t
@@ -1,13 +1,17 @@
 Compile the modules:
 
-  $ odoc compile -c module-a -c src-source root.mld
+  $ odoc compile -c module-a -c srctree-source root.mld
 
   $ printf "a.ml\n" > source_tree.map
-  $ odoc source-tree -I . --parent page-root -o src-source.odoc source_tree.map
+  $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
   $ ocamlc -c a.mli a.ml -bin-annot
-  $ odoc compile --cmt a.cmt --source-name a.ml --source-parent-file src-source.odoc -I . a.cmti
-  $ odoc link a.odoc
+
+  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . a.cmt
+  $ odoc compile -I . a.cmti
+
+  $ odoc link -I . src-a.odoc
+  $ odoc link -I . a.odoc
 
 Show the locations:
 

--- a/test/sources/lookup_def_wrapped.t/run.t
+++ b/test/sources/lookup_def_wrapped.t/run.t
@@ -2,26 +2,35 @@ Make sure wrapped libraries don't interfere with generating the source code.
 Test both canonical paths and hidden units.
 It's a simpler case than Dune's wrapping.
 
-  $ odoc compile -c module-main -c src-source root.mld
+  $ odoc compile -c module-main -c srctree-source root.mld
 
   $ printf "a.ml\nb.ml\nmain.ml\n" > source_tree.map
-  $ odoc source-tree -I . --parent page-root -o src-source.odoc source_tree.map
+  $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
   $ ocamlc -c -o main__A.cmo a.ml -bin-annot -I .
   $ ocamlc -c -o main__B.cmo b.ml -bin-annot -I .
   $ ocamlc -c main.ml -bin-annot -I .
 
-  $ odoc compile --source-name a.ml --source-parent-file src-source.odoc -I . main__A.cmt
-  $ odoc compile --source-name b.ml --source-parent-file src-source.odoc -I . main__B.cmt
-  $ odoc compile --source-name main.ml --source-parent-file src-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . main__A.cmt
+  $ odoc compile -I . main__A.cmt
+  $ odoc compile-src --source-path b.ml --source-parent-file srctree-source.odoc -I . main__B.cmt
+  $ odoc compile -I . main__B.cmt
+  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile -I . main.cmt
 
+  $ odoc link -I . src-main__A.odoc
   $ odoc link -I . main__A.odoc
+  $ odoc link -I . src-main__B.odoc
   $ odoc link -I . main__B.odoc
+  $ odoc link -I . src-main.odoc
   $ odoc link -I . main.odoc
 
-  $ odoc html-generate --source main.ml --indent -o html main.odocl
-  $ odoc html-generate --source a.ml --hidden --indent -o html main__A.odocl
-  $ odoc html-generate --source b.ml --hidden --indent -o html main__B.odocl
+  $ odoc html-generate --source main.ml --indent -o html src-main.odocl
+  $ odoc html-generate --indent -o html main.odocl
+  $ odoc html-generate --source a.ml --indent -o html src-main__A.odocl
+  $ odoc html-generate --hidden --indent -o html main__A.odocl
+  $ odoc html-generate --source b.ml --indent -o html src-main__B.odocl
+  $ odoc html-generate --hidden --indent -o html main__B.odocl
 
 Look if all the source files are generated:
 

--- a/test/sources/lookup_def_wrapped.t/run.t
+++ b/test/sources/lookup_def_wrapped.t/run.t
@@ -11,11 +11,11 @@ It's a simpler case than Dune's wrapping.
   $ ocamlc -c -o main__B.cmo b.ml -bin-annot -I .
   $ ocamlc -c main.ml -bin-annot -I .
 
-  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . main__A.cmt
+  $ odoc compile-src --source-path a.ml --parent srctree-source.odoc -I . main__A.cmt
   $ odoc compile -I . main__A.cmt
-  $ odoc compile-src --source-path b.ml --source-parent-file srctree-source.odoc -I . main__B.cmt
+  $ odoc compile-src --source-path b.ml --parent srctree-source.odoc -I . main__B.cmt
   $ odoc compile -I . main__B.cmt
-  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path main.ml --parent srctree-source.odoc -I . main.cmt
   $ odoc compile -I . main.cmt
 
   $ odoc link -I . src-main__A.odoc

--- a/test/sources/recursive_module.t/run.t
+++ b/test/sources/recursive_module.t/run.t
@@ -6,7 +6,7 @@ Checking that source links exists inside recursive modules.
   $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
   $ ocamlc -c main.ml -bin-annot -I .
-  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path main.ml --parent srctree-source.odoc -I . main.cmt
   $ odoc compile -I . main.cmt
   $ odoc link -I . src-main.odoc
   $ odoc link -I . main.odoc

--- a/test/sources/recursive_module.t/run.t
+++ b/test/sources/recursive_module.t/run.t
@@ -1,14 +1,17 @@
 Checking that source links exists inside recursive modules.
 
-  $ odoc compile -c module-main -c src-source root.mld
+  $ odoc compile -c module-main -c srctree-source root.mld
 
   $ printf "main.ml" > source_tree.map
-  $ odoc source-tree -I . --parent page-root -o src-source.odoc source_tree.map
+  $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
   $ ocamlc -c main.ml -bin-annot -I .
-  $ odoc compile --source-name main.ml --source-parent-file src-source.odoc -I . main.cmt
+  $ odoc compile-src --source-path main.ml --source-parent-file srctree-source.odoc -I . main.cmt
+  $ odoc compile -I . main.cmt
+  $ odoc link -I . src-main.odoc
   $ odoc link -I . main.odoc
-  $ odoc html-generate --source main.ml --indent -o html main.odocl
+  $ odoc html-generate --indent -o html main.odocl
+  $ odoc html-generate --source main.ml --indent -o html src-main.odocl
 
 Both modules should contain source links
 

--- a/test/sources/single_mli.t/run.t
+++ b/test/sources/single_mli.t/run.t
@@ -1,22 +1,28 @@
 Similar to Astring library.
 
-  $ odoc compile -c module-a -c src-source root.mld
+  $ odoc compile -c module-a -c srctree-source root.mld
 
   $ printf "a.ml\na_x.ml\n" > source_tree.map
-  $ odoc source-tree -I . --parent page-root -o src-source.odoc source_tree.map
+  $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
   $ ocamlc -c -o a_x.cmo a_x.ml -bin-annot -I .
   $ ocamlc -c a.mli -bin-annot -I .
   $ ocamlc -c a.ml -bin-annot -I .
 
-  $ odoc compile --hidden --source-name a_x.ml --source-parent-file src-source.odoc -I . a_x.cmt
-  $ odoc compile --cmt a.cmt --source-name a.ml --source-parent-file src-source.odoc -I . a.cmti
+  $ odoc compile-src --source-path a_x.ml --source-parent-file srctree-source.odoc -I . a_x.cmt
+  $ odoc compile --hidden -I . a_x.cmt
+  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . a.cmt
+  $ odoc compile -I . a.cmti
 
+  $ odoc link -I . src-a_x.odoc
   $ odoc link -I . a_x.odoc
+  $ odoc link -I . src-a.odoc
   $ odoc link -I . a.odoc
 
-  $ odoc html-generate --source a_x.ml --indent -o html a_x.odocl
-  $ odoc html-generate --source a.ml --indent -o html a.odocl
+  $ odoc html-generate --source a_x.ml --indent -o html src-a_x.odocl
+  $ odoc html-generate --indent -o html a_x.odocl
+  $ odoc html-generate --source a.ml --indent -o html src-a.odocl
+  $ odoc html-generate --indent -o html a.odocl
 
 Look if all the source files are generated:
 

--- a/test/sources/single_mli.t/run.t
+++ b/test/sources/single_mli.t/run.t
@@ -9,9 +9,9 @@ Similar to Astring library.
   $ ocamlc -c a.mli -bin-annot -I .
   $ ocamlc -c a.ml -bin-annot -I .
 
-  $ odoc compile-src --source-path a_x.ml --source-parent-file srctree-source.odoc -I . a_x.cmt
+  $ odoc compile-src --source-path a_x.ml --parent srctree-source.odoc -I . a_x.cmt
   $ odoc compile --hidden -I . a_x.cmt
-  $ odoc compile-src --source-path a.ml --source-parent-file srctree-source.odoc -I . a.cmt
+  $ odoc compile-src --source-path a.ml --parent srctree-source.odoc -I . a.cmt
   $ odoc compile -I . a.cmti
 
   $ odoc link -I . src-a_x.odoc

--- a/test/sources/source.t/run.t
+++ b/test/sources/source.t/run.t
@@ -101,7 +101,7 @@ Compile the pages with the --source option:
   $ printf "a.ml\n" > source_tree.map
   $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
-  $ odoc compile-src -I . --source-path a.ml --source-parent-file srctree-source.odoc a.cmt
+  $ odoc compile-src -I . --source-path a.ml --parent srctree-source.odoc a.cmt
   $ odoc compile -I . a.cmt
   $ odoc link -I . a.odoc
   $ odoc link -I . src-a.odoc

--- a/test/sources/source.t/run.t
+++ b/test/sources/source.t/run.t
@@ -90,34 +90,27 @@ Files containing some values:
 
 Source pages require a parent:
 
-  $ odoc compile -c module-a -c src-source -c src-source2 root.mld
+  $ odoc compile -c module-a -c srctree-source -c srctree-source2 root.mld
 
 Compile the modules:
 
   $ ocamlc -c a.ml -bin-annot
 
-Compile the pages without --source:
-
-  $ odoc compile a.cmt
-  $ odoc link -I . a.odoc
-  $ odoc html-generate --indent -o html a.odocl
-
-No source links are generated in the documentation:
-
-  $ ! grep source_link html/A/index.html -B 2
-
-Now, compile the pages with the --source option:
+Compile the pages with the --source option:
 
   $ printf "a.ml\n" > source_tree.map
-  $ odoc source-tree -I . --parent page-root -o src-source.odoc source_tree.map
+  $ odoc source-tree -I . --parent page-root -o srctree-source.odoc source_tree.map
 
-  $ odoc compile -I . --source-name a.ml --source-parent-file src-source.odoc a.cmt
+  $ odoc compile-src -I . --source-path a.ml --source-parent-file srctree-source.odoc a.cmt
+  $ odoc compile -I . a.cmt
   $ odoc link -I . a.odoc
+  $ odoc link -I . src-a.odoc
   $ odoc link -I . page-root.odoc
-  $ odoc link -I . src-source.odoc
-  $ odoc html-generate --indent -o html src-source.odocl
+  $ odoc link -I . srctree-source.odoc
+  $ odoc html-generate --indent -o html srctree-source.odocl
   $ odoc html-generate --indent -o html page-root.odocl
-  $ odoc html-generate --source a.ml --indent -o html a.odocl
+  $ odoc html-generate --indent -o html a.odocl
+  $ odoc html-generate --source a.ml --indent -o html src-a.odocl
   $ odoc support-files -o html
 
 Source links generated in the documentation:
@@ -357,7 +350,7 @@ Ids generated in the source code:
   id="module-Yoyo.type-bli.constructor-Aa"
   id="module-Yoyo.type-bli.constructor-Bb"
   id="val-segr"
-  id="val-{x}6"
+  id="val-{x}1"
   id="val-y"
   id="val-z"
   id="local_a_1"
@@ -374,7 +367,7 @@ Ids generated in the source code:
   id="class-cls"
   id="class-cls'"
   id="class-type-ct"
-  id="val-{x}7"
+  id="val-{x}2"
   id="module-X"
   id="module-X.type-t"
   id="module-X.type-t"
@@ -389,13 +382,13 @@ Ids generated in the source code:
   id="module-FF2"
   id="module-FF2.argument-1-A.module-E"
   id="module-FF2.argument-2-A.module-F"
-  id="val-{x}8"
+  id="val-{x}3"
   id="local_x_4"
   id="val-(*.+%)"
   id="val-a"
-  id="val-{b}9"
+  id="val-{b}4"
   id="val-c"
-  id="val-{x}10"
+  id="val-{x}5"
   id="val-b"
   id="val-x"
   id="val-list"

--- a/test/sources/source_hierarchy.t/run.t
+++ b/test/sources/source_hierarchy.t/run.t
@@ -13,11 +13,11 @@ Compile the modules:
 
 Now, compile the pages with the --source option. The source-name must be included in the source-children of the source-parent:
 
-  $ odoc compile-src -I . --source-path lib/a/a.ml --source-parent-file srctree-source.odoc a.cmt
+  $ odoc compile-src -I . --source-path lib/a/a.ml --parent srctree-source.odoc a.cmt
   $ odoc compile -I . a.cmt
-  $ odoc compile-src -I . --source-path lib/b/b.ml --source-parent-file srctree-source.odoc b.cmt
+  $ odoc compile-src -I . --source-path lib/b/b.ml --parent srctree-source.odoc b.cmt
   $ odoc compile -I . b.cmt
-  $ odoc compile-src -I . --source-path lib/main.ml --source-parent-file srctree-source.odoc c.cmt
+  $ odoc compile-src -I . --source-path lib/main.ml --parent srctree-source.odoc c.cmt
   $ odoc compile -I . c.cmt
   $ odoc link -I . page-root.odoc
   $ odoc link -I . a.odoc

--- a/test/sources/source_hierarchy.t/run.t
+++ b/test/sources/source_hierarchy.t/run.t
@@ -1,6 +1,6 @@
 A page can have source children.
 
-  $ odoc compile -c module-a -c module-b -c src-source root.mld
+  $ odoc compile -c module-a -c module-b -c srctree-source root.mld
 
   $ printf "lib/main.ml\nlib/b/b.ml\nlib/a/a.ml\n" > source.map
   $ odoc source-tree -I . --parent page-root source.map
@@ -13,19 +13,28 @@ Compile the modules:
 
 Now, compile the pages with the --source option. The source-name must be included in the source-children of the source-parent:
 
-  $ odoc compile -I . --source-name lib/a/a.ml --source-parent-file src-source.odoc a.cmt
-  $ odoc compile -I . --source-name lib/b/b.ml --source-parent-file src-source.odoc b.cmt
-  $ odoc compile -I . --source-name lib/main.ml --source-parent-file src-source.odoc c.cmt
+  $ odoc compile-src -I . --source-path lib/a/a.ml --source-parent-file srctree-source.odoc a.cmt
+  $ odoc compile -I . a.cmt
+  $ odoc compile-src -I . --source-path lib/b/b.ml --source-parent-file srctree-source.odoc b.cmt
+  $ odoc compile -I . b.cmt
+  $ odoc compile-src -I . --source-path lib/main.ml --source-parent-file srctree-source.odoc c.cmt
+  $ odoc compile -I . c.cmt
   $ odoc link -I . page-root.odoc
   $ odoc link -I . a.odoc
   $ odoc link -I . b.odoc
   $ odoc link -I . c.odoc
-  $ odoc link -I . src-source.odoc
+  $ odoc link -I . src-a.odoc
+  $ odoc link -I . src-b.odoc
+  $ odoc link -I . src-c.odoc
+  $ odoc link -I . srctree-source.odoc
   $ odoc html-generate --indent -o html page-root.odocl
-  $ odoc html-generate --indent -o html src-source.odocl
-  $ odoc html-generate --source a.ml --indent -o html a.odocl
-  $ odoc html-generate --source b.ml --indent -o html b.odocl
-  $ odoc html-generate --source c.ml --indent -o html c.odocl
+  $ odoc html-generate --indent -o html srctree-source.odocl
+  $ odoc html-generate --source a.ml --indent -o html src-a.odocl
+  $ odoc html-generate --indent -o html a.odocl
+  $ odoc html-generate --source b.ml --indent -o html src-b.odocl
+  $ odoc html-generate --indent -o html b.odocl
+  $ odoc html-generate --source c.ml --indent -o html src-c.odocl
+  $ odoc html-generate --indent -o html c.odocl
 
 Source pages and source directory pages are generated:
 

--- a/test/sources/source_hierarchy_source_root.t/run.t
+++ b/test/sources/source_hierarchy_source_root.t/run.t
@@ -1,6 +1,6 @@
 A page can have source children.
 
-  $ odoc compile -c module-a -c module-b -c src-source root.mld
+  $ odoc compile -c module-a -c module-b -c srctree-source root.mld
 
   $ printf "lib/main.ml\nlib/b/b.ml\nlib/a/a.ml\n" > source.map
   $ odoc source-tree -I . --parent page-root source.map
@@ -13,19 +13,28 @@ Compile the modules:
 
 Now, compile the pages with the --source option. The source-name must be included in the source-children of the source-parent:
 
-  $ odoc compile -I . --source-name lib/a/a.ml --source-parent-file src-source.odoc lib/a/a.cmt
-  $ odoc compile -I . --source-name lib/b/b.ml --source-parent-file src-source.odoc lib/b/b.cmt
-  $ odoc compile -I . --source-name lib/main.ml --source-parent-file src-source.odoc lib/main.cmt
+  $ odoc compile-src -I . --source-path lib/a/a.ml --source-parent-file srctree-source.odoc lib/a/a.cmt
+  $ odoc compile -I . lib/a/a.cmt
+  $ odoc compile-src -I . --source-path lib/b/b.ml --source-parent-file srctree-source.odoc lib/b/b.cmt
+  $ odoc compile -I . lib/b/b.cmt
+  $ odoc compile-src -I . --source-path lib/main.ml --source-parent-file srctree-source.odoc lib/main.cmt
+  $ odoc compile -I . lib/main.cmt
   $ odoc link -I . -I lib/a -I lib/b -I lib page-root.odoc
   $ odoc link -I . lib/a/a.odoc
   $ odoc link -I . lib/b/b.odoc
   $ odoc link -I . lib/main.odoc
-  $ odoc link -I . src-source.odoc
+  $ odoc link -I . lib/a/src-a.odoc
+  $ odoc link -I . lib/b/src-b.odoc
+  $ odoc link -I . lib/src-main.odoc
+  $ odoc link -I . srctree-source.odoc
   $ odoc html-generate --indent -o html page-root.odocl
-  $ odoc html-generate --indent -o html src-source.odocl
-  $ odoc html-generate --source-root . --indent -o html lib/a/a.odocl
-  $ odoc html-generate --source-root . --indent -o html lib/b/b.odocl
-  $ odoc html-generate --source-root . --indent -o html lib/main.odocl
+  $ odoc html-generate --indent -o html srctree-source.odocl
+  $ odoc html-generate --source-root . --indent -o html lib/a/src-a.odocl
+  $ odoc html-generate --indent -o html lib/a/a.odocl
+  $ odoc html-generate --source-root . --indent -o html lib/b/src-b.odocl
+  $ odoc html-generate --indent -o html lib/b/b.odocl
+  $ odoc html-generate --indent -o html lib/main.odocl
+  $ odoc html-generate --source-root . --indent -o html lib/src-main.odocl
 
 Source pages and source directory pages are generated:
 

--- a/test/sources/source_hierarchy_source_root.t/run.t
+++ b/test/sources/source_hierarchy_source_root.t/run.t
@@ -13,11 +13,11 @@ Compile the modules:
 
 Now, compile the pages with the --source option. The source-name must be included in the source-children of the source-parent:
 
-  $ odoc compile-src -I . --source-path lib/a/a.ml --source-parent-file srctree-source.odoc lib/a/a.cmt
+  $ odoc compile-src -I . --source-path lib/a/a.ml --parent srctree-source.odoc lib/a/a.cmt
   $ odoc compile -I . lib/a/a.cmt
-  $ odoc compile-src -I . --source-path lib/b/b.ml --source-parent-file srctree-source.odoc lib/b/b.cmt
+  $ odoc compile-src -I . --source-path lib/b/b.ml --parent srctree-source.odoc lib/b/b.cmt
   $ odoc compile -I . lib/b/b.cmt
-  $ odoc compile-src -I . --source-path lib/main.ml --source-parent-file srctree-source.odoc lib/main.cmt
+  $ odoc compile-src -I . --source-path lib/main.ml --parent srctree-source.odoc lib/main.cmt
   $ odoc compile -I . lib/main.cmt
   $ odoc link -I . -I lib/a -I lib/b -I lib page-root.odoc
   $ odoc link -I . lib/a/a.odoc

--- a/test/xref2/canonical_nested.t/run.t
+++ b/test/xref2/canonical_nested.t/run.t
@@ -54,7 +54,7 @@ unresolved in the paths though:
         "B"
       ]
     },
-    "locs": "None",
+    "source_loc": "None",
     "doc": [],
     "type_": {
       "Alias": [
@@ -120,7 +120,7 @@ unresolved in the paths though:
         "Container"
       ]
     },
-    "locs": "None",
+    "source_loc": "None",
     "doc": [],
     "type_": {
       "Alias": [
@@ -185,7 +185,7 @@ unresolved in the paths though:
         "B"
       ]
     },
-    "locs": "None",
+    "source_loc": "None",
     "doc": [],
     "type_": {
       "Alias": [
@@ -277,7 +277,7 @@ unresolved in the paths though:
                           "t"
                         ]
                       },
-                      "locs": "None",
+                      "source_loc": "None",
                       "doc": [],
                       "equation": {
                         "params": [],

--- a/test/xref2/classes.t/run.t
+++ b/test/xref2/classes.t/run.t
@@ -26,7 +26,7 @@ resolve correctly. All of the 'Class' json objects should contain
         "f"
       ]
     },
-    "locs": "None",
+    "source_loc": "None",
     "doc": [],
     "type_": {
       "Class": [
@@ -63,7 +63,7 @@ resolve correctly. All of the 'Class' json objects should contain
         "g"
       ]
     },
-    "locs": "None",
+    "source_loc": "None",
     "doc": [],
     "type_": {
       "Class": [

--- a/test/xref2/deep_substitution.t/run.t
+++ b/test/xref2/deep_substitution.t/run.t
@@ -37,7 +37,7 @@ its RHS correctly replaced with an `int`
         "t"
       ]
     },
-    "locs": "None",
+    "source_loc": "None",
     "doc": [],
     "equation": {
       "params": [],

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -616,8 +616,7 @@ let my_compilation_unit id (s : Odoc_model.Lang.Signature.t) =
     ; expansion = None
     ; linked = false
     ; canonical = None
-    ; source_info = None
-    ; shape_info = None
+    ; locs = None
 }
 
 let mkresolver () =

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -616,7 +616,7 @@ let my_compilation_unit id (s : Odoc_model.Lang.Signature.t) =
     ; expansion = None
     ; linked = false
     ; canonical = None
-    ; locs = None
+    ; source_loc = None
 }
 
 let mkresolver () =

--- a/test/xref2/resolve/test.md
+++ b/test/xref2/resolve/test.md
@@ -143,8 +143,7 @@ Simplest possible resolution:
           constraints = []};
         representation = None})];
     compiled = true; doc = []};
- expansion = None; linked = false; canonical = None; source_info = None;
- shape_info = None}
+ expansion = None; linked = false; locs = None; canonical = None}
 ```
 
 Let's look at a marginally more complicated example. In this case, our type `t`
@@ -317,8 +316,7 @@ Basic resolution 2, environment lookup:
           constraints = []};
         representation = None})];
     compiled = true; doc = []};
- expansion = None; linked = false; canonical = None; source_info = None;
- shape_info = None}
+ expansion = None; linked = false; locs = None; canonical = None}
 ```
 
 
@@ -520,8 +518,7 @@ Basic resolution 3, module type:
         representation = ...});
       ...];
     compiled = ...; doc = ...};
- expansion = ...; linked = ...; canonical = ...; source_info = ...;
- shape_info = ...}
+ expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```
 
 This example is very similar but there is one more level of nesting of the modules:
@@ -723,8 +720,7 @@ Basic resolution 4, module type:
         canonical = ...; hidden = ...});
       ...];
     compiled = ...; doc = ...};
- expansion = ...; linked = ...; canonical = ...; source_info = ...;
- shape_info = ...}
+ expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```
 
 This example is rather more interesting:
@@ -959,8 +955,7 @@ and then we can look up the type `t`.
               compiled = ...; doc = ...})};
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; canonical = ...; source_info = ...;
-  shape_info = ...}
+  expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```
 
 ```ocaml
@@ -1166,8 +1161,7 @@ and then we can look up the type `t`.
               compiled = ...; doc = ...})};
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; canonical = ...; source_info = ...;
-  shape_info = ...}
+  expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```
 
 Ensure a substitution is taken into account during resolution:
@@ -1349,8 +1343,7 @@ Ensure a substitution is taken into account during resolution:
          canonical = ...; hidden = ...});
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; canonical = ...; source_info = ...;
-  shape_info = ...}
+  expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```
 
 Ensure a destructive substitution is taken into account during resolution:
@@ -1532,8 +1525,7 @@ Ensure a destructive substitution is taken into account during resolution:
          canonical = ...; hidden = ...});
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; canonical = ...; source_info = ...;
-  shape_info = ...}
+  expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```
 
 Resolve a module alias:
@@ -1693,8 +1685,7 @@ Resolve a module alias:
           constraints = []};
         representation = None})];
     compiled = true; doc = ...};
- expansion = ...; linked = ...; canonical = ...; source_info = ...;
- shape_info = ...}
+ expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```
 
 Resolve a module alias:
@@ -1853,8 +1844,7 @@ Resolve a module alias:
         representation = ...});
       ...];
     compiled = ...; doc = ...};
- expansion = ...; linked = ...; canonical = ...; source_info = ...;
- shape_info = ...}
+ expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```
 
 Resolve a functor:
@@ -2035,8 +2025,7 @@ Resolve a functor:
          canonical = ...; hidden = ...});
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; canonical = ...; source_info = ...;
-  shape_info = ...}
+  expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```
 
 Resolve a functor:
@@ -2242,8 +2231,7 @@ Resolve a functor:
               p_path = ...}))};
       ...];
     compiled = ...; doc = ...};
- expansion = ...; linked = ...; canonical = ...; source_info = ...;
- shape_info = ...}
+ expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```
 
 ```ocaml skip
@@ -2459,6 +2447,5 @@ Functor app nightmare:
          canonical = ...; hidden = ...});
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; canonical = ...; source_info = ...;
-  shape_info = ...}
+  expansion = ...; linked = ...; locs = ...; canonical = ...}
 ```

--- a/test/xref2/resolve/test.md
+++ b/test/xref2/resolve/test.md
@@ -101,7 +101,7 @@ Simplest possible resolution:
                ihash = 818126955; ikey = "r_Root.p_None"},
               t);
           ihash = 1016576344; ikey = "t_t.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         equation =
          {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
           manifest = None; constraints = []};
@@ -119,7 +119,7 @@ Simplest possible resolution:
                ihash = 818126955; ikey = "r_Root.p_None"},
               u);
           ihash = 15973539; ikey = "t_u.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         equation =
          {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
           manifest =
@@ -143,7 +143,7 @@ Simplest possible resolution:
           constraints = []};
         representation = None})];
     compiled = true; doc = []};
- expansion = None; linked = false; locs = None; canonical = None}
+ expansion = None; linked = false; source_loc = None; canonical = None}
 ```
 
 Let's look at a marginally more complicated example. In this case, our type `t`
@@ -246,7 +246,7 @@ Basic resolution 2, environment lookup:
                ihash = 818126955; ikey = "r_Root.p_None"},
               M);
           ihash = 716453475; ikey = "m_M.r_Root.p_None"};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Signature
@@ -270,7 +270,7 @@ Basic resolution 2, environment lookup:
                         ihash = 716453475; ikey = "m_M.r_Root.p_None"},
                        t);
                    ihash = 746522241; ikey = "t_t.m_M.r_Root.p_None"};
-                 locs = None; doc = []; canonical = None;
+                 source_loc = None; doc = []; canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
@@ -290,7 +290,7 @@ Basic resolution 2, environment lookup:
                ihash = 818126955; ikey = "r_Root.p_None"},
               u);
           ihash = 15973539; ikey = "t_u.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         equation =
          {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
           manifest =
@@ -316,7 +316,7 @@ Basic resolution 2, environment lookup:
           constraints = []};
         representation = None})];
     compiled = true; doc = []};
- expansion = None; linked = false; locs = None; canonical = None}
+ expansion = None; linked = false; source_loc = None; canonical = None}
 ```
 
 
@@ -392,7 +392,7 @@ Basic resolution 3, module type:
                ihash = 818126955; ikey = "r_Root.p_None"},
               M);
           ihash = 459143770; ikey = "mt_M.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -416,7 +416,7 @@ Basic resolution 3, module type:
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        t);
                    ihash = 825731485; ikey = "t_t.mt_M.r_Root.p_None"};
-                 locs = None; doc = []; canonical = None;
+                 source_loc = None; doc = []; canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
@@ -435,7 +435,7 @@ Basic resolution 3, module type:
                ihash = 818126955; ikey = "r_Root.p_None"},
               N);
           ihash = 502470005; ikey = "m_N.r_Root.p_None"};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Path
@@ -462,7 +462,7 @@ Basic resolution 3, module type:
                              ihash = 502470005; ikey = "m_N.r_Root.p_None"},
                             t);
                         ihash = 598040815; ikey = "t_t.m_N.r_Root.p_None"};
-                      locs = None; doc = []; canonical = None;
+                      source_loc = None; doc = []; canonical = None;
                       equation =
                        {Odoc_model.Lang.TypeDecl.Equation.params = [];
                         private_ = false; manifest = None; constraints = []};
@@ -497,7 +497,7 @@ Basic resolution 3, module type:
                ihash = 818126955; ikey = "r_Root.p_None"},
               u);
           ihash = 15973539; ikey = "t_u.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         equation =
          {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
           manifest =
@@ -518,7 +518,7 @@ Basic resolution 3, module type:
         representation = ...});
       ...];
     compiled = ...; doc = ...};
- expansion = ...; linked = ...; locs = ...; canonical = ...}
+ expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 This example is very similar but there is one more level of nesting of the modules:
@@ -572,7 +572,7 @@ Basic resolution 4, module type:
                ihash = 818126955; ikey = "r_Root.p_None"},
               M);
           ihash = 459143770; ikey = "mt_M.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -596,7 +596,7 @@ Basic resolution 4, module type:
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        N);
                    ihash = 998243332; ikey = "m_N.mt_M.r_Root.p_None"};
-                 locs = None; doc = [];
+                 source_loc = None; doc = [];
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Signature
@@ -629,7 +629,7 @@ Basic resolution 4, module type:
                                 t);
                             ihash = 687003328;
                             ikey = "t_t.m_N.mt_M.r_Root.p_None"};
-                          locs = None; doc = []; canonical = None;
+                          source_loc = None; doc = []; canonical = None;
                           equation =
                            {Odoc_model.Lang.TypeDecl.Equation.params = [];
                             private_ = false; manifest = None;
@@ -651,7 +651,7 @@ Basic resolution 4, module type:
                ihash = 818126955; ikey = "r_Root.p_None"},
               A);
           ihash = 353272258; ikey = "m_A.r_Root.p_None"};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Path
@@ -678,7 +678,7 @@ Basic resolution 4, module type:
                              ihash = 353272258; ikey = "m_A.r_Root.p_None"},
                             N);
                         ihash = 456955352; ikey = "m_N.m_A.r_Root.p_None"};
-                      locs = None; doc = [];
+                      source_loc = None; doc = [];
                       type_ =
                        Odoc_model.Lang.Module.ModuleType
                         (Odoc_model.Lang.ModuleType.Signature
@@ -709,7 +709,7 @@ Basic resolution 4, module type:
                                       ihash = ...; ikey = ...},
                                      ...);
                                  ihash = ...; ikey = ...};
-                               locs = ...; doc = ...; canonical = ...;
+                               source_loc = ...; doc = ...; canonical = ...;
                                equation = ...; representation = ...});
                              ...];
                            compiled = ...; doc = ...});
@@ -720,7 +720,7 @@ Basic resolution 4, module type:
         canonical = ...; hidden = ...});
       ...];
     compiled = ...; doc = ...};
- expansion = ...; linked = ...; locs = ...; canonical = ...}
+ expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 This example is rather more interesting:
@@ -810,7 +810,7 @@ and then we can look up the type `t`.
                ihash = 818126955; ikey = "r_Root.p_None"},
               M);
           ihash = 459143770; ikey = "mt_M.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -833,7 +833,7 @@ and then we can look up the type `t`.
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        N);
                    ihash = 887387323; ikey = "mt_N.mt_M.r_Root.p_None"};
-                 locs = None; doc = []; canonical = None;
+                 source_loc = None; doc = []; canonical = None;
                  expr =
                   Some
                    (Odoc_model.Lang.ModuleType.Signature
@@ -866,7 +866,7 @@ and then we can look up the type `t`.
                                 t);
                             ihash = 652783314;
                             ikey = "t_t.mt_N.mt_M.r_Root.p_None"};
-                          locs = None; doc = []; canonical = None;
+                          source_loc = None; doc = []; canonical = None;
                           equation =
                            {Odoc_model.Lang.TypeDecl.Equation.params = [];
                             private_ = false; manifest = None;
@@ -892,7 +892,7 @@ and then we can look up the type `t`.
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        B);
                    ihash = 301928208; ikey = "m_B.mt_M.r_Root.p_None"};
-                 locs = None; doc = [];
+                 source_loc = None; doc = [];
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Path
@@ -928,7 +928,7 @@ and then we can look up the type `t`.
                                      t);
                                  ihash = 484865120;
                                  ikey = "t_t.m_B.mt_M.r_Root.p_None"};
-                               locs = None; doc = []; canonical = None;
+                               source_loc = None; doc = []; canonical = None;
                                equation =
                                 {Odoc_model.Lang.TypeDecl.Equation.params =
                                   [];
@@ -955,7 +955,7 @@ and then we can look up the type `t`.
               compiled = ...; doc = ...})};
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; locs = ...; canonical = ...}
+  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 ```ocaml
@@ -998,7 +998,7 @@ and then we can look up the type `t`.
                ihash = 818126955; ikey = "r_Root.p_None"},
               M);
           ihash = 459143770; ikey = "mt_M.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -1021,7 +1021,7 @@ and then we can look up the type `t`.
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        N);
                    ihash = 887387323; ikey = "mt_N.mt_M.r_Root.p_None"};
-                 locs = None; doc = []; canonical = None;
+                 source_loc = None; doc = []; canonical = None;
                  expr =
                   Some
                    (Odoc_model.Lang.ModuleType.Signature
@@ -1054,7 +1054,7 @@ and then we can look up the type `t`.
                                 t);
                             ihash = 652783314;
                             ikey = "t_t.mt_N.mt_M.r_Root.p_None"};
-                          locs = None; doc = []; canonical = None;
+                          source_loc = None; doc = []; canonical = None;
                           equation =
                            {Odoc_model.Lang.TypeDecl.Equation.params = [];
                             private_ = false; manifest = None;
@@ -1080,7 +1080,7 @@ and then we can look up the type `t`.
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        X);
                    ihash = 573009176; ikey = "m_X.mt_M.r_Root.p_None"};
-                 locs = None; doc = [];
+                 source_loc = None; doc = [];
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Signature
@@ -1113,7 +1113,7 @@ and then we can look up the type `t`.
                                 B);
                             ihash = 413241446;
                             ikey = "m_B.m_X.mt_M.r_Root.p_None"};
-                          locs = None; doc = [];
+                          source_loc = None; doc = [];
                           type_ =
                            Odoc_model.Lang.Module.ModuleType
                             (Odoc_model.Lang.ModuleType.Path
@@ -1147,7 +1147,7 @@ and then we can look up the type `t`.
                                                 ihash = ...; ikey = ...},
                                                ...);
                                            ihash = ...; ikey = ...};
-                                         locs = ...; doc = ...;
+                                         source_loc = ...; doc = ...;
                                          canonical = ...; equation = ...;
                                          representation = ...});
                                        ...];
@@ -1161,7 +1161,7 @@ and then we can look up the type `t`.
               compiled = ...; doc = ...})};
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; locs = ...; canonical = ...}
+  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 Ensure a substitution is taken into account during resolution:
@@ -1206,7 +1206,7 @@ Ensure a substitution is taken into account during resolution:
                ihash = 818126955; ikey = "r_Root.p_None"},
               A);
           ihash = 231492881; ikey = "mt_A.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -1230,7 +1230,7 @@ Ensure a substitution is taken into account during resolution:
                         ihash = 231492881; ikey = "mt_A.r_Root.p_None"},
                        M);
                    ihash = 564635453; ikey = "m_M.mt_A.r_Root.p_None"};
-                 locs = None; doc = [];
+                 source_loc = None; doc = [];
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Signature
@@ -1262,7 +1262,7 @@ Ensure a substitution is taken into account during resolution:
                                 S);
                             ihash = 3092406;
                             ikey = "mt_S.m_M.mt_A.r_Root.p_None"};
-                          locs = None; doc = []; canonical = None;
+                          source_loc = None; doc = []; canonical = None;
                           expr = None}];
                       compiled = true; doc = []});
                  canonical = None; hidden = false});
@@ -1285,7 +1285,7 @@ Ensure a substitution is taken into account during resolution:
                         ihash = 231492881; ikey = "mt_A.r_Root.p_None"},
                        N);
                    ihash = 50158313; ikey = "m_N.mt_A.r_Root.p_None"};
-                 locs = None; doc = [];
+                 source_loc = None; doc = [];
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Path
@@ -1333,7 +1333,7 @@ Ensure a substitution is taken into account during resolution:
               B);
           ihash = 814134997;
           ikey = "m_B.r_Ro"... (* string length 17; truncated *)};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Signature
@@ -1343,7 +1343,7 @@ Ensure a substitution is taken into account during resolution:
          canonical = ...; hidden = ...});
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; locs = ...; canonical = ...}
+  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 Ensure a destructive substitution is taken into account during resolution:
@@ -1388,7 +1388,7 @@ Ensure a destructive substitution is taken into account during resolution:
                ihash = 818126955; ikey = "r_Root.p_None"},
               A);
           ihash = 231492881; ikey = "mt_A.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -1412,7 +1412,7 @@ Ensure a destructive substitution is taken into account during resolution:
                         ihash = 231492881; ikey = "mt_A.r_Root.p_None"},
                        M);
                    ihash = 564635453; ikey = "m_M.mt_A.r_Root.p_None"};
-                 locs = None; doc = [];
+                 source_loc = None; doc = [];
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Signature
@@ -1444,7 +1444,7 @@ Ensure a destructive substitution is taken into account during resolution:
                                 S);
                             ihash = 3092406;
                             ikey = "mt_S.m_M.mt_A.r_Root.p_None"};
-                          locs = None; doc = []; canonical = None;
+                          source_loc = None; doc = []; canonical = None;
                           expr = None}];
                       compiled = true; doc = []});
                  canonical = None; hidden = false});
@@ -1467,7 +1467,7 @@ Ensure a destructive substitution is taken into account during resolution:
                         ihash = 231492881; ikey = "mt_A.r_Root.p_None"},
                        N);
                    ihash = 50158313; ikey = "m_N.mt_A.r_Root.p_None"};
-                 locs = None; doc = [];
+                 source_loc = None; doc = [];
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Path
@@ -1515,7 +1515,7 @@ Ensure a destructive substitution is taken into account during resolution:
               B);
           ihash = 814134997;
           ikey = "m_B.r_Ro"... (* string length 17; truncated *)};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Signature
@@ -1525,7 +1525,7 @@ Ensure a destructive substitution is taken into account during resolution:
          canonical = ...; hidden = ...});
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; locs = ...; canonical = ...}
+  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 Resolve a module alias:
@@ -1565,7 +1565,7 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               A);
           ihash = 353272258; ikey = "m_A.r_Root.p_None"};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Signature
@@ -1589,7 +1589,7 @@ Resolve a module alias:
                         ihash = 353272258; ikey = "m_A.r_Root.p_None"},
                        t);
                    ihash = 394964294; ikey = "t_t.m_A.r_Root.p_None"};
-                 locs = None; doc = []; canonical = None;
+                 source_loc = None; doc = []; canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
@@ -1609,7 +1609,7 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               B);
           ihash = 814134997; ikey = "m_B.r_Root.p_None"};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.Alias
           (`Resolved
@@ -1640,7 +1640,7 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               t);
           ihash = 1016576344; ikey = "t_t.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         equation =
          {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
           manifest =
@@ -1685,7 +1685,7 @@ Resolve a module alias:
           constraints = []};
         representation = None})];
     compiled = true; doc = ...};
- expansion = ...; linked = ...; locs = ...; canonical = ...}
+ expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 Resolve a module alias:
@@ -1726,7 +1726,7 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               A);
           ihash = 353272258; ikey = "m_A.r_Root.p_None"};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Signature
@@ -1750,7 +1750,7 @@ Resolve a module alias:
                         ihash = 353272258; ikey = "m_A.r_Root.p_None"},
                        t);
                    ihash = 394964294; ikey = "t_t.m_A.r_Root.p_None"};
-                 locs = None; doc = []; canonical = None;
+                 source_loc = None; doc = []; canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
@@ -1770,7 +1770,7 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               B);
           ihash = 814134997; ikey = "m_B.r_Root.p_None"};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.Alias
           (`Resolved
@@ -1801,7 +1801,7 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               C);
           ihash = 43786577; ikey = "m_C.r_Root.p_None"};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.Alias
           (`Resolved
@@ -1840,11 +1840,11 @@ Resolve a module alias:
       Odoc_model.Lang.Signature.Type (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.TypeDecl.id =
          {Odoc_model__Paths_types.iv = `Type (...); ihash = ...; ikey = ...};
-        locs = ...; doc = ...; canonical = ...; equation = ...;
+        source_loc = ...; doc = ...; canonical = ...; equation = ...;
         representation = ...});
       ...];
     compiled = ...; doc = ...};
- expansion = ...; linked = ...; locs = ...; canonical = ...}
+ expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 Resolve a functor:
@@ -1888,7 +1888,7 @@ Resolve a functor:
                ihash = 818126955; ikey = "r_Root.p_None"},
               S);
           ihash = 527535255; ikey = "mt_S.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -1912,7 +1912,7 @@ Resolve a functor:
                         ihash = 527535255; ikey = "mt_S.r_Root.p_None"},
                        t);
                    ihash = 130637260; ikey = "t_t.mt_S.r_Root.p_None"};
-                 locs = None; doc = []; canonical = None;
+                 source_loc = None; doc = []; canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
@@ -1931,7 +1931,7 @@ Resolve a functor:
                ihash = 818126955; ikey = "r_Root.p_None"},
               F);
           ihash = 748202139; ikey = "m_F.r_Root.p_None"};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Functor
@@ -1987,7 +1987,7 @@ Resolve a functor:
                                  t);
                              ihash = 1065278958;
                              ikey = "t_t.p_X.m_F.r_Root.p_None"};
-                           locs = None; doc = []; canonical = None;
+                           source_loc = None; doc = []; canonical = None;
                            equation =
                             {Odoc_model.Lang.TypeDecl.Equation.params = [];
                              private_ = false; manifest = None;
@@ -2025,7 +2025,7 @@ Resolve a functor:
          canonical = ...; hidden = ...});
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; locs = ...; canonical = ...}
+  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 Resolve a functor:
@@ -2091,7 +2091,7 @@ Resolve a functor:
                ihash = 818126955; ikey = "r_Root.p_None"},
               S);
           ihash = 527535255; ikey = "mt_S.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -2115,7 +2115,7 @@ Resolve a functor:
                         ihash = 527535255; ikey = "mt_S.r_Root.p_None"},
                        t);
                    ihash = 130637260; ikey = "t_t.mt_S.r_Root.p_None"};
-                 locs = None; doc = []; canonical = None;
+                 source_loc = None; doc = []; canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
@@ -2134,7 +2134,7 @@ Resolve a functor:
                ihash = 818126955; ikey = "r_Root.p_None"},
               S1);
           ihash = 289200525; ikey = "mt_S1.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Functor
@@ -2190,7 +2190,7 @@ Resolve a functor:
                                  t);
                              ihash = 993900890;
                              ikey = "t_t.p__.mt_S1.r_Root.p_None"};
-                           locs = None; doc = []; canonical = None;
+                           source_loc = None; doc = []; canonical = None;
                            equation =
                             {Odoc_model.Lang.TypeDecl.Equation.params = [];
                              private_ = false; manifest = None;
@@ -2224,14 +2224,14 @@ Resolve a functor:
                       {Odoc_model.Lang.TypeDecl.id =
                         {Odoc_model__Paths_types.iv = ...; ihash = ...;
                          ikey = ...};
-                       locs = ...; doc = ...; canonical = ...;
+                       source_loc = ...; doc = ...; canonical = ...;
                        equation = ...; representation = ...});
                      ...];
                    compiled = ...; doc = ...});
               p_path = ...}))};
       ...];
     compiled = ...; doc = ...};
- expansion = ...; linked = ...; locs = ...; canonical = ...}
+ expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 ```ocaml skip
@@ -2315,7 +2315,7 @@ Functor app nightmare:
                ihash = 818126955; ikey = "r_Root.p_None"},
               Type);
           ihash = 359972898; ikey = "mt_Type.r_Root.p_None"};
-        locs = None; doc = []; canonical = None;
+        source_loc = None; doc = []; canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -2338,7 +2338,7 @@ Functor app nightmare:
                         ihash = 359972898; ikey = "mt_Type.r_Root.p_None"},
                        T);
                    ihash = 1011869183; ikey = "mt_T.mt_Type.r_Root.p_None"};
-                 locs = None; doc = []; canonical = None; expr = None}];
+                 source_loc = None; doc = []; canonical = None; expr = None}];
              compiled = true; doc = []})};
       Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.Module.id =
@@ -2353,7 +2353,7 @@ Functor app nightmare:
                ihash = 818126955; ikey = "r_Root.p_None"},
               App);
           ihash = 855073208; ikey = "m_App.r_Root.p_None"};
-        locs = None; doc = [];
+        source_loc = None; doc = [];
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Functor
@@ -2408,7 +2408,7 @@ Functor app nightmare:
                                  T);
                              ihash = 167832761;
                              ikey = "mt_T.p_T.m_App.r_Root.p_None"};
-                           locs = None; doc = []; canonical = None;
+                           source_loc = None; doc = []; canonical = None;
                            expr = None}];
                        compiled = true; doc = []});
                   p_path =
@@ -2447,5 +2447,5 @@ Functor app nightmare:
          canonical = ...; hidden = ...});
        ...];
      compiled = ...; doc = ...};
-  expansion = ...; linked = ...; locs = ...; canonical = ...}
+  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```


### PR DESCRIPTION
This PR separate the compilation pipeline for interface and implementation. This is a backward incompatible change, but only for rendering source code. It introduces a new command, `compile-src`, which compiles to a new kind of odoc file: implementation files, named `src-<name>.odoc(l)`.

A good way to see the changes is to look at the diff in the source rendering tests, but here is a list of the changes:

- The `compile` command do not take the `--source-name` and `--source-parent-file` commands.
- The new `compile-src` command take `--source-path` and `--source-parent-file` command instead. It can only take a `<name>.cmt` file as input, and creates a value of type `Odoc_model.Lang.Implementation.t` which is stored in `src-<name>.odoc`. Basically, such type is a record containing an identifier, the source information extracted from the typedtree, the implementation shape and the `uid_to_id` map.
- When looking for a shape, we look in the `src-....odoc` files in the path.
- When html-generating, the `--source` and `--source-root` are restricted to implementation `odocl` files.

A notable change is that `--source-parent-file` and `--source-path` is required for implementation files, which forces to have them even when we only want to count occurrences, not render them.

Another change is that `--source` and `--source-root` are not anymore specific to the html rendering process. The reason is that with the current organization of the code, only the renderer can depend on backend-specific flags, not the transformation model -> document. Of course it is possible to change that, but that require further modifications which I'm not sure we want.

The reason for this change is the following:
- It separates two independent pipeline that were merged into one,
- It avoids having a single `.odocl` generate files in very different output directories, which can be a problem for some build systems.