### PR TITLE
docs: fix path to index.html in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Once installed, you can generate your project documentation with [Dune](https://
 $ dune build @doc
 ```
 
-Upon completion, you'll find your freshly minted docs in `_build/default/doc/html/index.html`:
+Upon completion, you'll find your freshly minted docs in `_build/default/_doc/_html/index.html`:
 
 ```
-$ open _build/default/doc/html/index.html
+$ open _build/default/_doc/_html/index.html
 ```
 
 For more in-depth information and usage instructions, see the [odoc website](https://ocaml.github.io/odoc).


### PR DESCRIPTION
Changes the path to `index.html` in the README.md to match the path in the [odoc documentation](https://ocaml.github.io/odoc/odoc_for_authors.html). 