### PR TITLE
Revert to outputing a content-empty file when rendering a hidden module (`2.4` branch)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 2.4.1
+
+# Fixed
+
+- Revert to outputing a file (without content) when rendering a hidden
+  compilation unit. This fixes cases where the dune rules would
+  fail. (@panglesd, #1069)
+
 # 2.4.0
 
 ### Added

--- a/src/odoc/odoc_link.ml
+++ b/src/odoc/odoc_link.ml
@@ -4,6 +4,34 @@ let link_page ~resolver ~filename page =
   let env = Resolver.build_env_for_page resolver page in
   Odoc_xref2.Link.resolve_page ~filename env page
 
+let content_for_hidden_modules =
+  let open Odoc_model in
+  let open Lang.Signature in
+  let with_loc v =
+    let open Location_ in
+    {
+      location =
+        {
+          file = "_none_";
+          start = { line = 1; column = 0 };
+          end_ = { line = 1; column = 0 };
+        };
+      value = v;
+    }
+  in
+  let sentence =
+    [
+      `Word "This";
+      `Space;
+      `Word "module";
+      `Space;
+      `Word "is";
+      `Space;
+      `Word "hidden.";
+    ]
+  in
+  [ Comment (`Docs [ with_loc @@ `Paragraph (List.map with_loc sentence) ]) ]
+
 let link_unit ~resolver ~filename m =
   let open Odoc_model in
   let open Lang.Compilation_unit in
@@ -11,7 +39,9 @@ let link_unit ~resolver ~filename m =
     if Root.Odoc_file.hidden m.root.file then
       {
         m with
-        content = Module { items = []; compiled = false; doc = [] };
+        content =
+          Module
+            { items = content_for_hidden_modules; compiled = false; doc = [] };
         expansion = None;
       }
     else m

--- a/src/odoc/rendering.ml
+++ b/src/odoc/rendering.ml
@@ -7,8 +7,7 @@ let documents_of_unit ~warnings_options ~syntax ~renderer ~extra unit =
   |> Odoc_model.Error.handle_warnings ~warnings_options
   >>= fun extra_docs ->
   Ok
-    (if unit.hidden then extra_docs
-     else Renderer.document_of_compilation_unit ~syntax unit :: extra_docs)
+    (Renderer.document_of_compilation_unit ~syntax unit :: extra_docs)
 
 let documents_of_page ~warnings_options ~syntax ~renderer ~extra page =
   Odoc_model.Error.catch_warnings (fun () ->

--- a/test/integration/json_expansion_with_sources.t/run.t
+++ b/test/integration/json_expansion_with_sources.t/run.t
@@ -14,6 +14,7 @@ Test the JSON output in the presence of expanded modules.
   $ odoc link -I . main.odoc
 
   $ odoc html-targets --source a.ml -o html main__A.odocl
+  html/Main__A/index.html
   html/root/source/a.ml.html
   $ odoc html-targets --source main.ml -o html main.odocl
   html/Main/index.html
@@ -21,6 +22,7 @@ Test the JSON output in the presence of expanded modules.
   html/Main/A/B/index.html
   html/root/source/main.ml.html
   $ odoc html-targets --source a.ml --as-json -o html main__A.odocl
+  html/Main__A/index.html.json
   html/root/source/a.ml.html.json
   $ odoc html-targets --source main.ml --as-json -o html main.odocl
   html/Main/index.html.json

--- a/test/sources/double_wrapped.t/run.t
+++ b/test/sources/double_wrapped.t/run.t
@@ -30,6 +30,10 @@ Look if all the source files are generated:
   html/Main/A
   html/Main/A/index.html
   html/Main/index.html
+  html/Main__
+  html/Main__/index.html
+  html/Main__A
+  html/Main__A/index.html
   html/root
   html/root/source
   html/root/source/a.ml.html

--- a/test/sources/lookup_def_wrapped.t/run.t
+++ b/test/sources/lookup_def_wrapped.t/run.t
@@ -33,6 +33,10 @@ Look if all the source files are generated:
   html/Main/B
   html/Main/B/index.html
   html/Main/index.html
+  html/Main__A
+  html/Main__A/index.html
+  html/Main__B
+  html/Main__B/index.html
   html/root
   html/root/source
   html/root/source/a.ml.html

--- a/test/sources/single_mli.t/run.t
+++ b/test/sources/single_mli.t/run.t
@@ -28,6 +28,8 @@ Look if all the source files are generated:
   html/A/X/Y/index.html
   html/A/X/index.html
   html/A/index.html
+  html/A_x
+  html/A_x/index.html
   html/root
   html/root/source
   html/root/source/a.ml.html
@@ -36,6 +38,7 @@ Look if all the source files are generated:
 Documentation for `A_x` is not generated for hidden modules:
 
   $ ! [ -f html/A_x/index.html ]
+  [1]
 
 Code source for `A_x` is wanted:
 

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -122,6 +122,6 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
     </nav>
     <header class="odoc-preamble">
      <h1>Module <code><span>A__b</span></code></h1>
-    </header><div class="odoc-content"></div>
+    </header><div class="odoc-content"><p>This module is hidden.</p></div>
    </body>
   </html>

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -26,6 +26,7 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
   html/test/A/index.html
   html/test/A/B/index.html
   $ odoc html-targets -o html a__b.odocl
+  html/test/A__b/index.html
 
   $ cat html/test/A/index.html
   <!DOCTYPE html>
@@ -103,7 +104,24 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
    </body>
   </html>
 
-`A__b` shouldn't render:
+`A__b` shouldn't have any real content:
 
-  $ ! cat html/test/A__b/index.html
-  cat: html/test/A__b/index.html: No such file or directory
+  $ cat html/test/A__b/index.html
+  <!DOCTYPE html>
+  <html xmlns="http://www.w3.org/1999/xhtml">
+   <head><title>A__b (test.A__b)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../odoc.css"/>
+    <meta name="generator" content="odoc %%VERSION%%"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+    <script src="../../highlight.pack.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+   </head>
+   <body class="odoc">
+    <nav class="odoc-nav"><a href="../index.html">Up</a> – 
+     <a href="../index.html">test</a> &#x00BB; A__b
+    </nav>
+    <header class="odoc-preamble">
+     <h1>Module <code><span>A__b</span></code></h1>
+    </header><div class="odoc-content"></div>
+   </body>
+  </html>


### PR DESCRIPTION
#1069 for the 2.4 branch.