### PR TITLE
Add a marshalled output for index generation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Path-references to hierarchical pages and modules (@Julow, #1151)
   Absolute (`{!/foo}`), relative (`{!./foo}`) and package-local (`{!//foo}`)
   are added.
+- Add a marshalled search index consumable by sherlodoc (@EmileTrotignon, @panglesd, #1084)
 
 ### Changed
 

--- a/odoc-driver.opam
+++ b/odoc-driver.opam
@@ -34,7 +34,7 @@ documentation for installed packages.
 
 depends: [
   "odoc" {= version}
-  "bos" 
+  "bos"
   "fpath"
   "yojson"
   "ocamlfind"
@@ -43,6 +43,7 @@ depends: [
   "eio_main"
   "progress"
   "cmdliner"
+  "sherlodoc"
 ]
 
 build: [

--- a/odoc-driver.opam
+++ b/odoc-driver.opam
@@ -43,11 +43,6 @@ depends: [
   "eio_main"
   "progress"
   "cmdliner"
-  "sherlodoc"
-]
-
-pin-depends: [
-  ["sherlodoc.dev" "git+https://github.com/emiletrotignon/sherlodoc.git#076cc2b"]
 ]
 
 build: [

--- a/odoc-driver.opam
+++ b/odoc-driver.opam
@@ -46,6 +46,10 @@ depends: [
   "sherlodoc"
 ]
 
+pin-depends: [
+  ["sherlodoc.dev" "git+https://github.com/emiletrotignon/sherlodoc.git#076cc2b"]
+]
+
 build: [
   ["dune" "subst"] {dev}
   [

--- a/src/driver/cmd_outputs.ml
+++ b/src/driver/cmd_outputs.ml
@@ -1,0 +1,20 @@
+let submit desc cmd output_file =
+  match Worker_pool.submit desc cmd output_file with
+  | Ok x -> x
+  | Error exn -> raise exn
+
+let compile_output = ref [ "" ]
+
+let compile_src_output = ref [ "" ]
+
+let link_output = ref [ "" ]
+
+let generate_output = ref [ "" ]
+
+let source_tree_output = ref [ "" ]
+
+let add_prefixed_output cmd list prefix lines =
+  if List.length lines > 0 then
+    list :=
+      !list
+      @ (Bos.Cmd.to_string cmd :: List.map (fun l -> prefix ^ ": " ^ l) lines)

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -8,4 +8,8 @@ type linked
 
 val link : compiled list -> linked list
 
+val index : Fpath.t -> Packages.set -> unit
+
+val sherlodoc : html_dir:Fpath.t -> odoc_dir:Fpath.t -> Packages.set -> unit
+
 val html_generate : Fpath.t -> linked list -> unit

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -25,6 +25,14 @@ val link :
   unit ->
   unit
 
+val compile_index :
+  ?ignore_output:bool ->
+  dst:Fpath.t ->
+  json:bool ->
+  include_rec:Fpath.set ->
+  unit ->
+  unit
+
 val html_generate :
   output_dir:string ->
   ?ignore_output:bool ->
@@ -36,11 +44,6 @@ val html_generate :
   unit
 val support_files : Fpath.t -> string list
 
-val compile_output : string list ref
-val compile_src_output : string list ref
-val link_output : string list ref
-val generate_output : string list ref
-val source_tree_output : string list ref
 val count_occurrences : Fpath.t -> string list
 val source_tree :
   ?ignore_output:bool -> parent:string -> output:Fpath.t -> Fpath.t -> unit

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -514,6 +514,8 @@ let run libs verbose odoc_dir html_dir stats nb_workers =
       (fun () ->
         let compiled = Compile.compile odoc_dir all in
         let linked = Compile.link compiled in
+        let () = Compile.index odoc_dir all in
+        let () = Compile.sherlodoc ~html_dir ~odoc_dir all in
         let () = Compile.html_generate html_dir linked in
         let _ = Odoc.support_files html_dir in
         ())

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -30,7 +30,6 @@ type modulety = {
   m_intf : intf;
   m_impl : impl option;
   m_hidden : bool;
-  m_package : string;
 }
 
 type mld = {
@@ -68,7 +67,7 @@ module Module = struct
 
   let is_hidden name = Astring.String.is_infix ~affix:"__" name
 
-  let vs m_package lib_name dir modules =
+  let vs pkg_name lib_name dir modules =
     let mk m_name =
       let exists ext =
         let p =
@@ -87,7 +86,7 @@ module Module = struct
             | _ -> None)
       in
       let mk_intf mif_path =
-        let mif_parent_id = Printf.sprintf "%s/lib/%s" m_package lib_name in
+        let mif_parent_id = Printf.sprintf "%s/lib/%s" pkg_name lib_name in
         let mif_odoc_file =
           Fpath.(
             v mif_parent_id
@@ -107,7 +106,7 @@ module Module = struct
         | Error _ -> failwith "bad deps"
       in
       let mk_impl mip_path =
-        let mip_parent_id = Printf.sprintf "%s/lib/%s" m_package lib_name in
+        let mip_parent_id = Printf.sprintf "%s/lib/%s" pkg_name lib_name in
         let mip_odoc_file =
           Fpath.(
             v mip_parent_id
@@ -124,7 +123,7 @@ module Module = struct
                   m "Found source file %a for %s" Fpath.pp src_path m_name);
               let src_name = Fpath.filename src_path in
               let src_id =
-                Printf.sprintf "%s/src/%s/%s" m_package lib_name src_name
+                Printf.sprintf "%s/src/%s/%s" pkg_name lib_name src_name
               in
               Some { src_path; src_id }
         in
@@ -143,7 +142,7 @@ module Module = struct
               Logs.err (fun m -> m "No files for module: %s" m_name);
               failwith "no files"
         in
-        Some { m_name; m_intf; m_impl; m_hidden; m_package }
+        Some { m_name; m_intf; m_impl; m_hidden }
       with _ ->
         Logs.err (fun m -> m "Error processing module %s. Ignoring." m_name);
         None

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -36,7 +36,6 @@ type modulety = {
   m_intf : intf;
   m_impl : impl option;
   m_hidden : bool;
-  m_package : string;
 }
 
 (** {1 Standalone pages units} *)

--- a/src/driver/sherlodoc.ml
+++ b/src/driver/sherlodoc.ml
@@ -1,0 +1,30 @@
+open Bos
+open Cmd_outputs
+
+let sherlodoc = Cmd.v "sherlodoc"
+
+let index ?(ignore_output = false) ~format ~inputs ~dst ?favored_prefixes () =
+  let desc = Printf.sprintf "Sherlodoc indexing at %s" (Fpath.to_string dst) in
+  let format =
+    Cmd.(v "--format" % match format with `marshal -> "marshal" | `js -> "js")
+  in
+  let favored_prefixes =
+    match favored_prefixes with
+    | None -> Cmd.empty
+    | Some favored_prefixes ->
+        Cmd.(v "--favoured_prefixes" % String.concat "," favored_prefixes)
+  in
+  let inputs = Cmd.(inputs |> List.map p |> of_list) in
+  let cmd =
+    Cmd.(
+      sherlodoc % "index" %% format %% favored_prefixes %% inputs % "-o" % p dst)
+  in
+  let lines = submit desc cmd (Some dst) in
+  if not ignore_output then
+    add_prefixed_output cmd link_output (Fpath.to_string dst) lines
+
+let js dst =
+  let cmd = Cmd.(sherlodoc % "js" % p dst) in
+  let desc = Printf.sprintf "Sherlodoc js at %s" (Fpath.to_string dst) in
+  let _lines = submit desc cmd (Some dst) in
+  ()

--- a/src/model/fold.mli
+++ b/src/model/fold.mli
@@ -28,18 +28,72 @@ type item =
 val unit : f:('a -> item -> 'a) -> 'a -> Compilation_unit.t -> 'a
 val page : f:('a -> item -> 'a) -> 'a -> Page.t -> 'a
 
+val signature :
+  f:('a -> item -> 'a) ->
+  Paths.Identifier.LabelParent.t ->
+  'a ->
+  Signature.t ->
+  'a
+val signature_item :
+  f:('a -> item -> 'a) ->
+  Paths.Identifier.LabelParent.t ->
+  'a ->
+  Signature.item ->
+  'a
 val docs :
   f:('a -> item -> 'a) ->
   Paths.Identifier.LabelParent.t ->
   'a ->
   Comment.docs_or_stop ->
   'a
-val class_type : f:('a -> item -> 'a) -> 'a -> ClassType.t -> 'a
-val class_ : f:('a -> item -> 'a) -> 'a -> Class.t -> 'a
+val include_ :
+  f:('a -> item -> 'a) ->
+  Paths.Identifier.LabelParent.t ->
+  'a ->
+  Include.t ->
+  'a
+val class_type :
+  f:('a -> item -> 'a) ->
+  Paths.Identifier.LabelParent.t ->
+  'a ->
+  ClassType.t ->
+  'a
+val class_signature :
+  f:('a -> item -> 'a) ->
+  Paths.Identifier.LabelParent.t ->
+  'a ->
+  ClassSignature.t ->
+  'a
+val class_signature_item :
+  f:('a -> item -> 'a) ->
+  Paths.Identifier.LabelParent.t ->
+  'a ->
+  ClassSignature.item ->
+  'a
+val class_ :
+  f:('a -> item -> 'a) -> Paths.Identifier.LabelParent.t -> 'a -> Class.t -> 'a
 val exception_ : f:('a -> item -> 'a) -> 'a -> Exception.t -> 'a
 val type_extension : f:('a -> item -> 'a) -> 'a -> Extension.t -> 'a
 val value : f:('a -> item -> 'a) -> 'a -> Value.t -> 'a
-val module_ : f:('a -> item -> 'a) -> 'a -> Module.t -> 'a
+val module_ :
+  f:('a -> item -> 'a) -> Paths.Identifier.LabelParent.t -> 'a -> Module.t -> 'a
 val type_decl : f:('a -> item -> 'a) -> 'a -> TypeDecl.t -> 'a
-val module_type : f:('a -> item -> 'a) -> 'a -> ModuleType.t -> 'a
+val module_type :
+  f:('a -> item -> 'a) ->
+  Paths.Identifier.LabelParent.t ->
+  'a ->
+  ModuleType.t ->
+  'a
+val simple_expansion :
+  f:('a -> item -> 'a) ->
+  Paths.Identifier.LabelParent.t ->
+  'a ->
+  ModuleType.simple_expansion ->
+  'a
+val module_type_expr :
+  f:('a -> item -> 'a) ->
+  Paths.Identifier.LabelParent.t ->
+  'a ->
+  ModuleType.expr ->
+  'a
 val functor_parameter : f:('a -> item -> 'a) -> 'a -> FunctorParameter.t -> 'a

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -643,6 +643,10 @@ module Identifier = struct
       mk_parent LocalName.to_string "sli" (fun (p, n) ->
           `SourceLocationInternal (p, n))
   end
+
+  module Hashtbl = struct
+    module Any = Hashtbl.Make (Any)
+  end
 end
 
 module Path = struct

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -236,6 +236,10 @@ module Identifier : sig
     end
   end
 
+  module Hashtbl : sig
+    module Any : Hashtbl.S with type key = Any.t
+  end
+
   module Mk : sig
     open Names
 

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -44,6 +44,11 @@ module Directory : sig
 
   val to_fpath : t -> Fpath.t
 
+  val fold_files_rec : ?ext:string -> ('a -> file -> 'a) -> 'a -> t -> 'a
+  (** [fold_files_rec_result ~ext f acc d] recursively folds [f] over the files
+      with extension matching [ext] (defaults to [""]) contained in [d]
+      and its sub directories. *)
+
   val fold_files_rec_result :
     ?ext:string ->
     ('a -> file -> ('a, msg) result) ->

--- a/src/odoc/indexing.ml
+++ b/src/odoc/indexing.ml
@@ -3,18 +3,26 @@ open Odoc_json_index
 open Or_error
 open Odoc_model
 
-let handle_file file ~unit ~page =
-  Odoc_file.load file >>= fun unit' ->
-  match unit' with
-  | { Odoc_file.content = Unit_content unit'; _ } when unit'.hidden ->
-      Error (`Msg "Hidden units are ignored when generating an index")
-  | { Odoc_file.content = Unit_content unit'; _ } (* when not unit'.hidden *) ->
-      Ok (unit unit')
-  | { Odoc_file.content = Page_content page'; _ } -> Ok (page page')
-  | _ ->
-      Error
-        (`Msg
-          "Only pages and unit are allowed as input when generating an index")
+module H = Odoc_model.Paths.Identifier.Hashtbl.Any
+
+let handle_file file ~unit ~page ~occ =
+  match Fpath.basename file with
+  | s when String.is_prefix ~affix:"index-" s ->
+      Odoc_file.load_index file >>= fun index -> Ok (occ index)
+  | _ -> (
+      Odoc_file.load file >>= fun unit' ->
+      match unit' with
+      | { Odoc_file.content = Unit_content unit'; _ } when unit'.hidden ->
+          Error (`Msg "Hidden units are ignored when generating an index")
+      | { Odoc_file.content = Unit_content unit'; _ }
+      (* when not unit'.hidden *) ->
+          Ok (unit unit')
+      | { Odoc_file.content = Page_content page'; _ } -> Ok (page page')
+      | _ ->
+          Error
+            (`Msg
+              "Only pages and unit are allowed as input when generating an \
+               index"))
 
 let parse_input_file input =
   let is_sep = function '\n' | '\r' -> true | _ -> false in
@@ -32,9 +40,7 @@ let parse_input_files input =
     (Ok []) input
   >>= fun files -> Ok (List.concat files)
 
-let compile ~output ~warnings_options inputs_in_file inputs =
-  parse_input_files inputs_in_file >>= fun files ->
-  let files = List.rev_append inputs files in
+let compile_to_json ~output ~warnings_options files =
   let output_channel =
     Fs.Directory.mkdir_p (Fs.File.dirname output);
     open_out_bin (Fs.File.to_string output)
@@ -53,6 +59,7 @@ let compile ~output ~warnings_options inputs_in_file inputs =
           handle_file
             ~unit:(print Json_search.unit acc)
             ~page:(print Json_search.page acc)
+            ~occ:(print Json_search.index acc)
             file
         with
         | Ok acc -> acc
@@ -66,3 +73,56 @@ let compile ~output ~warnings_options inputs_in_file inputs =
   result |> Error.handle_warnings ~warnings_options >>= fun (_ : bool) ->
   Format.fprintf output "]";
   Ok ()
+
+let compile_to_marshall ~output ~warnings_options files =
+  let final_index = H.create 10 in
+  let unit u =
+    Odoc_model.Fold.unit
+      ~f:(fun () item ->
+        let entries = Odoc_search.Entry.entries_of_item item in
+        List.iter
+          (fun entry -> H.add final_index entry.Odoc_search.Entry.id entry)
+          entries)
+      () u
+  in
+  let page p =
+    Odoc_model.Fold.page
+      ~f:(fun () item ->
+        let entries = Odoc_search.Entry.entries_of_item item in
+        List.iter
+          (fun entry -> H.add final_index entry.Odoc_search.Entry.id entry)
+          entries)
+      () p
+  in
+  let index i = H.iter (H.add final_index) i in
+  let index () =
+    List.fold_left
+      (fun acc file ->
+        match handle_file ~unit ~page ~occ:index file with
+        | Ok acc -> acc
+        | Error (`Msg m) ->
+            Error.raise_warning ~non_fatal:true
+              (Error.filename_only "%s" m (Fs.File.to_string file));
+            acc)
+      () files
+  in
+  let result = Error.catch_warnings index in
+  result |> Error.handle_warnings ~warnings_options >>= fun () ->
+  Ok (Odoc_file.save_index output final_index)
+
+let compile out_format ~output ~warnings_options ~includes_rec ~inputs_in_file
+    ~odocls =
+  parse_input_files inputs_in_file >>= fun files ->
+  let files = List.rev_append odocls files in
+  let files =
+    List.rev_append files
+      (includes_rec
+      |> List.map (fun include_rec ->
+             Fs.Directory.fold_files_rec ~ext:"odocl"
+               (fun files file -> file :: files)
+               [] include_rec)
+      |> List.concat)
+  in
+  match out_format with
+  | `JSON -> compile_to_json ~output ~warnings_options files
+  | `Marshall -> compile_to_marshall ~output ~warnings_options files

--- a/src/odoc/indexing.mli
+++ b/src/odoc/indexing.mli
@@ -4,13 +4,16 @@ val handle_file :
   Fpath.t ->
   unit:(Odoc_model.Lang.Compilation_unit.t -> 'a) ->
   page:(Odoc_model.Lang.Page.t -> 'a) ->
+  occ:(Odoc_search.Entry.t Odoc_model.Paths.Identifier.Hashtbl.Any.t -> 'a) ->
   ('a, [> msg ]) result
 (** This function is exposed for custom indexers that uses [odoc] as a library
     to generate their search index *)
 
 val compile :
+  [ `JSON | `Marshall ] ->
   output:Fs.file ->
   warnings_options:Odoc_model.Error.warnings_options ->
-  Fs.file list ->
-  Fs.file list ->
+  includes_rec:Fs.directory list ->
+  inputs_in_file:Fs.file list ->
+  odocls:Fs.file list ->
   (unit, [> msg ]) result

--- a/src/odoc/odoc_file.mli
+++ b/src/odoc/odoc_file.mli
@@ -55,3 +55,11 @@ val load : Fs.File.t -> (t, [> msg ]) result
 
 val load_root : Fs.File.t -> (Root.t, [> msg ]) result
 (** Only load the root. Faster than {!load}, used for looking up imports. *)
+
+val save_index :
+  Fs.File.t -> Odoc_search.Entry.t Paths.Identifier.Hashtbl.Any.t -> unit
+
+val load_index :
+  Fs.File.t ->
+  (Odoc_search.Entry.t Paths.Identifier.Hashtbl.Any.t, [> msg ]) result
+(** Load a [.odoc-index] file. *)

--- a/src/search/json_index/json_search.ml
+++ b/src/search/json_index/json_search.ml
@@ -214,3 +214,13 @@ let page ppf (page : Odoc_model.Lang.Page.t) =
   in
   let _first = Odoc_model.Fold.page ~f true page in
   ()
+
+let index ppf (index : Entry.t Odoc_model.Paths.Identifier.Hashtbl.Any.t) =
+  let _first =
+    Odoc_model.Paths.Identifier.Hashtbl.Any.fold
+      (fun _id entry first ->
+        let entry = (entry, Html.of_entry entry) in
+        output_json ppf first [ entry ])
+      index true
+  in
+  ()

--- a/src/search/json_index/json_search.mli
+++ b/src/search/json_index/json_search.mli
@@ -2,3 +2,7 @@
 
 val unit : Format.formatter -> Odoc_model.Lang.Compilation_unit.t -> unit
 val page : Format.formatter -> Odoc_model.Lang.Page.t -> unit
+val index :
+  Format.formatter ->
+  Odoc_search.Entry.t Odoc_model.Paths.Identifier.Hashtbl.Any.t ->
+  unit

--- a/test/search/html_search.t/run.t
+++ b/test/search/html_search.t/run.t
@@ -270,6 +270,7 @@ Passing a file which is not a correctly marshalled one:
   Warning: Error while unmarshalling "my_file": End_of_file
   
 
+
 Passing no file:
 
   $ odoc compile-index

--- a/test/search/id_standalone_comments.t/run.t
+++ b/test/search/id_standalone_comments.t/run.t
@@ -7,7 +7,11 @@ Compile and link the documentation
   $ odoc compile -I . main.cmt
   $ odoc link -I . main.odoc
 
-  $ odoc compile-index main.odocl
+  $ odoc compile-index --json --include-rec .
+We test that you can also pass a .odocl file directly.
+  $ odoc compile-index --json main.odocl -o index2.json
+Indexes should be the same no matter how the inputs were passed.
+  $ diff index.json index2.json
 
 Let's have a look at the links generated for standalone comments search entries:
 

--- a/test/search/module_aliases.t/run.t
+++ b/test/search/module_aliases.t/run.t
@@ -6,7 +6,7 @@ Compile and link the documentation
 
   $ odoc compile main.cmt
   $ odoc link main.odoc
-  $ odoc compile-index main.odocl
+  $ odoc compile-index --json --include-rec .
 
 Search results only redirect to their definition point (not the
 expansions). Comments link to the expansion they are in.


### PR DESCRIPTION
This PR adds a new marshalled output for the generation of index files.

This is desirable for several reasons:
- It allows to combine several pre-built indexes, making the index generation more incremental
- It can be read by other OCaml tools using odoc as library, for instance when building a search engine index (cc @EmileTrotignon). #1022 is also relevant.

The first commit fixes a bug in the computation of the ID of the page containing a standalone comment. The second commit is the actual change.

There are some design to discuss:
- This PR adds a `--marshall` flag to the `compile-index`: by default the output is json, but it is marshalled with this flag.
- The files containing marshelled indexes have to be prefixed by `index-` and have to have the `.odoc` extension.
- Currently, the format is a hashtable. I think it would be better to have a better datastructure, similar to the one to contain occurrences.
- The complexity when merging indexes many times is not ideal. For instance the following commands would be in O(n^2)
```
$ odoc compile-index --marshall -o index-all1.odoc a1.odocl
$ odoc compile-index --marshall -o index-all2.odoc a2.odocl index-a1.odoc
$ odoc compile-index --marshall -o index-all3.odoc a3.odocl index-a2.odoc
$ odoc compile-index --marshall -o index-all4.odoc a4.odocl index-a3.odoc
$ odoc compile-index --marshall -o index-all5.odoc a5.odocl index-a4.odoc
...
$ odoc compile-index --marshall -o index-all<n>.odoc a<n>.odocl index-a<n-1>.odoc
$
```
But I think that is ok.