### PR TITLE
Normalize whitespaces in codespans

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - Updated colors for code fragments (@EmileTrotignon, #1023)
 - Fixed complexity of looking up `.odoc` files (@panglesd, #1075)
+- Normalize whitespaces in codespans (@gpetiot, #1085)
+  A newline followed by any whitespaces is normalized as one space character.
 
 ### Changed
 

--- a/doc/odoc_for_authors.mld
+++ b/doc/odoc_for_authors.mld
@@ -276,6 +276,22 @@ For inline, language agnostic source code style, use square brackets: [ [ ... ] 
 (** Here, [f 0] is [None] *)
 ]}
 
+Two newlines in a row in an inline codeblock are forbidden, but in the interest
+of the 80 char rule, a single newline followed by horizontal space in an inline
+codeblock is considered as a single space:
+
+{[
+(**
+  A very loooooooooooooooooooooooong line and [List.map (fun x -> x +1)].
+
+  is equivalent to:
+
+  A very loooooooooooooooooooooooong line and [List.map
+  (fun x -> x +1)].
+
+*)
+]}
+
 All the other existing ways to insert code are meant to be used for code blocks,
 not inline code fragments. Those will be formatted as a code block and will end
 the paragraph. Attempting to use them inline will trigger a warning.

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -617,7 +617,7 @@ and code_span buffer nesting_level start_offset input = parse
           ~in_what:(Token.describe (`Code_span "")));
       Buffer.add_char buffer ' ';
       code_span buffer nesting_level start_offset input lexbuf }
-  | newline horizontal_space+
+  | newline horizontal_space*
     { Buffer.add_char buffer ' ';
       code_span buffer nesting_level start_offset input lexbuf }
 

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -263,6 +263,8 @@ let horizontal_space =
   [' ' '\t']
 let newline =
   '\n' | "\r\n"
+let whitespace =
+  horizontal_space | newline
 
 let reference_start =
   "{!" | "{{!" | "{:" | "{{:"
@@ -609,13 +611,13 @@ and code_span buffer nesting_level start_offset input = parse
     { Buffer.add_char buffer c;
       code_span buffer nesting_level start_offset input lexbuf }
 
-  | newline newline
+  | newline whitespace+ as sp
     { warning
         input
         (Parse_error.not_allowed
-          ~what:(Token.describe (`Blank_line "\n\n"))
+          ~what:(Token.describe (`Blank_line sp))
           ~in_what:(Token.describe (`Code_span "")));
-      Buffer.add_char buffer '\n';
+      Buffer.add_char buffer ' ';
       code_span buffer nesting_level start_offset input lexbuf }
 
   | eof

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -263,8 +263,6 @@ let horizontal_space =
   [' ' '\t']
 let newline =
   '\n' | "\r\n"
-let whitespace =
-  horizontal_space | newline
 
 let reference_start =
   "{!" | "{{!" | "{:" | "{{:"
@@ -611,13 +609,16 @@ and code_span buffer nesting_level start_offset input = parse
     { Buffer.add_char buffer c;
       code_span buffer nesting_level start_offset input lexbuf }
 
-  | newline whitespace+ as sp
+  | newline horizontal_space* (newline horizontal_space*)+
     { warning
         input
         (Parse_error.not_allowed
-          ~what:(Token.describe (`Blank_line sp))
+          ~what:(Token.describe (`Blank_line "\n\n"))
           ~in_what:(Token.describe (`Code_span "")));
       Buffer.add_char buffer ' ';
+      code_span buffer nesting_level start_offset input lexbuf }
+  | newline horizontal_space+
+    { Buffer.add_char buffer ' ';
       code_span buffer nesting_level start_offset input lexbuf }
 
   | eof

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -797,8 +797,7 @@ let%expect_test _ =
         {|
     ((output
       (((f.ml (1 0) (2 4))
-        (paragraph (((f.ml (1 0) (2 4)) (code_span  "foo\
-                                                   \nbar")))))))
+        (paragraph (((f.ml (1 0) (2 4)) (code_span "foo bar")))))))
      (warnings ())) |}]
 
     let cr_lf_preserved =
@@ -807,8 +806,7 @@ let%expect_test _ =
         {|
     ((output
       (((f.ml (1 0) (2 4))
-        (paragraph (((f.ml (1 0) (2 4)) (code_span  "foo\r\
-                                                   \nbar")))))))
+        (paragraph (((f.ml (1 0) (2 4)) (code_span "foo bar")))))))
      (warnings ())) |}]
 
     let no_double_new_line =

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -817,8 +817,7 @@ let%expect_test _ =
         {|
     ((output
       (((f.ml (1 0) (3 4))
-        (paragraph (((f.ml (1 0) (3 4)) (code_span  "foo\
-                                                   \nbar")))))))
+        (paragraph (((f.ml (1 0) (3 4)) (code_span "foo bar")))))))
      (warnings
       ( "File \"f.ml\", line 1, character 4 to line 3, character 0:\
        \nBlank line is not allowed in '[...]' (code)."))) |}]
@@ -829,8 +828,7 @@ let%expect_test _ =
         {|
     ((output
       (((f.ml (1 0) (3 4))
-        (paragraph (((f.ml (1 0) (3 4)) (code_span  "foo\
-                                                   \nbar")))))))
+        (paragraph (((f.ml (1 0) (3 4)) (code_span "foo bar")))))))
      (warnings
       ( "File \"f.ml\", line 1, character 4 to line 3, character 0:\
        \nBlank line is not allowed in '[...]' (code)."))) |}]

--- a/test/generators/cases/markup.mli
+++ b/test/generators/cases/markup.mli
@@ -60,6 +60,8 @@
     There is no differences between [a b] and [a
     b].
 
+    Consecutive whitespaces not after a newline are conserved as they are: [a   b].
+
     {1 Links and references}
 
     This is a {{:#} link}. It sends you to the top of this page. Links can have

--- a/test/generators/cases/markup.mli
+++ b/test/generators/cases/markup.mli
@@ -57,6 +57,8 @@
     Code can appear {b inside [other] markup}. Its display shouldn't be
     affected.
 
+    There is no differences between [a b] and [a
+    b].
 
     {1 Links and references}
 

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -125,6 +125,9 @@
    </p>
    <p>There is no differences between <code>a b</code> and <code>a b</code>.
    </p>
+   <p>Consecutive whitespaces not after a newline are conserved as they
+     are: <code>a   b</code>.
+   </p>
    <h2 id="links-and-references">
     <a href="#links-and-references" class="anchor"></a>Links and references
    </h2>

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -123,10 +123,7 @@
    <p>Code can appear <b>inside <code>other</code> markup</b>. Its display
      shouldn't be affected.
    </p>
-   <p>There is no differences between <code>a b</code> and 
-    <code>a
-              b</code>
-    .
+   <p>There is no differences between <code>a b</code> and <code>a b</code>.
    </p>
    <h2 id="links-and-references">
     <a href="#links-and-references" class="anchor"></a>Links and references

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -123,6 +123,11 @@
    <p>Code can appear <b>inside <code>other</code> markup</b>. Its display
      shouldn't be affected.
    </p>
+   <p>There is no differences between <code>a b</code> and 
+    <code>a
+              b</code>
+    .
+   </p>
    <h2 id="links-and-references">
     <a href="#links-and-references" class="anchor"></a>Links and references
    </h2>

--- a/test/generators/latex/Markup.tex
+++ b/test/generators/latex/Markup.tex
@@ -34,8 +34,7 @@ This is also true between \emph{non-}\ocamlinlinecode{code} markup \emph{and} \o
 
 Code can appear \bold{inside \ocamlinlinecode{other} markup}. Its display shouldn't be affected.
 
-There is no differences between \ocamlinlinecode{a b} and \ocamlinlinecode{a
-    b}.
+There is no differences between \ocamlinlinecode{a b} and \ocamlinlinecode{a b}.
 
 \subsection{Links and references\label{links-and-references}}%
 This is a \href{\#}{link}\footnote{\url{\#}}. It sends you to the top of this page. Links can have markup inside them: \href{\#}{\bold{bold}}\footnote{\url{\#}}, \href{\#}{\emph{italics}}\footnote{\url{\#}}, \href{\#}{\emph{emphasis}}\footnote{\url{\#}}, \href{\#}{super\textsuperscript{script}}\footnote{\url{\#}}, \href{\#}{sub\textsubscript{script}}\footnote{\url{\#}}, and \href{\#}{\ocamlinlinecode{code}}\footnote{\url{\#}}. Links can also be nested \emph{\href{\#}{inside}\footnote{\url{\#}}} markup. Links cannot be nested inside each other. This link has no replacement text: \href{\#}{\#}\footnote{\url{\#}}. The text is filled in by odoc. This is a shorthand link: \href{\#}{\#}\footnote{\url{\#}}. The text is also filled in by odoc in this case.

--- a/test/generators/latex/Markup.tex
+++ b/test/generators/latex/Markup.tex
@@ -36,6 +36,8 @@ Code can appear \bold{inside \ocamlinlinecode{other} markup}. Its display should
 
 There is no differences between \ocamlinlinecode{a b} and \ocamlinlinecode{a b}.
 
+Consecutive whitespaces not after a newline are conserved as they are: \ocamlinlinecode{a   b}.
+
 \subsection{Links and references\label{links-and-references}}%
 This is a \href{\#}{link}\footnote{\url{\#}}. It sends you to the top of this page. Links can have markup inside them: \href{\#}{\bold{bold}}\footnote{\url{\#}}, \href{\#}{\emph{italics}}\footnote{\url{\#}}, \href{\#}{\emph{emphasis}}\footnote{\url{\#}}, \href{\#}{super\textsuperscript{script}}\footnote{\url{\#}}, \href{\#}{sub\textsubscript{script}}\footnote{\url{\#}}, and \href{\#}{\ocamlinlinecode{code}}\footnote{\url{\#}}. Links can also be nested \emph{\href{\#}{inside}\footnote{\url{\#}}} markup. Links cannot be nested inside each other. This link has no replacement text: \href{\#}{\#}\footnote{\url{\#}}. The text is filled in by odoc. This is a shorthand link: \href{\#}{\#}\footnote{\url{\#}}. The text is also filled in by odoc in this case.
 

--- a/test/generators/latex/Markup.tex
+++ b/test/generators/latex/Markup.tex
@@ -34,6 +34,9 @@ This is also true between \emph{non-}\ocamlinlinecode{code} markup \emph{and} \o
 
 Code can appear \bold{inside \ocamlinlinecode{other} markup}. Its display shouldn't be affected.
 
+There is no differences between \ocamlinlinecode{a b} and \ocamlinlinecode{a
+    b}.
+
 \subsection{Links and references\label{links-and-references}}%
 This is a \href{\#}{link}\footnote{\url{\#}}. It sends you to the top of this page. Links can have markup inside them: \href{\#}{\bold{bold}}\footnote{\url{\#}}, \href{\#}{\emph{italics}}\footnote{\url{\#}}, \href{\#}{\emph{emphasis}}\footnote{\url{\#}}, \href{\#}{super\textsuperscript{script}}\footnote{\url{\#}}, \href{\#}{sub\textsubscript{script}}\footnote{\url{\#}}, and \href{\#}{\ocamlinlinecode{code}}\footnote{\url{\#}}. Links can also be nested \emph{\href{\#}{inside}\footnote{\url{\#}}} markup. Links cannot be nested inside each other. This link has no replacement text: \href{\#}{\#}\footnote{\url{\#}}. The text is filled in by odoc. This is a shorthand link: \href{\#}{\#}\footnote{\url{\#}}. The text is also filled in by odoc in this case.
 

--- a/test/generators/man/Markup.3o
+++ b/test/generators/man/Markup.3o
@@ -86,8 +86,7 @@ This is also true between non-code markup and code\.
 .sp 
 Code can appear \fBinside other markup\fR\. Its display shouldn't be affected\.
 .sp 
-There is no differences between a b and a
-    b\.
+There is no differences between a b and a b\.
 .nf 
 .sp 
 .in 3

--- a/test/generators/man/Markup.3o
+++ b/test/generators/man/Markup.3o
@@ -85,6 +85,9 @@ It's possible for two markup elements to appear \fBnext\fR \fIto\fR each other a
 This is also true between non-code markup and code\.
 .sp 
 Code can appear \fBinside other markup\fR\. Its display shouldn't be affected\.
+.sp 
+There is no differences between a b and a
+    b\.
 .nf 
 .sp 
 .in 3

--- a/test/generators/man/Markup.3o
+++ b/test/generators/man/Markup.3o
@@ -87,6 +87,8 @@ This is also true between non-code markup and code\.
 Code can appear \fBinside other markup\fR\. Its display shouldn't be affected\.
 .sp 
 There is no differences between a b and a b\.
+.sp 
+Consecutive whitespaces not after a newline are conserved as they are: a   b\.
 .nf 
 .sp 
 .in 3

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -551,7 +551,7 @@ let%expect_test _ =
       test "{2 [foo\nbar\r\nbaz]}";
       [%expect
         {|
-        {"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"foo-bar--baz"]},[{"`Code_span":"foo\nbar\r\nbaz"}]]}],"warnings":[]} |}]
+        {"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"foo-bar-baz"]},[{"`Code_span":"foo bar baz"}]]}],"warnings":[]} |}]
 
     let nested_style =
       test "{2 {e foo bar}}";


### PR DESCRIPTION
To summarize:
- A newline followed by any whitespaces should be considered to be one space character by odoc-parser and ocamlformat.
Consecutive whitespaces not after a newline are conserved as they are.
- Trim whitespaces at the beginning and end of code spans. Not related to the issue but as we making whitespaces a bit less significant, this is worth mentioning.