### PR TITLE
Doc sherlodoc

### DIFF
--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -740,7 +740,6 @@ This will generate sources, as well as documentation for non-hidden units.
 
 {[
 let generate_all ~search_uris odocl_files =
-  let relativize_opt = function None -> None | Some file -> Some (relativize file) in
   List.iter
     (fun { file; ignore_output = _; source; assets } ->
       ignore (html_generate ~assets ~search_uris file None);
@@ -759,7 +758,7 @@ its database.
 {[
 let opam_switch_prefix = Astring.String.Map.get "OPAM_SWITCH_PREFIX" env
 
-let locate_sherlodoc_js output_file =
+let create_sherlodoc_js output_file =
   let cmd = Cmd.(v "sherlodoc" % "js" % output_file) in
   let (), _ = OS.Cmd.(run_out cmd |> out_stdout) |> get_ok in
   ()
@@ -768,19 +767,19 @@ let build_search_db output_file odocl_files =
   let odocl_files = List.map (fun u -> Fpath.to_string u.file) odocl_files in
   let cmd =
     Cmd.(
-      v "sherlodoc_index" % "--format=js" % "-o" % output_file
+      v "sherlodoc" % "index" % "--format=js" % "-o" % output_file
       %% of_list odocl_files)
   in
   let (), _ = OS.Cmd.(run_out cmd |> out_stdout) |> get_ok in
   ()
 
 let generate_search_assets odocl_files =
-  ignore @@ OS.Dir.create Fpath.(v "html/odoc");
+  ignore @@ Result.get_ok (OS.Dir.create Fpath.(v "html/odoc"));
   (* Returned paths are relative to [html-generate]'s output directory. *)
   let sherlodoc_js_uri = "odoc/sherlodoc.js" in
   let sherlodoc_db_uri = "odoc/sherlodoc_db.js" in
   let output_prefix = "html/" in
-  locate_sherlodoc_js (output_prefix ^ sherlodoc_js_uri);
+  create_sherlodoc_js (output_prefix ^ sherlodoc_js_uri);
   build_search_db (output_prefix ^ sherlodoc_db_uri) odocl_files;
   List.map (fun str -> str |> Fpath.of_string |> Result.get_ok) [ sherlodoc_db_uri; sherlodoc_js_uri ]
 ]}
@@ -849,29 +848,49 @@ parent_child_spec.html
 sherlodoc_db.js
 sherlodoc.js
 source
+syntax_highlighter
+type_desc_to_yojson.html
 $ find html/odoc/odoc_html | sort
 html/odoc/odoc_html
 html/odoc/odoc_html/index.html
 html/odoc/odoc_html/Odoc_html
+html/odoc/odoc_html/Odoc_html__
 html/odoc/odoc_html/Odoc_html/Config
+html/odoc/odoc_html/Odoc_html__Config
 html/odoc/odoc_html/Odoc_html/Config/index.html
+html/odoc/odoc_html/Odoc_html__Config/index.html
 html/odoc/odoc_html/Odoc_html_frontend
 html/odoc/odoc_html/Odoc_html_frontend/index.html
 html/odoc/odoc_html/Odoc_html/Generator
+html/odoc/odoc_html/Odoc_html__Generator
 html/odoc/odoc_html/Odoc_html/Generator/index.html
+html/odoc/odoc_html/Odoc_html__Generator/index.html
 html/odoc/odoc_html/Odoc_html/Html_fragment_json
+html/odoc/odoc_html/Odoc_html__Html_fragment_json
 html/odoc/odoc_html/Odoc_html/Html_fragment_json/index.html
+html/odoc/odoc_html/Odoc_html__Html_fragment_json/index.html
 html/odoc/odoc_html/Odoc_html/Html_page
+html/odoc/odoc_html/Odoc_html__Html_page
 html/odoc/odoc_html/Odoc_html/Html_page/index.html
+html/odoc/odoc_html/Odoc_html__Html_page/index.html
+html/odoc/odoc_html/Odoc_html__Html_source
+html/odoc/odoc_html/Odoc_html__Html_source/index.html
 html/odoc/odoc_html/Odoc_html/index.html
+html/odoc/odoc_html/Odoc_html__/index.html
 html/odoc/odoc_html/Odoc_html/Json
 html/odoc/odoc_html/Odoc_html/Json/index.html
 html/odoc/odoc_html/Odoc_html/Link
+html/odoc/odoc_html/Odoc_html__Link
 html/odoc/odoc_html/Odoc_html/Link/index.html
+html/odoc/odoc_html/Odoc_html__Link/index.html
 html/odoc/odoc_html/Odoc_html/Link/Path
 html/odoc/odoc_html/Odoc_html/Link/Path/index.html
 html/odoc/odoc_html/Odoc_html/Types
+html/odoc/odoc_html/Odoc_html__Types
 html/odoc/odoc_html/Odoc_html/Types/index.html
+html/odoc/odoc_html/Odoc_html__Types/index.html
+html/odoc/odoc_html/Odoc_html__Utils
+html/odoc/odoc_html/Odoc_html__Utils/index.html
 ]}
 
 Some code to analyze the list of executed commands:

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -764,11 +764,22 @@ let create_sherlodoc_js output_file =
   ()
 
 let build_search_db output_file odocl_files =
-  let odocl_files = List.map (fun u -> Fpath.to_string u.file) odocl_files in
+  let regexp_dunder = Str.regexp_string "__" in
+  let odocl_files =
+    List.map (fun u ->
+      Fpath.to_string u.file) odocl_files
+      |> List.filter (fun name ->
+          try (ignore (Str.search_forward regexp_dunder name 0); false)
+          with Not_found -> true )
+      |> List.map (fun name ->
+          if String.starts_with ~prefix:"odoc" name then
+            ("--favoured=" ^ name)
+          else name )
+  in
   let cmd =
     Cmd.(
-      v "sherlodoc" % "index" % "--format=js" % "-o" % output_file
-      %% of_list odocl_files)
+      v "sherlodoc" % "index" % "--format=js" % {|--favoured-prefixes=""|}
+      % "-o" % output_file %% of_list odocl_files)
   in
   let (), _ = OS.Cmd.(run_out cmd |> out_stdout) |> get_ok in
   ()

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -51,7 +51,7 @@ a {e source parent}. This {{!page-parent_child_spec}parent/child relationship} i
 In the example below, there will be a file [odoc.mld] that corresponds with the top-level directory [odoc/]. It will be compiled as follows:
 
 {@sh skip[
-odoc compile odoc.mld --child page-odoc_model --child deps 
+odoc compile odoc.mld --child page-odoc_model --child deps
   --child src-source ...
 ]}
 
@@ -630,8 +630,6 @@ let update_api_reference_page () =
 Now we'll compile all of the parent [.mld] files. To ensure that the parents are compiled before the children, we start with [odoc.mld], then [deps.mld], and so on. The result of this file is a list of the resulting [odoc] files.
 
 {[
-let search_file = "index.js"
-
 let compile_mlds () =
   update_api_reference_page ();
   let mkpage x = "page-\"" ^ x ^ "\"" in
@@ -739,11 +737,10 @@ let link_all odoc_files =
 
 Now we simply run [odoc html-generate] over all of the resulting [odocl] files.
 This will generate sources, as well as documentation for non-hidden units.
-We notify the generator that the javascript file to use for search is [index.js].
 
 {[
-let generate_all odocl_files =
-  let search_uris = [ Fpath.v "minisearch.js"; Fpath.v "index.js" ] in
+let generate_all ~search_uris odocl_files =
+  let relativize_opt = function None -> None | Some file -> Some (relativize file) in
   List.iter
     (fun { file; ignore_output = _; source; assets } ->
       ignore (html_generate ~assets ~search_uris file None);
@@ -755,105 +752,47 @@ let generate_all odocl_files =
   support_files ()
 ]}
 
-
-Finally, we generate an index of all values, types, etc. This index is meant to be consumed by search engines, to create their own index. It is in json format. Generating the index is done via [odoc compile-index], which creates a json file.
-
-Some more details about the json format:
-
-{ul
-  {- The whole file is a json array.}
-  {- each entry of the array corresponds to an item to search. An entry is a json object, with the following fields:
-     {ul
-       {- ["id"], which is a string. It corresponds to the id of the entry, for instance: ["Stdlib.List.map"].}
-       {- ["doc"], which is a string. It corresponds to a "searchable" version of the docstring: one which is stripped from any html or specific markup. This is to avoid having too many results when searching ["class"], for instance.}
-       {- ["kind"] is a json object. It contains the fields:
-          {ul
-            {- ["kind"], a string encoding the kind of the entry (type, value, module, standalone comment, etc.)}
-            {- any information that is specific to it (for instance, a type has kind ["TypeDecl"] and also contains the constraints, manifest, and whether the type is private or not). For a comprehensive description of what information is available in this field, please refer to the source file: src/search/json_index/json_search.ml}}}
-       {- ["display"], which is a json object. It contains two fields:
-          {ul
-            {- ["url"], a string. It is the URL to the entry in the documentation, relative to the base of the documentation}
-            {- ["html"], also a string. It is the html odoc uses to display the entry in the search results.}}}}}}
-
-Search engines written in OCaml can also call the [Odoc_model.Fold.unit] and  [Odoc_model.Fold.page] function, in conjunction with [Odoc_search.Entry.entry_of_item] in order to get an OCaml value of each element to be indexed.
+This builds Sherlodoc's database. It returns a list of javascript files to be
+passed to [html-generate], one is Sherlodoc's search engine and the other is
+its database.
 
 {[
-let index_generate ?(ignore_output = false) () =
-  let open Cmd in
-  let files =
-    OS.Dir.contents (Fpath.v ".")
-    |> get_ok
-    |> List.filter (Fpath.has_ext "odocl")
-    |> List.filter (fun p ->
-           String.starts_with ~prefix:"src-" (Fpath.filename p))
-    |> List.map Fpath.to_string
-  in
-  let index_map = Fpath.v "index.map" in
-  let () = Bos.OS.File.write_lines index_map files |> get_ok in
+let opam_switch_prefix = Astring.String.Map.get "OPAM_SWITCH_PREFIX" env
+
+let locate_sherlodoc_js output_file =
+  let cmd = Cmd.(v "sherlodoc" % "js" % output_file) in
+  let (), _ = OS.Cmd.(run_out cmd |> out_stdout) |> get_ok in
+  ()
+
+let build_search_db output_file odocl_files =
+  let odocl_files = List.map (fun u -> Fpath.to_string u.file) odocl_files in
   let cmd =
-    odoc % "compile-index" % "-o" % "html/index.json" % "--file-list"
-    % p index_map
+    Cmd.(
+      v "sherlodoc_index" % "--format=js" % "-o" % output_file
+      %% of_list odocl_files)
   in
-  let lines = run cmd in
-  if not ignore_output then
-    add_prefixed_output cmd generate_output "index compilation" lines
+  let (), _ = OS.Cmd.(run_out cmd |> out_stdout) |> get_ok in
+  ()
+
+let generate_search_assets odocl_files =
+  OS.Dir.create Fpath.(v "html/odoc");
+  (* Returned paths are relative to [html-generate]'s output directory. *)
+  let sherlodoc_js_uri = "odoc/sherlodoc.js" in
+  let sherlodoc_db_uri = "odoc/sherlodoc_db.js" in
+  let output_prefix = "html/" in
+  locate_sherlodoc_js (output_prefix ^ sherlodoc_js_uri);
+  build_search_db (output_prefix ^ sherlodoc_db_uri) odocl_files;
+  [ sherlodoc_db_uri; sherlodoc_js_uri ]
 ]}
-
-We turn the JSON index into a javascript file. In order to never block the UI, this file will be used as a web worker by [odoc], to perform searches:
-
-- The search query will be sent as a plain string to the web worker, using the standard mechanism of message passing
-- The web worker has to sent back the result as a message to the main thread, containing the list of result. Each entry of this list must have the same form as it had in the original JSON file.
-- The file must be given to the [odoc-support] URI.
-
-In this driver, we use the minisearch javascript library. For more involved application, we could use [index.js] to call a server-side search engine via an API call.
-
-{[
-  let js_index () =
-    let index = Bos.OS.File.read Fpath.(v "html" / "index.json") |> get_ok in
- Bos.OS.File.writef (Fpath.v search_file) {|
- let documents =
-   %s
- ;
-
- let miniSearch = new MiniSearch({
-  fields: ['id', 'doc', 'entry_id'], // fields to index for full-text search
-   storeFields: ['display'], // fields to return with search results
-   idField: 'entry_id',
-   extractField: (document, fieldName) => {
-     if (fieldName === 'id') {
-       return document.id.map(e => e.kind + "-" + e.name).join('.')
-     }
-     return document[fieldName]
-   }
- })
-
-
- // Use a unique id since some entries' id are not unique (type extension or
- // standalone doc comments for instance)
- documents.forEach((entry,i) => entry.entry_id = i)
- miniSearch.addAll(documents);
-
- onmessage = (m) => {
-   let query = m.data;
-   let result = miniSearch.search(query);
-   postMessage(result.slice(0,200).map(a => a.display));
- }
- |} index |> get_ok ;
-    Bos.OS.Cmd.run Bos.Cmd.(v "cp" % search_file % "html/") |> get_ok;
-    Bos.OS.Cmd.run Bos.Cmd.(v "cp" % "minisearch.js" % "html/") |> get_ok;
-]}
-
-
 
 The following code executes all of the above, and we're done!
 
 {[
 let compiled = compile_all () in
 let linked = link_all compiled in
-let () = index_generate () in
-let _ = js_index () in
-let _ = count_occurrences (Fpath.v "occurrences-from-odoc.odoc") in
-generate_all linked
+let search_uris = generate_search_assets linked in
+let _ = count_occurrences (Fpath.v "occurrences-odoc_and_deps.odoc") in
+generate_all ~search_uris linked
 ]}
 
 Let's see if there was any output from the [odoc] invocations:
@@ -907,6 +846,8 @@ odoc_search.js
 odoc_xref2
 odoc_xref_test
 parent_child_spec.html
+sherlodoc_db.js
+sherlodoc.js
 source
 $ find html/odoc/odoc_html | sort
 html/odoc/odoc_html

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -775,14 +775,14 @@ let build_search_db output_file odocl_files =
   ()
 
 let generate_search_assets odocl_files =
-  OS.Dir.create Fpath.(v "html/odoc");
+  ignore @@ OS.Dir.create Fpath.(v "html/odoc");
   (* Returned paths are relative to [html-generate]'s output directory. *)
   let sherlodoc_js_uri = "odoc/sherlodoc.js" in
   let sherlodoc_db_uri = "odoc/sherlodoc_db.js" in
   let output_prefix = "html/" in
   locate_sherlodoc_js (output_prefix ^ sherlodoc_js_uri);
   build_search_db (output_prefix ^ sherlodoc_db_uri) odocl_files;
-  [ sherlodoc_db_uri; sherlodoc_js_uri ]
+  List.map (fun str -> str |> Fpath.of_string |> Result.get_ok) [ sherlodoc_db_uri; sherlodoc_js_uri ]
 ]}
 
 The following code executes all of the above, and we're done!

--- a/doc/dune
+++ b/doc/dune
@@ -31,6 +31,7 @@
   (> %{ocaml_version} 4.11))
  (deps
   (package odoc)
+  (package sherlodoc)
   (universe) ; Benchmark depends on the running time of odoc commands
   (glob_files *.mld)
   (glob_files *.js)


### PR DESCRIPTION
This is two things rebases https://github.com/ocaml/odoc/pull/1064, and update the sherlodoc interface to the definitive one released in sherlodoc.

This gives the benefits that stdlib results are not shown above odoc ones anymore.

It would be a bad idea to merge this because the driver would be hard to run properly: you need to have sherlodoc installed and linked to the current odoc version which is challenging during development.