### PR TITLE
Add clock emoji before 'since' tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
   (@panglesd, #976)
 - Separate compilation of interface and implementation files, using a new
   `compile-src` command (@panglesd, #1067).
+- Add clock emoji before `@since` tag (@yawaramin, #1089)
 
 ### Changed
 

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -725,13 +725,13 @@ td.def-doc *:first-child {
 /* Alert emoji */
 
 .alert::before, .deprecated::before {
-  content: '⚠️ ';
+  content: '⚠️ ' / '';
 }
 
 /* Since emoji */
 
 .since::before {
-  content: '🕚 ';
+  content: '🕚 ' / '';
 }
 
 /* Lists of modules */

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -728,6 +728,12 @@ td.def-doc *:first-child {
   content: '⚠️ ';
 }
 
+/* Since emoji */
+
+.since::before {
+  content: '🕚 ';
+}
+
 /* Lists of modules */
 
 .modules { list-style-type: none; margin-left: -3ex; }


### PR DESCRIPTION
Example:

<img width="950" alt="Screenshot 2024-03-07 at 00 26 03" src="https://github.com/ocaml/odoc/assets/6997/e6d6ad92-41cb-431a-b833-059b2083fb03">
