### PR TITLE
Fix missing headers for katex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
   compilation unit. This fixes cases where the dune rules would
   fail. (@panglesd, #1069)
 - Fix issue #1066 with extended opens (@jonludlam, #1082)
+- Fix missing katex headers (@panglesd, #1096)
 
 # 2.4.0
 

--- a/src/document/doctree.ml
+++ b/src/document/doctree.ml
@@ -369,7 +369,7 @@ end = struct
 
   and subpage : Subpage.t -> bool = fun x -> page x.content
 
-  and page : Page.t -> bool = fun x -> items x.items
+  and page : Page.t -> bool = fun x -> items x.preamble || items x.items
 
   and alternative : Alternative.t -> bool = function
     | Expansion x -> documentedsrc x.expansion


### PR DESCRIPTION
The preamble was not traversed when looking for math elements, resulting in a faulty math detection. Fix #1092.