### PR TITLE
Fix problem with exceptions and type extensions in extended opens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@
 - Revert to outputing a file (without content) when rendering a hidden
   compilation unit. This fixes cases where the dune rules would
   fail. (@panglesd, #1069)
-- Fix issue #1066 with extended opens (@jonludlam, #1082)
+- Fix issues #1066 and #1095 with extended opens (@jonludlam, #1082, #1100)
 - Fix missing katex headers (@panglesd, #1096)
 
 

--- a/src/loader/ident_env.cppo.ml
+++ b/src/loader/ident_env.cppo.ml
@@ -131,11 +131,11 @@ let rec extract_signature_type_items vis items =
       `ClassType (id, obj_id, None, vis'=Hidden, None) :: extract_signature_type_items vis rest
 #endif
 
-    | Sig_typext (id, constr, Text_exception, Exported) :: rest ->
+    | Sig_typext (id, constr, Text_exception, vis') :: rest when vis=vis' ->
       `Exception (id, Some constr.ext_loc)
       :: extract_signature_type_items vis rest
 
-    | Sig_typext (id, constr, _, Exported) :: rest ->
+    | Sig_typext (id, constr, _, vis') :: rest when vis=vis'->
       `Extension (id, Some constr.ext_loc)
       :: extract_signature_type_items vis rest
 


### PR DESCRIPTION
This is related to issue #1066, which was partially fixed by #1082. This PR sorts the remaining two instances of the problem: exceptions and type extensions.

Fixes #1095