### PR TITLE
5.2.0 support and shape: use amended query API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 - Add clock emoji before `@since` tag (@yawaramin, #1089)
 - Navigation for the search bar : use '/' to enter search, up and down arrows to
   select a result, and enter to follow the selected link. (@EmileTrotignon, #1088)
-- OCaml 5.2.0 compatibility (@Octachron, #1094)
+- OCaml 5.2.0 compatibility (@Octachron, #1094, #1112)
 
 ### Changed
 


### PR DESCRIPTION
This PR amends to the support for OCaml 5.2.0 to the updated version of the `Shape_reduce` queries API.