### PR TITLE
Add cheatsheet to the odoc manual

### DIFF
--- a/doc/cheatsheet.mld
+++ b/doc/cheatsheet.mld
@@ -9,7 +9,7 @@ Quick reference for the odoc language!
     {th Render as}}
   {tr
     {th Paragraphs}
-    {td {[
+    {td {@text[
       A first paragraph
 
       A second paragraph]}}
@@ -19,7 +19,7 @@ Quick reference for the odoc language!
       A second paragraph}}
   {tr
     {th {{!odoc_for_authors.sections}Headings}}
-    {td {[
+    {td {@text[
       {1 Title}
       {2 Subtitle}
       {3 Subsubtitle}
@@ -31,7 +31,7 @@ Quick reference for the odoc language!
 
       Standalone pages must start with a [0] heading:
 
-      {[
+      {@text[
         {0 Page big title}
       ]}}
     {td
@@ -43,15 +43,15 @@ Quick reference for the odoc language!
       See {%html:<a href="#my_id">Referenceable title</a>%}}}
   {tr
     {th {{!odoc_for_authors.basics}Bold, italic and emphasis}}
-    {td {[{b bold} text, {e italic text}, {e emphasized} text]}}
+    {td {@text[{b bold} text, {e italic text}, {e emphasized} text]}}
     {td   {b bold} text, {e italic text}, {e emphasized} text}}
   {tr
     {th {{!odoc_for_authors.basics}Subscripts and superscript}}
-    {td {[H{_ 2}O and 1{^ st}]}}
+    {td {@text[H{_ 2}O and 1{^ st}]}}
     {td   H{_ 2}O and 1{^ st}}}
   {tr
     {th {{!odoc_for_authors.links_and_references}Link} }
-    {td {[
+    {td {@text[
       Here is a link: {:https://www.example.com}.
 
       You can also click {{:https://www.example.com}here}.]}}
@@ -61,7 +61,7 @@ Quick reference for the odoc language!
       You can also click {{:https://www.example.com}here}.}}
   {tr
     {th {{!odoc_for_authors.links_and_references}References} }
-    {td {[
+    {td {@text[
       See {!Odoc_odoc.Compile.compile}.
 
       See {{!Odoc_odoc.Compile.compile}this function}.
@@ -75,7 +75,7 @@ Quick reference for the odoc language!
       See {{!odoc_for_authors.links_and_references}this section} for the syntax of references.}}
     {tr
       {th {{!odoc_for_authors.lists}Lists} }
-    {td {[
+    {td {@text[
       - First item
       - Second item
 
@@ -145,7 +145,7 @@ Quick reference for the odoc language!
     {td {v verbatim text v}}}
   {tr
     {th {{!odoc_for_authors.math}Math} }
-    {td {[
+    {td {@text[
       For inline math: {m \sqrt 2}.
 
       For display math:
@@ -159,7 +159,7 @@ Quick reference for the odoc language!
       {math \sqrt 2}}}
   {tr
     {th {{!odoc_for_authors.tables}Table} }
-    {td {[
+    {td {@text[
       Light syntax:
 
       {t | Header 1 | Header 2 |

--- a/doc/cheatsheet.mld
+++ b/doc/cheatsheet.mld
@@ -1,0 +1,225 @@
+{0 Cheatsheet}
+
+Quick reference for the odoc language!
+
+{table
+  {tr
+    {th }
+    {th [odoc] syntax}
+    {th Render as}}
+  {tr
+    {th Paragraphs}
+    {td {[
+      A first paragraph
+
+      A second paragraph]}}
+    {td
+      A first paragraph
+
+      A second paragraph}}
+  {tr
+    {th {{!odoc_for_authors.sections}Headings}}
+    {td {[
+      {1 Title}
+      {2 Subtitle}
+      {3 Subsubtitle}
+
+      {3:my_id Referenceable title}
+
+      See {!my_id}.
+      ]}
+
+      Standalone pages must start with a [0] heading:
+
+      {[
+        {0 Page big title}
+      ]}}
+    {td
+      {%html:<h1>Title</h1>%}
+      {%html:<h2>Subtitle</h2>%}
+      {%html:<h3>Subsubtitle</h3>%}
+      {%html:<h3 id="my_id">Referenceable title</h3>%}
+
+      See {%html:<a href="#my_id">Referenceable title</a>%}}}
+  {tr
+    {th {{!odoc_for_authors.basics}Bold, italic and emphasis}}
+    {td {[{b bold} text, {e italic text}, {e emphasized} text]}}
+    {td   {b bold} text, {e italic text}, {e emphasized} text}}
+  {tr
+    {th {{!odoc_for_authors.basics}Subscripts and superscript}}
+    {td {[H{_ 2}O and 1{^ st}]}}
+    {td   H{_ 2}O and 1{^ st}}}
+  {tr
+    {th {{!odoc_for_authors.links_and_references}Link} }
+    {td {[
+      Here is a link: {:https://www.example.com}.
+
+      You can also click {{:https://www.example.com}here}.]}}
+    {td
+      Here is a link: {:https://www.example.com}.
+
+      You can also click {{:https://www.example.com}here}.}}
+  {tr
+    {th {{!odoc_for_authors.links_and_references}References} }
+    {td {[
+      See {!Odoc_odoc.Compile.compile}.
+
+      See {{!Odoc_odoc.Compile.compile}this function}.
+
+      See {{!odoc_for_authors.links_and_references}this section} for the syntax of references.]}}
+    {td
+      See {!Odoc_odoc.Compile.compile}.
+
+      See {{!Odoc_odoc.Compile.compile}this function}.
+
+      See {{!odoc_for_authors.links_and_references}this section} for the syntax of references.}}
+    {tr
+      {th {{!odoc_for_authors.lists}Lists} }
+    {td {[
+      - First item
+      - Second item
+
+      + First ordered item
+      + Second numbered item
+
+      {ul
+        {- First item}
+        {- Second item}
+        {li can also be used}}
+
+      {ol
+        {- First numbered item}
+        {- Second numbered item}
+        {li can also be used}}]}}
+    {td
+      - First item
+      - Second item
+
+      + First ordered item
+      + Second numbered item
+
+      {ul
+        {- First item}
+        {- Second item}
+        {li can also be used}}
+
+      {ol
+        {- First numbered item}
+        {- Second numbered item}
+        {li can also be used}}}}
+  {tr
+    {th {{!odoc_for_authors.code_blocks}Code Blocks} }
+    {td {example@text[
+      Inline [code].
+
+      {[
+        let _ = "Block code"
+      ]}
+
+      {foo@text[
+        Code block with {[inner code block syntax]}
+      ]foo}
+
+      {@python[
+        [i+1 for i in xrange(2)]
+      ]}]example}}
+    {td
+
+      Inline [code].
+
+      {[
+        let _ = "Block code"
+      ]}
+
+      {foo@text[
+        Code block with {[inner code block syntax]}
+      ]foo}
+
+      {@python[
+        [i+1 for i in xrange(2)]
+      ]}}}
+  {tr
+    {th {{!odoc_for_authors.verbatim_blocks}Verbatim} }
+    {td {example@text[
+      {v verbatim text v}]example}}
+    {td {v verbatim text v}}}
+  {tr
+    {th {{!odoc_for_authors.math}Math} }
+    {td {[
+      For inline math: {m \sqrt 2}.
+
+      For display math:
+
+      {math \sqrt 2}]}}
+    {td
+      For inline math: {m \sqrt 2}.
+
+      For display math:
+
+      {math \sqrt 2}}}
+  {tr
+    {th {{!odoc_for_authors.tables}Table} }
+    {td {[
+      Light syntax:
+
+      {t | Header 1 | Header 2 |
+         |----------|----------|
+         | Cell 1   | Cell 2   |
+         | Cell 3   | Cell 4   |}
+
+      Explicit syntax:
+
+      {table
+        {tr
+          {th Header 1}
+          {th Header 2}}
+        {tr
+          {td Cell 1}
+          {td Cell 2}}
+        {tr
+          {td Cell 3}
+          {td Cell 4}}}]}}
+    {td
+      Light syntax:
+
+      {t | Header 1 | Header 2 |
+         |----------|----------|
+         | Cell 1   | Cell 2   |
+         | Cell 3   | Cell 4   |}
+
+      Explicit syntax:
+
+      {table
+        {tr
+          {th Header 1}
+          {th Header 2}}
+        {tr
+          {td Cell 1}
+          {td Cell 2}}
+        {tr
+          {td Cell 3}
+          {td Cell 4}}}}}
+  {tr
+    {th HTML }
+    {td {example@text[
+      {%html:
+        <blockquote>
+          Odoc language lack support for quotation!
+        </blockquote>
+      %}]example}}
+    {td
+      {%html:
+        <blockquote>
+          Odoc language lack support for quotation!
+        </blockquote>
+      %}}}
+  {tr
+    {th {{!page-odoc_for_authors.tags}Tags} }
+    {td {example@text[
+      @since 4.08
+
+      Tags are explained in {{!page-odoc_for_authors.tags}this section}.]example}}
+    {td
+      Since 4.08.
+
+      Tags are explained in {{!page-odoc_for_authors.tags}this section}.}}}

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -394,6 +394,7 @@ let extra_docs = [
     "parent_child_spec";
     "features";
     "odoc_for_authors";
+    "cheatsheet";
     "dune";
     "ocamldoc_differences";
     "api_reference";

--- a/doc/dune
+++ b/doc/dune
@@ -8,6 +8,7 @@
   interface
   ocamldoc_differences
   odoc_for_authors
+  cheatsheet
   parent_child_spec))
 
 ; Uncomment to run mdx on the documentation's code blocks.

--- a/doc/odoc.mld
+++ b/doc/odoc.mld
@@ -1,5 +1,7 @@
 {0 odoc}
 
+For a quick look at the [odoc] syntax, see the {{!cheatsheet}cheatsheet}!
+
 {1:overview What is [odoc]?}
 
 [odoc] is a documentation generator for OCaml. It reads doc comments

--- a/doc/odoc.mld
+++ b/doc/odoc.mld
@@ -47,6 +47,7 @@ setting, you'll need to understand {{!page-driver}how to drive [odoc]}.
 
 The main other pages of this site:
 - {!page-odoc_for_authors} Odoc For Authors
+- {!page-cheatsheet} The cheatsheet
 - {!page-features} Language Features
 - {!page-driver} Reference Driver
 - {!page-ocamldoc_differences} Differences from OCamldoc

--- a/doc/odoc_for_authors.mld
+++ b/doc/odoc_for_authors.mld
@@ -227,7 +227,7 @@ There are no differences in how [odoc] handles comment placement between [.ml]
 and [.mli] files, which is {{!page-ocamldoc_differences}another difference}
 from OCamldoc.
 
-{2 Basic markup}
+{2:basics Basic markup}
 
 Text within the comments can be formatted using the following markup. Firstly,
 the simple typesetting markup:
@@ -363,7 +363,7 @@ In a code block section, the section is ended with a [ \]} ], and in a
 verbatim formatted section, the section is ended with a whitespace character
 followed by [ v} ]. It is not currently possible to escape this in either case.
 
-{2 Links and References}
+{2:links_and_references Links and References}
 
 A link to a URL may be put into the text as follows:
 
@@ -480,7 +480,7 @@ unit or page must be {e compiled} and available to [odoc]. That is, when perform
 [-I] must contain the relevant [.odoc] file. This is normally the responsibility of
 the {{!page-driver}driver}.
 
-{2 Tags}
+{2:tags Tags}
 
 Tags are used to provide specific information for individual elements, such
 as author, version, parameters, etc. Tags start with an [@] symbol, appear
@@ -542,7 +542,7 @@ doesn't turn this into a link in the output HTML.
 (written between double quotes), with the given text as comment. {e Note:} 
 As with the file reference, [odoc] doesn't turn this into a link.
 
-{2 Mathematics}
+{2:math Mathematics}
 
 Odoc 2.2 introduced new markup for maths, available both for inline and block
 content. The syntax for the maths itself is LaTeX and it is rendered by {{:https://katex.org/}KaTeX}
@@ -559,7 +559,7 @@ in block form this becomes:
 See the {{:https://katex.org/docs/supported.html}KaTeX documentation} for the
 HTML mode LaTeX support status.
 
-{2 Tables}
+{2:tables Tables}
 
 Odoc 2.3 introduced new markup for tables. This markup comes in two flavors: the light syntax, and the heavy syntax.
 


### PR DESCRIPTION
This adds a cheatsheet to the odoc manual. Have a look at the rendered page [here](https://choum.net/panglesd/odoc_cheatsheet/cheatsheet.html).

The cheatsheet is rendered by odoc, which is not really focused on rendering cheatsheets, so it does not render ideally well.
If someone wants to contribute by adding some special css on this page to make it better, feel free!