### PR TITLE
Make `--source-id` optional when compiling implementations

### DIFF
--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -246,7 +246,7 @@ let compile_src file ?(output_dir = Fpath.v "./") ?(ignore_output = false)
     let ext = Fpath.get_ext file in
     let basename = Fpath.basename (Fpath.rem_ext file) in
     match ext with
-    | ".cmt" -> "src-" ^ basename ^ ".odoc"
+    | ".cmt" -> "impl-" ^ basename ^ ".odoc"
     | _ -> failwith ("bad extension: " ^ ext)
   in
   let output_file = Fpath.( / ) output_dir output_basename in
@@ -726,7 +726,7 @@ Linking is now straightforward. We link all [odoc] files.
 {[
 let src_file file =
   let fdir, fname = Fpath.split_base file in
-  let fname = Fpath.v ("src-" ^ Fpath.to_string fname) in
+  let fname = Fpath.v ("impl-" ^ Fpath.to_string fname) in
   Fpath.( // ) fdir fname
 
 let link_all odoc_files =
@@ -786,7 +786,7 @@ let index_generate ?(ignore_output = false) () =
     |> get_ok
     |> List.filter (Fpath.has_ext "odocl")
     |> List.filter (fun p ->
-           String.starts_with ~prefix:"src-" (Fpath.filename p))
+           String.starts_with ~prefix:"impl-" (Fpath.filename p))
     |> List.map Fpath.to_string
   in
   let index_map = Fpath.v "index.map" in

--- a/src/document/ML.mli
+++ b/src/document/ML.mli
@@ -27,7 +27,7 @@ val implementation :
   Lang.Implementation.t ->
   Syntax_highlighter.infos ->
   string ->
-  Types.Document.t
+  Types.Document.t list
 
 val type_expr : ?needs_parentheses:bool -> Lang.TypeExpr.t -> Codefmt.t
 

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1893,12 +1893,13 @@ module Make (Syntax : SYNTAX) = struct
 
     let implementation (v : Odoc_model.Lang.Implementation.t) syntax_info
         source_code =
-      Option.map
-        (fun id ->
-          Document.Source_page
-            (Source_page.source id syntax_info v.source_info source_code))
-        v.id
-      |> Option.to_list
+      match v.id with
+      | None -> []
+      | Some id ->
+          [
+            Document.Source_page
+              (Source_page.source id syntax_info v.source_info source_code);
+          ]
   end
 
   include Page

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1757,7 +1757,10 @@ module Make (Syntax : SYNTAX) = struct
     val source_tree : Lang.SourceTree.t -> Document.t list
 
     val implementation :
-      Lang.Implementation.t -> Syntax_highlighter.infos -> string -> Document.t
+      Lang.Implementation.t ->
+      Syntax_highlighter.infos ->
+      string ->
+      Document.t list
   end = struct
     let pack : Lang.Compilation_unit.Packed.t -> Item.t list =
      fun t ->
@@ -1890,8 +1893,12 @@ module Make (Syntax : SYNTAX) = struct
 
     let implementation (v : Odoc_model.Lang.Implementation.t) syntax_info
         source_code =
-      Document.Source_page
-        (Source_page.source v.id syntax_info v.source_info source_code)
+      Option.map
+        (fun id ->
+          Document.Source_page
+            (Source_page.source id syntax_info v.source_info source_code))
+        v.id
+      |> Option.to_list
   end
 
   include Page

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -112,7 +112,7 @@ module type GENERATOR = sig
     Odoc_model.Lang.Implementation.t ->
     Syntax_highlighter.infos ->
     string ->
-    Document.t
+    Document.t list
 
   val type_expr : ?needs_parentheses:bool -> Lang.TypeExpr.t -> text
 

--- a/src/document/reason.mli
+++ b/src/document/reason.mli
@@ -27,5 +27,5 @@ val implementation :
   Lang.Implementation.t ->
   Syntax_highlighter.infos ->
   string ->
-  Types.Document.t
+  Types.Document.t list
 (** Highlight the source as OCaml syntax *)

--- a/src/loader/implementation.ml
+++ b/src/loader/implementation.ml
@@ -359,9 +359,12 @@ let read_cmt_infos source_id shape_info impl digest root imports =
       and local_ident_to_loc = IdentHashtbl.create 10
       and uid_to_id = UidHashtbl.create 10 in
       let () =
-        populate_local_defs source_id traverse_infos loc_to_id
-          local_ident_to_loc;
-        populate_global_defs env source_id loc_to_id uid_to_loc uid_to_id
+        match source_id with
+        | None -> ()
+        | Some source_id ->
+            populate_local_defs source_id traverse_infos loc_to_id
+              local_ident_to_loc;
+            populate_global_defs env source_id loc_to_id uid_to_loc uid_to_id
       in
       let source_infos =
         process_occurrences env traverse_infos loc_to_id local_ident_to_loc
@@ -377,7 +380,8 @@ let read_cmt_infos source_id shape_info impl digest root imports =
         shape_info;
         imports;
       }
-  | None as shape_info -> {
+  | None as shape_info ->
+      {
         Odoc_model.Lang.Implementation.id = source_id;
         source_info = [];
         digest;

--- a/src/loader/implementation.mli
+++ b/src/loader/implementation.mli
@@ -1,7 +1,7 @@
 open Odoc_model
 
 val read_cmt_infos :
-  Paths.Identifier.Id.source_page ->
+  Paths.Identifier.Id.source_page option ->
   (Compat.shape * Compat.uid_to_loc) option ->
   Typedtree.structure ->
   string ->

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -210,8 +210,14 @@ let read_impl ~make_root ~filename ~source_id () =
                 | None -> raise Corrupted
                 | exception Not_found -> raise Corrupted)
           in
-          Odoc_model.Names.set_unique_ident
-            (Odoc_model.Paths.Identifier.fullname source_id |> String.concat "-");
+          let () =
+            match source_id with
+            | None -> Odoc_model.Names.set_unique_ident filename
+            | Some source_id ->
+                Odoc_model.Names.set_unique_ident
+                  (Odoc_model.Paths.Identifier.fullname source_id
+                  |> String.concat "-")
+          in
           let root =
             match make_root ~module_name:name ~digest with
             | Ok root -> root

--- a/src/loader/odoc_loader.mli
+++ b/src/loader/odoc_loader.mli
@@ -28,7 +28,7 @@ val read_cmt :
 val read_impl :
   make_root:make_root ->
   filename:string ->
-  source_id:Identifier.SourcePage.t ->
+  source_id:Identifier.SourcePage.t option ->
   (Lang.Implementation.t, Error.t) result Error.with_warnings
 
 val read_cmi :

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -511,7 +511,7 @@ end =
 
 module rec Implementation : sig
   type t = {
-    id : Identifier.SourcePage.t;
+    id : Identifier.SourcePage.t option;
     digest : Digest.t;
     root : Root.t;
     linked : bool;  (** Whether this unit has been linked. *)

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -523,6 +523,12 @@ module Identifier = struct
         [> `Root of ContainerPage.t option * ModuleName.t ] id =
       mk_parent_opt ModuleName.to_string "r" (fun (p, n) -> `Root (p, n))
 
+    let implementation =
+      mk_fresh
+        (fun s -> s)
+        "impl"
+        (fun s -> `Implementation (ModuleName.make_std s))
+
     let module_ :
         Signature.t * ModuleName.t ->
         [> `Module of Signature.t * ModuleName.t ] id =

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -255,6 +255,8 @@ module Identifier : sig
       ContainerPage.t option * ModuleName.t ->
       [> `Root of ContainerPage.t option * ModuleName.t ] id
 
+    val implementation : string -> [> `Implementation of ModuleName.t ] id
+
     val module_ :
       Signature.t * ModuleName.t ->
       [> `Module of Signature.t * ModuleName.t ] id

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -50,7 +50,10 @@ module Identifier = struct
   (** @canonical Odoc_model.Paths.Identifier.SourceLocation.t_pv *)
 
   type odoc_id_pv =
-    [ page_pv | source_page_pv | `Root of container_page option * ModuleName.t ]
+    [ page_pv
+    | source_page_pv
+    | `Root of container_page option * ModuleName.t
+    | `Implementation of ModuleName.t ]
   (** @canonical Odoc_model.Paths.Identifier.OdocId.t_pv *)
 
   and odoc_id = odoc_id_pv id

--- a/src/model/root.ml
+++ b/src/model/root.ml
@@ -82,6 +82,8 @@ let to_string t =
           (parent :> Paths.Identifier.OdocId.t)
           Names.ModuleName.fmt name
     | `Root (None, name) -> Format.fprintf fmt "%a" Names.ModuleName.fmt name
+    | `Implementation name ->
+        Format.fprintf fmt "impl(%a)" Names.ModuleName.fmt name
   in
 
   Format.asprintf "%a" pp t.id

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -705,7 +705,7 @@ and implementation_t =
   let open Lang.Implementation in
   Record
     [
-      F ("id", (fun t -> t.id), identifier);
+      F ("id", (fun t -> t.id), Option identifier);
       F ("digest", (fun t -> t.digest), Digest.t);
       F ("root", (fun t -> t.root), root);
     ]

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -422,7 +422,7 @@ module Compile_impl = struct
     let source_id =
       let doc = "The id of the source file" in
       Arg.(
-        required
+        value
         & opt (some string) None
         & info [ "source-id" ] ~doc ~docv:"/path/to/source.ml")
     in
@@ -1177,6 +1177,7 @@ module Occurrences = struct
     else if not (has_occurrences_prefix f) then
       Error (`Msg "Output file must be prefixed with 'occurrences-'.")
     else Ok f
+
   module Count = struct
     let count directories dst warnings_options include_hidden =
       dst_of_string dst >>= fun dst ->

--- a/src/odoc/occurrences.ml
+++ b/src/odoc/occurrences.ml
@@ -12,7 +12,7 @@ let string_starts_with ~prefix s =
   len_s >= len_pre && aux 0
 
 let handle_file file ~f =
-  if string_starts_with ~prefix:"src-" (Fpath.filename file) then
+  if string_starts_with ~prefix:"impl-" (Fpath.filename file) then
     Odoc_file.load file |> function
     | Error _ as e -> e
     | Ok unit' -> (

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -221,7 +221,7 @@ let add_unit_to_cache u =
   let target_name =
     (match u with
     | Odoc_file.Page_content _ -> "page-"
-    | Impl_content _ -> "src-"
+    | Impl_content _ -> "impl-"
     | Unit_content _ -> ""
     | Source_tree_content _ -> "page-")
     ^ unit_name u

--- a/src/odoc/source.ml
+++ b/src/odoc/source.ml
@@ -13,29 +13,39 @@ let resolve_and_substitute ~resolver ~make_root ~source_id input_file =
   let env = Resolver.build_compile_env_for_impl resolver impl in
   Odoc_xref2.Compile.compile_impl ~filename env impl |> Error.raise_warnings
 
-let root_of_implementation ~source_id ~module_name ~digest =
+let root_of_implementation ~module_name ~digest =
   let open Root in
   let file = Odoc_file.create_impl module_name in
-  let id :> Paths.Identifier.OdocId.t = source_id in
+  let id :> Paths.Identifier.OdocId.t =
+    Paths.Identifier.Mk.implementation module_name
+  in
   Ok { id; file; digest }
 
 let compile ~resolver ~output ~warnings_options ~source_id input =
-  let parent_id, name = Fpath.(split_base (v source_id)) in
-  if parent_id = Fpath.v "./" then
-    Error (`Msg "Source id cannot be in the root directory")
-  else
-    let parent = Compile.mk_id Fpath.(to_string (rem_empty_seg parent_id)) in
-
-    let source_id =
-      Paths.Identifier.Mk.source_page (parent, [ Fpath.to_string name ])
-    in
-    let make_root = root_of_implementation ~source_id in
-    let result =
-      Error.catch_errors_and_warnings (fun () ->
-          resolve_and_substitute ~resolver ~make_root ~source_id input)
-    in
-    (* Extract warnings to write them into the output file *)
-    let _, warnings = Error.unpack_warnings result in
-    Error.handle_errors_and_warnings ~warnings_options result >>= fun impl ->
-    Odoc_file.save_impl output ~warnings impl;
-    Ok ()
+  let source_id =
+    match source_id with
+    | None -> Ok None
+    | Some source_id ->
+        let parent_id, name = Fpath.(split_base (v source_id)) in
+        if parent_id = Fpath.v "./" then
+          Error (`Msg "Source id cannot be in the root directory")
+        else
+          let parent =
+            Compile.mk_id Fpath.(to_string (rem_empty_seg parent_id))
+          in
+          let source_id =
+            Paths.Identifier.Mk.source_page (parent, [ Fpath.to_string name ])
+          in
+          Ok (Some source_id)
+  in
+  source_id >>= fun source_id ->
+  let result =
+    Error.catch_errors_and_warnings (fun () ->
+        resolve_and_substitute ~resolver ~make_root:root_of_implementation
+          ~source_id input)
+  in
+  (* Extract warnings to write them into the output file *)
+  let _, warnings = Error.unpack_warnings result in
+  Error.handle_errors_and_warnings ~warnings_options result >>= fun impl ->
+  Odoc_file.save_impl output ~warnings impl;
+  Ok ()

--- a/src/xref2/shape_tools.cppo.ml
+++ b/src/xref2/shape_tools.cppo.ml
@@ -154,18 +154,17 @@ let lookup_shape : Env.t -> Shape.t -> Identifier.SourceLocation.t option =
 #endif
   unit_of_uid uid >>= fun unit_name ->
   match Env.lookup_impl unit_name env with
-  | None -> None
-  | Some impl -> (
+  | Some { shape_info ; id = Some id ; _} -> (
       let uid_to_id =
-        match impl.shape_info with
+        match shape_info with
         | Some (_, uid_to_id) -> uid_to_id
         | None -> Odoc_model.Compat.empty_map
       in
       match Shape.Uid.Map.find_opt uid uid_to_id with
       | Some x -> Some x
-      | None -> (
-          match impl with
-          | { id; _ } -> Some (MkId.source_location_mod id)))
+      | None ->  Some (MkId.source_location_mod id))
+  | None
+  | Some { id = None ; _} -> None
 
 let lookup_def :
     Env.t -> Identifier.NonSrc.t -> Identifier.SourceLocation.t option =

--- a/test/occurrences/double_wrapped.t/run.t
+++ b/test/occurrences/double_wrapped.t/run.t
@@ -12,11 +12,11 @@ The module B depends on both B and C, the module C only depends on A.
 
 Collecting occurrences is done on implementation files. 
 
-  $ odoc compile-impl --source-id src/a.ml -I . main__A.cmt --output-dir .
-  $ odoc compile-impl --source-id src/c.ml -I . main__C.cmt --output-dir .
-  $ odoc compile-impl --source-id src/b.ml -I . main__B.cmt --output-dir .
-  $ odoc compile-impl --source-id src/main__.ml -I . main__.cmt --output-dir .
-  $ odoc compile-impl --source-id src/main.ml -I . main.cmt --output-dir .
+  $ odoc compile-impl -I . main__A.cmt --output-dir .
+  $ odoc compile-impl -I . main__C.cmt --output-dir .
+  $ odoc compile-impl -I . main__B.cmt --output-dir .
+  $ odoc compile-impl -I . main__.cmt --output-dir .
+  $ odoc compile-impl -I . main.cmt --output-dir .
 
 We need the interface version to resolve the occurrences
 

--- a/test/occurrences/double_wrapped.t/run.t
+++ b/test/occurrences/double_wrapped.t/run.t
@@ -66,6 +66,9 @@ Uses of B.Z are not counted since they go to a hidden module.
 Uses of values Y.x and Z.y (in b.ml) are not counted since they come from a "local" module.
 
   $ occurrences_print occurrences-main.odoc | sort
+  Main was used directly 0 times and indirectly 2 times
+  Main.A was used directly 1 times and indirectly 0 times
+  Main.B was used directly 1 times and indirectly 0 times
 
   $ occurrences_print occurrences-main__.odoc | sort
 
@@ -74,9 +77,18 @@ A only uses "persistent" values: one it defines itself.
 
 "Aliased" values are not counted since they become persistent
   $ occurrences_print occurrences-main__B.odoc | sort
+  Main was used directly 0 times and indirectly 7 times
+  Main.A was used directly 2 times and indirectly 5 times
+  Main.A.(||>) was used directly 1 times and indirectly 0 times
+  Main.A.M was used directly 2 times and indirectly 0 times
+  Main.A.t was used directly 1 times and indirectly 0 times
+  Main.A.x was used directly 1 times and indirectly 0 times
 
 "Aliased" values are not counted since they become persistent
   $ occurrences_print occurrences-main__C.odoc | sort
+  Main was used directly 0 times and indirectly 2 times
+  Main.A was used directly 1 times and indirectly 1 times
+  Main.A.x was used directly 1 times and indirectly 0 times
 
 Now we can merge all tables
 
@@ -89,6 +101,13 @@ Now we can merge all tables
 
   $ occurrences_print occurrences-aggregated.odoc | sort > all_merged
   $ cat all_merged
+  Main was used directly 0 times and indirectly 11 times
+  Main.A was used directly 4 times and indirectly 6 times
+  Main.A.(||>) was used directly 1 times and indirectly 0 times
+  Main.A.M was used directly 2 times and indirectly 0 times
+  Main.A.t was used directly 1 times and indirectly 0 times
+  Main.A.x was used directly 2 times and indirectly 0 times
+  Main.B was used directly 1 times and indirectly 0 times
 
 Compare with the one created directly with all occurrences:
 
@@ -100,6 +119,28 @@ We can also include hidden ids:
 
   $ odoc count-occurrences -I main__B -o occurrences-b.odoc --include-hidden
   $ occurrences_print occurrences-b.odoc | sort
+  Main was used directly 0 times and indirectly 7 times
+  Main.A was used directly 2 times and indirectly 5 times
+  Main.A.(||>) was used directly 1 times and indirectly 0 times
+  Main.A.M was used directly 2 times and indirectly 0 times
+  Main.A.t was used directly 1 times and indirectly 0 times
+  Main.A.x was used directly 1 times and indirectly 0 times
+  Main__ was used directly 0 times and indirectly 2 times
+  Main__.C was used directly 1 times and indirectly 1 times
+  Main__.C.y was used directly 1 times and indirectly 0 times
 
   $ odoc count-occurrences -I . -o occurrences-all.odoc --include-hidden
   $ occurrences_print occurrences-all.odoc | sort
+  Main was used directly 0 times and indirectly 11 times
+  Main.A was used directly 4 times and indirectly 6 times
+  Main.A.(||>) was used directly 1 times and indirectly 0 times
+  Main.A.M was used directly 2 times and indirectly 0 times
+  Main.A.t was used directly 1 times and indirectly 0 times
+  Main.A.x was used directly 2 times and indirectly 0 times
+  Main.B was used directly 1 times and indirectly 0 times
+  Main__ was used directly 0 times and indirectly 2 times
+  Main__.C was used directly 1 times and indirectly 1 times
+  Main__.C.y was used directly 1 times and indirectly 0 times
+  Main__A was used directly 1 times and indirectly 0 times
+  Main__B was used directly 1 times and indirectly 0 times
+  Main__C was used directly 1 times and indirectly 0 times

--- a/test/sources/source.t/run.t
+++ b/test/sources/source.t/run.t
@@ -383,3 +383,16 @@ Ids generated in the source code:
   id="val-list"
   id="val-string"
   id="val-string2"
+
+
+Compiling without --source-id makes it impossible to generate the source:
+
+  $ odoc compile-impl -I . a.cmt
+  $ odoc compile -I . a.cmt
+  $ odoc link -I . a.odoc
+  $ odoc link -I . impl-a.odoc
+  $ odoc html-generate --indent -o html a.odocl
+  $ odoc html-generate --source a.ml --indent -o html impl-a.odocl
+  ERROR: The implementation unit was not compiled with --source-id.
+  [1]
+  $ odoc support-files -o html


### PR DESCRIPTION
`--source-id` is only needed when rendering implementations. However, compiling implementations can also be required for another feature: counting occurrences.

This PR makes `--source-id` option at compile time, but it remains mandatory to render source code.