### PR TITLE
Remove unwanted or duplicate doc in expansions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,8 @@
 - Fixed title content not being picked up across pages when rendering references
   (#1116, @panglesd)
 - Fix wrong links to standalone comments in search results (#1118, @panglesd)
+- Remove duplicated or unwanted comments (@Julow, #1133)
+  This could happen with inline includes.
 
 
 # 2.4.0

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -1579,7 +1579,7 @@ and expansion_of_module_path :
           let sg' =
             match m.doc with
             | [] -> sg
-            | docs -> { sg with items = Comment (`Docs docs) :: sg.items }
+            | doc -> { sg with doc }
           in
           if strengthen then
             Ok (Signature (Strengthen.signature (`Resolved p') sg'))

--- a/test/generators/html/Include2.html
+++ b/test/generators/html/Include2.html
@@ -40,7 +40,6 @@
        </span>
       </code>
      </summary>
-     <p>Comment about X that should not appear when including X below.</p>
      <div class="odoc-spec">
       <div class="spec type anchored" id="type-t">
        <a href="#type-t" class="anchor"></a>

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
@@ -15,9 +15,9 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Parameter <code><span>FunctorTypeOf.Collection</span></code></h1>
+   <p>This comment is for <code>CollectionModule</code>.</p>
   </header>
   <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C.html
@@ -14,9 +14,9 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Parameter <code><span>Recollection.C</span></code></h1>
+   <p>This comment is for <code>CollectionModule</code>.</p>
   </header>
   <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>

--- a/test/generators/html/Ocamlary-Recollection.html
+++ b/test/generators/html/Ocamlary-Recollection.html
@@ -13,6 +13,7 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Ocamlary.Recollection</span></code></h1>
+   <p>This comment is for <code>CollectionModule</code>.</p>
   </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
@@ -33,7 +34,6 @@
     </div>
    </div>
    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>

--- a/test/generators/html/Ocamlary-module-type-A-Q.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q.html
@@ -13,9 +13,9 @@
    <a href="Ocamlary-module-type-A.html">A</a> &#x00BB; Q
   </nav>
   <header class="odoc-preamble"><h1>Module <code><span>A.Q</span></code></h1>
+   <p>This comment is for <code>CollectionModule</code>.</p>
   </header>
   <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>

--- a/test/generators/html/Ocamlary-module-type-A.html
+++ b/test/generators/html/Ocamlary-module-type-A.html
@@ -32,6 +32,9 @@
       </span>
      </code>
     </div>
+    <div class="spec-doc">
+     <p>This comment is for <code>CollectionModule</code>.</p>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-B-Q.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q.html
@@ -13,9 +13,9 @@
    <a href="Ocamlary-module-type-B.html">B</a> &#x00BB; Q
   </nav>
   <header class="odoc-preamble"><h1>Module <code><span>B.Q</span></code></h1>
+   <p>This comment is for <code>CollectionModule</code>.</p>
   </header>
   <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>

--- a/test/generators/html/Ocamlary-module-type-B.html
+++ b/test/generators/html/Ocamlary-module-type-B.html
@@ -32,6 +32,9 @@
       </span>
      </code>
     </div>
+    <div class="spec-doc">
+     <p>This comment is for <code>CollectionModule</code>.</p>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-C-Q.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q.html
@@ -13,9 +13,9 @@
    <a href="Ocamlary-module-type-C.html">C</a> &#x00BB; Q
   </nav>
   <header class="odoc-preamble"><h1>Module <code><span>C.Q</span></code></h1>
+   <p>This comment is for <code>CollectionModule</code>.</p>
   </header>
   <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>

--- a/test/generators/html/Ocamlary-module-type-C.html
+++ b/test/generators/html/Ocamlary-module-type-C.html
@@ -50,6 +50,9 @@
         </span>
        </code>
       </div>
+      <div class="spec-doc">
+       <p>This comment is for <code>CollectionModule</code>.</p>
+      </div>
      </div>
     </details>
    </div>

--- a/test/generators/html/Ocamlary-module-type-COLLECTION.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION.html
@@ -14,9 +14,9 @@
   <header class="odoc-preamble">
    <h1>Module type <code><span>Ocamlary.COLLECTION</span></code></h1>
    <p>module type of</p>
+   <p>This comment is for <code>CollectionModule</code>.</p>
   </header>
   <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>

--- a/test/generators/html/Ocamlary-module-type-MMM-C.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C.html
@@ -14,9 +14,9 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>MMM.C</span></code></h1>
+   <p>This comment is for <code>CollectionModule</code>.</p>
   </header>
   <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-collection">
      <a href="#type-collection" class="anchor"></a>

--- a/test/generators/html/Ocamlary-module-type-MMM.html
+++ b/test/generators/html/Ocamlary-module-type-MMM.html
@@ -26,6 +26,9 @@
       </span>
      </code>
     </div>
+    <div class="spec-doc">
+     <p>This comment is for <code>CollectionModule</code>.</p>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -718,6 +718,9 @@
       </span>
      </code>
     </div>
+    <div class="spec-doc">
+     <p>This comment is for <code>CollectionModule</code>.</p>
+    </div>
    </div>
    <div class="odoc-spec">
     <div class="spec module-type anchored" id="module-type-MMM">

--- a/test/generators/latex/Include2.tex
+++ b/test/generators/latex/Include2.tex
@@ -3,9 +3,7 @@
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Comment about X that should not appear when including X below.\end{ocamlindent}%
 \medbreak
-\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[module-Include2-module-X]{\ocamlinlinecode{X}} \ocamltag{keyword}{end}Comment about X that should not appear when including X below.
-
-\label{module-Include2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = int}\\
+\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[module-Include2-module-X]{\ocamlinlinecode{X}} \ocamltag{keyword}{end}\label{module-Include2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = int}\\
 \label{module-Include2-module-Y}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Include2-module-Y]{\ocamlinlinecode{Y}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Include2-module-Y-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Top-comment of Y.\end{ocamlindent}%

--- a/test/generators/latex/Ocamlary.FunctorTypeOf.tex
+++ b/test/generators/latex/Ocamlary.FunctorTypeOf.tex
@@ -2,9 +2,7 @@
 This comment is for \ocamlinlinecode{FunctorTypeOf}.
 
 \subsection{Parameters\label{parameters}}%
-\label{module-Ocamlary-module-FunctorTypeOf-argument-1-Collection}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-FunctorTypeOf-argument-1-Collection]{\ocamlinlinecode{Collection}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.
-
-\label{module-Ocamlary-module-FunctorTypeOf-argument-1-Collection-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
+\label{module-Ocamlary-module-FunctorTypeOf-argument-1-Collection}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-FunctorTypeOf-argument-1-Collection]{\ocamlinlinecode{Collection}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-FunctorTypeOf-argument-1-Collection-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{module-Ocamlary-module-FunctorTypeOf-argument-1-Collection-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element}\\
 \label{module-Ocamlary-module-FunctorTypeOf-argument-1-Collection-module-InnerModuleA}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-FunctorTypeOf-argument-1-Collection-module-InnerModuleA]{\ocamlinlinecode{InnerModuleA}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-FunctorTypeOf-argument-1-Collection-module-InnerModuleA-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[module-Ocamlary-module-FunctorTypeOf-argument-1-Collection-type-collection]{\ocamlinlinecode{collection}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{t}.\end{ocamlindent}%

--- a/test/generators/latex/Ocamlary.Recollection.tex
+++ b/test/generators/latex/Ocamlary.Recollection.tex
@@ -1,8 +1,8 @@
 \section{Module \ocamlinlinecode{Ocamlary.\allowbreak{}Recollection}}\label{module-Ocamlary-module-Recollection}%
-\subsection{Parameters\label{parameters}}%
-\label{module-Ocamlary-module-Recollection-argument-1-C}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-Recollection-argument-1-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.
+This comment is for \ocamlinlinecode{CollectionModule}.
 
-\label{module-Ocamlary-module-Recollection-argument-1-C-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
+\subsection{Parameters\label{parameters}}%
+\label{module-Ocamlary-module-Recollection-argument-1-C}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-Recollection-argument-1-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-Recollection-argument-1-C-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{module-Ocamlary-module-Recollection-argument-1-C-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element}\\
 \label{module-Ocamlary-module-Recollection-argument-1-C-module-InnerModuleA}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-Recollection-argument-1-C-module-InnerModuleA]{\ocamlinlinecode{InnerModuleA}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-Recollection-argument-1-C-module-InnerModuleA-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[module-Ocamlary-module-Recollection-argument-1-C-type-collection]{\ocamlinlinecode{collection}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{t}.\end{ocamlindent}%
@@ -25,8 +25,6 @@
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \subsection{Signature\label{signature}}%
-This comment is for \ocamlinlinecode{CollectionModule}.
-
 \label{module-Ocamlary-module-Recollection-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection = \hyperref[module-Ocamlary-module-Recollection-argument-1-C-type-element]{\ocamlinlinecode{C.\allowbreak{}element}} list}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{module-Ocamlary-module-Recollection-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element = \hyperref[module-Ocamlary-module-Recollection-argument-1-C-type-collection]{\ocamlinlinecode{C.\allowbreak{}collection}}}\\

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -225,9 +225,7 @@ After exception title.
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.\end{ocamlindent}%
 \medbreak
-\label{module-Ocamlary-module-type-COLLECTION}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-COLLECTION]{\ocamlinlinecode{COLLECTION}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.
-
-\label{module-Ocamlary-module-type-COLLECTION-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
+\label{module-Ocamlary-module-type-COLLECTION}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-COLLECTION]{\ocamlinlinecode{COLLECTION}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-COLLECTION-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{module-Ocamlary-module-type-COLLECTION-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element}\\
 \label{module-Ocamlary-module-type-COLLECTION-module-InnerModuleA}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-COLLECTION-module-InnerModuleA]{\ocamlinlinecode{InnerModuleA}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-COLLECTION-module-InnerModuleA-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[module-Ocamlary-module-type-COLLECTION-type-collection]{\ocamlinlinecode{collection}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{t}.\end{ocamlindent}%
@@ -254,10 +252,9 @@ After exception title.
   (\hyperref[module-Ocamlary-module-Recollection-argument-1-C]{\ocamlinlinecode{C}} : \hyperref[module-Ocamlary-module-type-COLLECTION]{\ocamlinlinecode{COLLECTION}}) : 
   \hyperref[module-Ocamlary-module-type-COLLECTION]{\ocamlinlinecode{COLLECTION}}
     \ocamltag{keyword}{with} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-COLLECTION-type-collection]{\ocamlinlinecode{collection}} = \hyperref[module-Ocamlary-module-Recollection-argument-1-C-type-element]{\ocamlinlinecode{C.\allowbreak{}element}} list
-     \ocamltag{keyword}{and} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-COLLECTION-type-element]{\ocamlinlinecode{element}} = \hyperref[module-Ocamlary-module-Recollection-argument-1-C-type-collection]{\ocamlinlinecode{C.\allowbreak{}collection}}}\\
-\label{module-Ocamlary-module-type-MMM}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-MMM]{\ocamlinlinecode{MMM}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-MMM-module-C}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-MMM-module-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.
-
-\label{module-Ocamlary-module-type-MMM-module-C-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
+     \ocamltag{keyword}{and} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-COLLECTION-type-element]{\ocamlinlinecode{element}} = \hyperref[module-Ocamlary-module-Recollection-argument-1-C-type-collection]{\ocamlinlinecode{C.\allowbreak{}collection}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.\end{ocamlindent}%
+\medbreak
+\label{module-Ocamlary-module-type-MMM}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-MMM]{\ocamlinlinecode{MMM}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-MMM-module-C}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-MMM-module-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-MMM-module-C-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{module-Ocamlary-module-type-MMM-module-C-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element}\\
 \label{module-Ocamlary-module-type-MMM-module-C-module-InnerModuleA}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-MMM-module-C-module-InnerModuleA]{\ocamlinlinecode{InnerModuleA}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-MMM-module-C-module-InnerModuleA-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[module-Ocamlary-module-type-MMM-module-C-type-collection]{\ocamlinlinecode{collection}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{t}.\end{ocamlindent}%
@@ -278,7 +275,8 @@ After exception title.
 \label{module-Ocamlary-module-type-MMM-module-C-module-type-InnerModuleTypeA}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} InnerModuleTypeA = \hyperref[module-Ocamlary-module-type-MMM-module-C-module-InnerModuleA-module-type-InnerModuleTypeA']{\ocamlinlinecode{InnerModuleA.\allowbreak{}InnerModuleTypeA'}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{InnerModuleTypeA}.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
-\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.\end{ocamlindent}%
+\medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{module-Ocamlary-module-type-RECOLLECTION}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-RECOLLECTION]{\ocamlinlinecode{RECOLLECTION}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-RECOLLECTION-module-C}\ocamlcodefragment{\ocamltag{keyword}{module} C = \hyperref[module-Ocamlary-module-Recollection]{\ocamlinlinecode{Recollection(CollectionModule)}}}\\
@@ -306,9 +304,7 @@ After exception title.
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{module-Ocamlary-module-type-A}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-A]{\ocamlinlinecode{A}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-A-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
-\label{module-Ocamlary-module-type-A-module-Q}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-A-module-Q]{\ocamlinlinecode{Q}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.
-
-\label{module-Ocamlary-module-type-A-module-Q-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
+\label{module-Ocamlary-module-type-A-module-Q}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-A-module-Q]{\ocamlinlinecode{Q}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-A-module-Q-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{module-Ocamlary-module-type-A-module-Q-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element}\\
 \label{module-Ocamlary-module-type-A-module-Q-module-InnerModuleA}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-A-module-Q-module-InnerModuleA]{\ocamlinlinecode{InnerModuleA}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-A-module-Q-module-InnerModuleA-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[module-Ocamlary-module-type-A-module-Q-type-collection]{\ocamlinlinecode{collection}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{t}.\end{ocamlindent}%
@@ -329,13 +325,12 @@ After exception title.
 \label{module-Ocamlary-module-type-A-module-Q-module-type-InnerModuleTypeA}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} InnerModuleTypeA = \hyperref[module-Ocamlary-module-type-A-module-Q-module-InnerModuleA-module-type-InnerModuleTypeA']{\ocamlinlinecode{InnerModuleA.\allowbreak{}InnerModuleTypeA'}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{InnerModuleTypeA}.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
-\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.\end{ocamlindent}%
+\medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{module-Ocamlary-module-type-B}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-B]{\ocamlinlinecode{B}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-B-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
-\label{module-Ocamlary-module-type-B-module-Q}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-B-module-Q]{\ocamlinlinecode{Q}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.
-
-\label{module-Ocamlary-module-type-B-module-Q-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
+\label{module-Ocamlary-module-type-B-module-Q}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-B-module-Q]{\ocamlinlinecode{Q}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-B-module-Q-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{module-Ocamlary-module-type-B-module-Q-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element}\\
 \label{module-Ocamlary-module-type-B-module-Q-module-InnerModuleA}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-B-module-Q-module-InnerModuleA]{\ocamlinlinecode{InnerModuleA}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-B-module-Q-module-InnerModuleA-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[module-Ocamlary-module-type-B-module-Q-type-collection]{\ocamlinlinecode{collection}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{t}.\end{ocamlindent}%
@@ -356,13 +351,12 @@ After exception title.
 \label{module-Ocamlary-module-type-B-module-Q-module-type-InnerModuleTypeA}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} InnerModuleTypeA = \hyperref[module-Ocamlary-module-type-B-module-Q-module-InnerModuleA-module-type-InnerModuleTypeA']{\ocamlinlinecode{InnerModuleA.\allowbreak{}InnerModuleTypeA'}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{InnerModuleTypeA}.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
-\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.\end{ocamlindent}%
+\medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{module-Ocamlary-module-type-C}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\ocamltag{keyword}{include} \hyperref[module-Ocamlary-module-type-A]{\ocamlinlinecode{A}}\label{module-Ocamlary-module-type-C-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
-\label{module-Ocamlary-module-type-C-module-Q}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-C-module-Q]{\ocamlinlinecode{Q}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.
-
-\label{module-Ocamlary-module-type-C-module-Q-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
+\label{module-Ocamlary-module-type-C-module-Q}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-C-module-Q]{\ocamlinlinecode{Q}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-C-module-Q-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{module-Ocamlary-module-type-C-module-Q-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element}\\
 \label{module-Ocamlary-module-type-C-module-Q-module-InnerModuleA}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-C-module-Q-module-InnerModuleA]{\ocamlinlinecode{InnerModuleA}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{module-Ocamlary-module-type-C-module-Q-module-InnerModuleA-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[module-Ocamlary-module-type-C-module-Q-type-collection]{\ocamlinlinecode{collection}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{t}.\end{ocamlindent}%
@@ -383,7 +377,8 @@ After exception title.
 \label{module-Ocamlary-module-type-C-module-Q-module-type-InnerModuleTypeA}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} InnerModuleTypeA = \hyperref[module-Ocamlary-module-type-C-module-Q-module-InnerModuleA-module-type-InnerModuleTypeA']{\ocamlinlinecode{InnerModuleA.\allowbreak{}InnerModuleTypeA'}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{InnerModuleTypeA}.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
-\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}This comment is for \ocamlinlinecode{CollectionModule}.\end{ocamlindent}%
+\medbreak
 \ocamltag{keyword}{include} \hyperref[module-Ocamlary-module-type-B]{\ocamlinlinecode{B}} \ocamltag{keyword}{with} \ocamltag{keyword}{type} \hyperref[module-Ocamlary-module-type-B-type-t]{\ocamlinlinecode{t}} := \hyperref[module-Ocamlary-module-type-C-type-t]{\ocamlinlinecode{t}} \ocamltag{keyword}{and} \ocamltag{keyword}{module} \hyperref[module-Ocamlary-module-type-B-module-Q]{\ocamlinlinecode{Q}} := \hyperref[module-Ocamlary-module-type-C-module-Q]{\ocamlinlinecode{Q}}\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}This module type includes two signatures.\end{ocamlindent}%
 \medbreak

--- a/test/generators/man/Include2.3o
+++ b/test/generators/man/Include2.3o
@@ -18,10 +18,6 @@ Include2
 Comment about X that should not appear when including X below\.
 .nf 
 .sp 
-.fi 
-Comment about X that should not appear when including X below\.
-.nf 
-.sp 
 \f[CB]type\fR t = int
 .sp 
 \f[CB]module\fR Y : \f[CB]sig\fR \.\.\. \f[CB]end\fR

--- a/test/generators/man/Ocamlary.3o
+++ b/test/generators/man/Ocamlary.3o
@@ -495,11 +495,6 @@ This comment is for CollectionModule\.
 \f[CB]module\fR \f[CB]type\fR COLLECTION = \f[CB]sig\fR
 .br 
 .ti +2
-.fi 
-This comment is for CollectionModule\.
-.nf 
-.sp 
-.ti +2
 \f[CB]type\fR collection
 .fi 
 .br 
@@ -591,17 +586,17 @@ module type of
   COLLECTION
     \f[CB]with\fR \f[CB]type\fR collection = C\.element list
      \f[CB]and\fR \f[CB]type\fR element = C\.collection
+.fi 
+.br 
+.ti +2
+This comment is for CollectionModule\.
+.nf 
 .sp 
 \f[CB]module\fR \f[CB]type\fR MMM = \f[CB]sig\fR
 .br 
 .ti +2
 \f[CB]module\fR C : \f[CB]sig\fR
 .br 
-.ti +4
-.fi 
-This comment is for CollectionModule\.
-.nf 
-.sp 
 .ti +4
 \f[CB]type\fR collection
 .fi 
@@ -684,6 +679,12 @@ This comment is for InnerModuleTypeA\.
 .br 
 .ti +2
 \f[CB]end\fR
+.fi 
+.br 
+.ti +4
+This comment is for CollectionModule\.
+.nf 
+
 .br 
 \f[CB]end\fR
 .sp 
@@ -782,11 +783,6 @@ This comment is for InnerModuleTypeA\.
 \f[CB]module\fR Q : \f[CB]sig\fR
 .br 
 .ti +4
-.fi 
-This comment is for CollectionModule\.
-.nf 
-.sp 
-.ti +4
 \f[CB]type\fR collection
 .fi 
 .br 
@@ -868,6 +864,12 @@ This comment is for InnerModuleTypeA\.
 .br 
 .ti +2
 \f[CB]end\fR
+.fi 
+.br 
+.ti +4
+This comment is for CollectionModule\.
+.nf 
+
 .br 
 \f[CB]end\fR
 .sp 
@@ -880,11 +882,6 @@ This comment is for InnerModuleTypeA\.
 \f[CB]module\fR Q : \f[CB]sig\fR
 .br 
 .ti +4
-.fi 
-This comment is for CollectionModule\.
-.nf 
-.sp 
-.ti +4
 \f[CB]type\fR collection
 .fi 
 .br 
@@ -966,6 +963,12 @@ This comment is for InnerModuleTypeA\.
 .br 
 .ti +2
 \f[CB]end\fR
+.fi 
+.br 
+.ti +4
+This comment is for CollectionModule\.
+.nf 
+
 .br 
 \f[CB]end\fR
 .sp 
@@ -978,11 +981,6 @@ This comment is for InnerModuleTypeA\.
 \f[CB]module\fR Q : \f[CB]sig\fR
 .br 
 .ti +4
-.fi 
-This comment is for CollectionModule\.
-.nf 
-.sp 
-.ti +4
 \f[CB]type\fR collection
 .fi 
 .br 
@@ -1064,6 +1062,11 @@ This comment is for InnerModuleTypeA\.
 .br 
 .ti +2
 \f[CB]end\fR
+.fi 
+.br 
+.ti +4
+This comment is for CollectionModule\.
+.nf 
 .sp 
 .ti +2
 

--- a/test/generators/man/Ocamlary.FunctorTypeOf.3o
+++ b/test/generators/man/Ocamlary.FunctorTypeOf.3o
@@ -22,11 +22,6 @@ This comment is for FunctorTypeOf\.
 \f[CB]module\fR Collection : \f[CB]sig\fR
 .br 
 .ti +2
-.fi 
-This comment is for CollectionModule\.
-.nf 
-.sp 
-.ti +2
 \f[CB]type\fR collection
 .fi 
 .br 

--- a/test/generators/man/Ocamlary.Recollection.3o
+++ b/test/generators/man/Ocamlary.Recollection.3o
@@ -8,6 +8,9 @@ Ocamlary\.Recollection
 \fBModule Ocamlary\.Recollection\fR
 .in 
 .sp 
+.fi 
+This comment is for CollectionModule\.
+.nf 
 .SH Documentation
 .sp 
 .nf 
@@ -18,11 +21,6 @@ Ocamlary\.Recollection
 .sp 
 \f[CB]module\fR C : \f[CB]sig\fR
 .br 
-.ti +2
-.fi 
-This comment is for CollectionModule\.
-.nf 
-.sp 
 .ti +2
 \f[CB]type\fR collection
 .fi 
@@ -108,10 +106,6 @@ This comment is for InnerModuleTypeA\.
 .in 3
 \fB2 Signature\fR
 .in 
-.sp 
-.fi 
-This comment is for CollectionModule\.
-.nf 
 .sp 
 \f[CB]type\fR collection = C\.element list
 .fi 

--- a/test/xref2/dune
+++ b/test/xref2/dune
@@ -42,7 +42,8 @@
   shadow5
   js_stack_overflow
   expansion
-  github_issue_1066)
+  github_issue_1066
+  include_module_type_of_preamble)
  (enabled_if
   (>= %{ocaml_version} 4.08.0)))
 

--- a/test/xref2/include_module_type_of_preamble.t/bar.ml
+++ b/test/xref2/include_module_type_of_preamble.t/bar.ml
@@ -1,1 +1,10 @@
 include Foo
+
+module P = struct
+  (** Preamble for P. *)
+end
+
+(** Outside preamble for Q. *)
+module Q = struct
+  (** Inside preamble for Q. *)
+end

--- a/test/xref2/include_module_type_of_preamble.t/bar.ml
+++ b/test/xref2/include_module_type_of_preamble.t/bar.ml
@@ -1,0 +1,1 @@
+include Foo

--- a/test/xref2/include_module_type_of_preamble.t/foo.mli
+++ b/test/xref2/include_module_type_of_preamble.t/foo.mli
@@ -1,0 +1,8 @@
+(** Preamble for Foo. *)
+
+(** Preamble for O. *)
+module O : sig
+  val x : int
+end
+
+include module type of O (** @inline *)

--- a/test/xref2/include_module_type_of_preamble.t/run.t
+++ b/test/xref2/include_module_type_of_preamble.t/run.t
@@ -2,8 +2,7 @@
   $ odoc html-generate -o html --indent foo.odocl
   $ odoc html-generate -o html --indent bar.odocl
 
-Foo contains "Preamble for O" twice: once for the module O definition, once
-coming from the inline include.
+Foo contains "Preamble for O" once.
 
   $ cat html/test/Foo/index.html
   <!DOCTYPE html>
@@ -34,7 +33,7 @@ coming from the inline include.
         </span>
        </code>
       </div><div class="spec-doc"><p>Preamble for O.</p></div>
-     </div><p>Preamble for O.</p>
+     </div>
      <div class="odoc-spec">
       <div class="spec value anchored" id="val-x">
        <a href="#val-x" class="anchor"></a>
@@ -45,9 +44,8 @@ coming from the inline include.
    </body>
   </html>
 
-Bar includes Foo and should also contain "Preamble for O" twice.
+Bar includes Foo and should also contain "Preamble for O" once.
 Bar doesn't contain "Preamble for Foo" on purpose.
-TODO: It contains "Preamble for O" 3 times.
 
   $ cat html/test/Bar/index.html
   <!DOCTYPE html>
@@ -85,7 +83,7 @@ TODO: It contains "Preamble for O" 3 times.
           <span> = <a href="../Foo/O/index.html">Foo.O</a></span>
          </code>
         </div><div class="spec-doc"><p>Preamble for O.</p></div>
-       </div><p>Preamble for O.</p><p>Preamble for O.</p>
+       </div>
        <div class="odoc-spec">
         <div class="spec value anchored" id="val-x">
          <a href="#val-x" class="anchor"></a>

--- a/test/xref2/include_module_type_of_preamble.t/run.t
+++ b/test/xref2/include_module_type_of_preamble.t/run.t
@@ -46,8 +46,8 @@ coming from the inline include.
   </html>
 
 Bar includes Foo and should also contain "Preamble for O" twice.
+Bar doesn't contain "Preamble for Foo" on purpose.
 TODO: It contains "Preamble for O" 3 times.
-TODO: It doesn't contain "Preamble for Foo".
 
   $ cat html/test/Bar/index.html
   <!DOCTYPE html>

--- a/test/xref2/include_module_type_of_preamble.t/run.t
+++ b/test/xref2/include_module_type_of_preamble.t/run.t
@@ -1,0 +1,99 @@
+  $ compile foo.mli bar.ml
+  $ odoc html-generate -o html --indent foo.odocl
+  $ odoc html-generate -o html --indent bar.odocl
+
+Foo contains "Preamble for O" twice: once for the module O definition, once
+coming from the inline include.
+
+  $ cat html/test/Foo/index.html
+  <!DOCTYPE html>
+  <html xmlns="http://www.w3.org/1999/xhtml">
+   <head><title>Foo (test.Foo)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../odoc.css"/>
+    <meta name="generator" content="odoc %%VERSION%%"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+    <script src="../../highlight.pack.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+   </head>
+   <body class="odoc">
+    <nav class="odoc-nav"><a href="../index.html">Up</a> – 
+     <a href="../index.html">test</a> &#x00BB; Foo
+    </nav>
+    <header class="odoc-preamble"><h1>Module <code><span>Foo</span></code></h1>
+     <p>Preamble for Foo.</p>
+    </header>
+    <div class="odoc-content">
+     <div class="odoc-spec">
+      <div class="spec module anchored" id="module-O">
+       <a href="#module-O" class="anchor"></a>
+       <code>
+        <span><span class="keyword">module</span> <a href="O/index.html">O</a>
+        </span>
+        <span> : <span class="keyword">sig</span> ... 
+         <span class="keyword">end</span>
+        </span>
+       </code>
+      </div><div class="spec-doc"><p>Preamble for O.</p></div>
+     </div><p>Preamble for O.</p>
+     <div class="odoc-spec">
+      <div class="spec value anchored" id="val-x">
+       <a href="#val-x" class="anchor"></a>
+       <code><span><span class="keyword">val</span> x : int</span></code>
+      </div>
+     </div>
+    </div>
+   </body>
+  </html>
+
+Bar includes Foo and should also contain "Preamble for O" twice.
+TODO: It contains "Preamble for O" 3 times.
+TODO: It doesn't contain "Preamble for Foo".
+
+  $ cat html/test/Bar/index.html
+  <!DOCTYPE html>
+  <html xmlns="http://www.w3.org/1999/xhtml">
+   <head><title>Bar (test.Bar)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../odoc.css"/>
+    <meta name="generator" content="odoc %%VERSION%%"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+    <script src="../../highlight.pack.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+   </head>
+   <body class="odoc">
+    <nav class="odoc-nav"><a href="../index.html">Up</a> – 
+     <a href="../index.html">test</a> &#x00BB; Bar
+    </nav>
+    <header class="odoc-preamble"><h1>Module <code><span>Bar</span></code></h1>
+    </header>
+    <div class="odoc-content">
+     <div class="odoc-include">
+      <details open="open">
+       <summary class="spec include">
+        <code>
+         <span><span class="keyword">include</span> 
+          <span class="keyword">module</span> <span class="keyword">type</span>
+           <span class="keyword">of</span> <span class="keyword">struct</span>
+           <span class="keyword">include</span> 
+          <a href="../Foo/index.html">Foo</a> <span class="keyword">end</span>
+         </span>
+        </code>
+       </summary>
+       <div class="odoc-spec">
+        <div class="spec module anchored" id="module-O">
+         <a href="#module-O" class="anchor"></a>
+         <code><span><span class="keyword">module</span> O</span>
+          <span> = <a href="../Foo/O/index.html">Foo.O</a></span>
+         </code>
+        </div><div class="spec-doc"><p>Preamble for O.</p></div>
+       </div><p>Preamble for O.</p><p>Preamble for O.</p>
+       <div class="odoc-spec">
+        <div class="spec value anchored" id="val-x">
+         <a href="#val-x" class="anchor"></a>
+         <code><span><span class="keyword">val</span> x : int</span></code>
+        </div>
+       </div>
+      </details>
+     </div>
+    </div>
+   </body>
+  </html>

--- a/test/xref2/include_module_type_of_preamble.t/run.t
+++ b/test/xref2/include_module_type_of_preamble.t/run.t
@@ -92,6 +92,74 @@ Bar doesn't contain "Preamble for Foo" on purpose.
        </div>
       </details>
      </div>
+     <div class="odoc-spec">
+      <div class="spec module anchored" id="module-P">
+       <a href="#module-P" class="anchor"></a>
+       <code>
+        <span><span class="keyword">module</span> <a href="P/index.html">P</a>
+        </span>
+        <span> : <span class="keyword">sig</span> ... 
+         <span class="keyword">end</span>
+        </span>
+       </code>
+      </div><div class="spec-doc"><p>Preamble for P.</p></div>
+     </div>
+     <div class="odoc-spec">
+      <div class="spec module anchored" id="module-Q">
+       <a href="#module-Q" class="anchor"></a>
+       <code>
+        <span><span class="keyword">module</span> <a href="Q/index.html">Q</a>
+        </span>
+        <span> : <span class="keyword">sig</span> ... 
+         <span class="keyword">end</span>
+        </span>
+       </code>
+      </div><div class="spec-doc"><p>Outside preamble for Q.</p></div>
+     </div>
     </div>
+   </body>
+  </html>
+
+Check the preambles:
+
+  $ cat html/test/Bar/Q/index.html
+  <!DOCTYPE html>
+  <html xmlns="http://www.w3.org/1999/xhtml">
+   <head><title>Q (test.Bar.Q)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../../odoc.css"/>
+    <meta name="generator" content="odoc %%VERSION%%"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+    <script src="../../../highlight.pack.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+   </head>
+   <body class="odoc">
+    <nav class="odoc-nav"><a href="../index.html">Up</a> – 
+     <a href="../../index.html">test</a> &#x00BB; 
+     <a href="../index.html">Bar</a> &#x00BB; Q
+    </nav>
+    <header class="odoc-preamble">
+     <h1>Module <code><span>Bar.Q</span></code></h1>
+     <p>Outside preamble for Q.</p><p>Inside preamble for Q.</p>
+    </header><div class="odoc-content"></div>
+   </body>
+  </html>
+  $ cat html/test/Bar/P/index.html
+  <!DOCTYPE html>
+  <html xmlns="http://www.w3.org/1999/xhtml">
+   <head><title>P (test.Bar.P)</title><meta charset="utf-8"/>
+    <link rel="stylesheet" href="../../../odoc.css"/>
+    <meta name="generator" content="odoc %%VERSION%%"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+    <script src="../../../highlight.pack.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+   </head>
+   <body class="odoc">
+    <nav class="odoc-nav"><a href="../index.html">Up</a> – 
+     <a href="../../index.html">test</a> &#x00BB; 
+     <a href="../index.html">Bar</a> &#x00BB; P
+    </nav>
+    <header class="odoc-preamble">
+     <h1>Module <code><span>Bar.P</span></code></h1><p>Preamble for P.</p>
+    </header><div class="odoc-content"></div>
    </body>
   </html>

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -36,9 +36,9 @@ Everything should resolve:
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"With_type"]}}}
   {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"T"},{"`Word":"."}]}
   {"`Resolved":{"`Alias":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"External"]}},"X"]},{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Alias"]}}]}}
-  "None"
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"X"},{"`Word":"."}]}
   {"`Resolved":{"`Alias":[{"`Canonical":[{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Internal"]}},"C1"]},{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"C1"]}}}]},{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"C1"]}}]}}
-  "None"
+  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"C1"},{"`Word":"."}]}
   {"`Resolved":{"`Alias":[{"`Canonical":[{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Internal"]}},"C2"]},{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"C2"]}}}]},{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"C2"]}}]}}
   "None"
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Inline_include"]}}}


### PR DESCRIPTION
A module's `doc` field was propagated through expansions by synthetizing a comment at the top of the expanded signature. It's now propagated via the `doc` field of the signature.

In the case where the module has a comment and the signature has a top-comment, the module's comment is not propagated.

This fixes doc appearing multiple time when the signature is expanded mutliple time (eg. due to an include-module-type-of) and doc appearing when they shouldn't (eg. in a non-inline include).
This also moves the preambles into the right section in the generated HTML.
