### PR TITLE
Parsing of path-references to pages and modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 - OCaml 5.2.0 compatibility (@Octachron, #1094, #1112)
 - New driver package (@jonludlam, #1121)
 - Fix a big gap between the preamble and the content of a page (@EmileTrotignon, #1147)
-- Path-references to hierarchical pages and modules (@Julow, #1151)
+- Path-references to hierarchical pages and modules (@Julow, #1142, #1151)
   Absolute (`{!/foo}`), relative (`{!./foo}`) and package-local (`{!//foo}`)
   are added.
 - Add a marshalled search index consumable by sherlodoc (@EmileTrotignon, @panglesd, #1084)

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -61,7 +61,7 @@ module Reference = struct
         render_resolved (r :> t) ^ "." ^ InstanceVariableName.to_string s
     | `Label (_, s) -> LabelName.to_string s
 
-  let render_page_path (tag, cs) =
+  let render_path (tag, cs) =
     let tag =
       match tag with
       | `TRelativePath -> "./"
@@ -76,7 +76,9 @@ module Reference = struct
     | `Resolved r -> render_resolved r
     | `Root (n, _) -> n
     | `Dot (p, f) -> render_unresolved (p :> t) ^ "." ^ f
-    | `Page_path p -> render_page_path p
+    | `Page_path p -> render_path p
+    | `Module_path p -> render_path p
+    | `Any_path p -> render_path p
     | `Module (p, f) ->
         render_unresolved (p :> t) ^ "." ^ ModuleName.to_string f
     | `ModuleType (p, f) ->

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -61,12 +61,19 @@ module Reference = struct
         render_resolved (r :> t) ^ "." ^ InstanceVariableName.to_string s
     | `Label (_, s) -> LabelName.to_string s
 
+  let rec render_page_path = function
+    | `Root (s, `TRelativePath) -> "./" ^ s
+    | `Root (s, `TAbsolutePath) -> "/" ^ s
+    | `Root (s, `TCurrentPackage) -> "//" ^ s
+    | `Slash (p, s) -> render_page_path p ^ "/" ^ s
+
   let rec render_unresolved : Reference.t -> string =
     let open Reference in
     function
     | `Resolved r -> render_resolved r
     | `Root (n, _) -> n
     | `Dot (p, f) -> render_unresolved (p :> t) ^ "." ^ f
+    | `Page_path p -> render_page_path p
     | `Module (p, f) ->
         render_unresolved (p :> t) ^ "." ^ ModuleName.to_string f
     | `ModuleType (p, f) ->

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -61,11 +61,14 @@ module Reference = struct
         render_resolved (r :> t) ^ "." ^ InstanceVariableName.to_string s
     | `Label (_, s) -> LabelName.to_string s
 
-  let rec render_page_path = function
-    | `Root (s, `TRelativePath) -> "./" ^ s
-    | `Root (s, `TAbsolutePath) -> "/" ^ s
-    | `Root (s, `TCurrentPackage) -> "//" ^ s
-    | `Slash (p, s) -> render_page_path p ^ "/" ^ s
+  let render_page_path (tag, cs) =
+    let tag =
+      match tag with
+      | `TRelativePath -> "./"
+      | `TAbsolutePath -> "/"
+      | `TCurrentPackage -> "//"
+    in
+    tag ^ String.concat "/" cs
 
   let rec render_unresolved : Reference.t -> string =
     let open Reference in

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -1092,7 +1092,7 @@ module Reference = struct
   type t = Paths_types.Reference.any
 
   type tag_any = Paths_types.Reference.tag_any
-  type tag_path = Paths_types.Reference.tag_path
+  type tag_hierarchy = Paths_types.Reference.tag_hierarchy
 
   module Signature = struct
     type t = Paths_types.Reference.signature
@@ -1174,7 +1174,7 @@ module Reference = struct
     type t = Paths_types.Reference.page
   end
 
-  module Path = struct
-    type t = Paths_types.Reference.path
+  module Hierarchy = struct
+    type t = Paths_types.Reference.hierarchy
   end
 end

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -1092,6 +1092,7 @@ module Reference = struct
   type t = Paths_types.Reference.any
 
   type tag_any = Paths_types.Reference.tag_any
+  type tag_page_path = Paths_types.Reference.tag_page_path
 
   module Signature = struct
     type t = Paths_types.Reference.signature
@@ -1171,5 +1172,9 @@ module Reference = struct
 
   module Page = struct
     type t = Paths_types.Reference.page
+  end
+
+  module PagePath = struct
+    type t = Paths_types.Reference.page_path
   end
 end

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -1092,7 +1092,7 @@ module Reference = struct
   type t = Paths_types.Reference.any
 
   type tag_any = Paths_types.Reference.tag_any
-  type tag_page_path = Paths_types.Reference.tag_page_path
+  type tag_path = Paths_types.Reference.tag_path
 
   module Signature = struct
     type t = Paths_types.Reference.signature
@@ -1174,7 +1174,7 @@ module Reference = struct
     type t = Paths_types.Reference.page
   end
 
-  module PagePath = struct
-    type t = Paths_types.Reference.page_path
+  module Path = struct
+    type t = Paths_types.Reference.path
   end
 end

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -637,12 +637,12 @@ module rec Reference : sig
     type t = Paths_types.Reference.page
   end
 
-  module Path : sig
-    type t = Paths_types.Reference.path
+  module Hierarchy : sig
+    type t = Paths_types.Reference.hierarchy
   end
 
   type t = Paths_types.Reference.any
 
   type tag_any = Paths_types.Reference.tag_any
-  type tag_path = Paths_types.Reference.tag_path
+  type tag_hierarchy = Paths_types.Reference.tag_hierarchy
 end

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -637,12 +637,12 @@ module rec Reference : sig
     type t = Paths_types.Reference.page
   end
 
-  module PagePath : sig
-    type t = Paths_types.Reference.page_path
+  module Path : sig
+    type t = Paths_types.Reference.path
   end
 
   type t = Paths_types.Reference.any
 
   type tag_any = Paths_types.Reference.tag_any
-  type tag_page_path = Paths_types.Reference.tag_page_path
+  type tag_path = Paths_types.Reference.tag_path
 end

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -637,7 +637,12 @@ module rec Reference : sig
     type t = Paths_types.Reference.page
   end
 
+  module PagePath : sig
+    type t = Paths_types.Reference.page_path
+  end
+
   type t = Paths_types.Reference.any
 
   type tag_any = Paths_types.Reference.tag_any
+  type tag_page_path = Paths_types.Reference.tag_page_path
 end

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -553,6 +553,11 @@ module rec Reference : sig
 
   type tag_only_child_module = [ `TChildModule ]
 
+  type tag_page_path =
+    [ `TRelativePath (* {!identifier/} *)
+    | `TAbsolutePath (* {!/identifier} *)
+    | `TCurrentPackage (* {!//identifier} *) ]
+
   type tag_any =
     [ `TModule
     | `TModuleType
@@ -592,10 +597,16 @@ module rec Reference : sig
     | `TChildPage
     | `TChildModule ]
 
+  type page_path =
+    [ `Root of string * tag_page_path
+    | `Slash of page_path * string (* {!page_path/identifier} *) ]
+  (** @canonical Odoc_model.Paths.Reference.PagePath.t *)
+
   type signature =
     [ `Resolved of Resolved_reference.signature
     | `Root of string * tag_signature
     | `Dot of label_parent * string
+    | `Page_path of page_path
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t ]
   (** @canonical Odoc_model.Paths.Reference.Signature.t *)
@@ -629,6 +640,7 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.label_parent
     | `Root of string * tag_label_parent
     | `Dot of label_parent * string
+    | `Page_path of page_path
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Class of signature * ClassName.t
@@ -743,13 +755,15 @@ module rec Reference : sig
   type page =
     [ `Resolved of Resolved_reference.page
     | `Root of string * [ `TPage | `TUnknown ]
-    | `Dot of label_parent * string ]
+    | `Dot of label_parent * string
+    | `Page_path of page_path ]
   (** @canonical Odoc_model.Paths.Reference.Page.t *)
 
   type any =
     [ `Resolved of Resolved_reference.any
     | `Root of string * tag_any
     | `Dot of label_parent * string
+    | `Page_path of page_path
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -553,7 +553,7 @@ module rec Reference : sig
 
   type tag_only_child_module = [ `TChildModule ]
 
-  type tag_path =
+  type tag_hierarchy =
     [ `TRelativePath (* {!identifier/} *)
     | `TAbsolutePath (* {!/identifier} *)
     | `TCurrentPackage (* {!//identifier} *) ]
@@ -597,14 +597,14 @@ module rec Reference : sig
     | `TChildPage
     | `TChildModule ]
 
-  type path = tag_path * string list
-  (** @canonical Odoc_model.Paths.Reference.Path.t *)
+  type hierarchy = tag_hierarchy * string list
+  (** @canonical Odoc_model.Paths.Reference.Hierarchy.t *)
 
   type signature =
     [ `Resolved of Resolved_reference.signature
     | `Root of string * tag_signature
     | `Dot of label_parent * string
-    | `Module_path of path
+    | `Module_path of hierarchy
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t ]
   (** @canonical Odoc_model.Paths.Reference.Signature.t *)
@@ -629,7 +629,7 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.field_parent
     | `Root of string * tag_parent
     | `Dot of label_parent * string
-    | `Module_path of path
+    | `Module_path of hierarchy
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t ]
@@ -639,9 +639,9 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.label_parent
     | `Root of string * tag_label_parent
     | `Dot of label_parent * string
-    | `Page_path of path
-    | `Module_path of path
-    | `Any_path of path
+    | `Page_path of hierarchy
+    | `Module_path of hierarchy
+    | `Any_path of hierarchy
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Class of signature * ClassName.t
@@ -653,7 +653,7 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.module_
     | `Root of string * [ `TModule | `TUnknown ]
     | `Dot of label_parent * string
-    | `Module_path of path
+    | `Module_path of hierarchy
     | `Module of signature * ModuleName.t ]
   (** @canonical Odoc_model.Paths.Reference.Module.t *)
 
@@ -758,16 +758,16 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.page
     | `Root of string * [ `TPage | `TUnknown ]
     | `Dot of label_parent * string
-    | `Page_path of path ]
+    | `Page_path of hierarchy ]
   (** @canonical Odoc_model.Paths.Reference.Page.t *)
 
   type any =
     [ `Resolved of Resolved_reference.any
     | `Root of string * tag_any
     | `Dot of label_parent * string
-    | `Page_path of path
-    | `Module_path of path
-    | `Any_path of path
+    | `Page_path of hierarchy
+    | `Module_path of hierarchy
+    | `Any_path of hierarchy
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -597,9 +597,7 @@ module rec Reference : sig
     | `TChildPage
     | `TChildModule ]
 
-  type page_path =
-    [ `Root of string * tag_page_path
-    | `Slash of page_path * string (* {!page_path/identifier} *) ]
+  type page_path = tag_page_path * string list
   (** @canonical Odoc_model.Paths.Reference.PagePath.t *)
 
   type signature =

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -553,7 +553,7 @@ module rec Reference : sig
 
   type tag_only_child_module = [ `TChildModule ]
 
-  type tag_page_path =
+  type tag_path =
     [ `TRelativePath (* {!identifier/} *)
     | `TAbsolutePath (* {!/identifier} *)
     | `TCurrentPackage (* {!//identifier} *) ]
@@ -597,14 +597,14 @@ module rec Reference : sig
     | `TChildPage
     | `TChildModule ]
 
-  type page_path = tag_page_path * string list
-  (** @canonical Odoc_model.Paths.Reference.PagePath.t *)
+  type path = tag_path * string list
+  (** @canonical Odoc_model.Paths.Reference.Path.t *)
 
   type signature =
     [ `Resolved of Resolved_reference.signature
     | `Root of string * tag_signature
     | `Dot of label_parent * string
-    | `Page_path of page_path
+    | `Module_path of path
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t ]
   (** @canonical Odoc_model.Paths.Reference.Signature.t *)
@@ -629,6 +629,7 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.field_parent
     | `Root of string * tag_parent
     | `Dot of label_parent * string
+    | `Module_path of path
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t ]
@@ -638,7 +639,9 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.label_parent
     | `Root of string * tag_label_parent
     | `Dot of label_parent * string
-    | `Page_path of page_path
+    | `Page_path of path
+    | `Module_path of path
+    | `Any_path of path
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Class of signature * ClassName.t
@@ -650,6 +653,7 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.module_
     | `Root of string * [ `TModule | `TUnknown ]
     | `Dot of label_parent * string
+    | `Module_path of path
     | `Module of signature * ModuleName.t ]
   (** @canonical Odoc_model.Paths.Reference.Module.t *)
 
@@ -754,14 +758,16 @@ module rec Reference : sig
     [ `Resolved of Resolved_reference.page
     | `Root of string * [ `TPage | `TUnknown ]
     | `Dot of label_parent * string
-    | `Page_path of page_path ]
+    | `Page_path of path ]
   (** @canonical Odoc_model.Paths.Reference.Page.t *)
 
   type any =
     [ `Resolved of Resolved_reference.any
     | `Root of string * tag_any
     | `Dot of label_parent * string
-    | `Page_path of page_path
+    | `Page_path of path
+    | `Module_path of path
+    | `Any_path of path
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -554,9 +554,10 @@ module rec Reference : sig
   type tag_only_child_module = [ `TChildModule ]
 
   type tag_hierarchy =
-    [ `TRelativePath (* {!identifier/} *)
-    | `TAbsolutePath (* {!/identifier} *)
-    | `TCurrentPackage (* {!//identifier} *) ]
+    [ `TRelativePath  (** {!identifier/} *)
+    | `TAbsolutePath  (** {!/identifier} *)
+    | `TCurrentPackage  (** {!//identifier} *) ]
+  (** @canonical Odoc_model.Paths.Reference.tag_hierarchy *)
 
   type tag_any =
     [ `TModule
@@ -577,6 +578,7 @@ module rec Reference : sig
     | `TChildPage
     | `TChildModule
     | `TUnknown ]
+  (** @canonical Odoc_model.Paths.Reference.tag_any *)
 
   type tag_signature = [ `TUnknown | `TModule | `TModuleType ]
 

--- a/src/model/reference.ml
+++ b/src/model/reference.ml
@@ -233,7 +233,7 @@ let parse whole_reference_location s :
     Paths.Reference.t Error.with_errors_and_warnings =
   let open Paths.Reference in
   let open Names in
-  let rec path components next_token tokens : Path.t =
+  let rec path components next_token tokens : Hierarchy.t =
     match (next_token.kind, tokens) with
     | `End_in_slash, [] when next_token.identifier = "" ->
         (* {!/identifier} *)

--- a/src/model/reference.ml
+++ b/src/model/reference.ml
@@ -292,8 +292,7 @@ let parse whole_reference_location s :
         | `TModuleType ->
             `ModuleType
               (signature next_token tokens, ModuleTypeName.make_std identifier)
-        | `TPathComponent ->
-            `Module_path (path [ identifier ] next_token tokens)
+        | `TPathComponent -> assert false
         | _ ->
             expected ~expect_paths:true [ "module"; "module-type" ] location
             |> Error.raise_exception)
@@ -396,7 +395,7 @@ let parse whole_reference_location s :
         | `TClassType ->
             `ClassType
               (signature next_token tokens, ClassTypeName.make_std identifier)
-        | `TPathComponent -> `Page_path (path [ identifier ] next_token tokens)
+        | `TPathComponent -> assert false
         | _ ->
             expected ~expect_paths:true
               [ "module"; "module-type"; "type"; "class"; "class-type" ]
@@ -500,7 +499,7 @@ let parse whole_reference_location s :
             in
             (* Prefixed pages are not differentiated. *)
             `Page_path (path [ identifier ] next_token tokens)
-        | `TPathComponent -> `Page_path (path [ identifier ] next_token tokens))
+        | `TPathComponent -> assert false)
   in
 
   let old_kind, s, location =

--- a/src/model/reference.ml
+++ b/src/model/reference.ml
@@ -457,13 +457,20 @@ let parse whole_reference_location s :
               location
             |> Error.raise_exception
         | `TPage ->
-            let suggestion =
-              Printf.sprintf "'page-%s' should be first." identifier
+            let () =
+              match next_token.kind with
+              | `End_in_slash -> ()
+              | `None | `Prefixed _ ->
+                  let suggestion =
+                    Printf.sprintf "Reference pages as '<parent_path>/%s'."
+                      identifier
+                  in
+                  not_allowed ~what:"Page label"
+                    ~in_what:"on the right side of a dot" ~suggestion location
+                  |> Error.raise_exception
             in
-            not_allowed ~what:"Page label"
-              ~in_what:"the last component of a reference path" ~suggestion
-              location
-            |> Error.raise_exception
+            (* Prefixed pages are not differentiated. *)
+            `Page_path (page_path identifier next_token tokens)
         | `TRelativePath -> `Page_path (page_path identifier next_token tokens))
   in
 

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -283,7 +283,7 @@ module General_paths = struct
       | `SubstitutedT c -> C ("`SubstitutedT", (c :> rp), resolved_path)
       | `SubstitutedCT c -> C ("`SubstitutedCT", (c :> rp), resolved_path))
 
-  and page_path_reference : Paths.Reference.PagePath.t t =
+  and path_reference : Paths.Reference.Path.t t =
     let tag_page_path =
       Variant
         (function
@@ -299,7 +299,9 @@ module General_paths = struct
       | `Resolved x -> C ("`Resolved", x, resolved_reference)
       | `Root (x1, x2) -> C ("`Root", (x1, x2), Pair (string, reference_tag))
       | `Dot (x1, x2) -> C ("`Dot", ((x1 :> r), x2), Pair (reference, string))
-      | `Page_path x -> C ("`Page_path", x, page_path_reference)
+      | `Page_path x -> C ("`Page_path", x, path_reference)
+      | `Module_path x -> C ("`Module_path", x, path_reference)
+      | `Any_path x -> C ("`Any_path", x, path_reference)
       | `Module (x1, x2) ->
           C ("`Module", ((x1 :> r), x2), Pair (reference, Names.modulename))
       | `ModuleType (x1, x2) ->

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -283,7 +283,7 @@ module General_paths = struct
       | `SubstitutedT c -> C ("`SubstitutedT", (c :> rp), resolved_path)
       | `SubstitutedCT c -> C ("`SubstitutedCT", (c :> rp), resolved_path))
 
-  and path_reference : Paths.Reference.Path.t t =
+  and hierarchy_reference : Paths.Reference.Hierarchy.t t =
     let tag_page_path =
       Variant
         (function
@@ -299,9 +299,9 @@ module General_paths = struct
       | `Resolved x -> C ("`Resolved", x, resolved_reference)
       | `Root (x1, x2) -> C ("`Root", (x1, x2), Pair (string, reference_tag))
       | `Dot (x1, x2) -> C ("`Dot", ((x1 :> r), x2), Pair (reference, string))
-      | `Page_path x -> C ("`Page_path", x, path_reference)
-      | `Module_path x -> C ("`Module_path", x, path_reference)
-      | `Any_path x -> C ("`Any_path", x, path_reference)
+      | `Page_path x -> C ("`Page_path", x, hierarchy_reference)
+      | `Module_path x -> C ("`Module_path", x, hierarchy_reference)
+      | `Any_path x -> C ("`Any_path", x, hierarchy_reference)
       | `Module (x1, x2) ->
           C ("`Module", ((x1 :> r), x2), Pair (reference, Names.modulename))
       | `ModuleType (x1, x2) ->

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -291,12 +291,7 @@ module General_paths = struct
         | `TAbsolutePath -> C0 "`TAbsolutePath"
         | `TCurrentPackage -> C0 "`TCurrentPackage")
     in
-    Variant
-      (function
-      | `Root (identifier, kind) ->
-          C ("`Root", (identifier, kind), Pair (string, tag_page_path))
-      | `Slash (parent, identifier) ->
-          C ("`Slash", (parent, identifier), Pair (page_path_reference, string)))
+    Pair (tag_page_path, List string)
 
   and reference : r t =
     Variant

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -283,12 +283,28 @@ module General_paths = struct
       | `SubstitutedT c -> C ("`SubstitutedT", (c :> rp), resolved_path)
       | `SubstitutedCT c -> C ("`SubstitutedCT", (c :> rp), resolved_path))
 
+  and page_path_reference : Paths.Reference.PagePath.t t =
+    let tag_page_path =
+      Variant
+        (function
+        | `TRelativePath -> C0 "`TRelativePath"
+        | `TAbsolutePath -> C0 "`TAbsolutePath"
+        | `TCurrentPackage -> C0 "`TCurrentPackage")
+    in
+    Variant
+      (function
+      | `Root (identifier, kind) ->
+          C ("`Root", (identifier, kind), Pair (string, tag_page_path))
+      | `Slash (parent, identifier) ->
+          C ("`Slash", (parent, identifier), Pair (page_path_reference, string)))
+
   and reference : r t =
     Variant
       (function
       | `Resolved x -> C ("`Resolved", x, resolved_reference)
       | `Root (x1, x2) -> C ("`Root", (x1, x2), Pair (string, reference_tag))
       | `Dot (x1, x2) -> C ("`Dot", ((x1 :> r), x2), Pair (reference, string))
+      | `Page_path x -> C ("`Page_path", x, page_path_reference)
       | `Module (x1, x2) ->
           C ("`Module", ((x1 :> r), x2), Pair (reference, Names.modulename))
       | `ModuleType (x1, x2) ->

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -1660,8 +1660,7 @@ module Fmt = struct
           (parent :> t)
           (LabelName.to_string name)
 
-  and model_reference_page_path _c ppf
-      ((tag, components) : Reference.PagePath.t) =
+  and model_reference_path _c ppf ((tag, components) : Reference.Path.t) =
     (match tag with
     | `TRelativePath -> fpf ppf "./"
     | `TAbsolutePath -> fpf ppf "/"
@@ -1676,7 +1675,9 @@ module Fmt = struct
     | `Root (name, _) -> Format.fprintf ppf "unresolvedroot(%s)" name
     | `Dot (parent, str) ->
         Format.fprintf ppf "%a.%s" (model_reference c) (parent :> t) str
-    | `Page_path p -> model_reference_page_path c ppf p
+    | `Page_path p -> model_reference_path c ppf p
+    | `Module_path p -> model_reference_path c ppf p
+    | `Any_path p -> model_reference_path c ppf p
     | `Module (parent, name) ->
         Format.fprintf ppf "%a.%s" (model_reference c)
           (parent :> t)

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -1660,7 +1660,8 @@ module Fmt = struct
           (parent :> t)
           (LabelName.to_string name)
 
-  and model_reference_path _c ppf ((tag, components) : Reference.Path.t) =
+  and model_reference_hierarchy _c ppf
+      ((tag, components) : Reference.Hierarchy.t) =
     (match tag with
     | `TRelativePath -> fpf ppf "./"
     | `TAbsolutePath -> fpf ppf "/"
@@ -1675,9 +1676,9 @@ module Fmt = struct
     | `Root (name, _) -> Format.fprintf ppf "unresolvedroot(%s)" name
     | `Dot (parent, str) ->
         Format.fprintf ppf "%a.%s" (model_reference c) (parent :> t) str
-    | `Page_path p -> model_reference_path c ppf p
-    | `Module_path p -> model_reference_path c ppf p
-    | `Any_path p -> model_reference_path c ppf p
+    | `Page_path p -> model_reference_hierarchy c ppf p
+    | `Module_path p -> model_reference_hierarchy c ppf p
+    | `Any_path p -> model_reference_hierarchy c ppf p
     | `Module (parent, name) ->
         Format.fprintf ppf "%a.%s" (model_reference c)
           (parent :> t)

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -585,6 +585,7 @@ module Fmt = struct
   type path = Odoc_model.Paths.Path.t
   type rpath = Odoc_model.Paths.Path.Resolved.t
   open Odoc_model.Names
+  open Odoc_model.Paths
 
   let fpf = Format.fprintf
 
@@ -1659,13 +1660,22 @@ module Fmt = struct
           (parent :> t)
           (LabelName.to_string name)
 
-  and model_reference c ppf (r : Odoc_model.Paths.Reference.t) =
-    let open Odoc_model.Paths.Reference in
+  and model_reference_page_path c ppf (r : Reference.PagePath.t) =
+    match r with
+    | `Root (name, `TRelativePath) -> fpf ppf "./%s" name
+    | `Root (name, `TAbsolutePath) -> fpf ppf "/%s" name
+    | `Root (name, `TCurrentPackage) -> fpf ppf "//%s" name
+    | `Slash (parent, name) ->
+        fpf ppf "%a/%s" (model_reference_page_path c) parent name
+
+  and model_reference c ppf (r : Reference.t) =
+    let open Reference in
     match r with
     | `Resolved r' -> Format.fprintf ppf "r(%a)" (model_resolved_reference c) r'
     | `Root (name, _) -> Format.fprintf ppf "unresolvedroot(%s)" name
     | `Dot (parent, str) ->
         Format.fprintf ppf "%a.%s" (model_reference c) (parent :> t) str
+    | `Page_path p -> model_reference_page_path c ppf p
     | `Module (parent, name) ->
         Format.fprintf ppf "%a.%s" (model_reference c)
           (parent :> t)

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -1660,13 +1660,14 @@ module Fmt = struct
           (parent :> t)
           (LabelName.to_string name)
 
-  and model_reference_page_path c ppf (r : Reference.PagePath.t) =
-    match r with
-    | `Root (name, `TRelativePath) -> fpf ppf "./%s" name
-    | `Root (name, `TAbsolutePath) -> fpf ppf "/%s" name
-    | `Root (name, `TCurrentPackage) -> fpf ppf "//%s" name
-    | `Slash (parent, name) ->
-        fpf ppf "%a/%s" (model_reference_page_path c) parent name
+  and model_reference_page_path _c ppf
+      ((tag, components) : Reference.PagePath.t) =
+    (match tag with
+    | `TRelativePath -> fpf ppf "./"
+    | `TAbsolutePath -> fpf ppf "/"
+    | `TCurrentPackage -> fpf ppf "//");
+    let pp_sep ppf () = fpf ppf "/" in
+    Format.pp_print_list ~pp_sep Format.pp_print_string ppf components
 
   and model_reference c ppf (r : Reference.t) =
     let open Reference in

--- a/src/xref2/errors.ml
+++ b/src/xref2/errors.ml
@@ -9,7 +9,8 @@ module Tools_error = struct
       [ `Module of Cpath.module_ ]
       (* Failed to resolve a module path when applying a fragment item *) ]
 
-  type reference_kind = [ `S | `T | `C | `CT | `Page | `Cons | `Field | `Label ]
+  type reference_kind =
+    [ `S | `T | `C | `CT | `Page | `Cons | `Field | `Label | `Page_path ]
 
   type expansion_of_module_error =
     [ `OpaqueModule (* The module does not have an expansion *)
@@ -125,6 +126,7 @@ module Tools_error = struct
       | `Cons -> "constructor"
       | `Field -> "field"
       | `Label -> "label"
+      | `Page_path -> "page path"
     in
     Format.pp_print_string fmt k
 

--- a/src/xref2/errors.ml
+++ b/src/xref2/errors.ml
@@ -10,7 +10,17 @@ module Tools_error = struct
       (* Failed to resolve a module path when applying a fragment item *) ]
 
   type reference_kind =
-    [ `S | `T | `C | `CT | `Page | `Cons | `Field | `Label | `Page_path ]
+    [ `S
+    | `T
+    | `C
+    | `CT
+    | `Page
+    | `Cons
+    | `Field
+    | `Label
+    | `Page_path
+    | `Module_path
+    | `Any_path ]
 
   type expansion_of_module_error =
     [ `OpaqueModule (* The module does not have an expansion *)
@@ -126,7 +136,9 @@ module Tools_error = struct
       | `Cons -> "constructor"
       | `Field -> "field"
       | `Label -> "label"
-      | `Page_path -> "page path"
+      | `Page_path -> "path to a page"
+      | `Module_path -> "path to a module"
+      | `Any_path -> "path"
     in
     Format.pp_print_string fmt k
 

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -25,10 +25,11 @@ type type_lookup_result =
   | `C of class_lookup_result
   | `CT of class_type_lookup_result ]
 
+type page_path_lookup_result =
+  [ `S of signature_lookup_result | `P of page_lookup_result ]
+
 type label_parent_lookup_result =
-  [ `S of signature_lookup_result
-  | type_lookup_result
-  | `P of page_lookup_result ]
+  [ type_lookup_result | page_path_lookup_result ]
 
 type fragment_type_parent_lookup_result =
   [ `S of signature_lookup_result | `T of datatype_lookup_result ]
@@ -162,6 +163,10 @@ let module_type_lookup_to_signature_lookup env (ref, cp, m) =
   >>= Tools.assert_not_functor
   >>= fun sg -> Ok ((ref :> Resolved.Signature.t), `ModuleType cp, sg)
 
+let page_path_lookup_to_signature_lookup = function
+  | `S r -> Ok r
+  | `P _ as r -> wrong_kind_error [ `S ] r
+
 let type_lookup_to_class_signature_lookup =
   let resolved p' cs = Ok ((p' :> Resolved.ClassSignature.t), cs) in
   fun env -> function
@@ -174,6 +179,14 @@ let type_lookup_to_class_signature_lookup =
         Tools.class_signature_of_class_type env ct
         |> of_option ~error:(`Parent (`Parent_type `OpaqueClass))
         >>= resolved p'
+
+module Page_path = struct
+  type t = page_path_lookup_result
+
+  let in_env _env _page_path : t ref_result =
+    (* Not implemented *)
+    Error (`Wrong_kind ([ `S; `Page ], `Page_path))
+end
 
 module M = struct
   (** Module *)
@@ -635,7 +648,7 @@ module LP = struct
         Ok (`CT ct)
 end
 
-let rec resolve_label_parent_reference env r =
+let rec resolve_label_parent_reference env (r : LabelParent.t) =
   let label_parent_res_of_type_res : type_lookup_result -> _ =
    fun r -> Ok (r :> label_parent_lookup_result)
   in
@@ -670,6 +683,9 @@ let rec resolve_label_parent_reference env r =
   | `Root (name, `TChildModule) ->
       resolve_signature_reference env (`Root (name, `TModule)) >>= fun s ->
       Ok (`S s)
+  | `Page_path page_path ->
+      Page_path.in_env env page_path >>= fun r ->
+      Ok (r :> label_parent_lookup_result)
 
 and resolve_fragment_type_parent_reference (env : Env.t)
     (r : FragmentTypeParent.t) : (fragment_type_parent_lookup_result, _) result
@@ -735,6 +751,8 @@ and resolve_signature_reference :
               (MT.of_component env mt
                  (`ModuleType (parent_cp, name))
                  (`ModuleType (parent, name))))
+    | `Page_path page_path ->
+        Page_path.in_env env page_path >>= page_path_lookup_to_signature_lookup
   in
   resolve env'
 
@@ -772,6 +790,10 @@ let resolved_type_lookup = function
   | `T (r, _) -> resolved1 r
   | `C (r, _) -> resolved1 r
   | `CT (r, _) -> resolved1 r
+
+let resolved_page_path_lookup = function
+  | `S (r, _, _) -> resolved1 r
+  | `P (r, _) -> resolved1 r
 
 let resolve_reference_dot_sg env ~parent_path ~parent_ref ~parent_sg name =
   let parent_path = Tools.reresolve_parent env parent_path in
@@ -829,7 +851,7 @@ let resolve_reference_dot env parent name =
   | `P _ as page -> resolve_reference_dot_page env page name
 
 (** Warnings may be generated with [Error.implicit_warning] *)
-let resolve_reference =
+let resolve_reference : _ -> Reference.t -> _ =
   let resolved = resolved3 in
   fun env r ->
     match r with
@@ -916,6 +938,8 @@ let resolve_reference =
     | `InstanceVariable (parent, name) ->
         resolve_class_signature_reference env parent >>= fun p ->
         MV.in_class_signature env p name >>= resolved1
+    | `Page_path page_path ->
+        Page_path.in_env env page_path >>= resolved_page_path_lookup
 
 let resolve_module_reference env m =
   Odoc_model.Error.catch_warnings (fun () -> resolve_module_reference env m)

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -2353,7 +2353,7 @@ let%expect_test _ =
       test "{!foo.page-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nPage label is not allowed in the last component of a reference path.\nSuggestion: 'page-bar' should be first."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nPage label is not allowed in on the right side of a dot.\nSuggestion: Reference pages as '<parent_path>/bar'."]} |}]
 
     let inner_parent_something_in_something =
       test "{!foo.bar.field-baz}";
@@ -2806,7 +2806,7 @@ let%expect_test _ =
     let relative_tag_after_slash =
       test "{!foo/page-bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Code_span":"foo/page-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nPage label is not allowed in the last component of a reference path.\nSuggestion: 'page-bar' should be first."]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"bar"]}},[]]}]}],"warnings":[]} |}]
 
     let relative_tag_after_slash =
       test "{!foo/module-Bar}";
@@ -2839,6 +2839,11 @@ let%expect_test _ =
       test "{!./}";
       [%expect
         {| {"value":[{"`Paragraph":[{"`Code_span":"./"}]}],"warnings":["File \"f.ml\", line 1, characters 4-4:\nIdentifier in reference should not be empty."]} |}]
+
+    let err_page_prefix_after_dot =
+      test "{!foo.page-bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nPage label is not allowed in on the right side of a dot.\nSuggestion: Reference pages as '<parent_path>/bar'."]} |}]
 
     (* Old kind compatibility *)
 

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -2700,118 +2700,118 @@ let%expect_test _ =
     let abs =
       test "{!/foo/bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TAbsolutePath"]},"bar"]}},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TAbsolutePath",["foo","bar"]]},[]]}]}],"warnings":[]} |}]
 
     let abs_label_parent_page =
       test "{!/foo/bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TAbsolutePath"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TAbsolutePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let abs_label_parent_module =
       test "{!/foo/Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TAbsolutePath"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TAbsolutePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     (* References to current package root *)
 
     let root_to_page =
       test "{!//foo/bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"bar"]}},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TCurrentPackage",["foo","bar"]]},[]]}]}],"warnings":[]} |}]
 
     let root_to_module =
       test "{!//foo/Bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"Bar"]}},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TCurrentPackage",["foo","Bar"]]},[]]}]}],"warnings":[]} |}]
 
     let root_label_parent_page =
       test "{!//foo/bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TCurrentPackage",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let root_label_parent_module =
       test "{!//foo/Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TCurrentPackage",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     (* Relative paths *)
 
     let relative =
       test "{!foo/bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"bar"]}},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["foo","bar"]]},[]]}]}],"warnings":[]} |}]
 
     let relative =
       test "{!foo/bar/baz}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["foo","`TRelativePath"]},"bar"]},"baz"]}},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["foo","bar","baz"]]},[]]}]}],"warnings":[]} |}]
 
     let relative_module =
       test "{!foo/Bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"Bar"]}},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["foo","Bar"]]},[]]}]}],"warnings":[]} |}]
 
     let relative_label_parent_page =
       test "{!foo/bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TRelativePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let relative_label_parent_module =
       test "{!foo/Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TRelativePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let dot_relative =
       test "{!./bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Root":["bar","`TRelativePath"]}},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["bar"]]},[]]}]}],"warnings":[]} |}]
 
     let dot_relative_module =
       test "{!./Bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Root":["Bar","`TRelativePath"]}},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["Bar"]]},[]]}]}],"warnings":[]} |}]
 
     let dot_relative_label_parent_page =
       test "{!./bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Root":["bar","`TRelativePath"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TRelativePath",["bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let dot_relative_label_parent_module =
       test "{!./Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Root":["Bar","`TRelativePath"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TRelativePath",["Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     (* Prefix *)
 
     let abs_label_parent_page_prefix =
       test "{!/foo/bar.section-label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TAbsolutePath"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TAbsolutePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let abs_label_parent_module_prefix =
       test "{!/foo/Bar.section-label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TAbsolutePath"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TAbsolutePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let root_label_parent_page_prefix =
       test "{!//foo/bar.section-label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TCurrentPackage",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let root_label_parent_module_prefix =
       test "{!//foo/Bar.section-label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TCurrentPackage",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let relative_tag_after_slash =
       test "{!foo/page-bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"bar"]}},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["foo","bar"]]},[]]}]}],"warnings":[]} |}]
 
     let relative_tag_after_slash =
       test "{!foo/module-Bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Module":[{"`Page_path":{"`Root":["foo","`TRelativePath"]}},"Bar"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Module":[{"`Page_path":["`TRelativePath",["foo"]]},"Bar"]},[]]}]}],"warnings":[]} |}]
 
     (* Errors *)
 
@@ -2850,31 +2850,31 @@ let%expect_test _ =
     let oldkind_abs_page =
       test "{!section:/foo.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Root":["foo","`TAbsolutePath"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TAbsolutePath",["foo"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let oldkind_abs_module =
       test "{!section:/Foo.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Root":["Foo","`TAbsolutePath"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TAbsolutePath",["Foo"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let oldkind_relative_page =
       test "{!section:foo/bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TRelativePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let oldkind_relative_module =
       test "{!section:foo/Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TRelativePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let oldkind_root_page =
       test "{!section://foo/bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TCurrentPackage",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let oldkind_root_module =
       test "{!section://foo/Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TCurrentPackage",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
   end in
   ()

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -2692,3 +2692,184 @@ let%expect_test _ =
         {"value":[{"`Paragraph":[{"`Code_span":"\"\"foo\""}]}],"warnings":["File \"f.ml\", line 1, characters 2-9:\nUnmatched quotation!"]} |}]
   end in
   ()
+
+let%expect_test _ =
+  let module Reference_path = struct
+    (* Absolute references *)
+
+    let abs =
+      test "{!/foo/bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TAbsolutePath"]},"bar"]}},[]]}]}],"warnings":[]} |}]
+
+    let abs_label_parent_page =
+      test "{!/foo/bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TAbsolutePath"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let abs_label_parent_module =
+      test "{!/foo/Bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TAbsolutePath"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    (* References to current package root *)
+
+    let root_to_page =
+      test "{!//foo/bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"bar"]}},[]]}]}],"warnings":[]} |}]
+
+    let root_to_module =
+      test "{!//foo/Bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"Bar"]}},[]]}]}],"warnings":[]} |}]
+
+    let root_label_parent_page =
+      test "{!//foo/bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let root_label_parent_module =
+      test "{!//foo/Bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    (* Relative paths *)
+
+    let relative =
+      test "{!foo/bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"bar"]}},[]]}]}],"warnings":[]} |}]
+
+    let relative =
+      test "{!foo/bar/baz}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["foo","`TRelativePath"]},"bar"]},"baz"]}},[]]}]}],"warnings":[]} |}]
+
+    let relative_module =
+      test "{!foo/Bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"Bar"]}},[]]}]}],"warnings":[]} |}]
+
+    let relative_label_parent_page =
+      test "{!foo/bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let relative_label_parent_module =
+      test "{!foo/Bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let dot_relative =
+      test "{!./bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Root":["bar","`TRelativePath"]}},[]]}]}],"warnings":[]} |}]
+
+    let dot_relative_module =
+      test "{!./Bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":{"`Root":["Bar","`TRelativePath"]}},[]]}]}],"warnings":[]} |}]
+
+    let dot_relative_label_parent_page =
+      test "{!./bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Root":["bar","`TRelativePath"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let dot_relative_label_parent_module =
+      test "{!./Bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":{"`Root":["Bar","`TRelativePath"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    (* Prefix *)
+
+    let abs_label_parent_page_prefix =
+      test "{!/foo/bar.section-label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TAbsolutePath"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let abs_label_parent_module_prefix =
+      test "{!/foo/Bar.section-label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TAbsolutePath"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let root_label_parent_page_prefix =
+      test "{!//foo/bar.section-label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let root_label_parent_module_prefix =
+      test "{!//foo/Bar.section-label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let relative_tag_after_slash =
+      test "{!foo/page-bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"foo/page-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nPage label is not allowed in the last component of a reference path.\nSuggestion: 'page-bar' should be first."]} |}]
+
+    let relative_tag_after_slash =
+      test "{!foo/module-Bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Module":[{"`Page_path":{"`Root":["foo","`TRelativePath"]}},"Bar"]},[]]}]}],"warnings":[]} |}]
+
+    (* Errors *)
+
+    let err_abs_only =
+      test "{!/}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"/"}]}],"warnings":["File \"f.ml\", line 1, characters 3-3:\nIdentifier in reference should not be empty."]} |}]
+
+    let err_relative_only =
+      test "{!foo/}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"foo/"}]}],"warnings":["File \"f.ml\", line 1, characters 6-6:\nIdentifier in reference should not be empty."]} |}]
+
+    let err_root_only =
+      test "{!//}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"//"}]}],"warnings":["File \"f.ml\", line 1, characters 4-4:\nIdentifier in reference should not be empty."]} |}]
+
+    let err_relative_empty =
+      test "{!foo/}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"foo/"}]}],"warnings":["File \"f.ml\", line 1, characters 6-6:\nIdentifier in reference should not be empty."]} |}]
+
+    let err_dot_relative_empty =
+      test "{!./}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"./"}]}],"warnings":["File \"f.ml\", line 1, characters 4-4:\nIdentifier in reference should not be empty."]} |}]
+
+    (* Old kind compatibility *)
+
+    let oldkind_abs_page =
+      test "{!section:/foo.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Root":["foo","`TAbsolutePath"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let oldkind_abs_module =
+      test "{!section:/Foo.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Root":["Foo","`TAbsolutePath"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let oldkind_relative_page =
+      test "{!section:foo/bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let oldkind_relative_module =
+      test "{!section:foo/Bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TRelativePath"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let oldkind_root_page =
+      test "{!section://foo/bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+
+    let oldkind_root_module =
+      test "{!section://foo/Bar.label}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":{"`Slash":[{"`Root":["foo","`TCurrentPackage"]},"Bar"]}},"label"]},[]]}]}],"warnings":[]} |}]
+  end in
+  ()

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -2700,108 +2700,108 @@ let%expect_test _ =
     let abs =
       test "{!/foo/bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TAbsolutePath",["foo","bar"]]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Any_path":["`TAbsolutePath",["foo","bar"]]},[]]}]}],"warnings":[]} |}]
 
     let abs_label_parent_page =
       test "{!/foo/bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TAbsolutePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Any_path":["`TAbsolutePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let abs_label_parent_module =
       test "{!/foo/Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TAbsolutePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Any_path":["`TAbsolutePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     (* References to current package root *)
 
     let root_to_page =
       test "{!//foo/bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TCurrentPackage",["foo","bar"]]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Any_path":["`TCurrentPackage",["foo","bar"]]},[]]}]}],"warnings":[]} |}]
 
     let root_to_module =
       test "{!//foo/Bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TCurrentPackage",["foo","Bar"]]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Any_path":["`TCurrentPackage",["foo","Bar"]]},[]]}]}],"warnings":[]} |}]
 
     let root_label_parent_page =
       test "{!//foo/bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TCurrentPackage",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Any_path":["`TCurrentPackage",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let root_label_parent_module =
       test "{!//foo/Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TCurrentPackage",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Any_path":["`TCurrentPackage",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     (* Relative paths *)
 
     let relative =
       test "{!foo/bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["foo","bar"]]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Any_path":["`TRelativePath",["foo","bar"]]},[]]}]}],"warnings":[]} |}]
 
     let relative =
       test "{!foo/bar/baz}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["foo","bar","baz"]]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Any_path":["`TRelativePath",["foo","bar","baz"]]},[]]}]}],"warnings":[]} |}]
 
     let relative_module =
       test "{!foo/Bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["foo","Bar"]]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Any_path":["`TRelativePath",["foo","Bar"]]},[]]}]}],"warnings":[]} |}]
 
     let relative_label_parent_page =
       test "{!foo/bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TRelativePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Any_path":["`TRelativePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let relative_label_parent_module =
       test "{!foo/Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TRelativePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Any_path":["`TRelativePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let dot_relative =
       test "{!./bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["bar"]]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Any_path":["`TRelativePath",["bar"]]},[]]}]}],"warnings":[]} |}]
 
     let dot_relative_module =
       test "{!./Bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Page_path":["`TRelativePath",["Bar"]]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Any_path":["`TRelativePath",["Bar"]]},[]]}]}],"warnings":[]} |}]
 
     let dot_relative_label_parent_page =
       test "{!./bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TRelativePath",["bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Any_path":["`TRelativePath",["bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let dot_relative_label_parent_module =
       test "{!./Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Page_path":["`TRelativePath",["Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Dot":[{"`Any_path":["`TRelativePath",["Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     (* Prefix *)
 
     let abs_label_parent_page_prefix =
       test "{!/foo/bar.section-label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TAbsolutePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Any_path":["`TAbsolutePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let abs_label_parent_module_prefix =
       test "{!/foo/Bar.section-label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TAbsolutePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Any_path":["`TAbsolutePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let root_label_parent_page_prefix =
       test "{!//foo/bar.section-label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TCurrentPackage",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Any_path":["`TCurrentPackage",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let root_label_parent_module_prefix =
       test "{!//foo/Bar.section-label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TCurrentPackage",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Any_path":["`TCurrentPackage",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let relative_tag_after_slash =
       test "{!foo/page-bar}";
@@ -2811,7 +2811,12 @@ let%expect_test _ =
     let relative_tag_after_slash =
       test "{!foo/module-Bar}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Module":[{"`Page_path":["`TRelativePath",["foo"]]},"Bar"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Module_path":["`TRelativePath",["foo","Bar"]]},[]]}]}],"warnings":[]} |}]
+
+    let relative_tag_after_slash_label_parent =
+      test "{!page_path/page-pagename.section-sectionname}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TRelativePath",["page_path","pagename"]]},"sectionname"]},[]]}]}],"warnings":[]} |}]
 
     (* Errors *)
 
@@ -2845,36 +2850,41 @@ let%expect_test _ =
       [%expect
         {| {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nPage label is not allowed in on the right side of a dot.\nSuggestion: Reference pages as '<parent_path>/bar'."]} |}]
 
+    let err_unsupported_kind =
+      test "{!foo/type-bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"foo/type-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'page-', a path, or an unqualified reference."]} |}]
+
     (* Old kind compatibility *)
 
     let oldkind_abs_page =
       test "{!section:/foo.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TAbsolutePath",["foo"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Any_path":["`TAbsolutePath",["foo"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let oldkind_abs_module =
       test "{!section:/Foo.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TAbsolutePath",["Foo"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Any_path":["`TAbsolutePath",["Foo"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let oldkind_relative_page =
       test "{!section:foo/bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TRelativePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Any_path":["`TRelativePath",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let oldkind_relative_module =
       test "{!section:foo/Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TRelativePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Any_path":["`TRelativePath",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let oldkind_root_page =
       test "{!section://foo/bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TCurrentPackage",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Any_path":["`TCurrentPackage",["foo","bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
 
     let oldkind_root_module =
       test "{!section://foo/Bar.label}";
       [%expect
-        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Page_path":["`TCurrentPackage",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
+        {| {"value":[{"`Paragraph":[{"`Reference":[{"`Label":[{"`Any_path":["`TCurrentPackage",["foo","Bar"]]},"label"]},[]]}]}],"warnings":[]} |}]
   end in
   ()

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -1243,49 +1243,49 @@ let%expect_test _ =
       test "{!constructor-Foo.bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"constructor-Foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-17:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"constructor-Foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-17:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', a path, or an unqualified reference."]} |}]
 
     let something_in_exception =
       test "{!exception-Foo.bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"exception-Foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"exception-Foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', a path, or an unqualified reference."]} |}]
 
     let something_in_extension =
       test "{!extension-Foo.bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"extension-Foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"extension-Foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', a path, or an unqualified reference."]} |}]
 
     let something_in_field =
       test "{!field-foo.bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"field-foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"field-foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', a path, or an unqualified reference."]} |}]
 
     let something_in_section =
       test "{!section-foo.bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"section-foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-13:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"section-foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-13:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', a path, or an unqualified reference."]} |}]
 
     let something_in_instance_variable =
       test "{!instance-variable-foo.bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"instance-variable-foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-23:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"instance-variable-foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-23:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', a path, or an unqualified reference."]} |}]
 
     let something_in_method =
       test "{!method-foo.bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"method-foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-12:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"method-foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-12:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', a path, or an unqualified reference."]} |}]
 
     let something_in_val =
       test "{!val-foo.bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"val-foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-9:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"val-foo.bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-9:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', 'page-', a path, or an unqualified reference."]} |}]
 
     let something_in_something_nested =
       test "{!foo.bar.baz}";
@@ -1327,55 +1327,55 @@ let%expect_test _ =
       test "{!foo.page-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', a path, or an unqualified reference."]} |}]
 
     let something_in_constructor_nested =
       test "{!Foo.constructor-Bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.constructor-Bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-21:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.constructor-Bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-21:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', a path, or an unqualified reference."]} |}]
 
     let something_in_exception_nested =
       test "{!Foo.exception-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.exception-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.exception-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', a path, or an unqualified reference."]} |}]
 
     let something_in_extension_nested =
       test "{!Foo.extension-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.extension-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.extension-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', a path, or an unqualified reference."]} |}]
 
     let something_in_field_nested =
       test "{!foo.field-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.field-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.field-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', a path, or an unqualified reference."]} |}]
 
     let something_in_section_nested =
       test "{!foo.section-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.section-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-17:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.section-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-17:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', a path, or an unqualified reference."]} |}]
 
     let something_in_instance_variable_nested =
       test "{!foo.instance-variable-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.instance-variable-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-27:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.instance-variable-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-27:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', a path, or an unqualified reference."]} |}]
 
     let something_in_method_nested =
       test "{!foo.method-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.method-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-16:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.method-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-16:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', a path, or an unqualified reference."]} |}]
 
     let something_in_val_nested =
       test "{!Foo.val-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.val-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-13:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.val-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-13:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_empty =
       test "{!.module-Foo}";
@@ -1405,73 +1405,73 @@ let%expect_test _ =
       test "{!class-foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_class_type =
       test "{!class-type-foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-type-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-16:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-type-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-16:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_constructor =
       test "{!constructor-Foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"constructor-Foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-17:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"constructor-Foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-17:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_exception =
       test "{!exception-Foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"exception-Foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"exception-Foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_extension =
       test "{!extension-Foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"extension-Foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"extension-Foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-15:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_field =
       test "{!field-foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"field-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"field-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_section =
       test "{!section-foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"section-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-13:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"section-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-13:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_instance_variable =
       test "{!instance-variable-foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"instance-variable-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-23:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"instance-variable-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-23:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_method =
       test "{!method-foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"method-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-12:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"method-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-12:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_page =
       test "{!page-foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_type =
       test "{!type-foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"type-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"type-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_val =
       test "{!val-foo.module-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"val-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-9:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"val-foo.module-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-9:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_something_nested =
       test "{!Foo.Bar.module-Baz}";
@@ -1495,73 +1495,73 @@ let%expect_test _ =
       test "{!Foo.class-bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.class-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.class-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_class_type_nested =
       test "{!Foo.class-type-bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.class-type-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-20:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.class-type-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-20:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_constructor_nested =
       test "{!Foo.constructor-Bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.constructor-Bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-21:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.constructor-Bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-21:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_exception_nested =
       test "{!Foo.exception-Bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.exception-Bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.exception-Bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_extension_nested =
       test "{!Foo.extension-Bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.extension-Bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.extension-Bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-19:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_field_nested =
       test "{!foo.field-bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.field-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.field-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-15:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_section_nested =
       test "{!foo.section-bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.section-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-17:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.section-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-17:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_instance_variable_nested =
       test "{!foo.instance-variable-bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.instance-variable-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-27:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.instance-variable-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-27:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_method_nested =
       test "{!foo.method-bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.method-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-16:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.method-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-16:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_page_nested =
       test "{!foo.page-bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_type_nested =
       test "{!Foo.type-bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.type-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.type-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_in_val_nested =
       test "{!Foo.val-bar.module-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"Foo.val-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-13:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"Foo.val-bar.module-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-13:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_type_in_something =
       test "{!Foo.module-type-Bar}";
@@ -1585,13 +1585,13 @@ let%expect_test _ =
       test "{!class-foo.module-type-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-type-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-type-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let module_type_in_page =
       test "{!page-foo.module-type-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.module-type-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.module-type-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let type_in_something =
       test "{!Foo.type-bar}";
@@ -1615,13 +1615,13 @@ let%expect_test _ =
       test "{!class-foo.type-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.type-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.type-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let type_in_page =
       test "{!page-foo.type-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.type-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.type-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let constructor_in_empty =
       test "{!.constructor-Foo}";
@@ -2011,13 +2011,13 @@ let%expect_test _ =
       test "{!class-foo.exception-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.exception-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.exception-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let exception_in_page =
       test "{!page-foo.exception-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.exception-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.exception-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let extension_in_something =
       test "{!Foo.extension-Bar}";
@@ -2035,13 +2035,13 @@ let%expect_test _ =
       test "{!class-foo.extension-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.extension-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.extension-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let extension_in_page =
       test "{!page-foo.extension-Bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.extension-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.extension-Bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let val_in_something =
       test "{!Foo.val-bar}";
@@ -2059,13 +2059,13 @@ let%expect_test _ =
       test "{!class-foo.val-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.val-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.val-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let val_in_page =
       test "{!page-foo.val-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.val-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.val-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let class_in_something =
       test "{!Foo.class-bar}";
@@ -2083,13 +2083,13 @@ let%expect_test _ =
       test "{!class-foo.class-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let class_in_page =
       test "{!page-foo.class-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.class-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.class-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let class_type_in_something =
       test "{!Foo.class-type-bar}";
@@ -2107,13 +2107,13 @@ let%expect_test _ =
       test "{!class-foo.class-type-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-type-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-type-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let class_type_in_page =
       test "{!page-foo.class-type-bar}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.class-type-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"page-foo.class-type-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 2-10:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let method_in_empty =
       test "{!.method-foo}";
@@ -2389,7 +2389,7 @@ let%expect_test _ =
       test "{!class-foo.module-Bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-Bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-Bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_parent_module_type_in_module =
       test "{!module-Foo.module-type-Bar.field-baz}";
@@ -2401,7 +2401,7 @@ let%expect_test _ =
       test "{!class-foo.module-type-Bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-type-Bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-type-Bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_parent_type_in_module =
       test "{!module-Foo.type-bar.field-baz}";
@@ -2413,7 +2413,7 @@ let%expect_test _ =
       test "{!class-foo.type-bar.field-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.type-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.type-bar.field-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_parent_class_in_module =
       test "{!module-Foo.class-bar.field-baz}";
@@ -2461,7 +2461,7 @@ let%expect_test _ =
       test "{!class-foo.module-Bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-Bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-Bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_label_parent_module_type_in_module =
       test "{!module-Foo.module-type-Bar.baz}";
@@ -2473,7 +2473,7 @@ let%expect_test _ =
       test "{!class-foo.module-type-Bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-type-Bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-type-Bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_label_parent_type_in_module =
       test "{!module-Foo.type-bar.baz}";
@@ -2485,7 +2485,7 @@ let%expect_test _ =
       test "{!class-foo.type-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.type-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.type-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_label_parent_class_in_module =
       test "{!module-Foo.class-bar.baz}";
@@ -2497,7 +2497,7 @@ let%expect_test _ =
       test "{!class-foo.class-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_label_parent_class_type_in_module =
       test "{!module-Foo.class-bar.baz}";
@@ -2509,13 +2509,13 @@ let%expect_test _ =
       test "{!class-foo.class-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_page_in_something =
       test "{!foo.page-bar.baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"foo.page-bar.baz"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'module-type-', 'type-', 'class-', 'class-type-', a path, or an unqualified reference."]} |}]
 
     let inner_class_signature_something_in_something =
       test "{!foo.bar.method-baz}";
@@ -2539,7 +2539,7 @@ let%expect_test _ =
       test "{!class-foo.class-bar.method-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-bar.method-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-bar.method-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_class_signature_class_type_in_module =
       test "{!module-Foo.class-type-bar.method-baz}";
@@ -2551,7 +2551,7 @@ let%expect_test _ =
       test "{!class-foo.class-type-bar.method-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-type-bar.method-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.class-type-bar.method-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_signature_something_in_something =
       test "{!foo.bar.type-baz}";
@@ -2575,7 +2575,7 @@ let%expect_test _ =
       test "{!class-foo.module-Bar.type-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-Bar.type-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-Bar.type-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_signature_module_type_in_module =
       test "{!module-Foo.module-type-Bar.type-baz}";
@@ -2587,7 +2587,7 @@ let%expect_test _ =
       test "{!class-foo.module-type-Bar.type-baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-type-Bar.type-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.module-type-Bar.type-baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let inner_datatype_something_in_something =
       test "{!foo.bar.constructor-Baz}";
@@ -2611,7 +2611,7 @@ let%expect_test _ =
       test "{!class-foo.type-bar.constructor-Baz}";
       [%expect
         {|
-        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.type-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', or an unqualified reference."]} |}]
+        {"value":[{"`Paragraph":[{"`Code_span":"class-foo.type-bar.constructor-Baz"}]}],"warnings":["File \"f.ml\", line 1, characters 2-11:\nExpected 'module-', 'module-type-', a path, or an unqualified reference."]} |}]
 
     let kind_conflict =
       test "{!val:type-foo}";

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -2855,6 +2855,31 @@ let%expect_test _ =
       [%expect
         {| {"value":[{"`Paragraph":[{"`Code_span":"foo/type-bar"}]}],"warnings":["File \"f.ml\", line 1, characters 6-14:\nExpected 'module-', 'page-', a path, or an unqualified reference."]} |}]
 
+    let err_relative_empty_component =
+      test "{!foo//bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"foo//bar"}]}],"warnings":["File \"f.ml\", line 1, characters 6-6:\nIdentifier in path reference should not be empty."]} |}]
+
+    let err_current_package_empty_component =
+      test "{!///bar}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"///bar"}]}],"warnings":["File \"f.ml\", line 1, characters 4-4:\nIdentifier in path reference should not be empty."]} |}]
+
+    let err_last_empty_component =
+      test "{!foo/}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"foo/"}]}],"warnings":["File \"f.ml\", line 1, characters 6-6:\nIdentifier in reference should not be empty."]} |}]
+
+    let err_first_empty_component =
+      test "{!/}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"/"}]}],"warnings":["File \"f.ml\", line 1, characters 3-3:\nIdentifier in reference should not be empty."]} |}]
+
+    let err_current_package_empty_component =
+      test "{!//}";
+      [%expect
+        {| {"value":[{"`Paragraph":[{"`Code_span":"//"}]}],"warnings":["File \"f.ml\", line 1, characters 4-4:\nIdentifier in reference should not be empty."]} |}]
+
     (* Old kind compatibility *)
 
     let oldkind_abs_page =


### PR DESCRIPTION
Add the parsing of references to pages and modules containing a slash: `{!./foo}`, `{!/foo}`, `{!//foo}`. 
These are not resolved yet.