### PR TITLE
Fix gaps between preamble and content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,8 @@
 - Fixed title content not being picked up across pages when rendering references
   (#1116, @panglesd)
 - Fix wrong links to standalone comments in search results (#1118, @panglesd)
+- Fix a big gap between the preamble and the content of a page (#1146,
+  @panglesd)
 
 
 # 2.4.0

--- a/src/html/html_page.ml
+++ b/src/html/html_page.ml
@@ -210,10 +210,15 @@ let search_urls = %s;
 
   let body =
     html_of_breadcrumbs breadcrumbs
-    @ search_bar
-    @ [ Html.header ~a:[ Html.a_class [ "odoc-preamble" ] ] header ]
-    @ sidebar toc
-    @ [ Html.div ~a:[ Html.a_class [ "odoc-content" ] ] content ]
+    @ search_bar @ sidebar toc
+    @ [
+        Html.div
+          ~a:[ Html.a_class [ "odoc-main" ] ]
+          [
+            Html.header ~a:[ Html.a_class [ "odoc-preamble" ] ] header;
+            Html.div ~a:[ Html.a_class [ "odoc-content" ] ] content;
+          ];
+      ]
   in
 
   let htmlpp = Html.pp ~indent:(Config.indent config) () in

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -307,8 +307,8 @@ body.odoc-src {
   margin-right: calc(10vw + 20ex);
 }
 
-.odoc-content {
-  grid-row: 4;
+.odoc-main {
+  grid-row: 3;
   grid-column: 2;
 }
 
@@ -320,11 +320,6 @@ body.odoc-src {
 
 header {
   margin-bottom: 30px;
-}
-
-header.odoc-preamble {
-  grid-column: 2;
-  grid-row: 3;
 }
 
 nav {

--- a/test/generators/html/Alerts-Top1.html
+++ b/test/generators/html/Alerts-Top1.html
@@ -11,11 +11,13 @@
   <nav class="odoc-nav"><a href="Alerts.html">Up</a> – 
    <a href="Alerts.html">Alerts</a> &#x00BB; Top1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Alerts.Top1</span></code></h1><p>Top-comment.</p>
-   <ul class="at-tags">
-    <li class="deprecated"><span class="at-tag">deprecated</span> A</li>
-   </ul>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Alerts.Top1</span></code></h1><p>Top-comment.</p>
+    <ul class="at-tags">
+     <li class="deprecated"><span class="at-tag">deprecated</span> A</li>
+    </ul>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Alerts-Top2.html
+++ b/test/generators/html/Alerts-Top2.html
@@ -11,11 +11,13 @@
   <nav class="odoc-nav"><a href="Alerts.html">Up</a> – 
    <a href="Alerts.html">Alerts</a> &#x00BB; Top2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Alerts.Top2</span></code></h1><p>Top-comment.</p>
-   <ul class="at-tags">
-    <li class="deprecated"><span class="at-tag">deprecated</span> A</li>
-   </ul>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Alerts.Top2</span></code></h1><p>Top-comment.</p>
+    <ul class="at-tags">
+     <li class="deprecated"><span class="at-tag">deprecated</span> A</li>
+    </ul>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Alerts.html
+++ b/test/generators/html/Alerts.html
@@ -8,114 +8,117 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Alerts</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-a">
-     <a href="#val-a" class="anchor"></a>
-     <code><span><span class="keyword">val</span> a : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Alerts</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-a">
+      <a href="#val-a" class="anchor"></a>
+      <code><span><span class="keyword">val</span> a : int</span></code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="deprecated"><span class="at-tag">deprecated</span> a</li>
+      </ul>
+     </div>
     </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="deprecated"><span class="at-tag">deprecated</span> a</li>
-     </ul>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-b">
+      <a href="#val-b" class="anchor"></a>
+      <code><span><span class="keyword">val</span> b : int</span></code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="deprecated"><span class="at-tag">deprecated</span> 
+        <p>b.</p>
+       </li>
+      </ul>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-b">
-     <a href="#val-b" class="anchor"></a>
-     <code><span><span class="keyword">val</span> b : int</span></code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-c">
+      <a href="#val-c" class="anchor"></a>
+      <code><span><span class="keyword">val</span> c : int</span></code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="deprecated"><span class="at-tag">deprecated</span> </li>
+      </ul>
+     </div>
     </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="deprecated"><span class="at-tag">deprecated</span> <p>b.</p>
-      </li>
-     </ul>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Top1">
+      <a href="#module-Top1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Alerts-Top1.html">Top1</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Top-comment.</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-c">
-     <a href="#val-c" class="anchor"></a>
-     <code><span><span class="keyword">val</span> c : int</span></code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Top2">
+      <a href="#module-Top2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Alerts-Top2.html">Top2</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Top-comment.</p></div>
     </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="deprecated"><span class="at-tag">deprecated</span> </li>
-     </ul>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-d">
+      <a href="#val-d" class="anchor"></a>
+      <code><span><span class="keyword">val</span> d : int</span></code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="deprecated"><span class="at-tag">deprecated</span> 
+        A deprecated alert d
+       </li>
+      </ul>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Top1">
-     <a href="#module-Top1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Alerts-Top1.html">Top1</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Top-comment.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Top2">
-     <a href="#module-Top2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Alerts-Top2.html">Top2</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Top-comment.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-d">
-     <a href="#val-d" class="anchor"></a>
-     <code><span><span class="keyword">val</span> d : int</span></code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-d2">
+      <a href="#val-d2" class="anchor"></a>
+      <code><span><span class="keyword">val</span> d2 : int</span></code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="deprecated"><span class="at-tag">deprecated</span> </li>
+      </ul>
+     </div>
     </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="deprecated"><span class="at-tag">deprecated</span> 
-       A deprecated alert d
-      </li>
-     </ul>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-e">
+      <a href="#val-e" class="anchor"></a>
+      <code><span><span class="keyword">val</span> e : int</span></code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="alert"><span class="at-tag">alert</span> e an alert</li>
+      </ul>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-d2">
-     <a href="#val-d2" class="anchor"></a>
-     <code><span><span class="keyword">val</span> d2 : int</span></code>
-    </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="deprecated"><span class="at-tag">deprecated</span> </li>
-     </ul>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-e">
-     <a href="#val-e" class="anchor"></a>
-     <code><span><span class="keyword">val</span> e : int</span></code>
-    </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="alert"><span class="at-tag">alert</span> e an alert</li>
-     </ul>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-f">
-     <a href="#val-f" class="anchor"></a>
-     <code><span><span class="keyword">val</span> f : int</span></code>
-    </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="alert"><span class="at-tag">alert</span> f</li>
-     </ul>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-f">
+      <a href="#val-f" class="anchor"></a>
+      <code><span><span class="keyword">val</span> f : int</span></code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="alert"><span class="at-tag">alert</span> f</li>
+      </ul>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Alias-X.html
+++ b/test/generators/html/Alias-X.html
@@ -11,21 +11,23 @@
   <nav class="odoc-nav"><a href="Alias.html">Up</a> – 
    <a href="Alias.html">Alias</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Alias.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = int</span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>Module Foo__X documentation. This should appear in the documentation
-       for the alias to this module 'X'
-     </p>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Alias.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = int</span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>Module Foo__X documentation. This should appear in the documentation
+        for the alias to this module 'X'
+      </p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Alias.html
+++ b/test/generators/html/Alias.html
@@ -8,20 +8,22 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Alias</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Alias-X.html">X</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Alias</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> <a href="Alias-X.html">X</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Bugs.html
+++ b/test/generators/html/Bugs.html
@@ -8,36 +8,40 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Bugs</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-opt">
-     <a href="#type-opt" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a opt</span></span>
-      <span> = <span><span class="type-var">'a</span> option</span></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Bugs</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-opt">
+      <a href="#type-opt" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a opt</span></span>
+       <span> = <span><span class="type-var">'a</span> option</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> foo : 
-       <span><span class="optlabel">?bar</span>:
-        <span class="type-var">'a</span> <span class="arrow">&#45;&gt;</span>
-       </span> <span>unit <span class="arrow">&#45;&gt;</span></span>
-        unit
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>Triggers an assertion failure when 
-      <a href="https://github.com/ocaml/odoc/issues/101">
-       https://github.com/ocaml/odoc/issues/101
-      </a> is not fixed.
-     </p>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> foo : 
+        <span><span class="optlabel">?bar</span>:
+         <span class="type-var">'a</span> 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span>unit <span class="arrow">&#45;&gt;</span></span>
+         unit
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>Triggers an assertion failure when 
+       <a href="https://github.com/ocaml/odoc/issues/101">
+        https://github.com/ocaml/odoc/issues/101
+       </a> is not fixed.
+      </p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Bugs_post_406-class-let_open'.html
+++ b/test/generators/html/Bugs_post_406-class-let_open'.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Bugs_post_406.html">Up</a> – 
    <a href="Bugs_post_406.html">Bugs_post_406</a> &#x00BB; let_open'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Bugs_post_406.let_open'</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Bugs_post_406.let_open'</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Bugs_post_406-class-type-let_open.html
+++ b/test/generators/html/Bugs_post_406-class-type-let_open.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Bugs_post_406.html">Up</a> – 
    <a href="Bugs_post_406.html">Bugs_post_406</a> &#x00BB; let_open
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class type <code><span>Bugs_post_406.let_open</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class type <code><span>Bugs_post_406.let_open</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Bugs_post_406.html
+++ b/test/generators/html/Bugs_post_406.html
@@ -8,37 +8,40 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Bugs_post_406</span></code></h1>
-   <p>Let-open in class types, https://github.com/ocaml/odoc/issues/543
-     This was added to the language in 4.06
-   </p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec class-type anchored" id="class-type-let_open">
-     <a href="#class-type-let_open" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">type</span>  
-      </span>
-      <span><a href="Bugs_post_406-class-type-let_open.html">let_open</a>
-      </span>
-      <span> = <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Bugs_post_406</span></code></h1>
+    <p>Let-open in class types, https://github.com/ocaml/odoc/issues/543
+      This was added to the language in 4.06
+    </p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec class-type anchored" id="class-type-let_open">
+      <a href="#class-type-let_open" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">type</span>  
+       </span>
+       <span><a href="Bugs_post_406-class-type-let_open.html">let_open</a>
+       </span>
+       <span> = <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-let_open'">
-     <a href="#class-let_open'" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Bugs_post_406-class-let_open'.html">let_open'</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-let_open'">
+      <a href="#class-let_open'" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Bugs_post_406-class-let_open'.html">let_open'</a>
+       </span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Bugs_pre_410.html
+++ b/test/generators/html/Bugs_pre_410.html
@@ -8,39 +8,43 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Bugs_pre_410</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-opt'">
-     <a href="#type-opt'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a opt'</span></span>
-      <span> = <span>int option</span></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Bugs_pre_410</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-opt'">
+      <a href="#type-opt'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a opt'</span></span>
+       <span> = <span>int option</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo'">
-     <a href="#val-foo'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> foo' : 
-       <span><span class="optlabel">?bar</span>:
-        <span class="type-var">'a</span> <span class="arrow">&#45;&gt;</span>
-       </span> <span>unit <span class="arrow">&#45;&gt;</span></span>
-        unit
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>Similar to <code>Bugs</code>, but the printed type of 
-      <code>~bar</code> should be <code>int</code>, not <code>'a</code>
-      . This probably requires fixing in the compiler. See 
-      <a href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">
-       https://github.com/ocaml/odoc/pull/230#issuecomment-433226807
-      </a>.
-     </p>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo'">
+      <a href="#val-foo'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> foo' : 
+        <span><span class="optlabel">?bar</span>:
+         <span class="type-var">'a</span> 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span>unit <span class="arrow">&#45;&gt;</span></span>
+         unit
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>Similar to <code>Bugs</code>, but the printed type of 
+       <code>~bar</code> should be <code>int</code>, not <code>'a</code>
+       . This probably requires fixing in the compiler. See 
+       <a
+        href="https://github.com/ocaml/odoc/pull/230#issuecomment-433226807">
+        https://github.com/ocaml/odoc/pull/230#issuecomment-433226807
+       </a>.
+      </p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Class-class-empty_virtual'.html
+++ b/test/generators/html/Class-class-empty_virtual'.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Class.html">Up</a> – 
    <a href="Class.html">Class</a> &#x00BB; empty_virtual'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Class.empty_virtual'</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Class.empty_virtual'</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Class-class-mutually'.html
+++ b/test/generators/html/Class-class-mutually'.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Class.html">Up</a> – 
    <a href="Class.html">Class</a> &#x00BB; mutually'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Class.mutually'</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Class.mutually'</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Class-class-polymorphic'.html
+++ b/test/generators/html/Class-class-polymorphic'.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Class.html">Up</a> – 
    <a href="Class.html">Class</a> &#x00BB; polymorphic'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Class.polymorphic'</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Class.polymorphic'</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Class-class-recursive'.html
+++ b/test/generators/html/Class-class-recursive'.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Class.html">Up</a> – 
    <a href="Class.html">Class</a> &#x00BB; recursive'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Class.recursive'</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Class.recursive'</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Class-class-type-empty.html
+++ b/test/generators/html/Class-class-type-empty.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Class.html">Up</a> – 
    <a href="Class.html">Class</a> &#x00BB; empty
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class type <code><span>Class.empty</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class type <code><span>Class.empty</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Class-class-type-empty_virtual.html
+++ b/test/generators/html/Class-class-type-empty_virtual.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Class.html">Up</a> – 
    <a href="Class.html">Class</a> &#x00BB; empty_virtual
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class type <code><span>Class.empty_virtual</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class type <code><span>Class.empty_virtual</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Class-class-type-mutually.html
+++ b/test/generators/html/Class-class-type-mutually.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Class.html">Up</a> – 
    <a href="Class.html">Class</a> &#x00BB; mutually
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class type <code><span>Class.mutually</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class type <code><span>Class.mutually</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Class-class-type-polymorphic.html
+++ b/test/generators/html/Class-class-type-polymorphic.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Class.html">Up</a> – 
    <a href="Class.html">Class</a> &#x00BB; polymorphic
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class type <code><span>Class.polymorphic</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class type <code><span>Class.polymorphic</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Class-class-type-recursive.html
+++ b/test/generators/html/Class-class-type-recursive.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Class.html">Up</a> – 
    <a href="Class.html">Class</a> &#x00BB; recursive
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class type <code><span>Class.recursive</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class type <code><span>Class.recursive</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Class.html
+++ b/test/generators/html/Class.html
@@ -8,123 +8,126 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Class</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec class-type anchored" id="class-type-empty">
-     <a href="#class-type-empty" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">type</span>  
-      </span><span><a href="Class-class-type-empty.html">empty</a></span>
-      <span> = <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class-type anchored" id="class-type-mutually">
-     <a href="#class-type-mutually" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">type</span>  
-      </span>
-      <span><a href="Class-class-type-mutually.html">mutually</a></span>
-      <span> = <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class-type anchored" id="class-type-recursive">
-     <a href="#class-type-recursive" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">type</span>  
-      </span>
-      <span><a href="Class-class-type-recursive.html">recursive</a></span>
-      <span> = <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-mutually'">
-     <a href="#class-mutually'" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Class-class-mutually'.html">mutually'</a></span>
-      <span> : <a href="Class-class-type-mutually.html">mutually</a></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-recursive'">
-     <a href="#class-recursive'" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Class-class-recursive'.html">recursive'</a></span>
-      <span> : <a href="Class-class-type-recursive.html">recursive</a></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class-type anchored" id="class-type-empty_virtual">
-     <a href="#class-type-empty_virtual" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">type</span> <span class="keyword">virtual</span>
-         
-      </span>
-      <span><a href="Class-class-type-empty_virtual.html">empty_virtual</a>
-      </span>
-      <span> = <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-empty_virtual'">
-     <a href="#class-empty_virtual'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">virtual</span> 
-      </span>
-      <span><a href="Class-class-empty_virtual'.html">empty_virtual'</a>
-      </span><span> : <a href="Class-class-type-empty.html">empty</a></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class-type anchored" id="class-type-polymorphic">
-     <a href="#class-type-polymorphic" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">type</span> 'a 
-      </span>
-      <span><a href="Class-class-type-polymorphic.html">polymorphic</a>
-      </span>
-      <span> = <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-polymorphic'">
-     <a href="#class-polymorphic'" class="anchor"></a>
-     <code><span><span class="keyword">class</span> 'a </span>
-      <span><a href="Class-class-polymorphic'.html">polymorphic'</a></span>
-      <span> : 
-       <span><span class="type-var">'a</span> 
-        <a href="Class-class-type-polymorphic.html">polymorphic</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Class</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec class-type anchored" id="class-type-empty">
+      <a href="#class-type-empty" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">type</span>  
+       </span><span><a href="Class-class-type-empty.html">empty</a></span>
+       <span> = <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class-type anchored" id="class-type-mutually">
+      <a href="#class-type-mutually" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">type</span>  
+       </span>
+       <span><a href="Class-class-type-mutually.html">mutually</a></span>
+       <span> = <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class-type anchored" id="class-type-recursive">
+      <a href="#class-type-recursive" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">type</span>  
+       </span>
+       <span><a href="Class-class-type-recursive.html">recursive</a></span>
+       <span> = <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-mutually'">
+      <a href="#class-mutually'" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Class-class-mutually'.html">mutually'</a></span>
+       <span> : <a href="Class-class-type-mutually.html">mutually</a></span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-recursive'">
+      <a href="#class-recursive'" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Class-class-recursive'.html">recursive'</a></span>
+       <span> : <a href="Class-class-type-recursive.html">recursive</a>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class-type anchored" id="class-type-empty_virtual">
+      <a href="#class-type-empty_virtual" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">type</span> 
+        <span class="keyword">virtual</span>  
+       </span>
+       <span><a href="Class-class-type-empty_virtual.html">empty_virtual</a>
+       </span>
+       <span> = <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-empty_virtual'">
+      <a href="#class-empty_virtual'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">virtual</span> 
+       </span>
+       <span><a href="Class-class-empty_virtual'.html">empty_virtual'</a>
+       </span><span> : <a href="Class-class-type-empty.html">empty</a></span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class-type anchored" id="class-type-polymorphic">
+      <a href="#class-type-polymorphic" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">type</span> 'a 
+       </span>
+       <span><a href="Class-class-type-polymorphic.html">polymorphic</a>
+       </span>
+       <span> = <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-polymorphic'">
+      <a href="#class-polymorphic'" class="anchor"></a>
+      <code><span><span class="keyword">class</span> 'a </span>
+       <span><a href="Class-class-polymorphic'.html">polymorphic'</a></span>
+       <span> : 
+        <span><span class="type-var">'a</span> 
+         <a href="Class-class-type-polymorphic.html">polymorphic</a>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Class_comments-class-c.html
+++ b/test/generators/html/Class_comments-class-c.html
@@ -11,32 +11,34 @@
   <nav class="odoc-nav"><a href="Class_comments.html">Up</a> – 
    <a href="Class_comments.html">Class_comments</a> &#x00BB; c
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Class_comments.c</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec inherit">
-     <code>
-      <span><span class="keyword">inherit</span> 
-       <a href="Class_comments-class-x.html">x</a>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Inherit.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec">
-     <code>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = int
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Constraint.</p></div>
-   </div><p>Floating comment.</p>
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-bar">
-     <a href="#method-bar" class="anchor"></a>
-     <code><span><span class="keyword">method</span> bar : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Class_comments.c</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec inherit">
+      <code>
+       <span><span class="keyword">inherit</span> 
+        <a href="Class_comments-class-x.html">x</a>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Inherit.</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec">
+      <code>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = int
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Constraint.</p></div>
+    </div><p>Floating comment.</p>
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-bar">
+      <a href="#method-bar" class="anchor"></a>
+      <code><span><span class="keyword">method</span> bar : int</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Class_comments-class-x.html
+++ b/test/generators/html/Class_comments-class-x.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Class_comments.html">Up</a> – 
    <a href="Class_comments.html">Class_comments</a> &#x00BB; x
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Class_comments.x</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Class_comments.x</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Class_comments.html
+++ b/test/generators/html/Class_comments.html
@@ -8,30 +8,32 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Class_comments</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-x">
-     <a href="#class-x" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Class_comments-class-x.html">x</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Class_comments</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-x">
+      <a href="#class-x" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Class_comments-class-x.html">x</a></span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-c">
-     <a href="#class-c" class="anchor"></a>
-     <code><span><span class="keyword">class</span> 'a </span>
-      <span><a href="Class_comments-class-c.html">c</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-c">
+      <a href="#class-c" class="anchor"></a>
+      <code><span><span class="keyword">class</span> 'a </span>
+       <span><a href="Class_comments-class-c.html">c</a></span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/External.html
+++ b/test/generators/html/External.html
@@ -8,19 +8,21 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>External</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value external anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> foo : 
-       <span>unit <span class="arrow">&#45;&gt;</span></span> unit
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Foo <em>bar</em>.</p></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>External</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value external anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> foo : 
+        <span>unit <span class="arrow">&#45;&gt;</span></span> unit
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Foo <em>bar</em>.</p></div>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Functor-F1-argument-1-Arg.html
+++ b/test/generators/html/Functor-F1-argument-1-Arg.html
@@ -12,14 +12,16 @@
    <a href="Functor.html">Functor</a> &#x00BB; 
    <a href="Functor-F1.html">F1</a> &#x00BB; Arg
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>F1.Arg</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>F1.Arg</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-F1.html
+++ b/test/generators/html/Functor-F1.html
@@ -11,31 +11,33 @@
   <nav class="odoc-nav"><a href="Functor.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; F1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor.F1</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Arg">
-     <a href="#argument-1-Arg" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Functor-F1-argument-1-Arg.html">Arg</a></span>
-      <span> : <a href="Functor-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor.F1</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Arg">
+      <a href="#argument-1-Arg" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Functor-F1-argument-1-Arg.html">Arg</a></span>
+       <span> : <a href="Functor-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-F2-argument-1-Arg.html
+++ b/test/generators/html/Functor-F2-argument-1-Arg.html
@@ -12,14 +12,16 @@
    <a href="Functor.html">Functor</a> &#x00BB; 
    <a href="Functor-F2.html">F2</a> &#x00BB; Arg
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>F2.Arg</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>F2.Arg</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-F2.html
+++ b/test/generators/html/Functor-F2.html
@@ -11,34 +11,36 @@
   <nav class="odoc-nav"><a href="Functor.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; F2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor.F2</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Arg">
-     <a href="#argument-1-Arg" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Functor-F2-argument-1-Arg.html">Arg</a></span>
-      <span> : <a href="Functor-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor.F2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Arg">
+      <a href="#argument-1-Arg" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Functor-F2-argument-1-Arg.html">Arg</a></span>
+       <span> : <a href="Functor-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = <a href="Functor-F2-argument-1-Arg.html#type-t">Arg.t</a>
-      </span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = <a href="Functor-F2-argument-1-Arg.html#type-t">Arg.t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-F3-argument-1-Arg.html
+++ b/test/generators/html/Functor-F3-argument-1-Arg.html
@@ -12,14 +12,16 @@
    <a href="Functor.html">Functor</a> &#x00BB; 
    <a href="Functor-F3.html">F3</a> &#x00BB; Arg
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>F3.Arg</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>F3.Arg</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-F3.html
+++ b/test/generators/html/Functor-F3.html
@@ -11,34 +11,36 @@
   <nav class="odoc-nav"><a href="Functor.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; F3
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor.F3</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Arg">
-     <a href="#argument-1-Arg" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Functor-F3-argument-1-Arg.html">Arg</a></span>
-      <span> : <a href="Functor-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor.F3</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Arg">
+      <a href="#argument-1-Arg" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Functor-F3-argument-1-Arg.html">Arg</a></span>
+       <span> : <a href="Functor-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = <a href="Functor-F3-argument-1-Arg.html#type-t">Arg.t</a>
-      </span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = <a href="Functor-F3-argument-1-Arg.html#type-t">Arg.t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-F4-argument-1-Arg.html
+++ b/test/generators/html/Functor-F4-argument-1-Arg.html
@@ -12,14 +12,16 @@
    <a href="Functor.html">Functor</a> &#x00BB; 
    <a href="Functor-F4.html">F4</a> &#x00BB; Arg
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>F4.Arg</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>F4.Arg</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-F4.html
+++ b/test/generators/html/Functor-F4.html
@@ -11,31 +11,33 @@
   <nav class="odoc-nav"><a href="Functor.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; F4
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor.F4</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Arg">
-     <a href="#argument-1-Arg" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Functor-F4-argument-1-Arg.html">Arg</a></span>
-      <span> : <a href="Functor-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor.F4</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Arg">
+      <a href="#argument-1-Arg" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Functor-F4-argument-1-Arg.html">Arg</a></span>
+       <span> : <a href="Functor-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-F5.html
+++ b/test/generators/html/Functor-F5.html
@@ -11,22 +11,24 @@
   <nav class="odoc-nav"><a href="Functor.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; F5
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor.F5</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor.F5</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-module-type-S.html
+++ b/test/generators/html/Functor-module-type-S.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Functor.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Functor.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Functor.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-module-type-S1-argument-1-_.html
+++ b/test/generators/html/Functor-module-type-S1-argument-1-_.html
@@ -12,14 +12,16 @@
    <a href="Functor.html">Functor</a> &#x00BB; 
    <a href="Functor-module-type-S1.html">S1</a> &#x00BB; _
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>S1._</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>S1._</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor-module-type-S1.html
+++ b/test/generators/html/Functor-module-type-S1.html
@@ -11,31 +11,33 @@
   <nav class="odoc-nav"><a href="Functor.html">Up</a> – 
    <a href="Functor.html">Functor</a> &#x00BB; S1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Functor.S1</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-_">
-     <a href="#argument-1-_" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Functor-module-type-S1-argument-1-_.html">_</a></span>
-      <span> : <a href="Functor-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Functor.S1</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-_">
+      <a href="#argument-1-_" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Functor-module-type-S1-argument-1-_.html">_</a></span>
+       <span> : <a href="Functor-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor.html
+++ b/test/generators/html/Functor.html
@@ -8,110 +8,112 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Functor-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S1">
-     <a href="#module-type-S1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Functor-module-type-S1.html">S1</a>
-      </span>
-      <span> = <span class="keyword">functor</span>
-       <span> (<a href="Functor-module-type-S1-argument-1-_.html">_</a>
-         : <a href="Functor-module-type-S.html">S</a>) 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <a href="Functor-module-type-S.html">S</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-F1">
-     <a href="#module-F1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Functor-F1.html">F1</a>
-      </span>
-      <span> (<a href="Functor-F1-argument-1-Arg.html">Arg</a> : 
-       <a href="Functor-module-type-S.html">S</a>) : 
-       <a href="Functor-module-type-S.html">S</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-F2">
-     <a href="#module-F2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Functor-F2.html">F2</a>
-      </span>
-      <span> (<a href="Functor-F2-argument-1-Arg.html">Arg</a> : 
-       <a href="Functor-module-type-S.html">S</a>) : 
-       <a href="Functor-module-type-S.html">S</a> 
-       <span class="keyword">with</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Functor-module-type-S.html#type-t">t</a> = 
-        <a href="Functor-F2-argument-1-Arg.html#type-t">Arg.t</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Functor-module-type-S.html">S</a>
        </span>
-      </span>
-     </code>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-F3">
-     <a href="#module-F3" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Functor-F3.html">F3</a>
-      </span>
-      <span> (<a href="Functor-F3-argument-1-Arg.html">Arg</a> : 
-       <a href="Functor-module-type-S.html">S</a>) : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S1">
+      <a href="#module-type-S1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Functor-module-type-S1.html">S1</a>
+       </span>
+       <span> = <span class="keyword">functor</span>
+        <span> (<a href="Functor-module-type-S1-argument-1-_.html">_</a>
+          : <a href="Functor-module-type-S.html">S</a>) 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <a href="Functor-module-type-S.html">S</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-F4">
-     <a href="#module-F4" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Functor-F4.html">F4</a>
-      </span>
-      <span> (<a href="Functor-F4-argument-1-Arg.html">Arg</a> : 
-       <a href="Functor-module-type-S.html">S</a>) : 
-       <a href="Functor-module-type-S.html">S</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-F1">
+      <a href="#module-F1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Functor-F1.html">F1</a>
+       </span>
+       <span> (<a href="Functor-F1-argument-1-Arg.html">Arg</a> : 
+        <a href="Functor-module-type-S.html">S</a>) : 
+        <a href="Functor-module-type-S.html">S</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-F5">
-     <a href="#module-F5" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Functor-F5.html">F5</a>
-      </span><span> () : <a href="Functor-module-type-S.html">S</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-F2">
+      <a href="#module-F2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Functor-F2.html">F2</a>
+       </span>
+       <span> (<a href="Functor-F2-argument-1-Arg.html">Arg</a> : 
+        <a href="Functor-module-type-S.html">S</a>) : 
+        <a href="Functor-module-type-S.html">S</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Functor-module-type-S.html#type-t">t</a> = 
+         <a href="Functor-F2-argument-1-Arg.html#type-t">Arg.t</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-F3">
+      <a href="#module-F3" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Functor-F3.html">F3</a>
+       </span>
+       <span> (<a href="Functor-F3-argument-1-Arg.html">Arg</a> : 
+        <a href="Functor-module-type-S.html">S</a>) : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-F4">
+      <a href="#module-F4" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Functor-F4.html">F4</a>
+       </span>
+       <span> (<a href="Functor-F4-argument-1-Arg.html">Arg</a> : 
+        <a href="Functor-module-type-S.html">S</a>) : 
+        <a href="Functor-module-type-S.html">S</a>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-F5">
+      <a href="#module-F5" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Functor-F5.html">F5</a>
+       </span><span> () : <a href="Functor-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor2-X-argument-1-Y.html
+++ b/test/generators/html/Functor2-X-argument-1-Y.html
@@ -12,14 +12,16 @@
    <a href="Functor2.html">Functor2</a> &#x00BB; 
    <a href="Functor2-X.html">X</a> &#x00BB; Y
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>X.Y</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>X.Y</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor2-X-argument-2-Z.html
+++ b/test/generators/html/Functor2-X-argument-2-Z.html
@@ -12,14 +12,16 @@
    <a href="Functor2.html">Functor2</a> &#x00BB; 
    <a href="Functor2-X.html">X</a> &#x00BB; Z
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>X.Z</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>X.Z</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor2-X.html
+++ b/test/generators/html/Functor2-X.html
@@ -11,58 +11,60 @@
   <nav class="odoc-nav"><a href="Functor2.html">Up</a> – 
    <a href="Functor2.html">Functor2</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor2.X</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Y">
-     <a href="#argument-1-Y" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Functor2-X-argument-1-Y.html">Y</a></span>
-      <span> : <a href="Functor2-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor2.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Y">
+      <a href="#argument-1-Y" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Functor2-X-argument-1-Y.html">Y</a></span>
+       <span> : <a href="Functor2-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-2-Z">
-     <a href="#argument-2-Z" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Functor2-X-argument-2-Z.html">Z</a></span>
-      <span> : <a href="Functor2-module-type-S.html">S</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-2-Z">
+      <a href="#argument-2-Z" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Functor2-X-argument-2-Z.html">Z</a></span>
+       <span> : <a href="Functor2-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-y_t">
-     <a href="#type-y_t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> y_t</span>
-      <span> = <a href="Functor2-X-argument-1-Y.html#type-t">Y.t</a></span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-y_t">
+      <a href="#type-y_t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> y_t</span>
+       <span> = <a href="Functor2-X-argument-1-Y.html#type-t">Y.t</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-z_t">
-     <a href="#type-z_t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> z_t</span>
-      <span> = <a href="Functor2-X-argument-2-Z.html#type-t">Z.t</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-z_t">
+      <a href="#type-z_t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> z_t</span>
+       <span> = <a href="Functor2-X-argument-2-Z.html#type-t">Z.t</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-x_t">
-     <a href="#type-x_t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> x_t</span>
-      <span> = <a href="#type-y_t">y_t</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-x_t">
+      <a href="#type-x_t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> x_t</span>
+       <span> = <a href="#type-y_t">y_t</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor2-module-type-S.html
+++ b/test/generators/html/Functor2-module-type-S.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Functor2.html">Up</a> – 
    <a href="Functor2.html">Functor2</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Functor2.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Functor2.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor2-module-type-XF-argument-1-Y.html
+++ b/test/generators/html/Functor2-module-type-XF-argument-1-Y.html
@@ -12,14 +12,16 @@
     – <a href="Functor2.html">Functor2</a> &#x00BB; 
    <a href="Functor2-module-type-XF.html">XF</a> &#x00BB; Y
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>XF.Y</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>XF.Y</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor2-module-type-XF-argument-2-Z.html
+++ b/test/generators/html/Functor2-module-type-XF-argument-2-Z.html
@@ -12,14 +12,16 @@
     – <a href="Functor2.html">Functor2</a> &#x00BB; 
    <a href="Functor2-module-type-XF.html">XF</a> &#x00BB; Z
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>XF.Z</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>XF.Z</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor2-module-type-XF.html
+++ b/test/generators/html/Functor2-module-type-XF.html
@@ -11,62 +11,64 @@
   <nav class="odoc-nav"><a href="Functor2.html">Up</a> – 
    <a href="Functor2.html">Functor2</a> &#x00BB; XF
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Functor2.XF</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Y">
-     <a href="#argument-1-Y" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Functor2-module-type-XF-argument-1-Y.html">Y</a></span>
-      <span> : <a href="Functor2-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Functor2.XF</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Y">
+      <a href="#argument-1-Y" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Functor2-module-type-XF-argument-1-Y.html">Y</a></span>
+       <span> : <a href="Functor2-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-2-Z">
-     <a href="#argument-2-Z" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Functor2-module-type-XF-argument-2-Z.html">Z</a></span>
-      <span> : <a href="Functor2-module-type-S.html">S</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-2-Z">
+      <a href="#argument-2-Z" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Functor2-module-type-XF-argument-2-Z.html">Z</a></span>
+       <span> : <a href="Functor2-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-y_t">
-     <a href="#type-y_t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> y_t</span>
-      <span> = 
-       <a href="Functor2-module-type-XF-argument-1-Y.html#type-t">Y.t</a>
-      </span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-y_t">
+      <a href="#type-y_t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> y_t</span>
+       <span> = 
+        <a href="Functor2-module-type-XF-argument-1-Y.html#type-t">Y.t</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-z_t">
-     <a href="#type-z_t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> z_t</span>
-      <span> = 
-       <a href="Functor2-module-type-XF-argument-2-Z.html#type-t">Z.t</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-z_t">
+      <a href="#type-z_t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> z_t</span>
+       <span> = 
+        <a href="Functor2-module-type-XF-argument-2-Z.html#type-t">Z.t</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-x_t">
-     <a href="#type-x_t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> x_t</span>
-      <span> = <a href="#type-y_t">y_t</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-x_t">
+      <a href="#type-x_t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> x_t</span>
+       <span> = <a href="#type-y_t">y_t</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor2.html
+++ b/test/generators/html/Functor2.html
@@ -8,60 +8,62 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor2</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Functor2-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Functor2-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Functor2-X.html">X</a>
-      </span>
-      <span> (<a href="Functor2-X-argument-1-Y.html">Y</a> : 
-       <a href="Functor2-module-type-S.html">S</a>) (
-       <a href="Functor2-X-argument-2-Z.html">Z</a> : 
-       <a href="Functor2-module-type-S.html">S</a>) : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Functor2-X.html">X</a>
+       </span>
+       <span> (<a href="Functor2-X-argument-1-Y.html">Y</a> : 
+        <a href="Functor2-module-type-S.html">S</a>) (
+        <a href="Functor2-X-argument-2-Z.html">Z</a> : 
+        <a href="Functor2-module-type-S.html">S</a>) : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-XF">
-     <a href="#module-type-XF" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Functor2-module-type-XF.html">XF</a>
-      </span>
-      <span> = <span class="keyword">functor</span>
-       <span> (<a href="Functor2-module-type-XF-argument-1-Y.html">Y</a>
-         : <a href="Functor2-module-type-S.html">S</a>) 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <span class="keyword">functor</span>
-       <span> (<a href="Functor2-module-type-XF-argument-2-Z.html">Z</a>
-         : <a href="Functor2-module-type-S.html">S</a>) 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-XF">
+      <a href="#module-type-XF" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Functor2-module-type-XF.html">XF</a>
+       </span>
+       <span> = <span class="keyword">functor</span>
+        <span> (<a href="Functor2-module-type-XF-argument-1-Y.html">Y</a>
+          : <a href="Functor2-module-type-S.html">S</a>) 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span class="keyword">functor</span>
+        <span> (<a href="Functor2-module-type-XF-argument-2-Z.html">Z</a>
+          : <a href="Functor2-module-type-S.html">S</a>) 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor_ml-Bar.html
+++ b/test/generators/html/Functor_ml-Bar.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Functor_ml.html">Up</a> – 
    <a href="Functor_ml.html">Functor_ml</a> &#x00BB; Bar
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor_ml.Bar</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor_ml.Bar</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor_ml-Foo'-argument-1-X.html
+++ b/test/generators/html/Functor_ml-Foo'-argument-1-X.html
@@ -12,14 +12,16 @@
    <a href="Functor_ml.html">Functor_ml</a> &#x00BB; 
    <a href="Functor_ml-Foo'.html">Foo'</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>Foo'.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code><span><span class="keyword">val</span> foo : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>Foo'.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code><span><span class="keyword">val</span> foo : int</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor_ml-Foo'.html
+++ b/test/generators/html/Functor_ml-Foo'.html
@@ -11,35 +11,37 @@
   <nav class="odoc-nav"><a href="Functor_ml.html">Up</a> – 
    <a href="Functor_ml.html">Functor_ml</a> &#x00BB; Foo'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor_ml.Foo'</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-X">
-     <a href="#argument-1-X" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Functor_ml-Foo'-argument-1-X.html">X</a></span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor_ml.Foo'</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-X">
+      <a href="#argument-1-X" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Functor_ml-Foo'-argument-1-X.html">X</a></span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = <a href="Functor_ml-Bar.html#type-t">Bar.t</a></span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = <a href="Functor_ml-Bar.html#type-t">Bar.t</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Functor_ml.html
+++ b/test/generators/html/Functor_ml.html
@@ -8,49 +8,51 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Functor_ml</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Foo">
-     <a href="#module-Foo" class="anchor"></a>
-     <code><span><span class="keyword">module</span> Foo</span>
-      <span> (<a href="Functor_ml-Foo-argument-1-X.html">X</a> : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-       ) : <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <span class="xref-unresolved">Stdlib</span>.String
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Functor_ml</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Foo">
+      <a href="#module-Foo" class="anchor"></a>
+      <code><span><span class="keyword">module</span> Foo</span>
+       <span> (<a href="Functor_ml-Foo-argument-1-X.html">X</a> : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+        ) : <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <span class="xref-unresolved">Stdlib</span>.String
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Bar">
-     <a href="#module-Bar" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Functor_ml-Bar.html">Bar</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Bar">
+      <a href="#module-Bar" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Functor_ml-Bar.html">Bar</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Foo'">
-     <a href="#module-Foo'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Functor_ml-Foo'.html">Foo'</a>
-      </span>
-      <span> (<a href="Functor_ml-Foo'-argument-1-X.html">X</a> : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-       ) : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Foo'">
+      <a href="#module-Foo'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Functor_ml-Foo'.html">Foo'</a>
+       </span>
+       <span> (<a href="Functor_ml-Foo'-argument-1-X.html">X</a> : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+        ) : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Include-module-type-Dorminant_Module.html
+++ b/test/generators/html/Include-module-type-Dorminant_Module.html
@@ -11,30 +11,32 @@
   <nav class="odoc-nav"><a href="Include.html">Up</a> – 
    <a href="Include.html">Include</a> &#x00BB; Dorminant_Module
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Include.Dorminant_Module</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-include shadowed-include">
-    <details open="open">
-     <summary class="spec include">
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Include.Dorminant_Module</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-include shadowed-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Include-module-type-Inherent_Module.html">Inherent_Module
+         </a>
+        </span>
+       </code>
+      </summary>
+     </details>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-a">
+      <a href="#val-a" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
-        <a href="Include-module-type-Inherent_Module.html">Inherent_Module
-        </a>
+       <span><span class="keyword">val</span> a : 
+        <a href="Include.html#type-u">u</a>
        </span>
       </code>
-     </summary>
-    </details>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-a">
-     <a href="#val-a" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> a : 
-       <a href="Include.html#type-u">u</a>
-      </span>
-     </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Include-module-type-Inherent_Module.html
+++ b/test/generators/html/Include-module-type-Inherent_Module.html
@@ -11,18 +11,20 @@
   <nav class="odoc-nav"><a href="Include.html">Up</a> – 
    <a href="Include.html">Include</a> &#x00BB; Inherent_Module
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Include.Inherent_Module</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-a">
-     <a href="#val-a" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> a : 
-       <a href="Include.html#type-t">t</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Include.Inherent_Module</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-a">
+      <a href="#val-a" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> a : 
+        <a href="Include.html#type-t">t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Include-module-type-Inlined.html
+++ b/test/generators/html/Include-module-type-Inlined.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Include.html">Up</a> – 
    <a href="Include.html">Include</a> &#x00BB; Inlined
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Include.Inlined</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Include.Inlined</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Include-module-type-Not_inlined.html
+++ b/test/generators/html/Include-module-type-Not_inlined.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Include.html">Up</a> – 
    <a href="Include.html">Include</a> &#x00BB; Not_inlined
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Include.Not_inlined</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Include.Not_inlined</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Include-module-type-Not_inlined_and_closed.html
+++ b/test/generators/html/Include-module-type-Not_inlined_and_closed.html
@@ -11,15 +11,17 @@
   <nav class="odoc-nav"><a href="Include.html">Up</a> – 
    <a href="Include.html">Include</a> &#x00BB; Not_inlined_and_closed
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Include.Not_inlined_and_closed</span></code>
-   </h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-v">
-     <a href="#type-v" class="anchor"></a>
-     <code><span><span class="keyword">type</span> v</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Include.Not_inlined_and_closed</span></code>
+    </h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-v">
+      <a href="#type-v" class="anchor"></a>
+      <code><span><span class="keyword">type</span> v</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Include-module-type-Not_inlined_and_opened.html
+++ b/test/generators/html/Include-module-type-Not_inlined_and_opened.html
@@ -11,15 +11,17 @@
   <nav class="odoc-nav"><a href="Include.html">Up</a> – 
    <a href="Include.html">Include</a> &#x00BB; Not_inlined_and_opened
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Include.Not_inlined_and_opened</span></code>
-   </h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-w">
-     <a href="#type-w" class="anchor"></a>
-     <code><span><span class="keyword">type</span> w</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Include.Not_inlined_and_opened</span></code>
+    </h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-w">
+      <a href="#type-w" class="anchor"></a>
+      <code><span><span class="keyword">type</span> w</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Include.html
+++ b/test/generators/html/Include.html
@@ -8,206 +8,209 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Include</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Not_inlined">
-     <a href="#module-type-Not_inlined" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Include-module-type-Not_inlined.html">Not_inlined</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Include</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-Not_inlined">
+      <a href="#module-type-Not_inlined" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
         <a href="Include-module-type-Not_inlined.html">Not_inlined</a>
        </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-t">
-       <a href="#type-t" class="anchor"></a>
-       <code><span><span class="keyword">type</span> t</span></code>
-      </div>
      </div>
-    </details>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Inlined">
-     <a href="#module-type-Inlined" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Include-module-type-Inlined.html">Inlined</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Include-module-type-Not_inlined.html">Not_inlined</a>
+        </span>
+       </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-t">
+        <a href="#type-t" class="anchor"></a>
+        <code><span><span class="keyword">type</span> t</span></code>
+       </div>
+      </div>
+     </details>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored"
-     id="module-type-Not_inlined_and_closed">
-     <a href="#module-type-Not_inlined_and_closed" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Include-module-type-Not_inlined_and_closed.html">
-        Not_inlined_and_closed
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-include">
-    <details>
-     <summary class="spec include">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-Inlined">
+      <a href="#module-type-Inlined" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Include-module-type-Inlined.html">Inlined</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-Not_inlined_and_closed">
+      <a href="#module-type-Not_inlined_and_closed" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
         <a href="Include-module-type-Not_inlined_and_closed.html">
          Not_inlined_and_closed
         </a>
        </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-v">
-       <a href="#type-v" class="anchor"></a>
-       <code><span><span class="keyword">type</span> v</span></code>
-      </div>
      </div>
-    </details>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored"
-     id="module-type-Not_inlined_and_opened">
-     <a href="#module-type-Not_inlined_and_opened" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Include-module-type-Not_inlined_and_opened.html">
-        Not_inlined_and_opened
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
     </div>
-   </div>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
+    <div class="odoc-include">
+     <details>
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Include-module-type-Not_inlined_and_closed.html">
+          Not_inlined_and_closed
+         </a>
+        </span>
+       </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-v">
+        <a href="#type-v" class="anchor"></a>
+        <code><span><span class="keyword">type</span> v</span></code>
+       </div>
+      </div>
+     </details>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-Not_inlined_and_opened">
+      <a href="#module-type-Not_inlined_and_opened" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
         <a href="Include-module-type-Not_inlined_and_opened.html">
          Not_inlined_and_opened
         </a>
        </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-w">
-       <a href="#type-w" class="anchor"></a>
-       <code><span><span class="keyword">type</span> w</span></code>
-      </div>
      </div>
-    </details>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Inherent_Module">
-     <a href="#module-type-Inherent_Module" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Include-module-type-Inherent_Module.html">Inherent_Module</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
     </div>
-   </div>
-   <div class="odoc-include shadowed-include">
-    <details open="open">
-     <summary class="spec include">
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Include-module-type-Not_inlined_and_opened.html">
+          Not_inlined_and_opened
+         </a>
+        </span>
+       </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-w">
+        <a href="#type-w" class="anchor"></a>
+        <code><span><span class="keyword">type</span> w</span></code>
+       </div>
+      </div>
+     </details>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-Inherent_Module">
+      <a href="#module-type-Inherent_Module" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
         <a href="Include-module-type-Inherent_Module.html">Inherent_Module
         </a>
        </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
       </code>
-     </summary>
-    </details>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Dorminant_Module">
-     <a href="#module-type-Dorminant_Module" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Include-module-type-Dorminant_Module.html">Dorminant_Module
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
+    <div class="odoc-include shadowed-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Include-module-type-Inherent_Module.html">Inherent_Module
+         </a>
+        </span>
+       </code>
+      </summary>
+     </details>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-Dorminant_Module">
+      <a href="#module-type-Dorminant_Module" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
         <a href="Include-module-type-Dorminant_Module.html">Dorminant_Module
         </a>
        </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
       </code>
-     </summary>
-     <div class="odoc-include shadowed-include">
-      <details open="open">
-       <summary class="spec include">
-        <code>
-         <span><span class="keyword">include</span> 
-          <a href="Include-module-type-Inherent_Module.html">Inherent_Module
-          </a>
-         </span>
-        </code>
-       </summary>
-      </details>
      </div>
-     <div class="odoc-spec">
-      <div class="spec value anchored" id="val-a">
-       <a href="#val-a" class="anchor"></a>
+    </div>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
        <code>
-        <span><span class="keyword">val</span> a : <a href="#type-u">u</a>
+        <span><span class="keyword">include</span> 
+         <a href="Include-module-type-Dorminant_Module.html">Dorminant_Module
+         </a>
         </span>
        </code>
+      </summary>
+      <div class="odoc-include shadowed-include">
+       <details open="open">
+        <summary class="spec include">
+         <code>
+          <span><span class="keyword">include</span> 
+           <a href="Include-module-type-Inherent_Module.html">Inherent_Module
+           </a>
+          </span>
+         </code>
+        </summary>
+       </details>
       </div>
-     </div>
-    </details>
+      <div class="odoc-spec">
+       <div class="spec value anchored" id="val-a">
+        <a href="#val-a" class="anchor"></a>
+        <code>
+         <span><span class="keyword">val</span> a : <a href="#type-u">u</a>
+         </span>
+        </code>
+       </div>
+      </div>
+     </details>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Include2-X.html
+++ b/test/generators/html/Include2-X.html
@@ -11,17 +11,19 @@
   <nav class="odoc-nav"><a href="Include2.html">Up</a> – 
    <a href="Include2.html">Include2</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Include2.X</span></code></h1>
-   <p>Comment about X that should not appear when including X below.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = int</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Include2.X</span></code></h1>
+    <p>Comment about X that should not appear when including X below.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = int</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Include2-Y.html
+++ b/test/generators/html/Include2-Y.html
@@ -11,15 +11,17 @@
   <nav class="odoc-nav"><a href="Include2.html">Up</a> – 
    <a href="Include2.html">Include2</a> &#x00BB; Y
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Include2.Y</span></code></h1>
-   <p>Top-comment of Y.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Include2.Y</span></code></h1>
+    <p>Top-comment of Y.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Include2-Y_include_doc.html
+++ b/test/generators/html/Include2-Y_include_doc.html
@@ -11,36 +11,39 @@
   <nav class="odoc-nav"><a href="Include2.html">Up</a> – 
    <a href="Include2.html">Include2</a> &#x00BB; Y_include_doc
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Include2.Y_include_doc</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-include">
-    <div class="spec-doc">
-     <p>Doc attached to <code>include Y</code>. <code>Y</code>'s top-comment
-       shouldn't appear here.
-     </p>
-    </div>
-    <details open="open">
-     <summary class="spec include">
-      <code>
-       <span><span class="keyword">include</span> 
-        <span class="keyword">module</span> <span class="keyword">type</span>
-         <span class="keyword">of</span> <span class="keyword">struct</span>
-         <span class="keyword">include</span> <a href="Include2-Y.html">Y</a>
-         <span class="keyword">end</span>
-       </span>
-      </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-t">
-       <a href="#type-t" class="anchor"></a>
-       <code><span><span class="keyword">type</span> t</span>
-        <span> = <a href="Include2-Y.html#type-t">Y.t</a></span>
-       </code>
-      </div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Include2.Y_include_doc</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-include">
+     <div class="spec-doc">
+      <p>Doc attached to <code>include Y</code>. <code>Y</code>'s top-comment
+        shouldn't appear here.
+      </p>
      </div>
-    </details>
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <span class="keyword">module</span> 
+         <span class="keyword">type</span> <span class="keyword">of</span>
+          <span class="keyword">struct</span> 
+         <span class="keyword">include</span> <a href="Include2-Y.html">Y</a>
+          <span class="keyword">end</span>
+        </span>
+       </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-t">
+        <a href="#type-t" class="anchor"></a>
+        <code><span><span class="keyword">type</span> t</span>
+         <span> = <a href="Include2-Y.html#type-t">Y.t</a></span>
+        </code>
+       </div>
+      </div>
+     </details>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Include2-Y_include_synopsis.html
+++ b/test/generators/html/Include2-Y_include_synopsis.html
@@ -11,34 +11,37 @@
   <nav class="odoc-nav"><a href="Include2.html">Up</a> – 
    <a href="Include2.html">Include2</a> &#x00BB; Y_include_synopsis
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Include2.Y_include_synopsis</span></code></h1>
-   <p>The <code>include Y</code> below should have the synopsis from 
-    <code>Y</code>'s top-comment attached to it.
-   </p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
-      <code>
-       <span><span class="keyword">include</span> 
-        <span class="keyword">module</span> <span class="keyword">type</span>
-         <span class="keyword">of</span> <span class="keyword">struct</span>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Include2.Y_include_synopsis</span></code></h1>
+    <p>The <code>include Y</code> below should have the synopsis from
+      <code>Y</code>'s top-comment attached to it.
+    </p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <span class="keyword">module</span> 
+         <span class="keyword">type</span> <span class="keyword">of</span>
+          <span class="keyword">struct</span> 
          <span class="keyword">include</span> <a href="Include2-Y.html">Y</a>
-         <span class="keyword">end</span>
-       </span>
-      </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-t">
-       <a href="#type-t" class="anchor"></a>
-       <code><span><span class="keyword">type</span> t</span>
-        <span> = <a href="Include2-Y.html#type-t">Y.t</a></span>
+          <span class="keyword">end</span>
+        </span>
        </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-t">
+        <a href="#type-t" class="anchor"></a>
+        <code><span><span class="keyword">type</span> t</span>
+         <span> = <a href="Include2-Y.html#type-t">Y.t</a></span>
+        </code>
+       </div>
       </div>
-     </div>
-    </details>
+     </details>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Include2.html
+++ b/test/generators/html/Include2.html
@@ -8,91 +8,94 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Include2</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Include2-X.html">X</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>Comment about X that should not appear when including X below.</p>
-    </div>
-   </div>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Include2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
-        <span class="keyword">module</span> <span class="keyword">type</span>
-         <span class="keyword">of</span> <span class="keyword">struct</span>
-         <span class="keyword">include</span> <a href="Include2-X.html">X</a>
-         <span class="keyword">end</span>
+       <span><span class="keyword">module</span> 
+        <a href="Include2-X.html">X</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
        </span>
       </code>
-     </summary>
-     <p>Comment about X that should not appear when including X below.</p>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-t">
-       <a href="#type-t" class="anchor"></a>
-       <code><span><span class="keyword">type</span> t</span>
-        <span> = int</span>
-       </code>
-      </div>
      </div>
-    </details>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Include2-Y.html">Y</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Top-comment of Y.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y_include_synopsis">
-     <a href="#module-Y_include_synopsis" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Include2-Y_include_synopsis.html">Y_include_synopsis</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+     <div class="spec-doc">
+      <p>Comment about X that should not appear when including X below.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>The <code>include Y</code> below should have the synopsis from
-       <code>Y</code>'s top-comment attached to it.
-     </p>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <span class="keyword">module</span> 
+         <span class="keyword">type</span> <span class="keyword">of</span>
+          <span class="keyword">struct</span> 
+         <span class="keyword">include</span> <a href="Include2-X.html">X</a>
+          <span class="keyword">end</span>
+        </span>
+       </code>
+      </summary>
+      <p>Comment about X that should not appear when including X below.</p>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-t">
+        <a href="#type-t" class="anchor"></a>
+        <code><span><span class="keyword">type</span> t</span>
+         <span> = int</span>
+        </code>
+       </div>
+      </div>
+     </details>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y_include_doc">
-     <a href="#module-Y_include_doc" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Include2-Y_include_doc.html">Y_include_doc</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Include2-Y.html">Y</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Top-comment of Y.</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y_include_synopsis">
+      <a href="#module-Y_include_synopsis" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Include2-Y_include_synopsis.html">Y_include_synopsis</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>The <code>include Y</code> below should have the synopsis from
+        <code>Y</code>'s top-comment attached to it.
+      </p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y_include_doc">
+      <a href="#module-Y_include_doc" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Include2-Y_include_doc.html">Y_include_doc</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Include_sections-module-type-Something.html
+++ b/test/generators/html/Include_sections-module-type-Something.html
@@ -11,10 +11,6 @@
   <nav class="odoc-nav"><a href="Include_sections.html">Up</a> – 
    <a href="Include_sections.html">Include_sections</a> &#x00BB; Something
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Include_sections.Something</span></code></h1>
-   <p>A module type.</p>
-  </header>
   <nav class="odoc-toc">
    <ul>
     <li><a href="#something-1">Something 1</a>
@@ -22,33 +18,41 @@
     </li><li><a href="#something-1-bis">Something 1-bis</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-something">
-     <a href="#val-something" class="anchor"></a>
-     <code><span><span class="keyword">val</span> something : unit</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Include_sections.Something</span></code></h1>
+    <p>A module type.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-something">
+      <a href="#val-something" class="anchor"></a>
+      <code><span><span class="keyword">val</span> something : unit</span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="something-1"><a href="#something-1" class="anchor"></a>Something 1
-   </h2><p>foo</p>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code><span><span class="keyword">val</span> foo : unit</span></code>
+    <h2 id="something-1"><a href="#something-1" class="anchor"></a>Something
+      1
+    </h2><p>foo</p>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code><span><span class="keyword">val</span> foo : unit</span></code>
+     </div>
     </div>
+    <h3 id="something-2"><a href="#something-2" class="anchor"></a>Something
+      2
+    </h3>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-bar">
+      <a href="#val-bar" class="anchor"></a>
+      <code><span><span class="keyword">val</span> bar : unit</span></code>
+     </div><div class="spec-doc"><p>foo bar</p></div>
+    </div>
+    <h2 id="something-1-bis"><a href="#something-1-bis" class="anchor"></a>
+     Something 1-bis
+    </h2><p>Some text.</p>
    </div>
-   <h3 id="something-2"><a href="#something-2" class="anchor"></a>Something 2
-   </h3>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-bar">
-     <a href="#val-bar" class="anchor"></a>
-     <code><span><span class="keyword">val</span> bar : unit</span></code>
-    </div><div class="spec-doc"><p>foo bar</p></div>
-   </div>
-   <h2 id="something-1-bis"><a href="#something-1-bis" class="anchor"></a>
-    Something 1-bis
-   </h2><p>Some text.</p>
   </div>
  </body>
 </html>

--- a/test/generators/html/Include_sections.html
+++ b/test/generators/html/Include_sections.html
@@ -8,9 +8,6 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Include_sections</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul>
     <li><a href="#something-1">Something 1</a>
@@ -32,103 +29,110 @@
     </li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Something">
-     <a href="#module-type-Something" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Include_sections-module-type-Something.html">Something</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>A module type.</p></div>
-   </div>
-   <p>Let's include 
-    <a href="Include_sections-module-type-Something.html">
-     <code>Something</code>
-    </a> once
-   </p>
-   <h2 id="something-1"><a href="#something-1" class="anchor"></a>Something 1
-   </h2><p>foo</p>
-   <h3 id="something-2"><a href="#something-2" class="anchor"></a>Something 2
-   </h3>
-   <h2 id="something-1-bis"><a href="#something-1-bis" class="anchor"></a>
-    Something 1-bis
-   </h2><p>Some text.</p>
-   <h2 id="second-include"><a href="#second-include" class="anchor"></a>
-    Second include
-   </h2>
-   <p>Let's include 
-    <a href="Include_sections-module-type-Something.html">
-     <code>Something</code>
-    </a> a second time: the heading level should be shift here.
-   </p>
-   <h3 id="something-1_2"><a href="#something-1_2" class="anchor"></a>
-    Something 1
-   </h3><p>foo</p>
-   <h4 id="something-2_2"><a href="#something-2_2" class="anchor"></a>
-    Something 2
-   </h4>
-   <h3 id="something-1-bis_2">
-    <a href="#something-1-bis_2" class="anchor"></a>Something 1-bis
-   </h3><p>Some text.</p>
-   <h3 id="third-include"><a href="#third-include" class="anchor"></a>
-    Third include
-   </h3><p>Shifted some more.</p>
-   <h4 id="something-1_3"><a href="#something-1_3" class="anchor"></a>
-    Something 1
-   </h4><p>foo</p>
-   <h5 id="something-2_3"><a href="#something-2_3" class="anchor"></a>
-    Something 2
-   </h5>
-   <h4 id="something-1-bis_3">
-    <a href="#something-1-bis_3" class="anchor"></a>Something 1-bis
-   </h4><p>Some text.</p>
-   <p>And let's include it again, but without inlining it this time: 
-    the ToC shouldn't grow.
-   </p>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Include_sections</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-Something">
+      <a href="#module-type-Something" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
         <a href="Include_sections-module-type-Something.html">Something</a>
        </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec value anchored" id="val-something">
-       <a href="#val-something" class="anchor"></a>
-       <code><span><span class="keyword">val</span> something : unit</span>
+     </div><div class="spec-doc"><p>A module type.</p></div>
+    </div>
+    <p>Let's include 
+     <a href="Include_sections-module-type-Something.html">
+      <code>Something</code>
+     </a> once
+    </p>
+    <h2 id="something-1"><a href="#something-1" class="anchor"></a>Something
+      1
+    </h2><p>foo</p>
+    <h3 id="something-2"><a href="#something-2" class="anchor"></a>Something
+      2
+    </h3>
+    <h2 id="something-1-bis"><a href="#something-1-bis" class="anchor"></a>
+     Something 1-bis
+    </h2><p>Some text.</p>
+    <h2 id="second-include"><a href="#second-include" class="anchor"></a>
+     Second include
+    </h2>
+    <p>Let's include 
+     <a href="Include_sections-module-type-Something.html">
+      <code>Something</code>
+     </a> a second time: the heading level should be shift here.
+    </p>
+    <h3 id="something-1_2"><a href="#something-1_2" class="anchor"></a>
+     Something 1
+    </h3><p>foo</p>
+    <h4 id="something-2_2"><a href="#something-2_2" class="anchor"></a>
+     Something 2
+    </h4>
+    <h3 id="something-1-bis_2">
+     <a href="#something-1-bis_2" class="anchor"></a>Something 1-bis
+    </h3><p>Some text.</p>
+    <h3 id="third-include"><a href="#third-include" class="anchor"></a>
+     Third include
+    </h3><p>Shifted some more.</p>
+    <h4 id="something-1_3"><a href="#something-1_3" class="anchor"></a>
+     Something 1
+    </h4><p>foo</p>
+    <h5 id="something-2_3"><a href="#something-2_3" class="anchor"></a>
+     Something 2
+    </h5>
+    <h4 id="something-1-bis_3">
+     <a href="#something-1-bis_3" class="anchor"></a>Something 1-bis
+    </h4><p>Some text.</p>
+    <p>And let's include it again, but without inlining it this time:
+      the ToC shouldn't grow.
+    </p>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Include_sections-module-type-Something.html">Something</a>
+        </span>
        </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec value anchored" id="val-something">
+        <a href="#val-something" class="anchor"></a>
+        <code><span><span class="keyword">val</span> something : unit</span>
+        </code>
+       </div>
       </div>
-     </div>
-     <h2 id="something-1_4"><a href="#something-1_4" class="anchor"></a>
-      Something 1
-     </h2><p>foo</p>
-     <div class="odoc-spec">
-      <div class="spec value anchored" id="val-foo">
-       <a href="#val-foo" class="anchor"></a>
-       <code><span><span class="keyword">val</span> foo : unit</span></code>
+      <h2 id="something-1_4"><a href="#something-1_4" class="anchor"></a>
+       Something 1
+      </h2><p>foo</p>
+      <div class="odoc-spec">
+       <div class="spec value anchored" id="val-foo">
+        <a href="#val-foo" class="anchor"></a>
+        <code><span><span class="keyword">val</span> foo : unit</span></code>
+       </div>
       </div>
-     </div>
-     <h3 id="something-2_4"><a href="#something-2_4" class="anchor"></a>
-      Something 2
-     </h3>
-     <div class="odoc-spec">
-      <div class="spec value anchored" id="val-bar">
-       <a href="#val-bar" class="anchor"></a>
-       <code><span><span class="keyword">val</span> bar : unit</span></code>
-      </div><div class="spec-doc"><p>foo bar</p></div>
-     </div>
-     <h2 id="something-1-bis_4">
-      <a href="#something-1-bis_4" class="anchor"></a>Something 1-bis
-     </h2><p>Some text.</p>
-    </details>
+      <h3 id="something-2_4"><a href="#something-2_4" class="anchor"></a>
+       Something 2
+      </h3>
+      <div class="odoc-spec">
+       <div class="spec value anchored" id="val-bar">
+        <a href="#val-bar" class="anchor"></a>
+        <code><span><span class="keyword">val</span> bar : unit</span></code>
+       </div><div class="spec-doc"><p>foo bar</p></div>
+      </div>
+      <h2 id="something-1-bis_4">
+       <a href="#something-1-bis_4" class="anchor"></a>Something 1-bis
+      </h2><p>Some text.</p>
+     </details>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Interlude.html
+++ b/test/generators/html/Interlude.html
@@ -8,47 +8,49 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Interlude</span></code></h1>
-   <p>This is the comment associated to the module.</p>
-  </header>
-  <div class="odoc-content">
-   <p>Some separate stray text at the top of the module.</p>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code><span><span class="keyword">val</span> foo : unit</span></code>
-    </div><div class="spec-doc"><p>Foo.</p></div>
-   </div>
-   <p>Some stray text that is not associated with any signature item.</p>
-   <p>It has multiple paragraphs.</p>
-   <p>A separate block of stray text, adjacent to the preceding one.</p>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-bar">
-     <a href="#val-bar" class="anchor"></a>
-     <code><span><span class="keyword">val</span> bar : unit</span></code>
-    </div><div class="spec-doc"><p>Bar.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-multiple">
-     <a href="#val-multiple" class="anchor"></a>
-     <code><span><span class="keyword">val</span> multiple : unit</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Interlude</span></code></h1>
+    <p>This is the comment associated to the module.</p>
+   </header>
+   <div class="odoc-content">
+    <p>Some separate stray text at the top of the module.</p>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code><span><span class="keyword">val</span> foo : unit</span></code>
+     </div><div class="spec-doc"><p>Foo.</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-signature">
-     <a href="#val-signature" class="anchor"></a>
-     <code><span><span class="keyword">val</span> signature : unit</span>
-     </code>
+    <p>Some stray text that is not associated with any signature item.</p>
+    <p>It has multiple paragraphs.</p>
+    <p>A separate block of stray text, adjacent to the preceding one.</p>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-bar">
+      <a href="#val-bar" class="anchor"></a>
+      <code><span><span class="keyword">val</span> bar : unit</span></code>
+     </div><div class="spec-doc"><p>Bar.</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-items">
-     <a href="#val-items" class="anchor"></a>
-     <code><span><span class="keyword">val</span> items : unit</span></code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-multiple">
+      <a href="#val-multiple" class="anchor"></a>
+      <code><span><span class="keyword">val</span> multiple : unit</span>
+      </code>
+     </div>
     </div>
-   </div><p>Stray text at the bottom of the module.</p>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-signature">
+      <a href="#val-signature" class="anchor"></a>
+      <code><span><span class="keyword">val</span> signature : unit</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-items">
+      <a href="#val-items" class="anchor"></a>
+      <code><span><span class="keyword">val</span> items : unit</span></code>
+     </div>
+    </div><p>Stray text at the bottom of the module.</p>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Labels-A.html
+++ b/test/generators/html/Labels-A.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Labels.html">Up</a> – 
    <a href="Labels.html">Labels</a> &#x00BB; A
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Labels.A</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#L3">Attached to module</a></li></ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="L3"><a href="#L3" class="anchor"></a>Attached to module</h2>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Labels.A</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="L3"><a href="#L3" class="anchor"></a>Attached to module</h2>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Labels-class-c.html
+++ b/test/generators/html/Labels-class-c.html
@@ -11,13 +11,15 @@
   <nav class="odoc-nav"><a href="Labels.html">Up</a> – 
    <a href="Labels.html">Labels</a> &#x00BB; c
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Labels.c</span></code></h1>
-  </header>
   <nav class="odoc-toc"><ul><li><a href="#L7">Attached to class</a></li></ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="L7"><a href="#L7" class="anchor"></a>Attached to class</h2>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Labels.c</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="L7"><a href="#L7" class="anchor"></a>Attached to class</h2>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Labels-class-type-cs.html
+++ b/test/generators/html/Labels-class-type-cs.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Labels.html">Up</a> – 
    <a href="Labels.html">Labels</a> &#x00BB; cs
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class type <code><span>Labels.cs</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#L8">Attached to class type</a></li></ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="L8"><a href="#L8" class="anchor"></a>Attached to class type</h2>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class type <code><span>Labels.cs</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="L8"><a href="#L8" class="anchor"></a>Attached to class type</h2>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Labels-module-type-S.html
+++ b/test/generators/html/Labels-module-type-S.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Labels.html">Up</a> – 
    <a href="Labels.html">Labels</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Labels.S</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#L6">Attached to module type</a></li></ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="L6"><a href="#L6" class="anchor"></a>Attached to module type</h2>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Labels.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="L6"><a href="#L6" class="anchor"></a>Attached to module type</h2>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Labels.html
+++ b/test/generators/html/Labels.html
@@ -8,192 +8,195 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Labels</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#L1">Attached to unit</a></li>
     <li><a href="#L2">Attached to nothing</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="L1"><a href="#L1" class="anchor"></a>Attached to unit</h2>
-   <h2 id="L2"><a href="#L2" class="anchor"></a>Attached to nothing</h2>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-A">
-     <a href="#module-A" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Labels-A.html">A</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Labels</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="L1"><a href="#L1" class="anchor"></a>Attached to unit</h2>
+    <h2 id="L2"><a href="#L2" class="anchor"></a>Attached to nothing</h2>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-A">
+      <a href="#module-A" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Labels-A.html">A</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
-    </div><div class="spec-doc"><p>Attached to type</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-f">
-     <a href="#val-f" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> f : <a href="#type-t">t</a>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Attached to value</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value external anchored" id="val-e">
-     <a href="#val-e" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> e : 
-       <span>unit <span class="arrow">&#45;&gt;</span></span> 
-       <a href="#type-t">t</a>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Attached to external</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Labels-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div><div class="spec-doc"><p>Attached to type</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-c">
-     <a href="#class-c" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Labels-class-c.html">c</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-f">
+      <a href="#val-f" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> f : <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Attached to value</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class-type anchored" id="class-type-cs">
-     <a href="#class-type-cs" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">type</span>  
-      </span><span><a href="Labels-class-type-cs.html">cs</a></span>
-      <span> = <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value external anchored" id="val-e">
+      <a href="#val-e" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> e : 
+        <span>unit <span class="arrow">&#45;&gt;</span></span> 
+        <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Attached to external</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec exception anchored" id="exception-E">
-     <a href="#exception-E" class="anchor"></a>
-     <code><span><span class="keyword">exception</span> </span>
-      <span><span class="exception">E</span></span>
-     </code>
-    </div><div class="spec-doc"><p>Attached to exception</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-x">
-     <a href="#type-x" class="anchor"></a>
-     <code><span><span class="keyword">type</span> x</span><span> = </span>
-      <span>..</span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Labels-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-X">
-     <a href="#extension-decl-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <a href="#type-x">x</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-X" class="def variant extension anchored">
-       <a href="#extension-X" class="anchor"></a>
-       <code><span>| </span><span><span class="extension">X</span></span>
-       </code>
-      </li>
-     </ol>
-    </div><div class="spec-doc"><p>Attached to extension</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-substitution anchored" id="module-S">
-     <a href="#module-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> S := 
-       <a href="Labels-A.html">A</a>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Attached to module subst</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type subst anchored" id="type-s">
-     <a href="#type-s" class="anchor"></a>
-     <code><span><span class="keyword">type</span> s</span>
-      <span> := <a href="#type-t">t</a></span>
-     </code>
-    </div><div class="spec-doc"><p>Attached to type subst</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-u.A'" class="def variant constructor anchored">
-       <a href="#type-u.A'" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">A'</span></span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>Attached to constructor</p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-c">
+      <a href="#class-c" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Labels-class-c.html">c</a></span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-v">
-     <a href="#type-v" class="anchor"></a>
-     <code><span><span class="keyword">type</span> v</span><span> = </span>
-      <span>{</span>
-     </code>
-     <ol>
-      <li id="type-v.f" class="def record field anchored">
-       <a href="#type-v.f" class="anchor"></a>
-       <code><span>f : <a href="#type-t">t</a>;</span></code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>Attached to field</p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol><code><span>}</span></code>
+    <div class="odoc-spec">
+     <div class="spec class-type anchored" id="class-type-cs">
+      <a href="#class-type-cs" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">type</span>  
+       </span><span><a href="Labels-class-type-cs.html">cs</a></span>
+       <span> = <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div><p>Testing that labels can be referenced</p>
-   <ul><li><a href="#L1" title="L1">Attached to unit</a></li>
-    <li><a href="#L2" title="L2">Attached to nothing</a></li>
-    <li><a href="#L3" title="L3">Attached to module</a></li>
-    <li><a href="#L4" title="L4">Attached to type</a></li>
-    <li><a href="#L5" title="L5">Attached to value</a></li>
-    <li><a href="#L6" title="L6">Attached to module type</a></li>
-    <li><a href="#L7" title="L7">Attached to class</a></li>
-    <li><a href="#L8" title="L8">Attached to class type</a></li>
-    <li><a href="#L9" title="L9">Attached to exception</a></li>
-    <li><a href="#L10" title="L10">Attached to extension</a></li>
-    <li><a href="#L11" title="L11">Attached to module subst</a></li>
-    <li><a href="#L12" title="L12">Attached to type subst</a></li>
-    <li><a href="#L13" title="L13">Attached to constructor</a></li>
-    <li><a href="#L14" title="L14">Attached to field</a></li>
-   </ul>
+    <div class="odoc-spec">
+     <div class="spec exception anchored" id="exception-E">
+      <a href="#exception-E" class="anchor"></a>
+      <code><span><span class="keyword">exception</span> </span>
+       <span><span class="exception">E</span></span>
+      </code>
+     </div><div class="spec-doc"><p>Attached to exception</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-x">
+      <a href="#type-x" class="anchor"></a>
+      <code><span><span class="keyword">type</span> x</span><span> = </span>
+       <span>..</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-X">
+      <a href="#extension-decl-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <a href="#type-x">x</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-X" class="def variant extension anchored">
+        <a href="#extension-X" class="anchor"></a>
+        <code><span>| </span><span><span class="extension">X</span></span>
+        </code>
+       </li>
+      </ol>
+     </div><div class="spec-doc"><p>Attached to extension</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-substitution anchored" id="module-S">
+      <a href="#module-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> S := 
+        <a href="Labels-A.html">A</a>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Attached to module subst</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type subst anchored" id="type-s">
+      <a href="#type-s" class="anchor"></a>
+      <code><span><span class="keyword">type</span> s</span>
+       <span> := <a href="#type-t">t</a></span>
+      </code>
+     </div><div class="spec-doc"><p>Attached to type subst</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-u.A'" class="def variant constructor anchored">
+        <a href="#type-u.A'" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">A'</span></span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>Attached to constructor</p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-v">
+      <a href="#type-v" class="anchor"></a>
+      <code><span><span class="keyword">type</span> v</span><span> = </span>
+       <span>{</span>
+      </code>
+      <ol>
+       <li id="type-v.f" class="def record field anchored">
+        <a href="#type-v.f" class="anchor"></a>
+        <code><span>f : <a href="#type-t">t</a>;</span></code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>Attached to field</p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol><code><span>}</span></code>
+     </div>
+    </div><p>Testing that labels can be referenced</p>
+    <ul><li><a href="#L1" title="L1">Attached to unit</a></li>
+     <li><a href="#L2" title="L2">Attached to nothing</a></li>
+     <li><a href="#L3" title="L3">Attached to module</a></li>
+     <li><a href="#L4" title="L4">Attached to type</a></li>
+     <li><a href="#L5" title="L5">Attached to value</a></li>
+     <li><a href="#L6" title="L6">Attached to module type</a></li>
+     <li><a href="#L7" title="L7">Attached to class</a></li>
+     <li><a href="#L8" title="L8">Attached to class type</a></li>
+     <li><a href="#L9" title="L9">Attached to exception</a></li>
+     <li><a href="#L10" title="L10">Attached to extension</a></li>
+     <li><a href="#L11" title="L11">Attached to module subst</a></li>
+     <li><a href="#L12" title="L12">Attached to type subst</a></li>
+     <li><a href="#L13" title="L13">Attached to constructor</a></li>
+     <li><a href="#L14" title="L14">Attached to field</a></li>
+    </ul>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Markup-X.html
+++ b/test/generators/html/Markup-X.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Markup.html">Up</a> – 
    <a href="Markup.html">Markup</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Markup.X</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Markup.X</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Markup-Y.html
+++ b/test/generators/html/Markup-Y.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Markup.html">Up</a> – 
    <a href="Markup.html">Markup</a> &#x00BB; Y
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Markup.Y</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Markup.Y</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -30,10 +30,6 @@
   </script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Markup</span></code></h1>
-   <p>Here, we test the rendering of comment markup.</p>
-  </header>
   <nav class="odoc-toc">
    <ul>
     <li><a href="#sections">Sections</a>
@@ -62,314 +58,324 @@
     <li><a href="#tables">Tables</a></li><li><a href="#tags">Tags</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="sections"><a href="#sections" class="anchor"></a>Sections</h2>
-   <p>Let's get these done first, because sections will be used to break
-     up the rest of this test.
-   </p><p>Besides the section heading above, there are also</p>
-   <h3 id="subsection-headings">
-    <a href="#subsection-headings" class="anchor"></a>Subsection headings
-   </h3><p>and</p>
-   <h4 id="sub-subsection-headings">
-    <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection
-     headings
-   </h4>
-   <p>but odoc has banned deeper headings. There are also title headings,
-     but they are only allowed in mld files.
-   </p><h4 id="anchors"><a href="#anchors" class="anchor"></a>Anchors</h4>
-   <p>Sections can have attached 
-    <a href="#anchors" title="anchors">Anchors</a>, and it is possible
-     to <a href="#anchors" title="anchors">link</a> to them. Links to
-     section headers should not be set in source code style.
-   </p>
-   <h5 id="paragraph"><a href="#paragraph" class="anchor"></a>Paragraph</h5>
-   <p>Individual paragraphs can have a heading.</p>
-   <h6 id="subparagraph"><a href="#subparagraph" class="anchor"></a>
-    Subparagraph
-   </h6>
-   <p>Parts of a longer paragraph that can be considered alone can also
-     have headings.
-   </p><h2 id="styling"><a href="#styling" class="anchor"></a>Styling</h2>
-   <p>This paragraph has some styled elements: <b>bold</b> and <i>italic</i>
-    , <b><i>bold italic</i></b>, <em>emphasis</em>, 
-    <em><em class="odd">emphasis</em> within emphasis</em>, 
-    <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>
-    . The line spacing should be enough for superscripts and subscripts
-     not to look odd.
-   </p>
-   <p>Note: 
-    <i>In italics <em>emphasis</em> is rendered as normal text while 
-     <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in
-      italics.
-    </i> 
-    <i>It also work the same in 
-     <a href="#">links in italics with 
-      <em>emphasis <em class="odd">in</em> emphasis</em>.
-     </a>
-    </i>
-   </p>
-   <p><code>code</code> is a different kind of markup that doesn't allow
-     nested markup.
-   </p>
-   <p>It's possible for two markup elements to appear <b>next</b> <i>to</i>
-     each other and have a space, and appear <b>next</b><i>to</i> each
-     other with no space. It doesn't matter <b>how</b> <i>much</i> space
-     it was in the source: in this sentence, it was two space characters.
-     And in this one, there is <b>a</b> <i>newline</i>.
-   </p>
-   <p>This is also true between <em>non-</em><code>code</code> markup
-     <em>and</em> <code>code</code>.
-   </p>
-   <p>Code can appear <b>inside <code>other</code> markup</b>. Its display
-     shouldn't be affected.
-   </p>
-   <p>There is no differences between <code>a b</code> and <code>a b</code>.
-   </p>
-   <p>Consecutive whitespaces not after a newline are conserved as they
-     are: <code>a   b</code>.
-   </p>
-   <h2 id="links-and-references">
-    <a href="#links-and-references" class="anchor"></a>Links and references
-   </h2>
-   <p>This is a <a href="#">link</a>. It sends you to the top of this
-     page. Links can have markup inside them: <a href="#"><b>bold</b></a>
-    , <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>
-    , <a href="#">super<sup>script</sup></a>, 
-    <a href="#">sub<sub>script</sub></a>, and 
-    <a href="#"><code>code</code></a>. Links can also be nested 
-    <em><a href="#">inside</a></em> markup. Links cannot be nested inside
-     each other. This link has no replacement text: <a href="#">#</a>
-    . The text is filled in by odoc. This is a shorthand link: 
-    <a href="#">#</a>. The text is also filled in by odoc in this case.
-   </p>
-   <p>This is a reference to <a href="#val-foo"><code>foo</code></a>.
-     References can have replacement text: 
-    <a href="#val-foo" title="foo">the value foo</a>. Except for the 
-    special lookup support, references are pretty much just like links.
-     The replacement text can have nested styles: 
-    <a href="#val-foo" title="foo"><b>bold</b></a>, 
-    <a href="#val-foo" title="foo"><i>italic</i></a>, 
-    <a href="#val-foo" title="foo"><em>emphasis</em></a>, 
-    <a href="#val-foo" title="foo">super<sup>script</sup></a>, 
-    <a href="#val-foo" title="foo">sub<sub>script</sub></a>, and 
-    <a href="#val-foo" title="foo"><code>code</code></a>. It's also possible
-     to surround a reference in a style: 
-    <b><a href="#val-foo"><code>foo</code></a></b>. References can't 
-    be nested inside references, and links and references can't be nested
-     inside each other.
-   </p>
-   <h2 id="preformatted-text">
-    <a href="#preformatted-text" class="anchor"></a>Preformatted text
-   </h2><p>This is a code block:</p>
-   <pre class="language-ocaml">
-    <code>
-     let foo = ()
-     (** There are some nested comments in here, but an unpaired comment
-         terminator would terminate the whole doc surrounding comment. It's
-         best to keep code blocks no wider than 72 characters. *)
-     
-     let bar =
-       ignore foo
-    </code>
-   </pre><p>There are also verbatim blocks:</p>
-   <pre>The main difference is these don't get syntax highlighting.</pre>
-   <h2 id="lists"><a href="#lists" class="anchor"></a>Lists</h2>
-   <ul><li>This is a</li><li>shorthand bulleted list,</li>
-    <li>and the paragraphs in each list item support <em>styling</em>.</li>
-   </ul><ol><li>This is a</li><li>shorthand numbered list.</li></ol>
-   <ul>
-    <li>Shorthand list items can span multiple lines, however trying 
-     to put two paragraphs into a shorthand list item using a double 
-     line break
-    </li>
-   </ul><p>just creates a paragraph outside the list.</p>
-   <ul><li>Similarly, inserting a blank line between two list items</li></ul>
-   <ul><li>creates two separate lists.</li></ul>
-   <ul>
-    <li><p>To get around this limitation, one</p>
-     <p>can use explicitly-delimited lists.</p>
-    </li><li>This one is bulleted,</li>
-   </ul><ol><li>but there is also the numbered variant.</li></ol>
-   <ul>
-    <li>
-     <ul><li>lists</li><li>can be nested</li>
-      <li>and can include references</li>
-      <li><a href="#val-foo"><code>foo</code></a></li>
-     </ul>
-    </li>
-   </ul><h2 id="unicode"><a href="#unicode" class="anchor"></a>Unicode</h2>
-   <p>The parser supports any ASCII-compatible encoding, in particuλar
-     UTF-8.
-   </p><h2 id="raw-html"><a href="#raw-html" class="anchor"></a>Raw HTML</h2>
-   <p>Raw HTML can be <input type="text" placeholder="inserted"> as inline
-     elements into sentences.
-   </p>
-   
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Markup</span></code></h1>
+    <p>Here, we test the rendering of comment markup.</p>
+   </header>
+   <div class="odoc-content">
+    <h2 id="sections"><a href="#sections" class="anchor"></a>Sections</h2>
+    <p>Let's get these done first, because sections will be used to break
+      up the rest of this test.
+    </p><p>Besides the section heading above, there are also</p>
+    <h3 id="subsection-headings">
+     <a href="#subsection-headings" class="anchor"></a>Subsection headings
+    </h3><p>and</p>
+    <h4 id="sub-subsection-headings">
+     <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection
+      headings
+    </h4>
+    <p>but odoc has banned deeper headings. There are also title headings,
+      but they are only allowed in mld files.
+    </p><h4 id="anchors"><a href="#anchors" class="anchor"></a>Anchors</h4>
+    <p>Sections can have attached 
+     <a href="#anchors" title="anchors">Anchors</a>, and it is possible
+      to <a href="#anchors" title="anchors">link</a> to them. Links to
+      section headers should not be set in source code style.
+    </p>
+    <h5 id="paragraph"><a href="#paragraph" class="anchor"></a>Paragraph</h5>
+    <p>Individual paragraphs can have a heading.</p>
+    <h6 id="subparagraph"><a href="#subparagraph" class="anchor"></a>
+     Subparagraph
+    </h6>
+    <p>Parts of a longer paragraph that can be considered alone can also
+      have headings.
+    </p><h2 id="styling"><a href="#styling" class="anchor"></a>Styling</h2>
+    <p>This paragraph has some styled elements: <b>bold</b> and <i>italic</i>
+     , <b><i>bold italic</i></b>, <em>emphasis</em>, 
+     <em><em class="odd">emphasis</em> within emphasis</em>, 
+     <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>
+     . The line spacing should be enough for superscripts and subscripts
+      not to look odd.
+    </p>
+    <p>Note: 
+     <i>In italics <em>emphasis</em> is rendered as normal text while
+       <em>emphasis <em class="odd">in</em> emphasis</em> is rendered
+       in italics.
+     </i> 
+     <i>It also work the same in 
+      <a href="#">links in italics with 
+       <em>emphasis <em class="odd">in</em> emphasis</em>.
+      </a>
+     </i>
+    </p>
+    <p><code>code</code> is a different kind of markup that doesn't allow
+      nested markup.
+    </p>
+    <p>It's possible for two markup elements to appear <b>next</b> <i>to</i>
+      each other and have a space, and appear <b>next</b><i>to</i> each
+      other with no space. It doesn't matter <b>how</b> <i>much</i> space
+      it was in the source: in this sentence, it was two space characters.
+      And in this one, there is <b>a</b> <i>newline</i>.
+    </p>
+    <p>This is also true between <em>non-</em><code>code</code> markup
+      <em>and</em> <code>code</code>.
+    </p>
+    <p>Code can appear <b>inside <code>other</code> markup</b>. Its display
+      shouldn't be affected.
+    </p>
+    <p>There is no differences between <code>a b</code> and <code>a b</code>.
+    </p>
+    <p>Consecutive whitespaces not after a newline are conserved as they
+      are: <code>a   b</code>.
+    </p>
+    <h2 id="links-and-references">
+     <a href="#links-and-references" class="anchor"></a>Links and references
+    </h2>
+    <p>This is a <a href="#">link</a>. It sends you to the top of this
+      page. Links can have markup inside them: <a href="#"><b>bold</b></a>
+     , <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>
+     , <a href="#">super<sup>script</sup></a>, 
+     <a href="#">sub<sub>script</sub></a>, and 
+     <a href="#"><code>code</code></a>. Links can also be nested 
+     <em><a href="#">inside</a></em> markup. Links cannot be nested inside
+      each other. This link has no replacement text: <a href="#">#</a>
+     . The text is filled in by odoc. This is a shorthand link: 
+     <a href="#">#</a>. The text is also filled in by odoc in this case.
+    </p>
+    <p>This is a reference to <a href="#val-foo"><code>foo</code></a>
+     . References can have replacement text: 
+     <a href="#val-foo" title="foo">the value foo</a>. Except for the
+      special lookup support, references are pretty much just like links.
+      The replacement text can have nested styles: 
+     <a href="#val-foo" title="foo"><b>bold</b></a>, 
+     <a href="#val-foo" title="foo"><i>italic</i></a>, 
+     <a href="#val-foo" title="foo"><em>emphasis</em></a>, 
+     <a href="#val-foo" title="foo">super<sup>script</sup></a>, 
+     <a href="#val-foo" title="foo">sub<sub>script</sub></a>, and 
+     <a href="#val-foo" title="foo"><code>code</code></a>. It's also 
+     possible to surround a reference in a style: 
+     <b><a href="#val-foo"><code>foo</code></a></b>. References can't
+      be nested inside references, and links and references can't be 
+     nested inside each other.
+    </p>
+    <h2 id="preformatted-text">
+     <a href="#preformatted-text" class="anchor"></a>Preformatted text
+    </h2><p>This is a code block:</p>
+    <pre class="language-ocaml">
+     <code>
+      let foo = ()
+      (** There are some nested comments in here, but an unpaired comment
+          terminator would terminate the whole doc surrounding comment. It's
+          best to keep code blocks no wider than 72 characters. *)
+      
+      let bar =
+        ignore foo
+     </code>
+    </pre><p>There are also verbatim blocks:</p>
+    <pre>The main difference is these don't get syntax highlighting.</pre>
+    <h2 id="lists"><a href="#lists" class="anchor"></a>Lists</h2>
+    <ul><li>This is a</li><li>shorthand bulleted list,</li>
+     <li>and the paragraphs in each list item support <em>styling</em>.</li>
+    </ul><ol><li>This is a</li><li>shorthand numbered list.</li></ol>
+    <ul>
+     <li>Shorthand list items can span multiple lines, however trying
+       to put two paragraphs into a shorthand list item using a double
+       line break
+     </li>
+    </ul><p>just creates a paragraph outside the list.</p>
+    <ul><li>Similarly, inserting a blank line between two list items</li>
+    </ul><ul><li>creates two separate lists.</li></ul>
+    <ul>
+     <li><p>To get around this limitation, one</p>
+      <p>can use explicitly-delimited lists.</p>
+     </li><li>This one is bulleted,</li>
+    </ul><ol><li>but there is also the numbered variant.</li></ol>
+    <ul>
+     <li>
+      <ul><li>lists</li><li>can be nested</li>
+       <li>and can include references</li>
+       <li><a href="#val-foo"><code>foo</code></a></li>
+      </ul>
+     </li>
+    </ul><h2 id="unicode"><a href="#unicode" class="anchor"></a>Unicode</h2>
+    <p>The parser supports any ASCII-compatible encoding, in particuλar
+      UTF-8.
+    </p>
+    <h2 id="raw-html"><a href="#raw-html" class="anchor"></a>Raw HTML</h2>
+    <p>Raw HTML can be <input type="text" placeholder="inserted"> as 
+     inline elements into sentences.
+    </p>
+    
     <blockquote>
       If the raw HTML is the only thing in a paragraph, it is treated as a block
       element, and won't be wrapped in paragraph tags by the HTML generator.
     </blockquote>
     
-   <h2 id="math"><a href="#math" class="anchor"></a>Math</h2>
-   <p>Math elements can be inline: 
-    <code class="odoc-katex-math">\int_{-\infty}^\infty</code>, or blocks:
-   </p>
-   <div>
-    <pre class="odoc-katex-math display">
-         % \f is defined as #1f(#2) using the macro
-         \newcommand{\f}[2]{#1f(#2)}
-         \f\relax{x} = \int_{-\infty}^\infty
-         \f\hat\xi\,e^{2 \pi i \xi x}
-         \,d\xi
-         
-    </pre>
-   </div><h2 id="modules"><a href="#modules" class="anchor"></a>Modules</h2>
-   <ul class="modules"><li><a href="Markup-X.html"><code>X</code></a> </li>
-   </ul>
-   <ul class="modules"><li><a href="Markup-X.html"><code>X</code></a> </li>
-    <li><a href="Markup-Y.html"><code>Y</code></a> </li>
-   </ul><h2 id="tables"><a href="#tables" class="anchor"></a>Tables</h2>
-   <table class="odoc-table">
-    <tr><th style="text-align:left"><p>Left</p></th>
-     <th style="text-align:center"><p>Center</p></th>
-     <th style="text-align:right"><p>Right</p></th><th><p>Default</p></th>
-    </tr>
-    <tr><td style="text-align:left"><p>A</p></td>
-     <td style="text-align:center"><p>B</p></td>
-     <td style="text-align:right"><p>C</p></td><td><p>D</p></td>
-    </tr>
-   </table>
-   <table class="odoc-table">
-    <tr><th style="text-align:left"><p>Left</p></th>
-     <th style="text-align:center"><p>Center</p></th>
-     <th style="text-align:right"><p>Right</p></th><th><p>Default</p></th>
-    </tr>
-    <tr><td style="text-align:left"><p>A</p></td>
-     <td style="text-align:center"><p>B</p></td>
-     <td style="text-align:right"><p>C</p></td><td><p>D</p></td>
-    </tr>
-    <tr>
-     <td style="text-align:left">
-      <p>A much longer paragraph which will need to be wrapped and more
-        content and more content and some different content and we will
-        see what is does if we can see it
+    <h2 id="math"><a href="#math" class="anchor"></a>Math</h2>
+    <p>Math elements can be inline: 
+     <code class="odoc-katex-math">\int_{-\infty}^\infty</code>, or blocks:
+    </p>
+    <div>
+     <pre class="odoc-katex-math display">
+          % \f is defined as #1f(#2) using the macro
+          \newcommand{\f}[2]{#1f(#2)}
+          \f\relax{x} = \int_{-\infty}^\infty
+          \f\hat\xi\,e^{2 \pi i \xi x}
+          \,d\xi
+          
+     </pre>
+    </div><h2 id="modules"><a href="#modules" class="anchor"></a>Modules</h2>
+    <ul class="modules"><li><a href="Markup-X.html"><code>X</code></a> </li>
+    </ul>
+    <ul class="modules"><li><a href="Markup-X.html"><code>X</code></a> </li>
+     <li><a href="Markup-Y.html"><code>Y</code></a> </li>
+    </ul><h2 id="tables"><a href="#tables" class="anchor"></a>Tables</h2>
+    <table class="odoc-table">
+     <tr><th style="text-align:left"><p>Left</p></th>
+      <th style="text-align:center"><p>Center</p></th>
+      <th style="text-align:right"><p>Right</p></th><th><p>Default</p></th>
+     </tr>
+     <tr><td style="text-align:left"><p>A</p></td>
+      <td style="text-align:center"><p>B</p></td>
+      <td style="text-align:right"><p>C</p></td><td><p>D</p></td>
+     </tr>
+    </table>
+    <table class="odoc-table">
+     <tr><th style="text-align:left"><p>Left</p></th>
+      <th style="text-align:center"><p>Center</p></th>
+      <th style="text-align:right"><p>Right</p></th><th><p>Default</p></th>
+     </tr>
+     <tr><td style="text-align:left"><p>A</p></td>
+      <td style="text-align:center"><p>B</p></td>
+      <td style="text-align:right"><p>C</p></td><td><p>D</p></td>
+     </tr>
+     <tr>
+      <td style="text-align:left">
+       <p>A much longer paragraph which will need to be wrapped and more
+         content and more content and some different content and we will
+         see what is does if we can see it
+       </p>
+      </td>
+      <td style="text-align:center">
+       <p>B much longer paragraph which will need to be wrapped and more
+         content and more content and some different content and we will
+         see what is does if we can see it
+       </p>
+      </td>
+      <td style="text-align:right">
+       <p>C much longer paragraph which will need to be wrapped and more
+         content and more content and some different content and we will
+         see what is does if we can see it
+       </p>
+      </td>
+      <td>
+       <p>D much longer paragraph which will need to be wrapped and more
+         content and more content and some different content and we will
+         see what is does if we can see it
+       </p>
+      </td>
+     </tr>
+    </table>
+    <table class="odoc-table">
+     <tr><td><p>No</p></td><td><p>Header</p></td></tr>
+     <tr><td><p>A</p></td><td><p>B</p></td></tr>
+    </table>
+    <table class="odoc-table">
+     <tr><th><p>Header 1</p></th><th><p>Header 2</p></th></tr>
+     <tr><td><p>Data 1</p></td><td><p>Data 2</p></td></tr>
+    </table>
+    <table class="odoc-table">
+     <tr><th><p>Header 1</p></th><td><p>Data 1</p></td></tr>
+     <tr><th><p>Header 2</p></th><td><p>Data 2</p></td></tr>
+    </table><h2 id="tags"><a href="#tags" class="anchor"></a>Tags</h2>
+    <p>Each comment can end with zero or more tags. Here are some examples:
+    </p>
+    <ul class="at-tags">
+     <li class="author"><span class="at-tag">author</span> antron</li>
+    </ul>
+    <ul class="at-tags">
+     <li class="deprecated"><span class="at-tag">deprecated</span> 
+      <p>a <em>long</em> time ago</p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="parameter"><span class="at-tag">parameter</span> 
+      <span class="value">foo</span> <p>unused</p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="raises"><span class="at-tag">raises</span> 
+      <code>Failure</code> <p>always</p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="returns"><span class="at-tag">returns</span> <p>never</p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="see"><span class="at-tag">see</span> 
+      <a href="#" class="value">#</a> <p>this url</p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="see"><span class="at-tag">see</span> 
+      <code class="value">foo.ml</code> <p>this file</p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="see"><span class="at-tag">see</span> 
+      <span class="value">Foo</span> <p>this document</p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="since"><span class="at-tag">since</span> 0</li>
+    </ul>
+    <ul class="at-tags">
+     <li class="before"><span class="at-tag">before</span> 
+      <span class="value">1.0</span> 
+      <p>it was in b<sup>e</sup>t<sub>a</sub></p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="version"><span class="at-tag">version</span> -1</li>
+    </ul>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code><span><span class="keyword">val</span> foo : unit</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>Comments in structure items <b>support</b> <em>markup</em>, 
+       t<sup>o</sup><sub>o</sub>.
       </p>
-     </td>
-     <td style="text-align:center">
-      <p>B much longer paragraph which will need to be wrapped and more
-        content and more content and some different content and we will
-        see what is does if we can see it
-      </p>
-     </td>
-     <td style="text-align:right">
-      <p>C much longer paragraph which will need to be wrapped and more
-        content and more content and some different content and we will
-        see what is does if we can see it
-      </p>
-     </td>
-     <td>
-      <p>D much longer paragraph which will need to be wrapped and more
-        content and more content and some different content and we will
-        see what is does if we can see it
-      </p>
-     </td>
-    </tr>
-   </table>
-   <table class="odoc-table">
-    <tr><td><p>No</p></td><td><p>Header</p></td></tr>
-    <tr><td><p>A</p></td><td><p>B</p></td></tr>
-   </table>
-   <table class="odoc-table">
-    <tr><th><p>Header 1</p></th><th><p>Header 2</p></th></tr>
-    <tr><td><p>Data 1</p></td><td><p>Data 2</p></td></tr>
-   </table>
-   <table class="odoc-table">
-    <tr><th><p>Header 1</p></th><td><p>Data 1</p></td></tr>
-    <tr><th><p>Header 2</p></th><td><p>Data 2</p></td></tr>
-   </table><h2 id="tags"><a href="#tags" class="anchor"></a>Tags</h2>
-   <p>Each comment can end with zero or more tags. Here are some examples:
-   </p>
-   <ul class="at-tags">
-    <li class="author"><span class="at-tag">author</span> antron</li>
-   </ul>
-   <ul class="at-tags">
-    <li class="deprecated"><span class="at-tag">deprecated</span> 
-     <p>a <em>long</em> time ago</p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="parameter"><span class="at-tag">parameter</span> 
-     <span class="value">foo</span> <p>unused</p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="raises"><span class="at-tag">raises</span> 
-     <code>Failure</code> <p>always</p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="returns"><span class="at-tag">returns</span> <p>never</p></li>
-   </ul>
-   <ul class="at-tags">
-    <li class="see"><span class="at-tag">see</span> 
-     <a href="#" class="value">#</a> <p>this url</p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="see"><span class="at-tag">see</span> 
-     <code class="value">foo.ml</code> <p>this file</p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="see"><span class="at-tag">see</span> 
-     <span class="value">Foo</span> <p>this document</p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="since"><span class="at-tag">since</span> 0</li>
-   </ul>
-   <ul class="at-tags">
-    <li class="before"><span class="at-tag">before</span> 
-     <span class="value">1.0</span> 
-     <p>it was in b<sup>e</sup>t<sub>a</sub></p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="version"><span class="at-tag">version</span> -1</li>
-   </ul>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code><span><span class="keyword">val</span> foo : unit</span></code>
+     </div>
+    </div><p>Some modules to support references.</p>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Markup-X.html">X</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>Comments in structure items <b>support</b> <em>markup</em>, t
-      <sup>o</sup><sub>o</sub>.
-     </p>
-    </div>
-   </div><p>Some modules to support references.</p>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Markup-X.html">X</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Markup-Y.html">Y</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Markup-Y.html">Y</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module-M'.html
+++ b/test/generators/html/Module-M'.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; M'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module.M'</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module.M'</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module-Mutually.html
+++ b/test/generators/html/Module-Mutually.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; Mutually
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module.Mutually</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module.Mutually</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module-Recursive.html
+++ b/test/generators/html/Module-Recursive.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; Recursive
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module.Recursive</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module.Recursive</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module-module-type-S-M.html
+++ b/test/generators/html/Module-module-type-S-M.html
@@ -12,7 +12,10 @@
    <a href="Module.html">Module</a> &#x00BB; 
    <a href="Module-module-type-S.html">S</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>S.M</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S.M</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module-module-type-S.html
+++ b/test/generators/html/Module-module-type-S.html
@@ -11,48 +11,50 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-v">
-     <a href="#type-v" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a v</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-v">
+      <a href="#type-v" class="anchor"></a>
+      <code><span><span class="keyword">type</span> <span>'a v</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-w">
-     <a href="#type-w" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-w">
+      <a href="#type-w" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module-module-type-S-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module-module-type-S-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module-module-type-S3-M.html
+++ b/test/generators/html/Module-module-type-S3-M.html
@@ -12,8 +12,10 @@
    <a href="Module.html">Module</a> &#x00BB; 
    <a href="Module-module-type-S3.html">S3</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>S3.M</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S3.M</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module-module-type-S3.html
+++ b/test/generators/html/Module-module-type-S3.html
@@ -11,52 +11,54 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; S3
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module.S3</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = int</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module.S3</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = int</span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span>
-      <span> = string</span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span>
+       <span> = string</span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-v">
-     <a href="#type-v" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a v</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-v">
+      <a href="#type-v" class="anchor"></a>
+      <code><span><span class="keyword">type</span> <span>'a v</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-w">
-     <a href="#type-w" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-w">
+      <a href="#type-w" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module-module-type-S3-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module-module-type-S3-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module-module-type-S4-M.html
+++ b/test/generators/html/Module-module-type-S4-M.html
@@ -12,8 +12,10 @@
    <a href="Module.html">Module</a> &#x00BB; 
    <a href="Module-module-type-S4.html">S4</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>S4.M</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S4.M</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module-module-type-S4.html
+++ b/test/generators/html/Module-module-type-S4.html
@@ -11,42 +11,44 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; S4
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module.S4</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module.S4</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-v">
-     <a href="#type-v" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a v</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-v">
+      <a href="#type-v" class="anchor"></a>
+      <code><span><span class="keyword">type</span> <span>'a v</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-w">
-     <a href="#type-w" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-w">
+      <a href="#type-w" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module-module-type-S4-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module-module-type-S4-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module-module-type-S5-M.html
+++ b/test/generators/html/Module-module-type-S5-M.html
@@ -12,8 +12,10 @@
    <a href="Module.html">Module</a> &#x00BB; 
    <a href="Module-module-type-S5.html">S5</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>S5.M</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S5.M</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module-module-type-S5.html
+++ b/test/generators/html/Module-module-type-S5.html
@@ -11,41 +11,43 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; S5
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module.S5</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module.S5</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-w">
-     <a href="#type-w" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-w">
+      <a href="#type-w" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module-module-type-S5-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module-module-type-S5-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module-module-type-S6-M.html
+++ b/test/generators/html/Module-module-type-S6-M.html
@@ -12,8 +12,10 @@
    <a href="Module.html">Module</a> &#x00BB; 
    <a href="Module-module-type-S6.html">S6</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>S6.M</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S6.M</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module-module-type-S6.html
+++ b/test/generators/html/Module-module-type-S6.html
@@ -11,40 +11,42 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; S6
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module.S6</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module.S6</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-v">
-     <a href="#type-v" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a v</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-v">
+      <a href="#type-v" class="anchor"></a>
+      <code><span><span class="keyword">type</span> <span>'a v</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module-module-type-S6-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module-module-type-S6-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module-module-type-S7.html
+++ b/test/generators/html/Module-module-type-S7.html
@@ -11,43 +11,45 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; S7
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module.S7</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module.S7</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-v">
-     <a href="#type-v" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a v</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-v">
+      <a href="#type-v" class="anchor"></a>
+      <code><span><span class="keyword">type</span> <span>'a v</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-w">
-     <a href="#type-w" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-w">
+      <a href="#type-w" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code><span><span class="keyword">module</span> M</span>
-      <span> = <a href="Module-M'.html">M'</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code><span><span class="keyword">module</span> M</span>
+       <span> = <a href="Module-M'.html">M'</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module-module-type-S8.html
+++ b/test/generators/html/Module-module-type-S8.html
@@ -11,35 +11,37 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; S8
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module.S8</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module.S8</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-v">
-     <a href="#type-v" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a v</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-v">
+      <a href="#type-v" class="anchor"></a>
+      <code><span><span class="keyword">type</span> <span>'a v</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-w">
-     <a href="#type-w" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-w">
+      <a href="#type-w" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>('a, 'b) w</span></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module-module-type-S9.html
+++ b/test/generators/html/Module-module-type-S9.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Module.html">Up</a> – 
    <a href="Module.html">Module</a> &#x00BB; S9
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module.S9</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module.S9</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module.html
+++ b/test/generators/html/Module.html
@@ -8,233 +8,235 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module</span></code></h1><p>Foo.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code><span><span class="keyword">val</span> foo : unit</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module</span></code></h1><p>Foo.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code><span><span class="keyword">val</span> foo : unit</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>The module needs at least one signature item, otherwise a bug
+        causes the compiler to drop the module comment (above). See 
+       <a href="https://caml.inria.fr/mantis/view.php?id=7701">
+        https://caml.inria.fr/mantis/view.php?id=7701
+       </a>.
+      </p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>The module needs at least one signature item, otherwise a bug
-       causes the compiler to drop the module comment (above). See 
-      <a href="https://caml.inria.fr/mantis/view.php?id=7701">
-       https://caml.inria.fr/mantis/view.php?id=7701
-      </a>.
-     </p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S1">
-     <a href="#module-type-S1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> S1
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S2">
-     <a href="#module-type-S2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> S2
-      </span><span> = <a href="Module-module-type-S.html">S</a></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S3">
-     <a href="#module-type-S3" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module-module-type-S3.html">S3</a>
-      </span>
-      <span> = <a href="Module-module-type-S.html">S</a> 
-       <span class="keyword">with</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Module-module-type-S.html#type-t">t</a> = int
-       </span> <span class="keyword">and</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Module-module-type-S.html#type-u">u</a> = string
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module-module-type-S.html">S</a>
        </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S4">
-     <a href="#module-type-S4" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module-module-type-S4.html">S4</a>
-      </span>
-      <span> = <a href="Module-module-type-S.html">S</a> 
-       <span class="keyword">with</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Module-module-type-S.html#type-t">t</a> := int
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S5">
-     <a href="#module-type-S5" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module-module-type-S5.html">S5</a>
-      </span>
-      <span> = <a href="Module-module-type-S.html">S</a> 
-       <span class="keyword">with</span> 
-       <span><span class="keyword">type</span> 
-        <span>'a <a href="Module-module-type-S.html#type-v">v</a></span>
-         := <span><span class="type-var">'a</span> list</span>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S1">
+      <a href="#module-type-S1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> S1
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-result">
-     <a href="#type-result" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>('a, 'b) result</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S2">
+      <a href="#module-type-S2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> S2
+       </span><span> = <a href="Module-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S6">
-     <a href="#module-type-S6" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module-module-type-S6.html">S6</a>
-      </span>
-      <span> = <a href="Module-module-type-S.html">S</a> 
-       <span class="keyword">with</span> 
-       <span><span class="keyword">type</span> 
-        <span>('a, 'b) <a href="Module-module-type-S.html#type-w">w</a>
-        </span> := 
-        <span>
-         <span>(<span class="type-var">'a</span>, 
-          <span class="type-var">'b</span>)
-         </span> <a href="#type-result">result</a>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S3">
+      <a href="#module-type-S3" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module-module-type-S3.html">S3</a>
+       </span>
+       <span> = <a href="Module-module-type-S.html">S</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Module-module-type-S.html#type-t">t</a> = int
+        </span> <span class="keyword">and</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Module-module-type-S.html#type-u">u</a> = string
         </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M'">
-     <a href="#module-M'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module-M'.html">M'</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S7">
-     <a href="#module-type-S7" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module-module-type-S7.html">S7</a>
-      </span>
-      <span> = <a href="Module-module-type-S.html">S</a> 
-       <span class="keyword">with</span> 
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S4">
+      <a href="#module-type-S4" class="anchor"></a>
+      <code>
        <span><span class="keyword">module</span> 
-        <a href="Module-module-type-S-M.html">M</a> = 
+        <span class="keyword">type</span> 
+        <a href="Module-module-type-S4.html">S4</a>
+       </span>
+       <span> = <a href="Module-module-type-S.html">S</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Module-module-type-S.html#type-t">t</a> := int
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S5">
+      <a href="#module-type-S5" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module-module-type-S5.html">S5</a>
+       </span>
+       <span> = <a href="Module-module-type-S.html">S</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">type</span> 
+         <span>'a <a href="Module-module-type-S.html#type-v">v</a></span>
+          := <span><span class="type-var">'a</span> list</span>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-result">
+      <a href="#type-result" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>('a, 'b) result</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S6">
+      <a href="#module-type-S6" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module-module-type-S6.html">S6</a>
+       </span>
+       <span> = <a href="Module-module-type-S.html">S</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">type</span> 
+         <span>('a, 'b) <a href="Module-module-type-S.html#type-w">w</a>
+         </span> := 
+         <span>
+          <span>(<span class="type-var">'a</span>, 
+           <span class="type-var">'b</span>)
+          </span> <a href="#type-result">result</a>
+         </span>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M'">
+      <a href="#module-M'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
         <a href="Module-M'.html">M'</a>
        </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S8">
-     <a href="#module-type-S8" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module-module-type-S8.html">S8</a>
-      </span>
-      <span> = <a href="Module-module-type-S.html">S</a> 
-       <span class="keyword">with</span> 
-       <span><span class="keyword">module</span> 
-        <a href="Module-module-type-S-M.html">M</a> := 
-        <a href="Module-M'.html">M'</a>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S9">
-     <a href="#module-type-S9" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module-module-type-S9.html">S9</a>
-      </span>
-      <span> = <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <a href="Module-M'.html">M'</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S7">
+      <a href="#module-type-S7" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module-module-type-S7.html">S7</a>
+       </span>
+       <span> = <a href="Module-module-type-S.html">S</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <a href="Module-module-type-S-M.html">M</a> = 
+         <a href="Module-M'.html">M'</a>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Mutually">
-     <a href="#module-Mutually" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module-Mutually.html">Mutually</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S8">
+      <a href="#module-type-S8" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module-module-type-S8.html">S8</a>
+       </span>
+       <span> = <a href="Module-module-type-S.html">S</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <a href="Module-module-type-S-M.html">M</a> := 
+         <a href="Module-M'.html">M'</a>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Recursive">
-     <a href="#module-Recursive" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module-Recursive.html">Recursive</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S9">
+      <a href="#module-type-S9" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module-module-type-S9.html">S9</a>
+       </span>
+       <span> = <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <a href="Module-M'.html">M'</a>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Mutually">
+      <a href="#module-Mutually" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module-Mutually.html">Mutually</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Recursive">
+      <a href="#module-Recursive" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module-Recursive.html">Recursive</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_alias-module-type-A.html
+++ b/test/generators/html/Module_type_alias-module-type-A.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Module_type_alias.html">Up</a> – 
    <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB; A
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module_type_alias.A</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-a">
-     <a href="#type-a" class="anchor"></a>
-     <code><span><span class="keyword">type</span> a</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module_type_alias.A</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-a">
+      <a href="#type-a" class="anchor"></a>
+      <code><span><span class="keyword">type</span> a</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_alias-module-type-B-argument-1-C.html
+++ b/test/generators/html/Module_type_alias-module-type-B-argument-1-C.html
@@ -12,14 +12,16 @@
     – <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB;
     <a href="Module_type_alias-module-type-B.html">B</a> &#x00BB; C
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>B.C</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-c">
-     <a href="#type-c" class="anchor"></a>
-     <code><span><span class="keyword">type</span> c</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>B.C</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-c">
+      <a href="#type-c" class="anchor"></a>
+      <code><span><span class="keyword">type</span> c</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_alias-module-type-B.html
+++ b/test/generators/html/Module_type_alias-module-type-B.html
@@ -11,34 +11,37 @@
   <nav class="odoc-nav"><a href="Module_type_alias.html">Up</a> – 
    <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB; B
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module_type_alias.B</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-C">
-     <a href="#argument-1-C" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Module_type_alias-module-type-B-argument-1-C.html">C</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module_type_alias.B</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-C">
+      <a href="#argument-1-C" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span>
+        <a href="Module_type_alias-module-type-B-argument-1-C.html">C</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-b">
-     <a href="#type-b" class="anchor"></a>
-     <code><span><span class="keyword">type</span> b</span></code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-b">
+      <a href="#type-b" class="anchor"></a>
+      <code><span><span class="keyword">type</span> b</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_alias-module-type-E-argument-1-F.html
+++ b/test/generators/html/Module_type_alias-module-type-E-argument-1-F.html
@@ -12,14 +12,16 @@
     – <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB;
     <a href="Module_type_alias-module-type-E.html">E</a> &#x00BB; F
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>E.F</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-f">
-     <a href="#type-f" class="anchor"></a>
-     <code><span><span class="keyword">type</span> f</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>E.F</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-f">
+      <a href="#type-f" class="anchor"></a>
+      <code><span><span class="keyword">type</span> f</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_alias-module-type-E-argument-2-C.html
+++ b/test/generators/html/Module_type_alias-module-type-E-argument-2-C.html
@@ -12,14 +12,16 @@
     – <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB;
     <a href="Module_type_alias-module-type-E.html">E</a> &#x00BB; C
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>E.C</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-c">
-     <a href="#type-c" class="anchor"></a>
-     <code><span><span class="keyword">type</span> c</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>E.C</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-c">
+      <a href="#type-c" class="anchor"></a>
+      <code><span><span class="keyword">type</span> c</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_alias-module-type-E.html
+++ b/test/generators/html/Module_type_alias-module-type-E.html
@@ -11,46 +11,50 @@
   <nav class="odoc-nav"><a href="Module_type_alias.html">Up</a> – 
    <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB; E
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module_type_alias.E</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-F">
-     <a href="#argument-1-F" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Module_type_alias-module-type-E-argument-1-F.html">F</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module_type_alias.E</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-F">
+      <a href="#argument-1-F" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span>
+        <a href="Module_type_alias-module-type-E-argument-1-F.html">F</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-2-C">
-     <a href="#argument-2-C" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Module_type_alias-module-type-E-argument-2-C.html">C</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-2-C">
+      <a href="#argument-2-C" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span>
+        <a href="Module_type_alias-module-type-E-argument-2-C.html">C</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-b">
-     <a href="#type-b" class="anchor"></a>
-     <code><span><span class="keyword">type</span> b</span></code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-b">
+      <a href="#type-b" class="anchor"></a>
+      <code><span><span class="keyword">type</span> b</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_alias-module-type-G-argument-1-H.html
+++ b/test/generators/html/Module_type_alias-module-type-G-argument-1-H.html
@@ -12,14 +12,16 @@
     – <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB;
     <a href="Module_type_alias-module-type-G.html">G</a> &#x00BB; H
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>G.H</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-h">
-     <a href="#type-h" class="anchor"></a>
-     <code><span><span class="keyword">type</span> h</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>G.H</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-h">
+      <a href="#type-h" class="anchor"></a>
+      <code><span><span class="keyword">type</span> h</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_alias-module-type-G.html
+++ b/test/generators/html/Module_type_alias-module-type-G.html
@@ -11,34 +11,37 @@
   <nav class="odoc-nav"><a href="Module_type_alias.html">Up</a> – 
    <a href="Module_type_alias.html">Module_type_alias</a> &#x00BB; G
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module_type_alias.G</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-H">
-     <a href="#argument-1-H" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Module_type_alias-module-type-G-argument-1-H.html">H</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module_type_alias.G</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-H">
+      <a href="#argument-1-H" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span>
+        <a href="Module_type_alias-module-type-G-argument-1-H.html">H</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-a">
-     <a href="#type-a" class="anchor"></a>
-     <code><span><span class="keyword">type</span> a</span></code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-a">
+      <a href="#type-a" class="anchor"></a>
+      <code><span><span class="keyword">type</span> a</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_alias.html
+++ b/test/generators/html/Module_type_alias.html
@@ -8,103 +8,105 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module_type_alias</span></code></h1>
-   <p>Module Type Aliases</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-A">
-     <a href="#module-type-A" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_alias-module-type-A.html">A</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module_type_alias</span></code></h1>
+    <p>Module Type Aliases</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-A">
+      <a href="#module-type-A" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_alias-module-type-A.html">A</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-B">
-     <a href="#module-type-B" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_alias-module-type-B.html">B</a>
-      </span>
-      <span> = <span class="keyword">functor</span>
-       <span> (
-        <a href="Module_type_alias-module-type-B-argument-1-C.html">C</a>
-         : <span class="keyword">sig</span> ... 
-        <span class="keyword">end</span>) 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-B">
+      <a href="#module-type-B" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_alias-module-type-B.html">B</a>
+       </span>
+       <span> = <span class="keyword">functor</span>
+        <span> (
+         <a href="Module_type_alias-module-type-B-argument-1-C.html">C</a>
+          : <span class="keyword">sig</span> ... 
+         <span class="keyword">end</span>) 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-D">
-     <a href="#module-type-D" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> D
-      </span>
-      <span> = <a href="Module_type_alias-module-type-A.html">A</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-D">
+      <a href="#module-type-D" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> D
+       </span>
+       <span> = <a href="Module_type_alias-module-type-A.html">A</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-E">
-     <a href="#module-type-E" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_alias-module-type-E.html">E</a>
-      </span>
-      <span> = <span class="keyword">functor</span>
-       <span> (
-        <a href="Module_type_alias-module-type-E-argument-1-F.html">F</a>
-         : <span class="keyword">sig</span> ... 
-        <span class="keyword">end</span>) 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <a href="Module_type_alias-module-type-B.html">B</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-E">
+      <a href="#module-type-E" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_alias-module-type-E.html">E</a>
+       </span>
+       <span> = <span class="keyword">functor</span>
+        <span> (
+         <a href="Module_type_alias-module-type-E-argument-1-F.html">F</a>
+          : <span class="keyword">sig</span> ... 
+         <span class="keyword">end</span>) 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <a href="Module_type_alias-module-type-B.html">B</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-G">
-     <a href="#module-type-G" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_alias-module-type-G.html">G</a>
-      </span>
-      <span> = <span class="keyword">functor</span>
-       <span> (
-        <a href="Module_type_alias-module-type-G-argument-1-H.html">H</a>
-         : <span class="keyword">sig</span> ... 
-        <span class="keyword">end</span>) 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <a href="Module_type_alias-module-type-A.html">D</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-G">
+      <a href="#module-type-G" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_alias-module-type-G.html">G</a>
+       </span>
+       <span> = <span class="keyword">functor</span>
+        <span> (
+         <a href="Module_type_alias-module-type-G-argument-1-H.html">H</a>
+          : <span class="keyword">sig</span> ... 
+         <span class="keyword">end</span>) 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <a href="Module_type_alias-module-type-A.html">D</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-I">
-     <a href="#module-type-I" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> I
-      </span>
-      <span> = <a href="Module_type_alias-module-type-B.html">B</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-I">
+      <a href="#module-type-I" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> I
+       </span>
+       <span> = <a href="Module_type_alias-module-type-B.html">B</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_of-T-N.html
+++ b/test/generators/html/Module_type_of-T-N.html
@@ -12,15 +12,18 @@
    <a href="Module_type_of.html">Module_type_of</a> &#x00BB; 
    <a href="Module_type_of-T.html">T</a> &#x00BB; N
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>T.N</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = <a href="Module_type_of-X.html#type-t">M.t</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>T.N</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = <a href="Module_type_of-X.html#type-t">M.t</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_of-T-module-type-T.html
+++ b/test/generators/html/Module_type_of-T-module-type-T.html
@@ -12,14 +12,16 @@
    <a href="Module_type_of.html">Module_type_of</a> &#x00BB; 
    <a href="Module_type_of-T.html">T</a> &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>T.T</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>T.T</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_of-T.html
+++ b/test/generators/html/Module_type_of-T.html
@@ -11,46 +11,49 @@
   <nav class="odoc-nav"><a href="Module_type_of.html">Up</a> – 
    <a href="Module_type_of.html">Module_type_of</a> &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module_type_of.T</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_of-T-module-type-T.html">T</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module_type_of.T</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_of-T-module-type-T.html">T</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code><span><span class="keyword">module</span> M</span>
-      <span> = <a href="Module_type_of-X.html">X</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code><span><span class="keyword">module</span> M</span>
+       <span> = <a href="Module_type_of-X.html">X</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_of-T-N.html">N</a>
-      </span>
-      <span> : <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <span class="keyword">struct</span> 
-       <span class="keyword">include</span> 
-       <a href="Module_type_of-X.html">M</a> <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_of-T-N.html">N</a>
+       </span>
+       <span> : <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <span class="keyword">struct</span> 
+        <span class="keyword">include</span> 
+        <a href="Module_type_of-X.html">M</a> 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_of-X.html
+++ b/test/generators/html/Module_type_of-X.html
@@ -11,20 +11,22 @@
   <nav class="odoc-nav"><a href="Module_type_of.html">Up</a> – 
    <a href="Module_type_of.html">Module_type_of</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module_type_of.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module_type_of.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_of-module-type-S-M.html
+++ b/test/generators/html/Module_type_of-module-type-S-M.html
@@ -12,13 +12,16 @@
     – <a href="Module_type_of.html">Module_type_of</a> &#x00BB; 
    <a href="Module_type_of-module-type-S.html">S</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>S.M</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S.M</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_of-module-type-S-N.html
+++ b/test/generators/html/Module_type_of-module-type-S-N.html
@@ -12,16 +12,19 @@
     – <a href="Module_type_of.html">Module_type_of</a> &#x00BB; 
    <a href="Module_type_of-module-type-S.html">S</a> &#x00BB; N
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>S.N</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = <a href="Module_type_of-module-type-S-M.html#type-t">M.t</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S.N</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = <a href="Module_type_of-module-type-S-M.html#type-t">M.t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_of-module-type-S-module-type-T.html
+++ b/test/generators/html/Module_type_of-module-type-S-module-type-T.html
@@ -12,14 +12,16 @@
     – <a href="Module_type_of.html">Module_type_of</a> &#x00BB; 
    <a href="Module_type_of-module-type-S.html">S</a> &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>S.T</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>S.T</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_of-module-type-S.html
+++ b/test/generators/html/Module_type_of-module-type-S.html
@@ -11,52 +11,54 @@
   <nav class="odoc-nav"><a href="Module_type_of.html">Up</a> – 
    <a href="Module_type_of.html">Module_type_of</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module_type_of.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_of-module-type-S-module-type-T.html">T</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module_type_of.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_of-module-type-S-module-type-T.html">T</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_of-module-type-S-M.html">M</a>
-      </span>
-      <span> : 
-       <a href="Module_type_of-module-type-S-module-type-T.html">T</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_of-module-type-S-M.html">M</a>
+       </span>
+       <span> : 
+        <a href="Module_type_of-module-type-S-module-type-T.html">T</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_of-module-type-S-N.html">N</a>
-      </span>
-      <span> : <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <span class="keyword">struct</span> 
-       <span class="keyword">include</span> 
-       <a href="Module_type_of-module-type-S-M.html">M</a> 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_of-module-type-S-N.html">N</a>
+       </span>
+       <span> : <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <span class="keyword">struct</span> 
+        <span class="keyword">include</span> 
+        <a href="Module_type_of-module-type-S-M.html">M</a> 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_of.html
+++ b/test/generators/html/Module_type_of.html
@@ -8,52 +8,54 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module_type_of</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_of-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_of-X.html">X</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-T">
-     <a href="#module-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_of-T.html">T</a>
-      </span>
-      <span> : <a href="Module_type_of-module-type-S.html">S</a> 
-       <span class="keyword">with</span> 
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module_type_of</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
        <span><span class="keyword">module</span> 
-        <a href="Module_type_of-module-type-S-M.html">M</a> = 
+        <span class="keyword">type</span> 
+        <a href="Module_type_of-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
         <a href="Module_type_of-X.html">X</a>
        </span>
-      </span>
-     </code>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-T">
+      <a href="#module-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_of-T.html">T</a>
+       </span>
+       <span> : <a href="Module_type_of-module-type-S.html">S</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <a href="Module_type_of-module-type-S-M.html">M</a> = 
+         <a href="Module_type_of-X.html">X</a>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Basic-module-type-a-M.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-a-M.html
@@ -15,7 +15,10 @@
    <a href="Module_type_subst-Basic-module-type-a.html">a</a> &#x00BB;
     M
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>a.M</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>a.M</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst-Basic-module-type-a.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-a.html
@@ -12,30 +12,32 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Basic.html">Basic</a> &#x00BB; a
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Basic.a</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-b">
-     <a href="#module-type-b" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> b
-      </span>
-      <span> = <a href="Module_type_subst-module-type-s.html">s</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Basic.a</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-b">
+      <a href="#module-type-b" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> b
+       </span>
+       <span> = <a href="Module_type_subst-module-type-s.html">s</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Basic-module-type-a-M.html">M</a>
-      </span>
-      <span> : <a href="Module_type_subst-module-type-s.html">b</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Basic-module-type-a-M.html">M</a>
+       </span>
+       <span> : <a href="Module_type_subst-module-type-s.html">b</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Basic-module-type-c-M.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-c-M.html
@@ -15,7 +15,10 @@
    <a href="Module_type_subst-Basic-module-type-c.html">c</a> &#x00BB;
     M
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>c.M</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>c.M</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst-Basic-module-type-c.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-c.html
@@ -12,19 +12,21 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Basic.html">Basic</a> &#x00BB; c
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Basic.c</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Basic-module-type-c-M.html">M</a>
-      </span>
-      <span> : <a href="Module_type_subst-module-type-s.html">s</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Basic.c</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Basic-module-type-c-M.html">M</a>
+       </span>
+       <span> : <a href="Module_type_subst-module-type-s.html">s</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Basic-module-type-u-module-type-T.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u-module-type-T.html
@@ -15,8 +15,10 @@
    <a href="Module_type_subst-Basic-module-type-u.html">u</a> &#x00BB;
     T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>u.T</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>u.T</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst-Basic-module-type-u.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u.html
@@ -12,23 +12,25 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Basic.html">Basic</a> &#x00BB; u
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Basic.u</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Basic-module-type-u-module-type-T.html">T
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Basic.u</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-Basic-module-type-u-module-type-T.html">T
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Basic-module-type-u2-M.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u2-M.html
@@ -15,8 +15,10 @@
    <a href="Module_type_subst-Basic-module-type-u2.html">u2</a> &#x00BB;
     M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>u2.M</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>u2.M</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst-Basic-module-type-u2-module-type-T.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u2-module-type-T.html
@@ -15,8 +15,10 @@
    <a href="Module_type_subst-Basic-module-type-u2.html">u2</a> &#x00BB;
     T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>u2.T</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>u2.T</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst-Basic-module-type-u2.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-u2.html
@@ -12,37 +12,39 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Basic.html">Basic</a> &#x00BB; u2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Basic.u2</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Basic-module-type-u2-module-type-T.html">T
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Basic.u2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-Basic-module-type-u2-module-type-T.html">T
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Basic-module-type-u2-M.html">M</a>
-      </span>
-      <span> : 
-       <a href="Module_type_subst-Basic-module-type-u2-module-type-T.html">T
-       </a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Basic-module-type-u2-M.html">M</a>
+       </span>
+       <span> : 
+        <a href="Module_type_subst-Basic-module-type-u2-module-type-T.html">T
+        </a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Basic-module-type-with_.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-with_.html
@@ -12,19 +12,21 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Basic.html">Basic</a> &#x00BB; with_
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Basic.with_</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> T
-      </span>
-      <span> = <a href="Module_type_subst-module-type-s.html">s</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Basic.with_</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> T
+       </span>
+       <span> = <a href="Module_type_subst-module-type-s.html">s</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Basic-module-type-with_2-M.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-with_2-M.html
@@ -15,8 +15,10 @@
    <a href="Module_type_subst-Basic-module-type-with_2.html">with_2</a>
     &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>with_2.M</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>with_2.M</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst-Basic-module-type-with_2-module-type-T.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-with_2-module-type-T.html
@@ -15,8 +15,10 @@
    <a href="Module_type_subst-Basic-module-type-with_2.html">with_2</a>
     &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>with_2.T</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>with_2.T</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst-Basic-module-type-with_2.html
+++ b/test/generators/html/Module_type_subst-Basic-module-type-with_2.html
@@ -12,41 +12,43 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Basic.html">Basic</a> &#x00BB; with_2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Basic.with_2</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Module_type_subst-Basic-module-type-with_2-module-type-T.html">
-        T
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Basic.with_2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Module_type_subst-Basic-module-type-with_2-module-type-T.html">
+         T
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Basic-module-type-with_2-M.html">M</a>
-      </span>
-      <span> : 
-       <a
-        href="Module_type_subst-Basic-module-type-with_2-module-type-T.html">
-        T
-       </a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Basic-module-type-with_2-M.html">M</a>
+       </span>
+       <span> : 
+        <a
+         href="Module_type_subst-Basic-module-type-with_2-module-type-T.html">
+         T
+        </a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Basic.html
+++ b/test/generators/html/Module_type_subst-Basic.html
@@ -11,108 +11,111 @@
   <nav class="odoc-nav"><a href="Module_type_subst.html">Up</a> – 
    <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB; Basic
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module_type_subst.Basic</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-u">
-     <a href="#module-type-u" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Basic-module-type-u.html">u</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-with_">
-     <a href="#module-type-with_" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Basic-module-type-with_.html">with_</a>
-      </span>
-      <span> = <a href="Module_type_subst-Basic-module-type-u.html">u</a>
-        <span class="keyword">with</span> 
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module_type_subst.Basic</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-u">
+      <a href="#module-type-u" class="anchor"></a>
+      <code>
        <span><span class="keyword">module</span> 
         <span class="keyword">type</span> 
-        <a href="Module_type_subst-Basic-module-type-u-module-type-T.html">T
-        </a> = <a href="Module_type_subst-module-type-s.html">s</a>
+        <a href="Module_type_subst-Basic-module-type-u.html">u</a>
        </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-u2">
-     <a href="#module-type-u2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Basic-module-type-u2.html">u2</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-with_2">
-     <a href="#module-type-with_2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Basic-module-type-with_2.html">with_2</a>
-      </span>
-      <span> = <a href="Module_type_subst-Basic-module-type-u2.html">u2</a>
-        <span class="keyword">with</span> 
-       <span><span class="keyword">module</span> 
-        <span class="keyword">type</span> 
-        <a href="Module_type_subst-Basic-module-type-u2-module-type-T.html">T
-        </a> = <span class="keyword">sig</span> ... 
+       <span> = <span class="keyword">sig</span> ... 
         <span class="keyword">end</span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-a">
-     <a href="#module-type-a" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Basic-module-type-a.html">a</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-c">
-     <a href="#module-type-c" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Basic-module-type-c.html">c</a>
-      </span>
-      <span> = <a href="Module_type_subst-Basic-module-type-a.html">a</a>
-        <span class="keyword">with</span> 
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-with_">
+      <a href="#module-type-with_" class="anchor"></a>
+      <code>
        <span><span class="keyword">module</span> 
         <span class="keyword">type</span> 
-        <a href="Module_type_subst-Basic-module-type-a-module-type-b.html">b
-        </a> := <a href="Module_type_subst-module-type-s.html">s</a>
+        <a href="Module_type_subst-Basic-module-type-with_.html">with_</a>
        </span>
-      </span>
-     </code>
+       <span> = <a href="Module_type_subst-Basic-module-type-u.html">u</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <span class="keyword">type</span> 
+         <a href="Module_type_subst-Basic-module-type-u-module-type-T.html">T
+         </a> = <a href="Module_type_subst-module-type-s.html">s</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-u2">
+      <a href="#module-type-u2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-Basic-module-type-u2.html">u2</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-with_2">
+      <a href="#module-type-with_2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-Basic-module-type-with_2.html">with_2</a>
+       </span>
+       <span> = <a href="Module_type_subst-Basic-module-type-u2.html">u2</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <span class="keyword">type</span> 
+         <a href="Module_type_subst-Basic-module-type-u2-module-type-T.html">
+          T
+         </a> = <span class="keyword">sig</span> ... 
+         <span class="keyword">end</span>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-a">
+      <a href="#module-type-a" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-Basic-module-type-a.html">a</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-c">
+      <a href="#module-type-c" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-Basic-module-type-c.html">c</a>
+       </span>
+       <span> = <a href="Module_type_subst-Basic-module-type-a.html">a</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <span class="keyword">type</span> 
+         <a href="Module_type_subst-Basic-module-type-a-module-type-b.html">b
+         </a> := <a href="Module_type_subst-module-type-s.html">s</a>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Local-module-type-local.html
+++ b/test/generators/html/Module_type_subst-Local-module-type-local.html
@@ -12,17 +12,19 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Local.html">Local</a> &#x00BB; local
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Local.local</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = <a href="Module_type_subst-Local.html#type-local">local</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Local.local</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = <a href="Module_type_subst-Local.html#type-local">local</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Local-module-type-s.html
+++ b/test/generators/html/Module_type_subst-Local-module-type-s.html
@@ -12,8 +12,10 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Local.html">Local</a> &#x00BB; s
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Local.s</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Local.s</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst-Local.html
+++ b/test/generators/html/Module_type_subst-Local.html
@@ -11,57 +11,59 @@
   <nav class="odoc-nav"><a href="Module_type_subst.html">Up</a> – 
    <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB; Local
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module_type_subst.Local</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type subst anchored" id="type-local">
-     <a href="#type-local" class="anchor"></a>
-     <code><span><span class="keyword">type</span> local</span>
-      <span> := int * int</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module_type_subst.Local</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type subst anchored" id="type-local">
+      <a href="#type-local" class="anchor"></a>
+      <code><span><span class="keyword">type</span> local</span>
+       <span> := int * int</span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-local">
-     <a href="#module-type-local" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Local-module-type-local.html">local</a>
-      </span>
-      <span> := <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-local">
+      <a href="#module-type-local" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-Local-module-type-local.html">local</a>
+       </span>
+       <span> := <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-w">
-     <a href="#module-type-w" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> w
-      </span>
-      <span> = 
-       <a href="Module_type_subst-Local-module-type-local.html">local</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-w">
+      <a href="#module-type-w" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> w
+       </span>
+       <span> = 
+        <a href="Module_type_subst-Local-module-type-local.html">local</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-s">
-     <a href="#module-type-s" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Local-module-type-s.html">s</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-s">
+      <a href="#module-type-s" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-Local-module-type-s.html">s</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Nested-module-type-nested-N-module-type-t.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-nested-N-module-type-t.html
@@ -17,8 +17,10 @@
    <a href="Module_type_subst-Nested-module-type-nested-N.html">N</a>
     &#x00BB; t
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>N.t</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>N.t</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst-Nested-module-type-nested-N.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-nested-N.html
@@ -15,25 +15,27 @@
    <a href="Module_type_subst-Nested-module-type-nested.html">nested</a>
     &#x00BB; N
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>nested.N</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-t">
-     <a href="#module-type-t" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Module_type_subst-Nested-module-type-nested-N-module-type-t.html"
-        >t
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>nested.N</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-t">
+      <a href="#module-type-t" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Module_type_subst-Nested-module-type-nested-N-module-type-t.html"
+         >t
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Nested-module-type-nested.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-nested.html
@@ -12,21 +12,23 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Nested.html">Nested</a> &#x00BB; nested
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Nested.nested</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Nested-module-type-nested-N.html">N</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Nested.nested</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Nested-module-type-nested-N.html">N</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_-N.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_-N.html
@@ -15,19 +15,21 @@
    <a href="Module_type_subst-Nested-module-type-with_.html">with_</a>
     &#x00BB; N
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>with_.N</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-t">
-     <a href="#module-type-t" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> t
-      </span>
-      <span> = <a href="Module_type_subst-module-type-s.html">s</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>with_.N</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-t">
+      <a href="#module-type-t" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> t
+       </span>
+       <span> = <a href="Module_type_subst-module-type-s.html">s</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_.html
@@ -12,21 +12,23 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Nested.html">Nested</a> &#x00BB; with_
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Nested.with_</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Nested-module-type-with_-N.html">N</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Nested.with_</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Nested-module-type-with_-N.html">N</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_subst-N.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_subst-N.html
@@ -15,8 +15,10 @@
    <a href="Module_type_subst-Nested-module-type-with_subst.html">with_subst
    </a> &#x00BB; N
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>with_subst.N</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>with_subst.N</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst-Nested-module-type-with_subst.html
+++ b/test/generators/html/Module_type_subst-Nested-module-type-with_subst.html
@@ -12,21 +12,24 @@
     – <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB;
     <a href="Module_type_subst-Nested.html">Nested</a> &#x00BB; with_subst
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Nested.with_subst</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Nested-module-type-with_subst-N.html">N</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Nested.with_subst</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Nested-module-type-with_subst-N.html">N
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Nested.html
+++ b/test/generators/html/Module_type_subst-Nested.html
@@ -11,68 +11,70 @@
   <nav class="odoc-nav"><a href="Module_type_subst.html">Up</a> – 
    <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB; Nested
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module_type_subst.Nested</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-nested">
-     <a href="#module-type-nested" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Nested-module-type-nested.html">nested</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-with_">
-     <a href="#module-type-with_" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Nested-module-type-with_.html">with_</a>
-      </span>
-      <span> = 
-       <a href="Module_type_subst-Nested-module-type-nested.html">nested</a>
-        <span class="keyword">with</span> 
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module_type_subst.Nested</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-nested">
+      <a href="#module-type-nested" class="anchor"></a>
+      <code>
        <span><span class="keyword">module</span> 
         <span class="keyword">type</span> 
-        <a
-         href="Module_type_subst-Nested-module-type-nested-N-module-type-t.html"
-         >N.t
-        </a> = <a href="Module_type_subst-module-type-s.html">s</a>
+        <a href="Module_type_subst-Nested-module-type-nested.html">nested</a>
        </span>
-      </span>
-     </code>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-with_subst">
-     <a href="#module-type-with_subst" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Nested-module-type-with_subst.html">
-        with_subst
-       </a>
-      </span>
-      <span> = 
-       <a href="Module_type_subst-Nested-module-type-nested.html">nested</a>
-        <span class="keyword">with</span> 
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-with_">
+      <a href="#module-type-with_" class="anchor"></a>
+      <code>
        <span><span class="keyword">module</span> 
         <span class="keyword">type</span> 
-        <a
-         href="Module_type_subst-Nested-module-type-nested-N-module-type-t.html"
-         >N.t
-        </a> := <a href="Module_type_subst-module-type-s.html">s</a>
+        <a href="Module_type_subst-Nested-module-type-with_.html">with_</a>
        </span>
-      </span>
-     </code>
+       <span> = 
+        <a href="Module_type_subst-Nested-module-type-nested.html">nested</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <span class="keyword">type</span> 
+         <a
+          href="Module_type_subst-Nested-module-type-nested-N-module-type-t.html"
+          >N.t
+         </a> = <a href="Module_type_subst-module-type-s.html">s</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-with_subst">
+      <a href="#module-type-with_subst" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-Nested-module-type-with_subst.html">
+         with_subst
+        </a>
+       </span>
+       <span> = 
+        <a href="Module_type_subst-Nested-module-type-nested.html">nested</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <span class="keyword">type</span> 
+         <a
+          href="Module_type_subst-Nested-module-type-nested-N-module-type-t.html"
+          >N.t
+         </a> := <a href="Module_type_subst-module-type-s.html">s</a>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b-module-type-c.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b-module-type-c.html
@@ -23,25 +23,27 @@
     >b
    </a> &#x00BB; c
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>b.c</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-t.A" class="def variant constructor anchored">
-       <a href="#type-t.A" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">A</span> 
-         <span class="keyword">of</span> <a href="#type-t">t</a>
-        </span>
-       </code>
-      </li>
-     </ol>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>b.c</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-t.A" class="def variant constructor anchored">
+        <a href="#type-t.A" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">A</span> 
+          <span class="keyword">of</span> <a href="#type-t">t</a>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a-module-type-b.html
@@ -17,25 +17,27 @@
    <a href="Module_type_subst-Structural-module-type-u-module-type-a.html">a
    </a> &#x00BB; b
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>a.b</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-c">
-     <a href="#module-type-c" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Module_type_subst-Structural-module-type-u-module-type-a-module-type-b-module-type-c.html"
-        >c
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>a.b</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-c">
+      <a href="#module-type-c" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Module_type_subst-Structural-module-type-u-module-type-a-module-type-b-module-type-c.html"
+         >c
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u-module-type-a.html
@@ -15,25 +15,27 @@
     <a href="Module_type_subst-Structural-module-type-u.html">u</a> &#x00BB;
     a
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>u.a</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-b">
-     <a href="#module-type-b" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Module_type_subst-Structural-module-type-u-module-type-a-module-type-b.html"
-        >b
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>u.a</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-b">
+      <a href="#module-type-b" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Module_type_subst-Structural-module-type-u-module-type-a-module-type-b.html"
+         >b
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural-module-type-u.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-u.html
@@ -13,25 +13,27 @@
     <a href="Module_type_subst-Structural.html">Structural</a> &#x00BB;
     u
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Structural.u</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-a">
-     <a href="#module-type-a" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Module_type_subst-Structural-module-type-u-module-type-a.html">
-        a
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Structural.u</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-a">
+      <a href="#module-type-a" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Module_type_subst-Structural-module-type-u-module-type-a.html">
+         a
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b-module-type-c.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b-module-type-c.html
@@ -23,25 +23,27 @@
     >b
    </a> &#x00BB; c
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>b.c</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-t.A" class="def variant constructor anchored">
-       <a href="#type-t.A" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">A</span> 
-         <span class="keyword">of</span> <a href="#type-t">t</a>
-        </span>
-       </code>
-      </li>
-     </ol>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>b.c</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-t.A" class="def variant constructor anchored">
+        <a href="#type-t.A" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">A</span> 
+          <span class="keyword">of</span> <a href="#type-t">t</a>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a-module-type-b.html
@@ -17,25 +17,27 @@
    <a href="Module_type_subst-Structural-module-type-w-module-type-a.html">a
    </a> &#x00BB; b
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>a.b</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-c">
-     <a href="#module-type-c" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Module_type_subst-Structural-module-type-w-module-type-a-module-type-b-module-type-c.html"
-        >c
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>a.b</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-c">
+      <a href="#module-type-c" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Module_type_subst-Structural-module-type-w-module-type-a-module-type-b-module-type-c.html"
+         >c
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w-module-type-a.html
@@ -15,25 +15,27 @@
     <a href="Module_type_subst-Structural-module-type-w.html">w</a> &#x00BB;
     a
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>w.a</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-b">
-     <a href="#module-type-b" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Module_type_subst-Structural-module-type-w-module-type-a-module-type-b.html"
-        >b
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>w.a</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-b">
+      <a href="#module-type-b" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Module_type_subst-Structural-module-type-w-module-type-a-module-type-b.html"
+         >b
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural-module-type-w.html
+++ b/test/generators/html/Module_type_subst-Structural-module-type-w.html
@@ -13,25 +13,27 @@
     <a href="Module_type_subst-Structural.html">Structural</a> &#x00BB;
     w
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Structural.w</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-a">
-     <a href="#module-type-a" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Module_type_subst-Structural-module-type-w-module-type-a.html">
-        a
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Structural.w</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-a">
+      <a href="#module-type-a" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Module_type_subst-Structural-module-type-w-module-type-a.html">
+         a
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-Structural.html
+++ b/test/generators/html/Module_type_subst-Structural.html
@@ -11,45 +11,47 @@
   <nav class="odoc-nav"><a href="Module_type_subst.html">Up</a> – 
    <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB; Structural
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module_type_subst.Structural</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-u">
-     <a href="#module-type-u" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Structural-module-type-u.html">u</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-w">
-     <a href="#module-type-w" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-Structural-module-type-w.html">w</a>
-      </span>
-      <span> = 
-       <a href="Module_type_subst-Structural-module-type-u.html">u</a>
-        <span class="keyword">with</span> 
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module_type_subst.Structural</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-u">
+      <a href="#module-type-u" class="anchor"></a>
+      <code>
        <span><span class="keyword">module</span> 
         <span class="keyword">type</span> 
-        <a
-         href="Module_type_subst-Structural-module-type-u-module-type-a.html">
-         a
-        </a> = <span class="keyword">sig</span> ... 
+        <a href="Module_type_subst-Structural-module-type-u.html">u</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
         <span class="keyword">end</span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-w">
+      <a href="#module-type-w" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-Structural-module-type-w.html">w</a>
+       </span>
+       <span> = 
+        <a href="Module_type_subst-Structural-module-type-u.html">u</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <span class="keyword">type</span> 
+         <a
+          href="Module_type_subst-Structural-module-type-u-module-type-a.html">
+          a
+         </a> = <span class="keyword">sig</span> ... 
+         <span class="keyword">end</span>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Module_type_subst-module-type-s.html
+++ b/test/generators/html/Module_type_subst-module-type-s.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Module_type_subst.html">Up</a> – 
    <a href="Module_type_subst.html">Module_type_subst</a> &#x00BB; s
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Module_type_subst.s</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Module_type_subst.s</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Module_type_subst.html
+++ b/test/generators/html/Module_type_subst.html
@@ -8,74 +8,76 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Module_type_subst</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Local">
-     <a href="#module-Local" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Local.html">Local</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Module_type_subst</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Local">
+      <a href="#module-Local" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Local.html">Local</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-s">
-     <a href="#module-type-s" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Module_type_subst-module-type-s.html">s</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-s">
+      <a href="#module-type-s" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Module_type_subst-module-type-s.html">s</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Basic">
-     <a href="#module-Basic" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Basic.html">Basic</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Basic">
+      <a href="#module-Basic" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Basic.html">Basic</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Nested">
-     <a href="#module-Nested" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Nested.html">Nested</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Nested">
+      <a href="#module-Nested" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Nested.html">Nested</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Structural">
-     <a href="#module-Structural" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Module_type_subst-Structural.html">Structural</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Structural">
+      <a href="#module-Structural" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Module_type_subst-Structural.html">Structural</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Nested-F-argument-1-Arg1.html
+++ b/test/generators/html/Nested-F-argument-1-Arg1.html
@@ -12,29 +12,31 @@
    <a href="Nested.html">Nested</a> &#x00BB; <a href="Nested-F.html">F</a>
     &#x00BB; Arg1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>F.Arg1</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#type">Type</a></li><li><a href="#values">Values</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
-    </div><div class="spec-doc"><p>Some type.</p></div>
-   </div><h2 id="values"><a href="#values" class="anchor"></a>Values</h2>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-y">
-     <a href="#val-y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> y : <a href="#type-t">t</a>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>The value of y.</p></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>F.Arg1</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div><div class="spec-doc"><p>Some type.</p></div>
+    </div><h2 id="values"><a href="#values" class="anchor"></a>Values</h2>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-y">
+      <a href="#val-y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> y : <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>The value of y.</p></div>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Nested-F-argument-2-Arg2.html
+++ b/test/generators/html/Nested-F-argument-2-Arg2.html
@@ -12,17 +12,19 @@
    <a href="Nested.html">Nested</a> &#x00BB; <a href="Nested-F.html">F</a>
     &#x00BB; Arg2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>F.Arg2</span></code></h1>
-  </header>
   <nav class="odoc-toc"><ul><li><a href="#type">Type</a></li></ul></nav>
-  <div class="odoc-content">
-   <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
-    </div><div class="spec-doc"><p>Some type.</p></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>F.Arg2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div><div class="spec-doc"><p>Some type.</p></div>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Nested-F.html
+++ b/test/generators/html/Nested-F.html
@@ -11,50 +11,52 @@
   <nav class="odoc-nav"><a href="Nested.html">Up</a> – 
    <a href="Nested.html">Nested</a> &#x00BB; F
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Nested.F</span></code></h1>
-   <p>This is a functor F.</p><p>Some additional comments.</p>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
     <li><a href="#type">Type</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Arg1">
-     <a href="#argument-1-Arg1" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Nested-F-argument-1-Arg1.html">Arg1</a></span>
-      <span> : <a href="Nested-module-type-Y.html">Y</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Nested.F</span></code></h1>
+    <p>This is a functor F.</p><p>Some additional comments.</p>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Arg1">
+      <a href="#argument-1-Arg1" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Nested-F-argument-1-Arg1.html">Arg1</a></span>
+       <span> : <a href="Nested-module-type-Y.html">Y</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-2-Arg2">
-     <a href="#argument-2-Arg2" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Nested-F-argument-2-Arg2.html">Arg2</a></span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-2-Arg2">
+      <a href="#argument-2-Arg2" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Nested-F-argument-2-Arg2.html">Arg2</a></span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = <a href="Nested-F-argument-1-Arg1.html#type-t">Arg1.t</a>
-        * <a href="Nested-F-argument-2-Arg2.html#type-t">Arg2.t</a>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Some type.</p></div>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = <a href="Nested-F-argument-1-Arg1.html#type-t">Arg1.t</a>
+         * <a href="Nested-F-argument-2-Arg2.html#type-t">Arg2.t</a>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Some type.</p></div>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Nested-X.html
+++ b/test/generators/html/Nested-X.html
@@ -11,30 +11,32 @@
   <nav class="odoc-nav"><a href="Nested.html">Up</a> – 
    <a href="Nested.html">Nested</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Nested.X</span></code></h1><p>This is module X.</p>
-   <p>Some additional comments.</p>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#type">Type</a></li><li><a href="#values">Values</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
-    </div><div class="spec-doc"><p>Some type.</p></div>
-   </div><h2 id="values"><a href="#values" class="anchor"></a>Values</h2>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-x">
-     <a href="#val-x" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> x : <a href="#type-t">t</a>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>The value of x.</p></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Nested.X</span></code></h1>
+    <p>This is module X.</p><p>Some additional comments.</p>
+   </header>
+   <div class="odoc-content">
+    <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div><div class="spec-doc"><p>Some type.</p></div>
+    </div><h2 id="values"><a href="#values" class="anchor"></a>Values</h2>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-x">
+      <a href="#val-x" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> x : <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>The value of x.</p></div>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Nested-class-inherits.html
+++ b/test/generators/html/Nested-class-inherits.html
@@ -11,17 +11,19 @@
   <nav class="odoc-nav"><a href="Nested.html">Up</a> – 
    <a href="Nested.html">Nested</a> &#x00BB; inherits
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Nested.inherits</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec inherit">
-     <code>
-      <span><span class="keyword">inherit</span> 
-       <a href="Nested-class-z.html">z</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Nested.inherits</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec inherit">
+      <code>
+       <span><span class="keyword">inherit</span> 
+        <a href="Nested-class-z.html">z</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Nested-class-z.html
+++ b/test/generators/html/Nested-class-z.html
@@ -11,45 +11,47 @@
   <nav class="odoc-nav"><a href="Nested.html">Up</a> – 
    <a href="Nested.html">Nested</a> &#x00BB; z
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Nested.z</span></code></h1><p>This is class z.</p>
-   <p>Some additional comments.</p>
-  </header>
   <nav class="odoc-toc"><ul><li><a href="#methods">Methods</a></li></ul>
   </nav>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value instance-variable anchored" id="val-y">
-     <a href="#val-y" class="anchor"></a>
-     <code><span><span class="keyword">val</span> y : int</span></code>
-    </div><div class="spec-doc"><p>Some value.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value instance-variable anchored" id="val-y'">
-     <a href="#val-y'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> 
-       <span class="keyword">mutable</span> 
-       <span class="keyword">virtual</span> y' : int
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Nested.z</span></code></h1><p>This is class z.</p>
+    <p>Some additional comments.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value instance-variable anchored" id="val-y">
+      <a href="#val-y" class="anchor"></a>
+      <code><span><span class="keyword">val</span> y : int</span></code>
+     </div><div class="spec-doc"><p>Some value.</p></div>
     </div>
-   </div><h2 id="methods"><a href="#methods" class="anchor"></a>Methods</h2>
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-z">
-     <a href="#method-z" class="anchor"></a>
-     <code><span><span class="keyword">method</span> z : int</span></code>
-    </div><div class="spec-doc"><p>Some method.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-z'">
-     <a href="#method-z'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">method</span> 
-       <span class="keyword">private</span> 
-       <span class="keyword">virtual</span> z' : int
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value instance-variable anchored" id="val-y'">
+      <a href="#val-y'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> 
+        <span class="keyword">mutable</span> 
+        <span class="keyword">virtual</span> y' : int
+       </span>
+      </code>
+     </div>
+    </div><h2 id="methods"><a href="#methods" class="anchor"></a>Methods</h2>
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-z">
+      <a href="#method-z" class="anchor"></a>
+      <code><span><span class="keyword">method</span> z : int</span></code>
+     </div><div class="spec-doc"><p>Some method.</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-z'">
+      <a href="#method-z'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">method</span> 
+        <span class="keyword">private</span> 
+        <span class="keyword">virtual</span> z' : int
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Nested-module-type-Y.html
+++ b/test/generators/html/Nested-module-type-Y.html
@@ -11,30 +11,32 @@
   <nav class="odoc-nav"><a href="Nested.html">Up</a> – 
    <a href="Nested.html">Nested</a> &#x00BB; Y
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Nested.Y</span></code></h1>
-   <p>This is module type Y.</p><p>Some additional comments.</p>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#type">Type</a></li><li><a href="#values">Values</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
-    </div><div class="spec-doc"><p>Some type.</p></div>
-   </div><h2 id="values"><a href="#values" class="anchor"></a>Values</h2>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-y">
-     <a href="#val-y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> y : <a href="#type-t">t</a>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>The value of y.</p></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Nested.Y</span></code></h1>
+    <p>This is module type Y.</p><p>Some additional comments.</p>
+   </header>
+   <div class="odoc-content">
+    <h2 id="type"><a href="#type" class="anchor"></a>Type</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div><div class="spec-doc"><p>Some type.</p></div>
+    </div><h2 id="values"><a href="#values" class="anchor"></a>Values</h2>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-y">
+      <a href="#val-y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> y : <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>The value of y.</p></div>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Nested.html
+++ b/test/generators/html/Nested.html
@@ -8,10 +8,6 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Nested</span></code></h1>
-   <p>This comment needs to be here before #235 is fixed.</p>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#module">Module</a></li>
     <li><a href="#module-type">Module type</a></li>
@@ -19,76 +15,85 @@
     <li><a href="#class">Class</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="module"><a href="#module" class="anchor"></a>Module</h2>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Nested-X.html">X</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>This is module X.</p></div>
-   </div>
-   <h2 id="module-type"><a href="#module-type" class="anchor"></a>Module type
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Y">
-     <a href="#module-type-Y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Nested-module-type-Y.html">Y</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>This is module type Y.</p></div>
-   </div><h2 id="functor"><a href="#functor" class="anchor"></a>Functor</h2>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-F">
-     <a href="#module-F" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Nested-F.html">F</a>
-      </span>
-      <span> (<a href="Nested-F-argument-1-Arg1.html">Arg1</a> : 
-       <a href="Nested-module-type-Y.html">Y</a>) (
-       <a href="Nested-F-argument-2-Arg2.html">Arg2</a> : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-       ) : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>This is a functor F.</p></div>
-   </div><h2 id="class"><a href="#class" class="anchor"></a>Class</h2>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-z">
-     <a href="#class-z" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">virtual</span> 
-      </span><span><a href="Nested-class-z.html">z</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>This is class z.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-inherits">
-     <a href="#class-inherits" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">virtual</span> 
-      </span><span><a href="Nested-class-inherits.html">inherits</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Nested</span></code></h1>
+    <p>This comment needs to be here before #235 is fixed.</p>
+   </header>
+   <div class="odoc-content">
+    <h2 id="module"><a href="#module" class="anchor"></a>Module</h2>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Nested-X.html">X</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>This is module X.</p></div>
+    </div>
+    <h2 id="module-type"><a href="#module-type" class="anchor"></a>Module
+      type
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-Y">
+      <a href="#module-type-Y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Nested-module-type-Y.html">Y</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>This is module type Y.</p></div>
+    </div><h2 id="functor"><a href="#functor" class="anchor"></a>Functor</h2>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-F">
+      <a href="#module-F" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Nested-F.html">F</a>
+       </span>
+       <span> (<a href="Nested-F-argument-1-Arg1.html">Arg1</a> : 
+        <a href="Nested-module-type-Y.html">Y</a>) (
+        <a href="Nested-F-argument-2-Arg2.html">Arg2</a> : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+        ) : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>This is a functor F.</p></div>
+    </div><h2 id="class"><a href="#class" class="anchor"></a>Class</h2>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-z">
+      <a href="#class-z" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">virtual</span> 
+       </span><span><a href="Nested-class-z.html">z</a></span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>This is class z.</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-inherits">
+      <a href="#class-inherits" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">virtual</span> 
+       </span><span><a href="Nested-class-inherits.html">inherits</a></span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-E.html
+++ b/test/generators/html/Ocamlary-Aliases-E.html
@@ -12,25 +12,27 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; E
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Aliases.E</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Aliases.E</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
-       </span> <a href="#type-t">t</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
+        </span> <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-Foo-A.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-A.html
@@ -13,25 +13,27 @@
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; 
    <a href="Ocamlary-Aliases-Foo.html">Foo</a> &#x00BB; A
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Foo.A</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Foo.A</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
-       </span> <a href="#type-t">t</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
+        </span> <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-Foo-B.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-B.html
@@ -13,25 +13,27 @@
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; 
    <a href="Ocamlary-Aliases-Foo.html">Foo</a> &#x00BB; B
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Foo.B</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Foo.B</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
-       </span> <a href="#type-t">t</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
+        </span> <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-Foo-C.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-C.html
@@ -13,25 +13,27 @@
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; 
    <a href="Ocamlary-Aliases-Foo.html">Foo</a> &#x00BB; C
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Foo.C</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Foo.C</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
-       </span> <a href="#type-t">t</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
+        </span> <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-Foo-D.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-D.html
@@ -13,25 +13,27 @@
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; 
    <a href="Ocamlary-Aliases-Foo.html">Foo</a> &#x00BB; D
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Foo.D</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Foo.D</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
-       </span> <a href="#type-t">t</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
+        </span> <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-Foo-E.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo-E.html
@@ -13,25 +13,27 @@
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; 
    <a href="Ocamlary-Aliases-Foo.html">Foo</a> &#x00BB; E
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Foo.E</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Foo.E</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
-       </span> <a href="#type-t">t</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
+        </span> <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-Foo.html
+++ b/test/generators/html/Ocamlary-Aliases-Foo.html
@@ -12,73 +12,75 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; Foo
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Aliases.Foo</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-A">
-     <a href="#module-A" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-Foo-A.html">A</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Aliases.Foo</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-A">
+      <a href="#module-A" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases-Foo-A.html">A</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-B">
-     <a href="#module-B" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-Foo-B.html">B</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-B">
+      <a href="#module-B" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases-Foo-B.html">B</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-C">
-     <a href="#module-C" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-Foo-C.html">C</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-C">
+      <a href="#module-C" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases-Foo-C.html">C</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-D">
-     <a href="#module-D" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-Foo-D.html">D</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-D">
+      <a href="#module-D" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases-Foo-D.html">D</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-E">
-     <a href="#module-E" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-Foo-E.html">E</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-E">
+      <a href="#module-E" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases-Foo-E.html">E</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-P1-Y.html
+++ b/test/generators/html/Ocamlary-Aliases-P1-Y.html
@@ -13,25 +13,27 @@
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; 
    <a href="Ocamlary-Aliases-P1.html">P1</a> &#x00BB; Y
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>P1.Y</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>P1.Y</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
-       </span> <a href="#type-t">t</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
+        </span> <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-P1.html
+++ b/test/generators/html/Ocamlary-Aliases-P1.html
@@ -12,21 +12,23 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; P1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Aliases.P1</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-P1-Y.html">Y</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Aliases.P1</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases-P1-Y.html">Y</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-P2-Z.html
+++ b/test/generators/html/Ocamlary-Aliases-P2-Z.html
@@ -13,25 +13,27 @@
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; 
    <a href="Ocamlary-Aliases-P2.html">P2</a> &#x00BB; Z
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>P2.Z</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>P2.Z</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
-       </span> <a href="#type-t">t</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
+        </span> <a href="#type-t">t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-P2.html
+++ b/test/generators/html/Ocamlary-Aliases-P2.html
@@ -12,21 +12,23 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; P2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Aliases.P2</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Z">
-     <a href="#module-Z" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-P2-Z.html">Z</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Aliases.P2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Z">
+      <a href="#module-Z" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases-P2-Z.html">Z</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases-Std.html
+++ b/test/generators/html/Ocamlary-Aliases-Std.html
@@ -12,48 +12,50 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Aliases.html">Aliases</a> &#x00BB; Std
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Aliases.Std</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-A">
-     <a href="#module-A" class="anchor"></a>
-     <code><span><span class="keyword">module</span> A</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-A.html">Foo.A</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Aliases.Std</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-A">
+      <a href="#module-A" class="anchor"></a>
+      <code><span><span class="keyword">module</span> A</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-A.html">Foo.A</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-B">
-     <a href="#module-B" class="anchor"></a>
-     <code><span><span class="keyword">module</span> B</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-B.html">Foo.B</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-B">
+      <a href="#module-B" class="anchor"></a>
+      <code><span><span class="keyword">module</span> B</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-B.html">Foo.B</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-C">
-     <a href="#module-C" class="anchor"></a>
-     <code><span><span class="keyword">module</span> C</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-C.html">Foo.C</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-C">
+      <a href="#module-C" class="anchor"></a>
+      <code><span><span class="keyword">module</span> C</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-C.html">Foo.C</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-D">
-     <a href="#module-D" class="anchor"></a>
-     <code><span><span class="keyword">module</span> D</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-D.html">Foo.D</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-D">
+      <a href="#module-D" class="anchor"></a>
+      <code><span><span class="keyword">module</span> D</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-D.html">Foo.D</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-E">
-     <a href="#module-E" class="anchor"></a>
-     <code><span><span class="keyword">module</span> E</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-E.html">Foo.E</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-E">
+      <a href="#module-E" class="anchor"></a>
+      <code><span><span class="keyword">module</span> E</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-E.html">Foo.E</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Aliases.html
+++ b/test/generators/html/Ocamlary-Aliases.html
@@ -11,227 +11,230 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Aliases
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Aliases</span></code></h1>
-   <p>Let's imitate jst's layout.</p>
-  </header>
   <nav class="odoc-toc"><ul><li><a href="#incl">include of Foo</a></li></ul>
   </nav>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Foo">
-     <a href="#module-Foo" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-Foo.html">Foo</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-A'">
-     <a href="#module-A'" class="anchor"></a>
-     <code><span><span class="keyword">module</span> A'</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-A.html">Foo.A</a></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-tata">
-     <a href="#type-tata" class="anchor"></a>
-     <code><span><span class="keyword">type</span> tata</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-A.html#type-t">Foo.A.t</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-tbtb">
-     <a href="#type-tbtb" class="anchor"></a>
-     <code><span><span class="keyword">type</span> tbtb</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-B.html#type-t">Foo.B.t</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-tete">
-     <a href="#type-tete" class="anchor"></a>
-     <code><span><span class="keyword">type</span> tete</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-tata'">
-     <a href="#type-tata'" class="anchor"></a>
-     <code><span><span class="keyword">type</span> tata'</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-A.html#type-t">A'.t</a></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-tete2">
-     <a href="#type-tete2" class="anchor"></a>
-     <code><span><span class="keyword">type</span> tete2</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-E.html#type-t">Foo.E.t</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Std">
-     <a href="#module-Std" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-Std.html">Std</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-stde">
-     <a href="#type-stde" class="anchor"></a>
-     <code><span><span class="keyword">type</span> stde</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-E.html#type-t">Std.E.t</a>
-      </span>
-     </code>
-    </div>
-   </div><h4 id="incl"><a href="#incl" class="anchor"></a>include of Foo</h4>
-   <p>Just for giggle, let's see what happens when we include 
-    <a href="Ocamlary-Aliases-Foo.html"><code>Foo</code></a>.
-   </p>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Aliases</span></code></h1>
+    <p>Let's imitate jst's layout.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Foo">
+      <a href="#module-Foo" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
-        <span class="keyword">module</span> <span class="keyword">type</span>
-         <span class="keyword">of</span> 
+       <span><span class="keyword">module</span> 
         <a href="Ocamlary-Aliases-Foo.html">Foo</a>
        </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-A">
-       <a href="#module-A" class="anchor"></a>
-       <code><span><span class="keyword">module</span> A</span>
-        <span> = <a href="Ocamlary-Aliases-Foo-A.html">Foo.A</a></span>
-       </code>
-      </div>
      </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-B">
-       <a href="#module-B" class="anchor"></a>
-       <code><span><span class="keyword">module</span> B</span>
-        <span> = <a href="Ocamlary-Aliases-Foo-B.html">Foo.B</a></span>
-       </code>
-      </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-A'">
+      <a href="#module-A'" class="anchor"></a>
+      <code><span><span class="keyword">module</span> A'</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-A.html">Foo.A</a></span>
+      </code>
      </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-C">
-       <a href="#module-C" class="anchor"></a>
-       <code><span><span class="keyword">module</span> C</span>
-        <span> = <a href="Ocamlary-Aliases-Foo-C.html">Foo.C</a></span>
-       </code>
-      </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-tata">
+      <a href="#type-tata" class="anchor"></a>
+      <code><span><span class="keyword">type</span> tata</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-A.html#type-t">Foo.A.t</a>
+       </span>
+      </code>
      </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-D">
-       <a href="#module-D" class="anchor"></a>
-       <code><span><span class="keyword">module</span> D</span>
-        <span> = <a href="Ocamlary-Aliases-Foo-D.html">Foo.D</a></span>
-       </code>
-      </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-tbtb">
+      <a href="#type-tbtb" class="anchor"></a>
+      <code><span><span class="keyword">type</span> tbtb</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-B.html#type-t">Foo.B.t</a>
+       </span>
+      </code>
      </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-E">
-       <a href="#module-E" class="anchor"></a>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-tete">
+      <a href="#type-tete" class="anchor"></a>
+      <code><span><span class="keyword">type</span> tete</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-tata'">
+      <a href="#type-tata'" class="anchor"></a>
+      <code><span><span class="keyword">type</span> tata'</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-A.html#type-t">A'.t</a></span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-tete2">
+      <a href="#type-tete2" class="anchor"></a>
+      <code><span><span class="keyword">type</span> tete2</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-E.html#type-t">Foo.E.t</a>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Std">
+      <a href="#module-Std" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases-Std.html">Std</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-stde">
+      <a href="#type-stde" class="anchor"></a>
+      <code><span><span class="keyword">type</span> stde</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-E.html#type-t">Std.E.t</a>
+       </span>
+      </code>
+     </div>
+    </div>
+    <h4 id="incl"><a href="#incl" class="anchor"></a>include of Foo</h4>
+    <p>Just for giggle, let's see what happens when we include 
+     <a href="Ocamlary-Aliases-Foo.html"><code>Foo</code></a>.
+    </p>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
        <code>
-        <span><span class="keyword">module</span> 
-         <a href="Ocamlary-Aliases-E.html">E</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
+        <span><span class="keyword">include</span> 
+         <span class="keyword">module</span> 
+         <span class="keyword">type</span> <span class="keyword">of</span>
+          <a href="Ocamlary-Aliases-Foo.html">Foo</a>
         </span>
        </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-A">
+        <a href="#module-A" class="anchor"></a>
+        <code><span><span class="keyword">module</span> A</span>
+         <span> = <a href="Ocamlary-Aliases-Foo-A.html">Foo.A</a></span>
+        </code>
+       </div>
       </div>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-B">
+        <a href="#module-B" class="anchor"></a>
+        <code><span><span class="keyword">module</span> B</span>
+         <span> = <a href="Ocamlary-Aliases-Foo-B.html">Foo.B</a></span>
+        </code>
+       </div>
+      </div>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-C">
+        <a href="#module-C" class="anchor"></a>
+        <code><span><span class="keyword">module</span> C</span>
+         <span> = <a href="Ocamlary-Aliases-Foo-C.html">Foo.C</a></span>
+        </code>
+       </div>
+      </div>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-D">
+        <a href="#module-D" class="anchor"></a>
+        <code><span><span class="keyword">module</span> D</span>
+         <span> = <a href="Ocamlary-Aliases-Foo-D.html">Foo.D</a></span>
+        </code>
+       </div>
+      </div>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-E">
+        <a href="#module-E" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <a href="Ocamlary-Aliases-E.html">E</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+      </div>
+     </details>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-testa">
+      <a href="#type-testa" class="anchor"></a>
+      <code><span><span class="keyword">type</span> testa</span>
+       <span> = <a href="Ocamlary-Aliases-Foo-A.html#type-t">A.t</a></span>
+      </code>
      </div>
-    </details>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-testa">
-     <a href="#type-testa" class="anchor"></a>
-     <code><span><span class="keyword">type</span> testa</span>
-      <span> = <a href="Ocamlary-Aliases-Foo-A.html#type-t">A.t</a></span>
-     </code>
     </div>
-   </div>
-   <p>And also, let's refer to 
-    <a href="Ocamlary-Aliases-Foo-A.html#type-t"><code>A.t</code></a>
-     and 
-    <a href="Ocamlary-Aliases-Foo-B.html#val-id"><code>Foo.B.id</code></a>
-   </p>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-P1">
-     <a href="#module-P1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-P1.html">P1</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <p>And also, let's refer to 
+     <a href="Ocamlary-Aliases-Foo-A.html#type-t"><code>A.t</code></a>
+      and 
+     <a href="Ocamlary-Aliases-Foo-B.html#val-id"><code>Foo.B.id</code></a>
+    </p>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-P1">
+      <a href="#module-P1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases-P1.html">P1</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-P2">
-     <a href="#module-P2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases-P2.html">P2</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-P2">
+      <a href="#module-P2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases-P2.html">P2</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X1">
-     <a href="#module-X1" class="anchor"></a>
-     <code><span><span class="keyword">module</span> X1</span>
-      <span> = <a href="Ocamlary-Aliases-P2-Z.html">P2.Z</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X1">
+      <a href="#module-X1" class="anchor"></a>
+      <code><span><span class="keyword">module</span> X1</span>
+       <span> = <a href="Ocamlary-Aliases-P2-Z.html">P2.Z</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X2">
-     <a href="#module-X2" class="anchor"></a>
-     <code><span><span class="keyword">module</span> X2</span>
-      <span> = <a href="Ocamlary-Aliases-P2-Z.html">P2.Z</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X2">
+      <a href="#module-X2" class="anchor"></a>
+      <code><span><span class="keyword">module</span> X2</span>
+       <span> = <a href="Ocamlary-Aliases-P2-Z.html">P2.Z</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-p1">
-     <a href="#type-p1" class="anchor"></a>
-     <code><span><span class="keyword">type</span> p1</span>
-      <span> = <a href="Ocamlary-Aliases-P2-Z.html#type-t">X1.t</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-p1">
+      <a href="#type-p1" class="anchor"></a>
+      <code><span><span class="keyword">type</span> p1</span>
+       <span> = <a href="Ocamlary-Aliases-P2-Z.html#type-t">X1.t</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-p2">
-     <a href="#type-p2" class="anchor"></a>
-     <code><span><span class="keyword">type</span> p2</span>
-      <span> = <a href="Ocamlary-Aliases-P2-Z.html#type-t">X2.t</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-p2">
+      <a href="#type-p2" class="anchor"></a>
+      <code><span><span class="keyword">type</span> p2</span>
+       <span> = <a href="Ocamlary-Aliases-P2-Z.html#type-t">X2.t</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Buffer.html
+++ b/test/generators/html/Ocamlary-Buffer.html
@@ -11,21 +11,23 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Buffer
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Buffer</span></code></h1>
-   <p>References are resolved after everything, so <code>{!Buffer.t}</code>
-     won't resolve.
-   </p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-f">
-     <a href="#val-f" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> f : 
-       <span>int <span class="arrow">&#45;&gt;</span></span> unit
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Buffer</span></code></h1>
+    <p>References are resolved after everything, so <code>{!Buffer.t}</code>
+      won't resolve.
+    </p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-f">
+      <a href="#val-f" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> f : 
+        <span>int <span class="arrow">&#45;&gt;</span></span> unit
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-CanonicalTest-Base-List.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base-List.html
@@ -13,29 +13,31 @@
    <a href="Ocamlary-CanonicalTest.html">CanonicalTest</a> &#x00BB; 
    <a href="Ocamlary-CanonicalTest-Base.html">Base</a> &#x00BB; List
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Base.List</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a t</span></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Base.List</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> <span>'a t</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span>
+         <span><span class="type-var">'a</span> <a href="#type-t">t</a>
+         </span> <span class="arrow">&#45;&gt;</span>
+        </span> 
         <span><span class="type-var">'a</span> <a href="#type-t">t</a></span>
-         <span class="arrow">&#45;&gt;</span>
-       </span> 
-       <span><span class="type-var">'a</span> <a href="#type-t">t</a></span>
-      </span>
-     </code>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-CanonicalTest-Base.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base.html
@@ -12,21 +12,23 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-CanonicalTest.html">CanonicalTest</a> &#x00BB; Base
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>CanonicalTest.Base</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-List">
-     <a href="#module-List" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-CanonicalTest-Base-List.html">List</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>CanonicalTest.Base</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-List">
+      <a href="#module-List" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-CanonicalTest-Base-List.html">List</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-CanonicalTest-Base_Tests-C.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base_Tests-C.html
@@ -15,29 +15,31 @@
    <a href="Ocamlary-CanonicalTest-Base_Tests.html">Base_Tests</a> &#x00BB;
     C
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Base_Tests.C</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a t</span></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Base_Tests.C</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> <span>'a t</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span>
+         <span><span class="type-var">'a</span> <a href="#type-t">t</a>
+         </span> <span class="arrow">&#45;&gt;</span>
+        </span> 
         <span><span class="type-var">'a</span> <a href="#type-t">t</a></span>
-         <span class="arrow">&#45;&gt;</span>
-       </span> 
-       <span><span class="type-var">'a</span> <a href="#type-t">t</a></span>
-      </span>
-     </code>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-CanonicalTest-Base_Tests.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-Base_Tests.html
@@ -13,82 +13,84 @@
    <a href="Ocamlary-CanonicalTest.html">CanonicalTest</a> &#x00BB; 
    Base_Tests
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>CanonicalTest.Base_Tests</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-C">
-     <a href="#module-C" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-CanonicalTest-Base_Tests-C.html">C</a>
-      </span>
-      <span> : <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <a href="Ocamlary-CanonicalTest-Base-List.html">Base.List</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>CanonicalTest.Base_Tests</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-C">
+      <a href="#module-C" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-CanonicalTest-Base_Tests-C.html">C</a>
+       </span>
+       <span> : <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <a href="Ocamlary-CanonicalTest-Base-List.html">Base.List</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-L">
-     <a href="#module-L" class="anchor"></a>
-     <code><span><span class="keyword">module</span> L</span>
-      <span> = <a href="Ocamlary-CanonicalTest-Base-List.html">Base.List</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-L">
+      <a href="#module-L" class="anchor"></a>
+      <code><span><span class="keyword">module</span> L</span>
+       <span> = <a href="Ocamlary-CanonicalTest-Base-List.html">Base.List</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> foo : 
-       <span>
-        <span>int 
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> foo : 
+        <span>
+         <span>int 
+          <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">L.t</a>
+         </span> <span class="arrow">&#45;&gt;</span>
+        </span> 
+        <span>float 
          <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">L.t</a>
-        </span> <span class="arrow">&#45;&gt;</span>
-       </span> 
-       <span>float 
-        <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">L.t</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-bar">
-     <a href="#val-bar" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> bar : 
-       <span>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-bar">
+      <a href="#val-bar" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> bar : 
+        <span>
+         <span><span class="type-var">'a</span> 
+          <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">Base.List.t
+          </a>
+         </span> <span class="arrow">&#45;&gt;</span>
+        </span> 
         <span><span class="type-var">'a</span> 
          <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">Base.List.t
          </a>
-        </span> <span class="arrow">&#45;&gt;</span>
-       </span> 
-       <span><span class="type-var">'a</span> 
-        <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">Base.List.t
-        </a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-baz">
-     <a href="#val-baz" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> baz : 
-       <span>
-        <span><span class="type-var">'a</span> 
-         <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">Base.List.t
-         </a>
-        </span> <span class="arrow">&#45;&gt;</span>
-       </span> unit
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-baz">
+      <a href="#val-baz" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> baz : 
+        <span>
+         <span><span class="type-var">'a</span> 
+          <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">Base.List.t
+          </a>
+         </span> <span class="arrow">&#45;&gt;</span>
+        </span> unit
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-CanonicalTest-List_modif.html
+++ b/test/generators/html/Ocamlary-CanonicalTest-List_modif.html
@@ -13,35 +13,37 @@
    <a href="Ocamlary-CanonicalTest.html">CanonicalTest</a> &#x00BB; 
    List_modif
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>CanonicalTest.List_modif</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'c t</span></span>
-      <span> = 
-       <span><span class="type-var">'c</span> 
-        <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">Base.List.t
-        </a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>CanonicalTest.List_modif</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> <span>'c t</span></span>
+       <span> = 
+        <span><span class="type-var">'c</span> 
+         <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">Base.List.t
+         </a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-id">
-     <a href="#val-id" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> id : 
-       <span>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-id">
+      <a href="#val-id" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> id : 
+        <span>
+         <span><span class="type-var">'a</span> <a href="#type-t">t</a>
+         </span> <span class="arrow">&#45;&gt;</span>
+        </span> 
         <span><span class="type-var">'a</span> <a href="#type-t">t</a></span>
-         <span class="arrow">&#45;&gt;</span>
-       </span> 
-       <span><span class="type-var">'a</span> <a href="#type-t">t</a></span>
-      </span>
-     </code>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-CanonicalTest.html
+++ b/test/generators/html/Ocamlary-CanonicalTest.html
@@ -11,57 +11,60 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; CanonicalTest
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.CanonicalTest</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Base">
-     <a href="#module-Base" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-CanonicalTest-Base.html">Base</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.CanonicalTest</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Base">
+      <a href="#module-Base" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-CanonicalTest-Base.html">Base</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Base_Tests">
-     <a href="#module-Base_Tests" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-CanonicalTest-Base_Tests.html">Base_Tests</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Base_Tests">
+      <a href="#module-Base_Tests" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-CanonicalTest-Base_Tests.html">Base_Tests</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-List_modif">
-     <a href="#module-List_modif" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-CanonicalTest-List_modif.html">List_modif</a>
-      </span>
-      <span> : <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <a href="Ocamlary-CanonicalTest-Base-List.html">Base.List</a>
-        <span class="keyword">with</span> 
-       <span><span class="keyword">type</span> 
-        <span>'c <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">t</a>
-        </span> = 
-        <span><span class="type-var">'c</span> 
-         <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">Base.List.t
-         </a>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-List_modif">
+      <a href="#module-List_modif" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-CanonicalTest-List_modif.html">List_modif</a>
+       </span>
+       <span> : <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <a href="Ocamlary-CanonicalTest-Base-List.html">Base.List</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">type</span> 
+         <span>'c 
+          <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">t</a>
+         </span> = 
+         <span><span class="type-var">'c</span> 
+          <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">Base.List.t
+          </a>
+         </span>
         </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html
@@ -16,23 +16,25 @@
     <a href="Ocamlary-CollectionModule-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
-   <p>This comment is for <code>InnerModuleA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <span><span>(unit, unit)</span> 
-        <a href="Ocamlary.html#type-a_function">a_function</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
+    <p>This comment is for <code>InnerModuleA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <span><span>(unit, unit)</span> 
+         <a href="Ocamlary.html#type-a_function">a_function</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -18,24 +18,26 @@
     <a href="Ocamlary-CollectionModule-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleTypeA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
-   </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html#type-t"
-        >InnerModuleA'.t
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
+    </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html#type-t"
+         >InnerModuleA'.t
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-CollectionModule-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-CollectionModule-InnerModuleA.html
@@ -13,59 +13,62 @@
    <a href="Ocamlary-CollectionModule.html">CollectionModule</a> &#x00BB;
     InnerModuleA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>CollectionModule.InnerModuleA</span></code></h1>
-   <p>This comment is for <code>InnerModuleA</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a href="Ocamlary-CollectionModule.html#type-collection">collection
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>CollectionModule.InnerModuleA</span></code></h1>
+    <p>This comment is for <code>InnerModuleA</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a href="Ocamlary-CollectionModule.html#type-collection">collection
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA'">
-     <a href="#module-InnerModuleA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html">
-        InnerModuleA'
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA'">
+      <a href="#module-InnerModuleA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-CollectionModule-InnerModuleA-InnerModuleA'.html">
+         InnerModuleA'
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA'</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA'</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
-     <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleTypeA'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-InnerModuleTypeA'">
+      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleTypeA'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-CollectionModule.html
+++ b/test/generators/html/Ocamlary-CollectionModule.html
@@ -11,58 +11,62 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; CollectionModule
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.CollectionModule</span></code></h1>
-   <p>This comment is for <code>CollectionModule</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-collection">
-     <a href="#type-collection" class="anchor"></a>
-     <code><span><span class="keyword">type</span> collection</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.CollectionModule</span></code></h1>
+    <p>This comment is for <code>CollectionModule</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-collection">
+      <a href="#type-collection" class="anchor"></a>
+      <code><span><span class="keyword">type</span> collection</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>collection</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>collection</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-element">
+      <a href="#type-element" class="anchor"></a>
+      <code><span><span class="keyword">type</span> element</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-element">
-     <a href="#type-element" class="anchor"></a>
-     <code><span><span class="keyword">type</span> element</span></code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA">
+      <a href="#module-InnerModuleA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-CollectionModule-InnerModuleA.html">InnerModuleA
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA</code>.</p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA">
-     <a href="#module-InnerModuleA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-CollectionModule-InnerModuleA.html">InnerModuleA</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
-     <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> InnerModuleTypeA
-      </span>
-      <span> = 
-       <a
-        href="Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleA.InnerModuleTypeA'
-       </a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
+      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> InnerModuleTypeA
+       </span>
+       <span> = 
+        <a
+         href="Ocamlary-CollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleA.InnerModuleTypeA'
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep1-X-Y-class-c.html
+++ b/test/generators/html/Ocamlary-Dep1-X-Y-class-c.html
@@ -14,13 +14,15 @@
    <a href="Ocamlary-Dep1-X.html">X</a> &#x00BB; 
    <a href="Ocamlary-Dep1-X-Y.html">Y</a> &#x00BB; c
   </nav>
-  <header class="odoc-preamble"><h1>Class <code><span>Y.c</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-m">
-     <a href="#method-m" class="anchor"></a>
-     <code><span><span class="keyword">method</span> m : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble"><h1>Class <code><span>Y.c</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-m">
+      <a href="#method-m" class="anchor"></a>
+      <code><span><span class="keyword">method</span> m : int</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep1-X-Y.html
+++ b/test/generators/html/Ocamlary-Dep1-X-Y.html
@@ -13,18 +13,21 @@
    <a href="Ocamlary-Dep1.html">Dep1</a> &#x00BB; 
    <a href="Ocamlary-Dep1-X.html">X</a> &#x00BB; Y
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>X.Y</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-c">
-     <a href="#class-c" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Ocamlary-Dep1-X-Y-class-c.html">c</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>X.Y</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-c">
+      <a href="#class-c" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Ocamlary-Dep1-X-Y-class-c.html">c</a></span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep1-X.html
+++ b/test/generators/html/Ocamlary-Dep1-X.html
@@ -12,18 +12,21 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep1.html">Dep1</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Dep1.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep1-X-Y.html">Y</a>
-      </span><span> : <a href="Ocamlary-Dep1-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Dep1.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep1-X-Y.html">Y</a>
+       </span>
+       <span> : <a href="Ocamlary-Dep1-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep1-module-type-S-class-c.html
+++ b/test/generators/html/Ocamlary-Dep1-module-type-S-class-c.html
@@ -13,13 +13,15 @@
    <a href="Ocamlary-Dep1.html">Dep1</a> &#x00BB; 
    <a href="Ocamlary-Dep1-module-type-S.html">S</a> &#x00BB; c
   </nav>
-  <header class="odoc-preamble"><h1>Class <code><span>S.c</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-m">
-     <a href="#method-m" class="anchor"></a>
-     <code><span><span class="keyword">method</span> m : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble"><h1>Class <code><span>S.c</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-m">
+      <a href="#method-m" class="anchor"></a>
+      <code><span><span class="keyword">method</span> m : int</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep1-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep1-module-type-S.html
@@ -12,19 +12,21 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep1.html">Dep1</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Dep1.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-c">
-     <a href="#class-c" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Ocamlary-Dep1-module-type-S-class-c.html">c</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Dep1.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-c">
+      <a href="#class-c" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Ocamlary-Dep1-module-type-S-class-c.html">c</a></span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep1.html
+++ b/test/generators/html/Ocamlary-Dep1.html
@@ -11,35 +11,37 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep1</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-Dep1-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep1</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-Dep1-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep1-X.html">X</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep1-X.html">X</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep11-module-type-S-class-c.html
+++ b/test/generators/html/Ocamlary-Dep11-module-type-S-class-c.html
@@ -13,13 +13,15 @@
    <a href="Ocamlary-Dep11.html">Dep11</a> &#x00BB; 
    <a href="Ocamlary-Dep11-module-type-S.html">S</a> &#x00BB; c
   </nav>
-  <header class="odoc-preamble"><h1>Class <code><span>S.c</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-m">
-     <a href="#method-m" class="anchor"></a>
-     <code><span><span class="keyword">method</span> m : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble"><h1>Class <code><span>S.c</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-m">
+      <a href="#method-m" class="anchor"></a>
+      <code><span><span class="keyword">method</span> m : int</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep11-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep11-module-type-S.html
@@ -12,19 +12,21 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep11.html">Dep11</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Dep11.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-c">
-     <a href="#class-c" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Ocamlary-Dep11-module-type-S-class-c.html">c</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Dep11.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-c">
+      <a href="#class-c" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Ocamlary-Dep11-module-type-S-class-c.html">c</a></span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep11.html
+++ b/test/generators/html/Ocamlary-Dep11.html
@@ -11,22 +11,24 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep11
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep11</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-Dep11-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep11</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-Dep11-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep12-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep12-argument-1-Arg.html
@@ -12,18 +12,20 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep12.html">Dep12</a> &#x00BB; Arg
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>Dep12.Arg</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> S
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>Dep12.Arg</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> S
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep12.html
+++ b/test/generators/html/Ocamlary-Dep12.html
@@ -11,40 +11,42 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep12
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep12</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Arg">
-     <a href="#argument-1-Arg" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Ocamlary-Dep12-argument-1-Arg.html">Arg</a></span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep12</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Arg">
+      <a href="#argument-1-Arg" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Ocamlary-Dep12-argument-1-Arg.html">Arg</a></span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> T
-      </span>
-      <span> = 
-       <a href="Ocamlary-Dep12-argument-1-Arg.html#module-type-S">Arg.S</a>
-      </span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> T
+       </span>
+       <span> = 
+        <a href="Ocamlary-Dep12-argument-1-Arg.html#module-type-S">Arg.S</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep13-class-c.html
+++ b/test/generators/html/Ocamlary-Dep13-class-c.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep13.html">Dep13</a> &#x00BB; c
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Dep13.c</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-m">
-     <a href="#method-m" class="anchor"></a>
-     <code><span><span class="keyword">method</span> m : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Dep13.c</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-m">
+      <a href="#method-m" class="anchor"></a>
+      <code><span><span class="keyword">method</span> m : int</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep13.html
+++ b/test/generators/html/Ocamlary-Dep13.html
@@ -11,19 +11,21 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep13
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep13</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-c">
-     <a href="#class-c" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Ocamlary-Dep13-class-c.html">c</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep13</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-c">
+      <a href="#class-c" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Ocamlary-Dep13-class-c.html">c</a></span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep2-A.html
+++ b/test/generators/html/Ocamlary-Dep2-A.html
@@ -12,18 +12,20 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep2.html">Dep2</a> &#x00BB; A
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Dep2.A</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code><span><span class="keyword">module</span> Y</span>
-      <span> : 
-       <a href="Ocamlary-Dep2-argument-1-Arg.html#module-type-S">Arg.S</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Dep2.A</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code><span><span class="keyword">module</span> Y</span>
+       <span> : 
+        <a href="Ocamlary-Dep2-argument-1-Arg.html#module-type-S">Arg.S</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep2-argument-1-Arg-X.html
+++ b/test/generators/html/Ocamlary-Dep2-argument-1-Arg-X.html
@@ -13,18 +13,20 @@
    <a href="Ocamlary-Dep2.html">Dep2</a> &#x00BB; 
    <a href="Ocamlary-Dep2-argument-1-Arg.html">Arg</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Arg.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code><span><span class="keyword">module</span> Y</span>
-      <span> : 
-       <a href="Ocamlary-Dep2-argument-1-Arg.html#module-type-S">S</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Arg.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code><span><span class="keyword">module</span> Y</span>
+       <span> : 
+        <a href="Ocamlary-Dep2-argument-1-Arg.html#module-type-S">S</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep2-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep2-argument-1-Arg.html
@@ -12,31 +12,33 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep2.html">Dep2</a> &#x00BB; Arg
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>Dep2.Arg</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> S
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>Dep2.Arg</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> S
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep2-argument-1-Arg-X.html">X</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep2-argument-1-Arg-X.html">X</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep2.html
+++ b/test/generators/html/Ocamlary-Dep2.html
@@ -11,48 +11,50 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep2</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Arg">
-     <a href="#argument-1-Arg" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Ocamlary-Dep2-argument-1-Arg.html">Arg</a></span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Arg">
+      <a href="#argument-1-Arg" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Ocamlary-Dep2-argument-1-Arg.html">Arg</a></span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-A">
-     <a href="#module-A" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep2-A.html">A</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-A">
+      <a href="#module-A" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep2-A.html">A</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-B">
-     <a href="#module-B" class="anchor"></a>
-     <code><span><span class="keyword">module</span> B</span>
-      <span> = <a href="Ocamlary-Dep2-A.html#module-Y">A.Y</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-B">
+      <a href="#module-B" class="anchor"></a>
+      <code><span><span class="keyword">module</span> B</span>
+       <span> = <a href="Ocamlary-Dep2-A.html#module-Y">A.Y</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep3.html
+++ b/test/generators/html/Ocamlary-Dep3.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep3
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep3</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-a">
-     <a href="#type-a" class="anchor"></a>
-     <code><span><span class="keyword">type</span> a</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep3</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-a">
+      <a href="#type-a" class="anchor"></a>
+      <code><span><span class="keyword">type</span> a</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep4-X.html
+++ b/test/generators/html/Ocamlary-Dep4-X.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep4.html">Dep4</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Dep4.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-b">
-     <a href="#type-b" class="anchor"></a>
-     <code><span><span class="keyword">type</span> b</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Dep4.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-b">
+      <a href="#type-b" class="anchor"></a>
+      <code><span><span class="keyword">type</span> b</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep4-module-type-S-X.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-S-X.html
@@ -13,13 +13,16 @@
    <a href="Ocamlary-Dep4.html">Dep4</a> &#x00BB; 
    <a href="Ocamlary-Dep4-module-type-S.html">S</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>S.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-b">
-     <a href="#type-b" class="anchor"></a>
-     <code><span><span class="keyword">type</span> b</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-b">
+      <a href="#type-b" class="anchor"></a>
+      <code><span><span class="keyword">type</span> b</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep4-module-type-S-Y.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-S-Y.html
@@ -13,7 +13,10 @@
    <a href="Ocamlary-Dep4.html">Dep4</a> &#x00BB; 
    <a href="Ocamlary-Dep4-module-type-S.html">S</a> &#x00BB; Y
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>S.Y</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S.Y</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-Dep4-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-S.html
@@ -12,31 +12,34 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep4.html">Dep4</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Dep4.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep4-module-type-S-X.html">X</a>
-      </span><span> : <a href="Ocamlary-Dep4-module-type-T.html">T</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Dep4.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep4-module-type-S-X.html">X</a>
+       </span>
+       <span> : <a href="Ocamlary-Dep4-module-type-T.html">T</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep4-module-type-S-Y.html">Y</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep4-module-type-S-Y.html">Y</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep4-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep4-module-type-T.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep4.html">Dep4</a> &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Dep4.T</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-b">
-     <a href="#type-b" class="anchor"></a>
-     <code><span><span class="keyword">type</span> b</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Dep4.T</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-b">
+      <a href="#type-b" class="anchor"></a>
+      <code><span><span class="keyword">type</span> b</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep4.html
+++ b/test/generators/html/Ocamlary-Dep4.html
@@ -11,46 +11,49 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep4
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep4</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-Dep4-module-type-T.html">T</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep4</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-Dep4-module-type-T.html">T</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-Dep4-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-Dep4-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep4-X.html">X</a>
-      </span><span> : <a href="Ocamlary-Dep4-module-type-T.html">T</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep4-X.html">X</a>
+       </span>
+       <span> : <a href="Ocamlary-Dep4-module-type-T.html">T</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep5-Z.html
+++ b/test/generators/html/Ocamlary-Dep5-Z.html
@@ -12,26 +12,28 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep5.html">Dep5</a> &#x00BB; Z
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Dep5.Z</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code><span><span class="keyword">module</span> X</span>
-      <span> : 
-       <a href="Ocamlary-Dep5-argument-1-Arg.html#module-type-T">Arg.T</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Dep5.Z</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code><span><span class="keyword">module</span> X</span>
+       <span> : 
+        <a href="Ocamlary-Dep5-argument-1-Arg.html#module-type-T">Arg.T</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code><span><span class="keyword">module</span> Y</span>
-      <span> = <a href="Ocamlary-Dep3.html">Dep3</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code><span><span class="keyword">module</span> Y</span>
+       <span> = <a href="Ocamlary-Dep3.html">Dep3</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html
@@ -16,7 +16,10 @@
    <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S.html">S</a> &#x00BB;
     Y
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>S.Y</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S.Y</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg-module-type-S.html
@@ -13,31 +13,33 @@
    <a href="Ocamlary-Dep5.html">Dep5</a> &#x00BB; 
    <a href="Ocamlary-Dep5-argument-1-Arg.html">Arg</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Arg.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code><span><span class="keyword">module</span> X</span>
-      <span> : 
-       <a href="Ocamlary-Dep5-argument-1-Arg.html#module-type-T">T</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Arg.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code><span><span class="keyword">module</span> X</span>
+       <span> : 
+        <a href="Ocamlary-Dep5-argument-1-Arg.html#module-type-T">T</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html">Y</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html">Y</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep5-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep5-argument-1-Arg.html
@@ -12,40 +12,42 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep5.html">Dep5</a> &#x00BB; Arg
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>Dep5.Arg</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> T
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>Dep5.Arg</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> T
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code><span><span class="keyword">module</span> X</span>
-      <span> : <a href="#module-type-T">T</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code><span><span class="keyword">module</span> X</span>
+       <span> : <a href="#module-type-T">T</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep5.html
+++ b/test/generators/html/Ocamlary-Dep5.html
@@ -11,45 +11,47 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep5
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep5</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Arg">
-     <a href="#argument-1-Arg" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Ocamlary-Dep5-argument-1-Arg.html">Arg</a></span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Z">
-     <a href="#module-Z" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep5-Z.html">Z</a>
-      </span>
-      <span> : 
-       <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S.html">Arg.S</a>
-        <span class="keyword">with</span> 
-       <span><span class="keyword">module</span> 
-        <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html">Y</a>
-         = <a href="Ocamlary-Dep3.html">Dep3</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep5</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Arg">
+      <a href="#argument-1-Arg" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Ocamlary-Dep5-argument-1-Arg.html">Arg</a></span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+    </div>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Z">
+      <a href="#module-Z" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep5-Z.html">Z</a>
+       </span>
+       <span> : 
+        <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S.html">Arg.S</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <a href="Ocamlary-Dep5-argument-1-Arg-module-type-S-Y.html">Y</a>
+          = <a href="Ocamlary-Dep3.html">Dep3</a>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep6-X-Y.html
+++ b/test/generators/html/Ocamlary-Dep6-X-Y.html
@@ -13,13 +13,16 @@
    <a href="Ocamlary-Dep6.html">Dep6</a> &#x00BB; 
    <a href="Ocamlary-Dep6-X.html">X</a> &#x00BB; Y
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>X.Y</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-d">
-     <a href="#type-d" class="anchor"></a>
-     <code><span><span class="keyword">type</span> d</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>X.Y</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-d">
+      <a href="#type-d" class="anchor"></a>
+      <code><span><span class="keyword">type</span> d</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep6-X.html
+++ b/test/generators/html/Ocamlary-Dep6-X.html
@@ -12,28 +12,32 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep6.html">Dep6</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Dep6.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-R">
-     <a href="#module-type-R" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> R
-      </span><span> = <a href="Ocamlary-Dep6-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Dep6.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-R">
+      <a href="#module-type-R" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> R
+       </span>
+       <span> = <a href="Ocamlary-Dep6-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep6-X-Y.html">Y</a>
-      </span><span> : <a href="Ocamlary-Dep6-module-type-S.html">R</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep6-X-Y.html">Y</a>
+       </span>
+       <span> : <a href="Ocamlary-Dep6-module-type-S.html">R</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep6-module-type-S.html
+++ b/test/generators/html/Ocamlary-Dep6-module-type-S.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep6.html">Dep6</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Dep6.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-d">
-     <a href="#type-d" class="anchor"></a>
-     <code><span><span class="keyword">type</span> d</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Dep6.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-d">
+      <a href="#type-d" class="anchor"></a>
+      <code><span><span class="keyword">type</span> d</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep6-module-type-T-Y.html
+++ b/test/generators/html/Ocamlary-Dep6-module-type-T-Y.html
@@ -13,13 +13,16 @@
    <a href="Ocamlary-Dep6.html">Dep6</a> &#x00BB; 
    <a href="Ocamlary-Dep6-module-type-T.html">T</a> &#x00BB; Y
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>T.Y</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-d">
-     <a href="#type-d" class="anchor"></a>
-     <code><span><span class="keyword">type</span> d</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>T.Y</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-d">
+      <a href="#type-d" class="anchor"></a>
+      <code><span><span class="keyword">type</span> d</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep6-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep6-module-type-T.html
@@ -12,28 +12,32 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep6.html">Dep6</a> &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Dep6.T</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-R">
-     <a href="#module-type-R" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> R
-      </span><span> = <a href="Ocamlary-Dep6-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Dep6.T</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-R">
+      <a href="#module-type-R" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> R
+       </span>
+       <span> = <a href="Ocamlary-Dep6-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep6-module-type-T-Y.html">Y</a>
-      </span><span> : <a href="Ocamlary-Dep6-module-type-S.html">R</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep6-module-type-T-Y.html">Y</a>
+       </span>
+       <span> : <a href="Ocamlary-Dep6-module-type-S.html">R</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep6.html
+++ b/test/generators/html/Ocamlary-Dep6.html
@@ -11,46 +11,49 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep6
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep6</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-Dep6-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep6</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-Dep6-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-Dep6-module-type-T.html">T</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-Dep6-module-type-T.html">T</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep6-X.html">X</a>
-      </span><span> : <a href="Ocamlary-Dep6-module-type-T.html">T</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep6-X.html">X</a>
+       </span>
+       <span> : <a href="Ocamlary-Dep6-module-type-T.html">T</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep7-M.html
+++ b/test/generators/html/Ocamlary-Dep7-M.html
@@ -12,31 +12,33 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep7.html">Dep7</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Dep7.M</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-R">
-     <a href="#module-type-R" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> R
-      </span>
-      <span> = 
-       <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">Arg.S</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Dep7.M</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-R">
+      <a href="#module-type-R" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> R
+       </span>
+       <span> = 
+        <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">Arg.S</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code><span><span class="keyword">module</span> Y</span>
-      <span> : 
-       <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">R</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code><span><span class="keyword">module</span> Y</span>
+       <span> : 
+        <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">R</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg-X.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg-X.html
@@ -13,31 +13,33 @@
    <a href="Ocamlary-Dep7.html">Dep7</a> &#x00BB; 
    <a href="Ocamlary-Dep7-argument-1-Arg.html">Arg</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Arg.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-R">
-     <a href="#module-type-R" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> R
-      </span>
-      <span> = 
-       <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">S</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Arg.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-R">
+      <a href="#module-type-R" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> R
+       </span>
+       <span> = 
+        <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">S</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code><span><span class="keyword">module</span> Y</span>
-      <span> : 
-       <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">R</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code><span><span class="keyword">module</span> Y</span>
+       <span> : 
+        <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">R</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg-module-type-T.html
@@ -13,31 +13,33 @@
    <a href="Ocamlary-Dep7.html">Dep7</a> &#x00BB; 
    <a href="Ocamlary-Dep7-argument-1-Arg.html">Arg</a> &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Arg.T</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-R">
-     <a href="#module-type-R" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> R
-      </span>
-      <span> = 
-       <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">S</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Arg.T</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-R">
+      <a href="#module-type-R" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> R
+       </span>
+       <span> = 
+        <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">S</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code><span><span class="keyword">module</span> Y</span>
-      <span> : 
-       <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">R</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code><span><span class="keyword">module</span> Y</span>
+       <span> : 
+        <a href="Ocamlary-Dep7-argument-1-Arg.html#module-type-S">R</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep7-argument-1-Arg.html
+++ b/test/generators/html/Ocamlary-Dep7-argument-1-Arg.html
@@ -12,45 +12,47 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep7.html">Dep7</a> &#x00BB; Arg
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>Dep7.Arg</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> S
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>Dep7.Arg</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> S
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-Dep7-argument-1-Arg-module-type-T.html">T</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-Dep7-argument-1-Arg-module-type-T.html">T</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep7-argument-1-Arg-X.html">X</a>
-      </span>
-      <span> : 
-       <a href="Ocamlary-Dep7-argument-1-Arg-module-type-T.html">T</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep7-argument-1-Arg-X.html">X</a>
+       </span>
+       <span> : 
+        <a href="Ocamlary-Dep7-argument-1-Arg-module-type-T.html">T</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep7.html
+++ b/test/generators/html/Ocamlary-Dep7.html
@@ -11,40 +11,42 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep7
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep7</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Arg">
-     <a href="#argument-1-Arg" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Ocamlary-Dep7-argument-1-Arg.html">Arg</a></span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep7</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Arg">
+      <a href="#argument-1-Arg" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Ocamlary-Dep7-argument-1-Arg.html">Arg</a></span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep7-M.html">M</a>
-      </span>
-      <span> : 
-       <a href="Ocamlary-Dep7-argument-1-Arg-module-type-T.html">Arg.T</a>
-      </span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep7-M.html">M</a>
+       </span>
+       <span> : 
+        <a href="Ocamlary-Dep7-argument-1-Arg-module-type-T.html">Arg.T</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep8-module-type-T.html
+++ b/test/generators/html/Ocamlary-Dep8-module-type-T.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep8.html">Dep8</a> &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Dep8.T</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Dep8.T</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep8.html
+++ b/test/generators/html/Ocamlary-Dep8.html
@@ -11,22 +11,24 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep8
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep8</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-Dep8-module-type-T.html">T</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep8</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-Dep8-module-type-T.html">T</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep9-argument-1-X.html
+++ b/test/generators/html/Ocamlary-Dep9-argument-1-X.html
@@ -12,18 +12,20 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Dep9.html">Dep9</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>Dep9.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> T
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>Dep9.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> T
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Dep9.html
+++ b/test/generators/html/Ocamlary-Dep9.html
@@ -11,40 +11,42 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep9
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Dep9</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-X">
-     <a href="#argument-1-X" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Ocamlary-Dep9-argument-1-X.html">X</a></span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Dep9</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-X">
+      <a href="#argument-1-X" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Ocamlary-Dep9-argument-1-X.html">X</a></span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> T
-      </span>
-      <span> = 
-       <a href="Ocamlary-Dep9-argument-1-X.html#module-type-T">X.T</a>
-      </span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> T
+       </span>
+       <span> = 
+        <a href="Ocamlary-Dep9-argument-1-X.html#module-type-T">X.T</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-DoubleInclude1-DoubleInclude2.html
+++ b/test/generators/html/Ocamlary-DoubleInclude1-DoubleInclude2.html
@@ -13,15 +13,17 @@
    <a href="Ocamlary-DoubleInclude1.html">DoubleInclude1</a> &#x00BB;
     DoubleInclude2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>DoubleInclude1.DoubleInclude2</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-double_include">
-     <a href="#type-double_include" class="anchor"></a>
-     <code><span><span class="keyword">type</span> double_include</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>DoubleInclude1.DoubleInclude2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-double_include">
+      <a href="#type-double_include" class="anchor"></a>
+      <code><span><span class="keyword">type</span> double_include</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-DoubleInclude1.html
+++ b/test/generators/html/Ocamlary-DoubleInclude1.html
@@ -11,22 +11,24 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; DoubleInclude1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.DoubleInclude1</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-DoubleInclude2">
-     <a href="#module-DoubleInclude2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-DoubleInclude1-DoubleInclude2.html">DoubleInclude2
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.DoubleInclude1</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-DoubleInclude2">
+      <a href="#module-DoubleInclude2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-DoubleInclude1-DoubleInclude2.html">DoubleInclude2
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-DoubleInclude3-DoubleInclude2.html
+++ b/test/generators/html/Ocamlary-DoubleInclude3-DoubleInclude2.html
@@ -13,15 +13,17 @@
    <a href="Ocamlary-DoubleInclude3.html">DoubleInclude3</a> &#x00BB;
     DoubleInclude2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>DoubleInclude3.DoubleInclude2</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-double_include">
-     <a href="#type-double_include" class="anchor"></a>
-     <code><span><span class="keyword">type</span> double_include</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>DoubleInclude3.DoubleInclude2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-double_include">
+      <a href="#type-double_include" class="anchor"></a>
+      <code><span><span class="keyword">type</span> double_include</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-DoubleInclude3.html
+++ b/test/generators/html/Ocamlary-DoubleInclude3.html
@@ -11,36 +11,39 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; DoubleInclude3
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.DoubleInclude3</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
-      <code>
-       <span><span class="keyword">include</span> 
-        <span class="keyword">module</span> <span class="keyword">type</span>
-         <span class="keyword">of</span> 
-        <a href="Ocamlary-DoubleInclude1.html">DoubleInclude1</a>
-       </span>
-      </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-DoubleInclude2">
-       <a href="#module-DoubleInclude2" class="anchor"></a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.DoubleInclude3</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
        <code>
-        <span><span class="keyword">module</span> 
-         <a href="Ocamlary-DoubleInclude3-DoubleInclude2.html">DoubleInclude2
-         </a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
+        <span><span class="keyword">include</span> 
+         <span class="keyword">module</span> 
+         <span class="keyword">type</span> <span class="keyword">of</span>
+          <a href="Ocamlary-DoubleInclude1.html">DoubleInclude1</a>
         </span>
        </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-DoubleInclude2">
+        <a href="#module-DoubleInclude2" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <a href="Ocamlary-DoubleInclude3-DoubleInclude2.html">
+           DoubleInclude2
+          </a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
       </div>
-     </div>
-    </details>
+     </details>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-Empty.html
+++ b/test/generators/html/Ocamlary-Empty.html
@@ -11,10 +11,12 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Empty
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Empty</span></code></h1>
-   <p>A plain, empty module</p>
-   <p>This module has a signature without any members.</p>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Empty</span></code></h1>
+    <p>A plain, empty module</p>
+    <p>This module has a signature without any members.</p>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-ExtMod.html
+++ b/test/generators/html/Ocamlary-ExtMod.html
@@ -11,34 +11,36 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; ExtMod
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.ExtMod</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span><span> = </span>
-      <span>..</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.ExtMod</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span><span> = </span>
+       <span>..</span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored"
-     id="extension-decl-Leisureforce">
-     <a href="#extension-decl-Leisureforce" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <a href="#type-t">t</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-Leisureforce" class="def variant extension anchored">
-       <a href="#extension-Leisureforce" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="extension">Leisureforce</span></span>
-       </code>
-      </li>
-     </ol>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored"
+      id="extension-decl-Leisureforce">
+      <a href="#extension-decl-Leisureforce" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <a href="#type-t">t</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-Leisureforce" class="def variant extension anchored">
+        <a href="#extension-Leisureforce" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="extension">Leisureforce</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html
@@ -22,23 +22,25 @@
     InnerModuleA
    </a> &#x00BB; InnerModuleA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
-   <p>This comment is for <code>InnerModuleA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <span><span>(unit, unit)</span> 
-        <a href="Ocamlary.html#type-a_function">a_function</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
+    <p>This comment is for <code>InnerModuleA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <span><span>(unit, unit)</span> 
+         <a href="Ocamlary.html#type-a_function">a_function</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -22,24 +22,26 @@
     InnerModuleA
    </a> &#x00BB; InnerModuleTypeA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
-   </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html#type-t"
-        >InnerModuleA'.t
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
+    </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html#type-t"
+         >InnerModuleA'.t
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html
@@ -16,62 +16,65 @@
    <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">Collection</a>
     &#x00BB; InnerModuleA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Collection.InnerModuleA</span></code></h1>
-   <p>This comment is for <code>InnerModuleA</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-FunctorTypeOf-argument-1-Collection.html#type-collection"
-        >collection
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Collection.InnerModuleA</span></code></h1>
+    <p>This comment is for <code>InnerModuleA</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-FunctorTypeOf-argument-1-Collection.html#type-collection"
+         >collection
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA'">
-     <a href="#module-InnerModuleA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a
-        href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html"
-        >InnerModuleA'
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA'">
+      <a href="#module-InnerModuleA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a
+         href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-InnerModuleA'.html"
+         >InnerModuleA'
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA'</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA'</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
-     <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleTypeA'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-InnerModuleTypeA'">
+      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleTypeA'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf-argument-1-Collection.html
@@ -13,61 +13,64 @@
    <a href="Ocamlary-FunctorTypeOf.html">FunctorTypeOf</a> &#x00BB; 
    Collection
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>FunctorTypeOf.Collection</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-collection">
-     <a href="#type-collection" class="anchor"></a>
-     <code><span><span class="keyword">type</span> collection</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>FunctorTypeOf.Collection</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <p>This comment is for <code>CollectionModule</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-collection">
+      <a href="#type-collection" class="anchor"></a>
+      <code><span><span class="keyword">type</span> collection</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>collection</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>collection</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-element">
+      <a href="#type-element" class="anchor"></a>
+      <code><span><span class="keyword">type</span> element</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-element">
-     <a href="#type-element" class="anchor"></a>
-     <code><span><span class="keyword">type</span> element</span></code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA">
+      <a href="#module-InnerModuleA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a
+         href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html">
+         InnerModuleA
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA</code>.</p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA">
-     <a href="#module-InnerModuleA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a
-        href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA.html">
-        InnerModuleA
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
-     <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> InnerModuleTypeA
-      </span>
-      <span> = 
-       <a
-        href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleA.InnerModuleTypeA'
-       </a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
+      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> InnerModuleTypeA
+       </span>
+       <span> = 
+        <a
+         href="Ocamlary-FunctorTypeOf-argument-1-Collection-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleA.InnerModuleTypeA'
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-FunctorTypeOf.html
+++ b/test/generators/html/Ocamlary-FunctorTypeOf.html
@@ -11,47 +11,50 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; FunctorTypeOf
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.FunctorTypeOf</span></code></h1>
-   <p>This comment is for <code>FunctorTypeOf</code>.</p>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-Collection">
-     <a href="#argument-1-Collection" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span>
-       <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">Collection
-       </a>
-      </span>
-      <span> : <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <a href="Ocamlary-CollectionModule.html">CollectionModule</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.FunctorTypeOf</span></code></h1>
+    <p>This comment is for <code>FunctorTypeOf</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-Collection">
+      <a href="#argument-1-Collection" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span>
+        <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">
+         Collection
+        </a>
+       </span>
+       <span> : <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <a href="Ocamlary-CollectionModule.html">CollectionModule</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-FunctorTypeOf-argument-1-Collection.html#type-collection"
-        >Collection.collection
-       </a>
-      </span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-FunctorTypeOf-argument-1-Collection.html#type-collection"
+         >Collection.collection
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-IncludeInclude1-IncludeInclude2_M.html
+++ b/test/generators/html/Ocamlary-IncludeInclude1-IncludeInclude2_M.html
@@ -14,9 +14,11 @@
    <a href="Ocamlary-IncludeInclude1.html">IncludeInclude1</a> &#x00BB;
     IncludeInclude2_M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>IncludeInclude1.IncludeInclude2_M</span></code>
-   </h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>IncludeInclude1.IncludeInclude2_M</span></code>
+    </h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html
+++ b/test/generators/html/Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html
@@ -14,16 +14,18 @@
    <a href="Ocamlary-IncludeInclude1.html">IncludeInclude1</a> &#x00BB;
     IncludeInclude2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>IncludeInclude1.IncludeInclude2</span></code>
-   </h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-include_include">
-     <a href="#type-include_include" class="anchor"></a>
-     <code><span><span class="keyword">type</span> include_include</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>IncludeInclude1.IncludeInclude2</span></code>
+    </h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-include_include">
+      <a href="#type-include_include" class="anchor"></a>
+      <code><span><span class="keyword">type</span> include_include</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-IncludeInclude1.html
+++ b/test/generators/html/Ocamlary-IncludeInclude1.html
@@ -11,39 +11,41 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; IncludeInclude1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.IncludeInclude1</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-IncludeInclude2">
-     <a href="#module-type-IncludeInclude2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html">
-        IncludeInclude2
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.IncludeInclude1</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-IncludeInclude2">
+      <a href="#module-type-IncludeInclude2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-IncludeInclude1-module-type-IncludeInclude2.html">
+         IncludeInclude2
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-IncludeInclude2_M">
-     <a href="#module-IncludeInclude2_M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-IncludeInclude1-IncludeInclude2_M.html">
-        IncludeInclude2_M
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-IncludeInclude2_M">
+      <a href="#module-IncludeInclude2_M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-IncludeInclude1-IncludeInclude2_M.html">
+         IncludeInclude2_M
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-IncludeInclude2_M.html
+++ b/test/generators/html/Ocamlary-IncludeInclude2_M.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; IncludeInclude2_M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.IncludeInclude2_M</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.IncludeInclude2_M</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-IncludedA.html
+++ b/test/generators/html/Ocamlary-IncludedA.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; IncludedA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.IncludedA</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.IncludedA</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-M.html
+++ b/test/generators/html/Ocamlary-M.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.M</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.M</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-ModuleWithSignature.html
+++ b/test/generators/html/Ocamlary-ModuleWithSignature.html
@@ -11,12 +11,14 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; ModuleWithSignature
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.ModuleWithSignature</span></code></h1>
-   <p>A plain module of a signature of 
-    <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
-     (reference)
-   </p>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.ModuleWithSignature</span></code></h1>
+    <p>A plain module of a signature of 
+     <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
+      (reference)
+    </p>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-ModuleWithSignatureAlias.html
+++ b/test/generators/html/Ocamlary-ModuleWithSignatureAlias.html
@@ -12,14 +12,16 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; ModuleWithSignatureAlias
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.ModuleWithSignatureAlias</span></code>
-   </h1><p>A plain module with an alias signature</p>
-   <ul class="at-tags">
-    <li class="deprecated"><span class="at-tag">deprecated</span> 
-     <p>I don't like this element any more.</p>
-    </li>
-   </ul>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.ModuleWithSignatureAlias</span></code>
+    </h1><p>A plain module with an alias signature</p>
+    <ul class="at-tags">
+     <li class="deprecated"><span class="at-tag">deprecated</span> 
+      <p>I don't like this element any more.</p>
+     </li>
+    </ul>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-One.html
+++ b/test/generators/html/Ocamlary-One.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; One
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.One</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-one">
-     <a href="#type-one" class="anchor"></a>
-     <code><span><span class="keyword">type</span> one</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.One</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-one">
+      <a href="#type-one" class="anchor"></a>
+      <code><span><span class="keyword">type</span> one</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Only_a_module.html
+++ b/test/generators/html/Ocamlary-Only_a_module.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Only_a_module
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Only_a_module</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Only_a_module</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html
@@ -16,23 +16,25 @@
    <a href="Ocamlary-Recollection-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
-   <p>This comment is for <code>InnerModuleA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <span><span>(unit, unit)</span> 
-        <a href="Ocamlary.html#type-a_function">a_function</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
+    <p>This comment is for <code>InnerModuleA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <span><span>(unit, unit)</span> 
+         <a href="Ocamlary.html#type-a_function">a_function</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -17,23 +17,26 @@
    <a href="Ocamlary-Recollection-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleTypeA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
-   </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a href="Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html#type-t">
-        InnerModuleA'.t
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
+    </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html#type-t">
+         InnerModuleA'.t
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-Recollection-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-Recollection-InnerModuleA.html
@@ -13,58 +13,61 @@
    <a href="Ocamlary-Recollection.html">Recollection</a> &#x00BB; 
    InnerModuleA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Recollection.InnerModuleA</span></code></h1>
-   <p>This comment is for <code>InnerModuleA</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a href="Ocamlary-Recollection.html#type-collection">collection</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Recollection.InnerModuleA</span></code></h1>
+    <p>This comment is for <code>InnerModuleA</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a href="Ocamlary-Recollection.html#type-collection">collection</a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA'">
-     <a href="#module-InnerModuleA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html">
-        InnerModuleA'
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA'">
+      <a href="#module-InnerModuleA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Recollection-InnerModuleA-InnerModuleA'.html">
+         InnerModuleA'
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA'</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA'</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
-     <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleTypeA'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-InnerModuleTypeA'">
+      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleTypeA'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html
@@ -18,23 +18,25 @@
     InnerModuleA
    </a> &#x00BB; InnerModuleA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
-   <p>This comment is for <code>InnerModuleA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <span><span>(unit, unit)</span> 
-        <a href="Ocamlary.html#type-a_function">a_function</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
+    <p>This comment is for <code>InnerModuleA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <span><span>(unit, unit)</span> 
+         <a href="Ocamlary.html#type-a_function">a_function</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -19,24 +19,26 @@
     InnerModuleA
    </a> &#x00BB; InnerModuleTypeA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
-   </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html#type-t"
-        >InnerModuleA'.t
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
+    </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html#type-t"
+         >InnerModuleA'.t
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C-InnerModuleA.html
@@ -15,61 +15,64 @@
    <a href="Ocamlary-Recollection-argument-1-C.html">C</a> &#x00BB; 
    InnerModuleA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>C.InnerModuleA</span></code></h1>
-   <p>This comment is for <code>InnerModuleA</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a href="Ocamlary-Recollection-argument-1-C.html#type-collection">
-        collection
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>C.InnerModuleA</span></code></h1>
+    <p>This comment is for <code>InnerModuleA</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a href="Ocamlary-Recollection-argument-1-C.html#type-collection">
+         collection
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA'">
-     <a href="#module-InnerModuleA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a
-        href="Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html"
-        >InnerModuleA'
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA'">
+      <a href="#module-InnerModuleA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a
+         href="Ocamlary-Recollection-argument-1-C-InnerModuleA-InnerModuleA'.html"
+         >InnerModuleA'
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA'</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA'</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
-     <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleTypeA'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-InnerModuleTypeA'">
+      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleTypeA'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Recollection-argument-1-C.html
+++ b/test/generators/html/Ocamlary-Recollection-argument-1-C.html
@@ -12,60 +12,63 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-Recollection.html">Recollection</a> &#x00BB; C
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>Recollection.C</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-collection">
-     <a href="#type-collection" class="anchor"></a>
-     <code><span><span class="keyword">type</span> collection</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>Recollection.C</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <p>This comment is for <code>CollectionModule</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-collection">
+      <a href="#type-collection" class="anchor"></a>
+      <code><span><span class="keyword">type</span> collection</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>collection</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>collection</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-element">
+      <a href="#type-element" class="anchor"></a>
+      <code><span><span class="keyword">type</span> element</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-element">
-     <a href="#type-element" class="anchor"></a>
-     <code><span><span class="keyword">type</span> element</span></code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA">
+      <a href="#module-InnerModuleA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Recollection-argument-1-C-InnerModuleA.html">
+         InnerModuleA
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA</code>.</p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA">
-     <a href="#module-InnerModuleA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Recollection-argument-1-C-InnerModuleA.html">
-        InnerModuleA
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
-     <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> InnerModuleTypeA
-      </span>
-      <span> = 
-       <a
-        href="Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleA.InnerModuleTypeA'
-       </a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
+      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> InnerModuleTypeA
+       </span>
+       <span> = 
+        <a
+         href="Ocamlary-Recollection-argument-1-C-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleA.InnerModuleTypeA'
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-Recollection.html
+++ b/test/generators/html/Ocamlary-Recollection.html
@@ -11,90 +11,93 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Recollection
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.Recollection</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-C">
-     <a href="#argument-1-C" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Ocamlary-Recollection-argument-1-C.html">C</a></span>
-      <span> : <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <p>This comment is for <code>CollectionModule</code>.</p>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-collection">
-     <a href="#type-collection" class="anchor"></a>
-     <code><span><span class="keyword">type</span> collection</span>
-      <span> = 
-       <span>
-        <a href="Ocamlary-Recollection-argument-1-C.html#type-element">
-         C.element
-        </a> list
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.Recollection</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-C">
+      <a href="#argument-1-C" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Ocamlary-Recollection-argument-1-C.html">C</a></span>
+       <span> : <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>collection</code>.</p>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <p>This comment is for <code>CollectionModule</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-collection">
+      <a href="#type-collection" class="anchor"></a>
+      <code><span><span class="keyword">type</span> collection</span>
+       <span> = 
+        <span>
+         <a href="Ocamlary-Recollection-argument-1-C.html#type-element">
+          C.element
+         </a> list
+        </span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>collection</code>.</p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-element">
-     <a href="#type-element" class="anchor"></a>
-     <code><span><span class="keyword">type</span> element</span>
-      <span> = 
-       <a href="Ocamlary-Recollection-argument-1-C.html#type-collection">
-        C.collection
-       </a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-element">
+      <a href="#type-element" class="anchor"></a>
+      <code><span><span class="keyword">type</span> element</span>
+       <span> = 
+        <a href="Ocamlary-Recollection-argument-1-C.html#type-collection">
+         C.collection
+        </a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA">
-     <a href="#module-InnerModuleA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Recollection-InnerModuleA.html">InnerModuleA</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA">
+      <a href="#module-InnerModuleA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Recollection-InnerModuleA.html">InnerModuleA</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
-     <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> InnerModuleTypeA
-      </span>
-      <span> = 
-       <a
-        href="Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleA.InnerModuleTypeA'
-       </a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
+      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> InnerModuleTypeA
+       </span>
+       <span> = 
+        <a
+         href="Ocamlary-Recollection-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleA.InnerModuleTypeA'
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With10-module-type-T-M.html
+++ b/test/generators/html/Ocamlary-With10-module-type-T-M.html
@@ -13,17 +13,20 @@
    <a href="Ocamlary-With10.html">With10</a> &#x00BB; 
    <a href="Ocamlary-With10-module-type-T.html">T</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>T.M</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> S
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>T.M</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> S
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With10-module-type-T.html
+++ b/test/generators/html/Ocamlary-With10-module-type-T.html
@@ -12,32 +12,34 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-With10.html">With10</a> &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>With10.T</span></code></h1>
-   <p><a href="#"><code>With10.T</code></a> is a submodule type.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With10-module-type-T-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>With10.T</span></code></h1>
+    <p><a href="#"><code>With10.T</code></a> is a submodule type.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With10-module-type-T-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code><span><span class="keyword">module</span> N</span>
-      <span> : 
-       <a href="Ocamlary-With10-module-type-T-M.html#module-type-S">M.S</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code><span><span class="keyword">module</span> N</span>
+       <span> : 
+        <a href="Ocamlary-With10-module-type-T-M.html#module-type-S">M.S</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With10.html
+++ b/test/generators/html/Ocamlary-With10.html
@@ -11,28 +11,30 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With10
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.With10</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-With10-module-type-T.html">T</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>
-      <a href="Ocamlary-With10-module-type-T.html"><code>With10.T</code></a>
-       is a submodule type.
-     </p>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.With10</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-With10-module-type-T.html">T</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>
+       <a href="Ocamlary-With10-module-type-T.html"><code>With10.T</code></a>
+        is a submodule type.
+      </p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With2-module-type-S.html
+++ b/test/generators/html/Ocamlary-With2-module-type-S.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-With2.html">With2</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>With2.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>With2.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With2.html
+++ b/test/generators/html/Ocamlary-With2.html
@@ -11,22 +11,24 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.With2</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-With2-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.With2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-With2-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With3-N.html
+++ b/test/generators/html/Ocamlary-With3-N.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-With3.html">With3</a> &#x00BB; N
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>With3.N</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>With3.N</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With3.html
+++ b/test/generators/html/Ocamlary-With3.html
@@ -11,27 +11,29 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With3
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.With3</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code><span><span class="keyword">module</span> M</span>
-      <span> = <a href="Ocamlary-With2.html">With2</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.With3</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code><span><span class="keyword">module</span> M</span>
+       <span> = <a href="Ocamlary-With2.html">With2</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With3-N.html">N</a>
-      </span>
-      <span> : <a href="Ocamlary-With2-module-type-S.html">M.S</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With3-N.html">N</a>
+       </span>
+       <span> : <a href="Ocamlary-With2-module-type-S.html">M.S</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With4-N.html
+++ b/test/generators/html/Ocamlary-With4-N.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-With4.html">With4</a> &#x00BB; N
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>With4.N</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>With4.N</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With4.html
+++ b/test/generators/html/Ocamlary-With4.html
@@ -11,19 +11,22 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With4
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.With4</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With4-N.html">N</a>
-      </span>
-      <span> : <a href="Ocamlary-With2.html#module-type-S">With2.S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.With4</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With4-N.html">N</a>
+       </span>
+       <span> : <a href="Ocamlary-With2.html#module-type-S">With2.S</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With5-N.html
+++ b/test/generators/html/Ocamlary-With5-N.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-With5.html">With5</a> &#x00BB; N
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>With5.N</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>With5.N</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With5-module-type-S.html
+++ b/test/generators/html/Ocamlary-With5-module-type-S.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-With5.html">With5</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>With5.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>With5.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With5.html
+++ b/test/generators/html/Ocamlary-With5.html
@@ -11,33 +11,35 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With5
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.With5</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-With5-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.With5</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-With5-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With5-N.html">N</a>
-      </span>
-      <span> : <a href="Ocamlary-With5-module-type-S.html">S</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With5-N.html">N</a>
+       </span>
+       <span> : <a href="Ocamlary-With5-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With6-module-type-T-M.html
+++ b/test/generators/html/Ocamlary-With6-module-type-T-M.html
@@ -13,25 +13,28 @@
    <a href="Ocamlary-With6.html">With6</a> &#x00BB; 
    <a href="Ocamlary-With6-module-type-T.html">T</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>T.M</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> S
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>T.M</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> S
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code><span><span class="keyword">module</span> N</span>
-      <span> : <a href="#module-type-S">S</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code><span><span class="keyword">module</span> N</span>
+       <span> : <a href="#module-type-S">S</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With6-module-type-T.html
+++ b/test/generators/html/Ocamlary-With6-module-type-T.html
@@ -12,21 +12,23 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-With6.html">With6</a> &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>With6.T</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With6-module-type-T-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>With6.T</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With6-module-type-T-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With6.html
+++ b/test/generators/html/Ocamlary-With6.html
@@ -11,22 +11,24 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With6
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.With6</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-With6-module-type-T.html">T</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.With6</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-With6-module-type-T.html">T</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With7-argument-1-X.html
+++ b/test/generators/html/Ocamlary-With7-argument-1-X.html
@@ -12,18 +12,20 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-With7.html">With7</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>With7.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> T
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>With7.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> T
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With7.html
+++ b/test/generators/html/Ocamlary-With7.html
@@ -11,40 +11,42 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With7
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.With7</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-X">
-     <a href="#argument-1-X" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Ocamlary-With7-argument-1-X.html">X</a></span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.With7</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-X">
+      <a href="#argument-1-X" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Ocamlary-With7-argument-1-X.html">X</a></span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> T
-      </span>
-      <span> = 
-       <a href="Ocamlary-With7-argument-1-X.html#module-type-T">X.T</a>
-      </span>
-     </code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> T
+       </span>
+       <span> = 
+        <a href="Ocamlary-With7-argument-1-X.html#module-type-T">X.T</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With9-module-type-S.html
+++ b/test/generators/html/Ocamlary-With9-module-type-S.html
@@ -12,14 +12,16 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-With9.html">With9</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>With9.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>With9.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-With9.html
+++ b/test/generators/html/Ocamlary-With9.html
@@ -11,22 +11,24 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With9
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary.With9</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-With9-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary.With9</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-With9-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-class-empty_class.html
+++ b/test/generators/html/Ocamlary-class-empty_class.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; empty_class
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Ocamlary.empty_class</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Ocamlary.empty_class</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-class-one_method_class.html
+++ b/test/generators/html/Ocamlary-class-one_method_class.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; one_method_class
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Ocamlary.one_method_class</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-go">
-     <a href="#method-go" class="anchor"></a>
-     <code><span><span class="keyword">method</span> go : unit</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Ocamlary.one_method_class</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-go">
+      <a href="#method-go" class="anchor"></a>
+      <code><span><span class="keyword">method</span> go : unit</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-class-param_class.html
+++ b/test/generators/html/Ocamlary-class-param_class.html
@@ -11,18 +11,20 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; param_class
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Ocamlary.param_class</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-v">
-     <a href="#method-v" class="anchor"></a>
-     <code>
-      <span><span class="keyword">method</span> v : 
-       <span class="type-var">'a</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Ocamlary.param_class</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-v">
+      <a href="#method-v" class="anchor"></a>
+      <code>
+       <span><span class="keyword">method</span> v : 
+        <span class="type-var">'a</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-class-two_method_class.html
+++ b/test/generators/html/Ocamlary-class-two_method_class.html
@@ -11,25 +11,27 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; two_method_class
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Ocamlary.two_method_class</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-one">
-     <a href="#method-one" class="anchor"></a>
-     <code>
-      <span><span class="keyword">method</span> one : 
-       <a href="Ocamlary-class-one_method_class.html">one_method_class</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Ocamlary.two_method_class</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-one">
+      <a href="#method-one" class="anchor"></a>
+      <code>
+       <span><span class="keyword">method</span> one : 
+        <a href="Ocamlary-class-one_method_class.html">one_method_class</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec method anchored" id="method-undo">
-     <a href="#method-undo" class="anchor"></a>
-     <code><span><span class="keyword">method</span> undo : unit</span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec method anchored" id="method-undo">
+      <a href="#method-undo" class="anchor"></a>
+      <code><span><span class="keyword">method</span> undo : unit</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html
@@ -16,23 +16,25 @@
    <a href="Ocamlary-module-type-A-Q-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
-   <p>This comment is for <code>InnerModuleA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <span><span>(unit, unit)</span> 
-        <a href="Ocamlary.html#type-a_function">a_function</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
+    <p>This comment is for <code>InnerModuleA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <span><span>(unit, unit)</span> 
+         <a href="Ocamlary.html#type-a_function">a_function</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -17,24 +17,26 @@
    <a href="Ocamlary-module-type-A-Q-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleTypeA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
-   </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html#type-t">
-        InnerModuleA'.t
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
+    </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html#type-t"
+         >InnerModuleA'.t
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q-InnerModuleA.html
@@ -13,58 +13,62 @@
    <a href="Ocamlary-module-type-A.html">A</a> &#x00BB; 
    <a href="Ocamlary-module-type-A-Q.html">Q</a> &#x00BB; InnerModuleA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Q.InnerModuleA</span></code></h1>
-   <p>This comment is for <code>InnerModuleA</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a href="Ocamlary-module-type-A-Q.html#type-collection">collection</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Q.InnerModuleA</span></code></h1>
+    <p>This comment is for <code>InnerModuleA</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a href="Ocamlary-module-type-A-Q.html#type-collection">collection
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA'">
-     <a href="#module-InnerModuleA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html">
-        InnerModuleA'
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA'">
+      <a href="#module-InnerModuleA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-A-Q-InnerModuleA-InnerModuleA'.html">
+         InnerModuleA'
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA'</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA'</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
-     <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleTypeA'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-InnerModuleTypeA'">
+      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleTypeA'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-A-Q.html
+++ b/test/generators/html/Ocamlary-module-type-A-Q.html
@@ -12,57 +12,61 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-module-type-A.html">A</a> &#x00BB; Q
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>A.Q</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-collection">
-     <a href="#type-collection" class="anchor"></a>
-     <code><span><span class="keyword">type</span> collection</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>A.Q</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <p>This comment is for <code>CollectionModule</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-collection">
+      <a href="#type-collection" class="anchor"></a>
+      <code><span><span class="keyword">type</span> collection</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>collection</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>collection</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-element">
+      <a href="#type-element" class="anchor"></a>
+      <code><span><span class="keyword">type</span> element</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-element">
-     <a href="#type-element" class="anchor"></a>
-     <code><span><span class="keyword">type</span> element</span></code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA">
+      <a href="#module-InnerModuleA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-A-Q-InnerModuleA.html">InnerModuleA</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA</code>.</p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA">
-     <a href="#module-InnerModuleA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-A-Q-InnerModuleA.html">InnerModuleA</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
-     <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> InnerModuleTypeA
-      </span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleA.InnerModuleTypeA'
-       </a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
+      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> InnerModuleTypeA
+       </span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-A-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleA.InnerModuleTypeA'
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-A.html
+++ b/test/generators/html/Ocamlary-module-type-A.html
@@ -11,26 +11,28 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; A
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.A</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.A</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Q">
-     <a href="#module-Q" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-A-Q.html">Q</a>
-      </span>
-      <span> : <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Q">
+      <a href="#module-Q" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-A-Q.html">Q</a>
+       </span>
+       <span> : <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html
@@ -16,23 +16,25 @@
    <a href="Ocamlary-module-type-B-Q-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
-   <p>This comment is for <code>InnerModuleA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <span><span>(unit, unit)</span> 
-        <a href="Ocamlary.html#type-a_function">a_function</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
+    <p>This comment is for <code>InnerModuleA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <span><span>(unit, unit)</span> 
+         <a href="Ocamlary.html#type-a_function">a_function</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -17,24 +17,26 @@
    <a href="Ocamlary-module-type-B-Q-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleTypeA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
-   </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html#type-t">
-        InnerModuleA'.t
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
+    </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html#type-t"
+         >InnerModuleA'.t
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q-InnerModuleA.html
@@ -13,58 +13,62 @@
    <a href="Ocamlary-module-type-B.html">B</a> &#x00BB; 
    <a href="Ocamlary-module-type-B-Q.html">Q</a> &#x00BB; InnerModuleA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Q.InnerModuleA</span></code></h1>
-   <p>This comment is for <code>InnerModuleA</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a href="Ocamlary-module-type-B-Q.html#type-collection">collection</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Q.InnerModuleA</span></code></h1>
+    <p>This comment is for <code>InnerModuleA</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a href="Ocamlary-module-type-B-Q.html#type-collection">collection
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA'">
-     <a href="#module-InnerModuleA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html">
-        InnerModuleA'
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA'">
+      <a href="#module-InnerModuleA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-B-Q-InnerModuleA-InnerModuleA'.html">
+         InnerModuleA'
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA'</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA'</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
-     <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleTypeA'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-InnerModuleTypeA'">
+      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleTypeA'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-B-Q.html
+++ b/test/generators/html/Ocamlary-module-type-B-Q.html
@@ -12,57 +12,61 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-module-type-B.html">B</a> &#x00BB; Q
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>B.Q</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-collection">
-     <a href="#type-collection" class="anchor"></a>
-     <code><span><span class="keyword">type</span> collection</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>B.Q</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <p>This comment is for <code>CollectionModule</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-collection">
+      <a href="#type-collection" class="anchor"></a>
+      <code><span><span class="keyword">type</span> collection</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>collection</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>collection</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-element">
+      <a href="#type-element" class="anchor"></a>
+      <code><span><span class="keyword">type</span> element</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-element">
-     <a href="#type-element" class="anchor"></a>
-     <code><span><span class="keyword">type</span> element</span></code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA">
+      <a href="#module-InnerModuleA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-B-Q-InnerModuleA.html">InnerModuleA</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA</code>.</p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA">
-     <a href="#module-InnerModuleA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-B-Q-InnerModuleA.html">InnerModuleA</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
-     <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> InnerModuleTypeA
-      </span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleA.InnerModuleTypeA'
-       </a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
+      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> InnerModuleTypeA
+       </span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-B-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleA.InnerModuleTypeA'
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-B.html
+++ b/test/generators/html/Ocamlary-module-type-B.html
@@ -11,26 +11,28 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; B
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.B</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.B</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Q">
-     <a href="#module-Q" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-B-Q.html">Q</a>
-      </span>
-      <span> : <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Q">
+      <a href="#module-Q" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-B-Q.html">Q</a>
+       </span>
+       <span> : <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html
@@ -16,23 +16,25 @@
    <a href="Ocamlary-module-type-C-Q-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
-   <p>This comment is for <code>InnerModuleA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <span><span>(unit, unit)</span> 
-        <a href="Ocamlary.html#type-a_function">a_function</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
+    <p>This comment is for <code>InnerModuleA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <span><span>(unit, unit)</span> 
+         <a href="Ocamlary.html#type-a_function">a_function</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -17,24 +17,26 @@
    <a href="Ocamlary-module-type-C-Q-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleTypeA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
-   </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html#type-t">
-        InnerModuleA'.t
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
+    </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html#type-t"
+         >InnerModuleA'.t
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q-InnerModuleA.html
@@ -13,58 +13,62 @@
    <a href="Ocamlary-module-type-C.html">C</a> &#x00BB; 
    <a href="Ocamlary-module-type-C-Q.html">Q</a> &#x00BB; InnerModuleA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Q.InnerModuleA</span></code></h1>
-   <p>This comment is for <code>InnerModuleA</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a href="Ocamlary-module-type-C-Q.html#type-collection">collection</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Q.InnerModuleA</span></code></h1>
+    <p>This comment is for <code>InnerModuleA</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a href="Ocamlary-module-type-C-Q.html#type-collection">collection
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA'">
-     <a href="#module-InnerModuleA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html">
-        InnerModuleA'
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA'">
+      <a href="#module-InnerModuleA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-C-Q-InnerModuleA-InnerModuleA'.html">
+         InnerModuleA'
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA'</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA'</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
-     <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleTypeA'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-InnerModuleTypeA'">
+      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleTypeA'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-C-Q.html
+++ b/test/generators/html/Ocamlary-module-type-C-Q.html
@@ -12,57 +12,61 @@
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-module-type-C.html">C</a> &#x00BB; Q
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>C.Q</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-collection">
-     <a href="#type-collection" class="anchor"></a>
-     <code><span><span class="keyword">type</span> collection</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>C.Q</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <p>This comment is for <code>CollectionModule</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-collection">
+      <a href="#type-collection" class="anchor"></a>
+      <code><span><span class="keyword">type</span> collection</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>collection</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>collection</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-element">
+      <a href="#type-element" class="anchor"></a>
+      <code><span><span class="keyword">type</span> element</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-element">
-     <a href="#type-element" class="anchor"></a>
-     <code><span><span class="keyword">type</span> element</span></code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA">
+      <a href="#module-InnerModuleA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-C-Q-InnerModuleA.html">InnerModuleA</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA</code>.</p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA">
-     <a href="#module-InnerModuleA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-C-Q-InnerModuleA.html">InnerModuleA</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
-     <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> InnerModuleTypeA
-      </span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleA.InnerModuleTypeA'
-       </a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
+      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> InnerModuleTypeA
+       </span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-C-Q-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleA.InnerModuleTypeA'
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-C.html
+++ b/test/generators/html/Ocamlary-module-type-C.html
@@ -11,67 +11,69 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; C
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.C</span></code></h1>
-   <p>This module type includes two signatures.</p>
-   <ul>
-    <li>it includes <a href="Ocamlary-module-type-A.html"><code>A</code></a>
-    </li>
-    <li>it includes <a href="Ocamlary-module-type-B.html"><code>B</code></a>
-      with some substitution
-    </li>
-   </ul>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
-      <code>
-       <span><span class="keyword">include</span> 
-        <a href="Ocamlary-module-type-A.html">A</a>
-       </span>
-      </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-t">
-       <a href="#type-t" class="anchor"></a>
-       <code><span><span class="keyword">type</span> t</span></code>
-      </div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-Q">
-       <a href="#module-Q" class="anchor"></a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.C</span></code></h1>
+    <p>This module type includes two signatures.</p>
+    <ul>
+     <li>it includes <a href="Ocamlary-module-type-A.html"><code>A</code></a>
+     </li>
+     <li>it includes <a href="Ocamlary-module-type-B.html"><code>B</code></a>
+       with some substitution
+     </li>
+    </ul>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
        <code>
-        <span><span class="keyword">module</span> 
-         <a href="Ocamlary-module-type-C-Q.html">Q</a>
-        </span>
-        <span> : 
-         <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
+        <span><span class="keyword">include</span> 
+         <a href="Ocamlary-module-type-A.html">A</a>
         </span>
        </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-t">
+        <a href="#type-t" class="anchor"></a>
+        <code><span><span class="keyword">type</span> t</span></code>
+       </div>
       </div>
-     </div>
-    </details>
-   </div>
-   <div class="odoc-include shadowed-include">
-    <details open="open">
-     <summary class="spec include">
-      <code>
-       <span><span class="keyword">include</span> 
-        <a href="Ocamlary-module-type-B.html">B</a> 
-        <span class="keyword">with</span> 
-        <span><span class="keyword">type</span> 
-         <a href="Ocamlary-module-type-B.html#type-t">t</a> := 
-         <a href="#type-t">t</a>
-        </span> <span class="keyword">and</span> 
-        <span><span class="keyword">module</span> 
-         <a href="Ocamlary-module-type-B-Q.html">Q</a> := 
-         <a href="Ocamlary-module-type-C-Q.html">Q</a>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-Q">
+        <a href="#module-Q" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <a href="Ocamlary-module-type-C-Q.html">Q</a>
+         </span>
+         <span> : 
+          <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
+         </span>
+        </code>
+       </div>
+      </div>
+     </details>
+    </div>
+    <div class="odoc-include shadowed-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Ocamlary-module-type-B.html">B</a> 
+         <span class="keyword">with</span> 
+         <span><span class="keyword">type</span> 
+          <a href="Ocamlary-module-type-B.html#type-t">t</a> := 
+          <a href="#type-t">t</a>
+         </span> <span class="keyword">and</span> 
+         <span><span class="keyword">module</span> 
+          <a href="Ocamlary-module-type-B-Q.html">Q</a> := 
+          <a href="Ocamlary-module-type-C-Q.html">Q</a>
+         </span>
         </span>
-       </span>
-      </code>
-     </summary>
-    </details>
+       </code>
+      </summary>
+     </details>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html
@@ -17,23 +17,25 @@
    <a href="Ocamlary-module-type-COLLECTION-InnerModuleA.html">InnerModuleA
    </a> &#x00BB; InnerModuleA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
-   <p>This comment is for <code>InnerModuleA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <span><span>(unit, unit)</span> 
-        <a href="Ocamlary.html#type-a_function">a_function</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
+    <p>This comment is for <code>InnerModuleA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <span><span>(unit, unit)</span> 
+         <a href="Ocamlary.html#type-a_function">a_function</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -18,24 +18,26 @@
    <a href="Ocamlary-module-type-COLLECTION-InnerModuleA.html">InnerModuleA
    </a> &#x00BB; InnerModuleTypeA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
-   </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html#type-t"
-        >InnerModuleA'.t
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
+    </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html#type-t"
+         >InnerModuleA'.t
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION-InnerModuleA.html
@@ -13,61 +13,64 @@
    <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a> &#x00BB;
     InnerModuleA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>COLLECTION.InnerModuleA</span></code></h1>
-   <p>This comment is for <code>InnerModuleA</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a href="Ocamlary-module-type-COLLECTION.html#type-collection">
-        collection
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>COLLECTION.InnerModuleA</span></code></h1>
+    <p>This comment is for <code>InnerModuleA</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a href="Ocamlary-module-type-COLLECTION.html#type-collection">
+         collection
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA'">
-     <a href="#module-InnerModuleA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a
-        href="Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html">
-        InnerModuleA'
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA'">
+      <a href="#module-InnerModuleA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a
+         href="Ocamlary-module-type-COLLECTION-InnerModuleA-InnerModuleA'.html"
+         >InnerModuleA'
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA'</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA'</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
-     <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleTypeA'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-InnerModuleTypeA'">
+      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleTypeA'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-COLLECTION.html
+++ b/test/generators/html/Ocamlary-module-type-COLLECTION.html
@@ -11,61 +11,64 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; COLLECTION
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.COLLECTION</span></code></h1>
-   <p>module type of</p>
-  </header>
-  <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-collection">
-     <a href="#type-collection" class="anchor"></a>
-     <code><span><span class="keyword">type</span> collection</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.COLLECTION</span></code></h1>
+    <p>module type of</p>
+   </header>
+   <div class="odoc-content">
+    <p>This comment is for <code>CollectionModule</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-collection">
+      <a href="#type-collection" class="anchor"></a>
+      <code><span><span class="keyword">type</span> collection</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>collection</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>collection</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-element">
+      <a href="#type-element" class="anchor"></a>
+      <code><span><span class="keyword">type</span> element</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-element">
-     <a href="#type-element" class="anchor"></a>
-     <code><span><span class="keyword">type</span> element</span></code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA">
+      <a href="#module-InnerModuleA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-COLLECTION-InnerModuleA.html">
+         InnerModuleA
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA</code>.</p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA">
-     <a href="#module-InnerModuleA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-COLLECTION-InnerModuleA.html">
-        InnerModuleA
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
-     <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> InnerModuleTypeA
-      </span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleA.InnerModuleTypeA'
-       </a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
+      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> InnerModuleTypeA
+       </span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-COLLECTION-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleA.InnerModuleTypeA'
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-Dep10.html
+++ b/test/generators/html/Ocamlary-module-type-Dep10.html
@@ -11,16 +11,18 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Dep10
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.Dep10</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = int</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.Dep10</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = int</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-Empty.html
+++ b/test/generators/html/Ocamlary-module-type-Empty.html
@@ -11,15 +11,17 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; Empty
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.Empty</span></code></h1>
-   <p>An ambiguous, misnamed module type</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.Empty</span></code></h1>
+    <p>An ambiguous, misnamed module type</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-EmptySig.html
+++ b/test/generators/html/Ocamlary-module-type-EmptySig.html
@@ -11,9 +11,11 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; EmptySig
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.EmptySig</span></code></h1>
-   <p>A plain, empty module signature</p>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.EmptySig</span></code></h1>
+    <p>A plain, empty module signature</p>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-module-type-IncludeInclude2.html
+++ b/test/generators/html/Ocamlary-module-type-IncludeInclude2.html
@@ -11,15 +11,17 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; IncludeInclude2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.IncludeInclude2</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-include_include">
-     <a href="#type-include_include" class="anchor"></a>
-     <code><span><span class="keyword">type</span> include_include</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.IncludeInclude2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-include_include">
+      <a href="#type-include_include" class="anchor"></a>
+      <code><span><span class="keyword">type</span> include_include</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-IncludeModuleType.html
+++ b/test/generators/html/Ocamlary-module-type-IncludeModuleType.html
@@ -11,24 +11,26 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; IncludeModuleType
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.IncludeModuleType</span></code></h1>
-   <p>This comment is for <code>IncludeModuleType</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-include shadowed-include">
-    <div class="spec-doc">
-     <p>This comment is for <code>include EmptySigAlias</code>.</p>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.IncludeModuleType</span></code></h1>
+    <p>This comment is for <code>IncludeModuleType</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-include shadowed-include">
+     <div class="spec-doc">
+      <p>This comment is for <code>include EmptySigAlias</code>.</p>
+     </div>
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Ocamlary-module-type-EmptySig.html">EmptySigAlias</a>
+        </span>
+       </code>
+      </summary>
+     </details>
     </div>
-    <details open="open">
-     <summary class="spec include">
-      <code>
-       <span><span class="keyword">include</span> 
-        <a href="Ocamlary-module-type-EmptySig.html">EmptySigAlias</a>
-       </span>
-      </code>
-     </summary>
-    </details>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-IncludedB.html
+++ b/test/generators/html/Ocamlary-module-type-IncludedB.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; IncludedB
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.IncludedB</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-s">
-     <a href="#type-s" class="anchor"></a>
-     <code><span><span class="keyword">type</span> s</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.IncludedB</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-s">
+      <a href="#type-s" class="anchor"></a>
+      <code><span><span class="keyword">type</span> s</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-M.html
+++ b/test/generators/html/Ocamlary-module-type-M.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.M</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.M</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html
@@ -17,23 +17,25 @@
    <a href="Ocamlary-module-type-MMM-C-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
-   <p>This comment is for <code>InnerModuleA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <span><span>(unit, unit)</span> 
-        <a href="Ocamlary.html#type-a_function">a_function</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
+    <p>This comment is for <code>InnerModuleA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <span><span>(unit, unit)</span> 
+         <a href="Ocamlary.html#type-a_function">a_function</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -17,24 +17,26 @@
    <a href="Ocamlary-module-type-MMM-C-InnerModuleA.html">InnerModuleA</a>
     &#x00BB; InnerModuleTypeA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
-   </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html#type-t"
-        >InnerModuleA'.t
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
+    </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html#type-t"
+         >InnerModuleA'.t
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C-InnerModuleA.html
@@ -13,59 +13,62 @@
    <a href="Ocamlary-module-type-MMM.html">MMM</a> &#x00BB; 
    <a href="Ocamlary-module-type-MMM-C.html">C</a> &#x00BB; InnerModuleA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>C.InnerModuleA</span></code></h1>
-   <p>This comment is for <code>InnerModuleA</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a href="Ocamlary-module-type-MMM-C.html#type-collection">collection
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>C.InnerModuleA</span></code></h1>
+    <p>This comment is for <code>InnerModuleA</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a href="Ocamlary-module-type-MMM-C.html#type-collection">collection
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA'">
-     <a href="#module-InnerModuleA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html">
-        InnerModuleA'
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA'">
+      <a href="#module-InnerModuleA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-MMM-C-InnerModuleA-InnerModuleA'.html">
+         InnerModuleA'
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA'</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA'</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
-     <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleTypeA'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-InnerModuleTypeA'">
+      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleTypeA'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-MMM-C.html
+++ b/test/generators/html/Ocamlary-module-type-MMM-C.html
@@ -12,59 +12,62 @@
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-module-type-MMM.html">MMM</a> &#x00BB; C
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>MMM.C</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <p>This comment is for <code>CollectionModule</code>.</p>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-collection">
-     <a href="#type-collection" class="anchor"></a>
-     <code><span><span class="keyword">type</span> collection</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>MMM.C</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <p>This comment is for <code>CollectionModule</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-collection">
+      <a href="#type-collection" class="anchor"></a>
+      <code><span><span class="keyword">type</span> collection</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>collection</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>collection</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-element">
+      <a href="#type-element" class="anchor"></a>
+      <code><span><span class="keyword">type</span> element</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-element">
-     <a href="#type-element" class="anchor"></a>
-     <code><span><span class="keyword">type</span> element</span></code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA">
+      <a href="#module-InnerModuleA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-MMM-C-InnerModuleA.html">InnerModuleA
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA</code>.</p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA">
-     <a href="#module-InnerModuleA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-MMM-C-InnerModuleA.html">InnerModuleA
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
-     <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> InnerModuleTypeA
-      </span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleA.InnerModuleTypeA'
-       </a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-InnerModuleTypeA">
+      <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> InnerModuleTypeA
+       </span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-MMM-C-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleA.InnerModuleTypeA'
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-MMM.html
+++ b/test/generators/html/Ocamlary-module-type-MMM.html
@@ -11,20 +11,22 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; MMM
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.MMM</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-C">
-     <a href="#module-C" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-MMM-C.html">C</a>
-      </span>
-      <span> : <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.MMM</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-C">
+      <a href="#module-C" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-MMM-C.html">C</a>
+       </span>
+       <span> : <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-MissingComment.html
+++ b/test/generators/html/Ocamlary-module-type-MissingComment.html
@@ -11,15 +11,17 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; MissingComment
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.MissingComment</span></code></h1>
-   <p>An ambiguous, misnamed module type</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.MissingComment</span></code></h1>
+    <p>An ambiguous, misnamed module type</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html
+++ b/test/generators/html/Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html
@@ -14,16 +14,18 @@
    <a href="Ocamlary-module-type-NestedInclude1.html">NestedInclude1</a>
     &#x00BB; NestedInclude2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>NestedInclude1.NestedInclude2</span></code>
-   </h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-nested_include">
-     <a href="#type-nested_include" class="anchor"></a>
-     <code><span><span class="keyword">type</span> nested_include</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>NestedInclude1.NestedInclude2</span></code>
+    </h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-nested_include">
+      <a href="#type-nested_include" class="anchor"></a>
+      <code><span><span class="keyword">type</span> nested_include</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-NestedInclude1.html
+++ b/test/generators/html/Ocamlary-module-type-NestedInclude1.html
@@ -11,25 +11,27 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; NestedInclude1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.NestedInclude1</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-NestedInclude2">
-     <a href="#module-type-NestedInclude2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html"
-        >NestedInclude2
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.NestedInclude1</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-NestedInclude2">
+      <a href="#module-type-NestedInclude2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-module-type-NestedInclude1-module-type-NestedInclude2.html"
+         >NestedInclude2
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-NestedInclude2.html
+++ b/test/generators/html/Ocamlary-module-type-NestedInclude2.html
@@ -11,15 +11,17 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; NestedInclude2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.NestedInclude2</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-nested_include">
-     <a href="#type-nested_include" class="anchor"></a>
-     <code><span><span class="keyword">type</span> nested_include</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.NestedInclude2</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-nested_include">
+      <a href="#type-nested_include" class="anchor"></a>
+      <code><span><span class="keyword">type</span> nested_include</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-RECOLLECTION.html
+++ b/test/generators/html/Ocamlary-module-type-RECOLLECTION.html
@@ -11,19 +11,21 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; RECOLLECTION
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.RECOLLECTION</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-C">
-     <a href="#module-C" class="anchor"></a>
-     <code><span><span class="keyword">module</span> C</span>
-      <span> = 
-       <a href="Ocamlary-Recollection.html">Recollection(CollectionModule)
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.RECOLLECTION</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-C">
+      <a href="#module-C" class="anchor"></a>
+      <code><span><span class="keyword">module</span> C</span>
+       <span> = 
+        <a href="Ocamlary-Recollection.html">Recollection(CollectionModule)
+        </a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html
@@ -19,23 +19,25 @@
     InnerModuleA
    </a> &#x00BB; InnerModuleA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
-   <p>This comment is for <code>InnerModuleA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <span><span>(unit, unit)</span> 
-        <a href="Ocamlary.html#type-a_function">a_function</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>InnerModuleA.InnerModuleA'</span></code></h1>
+    <p>This comment is for <code>InnerModuleA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <span><span>(unit, unit)</span> 
+         <a href="Ocamlary.html#type-a_function">a_function</a>
+        </span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html
@@ -20,24 +20,26 @@
     InnerModuleA
    </a> &#x00BB; InnerModuleTypeA'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
-   </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a
-        href="Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html#type-t"
-        >InnerModuleA'.t
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>InnerModuleA.InnerModuleTypeA'</span></code>
+    </h1><p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html#type-t"
+         >InnerModuleA'.t
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule-InnerModuleA.html
@@ -14,61 +14,65 @@
    <a href="Ocamlary-module-type-RecollectionModule.html">RecollectionModule
    </a> &#x00BB; InnerModuleA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>RecollectionModule.InnerModuleA</span></code></h1>
-   <p>This comment is for <code>InnerModuleA</code>.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = 
-       <a href="Ocamlary-module-type-RecollectionModule.html#type-collection">
-        collection
-       </a>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>RecollectionModule.InnerModuleA</span></code></h1>
+    <p>This comment is for <code>InnerModuleA</code>.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = 
+        <a
+         href="Ocamlary-module-type-RecollectionModule.html#type-collection">
+         collection
+        </a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>t</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-InnerModuleA'">
-     <a href="#module-InnerModuleA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a
-        href="Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html"
-        >InnerModuleA'
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-InnerModuleA'">
+      <a href="#module-InnerModuleA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a
+         href="Ocamlary-module-type-RecollectionModule-InnerModuleA-InnerModuleA'.html"
+         >InnerModuleA'
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleA'</code>.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleA'</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-InnerModuleTypeA'">
-     <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a
-        href="Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html"
-        >InnerModuleTypeA'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-InnerModuleTypeA'">
+      <a href="#module-type-InnerModuleTypeA'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a
+         href="Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html"
+         >InnerModuleTypeA'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>InnerModuleTypeA'</code>.</p>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-RecollectionModule.html
+++ b/test/generators/html/Ocamlary-module-type-RecollectionModule.html
@@ -11,84 +11,88 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; RecollectionModule
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.RecollectionModule</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
-      <code>
-       <span><span class="keyword">include</span> 
-        <span class="keyword">sig</span> ... <span class="keyword">end</span>
-       </span>
-      </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-collection">
-       <a href="#type-collection" class="anchor"></a>
-       <code><span><span class="keyword">type</span> collection</span>
-        <span> = 
-         <span>
-          <a href="Ocamlary-CollectionModule.html#type-element">
-           CollectionModule.element
-          </a> list
-         </span>
-        </span>
-       </code>
-      </div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-element">
-       <a href="#type-element" class="anchor"></a>
-       <code><span><span class="keyword">type</span> element</span>
-        <span> = 
-         <a href="Ocamlary-CollectionModule.html#type-collection">
-          CollectionModule.collection
-         </a>
-        </span>
-       </code>
-      </div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-InnerModuleA">
-       <a href="#module-InnerModuleA" class="anchor"></a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.RecollectionModule</span></code>
+    </h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
        <code>
-        <span><span class="keyword">module</span> 
-         <a href="Ocamlary-module-type-RecollectionModule-InnerModuleA.html">
-          InnerModuleA
-         </a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
+        <span><span class="keyword">include</span> 
+         <span class="keyword">sig</span> ... 
          <span class="keyword">end</span>
         </span>
        </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-collection">
+        <a href="#type-collection" class="anchor"></a>
+        <code><span><span class="keyword">type</span> collection</span>
+         <span> = 
+          <span>
+           <a href="Ocamlary-CollectionModule.html#type-element">
+            CollectionModule.element
+           </a> list
+          </span>
+         </span>
+        </code>
+       </div>
       </div>
-      <div class="spec-doc">
-       <p>This comment is for <code>InnerModuleA</code>.</p>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-element">
+        <a href="#type-element" class="anchor"></a>
+        <code><span><span class="keyword">type</span> element</span>
+         <span> = 
+          <a href="Ocamlary-CollectionModule.html#type-collection">
+           CollectionModule.collection
+          </a>
+         </span>
+        </code>
+       </div>
       </div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec module-type anchored"
-       id="module-type-InnerModuleTypeA">
-       <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> 
-         <span class="keyword">type</span> InnerModuleTypeA
-        </span>
-        <span> = 
-         <a
-          href="Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html"
-          >InnerModuleA.InnerModuleTypeA'
-         </a>
-        </span>
-       </code>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-InnerModuleA">
+        <a href="#module-InnerModuleA" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <a href="Ocamlary-module-type-RecollectionModule-InnerModuleA.html">
+           InnerModuleA
+          </a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+       <div class="spec-doc">
+        <p>This comment is for <code>InnerModuleA</code>.</p>
+       </div>
       </div>
-      <div class="spec-doc">
-       <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+      <div class="odoc-spec">
+       <div class="spec module-type anchored"
+        id="module-type-InnerModuleTypeA">
+        <a href="#module-type-InnerModuleTypeA" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <span class="keyword">type</span> InnerModuleTypeA
+         </span>
+         <span> = 
+          <a
+           href="Ocamlary-module-type-RecollectionModule-InnerModuleA-module-type-InnerModuleTypeA'.html"
+           >InnerModuleA.InnerModuleTypeA'
+          </a>
+         </span>
+        </code>
+       </div>
+       <div class="spec-doc">
+        <p>This comment is for <code>InnerModuleTypeA</code>.</p>
+       </div>
       </div>
-     </div>
-    </details>
+     </details>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Ocamlary-module-type-SigForMod-Inner-module-type-Empty.html
+++ b/test/generators/html/Ocamlary-module-type-SigForMod-Inner-module-type-Empty.html
@@ -15,8 +15,10 @@
     <a href="Ocamlary-module-type-SigForMod-Inner.html">Inner</a> &#x00BB;
     Empty
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Inner.Empty</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Inner.Empty</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-module-type-SigForMod-Inner.html
+++ b/test/generators/html/Ocamlary-module-type-SigForMod-Inner.html
@@ -13,24 +13,26 @@
    <a href="Ocamlary-module-type-SigForMod.html">SigForMod</a> &#x00BB;
     Inner
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>SigForMod.Inner</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Empty">
-     <a href="#module-type-Empty" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-SigForMod-Inner-module-type-Empty.html">
-        Empty
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>SigForMod.Inner</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-Empty">
+      <a href="#module-type-Empty" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-SigForMod-Inner-module-type-Empty.html">
+         Empty
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-SigForMod.html
+++ b/test/generators/html/Ocamlary-module-type-SigForMod.html
@@ -11,22 +11,24 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; SigForMod
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.SigForMod</span></code></h1>
-   <p>There's a signature in a module in this signature.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Inner">
-     <a href="#module-Inner" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-SigForMod-Inner.html">Inner</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.SigForMod</span></code></h1>
+    <p>There's a signature in a module in this signature.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Inner">
+      <a href="#module-Inner" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-SigForMod-Inner.html">Inner</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-EmptySig.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-EmptySig.html
@@ -13,15 +13,17 @@
    <a href="Ocamlary-module-type-SuperSig.html">SuperSig</a> &#x00BB;
     EmptySig
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>SuperSig.EmptySig</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-not_actually_empty">
-     <a href="#type-not_actually_empty" class="anchor"></a>
-     <code><span><span class="keyword">type</span> not_actually_empty</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>SuperSig.EmptySig</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-not_actually_empty">
+      <a href="#type-not_actually_empty" class="anchor"></a>
+      <code><span><span class="keyword">type</span> not_actually_empty</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-One.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-One.html
@@ -13,14 +13,16 @@
    <a href="Ocamlary-module-type-SuperSig.html">SuperSig</a> &#x00BB;
     One
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>SuperSig.One</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-two">
-     <a href="#type-two" class="anchor"></a>
-     <code><span><span class="keyword">type</span> two</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>SuperSig.One</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-two">
+      <a href="#type-two" class="anchor"></a>
+      <code><span><span class="keyword">type</span> two</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html
@@ -16,15 +16,17 @@
    <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html">SubSigA
    </a> &#x00BB; SubSigAMod
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>SubSigA.SubSigAMod</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-sub_sig_a_mod">
-     <a href="#type-sub_sig_a_mod" class="anchor"></a>
-     <code><span><span class="keyword">type</span> sub_sig_a_mod</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>SubSigA.SubSigAMod</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-sub_sig_a_mod">
+      <a href="#type-sub_sig_a_mod" class="anchor"></a>
+      <code><span><span class="keyword">type</span> sub_sig_a_mod</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA.html
@@ -13,39 +13,41 @@
    <a href="Ocamlary-module-type-SuperSig.html">SuperSig</a> &#x00BB;
     SubSigA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>SuperSig.SubSigA</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul>
     <li><a href="#subSig">A Labeled Section Header Inside of a Signature</a>
     </li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h4 id="subSig"><a href="#subSig" class="anchor"></a>A Labeled Section
-     Header Inside of a Signature
-   </h4>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>SuperSig.SubSigA</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h4 id="subSig"><a href="#subSig" class="anchor"></a>A Labeled Section
+      Header Inside of a Signature
+    </h4>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-SubSigAMod">
-     <a href="#module-SubSigAMod" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a
-        href="Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html"
-        >SubSigAMod
-       </a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-SubSigAMod">
+      <a href="#module-SubSigAMod" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a
+         href="Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod.html"
+         >SubSigAMod
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigB.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigB.html
@@ -13,9 +13,6 @@
    <a href="Ocamlary-module-type-SuperSig.html">SuperSig</a> &#x00BB;
     SubSigB
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>SuperSig.SubSigB</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul>
     <li>
@@ -24,14 +21,19 @@
     </li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h4 id="subSig"><a href="#subSig" class="anchor"></a>Another Labeled
-     Section Header Inside of a Signature
-   </h4>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>SuperSig.SubSigB</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h4 id="subSig"><a href="#subSig" class="anchor"></a>Another Labeled
+      Section Header Inside of a Signature
+    </h4>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SuperSig.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SuperSig.html
@@ -13,8 +13,10 @@
    <a href="Ocamlary-module-type-SuperSig.html">SuperSig</a> &#x00BB;
     SuperSig
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>SuperSig.SuperSig</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>SuperSig.SuperSig</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Ocamlary-module-type-SuperSig.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig.html
@@ -11,86 +11,88 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; SuperSig
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.SuperSig</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-SubSigA">
-     <a href="#module-type-SubSigA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html">
-        SubSigA
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.SuperSig</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-SubSigA">
+      <a href="#module-type-SubSigA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html">
+         SubSigA
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-SubSigB">
-     <a href="#module-type-SubSigB" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-SuperSig-module-type-SubSigB.html">
-        SubSigB
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-SubSigB">
+      <a href="#module-type-SubSigB" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-SuperSig-module-type-SubSigB.html">
+         SubSigB
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-EmptySig">
-     <a href="#module-type-EmptySig" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-SuperSig-module-type-EmptySig.html">
-        EmptySig
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-EmptySig">
+      <a href="#module-type-EmptySig" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-SuperSig-module-type-EmptySig.html">
+         EmptySig
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-One">
-     <a href="#module-type-One" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-SuperSig-module-type-One.html">One</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-One">
+      <a href="#module-type-One" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-SuperSig-module-type-One.html">One</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-SuperSig">
-     <a href="#module-type-SuperSig" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-SuperSig-module-type-SuperSig.html">
-        SuperSig
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-SuperSig">
+      <a href="#module-type-SuperSig" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-SuperSig-module-type-SuperSig.html">
+         SuperSig
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-ToInclude-IncludedA.html
+++ b/test/generators/html/Ocamlary-module-type-ToInclude-IncludedA.html
@@ -13,14 +13,16 @@
    <a href="Ocamlary-module-type-ToInclude.html">ToInclude</a> &#x00BB;
     IncludedA
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>ToInclude.IncludedA</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>ToInclude.IncludedA</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-ToInclude-module-type-IncludedB.html
+++ b/test/generators/html/Ocamlary-module-type-ToInclude-module-type-IncludedB.html
@@ -13,14 +13,16 @@
    <a href="Ocamlary-module-type-ToInclude.html">ToInclude</a> &#x00BB;
     IncludedB
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>ToInclude.IncludedB</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-s">
-     <a href="#type-s" class="anchor"></a>
-     <code><span><span class="keyword">type</span> s</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>ToInclude.IncludedB</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-s">
+      <a href="#type-s" class="anchor"></a>
+      <code><span><span class="keyword">type</span> s</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-ToInclude.html
+++ b/test/generators/html/Ocamlary-module-type-ToInclude.html
@@ -11,37 +11,39 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; ToInclude
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.ToInclude</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-IncludedA">
-     <a href="#module-IncludedA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-ToInclude-IncludedA.html">IncludedA</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.ToInclude</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-IncludedA">
+      <a href="#module-IncludedA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-ToInclude-IncludedA.html">IncludedA</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-IncludedB">
-     <a href="#module-type-IncludedB" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-ToInclude-module-type-IncludedB.html">
-        IncludedB
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-IncludedB">
+      <a href="#module-type-IncludedB" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-ToInclude-module-type-IncludedB.html">
+         IncludedB
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-TypeExt.html
+++ b/test/generators/html/Ocamlary-module-type-TypeExt.html
@@ -11,43 +11,45 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; TypeExt
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.TypeExt</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span><span> = </span>
-      <span>..</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.TypeExt</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span><span> = </span>
+       <span>..</span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-C">
-     <a href="#extension-decl-C" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <a href="#type-t">t</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-C" class="def variant extension anchored">
-       <a href="#extension-C" class="anchor"></a>
-       <code><span>| </span><span><span class="extension">C</span></span>
-       </code>
-      </li>
-     </ol>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-C">
+      <a href="#extension-decl-C" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <a href="#type-t">t</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-C" class="def variant extension anchored">
+        <a href="#extension-C" class="anchor"></a>
+        <code><span>| </span><span><span class="extension">C</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-f">
-     <a href="#val-f" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> f : 
-       <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
-       </span> unit
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-f">
+      <a href="#val-f" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> f : 
+        <span><a href="#type-t">t</a> <span class="arrow">&#45;&gt;</span>
+        </span> unit
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-TypeExtPruned.html
+++ b/test/generators/html/Ocamlary-module-type-TypeExtPruned.html
@@ -11,37 +11,39 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; TypeExtPruned
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.TypeExtPruned</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-C">
-     <a href="#extension-decl-C" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <a href="Ocamlary.html#type-new_t">new_t</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-C" class="def variant extension anchored">
-       <a href="#extension-C" class="anchor"></a>
-       <code><span>| </span><span><span class="extension">C</span></span>
-       </code>
-      </li>
-     </ol>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.TypeExtPruned</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-C">
+      <a href="#extension-decl-C" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <a href="Ocamlary.html#type-new_t">new_t</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-C" class="def variant extension anchored">
+        <a href="#extension-C" class="anchor"></a>
+        <code><span>| </span><span><span class="extension">C</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-f">
-     <a href="#val-f" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> f : 
-       <span><a href="Ocamlary.html#type-new_t">new_t</a> 
-        <span class="arrow">&#45;&gt;</span>
-       </span> unit
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-f">
+      <a href="#val-f" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> f : 
+        <span><a href="Ocamlary.html#type-new_t">new_t</a> 
+         <span class="arrow">&#45;&gt;</span>
+        </span> unit
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-With1-M.html
+++ b/test/generators/html/Ocamlary-module-type-With1-M.html
@@ -12,18 +12,20 @@
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-module-type-With1.html">With1</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>With1.M</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> S
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>With1.M</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> S
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-With1.html
+++ b/test/generators/html/Ocamlary-module-type-With1.html
@@ -11,31 +11,33 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.With1</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-With1-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.With1</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-With1-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code><span><span class="keyword">module</span> N</span>
-      <span> : 
-       <a href="Ocamlary-module-type-With1-M.html#module-type-S">M.S</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code><span><span class="keyword">module</span> N</span>
+       <span> : 
+        <a href="Ocamlary-module-type-With1-M.html#module-type-S">M.S</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-With11-N.html
+++ b/test/generators/html/Ocamlary-module-type-With11-N.html
@@ -12,16 +12,18 @@
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-module-type-With11.html">With11</a> &#x00BB; N
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>With11.N</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = int</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>With11.N</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = int</span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-With11.html
+++ b/test/generators/html/Ocamlary-module-type-With11.html
@@ -11,32 +11,34 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With11
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.With11</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code><span><span class="keyword">module</span> M</span>
-      <span> = <a href="Ocamlary-With9.html">With9</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.With11</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code><span><span class="keyword">module</span> M</span>
+       <span> = <a href="Ocamlary-With9.html">With9</a></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-With11-N.html">N</a>
-      </span>
-      <span> : <a href="Ocamlary-With9-module-type-S.html">M.S</a> 
-       <span class="keyword">with</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Ocamlary-With9-module-type-S.html#type-t">t</a> = int
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-With11-N.html">N</a>
        </span>
-      </span>
-     </code>
+       <span> : <a href="Ocamlary-With9-module-type-S.html">M.S</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Ocamlary-With9-module-type-S.html#type-t">t</a> = int
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-With8-M-N.html
+++ b/test/generators/html/Ocamlary-module-type-With8-M-N.html
@@ -13,15 +13,18 @@
    <a href="Ocamlary-module-type-With8.html">With8</a> &#x00BB; 
    <a href="Ocamlary-module-type-With8-M.html">M</a> &#x00BB; N
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>M.N</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = <a href="Ocamlary-With5-N.html#type-t">With5.N.t</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>M.N</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = <a href="Ocamlary-With5-N.html#type-t">With5.N.t</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-With8-M.html
+++ b/test/generators/html/Ocamlary-module-type-With8-M.html
@@ -12,41 +12,44 @@
     – <a href="Ocamlary.html">Ocamlary</a> &#x00BB; 
    <a href="Ocamlary-module-type-With8.html">With8</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>With8.M</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> S
-      </span>
-      <span> = <a href="Ocamlary-With5-module-type-S.html">With5.S</a></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-With8-M-N.html">N</a>
-      </span>
-      <span> : <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <span class="keyword">struct</span> 
-       <span class="keyword">include</span> 
-       <a href="Ocamlary-With5-N.html">With5.N</a> 
-       <span class="keyword">end</span> <span class="keyword">with</span>
-        
-       <span><span class="keyword">type</span> 
-        <a href="Ocamlary-With5-N.html#type-t">t</a> = 
-        <a href="Ocamlary-With5-N.html#type-t">With5.N.t</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>With8.M</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> S
        </span>
-      </span>
-     </code>
+       <span> = <a href="Ocamlary-With5-module-type-S.html">With5.S</a>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-With8-M-N.html">N</a>
+       </span>
+       <span> : <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <span class="keyword">struct</span> 
+        <span class="keyword">include</span> 
+        <a href="Ocamlary-With5-N.html">With5.N</a> 
+        <span class="keyword">end</span> <span class="keyword">with</span>
+         
+        <span><span class="keyword">type</span> 
+         <a href="Ocamlary-With5-N.html#type-t">t</a> = 
+         <a href="Ocamlary-With5-N.html#type-t">With5.N.t</a>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary-module-type-With8.html
+++ b/test/generators/html/Ocamlary-module-type-With8.html
@@ -11,30 +11,32 @@
   <nav class="odoc-nav"><a href="Ocamlary.html">Up</a> – 
    <a href="Ocamlary.html">Ocamlary</a> &#x00BB; With8
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Ocamlary.With8</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-module-type-With8-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <span class="keyword">struct</span> 
-       <span class="keyword">include</span> 
-       <a href="Ocamlary-With5.html">With5</a> 
-       <span class="keyword">end</span> <span class="keyword">with</span>
-        
-       <span><span class="keyword">type</span> 
-        <a href="Ocamlary-With5-N.html#type-t">N.t</a> = 
-        <a href="Ocamlary-With5-N.html#type-t">With5.N.t</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Ocamlary.With8</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-module-type-With8-M.html">M</a>
        </span>
-      </span>
-     </code>
+       <span> : <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <span class="keyword">struct</span> 
+        <span class="keyword">include</span> 
+        <a href="Ocamlary-With5.html">With5</a> 
+        <span class="keyword">end</span> <span class="keyword">with</span>
+         
+        <span><span class="keyword">type</span> 
+         <a href="Ocamlary-With5-N.html#type-t">N.t</a> = 
+         <a href="Ocamlary-With5-N.html#type-t">With5.N.t</a>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -8,25 +8,6 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Ocamlary</span></code></h1>
-   <p>This is an <i>interface</i> with <b>all</b> of the 
-    <em>module system</em> features. This documentation demonstrates:
-   </p>
-   <ul><li>comment formatting</li><li>unassociated comments</li>
-    <li>documentation sections</li>
-    <li><p>module system documentation including</p>
-     <ol><li>submodules</li><li>module aliases</li><li>module types</li>
-      <li>module type aliases</li><li>modules with signatures</li>
-      <li>modules with aliased signatures</li>
-     </ol>
-    </li>
-   </ul><p>A numbered list:</p><ol><li>3</li><li>2</li><li>1</li></ol>
-   <p>David Sheets is the author.</p>
-   <ul class="at-tags">
-    <li class="author"><span class="at-tag">author</span> David Sheets</li>
-   </ul>
-  </header>
   <nav class="odoc-toc">
    <ul>
     <li><a href="#level-1">Level 1</a>
@@ -70,2896 +51,2940 @@
     <li><a href="#unresolved-references">Unresolved references</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <p>You may find more information about this HTML documentation renderer
-     at 
-    <a href="https://github.com/dsheets/ocamlary">github.com/dsheets/ocamlary
-    </a>.
-   </p><p>This is some verbatim text:</p><pre>verbatim</pre>
-   <p>This is some verbatim text:</p><pre>[][df[]]}}</pre>
-   <p>Here is some raw LaTeX: </p>
-   <p>Here is an index table of <code>Empty</code> modules:</p>
-   <ul class="modules">
-    <li><a href="Ocamlary-Empty.html"><code>Empty</code></a> 
-     <span class="synopsis">A plain, empty module</span>
-    </li>
-    <li><a href="Ocamlary-Empty.html"><code>EmptyAlias</code></a> 
-     <span class="synopsis">A plain module alias of <code>Empty</code></span>
-    </li>
-   </ul><p>Odoc doesn't support <code>{!indexlist}</code>.</p>
-   <p>Here is some superscript: x<sup>2</sup></p>
-   <p>Here is some subscript: x<sub>0</sub></p>
-   <p>Here are some escaped brackets: { [ @ ] }</p>
-   <p>Here is some <em>emphasis</em> <code>followed by code</code>.</p>
-   <p>An unassociated comment</p>
-   <h2 id="level-1"><a href="#level-1" class="anchor"></a>Level 1</h2>
-   <h3 id="level-2"><a href="#level-2" class="anchor"></a>Level 2</h3>
-   <h4 id="level-3"><a href="#level-3" class="anchor"></a>Level 3</h4>
-   <h5 id="level-4"><a href="#level-4" class="anchor"></a>Level 4</h5>
-   <h4 id="basic-module-stuff">
-    <a href="#basic-module-stuff" class="anchor"></a>Basic module stuff
-   </h4>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Empty">
-     <a href="#module-Empty" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Empty.html">Empty</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Ocamlary</span></code></h1>
+    <p>This is an <i>interface</i> with <b>all</b> of the 
+     <em>module system</em> features. This documentation demonstrates:
+    </p>
+    <ul><li>comment formatting</li><li>unassociated comments</li>
+     <li>documentation sections</li>
+     <li><p>module system documentation including</p>
+      <ol><li>submodules</li><li>module aliases</li><li>module types</li>
+       <li>module type aliases</li><li>modules with signatures</li>
+       <li>modules with aliased signatures</li>
+      </ol>
+     </li>
+    </ul><p>A numbered list:</p><ol><li>3</li><li>2</li><li>1</li></ol>
+    <p>David Sheets is the author.</p>
+    <ul class="at-tags">
+     <li class="author"><span class="at-tag">author</span> David Sheets</li>
+    </ul>
+   </header>
+   <div class="odoc-content">
+    <p>You may find more information about this HTML documentation renderer
+      at 
+     <a href="https://github.com/dsheets/ocamlary">
+      github.com/dsheets/ocamlary
+     </a>.
+    </p><p>This is some verbatim text:</p><pre>verbatim</pre>
+    <p>This is some verbatim text:</p><pre>[][df[]]}}</pre>
+    <p>Here is some raw LaTeX: </p>
+    <p>Here is an index table of <code>Empty</code> modules:</p>
+    <ul class="modules">
+     <li><a href="Ocamlary-Empty.html"><code>Empty</code></a> 
+      <span class="synopsis">A plain, empty module</span>
+     </li>
+     <li><a href="Ocamlary-Empty.html"><code>EmptyAlias</code></a> 
+      <span class="synopsis">A plain module alias of <code>Empty</code>
       </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>A plain, empty module</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Empty">
-     <a href="#module-type-Empty" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-Empty.html">Empty</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc"><p>An ambiguous, misnamed module type</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-MissingComment">
-     <a href="#module-type-MissingComment" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-MissingComment.html">MissingComment</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc"><p>An ambiguous, misnamed module type</p></div>
-   </div><h2 id="s9000"><a href="#s9000" class="anchor"></a>Section 9000</h2>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-EmptyAlias">
-     <a href="#module-EmptyAlias" class="anchor"></a>
-     <code><span><span class="keyword">module</span> EmptyAlias</span>
-      <span> = <a href="Ocamlary-Empty.html">Empty</a></span>
-     </code>
-    </div>
-    <div class="spec-doc"><p>A plain module alias of <code>Empty</code></p>
-    </div>
-   </div>
-   <h4 id="emptySig"><a href="#emptySig" class="anchor"></a>EmptySig</h4>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-EmptySig">
-     <a href="#module-type-EmptySig" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-EmptySig.html">EmptySig</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>A plain, empty module signature</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-EmptySigAlias">
-     <a href="#module-type-EmptySigAlias" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> EmptySigAlias
-      </span>
-      <span> = <a href="Ocamlary-module-type-EmptySig.html">EmptySig</a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc"><p>A plain, empty module signature alias of</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-ModuleWithSignature">
-     <a href="#module-ModuleWithSignature" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-ModuleWithSignature.html">ModuleWithSignature</a>
-      </span>
-      <span> : <a href="Ocamlary-module-type-EmptySig.html">EmptySig</a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>A plain module of a signature of 
-      <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
-       (reference)
-     </p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-ModuleWithSignatureAlias">
-     <a href="#module-ModuleWithSignatureAlias" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-ModuleWithSignatureAlias.html">
-        ModuleWithSignatureAlias
-       </a>
-      </span>
-      <span> : <a href="Ocamlary-module-type-EmptySig.html">EmptySigAlias</a>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc"><p>A plain module with an alias signature</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-One">
-     <a href="#module-One" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-One.html">One</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-SigForMod">
-     <a href="#module-type-SigForMod" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-SigForMod.html">SigForMod</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>There's a signature in a module in this signature.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-SuperSig">
-     <a href="#module-type-SuperSig" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-SuperSig.html">SuperSig</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <p>For a good time, see 
-    <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig"
-     title="subSig">A Labeled Section Header Inside of a Signature
-    </a> or 
-    <a href="Ocamlary-module-type-SuperSig-module-type-SubSigB.html#subSig"
-     title="subSig">Another Labeled Section Header Inside of a Signature
-    </a> or 
-    <a href="Ocamlary-module-type-SuperSig-module-type-EmptySig.html">
-     <code>SuperSig.EmptySig</code>
-    </a>. Section <a href="#s9000" title="s9000">Section 9000</a> is 
-    also interesting. <a href="#emptySig" title="emptySig">EmptySig</a>
-     is the section and 
-    <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
-     is the module signature.
-   </p>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Buffer">
-     <a href="#module-Buffer" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Buffer.html">Buffer</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>References are resolved after everything, so <code>{!Buffer.t}</code>
-       won't resolve.
-     </p>
-    </div>
-   </div><p>Some text before exception title.</p>
-   <h4 id="basic-exception-stuff">
-    <a href="#basic-exception-stuff" class="anchor"></a>Basic exception
-     stuff
-   </h4><p>After exception title.</p>
-   <div class="odoc-spec">
-    <div class="spec exception anchored" id="exception-Kaboom">
-     <a href="#exception-Kaboom" class="anchor"></a>
-     <code><span><span class="keyword">exception</span> </span>
-      <span><span class="exception">Kaboom</span> 
-       <span class="keyword">of</span> unit
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Unary exception constructor</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec exception anchored" id="exception-Kablam">
-     <a href="#exception-Kablam" class="anchor"></a>
-     <code><span><span class="keyword">exception</span> </span>
-      <span><span class="exception">Kablam</span> 
-       <span class="keyword">of</span> unit * unit
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Binary exception constructor</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec exception anchored" id="exception-Kapow">
-     <a href="#exception-Kapow" class="anchor"></a>
-     <code><span><span class="keyword">exception</span> </span>
-      <span><span class="exception">Kapow</span> 
-       <span class="keyword">of</span> unit * unit
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>Unary exception constructor over binary tuple</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec exception anchored" id="exception-EmptySig">
-     <a href="#exception-EmptySig" class="anchor"></a>
-     <code><span><span class="keyword">exception</span> </span>
-      <span><span class="exception">EmptySig</span></span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>
-      <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
-       is a module and 
-      <a href="#exception-EmptySig"><code>EmptySig</code></a> is this
-       exception.
-     </p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec exception anchored" id="exception-EmptySigAlias">
-     <a href="#exception-EmptySigAlias" class="anchor"></a>
-     <code><span><span class="keyword">exception</span> </span>
-      <span><span class="exception">EmptySigAlias</span></span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p><a href="#exception-EmptySigAlias"><code>EmptySigAlias</code></a>
-       is this exception.
-     </p>
-    </div>
-   </div>
-   <h4 id="basic-type-and-value-stuff-with-advanced-doc-comments">
-    <a href="#basic-type-and-value-stuff-with-advanced-doc-comments"
-     class="anchor">
-    </a>Basic type and value stuff with advanced doc comments
-   </h4>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-a_function">
-     <a href="#type-a_function" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>('a, 'b) a_function</span>
-      </span>
-      <span> = 
-       <span><span class="type-var">'a</span> 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <span class="type-var">'b</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p><a href="#type-a_function"><code>a_function</code></a> is this
-       type and <a href="#val-a_function"><code>a_function</code></a>
-       is the value below.
-     </p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-a_function">
-     <a href="#val-a_function" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> a_function : 
-       <span><span class="label">x</span>:int 
-        <span class="arrow">&#45;&gt;</span>
-       </span> int
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This is <code>a_function</code> with param and return type.</p>
-     <ul class="at-tags">
-      <li class="parameter"><span class="at-tag">parameter</span> 
-       <span class="value">x</span> <p>the <code>x</code> coordinate</p>
-      </li>
-     </ul>
-     <ul class="at-tags">
-      <li class="returns"><span class="at-tag">returns</span> 
-       <p>the <code>y</code> coordinate</p>
-      </li>
-     </ul>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-fun_fun_fun">
-     <a href="#val-fun_fun_fun" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> fun_fun_fun : 
-       <span>
-        <span>(
-         <span><span>(int, int)</span> 
-          <a href="#type-a_function">a_function</a>
-         </span>, 
-         <span><span>(unit, unit)</span> 
-          <a href="#type-a_function">a_function</a>
-         </span>)
-        </span> <a href="#type-a_function">a_function</a>
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-fun_maybe">
-     <a href="#val-fun_maybe" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> fun_maybe : 
-       <span><span class="optlabel">?yes</span>:unit 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <span>unit <span class="arrow">&#45;&gt;</span></span>
-        int
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-not_found">
-     <a href="#val-not_found" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> not_found : 
-       <span>unit <span class="arrow">&#45;&gt;</span></span> unit
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="raises"><span class="at-tag">raises</span> 
-       <code>Not_found</code> <p>That's all it does</p>
-      </li>
-     </ul>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-kaboom">
-     <a href="#val-kaboom" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> kaboom : 
-       <span>unit <span class="arrow">&#45;&gt;</span></span> unit
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="raises"><span class="at-tag">raises</span> 
-       <a href="#exception-Kaboom"><code>Kaboom</code></a> 
-       <p>That's all it does</p>
-      </li>
-     </ul>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-ocaml_org">
-     <a href="#val-ocaml_org" class="anchor"></a>
-     <code><span><span class="keyword">val</span> ocaml_org : string</span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="see"><span class="at-tag">see</span> 
-       <a href="http://ocaml.org/" class="value">http://ocaml.org/</a>
-        <p>The OCaml Web site</p>
-      </li>
-     </ul>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-some_file">
-     <a href="#val-some_file" class="anchor"></a>
-     <code><span><span class="keyword">val</span> some_file : string</span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="see"><span class="at-tag">see</span> 
-       <code class="value">some_file</code> 
-       <p>The file called <code>some_file</code></p>
-      </li>
-     </ul>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-some_doc">
-     <a href="#val-some_doc" class="anchor"></a>
-     <code><span><span class="keyword">val</span> some_doc : string</span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <ul class="at-tags">
-      <li class="see"><span class="at-tag">see</span> 
-       <span class="value">some_doc</span> 
-       <p>The document called <code>some_doc</code></p>
-      </li>
-     </ul>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-since_mesozoic">
-     <a href="#val-since_mesozoic" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> since_mesozoic : unit</span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This value was introduced in the Mesozoic era.</p>
-     <ul class="at-tags">
-      <li class="since"><span class="at-tag">since</span> mesozoic</li>
-     </ul>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-changing">
-     <a href="#val-changing" class="anchor"></a>
-     <code><span><span class="keyword">val</span> changing : unit</span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This value has had changes in 1.0.0, 1.1.0, and 1.2.0.</p>
-     <ul class="at-tags">
-      <li class="before"><span class="at-tag">before</span> 
-       <span class="value">1.0.0</span> <p>before 1.0.0</p>
-      </li>
-     </ul>
-     <ul class="at-tags">
-      <li class="before"><span class="at-tag">before</span> 
-       <span class="value">1.1.0</span> <p>before 1.1.0</p>
-      </li>
-     </ul>
-     <ul class="at-tags">
-      <li class="version"><span class="at-tag">version</span> 1.2.0</li>
-     </ul>
-    </div>
-   </div>
-   <h4 id="some-operators"><a href="#some-operators" class="anchor"></a>
-    Some Operators
-   </h4>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(~-)">
-     <a href="#val-(~-)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (~-) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(!)">
-     <a href="#val-(!)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (!) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(@)">
-     <a href="#val-(@)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (@) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-($)">
-     <a href="#val-($)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> ($) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(%)">
-     <a href="#val-(%)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (%) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(&amp;)">
-     <a href="#val-(&amp;)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (&amp;) : unit</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(*)">
-     <a href="#val-(*)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (*) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(-)">
-     <a href="#val-(-)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (-) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(+)">
-     <a href="#val-(+)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (+) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(-?)">
-     <a href="#val-(-?)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (-?) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(/)">
-     <a href="#val-(/)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (/) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(:=)">
-     <a href="#val-(:=)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (:=) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(=)">
-     <a href="#val-(=)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (=) : unit</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-(land)">
-     <a href="#val-(land)" class="anchor"></a>
-     <code><span><span class="keyword">val</span> (land) : unit</span></code>
-    </div>
-   </div>
-   <h4 id="advanced-module-stuff">
-    <a href="#advanced-module-stuff" class="anchor"></a>Advanced Module
-     Stuff
-   </h4>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-CollectionModule">
-     <a href="#module-CollectionModule" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-CollectionModule.html">CollectionModule</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>CollectionModule</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-COLLECTION">
-     <a href="#module-type-COLLECTION" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
-      </span>
-      <span> = <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <a href="Ocamlary-CollectionModule.html">CollectionModule</a>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>module type of</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Recollection">
-     <a href="#module-Recollection" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Recollection.html">Recollection</a>
-      </span>
-      <span>
-              
-       (<a href="Ocamlary-Recollection-argument-1-C.html">C</a> : 
-       <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>)
-        : 
-            
-       <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
-                                                                        
-       <span class="keyword">with</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Ocamlary-module-type-COLLECTION.html#type-collection">
-         collection
-        </a> = 
-        <span>
-         <a href="Ocamlary-Recollection-argument-1-C.html#type-element">
-          C.element
-         </a> list
-        </span>
-       </span>
-                  
-        <span class="keyword">and</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Ocamlary-module-type-COLLECTION.html#type-element">element
-        </a> = 
-        <a href="Ocamlary-Recollection-argument-1-C.html#type-collection">
-         C.collection
-        </a>
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-MMM">
-     <a href="#module-type-MMM" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-MMM.html">MMM</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-RECOLLECTION">
-     <a href="#module-type-RECOLLECTION" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-RECOLLECTION.html">RECOLLECTION</a>
-      </span>
-      <span> = <a href="Ocamlary-module-type-MMM.html">MMM</a> 
-       <span class="keyword">with</span> 
-       <span><span class="keyword">module</span> 
-        <a href="Ocamlary-module-type-MMM-C.html">C</a> = 
-        <a href="Ocamlary-Recollection.html">Recollection(CollectionModule)
-        </a>
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored"
-     id="module-type-RecollectionModule">
-     <a href="#module-type-RecollectionModule" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-RecollectionModule.html">
-        RecollectionModule
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-A">
-     <a href="#module-type-A" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-A.html">A</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-B">
-     <a href="#module-type-B" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-B.html">B</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-C">
-     <a href="#module-type-C" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-C.html">C</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc"><p>This module type includes two signatures.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-FunctorTypeOf">
-     <a href="#module-FunctorTypeOf" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-FunctorTypeOf.html">FunctorTypeOf</a>
-      </span>
-      <span>
-              
-       (
-       <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">Collection
-       </a> : <span class="keyword">module</span> 
-       <span class="keyword">type</span> <span class="keyword">of</span>
-        <a href="Ocamlary-CollectionModule.html">CollectionModule</a>
-       ) : 
-             
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>FunctorTypeOf</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-IncludeModuleType">
-     <a href="#module-type-IncludeModuleType" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-IncludeModuleType.html">
-        IncludeModuleType
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>IncludeModuleType</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-ToInclude">
-     <a href="#module-type-ToInclude" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-ToInclude.html">ToInclude</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
+     </li>
+    </ul><p>Odoc doesn't support <code>{!indexlist}</code>.</p>
+    <p>Here is some superscript: x<sup>2</sup></p>
+    <p>Here is some subscript: x<sub>0</sub></p>
+    <p>Here are some escaped brackets: { [ @ ] }</p>
+    <p>Here is some <em>emphasis</em> <code>followed by code</code>.</p>
+    <p>An unassociated comment</p>
+    <h2 id="level-1"><a href="#level-1" class="anchor"></a>Level 1</h2>
+    <h3 id="level-2"><a href="#level-2" class="anchor"></a>Level 2</h3>
+    <h4 id="level-3"><a href="#level-3" class="anchor"></a>Level 3</h4>
+    <h5 id="level-4"><a href="#level-4" class="anchor"></a>Level 4</h5>
+    <h4 id="basic-module-stuff">
+     <a href="#basic-module-stuff" class="anchor"></a>Basic module stuff
+    </h4>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Empty">
+      <a href="#module-Empty" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
-        <a href="Ocamlary-module-type-ToInclude.html">ToInclude</a>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Empty.html">Empty</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
        </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-IncludedA">
-       <a href="#module-IncludedA" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> 
-         <a href="Ocamlary-IncludedA.html">IncludedA</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
-      </div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec module-type anchored" id="module-type-IncludedB">
-       <a href="#module-type-IncludedB" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> 
-         <span class="keyword">type</span> 
-         <a href="Ocamlary-module-type-IncludedB.html">IncludedB</a>
-        </span>
-        <span> = <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
-      </div>
-     </div>
-    </details>
-   </div>
-   <h4 id="advanced-type-stuff">
-    <a href="#advanced-type-stuff" class="anchor"></a>Advanced Type Stuff
-   </h4>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-record">
-     <a href="#type-record" class="anchor"></a>
-     <code><span><span class="keyword">type</span> record</span>
-      <span> = </span><span>{</span>
-     </code>
-     <ol>
-      <li id="type-record.field1" class="def record field anchored">
-       <a href="#type-record.field1" class="anchor"></a>
-       <code><span>field1 : int;</span></code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>This comment is for <code>field1</code>.</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-record.field2" class="def record field anchored">
-       <a href="#type-record.field2" class="anchor"></a>
-       <code><span>field2 : int;</span></code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>This comment is for <code>field2</code>.</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol><code><span>}</span></code>
+     </div><div class="spec-doc"><p>A plain, empty module</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>record</code>.</p>
-     <p>This comment is also for <code>record</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-mutable_record">
-     <a href="#type-mutable_record" class="anchor"></a>
-     <code><span><span class="keyword">type</span> mutable_record</span>
-      <span> = </span><span>{</span>
-     </code>
-     <ol>
-      <li id="type-mutable_record.a" class="def record field anchored">
-       <a href="#type-mutable_record.a" class="anchor"></a>
-       <code><span><span class="keyword">mutable</span> a : int;</span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p><code>a</code> is first and mutable</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-mutable_record.b" class="def record field anchored">
-       <a href="#type-mutable_record.b" class="anchor"></a>
-       <code><span>b : unit;</span></code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p><code>b</code> is second and immutable</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-mutable_record.c" class="def record field anchored">
-       <a href="#type-mutable_record.c" class="anchor"></a>
-       <code><span><span class="keyword">mutable</span> c : int;</span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p><code>c</code> is third and mutable</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol><code><span>}</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-universe_record">
-     <a href="#type-universe_record" class="anchor"></a>
-     <code><span><span class="keyword">type</span> universe_record</span>
-      <span> = </span><span>{</span>
-     </code>
-     <ol>
-      <li id="type-universe_record.nihilate" class="def record field
-       anchored"><a href="#type-universe_record.nihilate" class="anchor"></a>
-       <code>
-        <span>nihilate : 'a. 
-         <span><span class="type-var">'a</span> 
-          <span class="arrow">&#45;&gt;</span>
-         </span> unit;
-        </span>
-       </code>
-      </li>
-     </ol><code><span>}</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-variant">
-     <a href="#type-variant" class="anchor"></a>
-     <code><span><span class="keyword">type</span> variant</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-variant.TagA" class="def variant constructor anchored">
-       <a href="#type-variant.TagA" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">TagA</span></span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>This comment is for <code>TagA</code>.</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-variant.ConstrB" class="def variant constructor anchored">
-       <a href="#type-variant.ConstrB" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">ConstrB</span> 
-         <span class="keyword">of</span> int
-        </span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>This comment is for <code>ConstrB</code>.</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-variant.ConstrC" class="def variant constructor anchored">
-       <a href="#type-variant.ConstrC" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">ConstrC</span> 
-         <span class="keyword">of</span> int * int
-        </span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>This comment is for binary <code>ConstrC</code>.</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-variant.ConstrD" class="def variant constructor anchored">
-       <a href="#type-variant.ConstrD" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">ConstrD</span> 
-         <span class="keyword">of</span> int * int
-        </span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>This comment is for unary <code>ConstrD</code> of binary tuple.
-        </p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol>
-    </div>
-    <div class="spec-doc"><p>This comment is for <code>variant</code>.</p>
-     <p>This comment is also for <code>variant</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-poly_variant">
-     <a href="#type-poly_variant" class="anchor"></a>
-     <code><span><span class="keyword">type</span> poly_variant</span>
-      <span> = </span><span>[ </span>
-     </code>
-     <ol>
-      <li id="type-poly_variant.TagA" class="def variant constructor
-       anchored"><a href="#type-poly_variant.TagA" class="anchor"></a>
-       <code><span>| </span><span>`TagA</span></code>
-      </li>
-      <li id="type-poly_variant.ConstrB" class="def variant constructor
-       anchored"><a href="#type-poly_variant.ConstrB" class="anchor"></a>
-       <code><span>| </span>
-        <span>`ConstrB <span class="keyword">of</span> int</span>
-       </code>
-      </li>
-     </ol><code><span> ]</span></code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>poly_variant</code>.</p>
-     <p>Wow! It was a polymorphic variant!</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-full_gadt">
-     <a href="#type-full_gadt" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>(_, _) full_gadt</span>
-      </span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-full_gadt.Tag" class="def variant constructor anchored">
-       <a href="#type-full_gadt.Tag" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Tag</span> : 
-         <span><span>(unit, unit)</span> 
-          <a href="#type-full_gadt">full_gadt</a>
-         </span>
-        </span>
-       </code>
-      </li>
-      <li id="type-full_gadt.First" class="def variant constructor anchored">
-       <a href="#type-full_gadt.First" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">First</span> : 
-         <span class="type-var">'a</span> 
-         <span class="arrow">&#45;&gt;</span> 
-         <span><span>(<span class="type-var">'a</span>, unit)</span> 
-          <a href="#type-full_gadt">full_gadt</a>
-         </span>
-        </span>
-       </code>
-      </li>
-      <li id="type-full_gadt.Second" class="def variant constructor anchored">
-       <a href="#type-full_gadt.Second" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Second</span> : 
-         <span class="type-var">'a</span> 
-         <span class="arrow">&#45;&gt;</span> 
-         <span><span>(unit, <span class="type-var">'a</span>)</span> 
-          <a href="#type-full_gadt">full_gadt</a>
-         </span>
-        </span>
-       </code>
-      </li>
-      <li id="type-full_gadt.Exist" class="def variant constructor anchored">
-       <a href="#type-full_gadt.Exist" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Exist</span> : 
-         <span class="type-var">'a</span> * <span class="type-var">'b</span>
-          <span class="arrow">&#45;&gt;</span> 
-         <span><span>(<span class="type-var">'b</span>, unit)</span> 
-          <a href="#type-full_gadt">full_gadt</a>
-         </span>
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-    <div class="spec-doc"><p>This comment is for <code>full_gadt</code>.</p>
-     <p>Wow! It was a GADT!</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-partial_gadt">
-     <a href="#type-partial_gadt" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a partial_gadt</span>
-      </span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-partial_gadt.AscribeTag" class="def variant constructor
-       anchored"><a href="#type-partial_gadt.AscribeTag" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">AscribeTag</span> : 
-         <span><span class="type-var">'a</span> 
-          <a href="#type-partial_gadt">partial_gadt</a>
-         </span>
-        </span>
-       </code>
-      </li>
-      <li id="type-partial_gadt.OfTag" class="def variant constructor
-       anchored"><a href="#type-partial_gadt.OfTag" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">OfTag</span> 
-         <span class="keyword">of</span> 
-         <span><span class="type-var">'a</span> 
-          <a href="#type-partial_gadt">partial_gadt</a>
-         </span>
-        </span>
-       </code>
-      </li>
-      <li id="type-partial_gadt.ExistGadtTag" class="def variant constructor
-       anchored">
-       <a href="#type-partial_gadt.ExistGadtTag" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">ExistGadtTag</span> : 
-         <span>(
-          <span><span class="type-var">'a</span> 
-           <span class="arrow">&#45;&gt;</span>
-          </span> <span class="type-var">'b</span>)
-         </span> <span class="arrow">&#45;&gt;</span> 
-         <span><span class="type-var">'a</span> 
-          <a href="#type-partial_gadt">partial_gadt</a>
-         </span>
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>partial_gadt</code>.</p>
-     <p>Wow! It was a mixed GADT!</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-alias">
-     <a href="#type-alias" class="anchor"></a>
-     <code><span><span class="keyword">type</span> alias</span>
-      <span> = <a href="#type-variant">variant</a></span>
-     </code>
-    </div>
-    <div class="spec-doc"><p>This comment is for <code>alias</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-tuple">
-     <a href="#type-tuple" class="anchor"></a>
-     <code><span><span class="keyword">type</span> tuple</span>
-      <span> = 
-       <span>(<a href="#type-alias">alias</a> * 
-        <a href="#type-alias">alias</a>)
-       </span> * <a href="#type-alias">alias</a> * 
-       <span>(<a href="#type-alias">alias</a> * 
-        <a href="#type-alias">alias</a>)
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-Empty">
+      <a href="#module-type-Empty" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-Empty.html">Empty</a>
        </span>
-      </span>
-     </code>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>An ambiguous, misnamed module type</p></div>
     </div>
-    <div class="spec-doc"><p>This comment is for <code>tuple</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-MissingComment">
+      <a href="#module-type-MissingComment" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-MissingComment.html">MissingComment</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>An ambiguous, misnamed module type</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-variant_alias">
-     <a href="#type-variant_alias" class="anchor"></a>
-     <code><span><span class="keyword">type</span> variant_alias</span>
-      <span> = <a href="#type-variant">variant</a></span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-variant_alias.TagA" class="def variant constructor
-       anchored"><a href="#type-variant_alias.TagA" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">TagA</span></span>
-       </code>
-      </li>
-      <li id="type-variant_alias.ConstrB" class="def variant constructor
-       anchored"><a href="#type-variant_alias.ConstrB" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">ConstrB</span> 
-         <span class="keyword">of</span> int
-        </span>
-       </code>
-      </li>
-      <li id="type-variant_alias.ConstrC" class="def variant constructor
-       anchored"><a href="#type-variant_alias.ConstrC" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">ConstrC</span> 
-         <span class="keyword">of</span> int * int
-        </span>
-       </code>
-      </li>
-      <li id="type-variant_alias.ConstrD" class="def variant constructor
-       anchored"><a href="#type-variant_alias.ConstrD" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">ConstrD</span> 
-         <span class="keyword">of</span> int * int
-        </span>
-       </code>
-      </li>
-     </ol>
+    <h2 id="s9000"><a href="#s9000" class="anchor"></a>Section 9000</h2>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-EmptyAlias">
+      <a href="#module-EmptyAlias" class="anchor"></a>
+      <code><span><span class="keyword">module</span> EmptyAlias</span>
+       <span> = <a href="Ocamlary-Empty.html">Empty</a></span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>A plain module alias of <code>Empty</code></p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>variant_alias</code>.</p>
+    <h4 id="emptySig"><a href="#emptySig" class="anchor"></a>EmptySig</h4>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-EmptySig">
+      <a href="#module-type-EmptySig" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-EmptySig.html">EmptySig</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>A plain, empty module signature</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-record_alias">
-     <a href="#type-record_alias" class="anchor"></a>
-     <code><span><span class="keyword">type</span> record_alias</span>
-      <span> = <a href="#type-record">record</a></span><span> = </span>
-      <span>{</span>
-     </code>
-     <ol>
-      <li id="type-record_alias.field1" class="def record field anchored">
-       <a href="#type-record_alias.field1" class="anchor"></a>
-       <code><span>field1 : int;</span></code>
-      </li>
-      <li id="type-record_alias.field2" class="def record field anchored">
-       <a href="#type-record_alias.field2" class="anchor"></a>
-       <code><span>field2 : int;</span></code>
-      </li>
-     </ol><code><span>}</span></code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-EmptySigAlias">
+      <a href="#module-type-EmptySigAlias" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> EmptySigAlias
+       </span>
+       <span> = <a href="Ocamlary-module-type-EmptySig.html">EmptySig</a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>A plain, empty module signature alias of</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>record_alias</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-ModuleWithSignature">
+      <a href="#module-ModuleWithSignature" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-ModuleWithSignature.html">ModuleWithSignature</a>
+       </span>
+       <span> : <a href="Ocamlary-module-type-EmptySig.html">EmptySig</a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>A plain module of a signature of 
+       <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
+        (reference)
+      </p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-poly_variant_union">
-     <a href="#type-poly_variant_union" class="anchor"></a>
-     <code><span><span class="keyword">type</span> poly_variant_union</span>
-      <span> = </span><span>[ </span>
-     </code>
-     <ol>
-      <li id="type-poly_variant_union.poly_variant" class="def variant 
-       type anchored">
-       <a href="#type-poly_variant_union.poly_variant" class="anchor"></a>
-       <code><span>| </span>
-        <span><a href="#type-poly_variant">poly_variant</a></span>
-       </code>
-      </li>
-      <li id="type-poly_variant_union.TagC" class="def variant constructor
-       anchored"><a href="#type-poly_variant_union.TagC" class="anchor"></a>
-       <code><span>| </span><span>`TagC</span></code>
-      </li>
-     </ol><code><span> ]</span></code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-ModuleWithSignatureAlias">
+      <a href="#module-ModuleWithSignatureAlias" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-ModuleWithSignatureAlias.html">
+         ModuleWithSignatureAlias
+        </a>
+       </span>
+       <span> : 
+        <a href="Ocamlary-module-type-EmptySig.html">EmptySigAlias</a>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>A plain module with an alias signature</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>poly_variant_union</code>.</p>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-One">
+      <a href="#module-One" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-One.html">One</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-poly_poly_variant">
-     <a href="#type-poly_poly_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>'a poly_poly_variant</span>
-      </span><span> = </span><span>[ </span>
-     </code>
-     <ol>
-      <li id="type-poly_poly_variant.TagA" class="def variant constructor
-       anchored"><a href="#type-poly_poly_variant.TagA" class="anchor"></a>
-       <code><span>| </span>
-        <span>`TagA <span class="keyword">of</span> 
-         <span class="type-var">'a</span>
-        </span>
-       </code>
-      </li>
-     </ol><code><span> ]</span></code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-SigForMod">
+      <a href="#module-type-SigForMod" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-SigForMod.html">SigForMod</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>There's a signature in a module in this signature.</p>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-bin_poly_poly_variant">
-     <a href="#type-bin_poly_poly_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>('a, 'b) bin_poly_poly_variant</span>
-      </span><span> = </span><span>[ </span>
-     </code>
-     <ol>
-      <li id="type-bin_poly_poly_variant.TagA" class="def variant constructor
-       anchored">
-       <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a>
-       <code><span>| </span>
-        <span>`TagA <span class="keyword">of</span> 
-         <span class="type-var">'a</span>
-        </span>
-       </code>
-      </li>
-      <li id="type-bin_poly_poly_variant.ConstrB" class="def variant
-       constructor anchored">
-       <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a>
-       <code><span>| </span>
-        <span>`ConstrB <span class="keyword">of</span> 
-         <span class="type-var">'b</span>
-        </span>
-       </code>
-      </li>
-     </ol><code><span> ]</span></code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-SuperSig">
+      <a href="#module-type-SuperSig" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-SuperSig.html">SuperSig</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-open_poly_variant">
-     <a href="#type-open_poly_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>'a open_poly_variant</span>
-      </span>
-      <span> = <span>[&gt; `TagA ]</span> <span class="keyword">as</span> 'a
-      </span>
-     </code>
+    <p>For a good time, see 
+     <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig"
+      title="subSig">A Labeled Section Header Inside of a Signature
+     </a> or 
+     <a href="Ocamlary-module-type-SuperSig-module-type-SubSigB.html#subSig"
+      title="subSig">Another Labeled Section Header Inside of a Signature
+     </a> or 
+     <a href="Ocamlary-module-type-SuperSig-module-type-EmptySig.html">
+      <code>SuperSig.EmptySig</code>
+     </a>. Section <a href="#s9000" title="s9000">Section 9000</a> is
+      also interesting. <a href="#emptySig" title="emptySig">EmptySig</a>
+      is the section and 
+     <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
+      is the module signature.
+    </p>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Buffer">
+      <a href="#module-Buffer" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Buffer.html">Buffer</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>References are resolved after everything, so 
+       <code>{!Buffer.t}</code> won't resolve.
+      </p>
+     </div>
+    </div><p>Some text before exception title.</p>
+    <h4 id="basic-exception-stuff">
+     <a href="#basic-exception-stuff" class="anchor"></a>Basic exception
+      stuff
+    </h4><p>After exception title.</p>
+    <div class="odoc-spec">
+     <div class="spec exception anchored" id="exception-Kaboom">
+      <a href="#exception-Kaboom" class="anchor"></a>
+      <code><span><span class="keyword">exception</span> </span>
+       <span><span class="exception">Kaboom</span> 
+        <span class="keyword">of</span> unit
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Unary exception constructor</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-open_poly_variant2">
-     <a href="#type-open_poly_variant2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>'a open_poly_variant2</span>
-      </span>
-      <span> = <span>[&gt; <span>`ConstrB of int</span> ]</span> 
-       <span class="keyword">as</span> 'a
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec exception anchored" id="exception-Kablam">
+      <a href="#exception-Kablam" class="anchor"></a>
+      <code><span><span class="keyword">exception</span> </span>
+       <span><span class="exception">Kablam</span> 
+        <span class="keyword">of</span> unit * unit
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Binary exception constructor</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-open_poly_variant_alias">
-     <a href="#type-open_poly_variant_alias" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>'a open_poly_variant_alias</span>
-      </span>
-      <span> = 
-       <span>
+    <div class="odoc-spec">
+     <div class="spec exception anchored" id="exception-Kapow">
+      <a href="#exception-Kapow" class="anchor"></a>
+      <code><span><span class="keyword">exception</span> </span>
+       <span><span class="exception">Kapow</span> 
+        <span class="keyword">of</span> unit * unit
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>Unary exception constructor over binary tuple</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec exception anchored" id="exception-EmptySig">
+      <a href="#exception-EmptySig" class="anchor"></a>
+      <code><span><span class="keyword">exception</span> </span>
+       <span><span class="exception">EmptySig</span></span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>
+       <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
+        is a module and 
+       <a href="#exception-EmptySig"><code>EmptySig</code></a> is this
+        exception.
+      </p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec exception anchored" id="exception-EmptySigAlias">
+      <a href="#exception-EmptySigAlias" class="anchor"></a>
+      <code><span><span class="keyword">exception</span> </span>
+       <span><span class="exception">EmptySigAlias</span></span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p><a href="#exception-EmptySigAlias"><code>EmptySigAlias</code></a>
+        is this exception.
+      </p>
+     </div>
+    </div>
+    <h4 id="basic-type-and-value-stuff-with-advanced-doc-comments">
+     <a href="#basic-type-and-value-stuff-with-advanced-doc-comments"
+      class="anchor">
+     </a>Basic type and value stuff with advanced doc comments
+    </h4>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-a_function">
+      <a href="#type-a_function" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>('a, 'b) a_function</span>
+       </span>
+       <span> = 
         <span><span class="type-var">'a</span> 
-         <a href="#type-open_poly_variant">open_poly_variant</a>
-        </span> <a href="#type-open_poly_variant2">open_poly_variant2</a>
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-poly_fun">
-     <a href="#type-poly_fun" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a poly_fun</span></span>
-      <span> = 
-       <span><span>[&gt; <span>`ConstrB of int</span> ]</span> 
-        <span class="keyword">as</span> 'a 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <span class="type-var">'a</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-poly_fun_constraint">
-     <a href="#type-poly_fun_constraint" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>'a poly_fun_constraint</span>
-      </span>
-      <span> = 
-       <span><span class="type-var">'a</span> 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <span class="type-var">'a</span>
-      </span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = <span>[&gt; `TagA ]</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-closed_poly_variant">
-     <a href="#type-closed_poly_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>'a closed_poly_variant</span>
-      </span>
-      <span> = <span>[&lt; `One <span>| `Two</span> ]</span> 
-       <span class="keyword">as</span> 'a
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-clopen_poly_variant">
-     <a href="#type-clopen_poly_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>'a clopen_poly_variant</span>
-      </span>
-      <span> = 
-       <span>[&lt; `One <span><span>| `Two</span> of int</span> 
-        <span>| `Three</span> Two Three ]
-       </span> <span class="keyword">as</span> 'a
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-nested_poly_variant">
-     <a href="#type-nested_poly_variant" class="anchor"></a>
-     <code><span><span class="keyword">type</span> nested_poly_variant</span>
-      <span> = </span><span>[ </span>
-     </code>
-     <ol>
-      <li id="type-nested_poly_variant.A" class="def variant constructor
-       anchored"><a href="#type-nested_poly_variant.A" class="anchor"></a>
-       <code><span>| </span><span>`A</span></code>
-      </li>
-      <li id="type-nested_poly_variant.B" class="def variant constructor
-       anchored"><a href="#type-nested_poly_variant.B" class="anchor"></a>
-       <code><span>| </span>
-        <span>`B <span class="keyword">of</span> 
-         <span>[ `B1 <span>| `B2</span> ]</span>
-        </span>
-       </code>
-      </li>
-      <li id="type-nested_poly_variant.C" class="def variant constructor
-       anchored"><a href="#type-nested_poly_variant.C" class="anchor"></a>
-       <code><span>| </span><span>`C</span></code>
-      </li>
-      <li id="type-nested_poly_variant.D" class="def variant constructor
-       anchored"><a href="#type-nested_poly_variant.D" class="anchor"></a>
-       <code><span>| </span>
-        <span>`D <span class="keyword">of</span> 
-         <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span>
-        </span>
-       </code>
-      </li>
-     </ol><code><span> ]</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-full_gadt_alias">
-     <a href="#type-full_gadt_alias" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>('a, 'b) full_gadt_alias</span>
-      </span>
-      <span> = 
-       <span>
-        <span>(<span class="type-var">'a</span>, 
-         <span class="type-var">'b</span>)
-        </span> <a href="#type-full_gadt">full_gadt</a>
-       </span>
-      </span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-full_gadt_alias.Tag" class="def variant constructor
-       anchored"><a href="#type-full_gadt_alias.Tag" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Tag</span> : 
-         <span><span>(unit, unit)</span> 
-          <a href="#type-full_gadt_alias">full_gadt_alias</a>
-         </span>
-        </span>
-       </code>
-      </li>
-      <li id="type-full_gadt_alias.First" class="def variant constructor
-       anchored"><a href="#type-full_gadt_alias.First" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">First</span> : 
-         <span class="type-var">'a</span> 
-         <span class="arrow">&#45;&gt;</span> 
-         <span><span>(<span class="type-var">'a</span>, unit)</span> 
-          <a href="#type-full_gadt_alias">full_gadt_alias</a>
-         </span>
-        </span>
-       </code>
-      </li>
-      <li id="type-full_gadt_alias.Second" class="def variant constructor
-       anchored"><a href="#type-full_gadt_alias.Second" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Second</span> : 
-         <span class="type-var">'a</span> 
-         <span class="arrow">&#45;&gt;</span> 
-         <span><span>(unit, <span class="type-var">'a</span>)</span> 
-          <a href="#type-full_gadt_alias">full_gadt_alias</a>
-         </span>
-        </span>
-       </code>
-      </li>
-      <li id="type-full_gadt_alias.Exist" class="def variant constructor
-       anchored"><a href="#type-full_gadt_alias.Exist" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Exist</span> : 
-         <span class="type-var">'a</span> * <span class="type-var">'b</span>
-          <span class="arrow">&#45;&gt;</span> 
-         <span><span>(<span class="type-var">'b</span>, unit)</span> 
-          <a href="#type-full_gadt_alias">full_gadt_alias</a>
-         </span>
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>full_gadt_alias</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-partial_gadt_alias">
-     <a href="#type-partial_gadt_alias" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>'a partial_gadt_alias</span>
-      </span>
-      <span> = 
-       <span><span class="type-var">'a</span> 
-        <a href="#type-partial_gadt">partial_gadt</a>
-       </span>
-      </span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-partial_gadt_alias.AscribeTag" class="def variant
-       constructor anchored">
-       <a href="#type-partial_gadt_alias.AscribeTag" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">AscribeTag</span> : 
-         <span><span class="type-var">'a</span> 
-          <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
-         </span>
-        </span>
-       </code>
-      </li>
-      <li id="type-partial_gadt_alias.OfTag" class="def variant constructor
-       anchored"><a href="#type-partial_gadt_alias.OfTag" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">OfTag</span> 
-         <span class="keyword">of</span> 
-         <span><span class="type-var">'a</span> 
-          <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
-         </span>
-        </span>
-       </code>
-      </li>
-      <li id="type-partial_gadt_alias.ExistGadtTag" class="def variant
-       constructor anchored">
-       <a href="#type-partial_gadt_alias.ExistGadtTag" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">ExistGadtTag</span> : 
-         <span>(
-          <span><span class="type-var">'a</span> 
-           <span class="arrow">&#45;&gt;</span>
-          </span> <span class="type-var">'b</span>)
-         </span> <span class="arrow">&#45;&gt;</span> 
-         <span><span class="type-var">'a</span> 
-          <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
-         </span>
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for <code>partial_gadt_alias</code>.</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec exception anchored" id="exception-Exn_arrow">
-     <a href="#exception-Exn_arrow" class="anchor"></a>
-     <code><span><span class="keyword">exception</span> </span>
-      <span><span class="exception">Exn_arrow</span> : unit 
-       <span class="arrow">&#45;&gt;</span> exn
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for 
-      <a href="#exception-Exn_arrow"><code>Exn_arrow</code></a>.
-     </p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-mutual_constr_a">
-     <a href="#type-mutual_constr_a" class="anchor"></a>
-     <code><span><span class="keyword">type</span> mutual_constr_a</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-mutual_constr_a.A" class="def variant constructor
-       anchored"><a href="#type-mutual_constr_a.A" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">A</span></span>
-       </code>
-      </li>
-      <li id="type-mutual_constr_a.B_ish" class="def variant constructor
-       anchored"><a href="#type-mutual_constr_a.B_ish" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">B_ish</span> 
-         <span class="keyword">of</span> 
-         <a href="#type-mutual_constr_b">mutual_constr_b</a>
-        </span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>This comment is between 
-         <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a>
-          and 
-         <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>
-         .
-        </p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for 
-      <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a>
-       then <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>
-      .
-     </p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-mutual_constr_b">
-     <a href="#type-mutual_constr_b" class="anchor"></a>
-     <code><span><span class="keyword">and</span> mutual_constr_b</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-mutual_constr_b.B" class="def variant constructor
-       anchored"><a href="#type-mutual_constr_b.B" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">B</span></span>
-       </code>
-      </li>
-      <li id="type-mutual_constr_b.A_ish" class="def variant constructor
-       anchored"><a href="#type-mutual_constr_b.A_ish" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">A_ish</span> 
-         <span class="keyword">of</span> 
-         <a href="#type-mutual_constr_a">mutual_constr_a</a>
-        </span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>This comment must be here for the next to associate correctly.</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol>
-    </div>
-    <div class="spec-doc">
-     <p>This comment is for 
-      <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>
-       then <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a>
-      .
-     </p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-rec_obj">
-     <a href="#type-rec_obj" class="anchor"></a>
-     <code><span><span class="keyword">type</span> rec_obj</span>
-      <span> = 
-       <span>&lt; f : int ; g : 
-        <span>unit <span class="arrow">&#45;&gt;</span></span> unit ; 
-        h : <a href="#type-rec_obj">rec_obj</a> &gt;
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-open_obj">
-     <a href="#type-open_obj" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a open_obj</span></span>
-      <span> = 
-       <span>&lt; f : int ; g : 
-        <span>unit <span class="arrow">&#45;&gt;</span></span> unit.. &gt;
-       </span> <span class="keyword">as</span> 'a
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-oof">
-     <a href="#type-oof" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a oof</span></span>
-      <span> = 
-       <span><span>&lt; a : unit.. &gt;</span> 
-        <span class="keyword">as</span> 'a 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <span class="type-var">'a</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-any_obj">
-     <a href="#type-any_obj" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a any_obj</span></span>
-      <span> = <span>&lt; .. &gt;</span> <span class="keyword">as</span> 'a
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-empty_obj">
-     <a href="#type-empty_obj" class="anchor"></a>
-     <code><span><span class="keyword">type</span> empty_obj</span>
-      <span> = <span>&lt;  &gt;</span></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-one_meth">
-     <a href="#type-one_meth" class="anchor"></a>
-     <code><span><span class="keyword">type</span> one_meth</span>
-      <span> = <span>&lt; meth : unit &gt;</span></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-ext">
-     <a href="#type-ext" class="anchor"></a>
-     <code><span><span class="keyword">type</span> ext</span><span> = </span>
-      <span>..</span>
-     </code>
-    </div><div class="spec-doc"><p>A mystery wrapped in an ellipsis</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-ExtA">
-     <a href="#extension-decl-ExtA" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-ExtA" class="def variant extension anchored">
-       <a href="#extension-ExtA" class="anchor"></a>
-       <code><span>| </span><span><span class="extension">ExtA</span></span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-ExtB">
-     <a href="#extension-decl-ExtB" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-ExtB" class="def variant extension anchored">
-       <a href="#extension-ExtB" class="anchor"></a>
-       <code><span>| </span><span><span class="extension">ExtB</span></span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-ExtC">
-     <a href="#extension-decl-ExtC" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-ExtC" class="def variant extension anchored">
-       <a href="#extension-ExtC" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="extension">ExtC</span> 
-         <span class="keyword">of</span> unit
-        </span>
-       </code>
-      </li>
-      <li id="extension-ExtD" class="def variant extension anchored">
-       <a href="#extension-ExtD" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="extension">ExtD</span> 
-         <span class="keyword">of</span> <a href="#type-ext">ext</a>
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-ExtE">
-     <a href="#extension-decl-ExtE" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-ExtE" class="def variant extension anchored">
-       <a href="#extension-ExtE" class="anchor"></a>
-       <code><span>| </span><span><span class="extension">ExtE</span></span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-ExtF">
-     <a href="#extension-decl-ExtF" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <a href="#type-ext">ext</a>
-        += <span class="keyword">private</span> 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-ExtF" class="def variant extension anchored">
-       <a href="#extension-ExtF" class="anchor"></a>
-       <code><span>| </span><span><span class="extension">ExtF</span></span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-poly_ext">
-     <a href="#type-poly_ext" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a poly_ext</span></span>
-      <span> = </span><span>..</span>
-     </code>
-    </div><div class="spec-doc"><p>'a poly_ext</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-Foo">
-     <a href="#extension-decl-Foo" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <a href="#type-poly_ext">poly_ext</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-Foo" class="def variant extension anchored">
-       <a href="#extension-Foo" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="extension">Foo</span> 
-         <span class="keyword">of</span> <span class="type-var">'b</span>
-        </span>
-       </code>
-      </li>
-      <li id="extension-Bar" class="def variant extension anchored">
-       <a href="#extension-Bar" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="extension">Bar</span> 
-         <span class="keyword">of</span> <span class="type-var">'b</span>
-          * <span class="type-var">'b</span>
-        </span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>'b poly_ext</p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-Quux">
-     <a href="#extension-decl-Quux" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <a href="#type-poly_ext">poly_ext</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-Quux" class="def variant extension anchored">
-       <a href="#extension-Quux" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="extension">Quux</span> 
-         <span class="keyword">of</span> <span class="type-var">'c</span>
-        </span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>'c poly_ext</p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-ExtMod">
-     <a href="#module-ExtMod" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-ExtMod.html">ExtMod</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-ZzzTop0">
-     <a href="#extension-decl-ZzzTop0" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <a href="Ocamlary-ExtMod.html#type-t">ExtMod.t</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-ZzzTop0" class="def variant extension anchored">
-       <a href="#extension-ZzzTop0" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="extension">ZzzTop0</span></span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>It's got the rock</p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-ZzzTop">
-     <a href="#extension-decl-ZzzTop" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <a href="Ocamlary-ExtMod.html#type-t">ExtMod.t</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-ZzzTop" class="def variant extension anchored">
-       <a href="#extension-ZzzTop" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="extension">ZzzTop</span> 
-         <span class="keyword">of</span> unit
-        </span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>and it packs a unit.</p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value external anchored" id="val-launch_missiles">
-     <a href="#val-launch_missiles" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> launch_missiles : 
-       <span>unit <span class="arrow">&#45;&gt;</span></span> unit
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Rotate keys on my mark...</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-my_mod">
-     <a href="#type-my_mod" class="anchor"></a>
-     <code><span><span class="keyword">type</span> my_mod</span>
-      <span> = 
-       <span>(<span class="keyword">module</span> 
-        <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
-        )
-       </span>
-      </span>
-     </code>
-    </div>
-    <div class="spec-doc"><p>A brown paper package tied up with string</p>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-empty_class">
-     <a href="#class-empty_class" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Ocamlary-class-empty_class.html">empty_class</a></span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-one_method_class">
-     <a href="#class-one_method_class" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span>
-       <a href="Ocamlary-class-one_method_class.html">one_method_class</a>
-      </span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-two_method_class">
-     <a href="#class-two_method_class" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span>
-       <a href="Ocamlary-class-two_method_class.html">two_method_class</a>
-      </span>
-      <span> : <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-param_class">
-     <a href="#class-param_class" class="anchor"></a>
-     <code><span><span class="keyword">class</span> 'a </span>
-      <span><a href="Ocamlary-class-param_class.html">param_class</a></span>
-      <span> : 
-       <span><span class="type-var">'a</span> 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-my_unit_object">
-     <a href="#type-my_unit_object" class="anchor"></a>
-     <code><span><span class="keyword">type</span> my_unit_object</span>
-      <span> = 
-       <span>unit <a href="Ocamlary-class-param_class.html">param_class</a>
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-my_unit_class">
-     <a href="#type-my_unit_class" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a my_unit_class</span>
-      </span>
-      <span> = 
-       <span>unit <a href="Ocamlary-class-param_class.html">param_class</a>
-       </span> <span class="keyword">as</span> 'a
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep1">
-     <a href="#module-Dep1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep1.html">Dep1</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep2">
-     <a href="#module-Dep2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep2.html">Dep2</a>
-      </span>
-      <span> (<a href="Ocamlary-Dep2-argument-1-Arg.html">Arg</a> : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-       ) : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-dep1">
-     <a href="#type-dep1" class="anchor"></a>
-     <code><span><span class="keyword">type</span> dep1</span>
-      <span> = 
-       <a href="Ocamlary-Dep1-module-type-S-class-c.html">Dep2(Dep1).B.c</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep3">
-     <a href="#module-Dep3" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep3.html">Dep3</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep4">
-     <a href="#module-Dep4" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep4.html">Dep4</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep5">
-     <a href="#module-Dep5" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep5.html">Dep5</a>
-      </span>
-      <span> (<a href="Ocamlary-Dep5-argument-1-Arg.html">Arg</a> : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-       ) : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-dep2">
-     <a href="#type-dep2" class="anchor"></a>
-     <code><span><span class="keyword">type</span> dep2</span>
-      <span> = 
-       <a href="Ocamlary-Dep4-module-type-T.html#type-b">Dep5(Dep4).Z.X.b</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-dep3">
-     <a href="#type-dep3" class="anchor"></a>
-     <code><span><span class="keyword">type</span> dep3</span>
-      <span> = <a href="Ocamlary-Dep3.html#type-a">Dep5(Dep4).Z.Y.a</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep6">
-     <a href="#module-Dep6" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep6.html">Dep6</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep7">
-     <a href="#module-Dep7" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep7.html">Dep7</a>
-      </span>
-      <span> (<a href="Ocamlary-Dep7-argument-1-Arg.html">Arg</a> : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-       ) : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-dep4">
-     <a href="#type-dep4" class="anchor"></a>
-     <code><span><span class="keyword">type</span> dep4</span>
-      <span> = 
-       <a href="Ocamlary-Dep6-module-type-T-Y.html#type-d">Dep7(Dep6).M.Y.d
-       </a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep8">
-     <a href="#module-Dep8" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep8.html">Dep8</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep9">
-     <a href="#module-Dep9" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep9.html">Dep9</a>
-      </span>
-      <span> (<a href="Ocamlary-Dep9-argument-1-X.html">X</a> : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-       ) : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Dep10">
-     <a href="#module-type-Dep10" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-Dep10.html">Dep10</a>
-      </span>
-      <span> = <a href="Ocamlary-Dep8-module-type-T.html">Dep9(Dep8).T</a>
-        <span class="keyword">with</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Ocamlary-Dep8-module-type-T.html#type-t">t</a> = int
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep11">
-     <a href="#module-Dep11" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep11.html">Dep11</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep12">
-     <a href="#module-Dep12" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep12.html">Dep12</a>
-      </span>
-      <span> (<a href="Ocamlary-Dep12-argument-1-Arg.html">Arg</a> : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-       ) : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Dep13">
-     <a href="#module-Dep13" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Dep13.html">Dep13</a>
-      </span>
-      <span> : <a href="Ocamlary-Dep11-module-type-S.html">Dep12(Dep11).T</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-dep5">
-     <a href="#type-dep5" class="anchor"></a>
-     <code><span><span class="keyword">type</span> dep5</span>
-      <span> = 
-       <a href="Ocamlary-Dep11-module-type-S-class-c.html">Dep13.c</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-With1">
-     <a href="#module-type-With1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-With1.html">With1</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-With2">
-     <a href="#module-With2" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With2.html">With2</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-With3">
-     <a href="#module-With3" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With3.html">With3</a>
-      </span>
-      <span> : <a href="Ocamlary-module-type-With1.html">With1</a> 
-       <span class="keyword">with</span> 
-       <span><span class="keyword">module</span> 
-        <a href="Ocamlary-module-type-With1-M.html">M</a> = 
-        <a href="Ocamlary-With2.html">With2</a>
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-with1">
-     <a href="#type-with1" class="anchor"></a>
-     <code><span><span class="keyword">type</span> with1</span>
-      <span> = <a href="Ocamlary-With3-N.html#type-t">With3.N.t</a></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-With4">
-     <a href="#module-With4" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With4.html">With4</a>
-      </span>
-      <span> : <a href="Ocamlary-module-type-With1.html">With1</a> 
-       <span class="keyword">with</span> 
-       <span><span class="keyword">module</span> 
-        <a href="Ocamlary-module-type-With1-M.html">M</a> := 
-        <a href="Ocamlary-With2.html">With2</a>
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-with2">
-     <a href="#type-with2" class="anchor"></a>
-     <code><span><span class="keyword">type</span> with2</span>
-      <span> = <a href="Ocamlary-With4-N.html#type-t">With4.N.t</a></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-With5">
-     <a href="#module-With5" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With5.html">With5</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-With6">
-     <a href="#module-With6" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With6.html">With6</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-With7">
-     <a href="#module-With7" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With7.html">With7</a>
-      </span>
-      <span> (<a href="Ocamlary-With7-argument-1-X.html">X</a> : 
-       <span class="keyword">sig</span> ... <span class="keyword">end</span>
-       ) : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-With8">
-     <a href="#module-type-With8" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-With8.html">With8</a>
-      </span>
-      <span> =
-                
-       <a href="Ocamlary-With6-module-type-T.html">With7(With6).T</a>
-        <span class="keyword">with</span> 
-       <span><span class="keyword">module</span> 
-        <a href="Ocamlary-With6-module-type-T-M.html">M</a> = 
-        <a href="Ocamlary-With5.html">With5</a>
-       </span> <span class="keyword">and</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Ocamlary-With5-module-type-S.html#type-t">M.N.t</a> =
-         <a href="Ocamlary-With5-N.html#type-t">With5.N.t</a>
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-With9">
-     <a href="#module-With9" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With9.html">With9</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-With10">
-     <a href="#module-With10" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-With10.html">With10</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-With11">
-     <a href="#module-type-With11" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-With11.html">With11</a>
-      </span>
-      <span> = 
-       <a href="Ocamlary-With10-module-type-T.html">With7(With10).T</a>
-        <span class="keyword">with</span> 
-       <span><span class="keyword">module</span> 
-        <a href="Ocamlary-With10-module-type-T-M.html">M</a> = 
-        <a href="Ocamlary-With9.html">With9</a>
-       </span> <span class="keyword">and</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Ocamlary-With9-module-type-S.html#type-t">N.t</a> = 
-        int
-       </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-NestedInclude1">
-     <a href="#module-type-NestedInclude1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-NestedInclude1.html">NestedInclude1</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
-      <code>
-       <span><span class="keyword">include</span> 
-        <a href="Ocamlary-module-type-NestedInclude1.html">NestedInclude1</a>
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span class="type-var">'b</span>
        </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec module-type anchored" id="module-type-NestedInclude2">
-       <a href="#module-type-NestedInclude2" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> 
-         <span class="keyword">type</span> 
-         <a href="Ocamlary-module-type-NestedInclude2.html">NestedInclude2
+     </div>
+     <div class="spec-doc">
+      <p><a href="#type-a_function"><code>a_function</code></a> is this
+        type and <a href="#val-a_function"><code>a_function</code></a>
+        is the value below.
+      </p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-a_function">
+      <a href="#val-a_function" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> a_function : 
+        <span><span class="label">x</span>:int 
+         <span class="arrow">&#45;&gt;</span>
+        </span> int
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This is <code>a_function</code> with param and return type.</p>
+      <ul class="at-tags">
+       <li class="parameter"><span class="at-tag">parameter</span> 
+        <span class="value">x</span> <p>the <code>x</code> coordinate</p>
+       </li>
+      </ul>
+      <ul class="at-tags">
+       <li class="returns"><span class="at-tag">returns</span> 
+        <p>the <code>y</code> coordinate</p>
+       </li>
+      </ul>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-fun_fun_fun">
+      <a href="#val-fun_fun_fun" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> fun_fun_fun : 
+        <span>
+         <span>(
+          <span><span>(int, int)</span> 
+           <a href="#type-a_function">a_function</a>
+          </span>, 
+          <span><span>(unit, unit)</span> 
+           <a href="#type-a_function">a_function</a>
+          </span>)
+         </span> <a href="#type-a_function">a_function</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-fun_maybe">
+      <a href="#val-fun_maybe" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> fun_maybe : 
+        <span><span class="optlabel">?yes</span>:unit 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span>unit <span class="arrow">&#45;&gt;</span></span>
+         int
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-not_found">
+      <a href="#val-not_found" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> not_found : 
+        <span>unit <span class="arrow">&#45;&gt;</span></span> unit
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="raises"><span class="at-tag">raises</span> 
+        <code>Not_found</code> <p>That's all it does</p>
+       </li>
+      </ul>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-kaboom">
+      <a href="#val-kaboom" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> kaboom : 
+        <span>unit <span class="arrow">&#45;&gt;</span></span> unit
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="raises"><span class="at-tag">raises</span> 
+        <a href="#exception-Kaboom"><code>Kaboom</code></a> 
+        <p>That's all it does</p>
+       </li>
+      </ul>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-ocaml_org">
+      <a href="#val-ocaml_org" class="anchor"></a>
+      <code><span><span class="keyword">val</span> ocaml_org : string</span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="see"><span class="at-tag">see</span> 
+        <a href="http://ocaml.org/" class="value">http://ocaml.org/</a>
+         <p>The OCaml Web site</p>
+       </li>
+      </ul>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-some_file">
+      <a href="#val-some_file" class="anchor"></a>
+      <code><span><span class="keyword">val</span> some_file : string</span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="see"><span class="at-tag">see</span> 
+        <code class="value">some_file</code> 
+        <p>The file called <code>some_file</code></p>
+       </li>
+      </ul>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-some_doc">
+      <a href="#val-some_doc" class="anchor"></a>
+      <code><span><span class="keyword">val</span> some_doc : string</span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <ul class="at-tags">
+       <li class="see"><span class="at-tag">see</span> 
+        <span class="value">some_doc</span> 
+        <p>The document called <code>some_doc</code></p>
+       </li>
+      </ul>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-since_mesozoic">
+      <a href="#val-since_mesozoic" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> since_mesozoic : unit</span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This value was introduced in the Mesozoic era.</p>
+      <ul class="at-tags">
+       <li class="since"><span class="at-tag">since</span> mesozoic</li>
+      </ul>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-changing">
+      <a href="#val-changing" class="anchor"></a>
+      <code><span><span class="keyword">val</span> changing : unit</span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This value has had changes in 1.0.0, 1.1.0, and 1.2.0.</p>
+      <ul class="at-tags">
+       <li class="before"><span class="at-tag">before</span> 
+        <span class="value">1.0.0</span> <p>before 1.0.0</p>
+       </li>
+      </ul>
+      <ul class="at-tags">
+       <li class="before"><span class="at-tag">before</span> 
+        <span class="value">1.1.0</span> <p>before 1.1.0</p>
+       </li>
+      </ul>
+      <ul class="at-tags">
+       <li class="version"><span class="at-tag">version</span> 1.2.0</li>
+      </ul>
+     </div>
+    </div>
+    <h4 id="some-operators"><a href="#some-operators" class="anchor"></a>
+     Some Operators
+    </h4>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(~-)">
+      <a href="#val-(~-)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (~-) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(!)">
+      <a href="#val-(!)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (!) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(@)">
+      <a href="#val-(@)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (@) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-($)">
+      <a href="#val-($)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> ($) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(%)">
+      <a href="#val-(%)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (%) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(&amp;)">
+      <a href="#val-(&amp;)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (&amp;) : unit</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(*)">
+      <a href="#val-(*)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (*) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(-)">
+      <a href="#val-(-)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (-) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(+)">
+      <a href="#val-(+)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (+) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(-?)">
+      <a href="#val-(-?)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (-?) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(/)">
+      <a href="#val-(/)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (/) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(:=)">
+      <a href="#val-(:=)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (:=) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(=)">
+      <a href="#val-(=)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (=) : unit</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-(land)">
+      <a href="#val-(land)" class="anchor"></a>
+      <code><span><span class="keyword">val</span> (land) : unit</span>
+      </code>
+     </div>
+    </div>
+    <h4 id="advanced-module-stuff">
+     <a href="#advanced-module-stuff" class="anchor"></a>Advanced Module
+      Stuff
+    </h4>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-CollectionModule">
+      <a href="#module-CollectionModule" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-CollectionModule.html">CollectionModule</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>CollectionModule</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-COLLECTION">
+      <a href="#module-type-COLLECTION" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
+       </span>
+       <span> = <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <a href="Ocamlary-CollectionModule.html">CollectionModule</a>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>module type of</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Recollection">
+      <a href="#module-Recollection" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Recollection.html">Recollection</a>
+       </span>
+       <span>
+               
+        (<a href="Ocamlary-Recollection-argument-1-C.html">C</a> : 
+        <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
+        ) : 
+              
+        <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
+        
+            <span class="keyword">with</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Ocamlary-module-type-COLLECTION.html#type-collection">
+          collection
+         </a> = 
+         <span>
+          <a href="Ocamlary-Recollection-argument-1-C.html#type-element">
+           C.element
+          </a> list
+         </span>
+        </span>
+                   
+         <span class="keyword">and</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Ocamlary-module-type-COLLECTION.html#type-element">element
+         </a> = 
+         <a href="Ocamlary-Recollection-argument-1-C.html#type-collection">
+          C.collection
          </a>
         </span>
-        <span> = <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
-      </div>
+       </span>
+      </code>
      </div>
-    </details>
-   </div>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-MMM">
+      <a href="#module-type-MMM" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
-        <a href="Ocamlary-module-type-NestedInclude2.html">NestedInclude2</a>
-         <span class="keyword">with</span> 
-        <span><span class="keyword">type</span> 
-         <a
-          href="Ocamlary-module-type-NestedInclude2.html#type-nested_include">
-          nested_include
-         </a> = int
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-MMM.html">MMM</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-RECOLLECTION">
+      <a href="#module-type-RECOLLECTION" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-RECOLLECTION.html">RECOLLECTION</a>
+       </span>
+       <span> = <a href="Ocamlary-module-type-MMM.html">MMM</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <a href="Ocamlary-module-type-MMM-C.html">C</a> = 
+         <a href="Ocamlary-Recollection.html">Recollection(CollectionModule)
+         </a>
         </span>
        </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-nested_include">
-       <a href="#type-nested_include" class="anchor"></a>
-       <code><span><span class="keyword">type</span> nested_include</span>
-        <span> = int</span>
-       </code>
-      </div>
      </div>
-    </details>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-DoubleInclude1">
-     <a href="#module-DoubleInclude1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-DoubleInclude1.html">DoubleInclude1</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-DoubleInclude3">
-     <a href="#module-DoubleInclude3" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-DoubleInclude3.html">DoubleInclude3</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-RecollectionModule">
+      <a href="#module-type-RecollectionModule" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
-        <span class="keyword">module</span> <span class="keyword">type</span>
-         <span class="keyword">of</span> 
-        <a href="Ocamlary-DoubleInclude3-DoubleInclude2.html">
-         DoubleInclude3.DoubleInclude2
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-RecollectionModule.html">
+         RecollectionModule
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-A">
+      <a href="#module-type-A" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-A.html">A</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-B">
+      <a href="#module-type-B" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-B.html">B</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-C">
+      <a href="#module-type-C" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-C.html">C</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This module type includes two signatures.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-FunctorTypeOf">
+      <a href="#module-FunctorTypeOf" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-FunctorTypeOf.html">FunctorTypeOf</a>
+       </span>
+       <span>
+               
+        (
+        <a href="Ocamlary-FunctorTypeOf-argument-1-Collection.html">
+         Collection
+        </a> : <span class="keyword">module</span> 
+        <span class="keyword">type</span> <span class="keyword">of</span>
+         <a href="Ocamlary-CollectionModule.html">CollectionModule</a>
+        ) : 
+              
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>FunctorTypeOf</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-IncludeModuleType">
+      <a href="#module-type-IncludeModuleType" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-IncludeModuleType.html">
+         IncludeModuleType
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>IncludeModuleType</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-ToInclude">
+      <a href="#module-type-ToInclude" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-ToInclude.html">ToInclude</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Ocamlary-module-type-ToInclude.html">ToInclude</a>
+        </span>
+       </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-IncludedA">
+        <a href="#module-IncludedA" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <a href="Ocamlary-IncludedA.html">IncludedA</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+      </div>
+      <div class="odoc-spec">
+       <div class="spec module-type anchored" id="module-type-IncludedB">
+        <a href="#module-type-IncludedB" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <span class="keyword">type</span> 
+          <a href="Ocamlary-module-type-IncludedB.html">IncludedB</a>
+         </span>
+         <span> = <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+      </div>
+     </details>
+    </div>
+    <h4 id="advanced-type-stuff">
+     <a href="#advanced-type-stuff" class="anchor"></a>Advanced Type 
+     Stuff
+    </h4>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-record">
+      <a href="#type-record" class="anchor"></a>
+      <code><span><span class="keyword">type</span> record</span>
+       <span> = </span><span>{</span>
+      </code>
+      <ol>
+       <li id="type-record.field1" class="def record field anchored">
+        <a href="#type-record.field1" class="anchor"></a>
+        <code><span>field1 : int;</span></code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>This comment is for <code>field1</code>.</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-record.field2" class="def record field anchored">
+        <a href="#type-record.field2" class="anchor"></a>
+        <code><span>field2 : int;</span></code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>This comment is for <code>field2</code>.</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol><code><span>}</span></code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>record</code>.</p>
+      <p>This comment is also for <code>record</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-mutable_record">
+      <a href="#type-mutable_record" class="anchor"></a>
+      <code><span><span class="keyword">type</span> mutable_record</span>
+       <span> = </span><span>{</span>
+      </code>
+      <ol>
+       <li id="type-mutable_record.a" class="def record field anchored">
+        <a href="#type-mutable_record.a" class="anchor"></a>
+        <code><span><span class="keyword">mutable</span> a : int;</span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p><code>a</code> is first and mutable</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-mutable_record.b" class="def record field anchored">
+        <a href="#type-mutable_record.b" class="anchor"></a>
+        <code><span>b : unit;</span></code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p><code>b</code> is second and immutable</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-mutable_record.c" class="def record field anchored">
+        <a href="#type-mutable_record.c" class="anchor"></a>
+        <code><span><span class="keyword">mutable</span> c : int;</span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p><code>c</code> is third and mutable</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol><code><span>}</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-universe_record">
+      <a href="#type-universe_record" class="anchor"></a>
+      <code><span><span class="keyword">type</span> universe_record</span>
+       <span> = </span><span>{</span>
+      </code>
+      <ol>
+       <li id="type-universe_record.nihilate" class="def record field
+        anchored">
+        <a href="#type-universe_record.nihilate" class="anchor"></a>
+        <code>
+         <span>nihilate : 'a. 
+          <span><span class="type-var">'a</span> 
+           <span class="arrow">&#45;&gt;</span>
+          </span> unit;
+         </span>
+        </code>
+       </li>
+      </ol><code><span>}</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-variant">
+      <a href="#type-variant" class="anchor"></a>
+      <code><span><span class="keyword">type</span> variant</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-variant.TagA" class="def variant constructor anchored">
+        <a href="#type-variant.TagA" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">TagA</span></span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>This comment is for <code>TagA</code>.</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-variant.ConstrB" class="def variant constructor anchored">
+        <a href="#type-variant.ConstrB" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">ConstrB</span> 
+          <span class="keyword">of</span> int
+         </span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>This comment is for <code>ConstrB</code>.</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-variant.ConstrC" class="def variant constructor anchored">
+        <a href="#type-variant.ConstrC" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">ConstrC</span> 
+          <span class="keyword">of</span> int * int
+         </span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>This comment is for binary <code>ConstrC</code>.</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-variant.ConstrD" class="def variant constructor anchored">
+        <a href="#type-variant.ConstrD" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">ConstrD</span> 
+          <span class="keyword">of</span> int * int
+         </span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>This comment is for unary <code>ConstrD</code> of binary tuple.
+         </p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>variant</code>.</p>
+      <p>This comment is also for <code>variant</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-poly_variant">
+      <a href="#type-poly_variant" class="anchor"></a>
+      <code><span><span class="keyword">type</span> poly_variant</span>
+       <span> = </span><span>[ </span>
+      </code>
+      <ol>
+       <li id="type-poly_variant.TagA" class="def variant constructor
+        anchored"><a href="#type-poly_variant.TagA" class="anchor"></a>
+        <code><span>| </span><span>`TagA</span></code>
+       </li>
+       <li id="type-poly_variant.ConstrB" class="def variant constructor
+        anchored"><a href="#type-poly_variant.ConstrB" class="anchor"></a>
+        <code><span>| </span>
+         <span>`ConstrB <span class="keyword">of</span> int</span>
+        </code>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>poly_variant</code>.</p>
+      <p>Wow! It was a polymorphic variant!</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-full_gadt">
+      <a href="#type-full_gadt" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>(_, _) full_gadt</span>
+       </span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-full_gadt.Tag" class="def variant constructor anchored">
+        <a href="#type-full_gadt.Tag" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Tag</span> : 
+          <span><span>(unit, unit)</span> 
+           <a href="#type-full_gadt">full_gadt</a>
+          </span>
+         </span>
+        </code>
+       </li>
+       <li id="type-full_gadt.First" class="def variant constructor anchored">
+        <a href="#type-full_gadt.First" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">First</span> : 
+          <span class="type-var">'a</span> 
+          <span class="arrow">&#45;&gt;</span> 
+          <span><span>(<span class="type-var">'a</span>, unit)</span>
+            <a href="#type-full_gadt">full_gadt</a>
+          </span>
+         </span>
+        </code>
+       </li>
+       <li id="type-full_gadt.Second" class="def variant constructor
+        anchored"><a href="#type-full_gadt.Second" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Second</span> : 
+          <span class="type-var">'a</span> 
+          <span class="arrow">&#45;&gt;</span> 
+          <span><span>(unit, <span class="type-var">'a</span>)</span>
+            <a href="#type-full_gadt">full_gadt</a>
+          </span>
+         </span>
+        </code>
+       </li>
+       <li id="type-full_gadt.Exist" class="def variant constructor anchored">
+        <a href="#type-full_gadt.Exist" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Exist</span> : 
+          <span class="type-var">'a</span> * <span class="type-var">'b</span>
+           <span class="arrow">&#45;&gt;</span> 
+          <span><span>(<span class="type-var">'b</span>, unit)</span>
+            <a href="#type-full_gadt">full_gadt</a>
+          </span>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>full_gadt</code>.</p>
+      <p>Wow! It was a GADT!</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-partial_gadt">
+      <a href="#type-partial_gadt" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a partial_gadt</span>
+       </span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-partial_gadt.AscribeTag" class="def variant constructor
+        anchored"><a href="#type-partial_gadt.AscribeTag" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">AscribeTag</span> : 
+          <span><span class="type-var">'a</span> 
+           <a href="#type-partial_gadt">partial_gadt</a>
+          </span>
+         </span>
+        </code>
+       </li>
+       <li id="type-partial_gadt.OfTag" class="def variant constructor
+        anchored"><a href="#type-partial_gadt.OfTag" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">OfTag</span> 
+          <span class="keyword">of</span> 
+          <span><span class="type-var">'a</span> 
+           <a href="#type-partial_gadt">partial_gadt</a>
+          </span>
+         </span>
+        </code>
+       </li>
+       <li id="type-partial_gadt.ExistGadtTag" class="def variant constructor
+        anchored">
+        <a href="#type-partial_gadt.ExistGadtTag" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">ExistGadtTag</span> : 
+          <span>(
+           <span><span class="type-var">'a</span> 
+            <span class="arrow">&#45;&gt;</span>
+           </span> <span class="type-var">'b</span>)
+          </span> <span class="arrow">&#45;&gt;</span> 
+          <span><span class="type-var">'a</span> 
+           <a href="#type-partial_gadt">partial_gadt</a>
+          </span>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>partial_gadt</code>.</p>
+      <p>Wow! It was a mixed GADT!</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-alias">
+      <a href="#type-alias" class="anchor"></a>
+      <code><span><span class="keyword">type</span> alias</span>
+       <span> = <a href="#type-variant">variant</a></span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>alias</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-tuple">
+      <a href="#type-tuple" class="anchor"></a>
+      <code><span><span class="keyword">type</span> tuple</span>
+       <span> = 
+        <span>(<a href="#type-alias">alias</a> * 
+         <a href="#type-alias">alias</a>)
+        </span> * <a href="#type-alias">alias</a> * 
+        <span>(<a href="#type-alias">alias</a> * 
+         <a href="#type-alias">alias</a>)
+        </span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>This comment is for <code>tuple</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-variant_alias">
+      <a href="#type-variant_alias" class="anchor"></a>
+      <code><span><span class="keyword">type</span> variant_alias</span>
+       <span> = <a href="#type-variant">variant</a></span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-variant_alias.TagA" class="def variant constructor
+        anchored"><a href="#type-variant_alias.TagA" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">TagA</span></span>
+        </code>
+       </li>
+       <li id="type-variant_alias.ConstrB" class="def variant constructor
+        anchored"><a href="#type-variant_alias.ConstrB" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">ConstrB</span> 
+          <span class="keyword">of</span> int
+         </span>
+        </code>
+       </li>
+       <li id="type-variant_alias.ConstrC" class="def variant constructor
+        anchored"><a href="#type-variant_alias.ConstrC" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">ConstrC</span> 
+          <span class="keyword">of</span> int * int
+         </span>
+        </code>
+       </li>
+       <li id="type-variant_alias.ConstrD" class="def variant constructor
+        anchored"><a href="#type-variant_alias.ConstrD" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">ConstrD</span> 
+          <span class="keyword">of</span> int * int
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>variant_alias</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-record_alias">
+      <a href="#type-record_alias" class="anchor"></a>
+      <code><span><span class="keyword">type</span> record_alias</span>
+       <span> = <a href="#type-record">record</a></span><span> = </span>
+       <span>{</span>
+      </code>
+      <ol>
+       <li id="type-record_alias.field1" class="def record field anchored">
+        <a href="#type-record_alias.field1" class="anchor"></a>
+        <code><span>field1 : int;</span></code>
+       </li>
+       <li id="type-record_alias.field2" class="def record field anchored">
+        <a href="#type-record_alias.field2" class="anchor"></a>
+        <code><span>field2 : int;</span></code>
+       </li>
+      </ol><code><span>}</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>record_alias</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-poly_variant_union">
+      <a href="#type-poly_variant_union" class="anchor"></a>
+      <code><span><span class="keyword">type</span> poly_variant_union</span>
+       <span> = </span><span>[ </span>
+      </code>
+      <ol>
+       <li id="type-poly_variant_union.poly_variant" class="def variant 
+        type anchored">
+        <a href="#type-poly_variant_union.poly_variant" class="anchor"></a>
+        <code><span>| </span>
+         <span><a href="#type-poly_variant">poly_variant</a></span>
+        </code>
+       </li>
+       <li id="type-poly_variant_union.TagC" class="def variant constructor
+        anchored"><a href="#type-poly_variant_union.TagC" class="anchor"></a>
+        <code><span>| </span><span>`TagC</span></code>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>poly_variant_union</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-poly_poly_variant">
+      <a href="#type-poly_poly_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>'a poly_poly_variant</span>
+       </span><span> = </span><span>[ </span>
+      </code>
+      <ol>
+       <li id="type-poly_poly_variant.TagA" class="def variant constructor
+        anchored"><a href="#type-poly_poly_variant.TagA" class="anchor"></a>
+        <code><span>| </span>
+         <span>`TagA <span class="keyword">of</span> 
+          <span class="type-var">'a</span>
+         </span>
+        </code>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-bin_poly_poly_variant">
+      <a href="#type-bin_poly_poly_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>('a, 'b) bin_poly_poly_variant</span>
+       </span><span> = </span><span>[ </span>
+      </code>
+      <ol>
+       <li id="type-bin_poly_poly_variant.TagA" class="def variant
+        constructor anchored">
+        <a href="#type-bin_poly_poly_variant.TagA" class="anchor"></a>
+        <code><span>| </span>
+         <span>`TagA <span class="keyword">of</span> 
+          <span class="type-var">'a</span>
+         </span>
+        </code>
+       </li>
+       <li id="type-bin_poly_poly_variant.ConstrB" class="def variant
+        constructor anchored">
+        <a href="#type-bin_poly_poly_variant.ConstrB" class="anchor"></a>
+        <code><span>| </span>
+         <span>`ConstrB <span class="keyword">of</span> 
+          <span class="type-var">'b</span>
+         </span>
+        </code>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-open_poly_variant">
+      <a href="#type-open_poly_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>'a open_poly_variant</span>
+       </span>
+       <span> = <span>[&gt; `TagA ]</span> <span class="keyword">as</span> 'a
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-open_poly_variant2">
+      <a href="#type-open_poly_variant2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>'a open_poly_variant2</span>
+       </span>
+       <span> = <span>[&gt; <span>`ConstrB of int</span> ]</span> 
+        <span class="keyword">as</span> 'a
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-open_poly_variant_alias">
+      <a href="#type-open_poly_variant_alias" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>'a open_poly_variant_alias</span>
+       </span>
+       <span> = 
+        <span>
+         <span><span class="type-var">'a</span> 
+          <a href="#type-open_poly_variant">open_poly_variant</a>
+         </span> <a href="#type-open_poly_variant2">open_poly_variant2</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-poly_fun">
+      <a href="#type-poly_fun" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a poly_fun</span>
+       </span>
+       <span> = 
+        <span><span>[&gt; <span>`ConstrB of int</span> ]</span> 
+         <span class="keyword">as</span> 'a 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span class="type-var">'a</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-poly_fun_constraint">
+      <a href="#type-poly_fun_constraint" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>'a poly_fun_constraint</span>
+       </span>
+       <span> = 
+        <span><span class="type-var">'a</span> 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span class="type-var">'a</span>
+       </span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = <span>[&gt; `TagA ]</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-closed_poly_variant">
+      <a href="#type-closed_poly_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>'a closed_poly_variant</span>
+       </span>
+       <span> = <span>[&lt; `One <span>| `Two</span> ]</span> 
+        <span class="keyword">as</span> 'a
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-clopen_poly_variant">
+      <a href="#type-clopen_poly_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>'a clopen_poly_variant</span>
+       </span>
+       <span> = 
+        <span>[&lt; `One <span><span>| `Two</span> of int</span> 
+         <span>| `Three</span> Two Three ]
+        </span> <span class="keyword">as</span> 'a
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-nested_poly_variant">
+      <a href="#type-nested_poly_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> nested_poly_variant</span>
+       <span> = </span><span>[ </span>
+      </code>
+      <ol>
+       <li id="type-nested_poly_variant.A" class="def variant constructor
+        anchored"><a href="#type-nested_poly_variant.A" class="anchor"></a>
+        <code><span>| </span><span>`A</span></code>
+       </li>
+       <li id="type-nested_poly_variant.B" class="def variant constructor
+        anchored"><a href="#type-nested_poly_variant.B" class="anchor"></a>
+        <code><span>| </span>
+         <span>`B <span class="keyword">of</span> 
+          <span>[ `B1 <span>| `B2</span> ]</span>
+         </span>
+        </code>
+       </li>
+       <li id="type-nested_poly_variant.C" class="def variant constructor
+        anchored"><a href="#type-nested_poly_variant.C" class="anchor"></a>
+        <code><span>| </span><span>`C</span></code>
+       </li>
+       <li id="type-nested_poly_variant.D" class="def variant constructor
+        anchored"><a href="#type-nested_poly_variant.D" class="anchor"></a>
+        <code><span>| </span>
+         <span>`D <span class="keyword">of</span> 
+          <span>[ <span>`D1 of <span>[ `D1a ]</span></span> ]</span>
+         </span>
+        </code>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-full_gadt_alias">
+      <a href="#type-full_gadt_alias" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>('a, 'b) full_gadt_alias</span>
+       </span>
+       <span> = 
+        <span>
+         <span>(<span class="type-var">'a</span>, 
+          <span class="type-var">'b</span>)
+         </span> <a href="#type-full_gadt">full_gadt</a>
+        </span>
+       </span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-full_gadt_alias.Tag" class="def variant constructor
+        anchored"><a href="#type-full_gadt_alias.Tag" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Tag</span> : 
+          <span><span>(unit, unit)</span> 
+           <a href="#type-full_gadt_alias">full_gadt_alias</a>
+          </span>
+         </span>
+        </code>
+       </li>
+       <li id="type-full_gadt_alias.First" class="def variant constructor
+        anchored"><a href="#type-full_gadt_alias.First" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">First</span> : 
+          <span class="type-var">'a</span> 
+          <span class="arrow">&#45;&gt;</span> 
+          <span><span>(<span class="type-var">'a</span>, unit)</span>
+            <a href="#type-full_gadt_alias">full_gadt_alias</a>
+          </span>
+         </span>
+        </code>
+       </li>
+       <li id="type-full_gadt_alias.Second" class="def variant constructor
+        anchored"><a href="#type-full_gadt_alias.Second" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Second</span> : 
+          <span class="type-var">'a</span> 
+          <span class="arrow">&#45;&gt;</span> 
+          <span><span>(unit, <span class="type-var">'a</span>)</span>
+            <a href="#type-full_gadt_alias">full_gadt_alias</a>
+          </span>
+         </span>
+        </code>
+       </li>
+       <li id="type-full_gadt_alias.Exist" class="def variant constructor
+        anchored"><a href="#type-full_gadt_alias.Exist" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Exist</span> : 
+          <span class="type-var">'a</span> * <span class="type-var">'b</span>
+           <span class="arrow">&#45;&gt;</span> 
+          <span><span>(<span class="type-var">'b</span>, unit)</span>
+            <a href="#type-full_gadt_alias">full_gadt_alias</a>
+          </span>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>full_gadt_alias</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-partial_gadt_alias">
+      <a href="#type-partial_gadt_alias" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>'a partial_gadt_alias</span>
+       </span>
+       <span> = 
+        <span><span class="type-var">'a</span> 
+         <a href="#type-partial_gadt">partial_gadt</a>
+        </span>
+       </span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-partial_gadt_alias.AscribeTag" class="def variant
+        constructor anchored">
+        <a href="#type-partial_gadt_alias.AscribeTag" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">AscribeTag</span> : 
+          <span><span class="type-var">'a</span> 
+           <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
+          </span>
+         </span>
+        </code>
+       </li>
+       <li id="type-partial_gadt_alias.OfTag" class="def variant constructor
+        anchored">
+        <a href="#type-partial_gadt_alias.OfTag" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">OfTag</span> 
+          <span class="keyword">of</span> 
+          <span><span class="type-var">'a</span> 
+           <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
+          </span>
+         </span>
+        </code>
+       </li>
+       <li id="type-partial_gadt_alias.ExistGadtTag" class="def variant
+        constructor anchored">
+        <a href="#type-partial_gadt_alias.ExistGadtTag" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">ExistGadtTag</span> : 
+          <span>(
+           <span><span class="type-var">'a</span> 
+            <span class="arrow">&#45;&gt;</span>
+           </span> <span class="type-var">'b</span>)
+          </span> <span class="arrow">&#45;&gt;</span> 
+          <span><span class="type-var">'a</span> 
+           <a href="#type-partial_gadt_alias">partial_gadt_alias</a>
+          </span>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for <code>partial_gadt_alias</code>.</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec exception anchored" id="exception-Exn_arrow">
+      <a href="#exception-Exn_arrow" class="anchor"></a>
+      <code><span><span class="keyword">exception</span> </span>
+       <span><span class="exception">Exn_arrow</span> : unit 
+        <span class="arrow">&#45;&gt;</span> exn
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for 
+       <a href="#exception-Exn_arrow"><code>Exn_arrow</code></a>.
+      </p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-mutual_constr_a">
+      <a href="#type-mutual_constr_a" class="anchor"></a>
+      <code><span><span class="keyword">type</span> mutual_constr_a</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-mutual_constr_a.A" class="def variant constructor
+        anchored"><a href="#type-mutual_constr_a.A" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">A</span></span>
+        </code>
+       </li>
+       <li id="type-mutual_constr_a.B_ish" class="def variant constructor
+        anchored"><a href="#type-mutual_constr_a.B_ish" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">B_ish</span> 
+          <span class="keyword">of</span> 
+          <a href="#type-mutual_constr_b">mutual_constr_b</a>
+         </span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>This comment is between 
+          <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a>
+           and 
+          <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>
+          .
+         </p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for 
+       <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a>
+        then <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>
+       .
+      </p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-mutual_constr_b">
+      <a href="#type-mutual_constr_b" class="anchor"></a>
+      <code><span><span class="keyword">and</span> mutual_constr_b</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-mutual_constr_b.B" class="def variant constructor
+        anchored"><a href="#type-mutual_constr_b.B" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">B</span></span>
+        </code>
+       </li>
+       <li id="type-mutual_constr_b.A_ish" class="def variant constructor
+        anchored"><a href="#type-mutual_constr_b.A_ish" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">A_ish</span> 
+          <span class="keyword">of</span> 
+          <a href="#type-mutual_constr_a">mutual_constr_a</a>
+         </span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>This comment must be here for the next to associate correctly.
+         </p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol>
+     </div>
+     <div class="spec-doc">
+      <p>This comment is for 
+       <a href="#type-mutual_constr_b"><code>mutual_constr_b</code></a>
+        then <a href="#type-mutual_constr_a"><code>mutual_constr_a</code></a>
+       .
+      </p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-rec_obj">
+      <a href="#type-rec_obj" class="anchor"></a>
+      <code><span><span class="keyword">type</span> rec_obj</span>
+       <span> = 
+        <span>&lt; f : int ; g : 
+         <span>unit <span class="arrow">&#45;&gt;</span></span> unit 
+         ; h : <a href="#type-rec_obj">rec_obj</a> &gt;
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-open_obj">
+      <a href="#type-open_obj" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a open_obj</span>
+       </span>
+       <span> = 
+        <span>&lt; f : int ; g : 
+         <span>unit <span class="arrow">&#45;&gt;</span></span> unit.. &gt;
+        </span> <span class="keyword">as</span> 'a
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-oof">
+      <a href="#type-oof" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a oof</span></span>
+       <span> = 
+        <span><span>&lt; a : unit.. &gt;</span> 
+         <span class="keyword">as</span> 'a 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span class="type-var">'a</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-any_obj">
+      <a href="#type-any_obj" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a any_obj</span></span>
+       <span> = <span>&lt; .. &gt;</span> <span class="keyword">as</span> 'a
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-empty_obj">
+      <a href="#type-empty_obj" class="anchor"></a>
+      <code><span><span class="keyword">type</span> empty_obj</span>
+       <span> = <span>&lt;  &gt;</span></span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-one_meth">
+      <a href="#type-one_meth" class="anchor"></a>
+      <code><span><span class="keyword">type</span> one_meth</span>
+       <span> = <span>&lt; meth : unit &gt;</span></span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-ext">
+      <a href="#type-ext" class="anchor"></a>
+      <code><span><span class="keyword">type</span> ext</span>
+       <span> = </span><span>..</span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>A mystery wrapped in an ellipsis</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-ExtA">
+      <a href="#extension-decl-ExtA" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-ExtA" class="def variant extension anchored">
+        <a href="#extension-ExtA" class="anchor"></a>
+        <code><span>| </span><span><span class="extension">ExtA</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-ExtB">
+      <a href="#extension-decl-ExtB" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-ExtB" class="def variant extension anchored">
+        <a href="#extension-ExtB" class="anchor"></a>
+        <code><span>| </span><span><span class="extension">ExtB</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-ExtC">
+      <a href="#extension-decl-ExtC" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-ExtC" class="def variant extension anchored">
+        <a href="#extension-ExtC" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="extension">ExtC</span> 
+          <span class="keyword">of</span> unit
+         </span>
+        </code>
+       </li>
+       <li id="extension-ExtD" class="def variant extension anchored">
+        <a href="#extension-ExtD" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="extension">ExtD</span> 
+          <span class="keyword">of</span> <a href="#type-ext">ext</a>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-ExtE">
+      <a href="#extension-decl-ExtE" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <a href="#type-ext">ext</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-ExtE" class="def variant extension anchored">
+        <a href="#extension-ExtE" class="anchor"></a>
+        <code><span>| </span><span><span class="extension">ExtE</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-ExtF">
+      <a href="#extension-decl-ExtF" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <a href="#type-ext">ext</a>
+         += <span class="keyword">private</span> 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-ExtF" class="def variant extension anchored">
+        <a href="#extension-ExtF" class="anchor"></a>
+        <code><span>| </span><span><span class="extension">ExtF</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-poly_ext">
+      <a href="#type-poly_ext" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a poly_ext</span>
+       </span><span> = </span><span>..</span>
+      </code>
+     </div><div class="spec-doc"><p>'a poly_ext</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-Foo">
+      <a href="#extension-decl-Foo" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <a href="#type-poly_ext">poly_ext</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-Foo" class="def variant extension anchored">
+        <a href="#extension-Foo" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="extension">Foo</span> 
+          <span class="keyword">of</span> <span class="type-var">'b</span>
+         </span>
+        </code>
+       </li>
+       <li id="extension-Bar" class="def variant extension anchored">
+        <a href="#extension-Bar" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="extension">Bar</span> 
+          <span class="keyword">of</span> <span class="type-var">'b</span>
+           * <span class="type-var">'b</span>
+         </span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>'b poly_ext</p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-Quux">
+      <a href="#extension-decl-Quux" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <a href="#type-poly_ext">poly_ext</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-Quux" class="def variant extension anchored">
+        <a href="#extension-Quux" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="extension">Quux</span> 
+          <span class="keyword">of</span> <span class="type-var">'c</span>
+         </span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>'c poly_ext</p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-ExtMod">
+      <a href="#module-ExtMod" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-ExtMod.html">ExtMod</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-ZzzTop0">
+      <a href="#extension-decl-ZzzTop0" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <a href="Ocamlary-ExtMod.html#type-t">ExtMod.t</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-ZzzTop0" class="def variant extension anchored">
+        <a href="#extension-ZzzTop0" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="extension">ZzzTop0</span></span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>It's got the rock</p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-ZzzTop">
+      <a href="#extension-decl-ZzzTop" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <a href="Ocamlary-ExtMod.html#type-t">ExtMod.t</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-ZzzTop" class="def variant extension anchored">
+        <a href="#extension-ZzzTop" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="extension">ZzzTop</span> 
+          <span class="keyword">of</span> unit
+         </span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>and it packs a unit.</p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value external anchored" id="val-launch_missiles">
+      <a href="#val-launch_missiles" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> launch_missiles : 
+        <span>unit <span class="arrow">&#45;&gt;</span></span> unit
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Rotate keys on my mark...</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-my_mod">
+      <a href="#type-my_mod" class="anchor"></a>
+      <code><span><span class="keyword">type</span> my_mod</span>
+       <span> = 
+        <span>(<span class="keyword">module</span> 
+         <a href="Ocamlary-module-type-COLLECTION.html">COLLECTION</a>
+         )
+        </span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>A brown paper package tied up with string</p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-empty_class">
+      <a href="#class-empty_class" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Ocamlary-class-empty_class.html">empty_class</a></span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-one_method_class">
+      <a href="#class-one_method_class" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span>
+        <a href="Ocamlary-class-one_method_class.html">one_method_class</a>
+       </span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-two_method_class">
+      <a href="#class-two_method_class" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span>
+        <a href="Ocamlary-class-two_method_class.html">two_method_class</a>
+       </span>
+       <span> : <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-param_class">
+      <a href="#class-param_class" class="anchor"></a>
+      <code><span><span class="keyword">class</span> 'a </span>
+       <span><a href="Ocamlary-class-param_class.html">param_class</a></span>
+       <span> : 
+        <span><span class="type-var">'a</span> 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-my_unit_object">
+      <a href="#type-my_unit_object" class="anchor"></a>
+      <code><span><span class="keyword">type</span> my_unit_object</span>
+       <span> = 
+        <span>unit <a href="Ocamlary-class-param_class.html">param_class</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-my_unit_class">
+      <a href="#type-my_unit_class" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a my_unit_class</span>
+       </span>
+       <span> = 
+        <span>unit <a href="Ocamlary-class-param_class.html">param_class</a>
+        </span> <span class="keyword">as</span> 'a
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep1">
+      <a href="#module-Dep1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep1.html">Dep1</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep2">
+      <a href="#module-Dep2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep2.html">Dep2</a>
+       </span>
+       <span> (<a href="Ocamlary-Dep2-argument-1-Arg.html">Arg</a> : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+        ) : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-dep1">
+      <a href="#type-dep1" class="anchor"></a>
+      <code><span><span class="keyword">type</span> dep1</span>
+       <span> = 
+        <a href="Ocamlary-Dep1-module-type-S-class-c.html">Dep2(Dep1).B.c</a>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep3">
+      <a href="#module-Dep3" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep3.html">Dep3</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep4">
+      <a href="#module-Dep4" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep4.html">Dep4</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep5">
+      <a href="#module-Dep5" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep5.html">Dep5</a>
+       </span>
+       <span> (<a href="Ocamlary-Dep5-argument-1-Arg.html">Arg</a> : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+        ) : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-dep2">
+      <a href="#type-dep2" class="anchor"></a>
+      <code><span><span class="keyword">type</span> dep2</span>
+       <span> = 
+        <a href="Ocamlary-Dep4-module-type-T.html#type-b">Dep5(Dep4).Z.X.b
         </a>
        </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-double_include">
-       <a href="#type-double_include" class="anchor"></a>
-       <code><span><span class="keyword">type</span> double_include</span>
-       </code>
-      </div>
      </div>
-    </details>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-IncludeInclude1">
-     <a href="#module-IncludeInclude1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-IncludeInclude1.html">IncludeInclude1</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
     </div>
-   </div>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
-      <code>
-       <span><span class="keyword">include</span> 
-        <span class="keyword">module</span> <span class="keyword">type</span>
-         <span class="keyword">of</span> 
-        <a href="Ocamlary-IncludeInclude1.html">IncludeInclude1</a>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-dep3">
+      <a href="#type-dep3" class="anchor"></a>
+      <code><span><span class="keyword">type</span> dep3</span>
+       <span> = <a href="Ocamlary-Dep3.html#type-a">Dep5(Dep4).Z.Y.a</a>
        </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec module-type anchored" id="module-type-IncludeInclude2">
-       <a href="#module-type-IncludeInclude2" class="anchor"></a>
-       <code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep6">
+      <a href="#module-Dep6" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep6.html">Dep6</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep7">
+      <a href="#module-Dep7" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep7.html">Dep7</a>
+       </span>
+       <span> (<a href="Ocamlary-Dep7-argument-1-Arg.html">Arg</a> : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+        ) : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-dep4">
+      <a href="#type-dep4" class="anchor"></a>
+      <code><span><span class="keyword">type</span> dep4</span>
+       <span> = 
+        <a href="Ocamlary-Dep6-module-type-T-Y.html#type-d">Dep7(Dep6).M.Y.d
+        </a>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep8">
+      <a href="#module-Dep8" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep8.html">Dep8</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep9">
+      <a href="#module-Dep9" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep9.html">Dep9</a>
+       </span>
+       <span> (<a href="Ocamlary-Dep9-argument-1-X.html">X</a> : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+        ) : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-Dep10">
+      <a href="#module-type-Dep10" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-Dep10.html">Dep10</a>
+       </span>
+       <span> = <a href="Ocamlary-Dep8-module-type-T.html">Dep9(Dep8).T</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Ocamlary-Dep8-module-type-T.html#type-t">t</a> = int
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep11">
+      <a href="#module-Dep11" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep11.html">Dep11</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep12">
+      <a href="#module-Dep12" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep12.html">Dep12</a>
+       </span>
+       <span> (<a href="Ocamlary-Dep12-argument-1-Arg.html">Arg</a> : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+        ) : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Dep13">
+      <a href="#module-Dep13" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Dep13.html">Dep13</a>
+       </span>
+       <span> : 
+        <a href="Ocamlary-Dep11-module-type-S.html">Dep12(Dep11).T</a>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-dep5">
+      <a href="#type-dep5" class="anchor"></a>
+      <code><span><span class="keyword">type</span> dep5</span>
+       <span> = 
+        <a href="Ocamlary-Dep11-module-type-S-class-c.html">Dep13.c</a>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-With1">
+      <a href="#module-type-With1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-With1.html">With1</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-With2">
+      <a href="#module-With2" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With2.html">With2</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-With3">
+      <a href="#module-With3" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With3.html">With3</a>
+       </span>
+       <span> : <a href="Ocamlary-module-type-With1.html">With1</a> 
+        <span class="keyword">with</span> 
         <span><span class="keyword">module</span> 
-         <span class="keyword">type</span> 
+         <a href="Ocamlary-module-type-With1-M.html">M</a> = 
+         <a href="Ocamlary-With2.html">With2</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-with1">
+      <a href="#type-with1" class="anchor"></a>
+      <code><span><span class="keyword">type</span> with1</span>
+       <span> = <a href="Ocamlary-With3-N.html#type-t">With3.N.t</a></span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-With4">
+      <a href="#module-With4" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With4.html">With4</a>
+       </span>
+       <span> : <a href="Ocamlary-module-type-With1.html">With1</a> 
+        <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <a href="Ocamlary-module-type-With1-M.html">M</a> := 
+         <a href="Ocamlary-With2.html">With2</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-with2">
+      <a href="#type-with2" class="anchor"></a>
+      <code><span><span class="keyword">type</span> with2</span>
+       <span> = <a href="Ocamlary-With4-N.html#type-t">With4.N.t</a></span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-With5">
+      <a href="#module-With5" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With5.html">With5</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-With6">
+      <a href="#module-With6" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With6.html">With6</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-With7">
+      <a href="#module-With7" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With7.html">With7</a>
+       </span>
+       <span> (<a href="Ocamlary-With7-argument-1-X.html">X</a> : 
+        <span class="keyword">sig</span> ... <span class="keyword">end</span>
+        ) : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-With8">
+      <a href="#module-type-With8" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-With8.html">With8</a>
+       </span>
+       <span> =
+                 
+        <a href="Ocamlary-With6-module-type-T.html">With7(With6).T</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <a href="Ocamlary-With6-module-type-T-M.html">M</a> = 
+         <a href="Ocamlary-With5.html">With5</a>
+        </span> <span class="keyword">and</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Ocamlary-With5-module-type-S.html#type-t">M.N.t</a>
+          = <a href="Ocamlary-With5-N.html#type-t">With5.N.t</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-With9">
+      <a href="#module-With9" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With9.html">With9</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-With10">
+      <a href="#module-With10" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-With10.html">With10</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-With11">
+      <a href="#module-type-With11" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-With11.html">With11</a>
+       </span>
+       <span> = 
+        <a href="Ocamlary-With10-module-type-T.html">With7(With10).T</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">module</span> 
+         <a href="Ocamlary-With10-module-type-T-M.html">M</a> = 
+         <a href="Ocamlary-With9.html">With9</a>
+        </span> <span class="keyword">and</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Ocamlary-With9-module-type-S.html#type-t">N.t</a> =
+          int
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-NestedInclude1">
+      <a href="#module-type-NestedInclude1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-NestedInclude1.html">NestedInclude1</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Ocamlary-module-type-NestedInclude1.html">NestedInclude1
+         </a>
+        </span>
+       </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec module-type anchored" id="module-type-NestedInclude2">
+        <a href="#module-type-NestedInclude2" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <span class="keyword">type</span> 
+          <a href="Ocamlary-module-type-NestedInclude2.html">NestedInclude2
+          </a>
+         </span>
+         <span> = <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+      </div>
+     </details>
+    </div>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <a href="Ocamlary-module-type-NestedInclude2.html">NestedInclude2
+         </a> <span class="keyword">with</span> 
+         <span><span class="keyword">type</span> 
+          <a
+           href="Ocamlary-module-type-NestedInclude2.html#type-nested_include">
+           nested_include
+          </a> = int
+         </span>
+        </span>
+       </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-nested_include">
+        <a href="#type-nested_include" class="anchor"></a>
+        <code><span><span class="keyword">type</span> nested_include</span>
+         <span> = int</span>
+        </code>
+       </div>
+      </div>
+     </details>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-DoubleInclude1">
+      <a href="#module-DoubleInclude1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-DoubleInclude1.html">DoubleInclude1</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-DoubleInclude3">
+      <a href="#module-DoubleInclude3" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-DoubleInclude3.html">DoubleInclude3</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <span class="keyword">module</span> 
+         <span class="keyword">type</span> <span class="keyword">of</span>
+          
+         <a href="Ocamlary-DoubleInclude3-DoubleInclude2.html">
+          DoubleInclude3.DoubleInclude2
+         </a>
+        </span>
+       </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-double_include">
+        <a href="#type-double_include" class="anchor"></a>
+        <code><span><span class="keyword">type</span> double_include</span>
+        </code>
+       </div>
+      </div>
+     </details>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-IncludeInclude1">
+      <a href="#module-IncludeInclude1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-IncludeInclude1.html">IncludeInclude1</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
+         <span class="keyword">module</span> 
+         <span class="keyword">type</span> <span class="keyword">of</span>
+          <a href="Ocamlary-IncludeInclude1.html">IncludeInclude1</a>
+        </span>
+       </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec module-type anchored"
+        id="module-type-IncludeInclude2">
+        <a href="#module-type-IncludeInclude2" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <span class="keyword">type</span> 
+          <a href="Ocamlary-module-type-IncludeInclude2.html">IncludeInclude2
+          </a>
+         </span>
+         <span> = <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+      </div>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-IncludeInclude2_M">
+        <a href="#module-IncludeInclude2_M" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <a href="Ocamlary-IncludeInclude2_M.html">IncludeInclude2_M</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+      </div>
+     </details>
+    </div>
+    <div class="odoc-include">
+     <details open="open">
+      <summary class="spec include">
+       <code>
+        <span><span class="keyword">include</span> 
          <a href="Ocamlary-module-type-IncludeInclude2.html">IncludeInclude2
          </a>
         </span>
-        <span> = <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
        </code>
+      </summary>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-include_include">
+        <a href="#type-include_include" class="anchor"></a>
+        <code><span><span class="keyword">type</span> include_include</span>
+        </code>
+       </div>
       </div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-IncludeInclude2_M">
-       <a href="#module-IncludeInclude2_M" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> 
-         <a href="Ocamlary-IncludeInclude2_M.html">IncludeInclude2_M</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
-      </div>
-     </div>
-    </details>
-   </div>
-   <div class="odoc-include">
-    <details open="open">
-     <summary class="spec include">
+     </details>
+    </div>
+    <h2 id="indexmodules"><a href="#indexmodules" class="anchor"></a>
+     Trying the {!modules: ...} command.
+    </h2>
+    <p>With ocamldoc, toplevel units will be linked and documented, while
+      submodules will behave as simple references.
+    </p>
+    <p>With odoc, everything should be resolved (and linked) but only
+      toplevel units will be documented.
+    </p>
+    <ul class="modules">
+     <li><a href="Ocamlary-Dep1-X.html"><code>Dep1.X</code></a> </li>
+     <li>
+      <a href="Ocamlary-IncludeInclude1.html">
+       <code>Ocamlary.IncludeInclude1</code>
+      </a> 
+     </li>
+     <li><a href="#"><code>Ocamlary</code></a> 
+      <span class="synopsis">This is an <i>interface</i> with <b>all</b>
+        of the <em>module system</em> features. This documentation 
+       demonstrates:
+      </span>
+     </li>
+    </ul>
+    <h4 id="weirder-usages-involving-module-types">
+     <a href="#weirder-usages-involving-module-types" class="anchor"></a>
+     Weirder usages involving module types
+    </h4>
+    <ul class="modules">
+     <li>
+      <a href="Ocamlary-IncludeInclude1-IncludeInclude2_M.html">
+       <code>IncludeInclude1.IncludeInclude2_M</code>
+      </a> 
+     </li><li><a href="Ocamlary-Dep4-X.html"><code>Dep4.X</code></a> </li>
+    </ul>
+    <h2 id="playing-with-@canonical-paths">
+     <a href="#playing-with-@canonical-paths" class="anchor"></a>Playing
+      with @canonical paths
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-CanonicalTest">
+      <a href="#module-CanonicalTest" class="anchor"></a>
       <code>
-       <span><span class="keyword">include</span> 
-        <a href="Ocamlary-module-type-IncludeInclude2.html">IncludeInclude2
-        </a>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-CanonicalTest.html">CanonicalTest</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
        </span>
       </code>
-     </summary>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-include_include">
-       <a href="#type-include_include" class="anchor"></a>
-       <code><span><span class="keyword">type</span> include_include</span>
-       </code>
-      </div>
      </div>
-    </details>
-   </div>
-   <h2 id="indexmodules"><a href="#indexmodules" class="anchor"></a>Trying
-     the {!modules: ...} command.
-   </h2>
-   <p>With ocamldoc, toplevel units will be linked and documented, while
-     submodules will behave as simple references.
-   </p>
-   <p>With odoc, everything should be resolved (and linked) but only 
-    toplevel units will be documented.
-   </p>
-   <ul class="modules">
-    <li><a href="Ocamlary-Dep1-X.html"><code>Dep1.X</code></a> </li>
-    <li>
-     <a href="Ocamlary-IncludeInclude1.html">
-      <code>Ocamlary.IncludeInclude1</code>
-     </a> 
-    </li>
-    <li><a href="#"><code>Ocamlary</code></a> 
-     <span class="synopsis">This is an <i>interface</i> with <b>all</b>
-       of the <em>module system</em> features. This documentation 
-      demonstrates:
-     </span>
-    </li>
-   </ul>
-   <h4 id="weirder-usages-involving-module-types">
-    <a href="#weirder-usages-involving-module-types" class="anchor"></a>
-    Weirder usages involving module types
-   </h4>
-   <ul class="modules">
-    <li>
-     <a href="Ocamlary-IncludeInclude1-IncludeInclude2_M.html">
-      <code>IncludeInclude1.IncludeInclude2_M</code>
-     </a> 
-    </li><li><a href="Ocamlary-Dep4-X.html"><code>Dep4.X</code></a> </li>
-   </ul>
-   <h2 id="playing-with-@canonical-paths">
-    <a href="#playing-with-@canonical-paths" class="anchor"></a>Playing
-     with @canonical paths
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-CanonicalTest">
-     <a href="#module-CanonicalTest" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-CanonicalTest.html">CanonicalTest</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
     </div>
-   </div>
-   <p>Some ref to 
-    <a href="Ocamlary-CanonicalTest-Base_Tests-C.html#type-t">
-     <code>CanonicalTest.Base_Tests.C.t</code>
-    </a> and 
-    <a href="Ocamlary-CanonicalTest-Base-List.html#val-id">
-     <code>CanonicalTest.Base_Tests.L.id</code>
-    </a>. But also to 
-    <a href="Ocamlary-CanonicalTest-Base-List.html">
-     <code>CanonicalTest.Base.List</code>
-    </a> and 
-    <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">
-     <code>CanonicalTest.Base.List.t</code>
-    </a>
-   </p>
-   <h2 id="aliases"><a href="#aliases" class="anchor"></a>Aliases again</h2>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Aliases">
-     <a href="#module-Aliases" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Aliases.html">Aliases</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Let's imitate jst's layout.</p></div>
-   </div>
-   <h2 id="section-title-splicing">
-    <a href="#section-title-splicing" class="anchor"></a>Section title
-     splicing
-   </h2><p>I can refer to</p>
-   <ul>
-    <li><code>{!section:indexmodules}</code> : 
-     <a href="#indexmodules" title="indexmodules">Trying the {!modules:
-       ...} command.
+    <p>Some ref to 
+     <a href="Ocamlary-CanonicalTest-Base_Tests-C.html#type-t">
+      <code>CanonicalTest.Base_Tests.C.t</code>
+     </a> and 
+     <a href="Ocamlary-CanonicalTest-Base-List.html#val-id">
+      <code>CanonicalTest.Base_Tests.L.id</code>
+     </a>. But also to 
+     <a href="Ocamlary-CanonicalTest-Base-List.html">
+      <code>CanonicalTest.Base.List</code>
+     </a> and 
+     <a href="Ocamlary-CanonicalTest-Base-List.html#type-t">
+      <code>CanonicalTest.Base.List.t</code>
      </a>
-    </li>
-    <li><code>{!aliases}</code> : 
-     <a href="#aliases" title="aliases">Aliases again</a>
-    </li>
-   </ul><p>But also to things in submodules:</p>
-   <ul>
-    <li><code>{!section:SuperSig.SubSigA.subSig}</code> : 
-     <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig"
-      title="subSig">A Labeled Section Header Inside of a Signature
-     </a>
-    </li>
-    <li><code>{!Aliases.incl}</code> : 
-     <a href="Ocamlary-Aliases.html#incl" title="incl">include of Foo</a>
-    </li>
-   </ul><p>And just to make sure we do not mess up:</p>
-   <ul>
-    <li><code>{{!section:indexmodules}A}</code> : 
-     <a href="#indexmodules" title="indexmodules">A</a>
-    </li>
-    <li><code>{{!aliases}B}</code> : <a href="#aliases" title="aliases">B</a>
-    </li>
-    <li><code>{{!section:SuperSig.SubSigA.subSig}C}</code> : 
-     <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig"
-      title="subSig">C
-     </a>
-    </li>
-    <li><code>{{!Aliases.incl}D}</code> : 
-     <a href="Ocamlary-Aliases.html#incl" title="incl">D</a>
-    </li>
-   </ul>
-   <h2 id="new-reference-syntax">
-    <a href="#new-reference-syntax" class="anchor"></a>New reference 
-    syntax
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-M">
-     <a href="#module-type-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-M.html">M</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div><p>Here goes:</p>
-   <ul>
-    <li><code>{!module-M.t}</code> : 
-     <a href="Ocamlary-M.html#type-t"><code>M.t</code></a>
-    </li>
-    <li><code>{!module-type-M.t}</code> : 
-     <a href="Ocamlary-module-type-M.html#type-t"><code>M.t</code></a>
-    </li>
-   </ul>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Only_a_module">
-     <a href="#module-Only_a_module" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Ocamlary-Only_a_module.html">Only_a_module</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <ul>
-    <li><code>{!Only_a_module.t}</code> : 
-     <a href="Ocamlary-Only_a_module.html#type-t">
-      <code>Only_a_module.t</code>
-     </a>
-    </li>
-    <li><code>{!module-Only_a_module.t}</code> : 
-     <a href="Ocamlary-Only_a_module.html#type-t">
-      <code>Only_a_module.t</code>
-     </a>
-    </li>
-    <li><code>{!module-Only_a_module.type-t}</code> : 
-     <a href="Ocamlary-Only_a_module.html#type-t">
-      <code>Only_a_module.t</code>
-     </a>
-    </li>
-    <li><code>{!type:Only_a_module.t}</code> : 
-     <a href="Ocamlary-Only_a_module.html#type-t">
-      <code>Only_a_module.t</code>
-     </a>
-    </li>
-   </ul>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-TypeExt">
-     <a href="#module-type-TypeExt" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-TypeExt.html">TypeExt</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-new_t">
-     <a href="#type-new_t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> new_t</span>
-      <span> = </span><span>..</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-C">
-     <a href="#extension-decl-C" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <a href="#type-new_t">new_t</a>
-        += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-C" class="def variant extension anchored">
-       <a href="#extension-C" class="anchor"></a>
-       <code><span>| </span><span><span class="extension">C</span></span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-TypeExtPruned">
-     <a href="#module-type-TypeExtPruned" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Ocamlary-module-type-TypeExtPruned.html">TypeExtPruned</a>
-      </span>
-      <span> = <a href="Ocamlary-module-type-TypeExt.html">TypeExt</a>
-        <span class="keyword">with</span> 
-       <span><span class="keyword">type</span> 
-        <a href="Ocamlary-module-type-TypeExt.html#type-t">t</a> := 
-        <a href="#type-new_t">new_t</a>
+    </p>
+    <h2 id="aliases"><a href="#aliases" class="anchor"></a>Aliases again</h2>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Aliases">
+      <a href="#module-Aliases" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Aliases.html">Aliases</a>
        </span>
-      </span>
-     </code>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Let's imitate jst's layout.</p></div>
     </div>
+    <h2 id="section-title-splicing">
+     <a href="#section-title-splicing" class="anchor"></a>Section title
+      splicing
+    </h2><p>I can refer to</p>
+    <ul>
+     <li><code>{!section:indexmodules}</code> : 
+      <a href="#indexmodules" title="indexmodules">Trying the {!modules:
+        ...} command.
+      </a>
+     </li>
+     <li><code>{!aliases}</code> : 
+      <a href="#aliases" title="aliases">Aliases again</a>
+     </li>
+    </ul><p>But also to things in submodules:</p>
+    <ul>
+     <li><code>{!section:SuperSig.SubSigA.subSig}</code> : 
+      <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig"
+       title="subSig">A Labeled Section Header Inside of a Signature
+      </a>
+     </li>
+     <li><code>{!Aliases.incl}</code> : 
+      <a href="Ocamlary-Aliases.html#incl" title="incl">include of Foo</a>
+     </li>
+    </ul><p>And just to make sure we do not mess up:</p>
+    <ul>
+     <li><code>{{!section:indexmodules}A}</code> : 
+      <a href="#indexmodules" title="indexmodules">A</a>
+     </li>
+     <li><code>{{!aliases}B}</code> : 
+      <a href="#aliases" title="aliases">B</a>
+     </li>
+     <li><code>{{!section:SuperSig.SubSigA.subSig}C}</code> : 
+      <a href="Ocamlary-module-type-SuperSig-module-type-SubSigA.html#subSig"
+       title="subSig">C
+      </a>
+     </li>
+     <li><code>{{!Aliases.incl}D}</code> : 
+      <a href="Ocamlary-Aliases.html#incl" title="incl">D</a>
+     </li>
+    </ul>
+    <h2 id="new-reference-syntax">
+     <a href="#new-reference-syntax" class="anchor"></a>New reference
+      syntax
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-M">
+      <a href="#module-type-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-M.html">M</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div><p>Here goes:</p>
+    <ul>
+     <li><code>{!module-M.t}</code> : 
+      <a href="Ocamlary-M.html#type-t"><code>M.t</code></a>
+     </li>
+     <li><code>{!module-type-M.t}</code> : 
+      <a href="Ocamlary-module-type-M.html#type-t"><code>M.t</code></a>
+     </li>
+    </ul>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Only_a_module">
+      <a href="#module-Only_a_module" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Ocamlary-Only_a_module.html">Only_a_module</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <ul>
+     <li><code>{!Only_a_module.t}</code> : 
+      <a href="Ocamlary-Only_a_module.html#type-t">
+       <code>Only_a_module.t</code>
+      </a>
+     </li>
+     <li><code>{!module-Only_a_module.t}</code> : 
+      <a href="Ocamlary-Only_a_module.html#type-t">
+       <code>Only_a_module.t</code>
+      </a>
+     </li>
+     <li><code>{!module-Only_a_module.type-t}</code> : 
+      <a href="Ocamlary-Only_a_module.html#type-t">
+       <code>Only_a_module.t</code>
+      </a>
+     </li>
+     <li><code>{!type:Only_a_module.t}</code> : 
+      <a href="Ocamlary-Only_a_module.html#type-t">
+       <code>Only_a_module.t</code>
+      </a>
+     </li>
+    </ul>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-TypeExt">
+      <a href="#module-type-TypeExt" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-TypeExt.html">TypeExt</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-new_t">
+      <a href="#type-new_t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> new_t</span>
+       <span> = </span><span>..</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-C">
+      <a href="#extension-decl-C" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <a href="#type-new_t">new_t</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-C" class="def variant extension anchored">
+        <a href="#extension-C" class="anchor"></a>
+        <code><span>| </span><span><span class="extension">C</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-TypeExtPruned">
+      <a href="#module-type-TypeExtPruned" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Ocamlary-module-type-TypeExtPruned.html">TypeExtPruned</a>
+       </span>
+       <span> = <a href="Ocamlary-module-type-TypeExt.html">TypeExt</a>
+         <span class="keyword">with</span> 
+        <span><span class="keyword">type</span> 
+         <a href="Ocamlary-module-type-TypeExt.html#type-t">t</a> := 
+         <a href="#type-new_t">new_t</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <h2 id="unresolved-references">
+     <a href="#unresolved-references" class="anchor"></a>Unresolved 
+     references
+    </h2>
+    <ul><li><code>Stdlib.Invalid_argument</code></li>
+     <li><code>Hashtbl.t</code></li><li><code>Set.S.empty</code></li>
+     <li><code>CollectionModule.InnerModuleA.foo</code></li>
+    </ul>
    </div>
-   <h2 id="unresolved-references">
-    <a href="#unresolved-references" class="anchor"></a>Unresolved references
-   </h2>
-   <ul><li><code>Stdlib.Invalid_argument</code></li>
-    <li><code>Hashtbl.t</code></li><li><code>Set.S.empty</code></li>
-    <li><code>CollectionModule.InnerModuleA.foo</code></li>
-   </ul>
   </div>
  </body>
 </html>

--- a/test/generators/html/Recent-X.html
+++ b/test/generators/html/Recent-X.html
@@ -11,47 +11,49 @@
   <nav class="odoc-nav"><a href="Recent.html">Up</a> – 
    <a href="Recent.html">Recent</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Recent.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-substitution anchored" id="module-L">
-     <a href="#module-L" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> L := 
-       <a href="Recent-Z-Y.html">Z.Y</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span>
-      <span> = <span>int <a href="Recent-Z-Y-X.html#type-t">L.X.t</a></span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type subst anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span>
-      <span> := int</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-v">
-     <a href="#type-v" class="anchor"></a>
-     <code><span><span class="keyword">type</span> v</span>
-      <span> = 
-       <span><a href="#type-u">u</a> 
-        <a href="Recent-Z-Y-X.html#type-t">L.X.t</a>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Recent.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-substitution anchored" id="module-L">
+      <a href="#module-L" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> L := 
+        <a href="Recent-Z-Y.html">Z.Y</a>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span>
+       <span> = <span>int <a href="Recent-Z-Y-X.html#type-t">L.X.t</a></span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type subst anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span>
+       <span> := int</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-v">
+      <a href="#type-v" class="anchor"></a>
+      <code><span><span class="keyword">type</span> v</span>
+       <span> = 
+        <span><a href="#type-u">u</a> 
+         <a href="Recent-Z-Y-X.html#type-t">L.X.t</a>
+        </span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent-Z-Y-X.html
+++ b/test/generators/html/Recent-Z-Y-X.html
@@ -12,14 +12,17 @@
    <a href="Recent.html">Recent</a> &#x00BB; <a href="Recent-Z.html">Z</a>
     &#x00BB; <a href="Recent-Z-Y.html">Y</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>Y.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>'a t</span></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Y.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> <span>'a t</span></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent-Z-Y.html
+++ b/test/generators/html/Recent-Z-Y.html
@@ -12,20 +12,23 @@
    <a href="Recent.html">Recent</a> &#x00BB; <a href="Recent-Z.html">Z</a>
     &#x00BB; Y
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>Z.Y</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Recent-Z-Y-X.html">X</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Z.Y</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Recent-Z-Y-X.html">X</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent-Z.html
+++ b/test/generators/html/Recent-Z.html
@@ -11,21 +11,23 @@
   <nav class="odoc-nav"><a href="Recent.html">Up</a> – 
    <a href="Recent.html">Recent</a> &#x00BB; Z
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Recent.Z</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Y">
-     <a href="#module-Y" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Recent-Z-Y.html">Y</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Recent.Z</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Y">
+      <a href="#module-Y" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Recent-Z-Y.html">Y</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent-module-type-PolyS.html
+++ b/test/generators/html/Recent-module-type-PolyS.html
@@ -11,26 +11,28 @@
   <nav class="odoc-nav"><a href="Recent.html">Up</a> – 
    <a href="Recent.html">Recent</a> &#x00BB; PolyS
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Recent.PolyS</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span><span> = </span>
-      <span>[ </span>
-     </code>
-     <ol>
-      <li id="type-t.A" class="def variant constructor anchored">
-       <a href="#type-t.A" class="anchor"></a>
-       <code><span>| </span><span>`A</span></code>
-      </li>
-      <li id="type-t.B" class="def variant constructor anchored">
-       <a href="#type-t.B" class="anchor"></a>
-       <code><span>| </span><span>`B</span></code>
-      </li>
-     </ol><code><span> ]</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Recent.PolyS</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span><span> = </span>
+       <span>[ </span>
+      </code>
+      <ol>
+       <li id="type-t.A" class="def variant constructor anchored">
+        <a href="#type-t.A" class="anchor"></a>
+        <code><span>| </span><span>`A</span></code>
+       </li>
+       <li id="type-t.B" class="def variant constructor anchored">
+        <a href="#type-t.B" class="anchor"></a>
+        <code><span>| </span><span>`B</span></code>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent-module-type-S.html
+++ b/test/generators/html/Recent-module-type-S.html
@@ -11,8 +11,10 @@
   <nav class="odoc-nav"><a href="Recent.html">Up</a> – 
    <a href="Recent.html">Recent</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Recent.S</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Recent.S</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Recent-module-type-S1-argument-1-_.html
+++ b/test/generators/html/Recent-module-type-S1-argument-1-_.html
@@ -12,8 +12,10 @@
    <a href="Recent.html">Recent</a> &#x00BB; 
    <a href="Recent-module-type-S1.html">S1</a> &#x00BB; _
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>S1._</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>S1._</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Recent-module-type-S1.html
+++ b/test/generators/html/Recent-module-type-S1.html
@@ -11,27 +11,29 @@
   <nav class="odoc-nav"><a href="Recent.html">Up</a> – 
    <a href="Recent.html">Recent</a> &#x00BB; S1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Recent.S1</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-_">
-     <a href="#argument-1-_" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Recent-module-type-S1-argument-1-_.html">_</a></span>
-      <span> : <a href="Recent-module-type-S.html">S</a></span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Recent.S1</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-_">
+      <a href="#argument-1-_" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Recent-module-type-S1-argument-1-_.html">_</a></span>
+       <span> : <a href="Recent-module-type-S.html">S</a></span>
+      </code>
+     </div>
     </div>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
    </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
   </div>
  </body>
 </html>

--- a/test/generators/html/Recent.html
+++ b/test/generators/html/Recent.html
@@ -8,302 +8,308 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Recent</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Recent-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S1">
-     <a href="#module-type-S1" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Recent-module-type-S1.html">S1</a>
-      </span>
-      <span> = <span class="keyword">functor</span>
-       <span> (<a href="Recent-module-type-S1-argument-1-_.html">_</a>
-         : <a href="Recent-module-type-S.html">S</a>) 
-        <span class="arrow">&#45;&gt;</span>
-       </span> <a href="Recent-module-type-S.html">S</a>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-variant">
-     <a href="#type-variant" class="anchor"></a>
-     <code><span><span class="keyword">type</span> variant</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-variant.A" class="def variant constructor anchored">
-       <a href="#type-variant.A" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">A</span></span>
-       </code>
-      </li>
-      <li id="type-variant.B" class="def variant constructor anchored">
-       <a href="#type-variant.B" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">B</span> 
-         <span class="keyword">of</span> int
-        </span>
-       </code>
-      </li>
-      <li id="type-variant.C" class="def variant constructor anchored">
-       <a href="#type-variant.C" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">C</span></span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-variant.D" class="def variant constructor anchored">
-       <a href="#type-variant.D" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">D</span></span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p><em>bar</em></p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-variant.E" class="def variant constructor anchored">
-       <a href="#type-variant.E" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">E</span> 
-         <span class="keyword">of</span> 
-        </span><span>{</span>
-       </code>
-       <ol>
-        <li id="type-variant.a" class="def record field anchored">
-         <a href="#type-variant.a" class="anchor"></a>
-         <code><span>a : int;</span></code>
-        </li>
-       </ol><code><span>}</span></code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>_ gadt</span></span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-gadt.A" class="def variant constructor anchored">
-       <a href="#type-gadt.A" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">A</span> : 
-         <span>int <a href="#type-gadt">gadt</a></span>
-        </span>
-       </code>
-      </li>
-      <li id="type-gadt.B" class="def variant constructor anchored">
-       <a href="#type-gadt.B" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">B</span> : int 
-         <span class="arrow">&#45;&gt;</span> 
-         <span>string <a href="#type-gadt">gadt</a></span>
-        </span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-gadt.C" class="def variant constructor anchored">
-       <a href="#type-gadt.C" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">C</span> : </span><span>{</span>
-       </code>
-       <ol>
-        <li id="type-gadt.a" class="def record field anchored">
-         <a href="#type-gadt.a" class="anchor"></a>
-         <code><span>a : int;</span></code>
-        </li>
-       </ol>
-       <code><span>}</span>
-        <span> <span class="arrow">&#45;&gt;</span> 
-         <span>unit <a href="#type-gadt">gadt</a></span>
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-polymorphic_variant">
-     <a href="#type-polymorphic_variant" class="anchor"></a>
-     <code><span><span class="keyword">type</span> polymorphic_variant</span>
-      <span> = </span><span>[ </span>
-     </code>
-     <ol>
-      <li id="type-polymorphic_variant.A" class="def variant constructor
-       anchored"><a href="#type-polymorphic_variant.A" class="anchor"></a>
-       <code><span>| </span><span>`A</span></code>
-      </li>
-      <li id="type-polymorphic_variant.B" class="def variant constructor
-       anchored"><a href="#type-polymorphic_variant.B" class="anchor"></a>
-       <code><span>| </span>
-        <span>`B <span class="keyword">of</span> int</span>
-       </code>
-      </li>
-      <li id="type-polymorphic_variant.C" class="def variant constructor
-       anchored"><a href="#type-polymorphic_variant.C" class="anchor"></a>
-       <code><span>| </span><span>`C</span></code>
-       <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-polymorphic_variant.D" class="def variant constructor
-       anchored"><a href="#type-polymorphic_variant.D" class="anchor"></a>
-       <code><span>| </span><span>`D</span></code>
-       <div class="def-doc"><span class="comment-delim">(*</span><p>bar</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol><code><span> ]</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-empty_variant">
-     <a href="#type-empty_variant" class="anchor"></a>
-     <code><span><span class="keyword">type</span> empty_variant</span>
-      <span> = </span><span>|</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-nonrec_">
-     <a href="#type-nonrec_" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span class="keyword">nonrec</span> nonrec_
-      </span><span> = int</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-empty_conj">
-     <a href="#type-empty_conj" class="anchor"></a>
-     <code><span><span class="keyword">type</span> empty_conj</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-empty_conj.X" class="def variant constructor anchored">
-       <a href="#type-empty_conj.X" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">X</span> : 
-         <span>[&lt; 
-          <span>`X of &amp; <span class="type-var">'a</span> &amp; int
-            * float
-          </span> ]
-         </span> <span class="arrow">&#45;&gt;</span> 
-         <a href="#type-empty_conj">empty_conj</a>
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-conj">
-     <a href="#type-conj" class="anchor"></a>
-     <code><span><span class="keyword">type</span> conj</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-conj.X" class="def variant constructor anchored">
-       <a href="#type-conj.X" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">X</span> : 
-         <span>[&lt; 
-          <span>`X of int &amp; 
-           <span>[&lt; <span>`B of int &amp; float</span> ]</span>
-          </span> ]
-         </span> <span class="arrow">&#45;&gt;</span> 
-         <a href="#type-conj">conj</a>
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-empty_conj">
-     <a href="#val-empty_conj" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> empty_conj : 
-       <span>[&lt; 
-        <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float
-        </span> ]
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Recent</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Recent-module-type-S.html">S</a>
        </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-conj">
-     <a href="#val-conj" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> conj : 
-       <span>[&lt; 
-        <span>`X of int &amp; 
-         <span>[&lt; <span>`B of int &amp; float</span> ]</span>
-        </span> ]
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Z">
-     <a href="#module-Z" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Recent-Z.html">Z</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S1">
+      <a href="#module-type-S1" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Recent-module-type-S1.html">S1</a>
+       </span>
+       <span> = <span class="keyword">functor</span>
+        <span> (<a href="Recent-module-type-S1-argument-1-_.html">_</a>
+          : <a href="Recent-module-type-S.html">S</a>) 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <a href="Recent-module-type-S.html">S</a>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Recent-X.html">X</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-variant">
+      <a href="#type-variant" class="anchor"></a>
+      <code><span><span class="keyword">type</span> variant</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-variant.A" class="def variant constructor anchored">
+        <a href="#type-variant.A" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">A</span></span>
+        </code>
+       </li>
+       <li id="type-variant.B" class="def variant constructor anchored">
+        <a href="#type-variant.B" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">B</span> 
+          <span class="keyword">of</span> int
+         </span>
+        </code>
+       </li>
+       <li id="type-variant.C" class="def variant constructor anchored">
+        <a href="#type-variant.C" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">C</span></span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-variant.D" class="def variant constructor anchored">
+        <a href="#type-variant.D" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">D</span></span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p><em>bar</em></p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-variant.E" class="def variant constructor anchored">
+        <a href="#type-variant.E" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">E</span> 
+          <span class="keyword">of</span> 
+         </span><span>{</span>
+        </code>
+        <ol>
+         <li id="type-variant.a" class="def record field anchored">
+          <a href="#type-variant.a" class="anchor"></a>
+          <code><span>a : int;</span></code>
+         </li>
+        </ol><code><span>}</span></code>
+       </li>
+      </ol>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-PolyS">
-     <a href="#module-type-PolyS" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Recent-module-type-PolyS.html">PolyS</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-gadt">
+      <a href="#type-gadt" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>_ gadt</span></span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-gadt.A" class="def variant constructor anchored">
+        <a href="#type-gadt.A" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">A</span> : 
+          <span>int <a href="#type-gadt">gadt</a></span>
+         </span>
+        </code>
+       </li>
+       <li id="type-gadt.B" class="def variant constructor anchored">
+        <a href="#type-gadt.B" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">B</span> : int 
+          <span class="arrow">&#45;&gt;</span> 
+          <span>string <a href="#type-gadt">gadt</a></span>
+         </span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-gadt.C" class="def variant constructor anchored">
+        <a href="#type-gadt.C" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">C</span> : </span><span>{</span>
+        </code>
+        <ol>
+         <li id="type-gadt.a" class="def record field anchored">
+          <a href="#type-gadt.a" class="anchor"></a>
+          <code><span>a : int;</span></code>
+         </li>
+        </ol>
+        <code><span>}</span>
+         <span> <span class="arrow">&#45;&gt;</span> 
+          <span>unit <a href="#type-gadt">gadt</a></span>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-polymorphic_variant">
+      <a href="#type-polymorphic_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> polymorphic_variant</span>
+       <span> = </span><span>[ </span>
+      </code>
+      <ol>
+       <li id="type-polymorphic_variant.A" class="def variant constructor
+        anchored"><a href="#type-polymorphic_variant.A" class="anchor"></a>
+        <code><span>| </span><span>`A</span></code>
+       </li>
+       <li id="type-polymorphic_variant.B" class="def variant constructor
+        anchored"><a href="#type-polymorphic_variant.B" class="anchor"></a>
+        <code><span>| </span>
+         <span>`B <span class="keyword">of</span> int</span>
+        </code>
+       </li>
+       <li id="type-polymorphic_variant.C" class="def variant constructor
+        anchored"><a href="#type-polymorphic_variant.C" class="anchor"></a>
+        <code><span>| </span><span>`C</span></code>
+        <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-polymorphic_variant.D" class="def variant constructor
+        anchored"><a href="#type-polymorphic_variant.D" class="anchor"></a>
+        <code><span>| </span><span>`D</span></code>
+        <div class="def-doc"><span class="comment-delim">(*</span><p>bar</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-empty_variant">
+      <a href="#type-empty_variant" class="anchor"></a>
+      <code><span><span class="keyword">type</span> empty_variant</span>
+       <span> = </span><span>|</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-nonrec_">
+      <a href="#type-nonrec_" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span class="keyword">nonrec</span> nonrec_
+       </span><span> = int</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-empty_conj">
+      <a href="#type-empty_conj" class="anchor"></a>
+      <code><span><span class="keyword">type</span> empty_conj</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-empty_conj.X" class="def variant constructor anchored">
+        <a href="#type-empty_conj.X" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">X</span> : 
+          <span>[&lt; 
+           <span>`X of &amp; <span class="type-var">'a</span> &amp; int
+             * float
+           </span> ]
+          </span> <span class="arrow">&#45;&gt;</span> 
+          <a href="#type-empty_conj">empty_conj</a>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-conj">
+      <a href="#type-conj" class="anchor"></a>
+      <code><span><span class="keyword">type</span> conj</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-conj.X" class="def variant constructor anchored">
+        <a href="#type-conj.X" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">X</span> : 
+          <span>[&lt; 
+           <span>`X of int &amp; 
+            <span>[&lt; <span>`B of int &amp; float</span> ]</span>
+           </span> ]
+          </span> <span class="arrow">&#45;&gt;</span> 
+          <a href="#type-conj">conj</a>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-empty_conj">
+      <a href="#val-empty_conj" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> empty_conj : 
+        <span>[&lt; 
+         <span>`X of &amp; <span class="type-var">'a</span> &amp; int * float
+         </span> ]
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-conj">
+      <a href="#val-conj" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> conj : 
+        <span>[&lt; 
+         <span>`X of int &amp; 
+          <span>[&lt; <span>`B of int &amp; float</span> ]</span>
+         </span> ]
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Z">
+      <a href="#module-Z" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Recent-Z.html">Z</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Recent-X.html">X</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-PolyS">
+      <a href="#module-type-PolyS" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Recent-module-type-PolyS.html">PolyS</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent_impl-B.html
+++ b/test/generators/html/Recent_impl-B.html
@@ -11,22 +11,24 @@
   <nav class="odoc-nav"><a href="Recent_impl.html">Up</a> – 
    <a href="Recent_impl.html">Recent_impl</a> &#x00BB; B
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Recent_impl.B</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-t.B" class="def variant constructor anchored">
-       <a href="#type-t.B" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">B</span></span>
-       </code>
-      </li>
-     </ol>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Recent_impl.B</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-t.B" class="def variant constructor anchored">
+        <a href="#type-t.B" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">B</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent_impl-Foo-A.html
+++ b/test/generators/html/Recent_impl-Foo-A.html
@@ -12,22 +12,24 @@
    <a href="Recent_impl.html">Recent_impl</a> &#x00BB; 
    <a href="Recent_impl-Foo.html">Foo</a> &#x00BB; A
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Foo.A</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-t.A" class="def variant constructor anchored">
-       <a href="#type-t.A" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">A</span></span>
-       </code>
-      </li>
-     </ol>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Foo.A</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-t.A" class="def variant constructor anchored">
+        <a href="#type-t.A" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">A</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent_impl-Foo-B.html
+++ b/test/generators/html/Recent_impl-Foo-B.html
@@ -12,22 +12,24 @@
    <a href="Recent_impl.html">Recent_impl</a> &#x00BB; 
    <a href="Recent_impl-Foo.html">Foo</a> &#x00BB; B
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Foo.B</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-t.B" class="def variant constructor anchored">
-       <a href="#type-t.B" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">B</span></span>
-       </code>
-      </li>
-     </ol>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Foo.B</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span><span> = </span>
+      </code>
+      <ol>
+       <li id="type-t.B" class="def variant constructor anchored">
+        <a href="#type-t.B" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">B</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent_impl-Foo.html
+++ b/test/generators/html/Recent_impl-Foo.html
@@ -11,34 +11,36 @@
   <nav class="odoc-nav"><a href="Recent_impl.html">Up</a> – 
    <a href="Recent_impl.html">Recent_impl</a> &#x00BB; Foo
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Recent_impl.Foo</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-A">
-     <a href="#module-A" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Recent_impl-Foo-A.html">A</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Recent_impl.Foo</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-A">
+      <a href="#module-A" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Recent_impl-Foo-A.html">A</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-B">
-     <a href="#module-B" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Recent_impl-Foo-B.html">B</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-B">
+      <a href="#module-B" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Recent_impl-Foo-B.html">B</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent_impl-module-type-S-F-argument-1-_.html
+++ b/test/generators/html/Recent_impl-module-type-S-F-argument-1-_.html
@@ -13,8 +13,10 @@
    <a href="Recent_impl-module-type-S.html">S</a> &#x00BB; 
    <a href="Recent_impl-module-type-S-F.html">F</a> &#x00BB; _
   </nav>
-  <header class="odoc-preamble">
-   <h1>Parameter <code><span>F._</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Parameter <code><span>F._</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Recent_impl-module-type-S-F.html
+++ b/test/generators/html/Recent_impl-module-type-S-F.html
@@ -12,33 +12,36 @@
     – <a href="Recent_impl.html">Recent_impl</a> &#x00BB; 
    <a href="Recent_impl-module-type-S.html">S</a> &#x00BB; F
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>S.F</span></code></h1>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#parameters">Parameters</a></li>
     <li><a href="#signature">Signature</a></li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec parameter anchored" id="argument-1-_">
-     <a href="#argument-1-_" class="anchor"></a>
-     <code><span><span class="keyword">module</span> </span>
-      <span><a href="Recent_impl-module-type-S-F-argument-1-_.html">_</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S.F</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec parameter anchored" id="argument-1-_">
+      <a href="#argument-1-_" class="anchor"></a>
+      <code><span><span class="keyword">module</span> </span>
+       <span><a href="Recent_impl-module-type-S-F-argument-1-_.html">_</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+    <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent_impl-module-type-S-X.html
+++ b/test/generators/html/Recent_impl-module-type-S-X.html
@@ -12,7 +12,10 @@
     – <a href="Recent_impl.html">Recent_impl</a> &#x00BB; 
    <a href="Recent_impl-module-type-S.html">S</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble"><h1>Module <code><span>S.X</span></code></h1>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>S.X</span></code></h1>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Recent_impl-module-type-S.html
+++ b/test/generators/html/Recent_impl-module-type-S.html
@@ -11,46 +11,48 @@
   <nav class="odoc-nav"><a href="Recent_impl.html">Up</a> – 
    <a href="Recent_impl.html">Recent_impl</a> &#x00BB; S
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Recent_impl.S</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-F">
-     <a href="#module-F" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Recent_impl-module-type-S-F.html">F</a>
-      </span>
-      <span> (<a href="Recent_impl-module-type-S-F-argument-1-_.html">_</a>
-        : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>) : <span class="keyword">sig</span>
-        ... <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Recent_impl.S</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-F">
+      <a href="#module-F" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Recent_impl-module-type-S-F.html">F</a>
+       </span>
+       <span> (<a href="Recent_impl-module-type-S-F-argument-1-_.html">_</a>
+         : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>) : <span class="keyword">sig</span>
+         ... <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-X">
-     <a href="#module-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Recent_impl-module-type-S-X.html">X</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-X">
+      <a href="#module-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Recent_impl-module-type-S-X.html">X</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-f">
-     <a href="#val-f" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> f : 
-       <a href="Recent_impl-module-type-S-F.html#type-t">F(X).t</a>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-f">
+      <a href="#val-f" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> f : 
+        <a href="Recent_impl-module-type-S-F.html#type-t">F(X).t</a>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Recent_impl.html
+++ b/test/generators/html/Recent_impl.html
@@ -8,62 +8,64 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Recent_impl</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Foo">
-     <a href="#module-Foo" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Recent_impl-Foo.html">Foo</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Recent_impl</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Foo">
+      <a href="#module-Foo" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Recent_impl-Foo.html">Foo</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-B">
-     <a href="#module-B" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Recent_impl-B.html">B</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-B">
+      <a href="#module-B" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Recent_impl-B.html">B</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-S">
-     <a href="#module-type-S" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Recent_impl-module-type-S.html">S</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-S">
+      <a href="#module-type-S" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Recent_impl-module-type-S.html">S</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-B'">
-     <a href="#module-B'" class="anchor"></a>
-     <code><span><span class="keyword">module</span> B'</span>
-      <span> = <a href="Recent_impl-Foo-B.html">Foo.B</a></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-B'">
+      <a href="#module-B'" class="anchor"></a>
+      <code><span><span class="keyword">module</span> B'</span>
+       <span> = <a href="Recent_impl-Foo-B.html">Foo.B</a></span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Section.html
+++ b/test/generators/html/Section.html
@@ -8,12 +8,6 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Section</span></code></h1>
-   <p>This is the module comment. Eventually, sections won't be allowed
-     in it.
-   </p>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#empty-section">Empty section</a></li>
     <li><a href="#text-only">Text only</a></li>
@@ -35,40 +29,49 @@
     </li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="empty-section"><a href="#empty-section" class="anchor"></a>
-    Empty section
-   </h2>
-   <h2 id="text-only"><a href="#text-only" class="anchor"></a>Text only</h2>
-   <p>Foo bar.</p>
-   <h2 id="aside-only"><a href="#aside-only" class="anchor"></a>Aside only
-   </h2><p>Foo bar.</p>
-   <h2 id="value-only"><a href="#value-only" class="anchor"></a>Value only
-   </h2>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code><span><span class="keyword">val</span> foo : unit</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Section</span></code></h1>
+    <p>This is the module comment. Eventually, sections won't be allowed
+      in it.
+    </p>
+   </header>
+   <div class="odoc-content">
+    <h2 id="empty-section"><a href="#empty-section" class="anchor"></a>
+     Empty section
+    </h2>
+    <h2 id="text-only"><a href="#text-only" class="anchor"></a>Text only</h2>
+    <p>Foo bar.</p>
+    <h2 id="aside-only"><a href="#aside-only" class="anchor"></a>Aside only
+    </h2><p>Foo bar.</p>
+    <h2 id="value-only"><a href="#value-only" class="anchor"></a>Value only
+    </h2>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code><span><span class="keyword">val</span> foo : unit</span></code>
+     </div>
     </div>
+    <h2 id="empty-section_2"><a href="#empty-section_2" class="anchor"></a>
+     Empty section
+    </h2>
+    <h2 id="within-a-comment"><a href="#within-a-comment" class="anchor"></a>
+     within a comment
+    </h2>
+    <h3 id="and-one-with-a-nested-section">
+     <a href="#and-one-with-a-nested-section" class="anchor"></a>and 
+     one with a nested section
+    </h3>
+    <h2 id="this-section-title-has-markup">
+     <a href="#this-section-title-has-markup" class="anchor"></a>
+     <em>This</em> <code>section</code> <b>title</b> <sub>has</sub> 
+     <sup>markup</sup>
+    </h2>
+    <p>But links are impossible thanks to the parser, so we never have
+      trouble rendering a section title in a table of contents – no
+      link will be nested inside another link.
+    </p>
    </div>
-   <h2 id="empty-section_2"><a href="#empty-section_2" class="anchor"></a>
-    Empty section
-   </h2>
-   <h2 id="within-a-comment"><a href="#within-a-comment" class="anchor"></a>
-    within a comment
-   </h2>
-   <h3 id="and-one-with-a-nested-section">
-    <a href="#and-one-with-a-nested-section" class="anchor"></a>and one
-     with a nested section
-   </h3>
-   <h2 id="this-section-title-has-markup">
-    <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em>
-     <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
-   </h2>
-   <p>But links are impossible thanks to the parser, so we never have
-     trouble rendering a section title in a table of contents – no 
-    link will be nested inside another link.
-   </p>
   </div>
  </body>
 </html>

--- a/test/generators/html/Stop-N.html
+++ b/test/generators/html/Stop-N.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Stop.html">Up</a> – 
    <a href="Stop.html">Stop</a> &#x00BB; N
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Stop.N</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-quux">
-     <a href="#val-quux" class="anchor"></a>
-     <code><span><span class="keyword">val</span> quux : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Stop.N</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-quux">
+      <a href="#val-quux" class="anchor"></a>
+      <code><span><span class="keyword">val</span> quux : int</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Stop-O.html
+++ b/test/generators/html/Stop-O.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Stop.html">Up</a> – 
    <a href="Stop.html">Stop</a> &#x00BB; O
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Stop.O</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-bar">
-     <a href="#val-bar" class="anchor"></a>
-     <code><span><span class="keyword">val</span> bar : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Stop.O</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-bar">
+      <a href="#val-bar" class="anchor"></a>
+      <code><span><span class="keyword">val</span> bar : int</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Stop-P.html
+++ b/test/generators/html/Stop-P.html
@@ -11,14 +11,16 @@
   <nav class="odoc-nav"><a href="Stop.html">Up</a> – 
    <a href="Stop.html">Stop</a> &#x00BB; P
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Stop.P</span></code></h1><p>Doc.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-bar">
-     <a href="#val-bar" class="anchor"></a>
-     <code><span><span class="keyword">val</span> bar : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Stop.P</span></code></h1><p>Doc.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-bar">
+      <a href="#val-bar" class="anchor"></a>
+      <code><span><span class="keyword">val</span> bar : int</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Stop.html
+++ b/test/generators/html/Stop.html
@@ -8,74 +8,77 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Stop</span></code></h1>
-   <p>This test cases exercises stop comments.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code><span><span class="keyword">val</span> foo : int</span></code>
-    </div><div class="spec-doc"><p>This is normal commented text.</p></div>
-   </div>
-   <p>The next value is <code>bar</code>, and it should be missing from
-     the documentation. There is also an entire module, <code>M</code>
-    , which should also be hidden. It contains a nested stop comment,
-     but that stop comment should not turn documentation back on in this
-     outer module, because stop comments respect scope.
-   </p><p>Documentation is on again.</p>
-   <p>Now, we have a nested module, and it has a stop comment between
-     its two items. We want to see that the first item is displayed, 
-    but the second is missing, and the stop comment disables documenation
-     only in that module, and not in this outer module.
-   </p>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-N">
-     <a href="#module-N" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Stop-N.html">N</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Stop</span></code></h1>
+    <p>This test cases exercises stop comments.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code><span><span class="keyword">val</span> foo : int</span></code>
+     </div><div class="spec-doc"><p>This is normal commented text.</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-lol">
-     <a href="#val-lol" class="anchor"></a>
-     <code><span><span class="keyword">val</span> lol : int</span></code>
+    <p>The next value is <code>bar</code>, and it should be missing from
+      the documentation. There is also an entire module, <code>M</code>
+     , which should also be hidden. It contains a nested stop comment,
+      but that stop comment should not turn documentation back on in 
+     this outer module, because stop comments respect scope.
+    </p><p>Documentation is on again.</p>
+    <p>Now, we have a nested module, and it has a stop comment between
+      its two items. We want to see that the first item is displayed,
+      but the second is missing, and the stop comment disables documenation
+      only in that module, and not in this outer module.
+    </p>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-N">
+      <a href="#module-N" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> <a href="Stop-N.html">N</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <p>The first comment can also be a stop-comment. The test case 
-    <code>stop_first_comment.mli</code> is testing the same thing but
-     at the toplevel. We should see <code>bar</code> inside 
-    <a href="Stop-O.html"><code>O</code></a>.
-   </p>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-O">
-     <a href="#module-O" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Stop-O.html">O</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-lol">
+      <a href="#val-lol" class="anchor"></a>
+      <code><span><span class="keyword">val</span> lol : int</span></code>
+     </div>
     </div>
-   </div><p>The top-comment computation must not mess with stop comments.</p>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-P">
-     <a href="#module-P" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> <a href="Stop-P.html">P</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Doc.</p></div>
+    <p>The first comment can also be a stop-comment. The test case 
+     <code>stop_first_comment.mli</code> is testing the same thing but
+      at the toplevel. We should see <code>bar</code> inside 
+     <a href="Stop-O.html"><code>O</code></a>.
+    </p>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-O">
+      <a href="#module-O" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> <a href="Stop-O.html">O</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <p>The top-comment computation must not mess with stop comments.</p>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-P">
+      <a href="#module-P" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> <a href="Stop-P.html">P</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Doc.</p></div>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Stop_dead_link_doc-Foo.html
+++ b/test/generators/html/Stop_dead_link_doc-Foo.html
@@ -12,14 +12,16 @@
    <a href="Stop_dead_link_doc.html">Stop_dead_link_doc</a> &#x00BB; 
    Foo
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Stop_dead_link_doc.Foo</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Stop_dead_link_doc.Foo</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Stop_dead_link_doc.html
+++ b/test/generators/html/Stop_dead_link_doc.html
@@ -8,190 +8,194 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Stop_dead_link_doc</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Foo">
-     <a href="#module-Foo" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Stop_dead_link_doc-Foo.html">Foo</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Stop_dead_link_doc</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Foo">
+      <a href="#module-Foo" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Stop_dead_link_doc-Foo.html">Foo</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-foo">
-     <a href="#type-foo" class="anchor"></a>
-     <code><span><span class="keyword">type</span> foo</span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-foo.Bar" class="def variant constructor anchored">
-       <a href="#type-foo.Bar" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Bar</span> 
-         <span class="keyword">of</span> 
-         <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a>
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-bar">
-     <a href="#type-bar" class="anchor"></a>
-     <code><span><span class="keyword">type</span> bar</span><span> = </span>
-     </code>
-     <ol>
-      <li id="type-bar.Bar" class="def variant constructor anchored">
-       <a href="#type-bar.Bar" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Bar</span> 
-         <span class="keyword">of</span> 
-        </span><span>{</span>
-       </code>
-       <ol>
-        <li id="type-bar.field" class="def record field anchored">
-         <a href="#type-bar.field" class="anchor"></a>
-         <code>
-          <span>field : 
-           <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a>;
-          </span>
-         </code>
-        </li>
-       </ol><code><span>}</span></code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-foo_">
-     <a href="#type-foo_" class="anchor"></a>
-     <code><span><span class="keyword">type</span> foo_</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-foo_.Bar_" class="def variant constructor anchored">
-       <a href="#type-foo_.Bar_" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Bar_</span> 
-         <span class="keyword">of</span> int * 
-         <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a> * int
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-bar_">
-     <a href="#type-bar_" class="anchor"></a>
-     <code><span><span class="keyword">type</span> bar_</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-bar_.Bar__" class="def variant constructor anchored">
-       <a href="#type-bar_.Bar__" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Bar__</span> 
-         <span class="keyword">of</span> 
-         <span><a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a> option
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-foo">
+      <a href="#type-foo" class="anchor"></a>
+      <code><span><span class="keyword">type</span> foo</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-foo.Bar" class="def variant constructor anchored">
+        <a href="#type-foo.Bar" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Bar</span> 
+          <span class="keyword">of</span> 
+          <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a>
          </span>
-        </span>
-       </code>
-      </li>
-     </ol>
+        </code>
+       </li>
+      </ol>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-another_foo">
-     <a href="#type-another_foo" class="anchor"></a>
-     <code><span><span class="keyword">type</span> another_foo</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-another_foo.Bar" class="def variant constructor anchored">
-       <a href="#type-another_foo.Bar" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Bar</span> 
-         <span class="keyword">of</span> 
-         <span class="xref-unresolved">Another_Foo.t</span>
-        </span>
-       </code>
-      </li>
-     </ol>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-bar">
+      <a href="#type-bar" class="anchor"></a>
+      <code><span><span class="keyword">type</span> bar</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-bar.Bar" class="def variant constructor anchored">
+        <a href="#type-bar.Bar" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Bar</span> 
+          <span class="keyword">of</span> 
+         </span><span>{</span>
+        </code>
+        <ol>
+         <li id="type-bar.field" class="def record field anchored">
+          <a href="#type-bar.field" class="anchor"></a>
+          <code>
+           <span>field : 
+            <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a>;
+           </span>
+          </code>
+         </li>
+        </ol><code><span>}</span></code>
+       </li>
+      </ol>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-another_bar">
-     <a href="#type-another_bar" class="anchor"></a>
-     <code><span><span class="keyword">type</span> another_bar</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-another_bar.Bar" class="def variant constructor anchored">
-       <a href="#type-another_bar.Bar" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Bar</span> 
-         <span class="keyword">of</span> 
-        </span><span>{</span>
-       </code>
-       <ol>
-        <li id="type-another_bar.field" class="def record field anchored">
-         <a href="#type-another_bar.field" class="anchor"></a>
-         <code>
-          <span>field : <span class="xref-unresolved">Another_Foo.t</span>;
-          </span>
-         </code>
-        </li>
-       </ol><code><span>}</span></code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-another_foo_">
-     <a href="#type-another_foo_" class="anchor"></a>
-     <code><span><span class="keyword">type</span> another_foo_</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-another_foo_.Bar_" class="def variant constructor
-       anchored"><a href="#type-another_foo_.Bar_" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Bar_</span> 
-         <span class="keyword">of</span> int * 
-         <span class="xref-unresolved">Another_Foo.t</span> * int
-        </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-another_bar_">
-     <a href="#type-another_bar_" class="anchor"></a>
-     <code><span><span class="keyword">type</span> another_bar_</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-another_bar_.Bar__" class="def variant constructor
-       anchored"><a href="#type-another_bar_.Bar__" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">Bar__</span> 
-         <span class="keyword">of</span> 
-         <span><span class="xref-unresolved">Another_Foo.t</span> option
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-foo_">
+      <a href="#type-foo_" class="anchor"></a>
+      <code><span><span class="keyword">type</span> foo_</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-foo_.Bar_" class="def variant constructor anchored">
+        <a href="#type-foo_.Bar_" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Bar_</span> 
+          <span class="keyword">of</span> int * 
+          <a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a> * int
          </span>
-        </span>
-       </code>
-      </li>
-     </ol>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-bar_">
+      <a href="#type-bar_" class="anchor"></a>
+      <code><span><span class="keyword">type</span> bar_</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-bar_.Bar__" class="def variant constructor anchored">
+        <a href="#type-bar_.Bar__" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Bar__</span> 
+          <span class="keyword">of</span> 
+          <span><a href="Stop_dead_link_doc-Foo.html#type-t">Foo.t</a> option
+          </span>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-another_foo">
+      <a href="#type-another_foo" class="anchor"></a>
+      <code><span><span class="keyword">type</span> another_foo</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-another_foo.Bar" class="def variant constructor anchored">
+        <a href="#type-another_foo.Bar" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Bar</span> 
+          <span class="keyword">of</span> 
+          <span class="xref-unresolved">Another_Foo.t</span>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-another_bar">
+      <a href="#type-another_bar" class="anchor"></a>
+      <code><span><span class="keyword">type</span> another_bar</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-another_bar.Bar" class="def variant constructor anchored">
+        <a href="#type-another_bar.Bar" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Bar</span> 
+          <span class="keyword">of</span> 
+         </span><span>{</span>
+        </code>
+        <ol>
+         <li id="type-another_bar.field" class="def record field anchored">
+          <a href="#type-another_bar.field" class="anchor"></a>
+          <code>
+           <span>field : <span class="xref-unresolved">Another_Foo.t</span>;
+           </span>
+          </code>
+         </li>
+        </ol><code><span>}</span></code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-another_foo_">
+      <a href="#type-another_foo_" class="anchor"></a>
+      <code><span><span class="keyword">type</span> another_foo_</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-another_foo_.Bar_" class="def variant constructor
+        anchored"><a href="#type-another_foo_.Bar_" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Bar_</span> 
+          <span class="keyword">of</span> int * 
+          <span class="xref-unresolved">Another_Foo.t</span> * int
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-another_bar_">
+      <a href="#type-another_bar_" class="anchor"></a>
+      <code><span><span class="keyword">type</span> another_bar_</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-another_bar_.Bar__" class="def variant constructor
+        anchored"><a href="#type-another_bar_.Bar__" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">Bar__</span> 
+          <span class="keyword">of</span> 
+          <span><span class="xref-unresolved">Another_Foo.t</span> option
+          </span>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Stop_first_comment.html
+++ b/test/generators/html/Stop_first_comment.html
@@ -8,14 +8,16 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Stop_first_comment</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-bar">
-     <a href="#val-bar" class="anchor"></a>
-     <code><span><span class="keyword">val</span> bar : int</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Stop_first_comment</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-bar">
+      <a href="#val-bar" class="anchor"></a>
+      <code><span><span class="keyword">val</span> bar : int</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Tag_link.html
+++ b/test/generators/html/Tag_link.html
@@ -8,49 +8,51 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Tag_link</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-foo">
-     <a href="#val-foo" class="anchor"></a>
-     <code><span><span class="keyword">val</span> foo : unit</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Tag_link</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-foo">
+      <a href="#val-foo" class="anchor"></a>
+      <code><span><span class="keyword">val</span> foo : unit</span></code>
+     </div>
     </div>
-   </div>
-   <ul class="at-tags">
-    <li class="deprecated"><span class="at-tag">deprecated</span> 
-     <p><a href="#val-foo"><code>foo</code></a></p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="parameter"><span class="at-tag">parameter</span> 
-     <span class="value">foo</span> 
-     <p><a href="#val-foo"><code>foo</code></a></p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="raises"><span class="at-tag">raises</span> <code>Foo</code>
+    <ul class="at-tags">
+     <li class="deprecated"><span class="at-tag">deprecated</span> 
       <p><a href="#val-foo"><code>foo</code></a></p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="returns"><span class="at-tag">returns</span> 
-     <p><a href="#val-foo"><code>foo</code></a></p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="see"><span class="at-tag">see</span> 
-     <span class="value">foo</span> 
-     <p><a href="#val-foo"><code>foo</code></a></p>
-    </li>
-   </ul>
-   <ul class="at-tags">
-    <li class="before"><span class="at-tag">before</span> 
-     <span class="value">0.0.1</span> 
-     <p><a href="#val-foo"><code>foo</code></a></p>
-    </li>
-   </ul>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="parameter"><span class="at-tag">parameter</span> 
+      <span class="value">foo</span> 
+      <p><a href="#val-foo"><code>foo</code></a></p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="raises"><span class="at-tag">raises</span> <code>Foo</code>
+       <p><a href="#val-foo"><code>foo</code></a></p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="returns"><span class="at-tag">returns</span> 
+      <p><a href="#val-foo"><code>foo</code></a></p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="see"><span class="at-tag">see</span> 
+      <span class="value">foo</span> 
+      <p><a href="#val-foo"><code>foo</code></a></p>
+     </li>
+    </ul>
+    <ul class="at-tags">
+     <li class="before"><span class="at-tag">before</span> 
+      <span class="value">0.0.1</span> 
+      <p><a href="#val-foo"><code>foo</code></a></p>
+     </li>
+    </ul>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Toplevel_comments-Alias.html
+++ b/test/generators/html/Toplevel_comments-Alias.html
@@ -11,15 +11,17 @@
   <nav class="odoc-nav"><a href="Toplevel_comments.html">Up</a> – 
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; Alias
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Toplevel_comments.Alias</span></code></h1>
-   <p>Doc of <code>Alias</code>.</p><p>Doc of <code>T</code>, part 2.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Toplevel_comments.Alias</span></code></h1>
+    <p>Doc of <code>Alias</code>.</p><p>Doc of <code>T</code>, part 2.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Toplevel_comments-Comments_on_open-M.html
+++ b/test/generators/html/Toplevel_comments-Comments_on_open-M.html
@@ -14,14 +14,16 @@
    <a href="Toplevel_comments-Comments_on_open.html">Comments_on_open</a>
     &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Comments_on_open.M</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Comments_on_open.M</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Toplevel_comments-Comments_on_open.html
+++ b/test/generators/html/Toplevel_comments-Comments_on_open.html
@@ -12,31 +12,33 @@
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; 
    Comments_on_open
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Toplevel_comments.Comments_on_open</span></code>
-   </h1>
-  </header>
   <nav class="odoc-toc"><ul><li><a href="#sec">Section</a></li></ul></nav>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Toplevel_comments-Comments_on_open-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div><h3 id="sec"><a href="#sec" class="anchor"></a>Section</h3>
-   <p>Comments attached to open are treated as floating comments. Referencing
-     <a href="#sec" title="sec">Section</a> 
-    <a href="Toplevel_comments-Comments_on_open-M.html#type-t">
-     <code>M.t</code>
-    </a> works
-   </p>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Toplevel_comments.Comments_on_open</span></code>
+    </h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Toplevel_comments-Comments_on_open-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+    </div><h3 id="sec"><a href="#sec" class="anchor"></a>Section</h3>
+    <p>Comments attached to open are treated as floating comments. 
+     Referencing <a href="#sec" title="sec">Section</a> 
+     <a href="Toplevel_comments-Comments_on_open-M.html#type-t">
+      <code>M.t</code>
+     </a> works
+    </p>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Toplevel_comments-Include_inline'.html
+++ b/test/generators/html/Toplevel_comments-Include_inline'.html
@@ -12,16 +12,18 @@
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; 
    Include_inline'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Toplevel_comments.Include_inline'</span></code>
-   </h1><p>Doc of <code>Include_inline</code>, part 1.</p>
-   <p>Doc of <code>Include_inline</code>, part 2.</p>
-  </header>
-  <div class="odoc-content"><div class="spec-doc"><p>part 3</p></div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Toplevel_comments.Include_inline'</span></code>
+    </h1><p>Doc of <code>Include_inline</code>, part 1.</p>
+    <p>Doc of <code>Include_inline</code>, part 2.</p>
+   </header>
+   <div class="odoc-content"><div class="spec-doc"><p>part 3</p></div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Toplevel_comments-Include_inline.html
+++ b/test/generators/html/Toplevel_comments-Include_inline.html
@@ -12,15 +12,17 @@
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; 
    Include_inline
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Toplevel_comments.Include_inline</span></code></h1>
-   <p>Doc of <code>T</code>, part 2.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Toplevel_comments.Include_inline</span></code>
+    </h1><p>Doc of <code>T</code>, part 2.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Toplevel_comments-M''.html
+++ b/test/generators/html/Toplevel_comments-M''.html
@@ -11,10 +11,12 @@
   <nav class="odoc-nav"><a href="Toplevel_comments.html">Up</a> – 
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; M''
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Toplevel_comments.M''</span></code></h1>
-   <p>Doc of <code>M''</code>, part 1.</p>
-   <p>Doc of <code>M''</code>, part 2.</p>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Toplevel_comments.M''</span></code></h1>
+    <p>Doc of <code>M''</code>, part 1.</p>
+    <p>Doc of <code>M''</code>, part 2.</p>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Toplevel_comments-M'.html
+++ b/test/generators/html/Toplevel_comments-M'.html
@@ -11,9 +11,11 @@
   <nav class="odoc-nav"><a href="Toplevel_comments.html">Up</a> – 
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; M'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Toplevel_comments.M'</span></code></h1>
-   <p>Doc of <code>M'</code> from outside</p>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Toplevel_comments.M'</span></code></h1>
+    <p>Doc of <code>M'</code> from outside</p>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Toplevel_comments-M.html
+++ b/test/generators/html/Toplevel_comments-M.html
@@ -11,9 +11,11 @@
   <nav class="odoc-nav"><a href="Toplevel_comments.html">Up</a> – 
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; M
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Toplevel_comments.M</span></code></h1>
-   <p>Doc of <code>M</code></p>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Toplevel_comments.M</span></code></h1>
+    <p>Doc of <code>M</code></p>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Toplevel_comments-Ref_in_synopsis.html
+++ b/test/generators/html/Toplevel_comments-Ref_in_synopsis.html
@@ -12,18 +12,20 @@
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; 
    Ref_in_synopsis
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Toplevel_comments.Ref_in_synopsis</span></code>
-   </h1><p><a href="#type-t"><code>t</code></a>.</p>
-   <p>This reference should resolve in the context of this module, even
-     when used as a synopsis.
-   </p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Toplevel_comments.Ref_in_synopsis</span></code>
+    </h1><p><a href="#type-t"><code>t</code></a>.</p>
+    <p>This reference should resolve in the context of this module, even
+      when used as a synopsis.
+    </p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Toplevel_comments-class-c1.html
+++ b/test/generators/html/Toplevel_comments-class-c1.html
@@ -11,10 +11,12 @@
   <nav class="odoc-nav"><a href="Toplevel_comments.html">Up</a> – 
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; c1
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Toplevel_comments.c1</span></code></h1>
-   <p>Doc of <code>c1</code>, part 1.</p>
-   <p>Doc of <code>c1</code>, part 2.</p>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Toplevel_comments.c1</span></code></h1>
+    <p>Doc of <code>c1</code>, part 1.</p>
+    <p>Doc of <code>c1</code>, part 2.</p>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Toplevel_comments-class-c2.html
+++ b/test/generators/html/Toplevel_comments-class-c2.html
@@ -11,9 +11,11 @@
   <nav class="odoc-nav"><a href="Toplevel_comments.html">Up</a> – 
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; c2
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class <code><span>Toplevel_comments.c2</span></code></h1>
-   <p>Doc of <code>c2</code>.</p><p>Doc of <code>ct</code>, part 2.</p>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class <code><span>Toplevel_comments.c2</span></code></h1>
+    <p>Doc of <code>c2</code>.</p><p>Doc of <code>ct</code>, part 2.</p>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Toplevel_comments-class-type-ct.html
+++ b/test/generators/html/Toplevel_comments-class-type-ct.html
@@ -11,10 +11,12 @@
   <nav class="odoc-nav"><a href="Toplevel_comments.html">Up</a> – 
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; ct
   </nav>
-  <header class="odoc-preamble">
-   <h1>Class type <code><span>Toplevel_comments.ct</span></code></h1>
-   <p>Doc of <code>ct</code>, part 1.</p>
-   <p>Doc of <code>ct</code>, part 2.</p>
-  </header><div class="odoc-content"></div>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Class type <code><span>Toplevel_comments.ct</span></code></h1>
+    <p>Doc of <code>ct</code>, part 1.</p>
+    <p>Doc of <code>ct</code>, part 2.</p>
+   </header><div class="odoc-content"></div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Toplevel_comments-module-type-Include_inline_T'.html
+++ b/test/generators/html/Toplevel_comments-module-type-Include_inline_T'.html
@@ -12,17 +12,19 @@
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; 
    Include_inline_T'
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type 
-    <code><span>Toplevel_comments.Include_inline_T'</span></code>
-   </h1><p>Doc of <code>Include_inline_T'</code>, part 1.</p>
-   <p>Doc of <code>Include_inline_T'</code>, part 2.</p>
-  </header>
-  <div class="odoc-content"><div class="spec-doc"><p>part 3</p></div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type 
+     <code><span>Toplevel_comments.Include_inline_T'</span></code>
+    </h1><p>Doc of <code>Include_inline_T'</code>, part 1.</p>
+    <p>Doc of <code>Include_inline_T'</code>, part 2.</p>
+   </header>
+   <div class="odoc-content"><div class="spec-doc"><p>part 3</p></div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Toplevel_comments-module-type-Include_inline_T.html
+++ b/test/generators/html/Toplevel_comments-module-type-Include_inline_T.html
@@ -12,16 +12,18 @@
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; 
    Include_inline_T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type 
-    <code><span>Toplevel_comments.Include_inline_T</span></code>
-   </h1><p>Doc of <code>T</code>, part 2.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type 
+     <code><span>Toplevel_comments.Include_inline_T</span></code>
+    </h1><p>Doc of <code>T</code>, part 2.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Toplevel_comments-module-type-T.html
+++ b/test/generators/html/Toplevel_comments-module-type-T.html
@@ -11,15 +11,18 @@
   <nav class="odoc-nav"><a href="Toplevel_comments.html">Up</a> – 
    <a href="Toplevel_comments.html">Toplevel_comments</a> &#x00BB; T
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Toplevel_comments.T</span></code></h1>
-   <p>Doc of <code>T</code>, part 1.</p><p>Doc of <code>T</code>, part 2.</p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Toplevel_comments.T</span></code></h1>
+    <p>Doc of <code>T</code>, part 1.</p>
+    <p>Doc of <code>T</code>, part 2.</p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Toplevel_comments.html
+++ b/test/generators/html/Toplevel_comments.html
@@ -8,206 +8,211 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Toplevel_comments</span></code></h1>
-   <p>A doc comment at the beginning of a module is considered to be 
-    that module's doc.
-   </p>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-T">
-     <a href="#module-type-T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Toplevel_comments-module-type-T.html">T</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Doc of <code>T</code>, part 1.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Include_inline">
-     <a href="#module-Include_inline" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Toplevel_comments-Include_inline.html">Include_inline</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Doc of <code>T</code>, part 2.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Include_inline'">
-     <a href="#module-Include_inline'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Toplevel_comments-Include_inline'.html">Include_inline'</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Toplevel_comments</span></code></h1>
+    <p>A doc comment at the beginning of a module is considered to be
+      that module's doc.
+    </p>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-T">
+      <a href="#module-type-T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Toplevel_comments-module-type-T.html">T</a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Doc of <code>T</code>, part 1.</p></div>
     </div>
-    <div class="spec-doc"><p>Doc of <code>Include_inline</code>, part 1.</p>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Include_inline">
+      <a href="#module-Include_inline" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Toplevel_comments-Include_inline.html">Include_inline</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Doc of <code>T</code>, part 2.</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Include_inline_T">
-     <a href="#module-type-Include_inline_T" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Toplevel_comments-module-type-Include_inline_T.html">
-        Include_inline_T
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Doc of <code>T</code>, part 2.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-Include_inline_T'">
-     <a href="#module-type-Include_inline_T'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Toplevel_comments-module-type-Include_inline_T'.html">
-        Include_inline_T'
-       </a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Include_inline'">
+      <a href="#module-Include_inline'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Toplevel_comments-Include_inline'.html">Include_inline'</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>Doc of <code>Include_inline</code>, part 1.</p>
+     </div>
     </div>
-    <div class="spec-doc">
-     <p>Doc of <code>Include_inline_T'</code>, part 1.</p>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-Include_inline_T">
+      <a href="#module-type-Include_inline_T" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Toplevel_comments-module-type-Include_inline_T.html">
+         Include_inline_T
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Doc of <code>T</code>, part 2.</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M">
-     <a href="#module-M" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Toplevel_comments-M.html">M</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Doc of <code>M</code></p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M'">
-     <a href="#module-M'" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Toplevel_comments-M'.html">M'</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored"
+      id="module-type-Include_inline_T'">
+      <a href="#module-type-Include_inline_T'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Toplevel_comments-module-type-Include_inline_T'.html">
+         Include_inline_T'
+        </a>
+       </span>
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>Doc of <code>Include_inline_T'</code>, part 1.</p>
+     </div>
     </div>
-    <div class="spec-doc"><p>Doc of <code>M'</code> from outside</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-M''">
-     <a href="#module-M''" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Toplevel_comments-M''.html">M''</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Doc of <code>M''</code>, part 1.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Alias">
-     <a href="#module-Alias" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Toplevel_comments-Alias.html">Alias</a>
-      </span>
-      <span> : <a href="Toplevel_comments-module-type-T.html">T</a></span>
-     </code>
-    </div><div class="spec-doc"><p>Doc of <code>Alias</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-c1">
-     <a href="#class-c1" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Toplevel_comments-class-c1.html">c1</a></span>
-      <span> : <span>int <span class="arrow">&#45;&gt;</span></span> 
-       <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Doc of <code>c1</code>, part 1.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class-type anchored" id="class-type-ct">
-     <a href="#class-type-ct" class="anchor"></a>
-     <code>
-      <span><span class="keyword">class</span> 
-       <span class="keyword">type</span>  
-      </span>
-      <span><a href="Toplevel_comments-class-type-ct.html">ct</a></span>
-      <span> = <span class="keyword">object</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div><div class="spec-doc"><p>Doc of <code>ct</code>, part 1.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec class anchored" id="class-c2">
-     <a href="#class-c2" class="anchor"></a>
-     <code><span><span class="keyword">class</span> </span>
-      <span><a href="Toplevel_comments-class-c2.html">c2</a></span>
-      <span> : <a href="Toplevel_comments-class-type-ct.html">ct</a></span>
-     </code>
-    </div><div class="spec-doc"><p>Doc of <code>c2</code>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Ref_in_synopsis">
-     <a href="#module-Ref_in_synopsis" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Toplevel_comments-Ref_in_synopsis.html">Ref_in_synopsis</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M">
+      <a href="#module-M" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Toplevel_comments-M.html">M</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Doc of <code>M</code></p></div>
     </div>
-    <div class="spec-doc">
-     <p>
-      <a href="Toplevel_comments-Ref_in_synopsis.html#type-t"><code>t</code>
-      </a>.
-     </p>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M'">
+      <a href="#module-M'" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Toplevel_comments-M'.html">M'</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>Doc of <code>M'</code> from outside</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module anchored" id="module-Comments_on_open">
-     <a href="#module-Comments_on_open" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <a href="Toplevel_comments-Comments_on_open.html">Comments_on_open</a>
-      </span>
-      <span> : <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-M''">
+      <a href="#module-M''" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Toplevel_comments-M''.html">M''</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc"><p>Doc of <code>M''</code>, part 1.</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Alias">
+      <a href="#module-Alias" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Toplevel_comments-Alias.html">Alias</a>
+       </span>
+       <span> : <a href="Toplevel_comments-module-type-T.html">T</a></span>
+      </code>
+     </div><div class="spec-doc"><p>Doc of <code>Alias</code>.</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-c1">
+      <a href="#class-c1" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Toplevel_comments-class-c1.html">c1</a></span>
+       <span> : <span>int <span class="arrow">&#45;&gt;</span></span>
+         <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Doc of <code>c1</code>, part 1.</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class-type anchored" id="class-type-ct">
+      <a href="#class-type-ct" class="anchor"></a>
+      <code>
+       <span><span class="keyword">class</span> 
+        <span class="keyword">type</span>  
+       </span>
+       <span><a href="Toplevel_comments-class-type-ct.html">ct</a></span>
+       <span> = <span class="keyword">object</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div><div class="spec-doc"><p>Doc of <code>ct</code>, part 1.</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec class anchored" id="class-c2">
+      <a href="#class-c2" class="anchor"></a>
+      <code><span><span class="keyword">class</span> </span>
+       <span><a href="Toplevel_comments-class-c2.html">c2</a></span>
+       <span> : <a href="Toplevel_comments-class-type-ct.html">ct</a></span>
+      </code>
+     </div><div class="spec-doc"><p>Doc of <code>c2</code>.</p></div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Ref_in_synopsis">
+      <a href="#module-Ref_in_synopsis" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Toplevel_comments-Ref_in_synopsis.html">Ref_in_synopsis</a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
+     <div class="spec-doc">
+      <p>
+       <a href="Toplevel_comments-Ref_in_synopsis.html#type-t"><code>t</code>
+       </a>.
+      </p>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module anchored" id="module-Comments_on_open">
+      <a href="#module-Comments_on_open" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <a href="Toplevel_comments-Comments_on_open.html">Comments_on_open
+        </a>
+       </span>
+       <span> : <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Type-module-type-X.html
+++ b/test/generators/html/Type-module-type-X.html
@@ -11,20 +11,22 @@
   <nav class="odoc-nav"><a href="Type.html">Up</a> – 
    <a href="Type.html">Type</a> &#x00BB; X
   </nav>
-  <header class="odoc-preamble">
-   <h1>Module type <code><span>Type.X</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-t">
-     <a href="#type-t" class="anchor"></a>
-     <code><span><span class="keyword">type</span> t</span></code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module type <code><span>Type.X</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-t">
+      <a href="#type-t" class="anchor"></a>
+      <code><span><span class="keyword">type</span> t</span></code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-u">
-     <a href="#type-u" class="anchor"></a>
-     <code><span><span class="keyword">type</span> u</span></code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-u">
+      <a href="#type-u" class="anchor"></a>
+      <code><span><span class="keyword">type</span> u</span></code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Type.html
+++ b/test/generators/html/Type.html
@@ -8,825 +8,832 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1>Module <code><span>Type</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-abstract">
-     <a href="#type-abstract" class="anchor"></a>
-     <code><span><span class="keyword">type</span> abstract</span></code>
-    </div><div class="spec-doc"><p>Some <em>documentation</em>.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-alias">
-     <a href="#type-alias" class="anchor"></a>
-     <code><span><span class="keyword">type</span> alias</span>
-      <span> = int</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Type</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-abstract">
+      <a href="#type-abstract" class="anchor"></a>
+      <code><span><span class="keyword">type</span> abstract</span></code>
+     </div><div class="spec-doc"><p>Some <em>documentation</em>.</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-private_">
-     <a href="#type-private_" class="anchor"></a>
-     <code><span><span class="keyword">type</span> private_</span>
-      <span> = <span class="keyword">private</span> int</span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-alias">
+      <a href="#type-alias" class="anchor"></a>
+      <code><span><span class="keyword">type</span> alias</span>
+       <span> = int</span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-constructor">
-     <a href="#type-constructor" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a constructor</span>
-      </span><span> = <span class="type-var">'a</span></span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-private_">
+      <a href="#type-private_" class="anchor"></a>
+      <code><span><span class="keyword">type</span> private_</span>
+       <span> = <span class="keyword">private</span> int</span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-arrow">
-     <a href="#type-arrow" class="anchor"></a>
-     <code><span><span class="keyword">type</span> arrow</span>
-      <span> = <span>int <span class="arrow">&#45;&gt;</span></span> int
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-constructor">
+      <a href="#type-constructor" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a constructor</span>
+       </span><span> = <span class="type-var">'a</span></span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-higher_order">
-     <a href="#type-higher_order" class="anchor"></a>
-     <code><span><span class="keyword">type</span> higher_order</span>
-      <span> = 
-       <span>
-        <span>(<span>int <span class="arrow">&#45;&gt;</span></span> int)
-        </span> <span class="arrow">&#45;&gt;</span>
-       </span> int
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-arrow">
+      <a href="#type-arrow" class="anchor"></a>
+      <code><span><span class="keyword">type</span> arrow</span>
+       <span> = <span>int <span class="arrow">&#45;&gt;</span></span> int
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-labeled">
-     <a href="#type-labeled" class="anchor"></a>
-     <code><span><span class="keyword">type</span> labeled</span>
-      <span> = 
-       <span><span class="label">l</span>:int 
-        <span class="arrow">&#45;&gt;</span>
-       </span> int
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-higher_order">
+      <a href="#type-higher_order" class="anchor"></a>
+      <code><span><span class="keyword">type</span> higher_order</span>
+       <span> = 
+        <span>
+         <span>(<span>int <span class="arrow">&#45;&gt;</span></span> int)
+         </span> <span class="arrow">&#45;&gt;</span>
+        </span> int
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-optional">
-     <a href="#type-optional" class="anchor"></a>
-     <code><span><span class="keyword">type</span> optional</span>
-      <span> = 
-       <span><span class="optlabel">?l</span>:int 
-        <span class="arrow">&#45;&gt;</span>
-       </span> int
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-labeled_higher_order">
-     <a href="#type-labeled_higher_order" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> labeled_higher_order</span>
-      <span> = 
-       <span>
-        <span>(
-         <span><span class="label">l</span>:int 
-          <span class="arrow">&#45;&gt;</span>
-         </span> int)
-        </span> <span class="arrow">&#45;&gt;</span>
-       </span> 
-       <span>
-        <span>(
-         <span><span class="optlabel">?l</span>:int 
-          <span class="arrow">&#45;&gt;</span>
-         </span> int)
-        </span> <span class="arrow">&#45;&gt;</span>
-       </span> int
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-pair">
-     <a href="#type-pair" class="anchor"></a>
-     <code><span><span class="keyword">type</span> pair</span>
-      <span> = int * int</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-parens_dropped">
-     <a href="#type-parens_dropped" class="anchor"></a>
-     <code><span><span class="keyword">type</span> parens_dropped</span>
-      <span> = int * int</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-triple">
-     <a href="#type-triple" class="anchor"></a>
-     <code><span><span class="keyword">type</span> triple</span>
-      <span> = int * int * int</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-nested_pair">
-     <a href="#type-nested_pair" class="anchor"></a>
-     <code><span><span class="keyword">type</span> nested_pair</span>
-      <span> = <span>(int * int)</span> * int</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-instance">
-     <a href="#type-instance" class="anchor"></a>
-     <code><span><span class="keyword">type</span> instance</span>
-      <span> = <span>int <a href="#type-constructor">constructor</a></span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-long">
-     <a href="#type-long" class="anchor"></a>
-     <code><span><span class="keyword">type</span> long</span>
-      <span> =
-                
-       <span><a href="#type-labeled_higher_order">labeled_higher_order</a>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-labeled">
+      <a href="#type-labeled" class="anchor"></a>
+      <code><span><span class="keyword">type</span> labeled</span>
+       <span> = 
+        <span><span class="label">l</span>:int 
          <span class="arrow">&#45;&gt;</span>
+        </span> int
        </span>
-                
-       <span>
-        <span>[ `Bar 
-         <span><span>| `Baz</span> of <a href="#type-triple">triple</a>
-         </span> ]
-        </span> <span class="arrow">&#45;&gt;</span>
-       </span>
-                
-       <span><a href="#type-pair">pair</a> 
-        <span class="arrow">&#45;&gt;</span>
-       </span>
-                
-       <span><a href="#type-labeled">labeled</a> 
-        <span class="arrow">&#45;&gt;</span>
-       </span>
-                
-       <span><a href="#type-higher_order">higher_order</a> 
-        <span class="arrow">&#45;&gt;</span>
-       </span>
-                
-       <span>
-        <span>(<span>string <span class="arrow">&#45;&gt;</span></span> int)
-        </span> <span class="arrow">&#45;&gt;</span>
-       </span>
-                
-       <span>
-        <span><span>(int * float * char * string * char * unit)</span> option
-        </span> <span class="arrow">&#45;&gt;</span>
-       </span>
-                
-       <span><a href="#type-nested_pair">nested_pair</a> 
-        <span class="arrow">&#45;&gt;</span>
-       </span>
-                
-       <span><a href="#type-arrow">arrow</a> 
-        <span class="arrow">&#45;&gt;</span>
-       </span>
-                
-       <span>string <span class="arrow">&#45;&gt;</span></span>
-                                                                 
-       <span><a href="#type-nested_pair">nested_pair</a> array</span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-variant_e">
-     <a href="#type-variant_e" class="anchor"></a>
-     <code><span><span class="keyword">type</span> variant_e</span>
-      <span> = </span><span>{</span>
-     </code>
-     <ol>
-      <li id="type-variant_e.a" class="def record field anchored">
-       <a href="#type-variant_e.a" class="anchor"></a>
-       <code><span>a : int;</span></code>
-      </li>
-     </ol><code><span>}</span></code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-optional">
+      <a href="#type-optional" class="anchor"></a>
+      <code><span><span class="keyword">type</span> optional</span>
+       <span> = 
+        <span><span class="optlabel">?l</span>:int 
+         <span class="arrow">&#45;&gt;</span>
+        </span> int
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-variant">
-     <a href="#type-variant" class="anchor"></a>
-     <code><span><span class="keyword">type</span> variant</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-variant.A" class="def variant constructor anchored">
-       <a href="#type-variant.A" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">A</span></span>
-       </code>
-      </li>
-      <li id="type-variant.B" class="def variant constructor anchored">
-       <a href="#type-variant.B" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">B</span> 
-         <span class="keyword">of</span> int
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-labeled_higher_order">
+      <a href="#type-labeled_higher_order" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> labeled_higher_order</span>
+       <span> = 
+        <span>
+         <span>(
+          <span><span class="label">l</span>:int 
+           <span class="arrow">&#45;&gt;</span>
+          </span> int)
+         </span> <span class="arrow">&#45;&gt;</span>
+        </span> 
+        <span>
+         <span>(
+          <span><span class="optlabel">?l</span>:int 
+           <span class="arrow">&#45;&gt;</span>
+          </span> int)
+         </span> <span class="arrow">&#45;&gt;</span>
+        </span> int
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-pair">
+      <a href="#type-pair" class="anchor"></a>
+      <code><span><span class="keyword">type</span> pair</span>
+       <span> = int * int</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-parens_dropped">
+      <a href="#type-parens_dropped" class="anchor"></a>
+      <code><span><span class="keyword">type</span> parens_dropped</span>
+       <span> = int * int</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-triple">
+      <a href="#type-triple" class="anchor"></a>
+      <code><span><span class="keyword">type</span> triple</span>
+       <span> = int * int * int</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-nested_pair">
+      <a href="#type-nested_pair" class="anchor"></a>
+      <code><span><span class="keyword">type</span> nested_pair</span>
+       <span> = <span>(int * int)</span> * int</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-instance">
+      <a href="#type-instance" class="anchor"></a>
+      <code><span><span class="keyword">type</span> instance</span>
+       <span> = <span>int <a href="#type-constructor">constructor</a></span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-long">
+      <a href="#type-long" class="anchor"></a>
+      <code><span><span class="keyword">type</span> long</span>
+       <span> =
+                 
+        <span><a href="#type-labeled_higher_order">labeled_higher_order</a>
+          <span class="arrow">&#45;&gt;</span>
         </span>
-       </code>
-      </li>
-      <li id="type-variant.C" class="def variant constructor anchored">
-       <a href="#type-variant.C" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">C</span></span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-variant.D" class="def variant constructor anchored">
-       <a href="#type-variant.D" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">D</span></span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p><em>bar</em></p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-variant.E" class="def variant constructor anchored">
-       <a href="#type-variant.E" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">E</span> 
-         <span class="keyword">of</span> 
-         <a href="#type-variant_e">variant_e</a>
+                 
+        <span>
+         <span>[ `Bar 
+          <span><span>| `Baz</span> of <a href="#type-triple">triple</a>
+          </span> ]
+         </span> <span class="arrow">&#45;&gt;</span>
         </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-variant_c">
-     <a href="#type-variant_c" class="anchor"></a>
-     <code><span><span class="keyword">type</span> variant_c</span>
-      <span> = </span><span>{</span>
-     </code>
-     <ol>
-      <li id="type-variant_c.a" class="def record field anchored">
-       <a href="#type-variant_c.a" class="anchor"></a>
-       <code><span>a : int;</span></code>
-      </li>
-     </ol><code><span>}</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-gadt">
-     <a href="#type-gadt" class="anchor"></a>
-     <code><span><span class="keyword">type</span> <span>_ gadt</span></span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-gadt.A" class="def variant constructor anchored">
-       <a href="#type-gadt.A" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">A</span> : 
-         <span>int <a href="#type-gadt">gadt</a></span>
+                 
+        <span><a href="#type-pair">pair</a> 
+         <span class="arrow">&#45;&gt;</span>
         </span>
-       </code>
-      </li>
-      <li id="type-gadt.B" class="def variant constructor anchored">
-       <a href="#type-gadt.B" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">B</span> : int 
-         <span class="arrow">&#45;&gt;</span> 
-         <span>string <a href="#type-gadt">gadt</a></span>
+                 
+        <span><a href="#type-labeled">labeled</a> 
+         <span class="arrow">&#45;&gt;</span>
         </span>
-       </code>
-      </li>
-      <li id="type-gadt.C" class="def variant constructor anchored">
-       <a href="#type-gadt.C" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">C</span> : 
-         <a href="#type-variant_c">variant_c</a> 
-         <span class="arrow">&#45;&gt;</span> 
-         <span>unit <a href="#type-gadt">gadt</a></span>
+                 
+        <span><a href="#type-higher_order">higher_order</a> 
+         <span class="arrow">&#45;&gt;</span>
         </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-degenerate_gadt">
-     <a href="#type-degenerate_gadt" class="anchor"></a>
-     <code><span><span class="keyword">type</span> degenerate_gadt</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-degenerate_gadt.A" class="def variant constructor
-       anchored"><a href="#type-degenerate_gadt.A" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">A</span> : 
-         <a href="#type-degenerate_gadt">degenerate_gadt</a>
+                 
+        <span>
+         <span>(<span>string <span class="arrow">&#45;&gt;</span></span> int)
+         </span> <span class="arrow">&#45;&gt;</span>
         </span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-private_variant">
-     <a href="#type-private_variant" class="anchor"></a>
-     <code><span><span class="keyword">type</span> private_variant</span>
-      <span> = <span class="keyword">private</span> </span>
-     </code>
-     <ol>
-      <li id="type-private_variant.A" class="def variant constructor
-       anchored"><a href="#type-private_variant.A" class="anchor"></a>
-       <code><span>| </span><span><span class="constructor">A</span></span>
-       </code>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-record">
-     <a href="#type-record" class="anchor"></a>
-     <code><span><span class="keyword">type</span> record</span>
-      <span> = </span><span>{</span>
-     </code>
-     <ol>
-      <li id="type-record.a" class="def record field anchored">
-       <a href="#type-record.a" class="anchor"></a>
-       <code><span>a : int;</span></code>
-      </li>
-      <li id="type-record.b" class="def record field anchored">
-       <a href="#type-record.b" class="anchor"></a>
-       <code><span><span class="keyword">mutable</span> b : int;</span>
-       </code>
-      </li>
-      <li id="type-record.c" class="def record field anchored">
-       <a href="#type-record.c" class="anchor"></a>
-       <code><span>c : int;</span></code>
-       <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
-        <span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-record.d" class="def record field anchored">
-       <a href="#type-record.d" class="anchor"></a>
-       <code><span>d : int;</span></code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p><em>bar</em></p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="type-record.e" class="def record field anchored">
-       <a href="#type-record.e" class="anchor"></a>
-       <code><span>e : 'a. <span class="type-var">'a</span>;</span></code>
-      </li>
-     </ol><code><span>}</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-polymorphic_variant">
-     <a href="#type-polymorphic_variant" class="anchor"></a>
-     <code><span><span class="keyword">type</span> polymorphic_variant</span>
-      <span> = </span><span>[ </span>
-     </code>
-     <ol>
-      <li id="type-polymorphic_variant.A" class="def variant constructor
-       anchored"><a href="#type-polymorphic_variant.A" class="anchor"></a>
-       <code><span>| </span><span>`A</span></code>
-      </li>
-      <li id="type-polymorphic_variant.B" class="def variant constructor
-       anchored"><a href="#type-polymorphic_variant.B" class="anchor"></a>
-       <code><span>| </span>
-        <span>`B <span class="keyword">of</span> int</span>
-       </code>
-      </li>
-      <li id="type-polymorphic_variant.C" class="def variant constructor
-       anchored"><a href="#type-polymorphic_variant.C" class="anchor"></a>
-       <code><span>| </span>
-        <span>`C <span class="keyword">of</span> int * unit</span>
-       </code>
-      </li>
-      <li id="type-polymorphic_variant.D" class="def variant constructor
-       anchored"><a href="#type-polymorphic_variant.D" class="anchor"></a>
-       <code><span>| </span><span>`D</span></code>
-      </li>
-     </ol><code><span> ]</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-polymorphic_variant_extension">
-     <a href="#type-polymorphic_variant_extension" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> polymorphic_variant_extension
-      </span><span> = </span><span>[ </span>
-     </code>
-     <ol>
-      <li id="type-polymorphic_variant_extension.polymorphic_variant"
-       class="def variant type anchored">
-       <a href="#type-polymorphic_variant_extension.polymorphic_variant"
-        class="anchor">
-       </a>
-       <code><span>| </span>
-        <span><a href="#type-polymorphic_variant">polymorphic_variant</a>
+                 
+        <span>
+         <span><span>(int * float * char * string * char * unit)</span>
+           option
+         </span> <span class="arrow">&#45;&gt;</span>
         </span>
-       </code>
-      </li>
-      <li id="type-polymorphic_variant_extension.E" class="def variant
-       constructor anchored">
-       <a href="#type-polymorphic_variant_extension.E" class="anchor"></a>
-       <code><span>| </span><span>`E</span></code>
-      </li>
-     </ol><code><span> ]</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-nested_polymorphic_variant">
-     <a href="#type-nested_polymorphic_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> nested_polymorphic_variant
-      </span><span> = </span><span>[ </span>
-     </code>
-     <ol>
-      <li id="type-nested_polymorphic_variant.A" class="def variant
-       constructor anchored">
-       <a href="#type-nested_polymorphic_variant.A" class="anchor"></a>
-       <code><span>| </span>
-        <span>`A <span class="keyword">of</span> 
-         <span>[ `B <span>| `C</span> ]</span>
+                 
+        <span><a href="#type-nested_pair">nested_pair</a> 
+         <span class="arrow">&#45;&gt;</span>
         </span>
-       </code>
-      </li>
-     </ol><code><span> ]</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-private_extenion">
-     <a href="#type-private_extenion" class="anchor"></a>
-     <code><span><span class="keyword">type</span> private_extenion</span>
-      <span> = <span class="keyword">private</span> </span>
-      <span>[&gt; </span>
-     </code>
-     <ol>
-      <li id="type-private_extenion.polymorphic_variant" class="def variant
-       type anchored">
-       <a href="#type-private_extenion.polymorphic_variant" class="anchor">
-       </a>
-       <code><span>| </span>
-        <span><a href="#type-polymorphic_variant">polymorphic_variant</a>
+                 
+        <span><a href="#type-arrow">arrow</a> 
+         <span class="arrow">&#45;&gt;</span>
         </span>
-       </code>
-      </li>
-     </ol><code><span> ]</span></code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-object_">
-     <a href="#type-object_" class="anchor"></a>
-     <code><span><span class="keyword">type</span> object_</span>
-      <span> = <span>&lt; a : int ; b : int ; c : int &gt;</span></span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec module-type anchored" id="module-type-X">
-     <a href="#module-type-X" class="anchor"></a>
-     <code>
-      <span><span class="keyword">module</span> 
-       <span class="keyword">type</span> 
-       <a href="Type-module-type-X.html">X</a>
-      </span>
-      <span> = <span class="keyword">sig</span> ... 
-       <span class="keyword">end</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-module_">
-     <a href="#type-module_" class="anchor"></a>
-     <code><span><span class="keyword">type</span> module_</span>
-      <span> = 
-       <span>(<span class="keyword">module</span> 
-        <a href="Type-module-type-X.html">X</a>)
+                 
+        <span>string <span class="arrow">&#45;&gt;</span></span>
+                                                                  
+        <span><a href="#type-nested_pair">nested_pair</a> array</span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-module_substitution">
-     <a href="#type-module_substitution" class="anchor"></a>
-     <code><span><span class="keyword">type</span> module_substitution</span>
-      <span> = 
-       <span>(<span class="keyword">module</span> 
-        <a href="Type-module-type-X.html">X</a> 
-        <span class="keyword">with</span> <span class="keyword">type</span>
-         <a href="Type-module-type-X.html#type-t">t</a> = int 
-        <span class="keyword">and</span> <span class="keyword">type</span>
-         <a href="Type-module-type-X.html#type-u">u</a> = unit)
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-variant_e">
+      <a href="#type-variant_e" class="anchor"></a>
+      <code><span><span class="keyword">type</span> variant_e</span>
+       <span> = </span><span>{</span>
+      </code>
+      <ol>
+       <li id="type-variant_e.a" class="def record field anchored">
+        <a href="#type-variant_e.a" class="anchor"></a>
+        <code><span>a : int;</span></code>
+       </li>
+      </ol><code><span>}</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-variant">
+      <a href="#type-variant" class="anchor"></a>
+      <code><span><span class="keyword">type</span> variant</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-variant.A" class="def variant constructor anchored">
+        <a href="#type-variant.A" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">A</span></span>
+        </code>
+       </li>
+       <li id="type-variant.B" class="def variant constructor anchored">
+        <a href="#type-variant.B" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">B</span> 
+          <span class="keyword">of</span> int
+         </span>
+        </code>
+       </li>
+       <li id="type-variant.C" class="def variant constructor anchored">
+        <a href="#type-variant.C" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">C</span></span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-variant.D" class="def variant constructor anchored">
+        <a href="#type-variant.D" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">D</span></span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p><em>bar</em></p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-variant.E" class="def variant constructor anchored">
+        <a href="#type-variant.E" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">E</span> 
+          <span class="keyword">of</span> 
+          <a href="#type-variant_e">variant_e</a>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-variant_c">
+      <a href="#type-variant_c" class="anchor"></a>
+      <code><span><span class="keyword">type</span> variant_c</span>
+       <span> = </span><span>{</span>
+      </code>
+      <ol>
+       <li id="type-variant_c.a" class="def record field anchored">
+        <a href="#type-variant_c.a" class="anchor"></a>
+        <code><span>a : int;</span></code>
+       </li>
+      </ol><code><span>}</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-gadt">
+      <a href="#type-gadt" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>_ gadt</span></span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-gadt.A" class="def variant constructor anchored">
+        <a href="#type-gadt.A" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">A</span> : 
+          <span>int <a href="#type-gadt">gadt</a></span>
+         </span>
+        </code>
+       </li>
+       <li id="type-gadt.B" class="def variant constructor anchored">
+        <a href="#type-gadt.B" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">B</span> : int 
+          <span class="arrow">&#45;&gt;</span> 
+          <span>string <a href="#type-gadt">gadt</a></span>
+         </span>
+        </code>
+       </li>
+       <li id="type-gadt.C" class="def variant constructor anchored">
+        <a href="#type-gadt.C" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">C</span> : 
+          <a href="#type-variant_c">variant_c</a> 
+          <span class="arrow">&#45;&gt;</span> 
+          <span>unit <a href="#type-gadt">gadt</a></span>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-degenerate_gadt">
+      <a href="#type-degenerate_gadt" class="anchor"></a>
+      <code><span><span class="keyword">type</span> degenerate_gadt</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-degenerate_gadt.A" class="def variant constructor
+        anchored"><a href="#type-degenerate_gadt.A" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">A</span> : 
+          <a href="#type-degenerate_gadt">degenerate_gadt</a>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-private_variant">
+      <a href="#type-private_variant" class="anchor"></a>
+      <code><span><span class="keyword">type</span> private_variant</span>
+       <span> = <span class="keyword">private</span> </span>
+      </code>
+      <ol>
+       <li id="type-private_variant.A" class="def variant constructor
+        anchored"><a href="#type-private_variant.A" class="anchor"></a>
+        <code><span>| </span><span><span class="constructor">A</span></span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-record">
+      <a href="#type-record" class="anchor"></a>
+      <code><span><span class="keyword">type</span> record</span>
+       <span> = </span><span>{</span>
+      </code>
+      <ol>
+       <li id="type-record.a" class="def record field anchored">
+        <a href="#type-record.a" class="anchor"></a>
+        <code><span>a : int;</span></code>
+       </li>
+       <li id="type-record.b" class="def record field anchored">
+        <a href="#type-record.b" class="anchor"></a>
+        <code><span><span class="keyword">mutable</span> b : int;</span>
+        </code>
+       </li>
+       <li id="type-record.c" class="def record field anchored">
+        <a href="#type-record.c" class="anchor"></a>
+        <code><span>c : int;</span></code>
+        <div class="def-doc"><span class="comment-delim">(*</span><p>foo</p>
+         <span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-record.d" class="def record field anchored">
+        <a href="#type-record.d" class="anchor"></a>
+        <code><span>d : int;</span></code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p><em>bar</em></p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="type-record.e" class="def record field anchored">
+        <a href="#type-record.e" class="anchor"></a>
+        <code><span>e : 'a. <span class="type-var">'a</span>;</span></code>
+       </li>
+      </ol><code><span>}</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-polymorphic_variant">
+      <a href="#type-polymorphic_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> polymorphic_variant</span>
+       <span> = </span><span>[ </span>
+      </code>
+      <ol>
+       <li id="type-polymorphic_variant.A" class="def variant constructor
+        anchored"><a href="#type-polymorphic_variant.A" class="anchor"></a>
+        <code><span>| </span><span>`A</span></code>
+       </li>
+       <li id="type-polymorphic_variant.B" class="def variant constructor
+        anchored"><a href="#type-polymorphic_variant.B" class="anchor"></a>
+        <code><span>| </span>
+         <span>`B <span class="keyword">of</span> int</span>
+        </code>
+       </li>
+       <li id="type-polymorphic_variant.C" class="def variant constructor
+        anchored"><a href="#type-polymorphic_variant.C" class="anchor"></a>
+        <code><span>| </span>
+         <span>`C <span class="keyword">of</span> int * unit</span>
+        </code>
+       </li>
+       <li id="type-polymorphic_variant.D" class="def variant constructor
+        anchored"><a href="#type-polymorphic_variant.D" class="anchor"></a>
+        <code><span>| </span><span>`D</span></code>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-polymorphic_variant_extension">
+      <a href="#type-polymorphic_variant_extension" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> polymorphic_variant_extension
+       </span><span> = </span><span>[ </span>
+      </code>
+      <ol>
+       <li id="type-polymorphic_variant_extension.polymorphic_variant"
+        class="def variant type anchored">
+        <a href="#type-polymorphic_variant_extension.polymorphic_variant"
+         class="anchor">
+        </a>
+        <code><span>| </span>
+         <span><a href="#type-polymorphic_variant">polymorphic_variant</a>
+         </span>
+        </code>
+       </li>
+       <li id="type-polymorphic_variant_extension.E" class="def variant
+        constructor anchored">
+        <a href="#type-polymorphic_variant_extension.E" class="anchor"></a>
+        <code><span>| </span><span>`E</span></code>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-nested_polymorphic_variant">
+      <a href="#type-nested_polymorphic_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> nested_polymorphic_variant
+       </span><span> = </span><span>[ </span>
+      </code>
+      <ol>
+       <li id="type-nested_polymorphic_variant.A" class="def variant
+        constructor anchored">
+        <a href="#type-nested_polymorphic_variant.A" class="anchor"></a>
+        <code><span>| </span>
+         <span>`A <span class="keyword">of</span> 
+          <span>[ `B <span>| `C</span> ]</span>
+         </span>
+        </code>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-private_extenion">
+      <a href="#type-private_extenion" class="anchor"></a>
+      <code><span><span class="keyword">type</span> private_extenion</span>
+       <span> = <span class="keyword">private</span> </span>
+       <span>[&gt; </span>
+      </code>
+      <ol>
+       <li id="type-private_extenion.polymorphic_variant" class="def 
+        variant type anchored">
+        <a href="#type-private_extenion.polymorphic_variant" class="anchor">
+        </a>
+        <code><span>| </span>
+         <span><a href="#type-polymorphic_variant">polymorphic_variant</a>
+         </span>
+        </code>
+       </li>
+      </ol><code><span> ]</span></code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-object_">
+      <a href="#type-object_" class="anchor"></a>
+      <code><span><span class="keyword">type</span> object_</span>
+       <span> = <span>&lt; a : int ; b : int ; c : int &gt;</span></span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec module-type anchored" id="module-type-X">
+      <a href="#module-type-X" class="anchor"></a>
+      <code>
+       <span><span class="keyword">module</span> 
+        <span class="keyword">type</span> 
+        <a href="Type-module-type-X.html">X</a>
        </span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-covariant">
-     <a href="#type-covariant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>+'a covariant</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-contravariant">
-     <a href="#type-contravariant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>-'a contravariant</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-bivariant">
-     <a href="#type-bivariant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>_ bivariant</span></span>
-      <span> = int</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-binary">
-     <a href="#type-binary" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>('a, 'b) binary</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-using_binary">
-     <a href="#type-using_binary" class="anchor"></a>
-     <code><span><span class="keyword">type</span> using_binary</span>
-      <span> = 
-       <span><span>(int, int)</span> <a href="#type-binary">binary</a></span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-name">
-     <a href="#type-name" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'custom name</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-constrained">
-     <a href="#type-constrained" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a constrained</span>
-      </span><span> = <span class="type-var">'a</span></span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = int
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-exact_variant">
-     <a href="#type-exact_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a exact_variant</span>
-      </span><span> = <span class="type-var">'a</span></span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = 
-       <span>[ `A <span><span>| `B</span> of int</span> ]</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-lower_variant">
-     <a href="#type-lower_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a lower_variant</span>
-      </span><span> = <span class="type-var">'a</span></span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = 
-       <span>[&gt; `A <span><span>| `B</span> of int</span> ]</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-any_variant">
-     <a href="#type-any_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a any_variant</span>
-      </span><span> = <span class="type-var">'a</span></span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = <span>[&gt;  ]</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-upper_variant">
-     <a href="#type-upper_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a upper_variant</span>
-      </span><span> = <span class="type-var">'a</span></span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = 
-       <span>[&lt; `A <span><span>| `B</span> of int</span> ]</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-named_variant">
-     <a href="#type-named_variant" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a named_variant</span>
-      </span><span> = <span class="type-var">'a</span></span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = 
-       <span>[&lt; 
-        <a href="#type-polymorphic_variant">polymorphic_variant</a> ]
+       <span> = <span class="keyword">sig</span> ... 
+        <span class="keyword">end</span>
        </span>
-      </span>
-     </code>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-exact_object">
-     <a href="#type-exact_object" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a exact_object</span>
-      </span><span> = <span class="type-var">'a</span></span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = 
-       <span>&lt; a : int ; b : int &gt;</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-lower_object">
-     <a href="#type-lower_object" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a lower_object</span>
-      </span><span> = <span class="type-var">'a</span></span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = 
-       <span>&lt; a : int ; b : int.. &gt;</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-poly_object">
-     <a href="#type-poly_object" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> <span>'a poly_object</span>
-      </span><span> = <span class="type-var">'a</span></span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = 
-       <span>&lt; a : 'a. <span class="type-var">'a</span> &gt;</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-double_constrained">
-     <a href="#type-double_constrained" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <span>('a, 'b) double_constrained</span>
-      </span>
-      <span> = <span class="type-var">'a</span> * 
-       <span class="type-var">'b</span>
-      </span>
-      <span> <span class="keyword">constraint</span> 
-       <span class="type-var">'a</span> = int 
-       <span class="keyword">constraint</span> 
-       <span class="type-var">'b</span> = unit
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-as_">
-     <a href="#type-as_" class="anchor"></a>
-     <code><span><span class="keyword">type</span> as_</span>
-      <span> = int <span class="keyword">as</span> 'a * 
-       <span class="type-var">'a</span>
-      </span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-extensible">
-     <a href="#type-extensible" class="anchor"></a>
-     <code><span><span class="keyword">type</span> extensible</span>
-      <span> = </span><span>..</span>
-     </code>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type extension anchored" id="extension-decl-Extension">
-     <a href="#extension-decl-Extension" class="anchor"></a>
-     <code>
-      <span><span class="keyword">type</span> 
-       <a href="#type-extensible">extensible</a> += 
-      </span>
-     </code>
-     <ol>
-      <li id="extension-Extension" class="def variant extension anchored">
-       <a href="#extension-Extension" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="extension">Extension</span></span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>Documentation for 
-         <a href="#extension-Extension"><code>Extension</code></a>.
-        </p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-      <li id="extension-Another_extension" class="def variant extension
-       anchored"><a href="#extension-Another_extension" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="extension">Another_extension</span></span>
-       </code>
-       <div class="def-doc"><span class="comment-delim">(*</span>
-        <p>Documentation for 
-         <a href="#extension-Another_extension">
-          <code>Another_extension</code>
-         </a>.
-        </p><span class="comment-delim">*)</span>
-       </div>
-      </li>
-     </ol>
-    </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-mutually">
-     <a href="#type-mutually" class="anchor"></a>
-     <code><span><span class="keyword">type</span> mutually</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-mutually.A" class="def variant constructor anchored">
-       <a href="#type-mutually.A" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">A</span> 
-         <span class="keyword">of</span> 
-         <a href="#type-recursive">recursive</a>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-module_">
+      <a href="#type-module_" class="anchor"></a>
+      <code><span><span class="keyword">type</span> module_</span>
+       <span> = 
+        <span>(<span class="keyword">module</span> 
+         <a href="Type-module-type-X.html">X</a>)
         </span>
-       </code>
-      </li>
-     </ol>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec type anchored" id="type-recursive">
-     <a href="#type-recursive" class="anchor"></a>
-     <code><span><span class="keyword">and</span> recursive</span>
-      <span> = </span>
-     </code>
-     <ol>
-      <li id="type-recursive.B" class="def variant constructor anchored">
-       <a href="#type-recursive.B" class="anchor"></a>
-       <code><span>| </span>
-        <span><span class="constructor">B</span> 
-         <span class="keyword">of</span> 
-         <a href="#type-mutually">mutually</a>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-module_substitution">
+      <a href="#type-module_substitution" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> module_substitution</span>
+       <span> = 
+        <span>(<span class="keyword">module</span> 
+         <a href="Type-module-type-X.html">X</a> 
+         <span class="keyword">with</span> <span class="keyword">type</span>
+          <a href="Type-module-type-X.html#type-t">t</a> = int 
+         <span class="keyword">and</span> <span class="keyword">type</span>
+          <a href="Type-module-type-X.html#type-u">u</a> = unit)
         </span>
-       </code>
-      </li>
-     </ol>
+       </span>
+      </code>
+     </div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec exception anchored" id="exception-Foo">
-     <a href="#exception-Foo" class="anchor"></a>
-     <code><span><span class="keyword">exception</span> </span>
-      <span><span class="exception">Foo</span> 
-       <span class="keyword">of</span> int * int
-      </span>
-     </code>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-covariant">
+      <a href="#type-covariant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>+'a covariant</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-contravariant">
+      <a href="#type-contravariant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>-'a contravariant</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-bivariant">
+      <a href="#type-bivariant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>_ bivariant</span>
+       </span><span> = int</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-binary">
+      <a href="#type-binary" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>('a, 'b) binary</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-using_binary">
+      <a href="#type-using_binary" class="anchor"></a>
+      <code><span><span class="keyword">type</span> using_binary</span>
+       <span> = 
+        <span><span>(int, int)</span> <a href="#type-binary">binary</a>
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-name">
+      <a href="#type-name" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'custom name</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-constrained">
+      <a href="#type-constrained" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a constrained</span>
+       </span><span> = <span class="type-var">'a</span></span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = int
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-exact_variant">
+      <a href="#type-exact_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a exact_variant</span>
+       </span><span> = <span class="type-var">'a</span></span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = 
+        <span>[ `A <span><span>| `B</span> of int</span> ]</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-lower_variant">
+      <a href="#type-lower_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a lower_variant</span>
+       </span><span> = <span class="type-var">'a</span></span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = 
+        <span>[&gt; `A <span><span>| `B</span> of int</span> ]</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-any_variant">
+      <a href="#type-any_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a any_variant</span>
+       </span><span> = <span class="type-var">'a</span></span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = <span>[&gt;  ]</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-upper_variant">
+      <a href="#type-upper_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a upper_variant</span>
+       </span><span> = <span class="type-var">'a</span></span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = 
+        <span>[&lt; `A <span><span>| `B</span> of int</span> ]</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-named_variant">
+      <a href="#type-named_variant" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a named_variant</span>
+       </span><span> = <span class="type-var">'a</span></span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = 
+        <span>[&lt; 
+         <a href="#type-polymorphic_variant">polymorphic_variant</a> ]
+        </span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-exact_object">
+      <a href="#type-exact_object" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a exact_object</span>
+       </span><span> = <span class="type-var">'a</span></span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = 
+        <span>&lt; a : int ; b : int &gt;</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-lower_object">
+      <a href="#type-lower_object" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a lower_object</span>
+       </span><span> = <span class="type-var">'a</span></span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = 
+        <span>&lt; a : int ; b : int.. &gt;</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-poly_object">
+      <a href="#type-poly_object" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> <span>'a poly_object</span>
+       </span><span> = <span class="type-var">'a</span></span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = 
+        <span>&lt; a : 'a. <span class="type-var">'a</span> &gt;</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-double_constrained">
+      <a href="#type-double_constrained" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <span>('a, 'b) double_constrained</span>
+       </span>
+       <span> = <span class="type-var">'a</span> * 
+        <span class="type-var">'b</span>
+       </span>
+       <span> <span class="keyword">constraint</span> 
+        <span class="type-var">'a</span> = int 
+        <span class="keyword">constraint</span> 
+        <span class="type-var">'b</span> = unit
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-as_">
+      <a href="#type-as_" class="anchor"></a>
+      <code><span><span class="keyword">type</span> as_</span>
+       <span> = int <span class="keyword">as</span> 'a * 
+        <span class="type-var">'a</span>
+       </span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-extensible">
+      <a href="#type-extensible" class="anchor"></a>
+      <code><span><span class="keyword">type</span> extensible</span>
+       <span> = </span><span>..</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type extension anchored" id="extension-decl-Extension">
+      <a href="#extension-decl-Extension" class="anchor"></a>
+      <code>
+       <span><span class="keyword">type</span> 
+        <a href="#type-extensible">extensible</a> += 
+       </span>
+      </code>
+      <ol>
+       <li id="extension-Extension" class="def variant extension anchored">
+        <a href="#extension-Extension" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="extension">Extension</span></span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>Documentation for 
+          <a href="#extension-Extension"><code>Extension</code></a>.
+         </p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+       <li id="extension-Another_extension" class="def variant extension
+        anchored"><a href="#extension-Another_extension" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="extension">Another_extension</span></span>
+        </code>
+        <div class="def-doc"><span class="comment-delim">(*</span>
+         <p>Documentation for 
+          <a href="#extension-Another_extension">
+           <code>Another_extension</code>
+          </a>.
+         </p><span class="comment-delim">*)</span>
+        </div>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-mutually">
+      <a href="#type-mutually" class="anchor"></a>
+      <code><span><span class="keyword">type</span> mutually</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-mutually.A" class="def variant constructor anchored">
+        <a href="#type-mutually.A" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">A</span> 
+          <span class="keyword">of</span> 
+          <a href="#type-recursive">recursive</a>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec type anchored" id="type-recursive">
+      <a href="#type-recursive" class="anchor"></a>
+      <code><span><span class="keyword">and</span> recursive</span>
+       <span> = </span>
+      </code>
+      <ol>
+       <li id="type-recursive.B" class="def variant constructor anchored">
+        <a href="#type-recursive.B" class="anchor"></a>
+        <code><span>| </span>
+         <span><span class="constructor">B</span> 
+          <span class="keyword">of</span> 
+          <a href="#type-mutually">mutually</a>
+         </span>
+        </code>
+       </li>
+      </ol>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec exception anchored" id="exception-Foo">
+      <a href="#exception-Foo" class="anchor"></a>
+      <code><span><span class="keyword">exception</span> </span>
+       <span><span class="exception">Foo</span> 
+        <span class="keyword">of</span> int * int
+       </span>
+      </code>
+     </div>
     </div>
    </div>
   </div>

--- a/test/generators/html/Val.html
+++ b/test/generators/html/Val.html
@@ -8,30 +8,33 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble"><h1>Module <code><span>Val</span></code></h1>
-  </header>
-  <div class="odoc-content">
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-documented">
-     <a href="#val-documented" class="anchor"></a>
-     <code><span><span class="keyword">val</span> documented : unit</span>
-     </code>
-    </div><div class="spec-doc"><p>Foo.</p></div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-undocumented">
-     <a href="#val-undocumented" class="anchor"></a>
-     <code><span><span class="keyword">val</span> undocumented : unit</span>
-     </code>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1>Module <code><span>Val</span></code></h1>
+   </header>
+   <div class="odoc-content">
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-documented">
+      <a href="#val-documented" class="anchor"></a>
+      <code><span><span class="keyword">val</span> documented : unit</span>
+      </code>
+     </div><div class="spec-doc"><p>Foo.</p></div>
     </div>
-   </div>
-   <div class="odoc-spec">
-    <div class="spec value anchored" id="val-documented_above">
-     <a href="#val-documented_above" class="anchor"></a>
-     <code>
-      <span><span class="keyword">val</span> documented_above : unit</span>
-     </code>
-    </div><div class="spec-doc"><p>Bar.</p></div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-undocumented">
+      <a href="#val-undocumented" class="anchor"></a>
+      <code><span><span class="keyword">val</span> undocumented : unit</span>
+      </code>
+     </div>
+    </div>
+    <div class="odoc-spec">
+     <div class="spec value anchored" id="val-documented_above">
+      <a href="#val-documented_above" class="anchor"></a>
+      <code>
+       <span><span class="keyword">val</span> documented_above : unit</span>
+      </code>
+     </div><div class="spec-doc"><p>Bar.</p></div>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/mld.html
+++ b/test/generators/html/mld.html
@@ -8,12 +8,6 @@
   <script>hljs.initHighlightingOnLoad();</script>
  </head>
  <body class="odoc">
-  <header class="odoc-preamble">
-   <h1 id="mld-page"><a href="#mld-page" class="anchor"></a>Mld Page</h1>
-   <p>This is an <code>.mld</code> file. It doesn't have an auto-generated
-     title, like modules and other pages generated fully by odoc do.
-   </p><p>It will have a TOC generated from section headings.</p>
-  </header>
   <nav class="odoc-toc">
    <ul><li><a href="#section">Section</a></li>
     <li><a href="#another-section">Another section</a>
@@ -23,20 +17,29 @@
     </li>
    </ul>
   </nav>
-  <div class="odoc-content">
-   <h2 id="section"><a href="#section" class="anchor"></a>Section</h2>
-   <p>This is a section.</p><p>Another paragraph in section.</p>
-   <h2 id="another-section"><a href="#another-section" class="anchor"></a>
-    Another section
-   </h2><p>This is another section.</p><p>Another paragraph in section 2.</p>
-   <h3 id="subsection"><a href="#subsection" class="anchor"></a>Subsection
-   </h3><p>This is a subsection.</p><p>Another paragraph in subsection.</p>
-   <p>Yet another paragraph in subsection.</p>
-   <h3 id="another-subsection">
-    <a href="#another-subsection" class="anchor"></a>Another Subsection
-   </h3><p>This is another subsection.</p>
-   <p>Another paragraph in subsection 2.</p>
-   <p>Yet another paragraph in subsection 2.</p>
+  <div class="odoc-main">
+   <header class="odoc-preamble">
+    <h1 id="mld-page"><a href="#mld-page" class="anchor"></a>Mld Page</h1>
+    <p>This is an <code>.mld</code> file. It doesn't have an auto-generated
+      title, like modules and other pages generated fully by odoc do.
+    </p><p>It will have a TOC generated from section headings.</p>
+   </header>
+   <div class="odoc-content">
+    <h2 id="section"><a href="#section" class="anchor"></a>Section</h2>
+    <p>This is a section.</p><p>Another paragraph in section.</p>
+    <h2 id="another-section"><a href="#another-section" class="anchor"></a>
+     Another section
+    </h2><p>This is another section.</p>
+    <p>Another paragraph in section 2.</p>
+    <h3 id="subsection"><a href="#subsection" class="anchor"></a>Subsection
+    </h3><p>This is a subsection.</p><p>Another paragraph in subsection.</p>
+    <p>Yet another paragraph in subsection.</p>
+    <h3 id="another-subsection">
+     <a href="#another-subsection" class="anchor"></a>Another Subsection
+    </h3><p>This is another subsection.</p>
+    <p>Another paragraph in subsection 2.</p>
+    <p>Yet another paragraph in subsection 2.</p>
+   </div>
   </div>
  </body>
 </html>

--- a/test/integration/html_opts.t/run.t
+++ b/test/integration/html_opts.t/run.t
@@ -15,8 +15,8 @@ check it's got the expected content by looking for 'type-t'
   $ grep odoc-nav html/test/Test/index.html
     <nav class="odoc-nav"><a href="../index.html">Up</a> – 
   $ grep type-t html/test/Test/index.html
-      <div class="spec type anchored" id="type-t">
-       <a href="#type-t" class="anchor"></a>
+       <div class="spec type anchored" id="type-t">
+        <a href="#type-t" class="anchor"></a>
 
 Generate --as-json embeddable HTML fragment output:
 
@@ -30,7 +30,7 @@ Generate --as-json embeddable HTML fragment output:
 Check semantic_uris:
   $ odoc html-generate test2.odocl -o html --indent
   $ grep Test.t html/test/Test2/index.html
-         <a href="../Test/index.html#type-t">Test.t</a>
+          <a href="../Test/index.html#type-t">Test.t</a>
   $ odoc html-generate test2.odocl -o html --semantic-uris --indent
   $ grep Test.t html/test/Test2/index.html
-         <a href="../Test/#type-t">Test.t</a>
+          <a href="../Test/#type-t">Test.t</a>

--- a/test/sources/double_wrapped.t/run.t
+++ b/test/sources/double_wrapped.t/run.t
@@ -49,17 +49,19 @@ Look if all the source files are generated:
     <nav class="odoc-nav"><a href="../index.html">Up</a> – 
      <a href="../index.html">Main</a> &#x00BB; A
     </nav>
-    <header class="odoc-preamble">
-     <h1>Module <code><span>Main.A</span></code>
-      <a href="../../src/a.ml.html" class="source_link">Source</a>
-     </h1>
-    </header>
-    <div class="odoc-content">
-     <div class="odoc-spec">
-      <div class="spec value anchored" id="val-x">
-       <a href="#val-x" class="anchor"></a>
-       <a href="../../src/a.ml.html#val-x" class="source_link">Source</a>
-       <code><span><span class="keyword">val</span> x : int</span></code>
+    <div class="odoc-main">
+     <header class="odoc-preamble">
+      <h1>Module <code><span>Main.A</span></code>
+       <a href="../../src/a.ml.html" class="source_link">Source</a>
+      </h1>
+     </header>
+     <div class="odoc-content">
+      <div class="odoc-spec">
+       <div class="spec value anchored" id="val-x">
+        <a href="#val-x" class="anchor"></a>
+        <a href="../../src/a.ml.html#val-x" class="source_link">Source</a>
+        <code><span><span class="keyword">val</span> x : int</span></code>
+       </div>
       </div>
      </div>
     </div>

--- a/test/sources/functor.t/run.t
+++ b/test/sources/functor.t/run.t
@@ -48,17 +48,17 @@ Verify the behavior on functors.
 In this test, the functor expansion contains the right link.
 
   $ cat html/A/F/index.html | grep source_link -C 1
-     <h1>Module <code><span>A.F</span></code>
-      <a href="../../src/a.ml.html#module-F" class="source_link">Source</a>
-     </h1>
+      <h1>Module <code><span>A.F</span></code>
+       <a href="../../src/a.ml.html#module-F" class="source_link">Source</a>
+      </h1>
   --
-       <a href="#type-t" class="anchor"></a>
-       <a href="../../src/a.ml.html#module-F.type-t" class="source_link">Source
-       </a>
+        <a href="#type-t" class="anchor"></a>
+        <a href="../../src/a.ml.html#module-F.type-t" class="source_link">
+         Source
   --
-       <a href="#val-y" class="anchor"></a>
-       <a href="../../src/a.ml.html#module-F.val-y" class="source_link">Source
-       </a>
+        <a href="#val-y" class="anchor"></a>
+        <a href="../../src/a.ml.html#module-F.val-y" class="source_link">Source
+        </a>
 
   $ cat html/root/source/a.ml.html | grep L3
   cat: html/root/source/a.ml.html: No such file or directory
@@ -67,23 +67,23 @@ In this test, the functor expansion contains the right link.
 However, on functor results, there is a link to source in the file:
 
   $ cat html/B/R/index.html | grep source_link -C 2
-    <header class="odoc-preamble">
-     <h1>Module <code><span>B.R</span></code>
-      <a href="../../src/b.ml.html#module-R" class="source_link">Source</a>
-     </h1>
-    </header>
+     <header class="odoc-preamble">
+      <h1>Module <code><span>B.R</span></code>
+       <a href="../../src/b.ml.html#module-R" class="source_link">Source</a>
+      </h1>
+     </header>
   --
-      <div class="spec type anchored" id="type-t">
-       <a href="#type-t" class="anchor"></a>
-       <a href="../../src/a.ml.html#module-F.type-t" class="source_link">Source
-       </a>
-       <code><span><span class="keyword">type</span> t</span>
+       <div class="spec type anchored" id="type-t">
+        <a href="#type-t" class="anchor"></a>
+        <a href="../../src/a.ml.html#module-F.type-t" class="source_link">
+         Source
+        </a>
   --
-      <div class="spec value anchored" id="val-y">
-       <a href="#val-y" class="anchor"></a>
-       <a href="../../src/a.ml.html#module-F.val-y" class="source_link">Source
-       </a>
-       <code>
+       <div class="spec value anchored" id="val-y">
+        <a href="#val-y" class="anchor"></a>
+        <a href="../../src/a.ml.html#module-F.val-y" class="source_link">Source
+        </a>
+        <code>
 
 Source links in functor parameters might not make sense. Currently we generate none:
 

--- a/test/sources/include_in_expansion.t/run.t
+++ b/test/sources/include_in_expansion.t/run.t
@@ -27,14 +27,14 @@ In Main.A, the source parent of value x should be to Main__A, while the
 source parent of value y should be left to B.
 
   $ grep source_link html/Main/A/index.html -C 1
-     <h1>Module <code><span>Main.A</span></code>
-      <a href="../../src/a.ml.html" class="source_link">Source</a>
-     </h1>
+      <h1>Module <code><span>Main.A</span></code>
+       <a href="../../src/a.ml.html" class="source_link">Source</a>
+      </h1>
   --
-         <a href="#val-y" class="anchor"></a>
-         <a href="../../src/b.m.html#val-y" class="source_link">Source</a>
-         <code><span><span class="keyword">val</span> y : int</span></code>
+          <a href="#val-y" class="anchor"></a>
+          <a href="../../src/b.m.html#val-y" class="source_link">Source</a>
+          <code><span><span class="keyword">val</span> y : int</span></code>
   --
-       <a href="#val-x" class="anchor"></a>
-       <a href="../../src/a.ml.html#val-x" class="source_link">Source</a>
-       <code><span><span class="keyword">val</span> x : int</span></code>
+        <a href="#val-x" class="anchor"></a>
+        <a href="../../src/a.ml.html#val-x" class="source_link">Source</a>
+        <code><span><span class="keyword">val</span> x : int</span></code>

--- a/test/sources/lookup_def_wrapped.t/run.t
+++ b/test/sources/lookup_def_wrapped.t/run.t
@@ -61,17 +61,19 @@ Look if all the source files are generated:
     <nav class="odoc-nav"><a href="../index.html">Up</a> – 
      <a href="../index.html">Main</a> &#x00BB; A
     </nav>
-    <header class="odoc-preamble">
-     <h1>Module <code><span>Main.A</span></code>
-      <a href="../../src/a.ml.html" class="source_link">Source</a>
-     </h1>
-    </header>
-    <div class="odoc-content">
-     <div class="odoc-spec">
-      <div class="spec value anchored" id="val-x">
-       <a href="#val-x" class="anchor"></a>
-       <a href="../../src/a.ml.html#val-x" class="source_link">Source</a>
-       <code><span><span class="keyword">val</span> x : int</span></code>
+    <div class="odoc-main">
+     <header class="odoc-preamble">
+      <h1>Module <code><span>Main.A</span></code>
+       <a href="../../src/a.ml.html" class="source_link">Source</a>
+      </h1>
+     </header>
+     <div class="odoc-content">
+      <div class="odoc-spec">
+       <div class="spec value anchored" id="val-x">
+        <a href="#val-x" class="anchor"></a>
+        <a href="../../src/a.ml.html#val-x" class="source_link">Source</a>
+        <code><span><span class="keyword">val</span> x : int</span></code>
+       </div>
       </div>
      </div>
     </div>

--- a/test/sources/recursive_module.t/run.t
+++ b/test/sources/recursive_module.t/run.t
@@ -11,15 +11,15 @@ Checking that source links exists inside recursive modules.
 Both modules should contain source links
 
   $ grep source_link html/Main/A/index.html -C 2
-    <header class="odoc-preamble">
-     <h1>Module <code><span>Main.A</span></code>
-      <a href="../../src/main.ml.html#module-A" class="source_link">Source</a>
-     </h1>
-    </header>
+     <header class="odoc-preamble">
+      <h1>Module <code><span>Main.A</span></code>
+       <a href="../../src/main.ml.html#module-A" class="source_link">Source</a>
+      </h1>
+     </header>
 
   $ grep source_link html/Main/B/index.html -C 2
-    <header class="odoc-preamble">
-     <h1>Module <code><span>Main.B</span></code>
-      <a href="../../src/main.ml.html#module-B" class="source_link">Source</a>
-     </h1>
-    </header>
+     <header class="odoc-preamble">
+      <h1>Module <code><span>Main.B</span></code>
+       <a href="../../src/main.ml.html#module-B" class="source_link">Source</a>
+      </h1>
+     </header>

--- a/test/sources/single_mli.t/run.t
+++ b/test/sources/single_mli.t/run.t
@@ -48,14 +48,14 @@ Code source for `A_x` is wanted:
 `A` should contain a link to `A_x.ml.html`:
 
   $ grep source_link html/A/index.html
-      <a href="../src/a.ml.html" class="source_link">Source</a>
-       <a href="../src/a_x.ml.html" class="source_link">Source</a>
+       <a href="../src/a.ml.html" class="source_link">Source</a>
+        <a href="../src/a_x.ml.html" class="source_link">Source</a>
 
 `A.X` and `A.X.Y` should contain a link to `A_x.ml.html`:
 
   $ grep source_link html/A/X/index.html
-      <a href="../../src/a_x.ml.html" class="source_link">Source</a>
-       <a href="../../src/a_x.ml.html#module-Y" class="source_link">Source</a>
+       <a href="../../src/a_x.ml.html" class="source_link">Source</a>
+        <a href="../../src/a_x.ml.html#module-Y" class="source_link">Source</a>
   $ grep source_link html/A/X/Y/index.html
-      <a href="../../../src/a_x.ml.html#module-Y" class="source_link">Source
-       <a href="../../../src/a_x.ml.html#module-Y.val-z" class="source_link">
+       <a href="../../../src/a_x.ml.html#module-Y" class="source_link">Source
+        <a href="../../../src/a_x.ml.html#module-Y.val-z" class="source_link">

--- a/test/sources/source.t/run.t
+++ b/test/sources/source.t/run.t
@@ -105,141 +105,141 @@ Compile the pages with the --source option:
 Source links generated in the documentation:
 
   $ grep source_link html/A/index.html -B 2
-    <header class="odoc-preamble">
-     <h1>Module <code><span>A</span></code>
-      <a href="../src/a.ml.html" class="source_link">Source</a>
+     <header class="odoc-preamble">
+      <h1>Module <code><span>A</span></code>
+       <a href="../src/a.ml.html" class="source_link">Source</a>
   --
-      <div class="spec type anchored" id="type-t">
-       <a href="#type-t" class="anchor"></a>
-       <a href="../src/a.ml.html#type-t" class="source_link">Source</a>
+       <div class="spec type anchored" id="type-t">
+        <a href="#type-t" class="anchor"></a>
+        <a href="../src/a.ml.html#type-t" class="source_link">Source</a>
   --
-      <div class="spec type anchored" id="type-truc">
-       <a href="#type-truc" class="anchor"></a>
-       <a href="../src/a.ml.html#type-truc" class="source_link">Source</a>
+       <div class="spec type anchored" id="type-truc">
+        <a href="#type-truc" class="anchor"></a>
+        <a href="../src/a.ml.html#type-truc" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-xazaz">
-       <a href="#val-xazaz" class="anchor"></a>
-       <a href="../src/a.ml.html#val-xazaz" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-xazaz">
+        <a href="#val-xazaz" class="anchor"></a>
+        <a href="../src/a.ml.html#val-xazaz" class="source_link">Source</a>
   --
-      <div class="spec module anchored" id="module-Yoyo">
-       <a href="#module-Yoyo" class="anchor"></a>
-       <a href="../src/a.ml.html#module-Yoyo" class="source_link">Source</a>
+       <div class="spec module anchored" id="module-Yoyo">
+        <a href="#module-Yoyo" class="anchor"></a>
+        <a href="../src/a.ml.html#module-Yoyo" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-segr">
-       <a href="#val-segr" class="anchor"></a>
-       <a href="../src/a.ml.html#val-segr" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-segr">
+        <a href="#val-segr" class="anchor"></a>
+        <a href="../src/a.ml.html#val-segr" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-y">
-       <a href="#val-y" class="anchor"></a>
-       <a href="../src/a.ml.html#val-y" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-y">
+        <a href="#val-y" class="anchor"></a>
+        <a href="../src/a.ml.html#val-y" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-z">
-       <a href="#val-z" class="anchor"></a>
-       <a href="../src/a.ml.html#val-z" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-z">
+        <a href="#val-z" class="anchor"></a>
+        <a href="../src/a.ml.html#val-z" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-z'">
-       <a href="#val-z'" class="anchor"></a>
-       <a href="../src/a.ml.html#val-z'" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-z'">
+        <a href="#val-z'" class="anchor"></a>
+        <a href="../src/a.ml.html#val-z'" class="source_link">Source</a>
   --
-      <div class="spec module anchored" id="module-A">
-       <a href="#module-A" class="anchor"></a>
-       <a href="../src/a.ml.html#module-A" class="source_link">Source</a>
+       <div class="spec module anchored" id="module-A">
+        <a href="#module-A" class="anchor"></a>
+        <a href="../src/a.ml.html#module-A" class="source_link">Source</a>
   --
-      <div class="spec module anchored" id="module-B">
-       <a href="#module-B" class="anchor"></a>
-       <a href="../src/a.ml.html#module-A" class="source_link">Source</a>
+       <div class="spec module anchored" id="module-B">
+        <a href="#module-B" class="anchor"></a>
+        <a href="../src/a.ml.html#module-A" class="source_link">Source</a>
   --
-      <div class="spec module-type anchored" id="module-type-T">
-       <a href="#module-type-T" class="anchor"></a>
-       <a href="../src/a.ml.html#module-type-T" class="source_link">Source</a>
+       <div class="spec module-type anchored" id="module-type-T">
+        <a href="#module-type-T" class="anchor"></a>
+        <a href="../src/a.ml.html#module-type-T" class="source_link">Source</a>
   --
-      <div class="spec module-type anchored" id="module-type-U">
-       <a href="#module-type-U" class="anchor"></a>
-       <a href="../src/a.ml.html#module-type-U" class="source_link">Source</a>
+       <div class="spec module-type anchored" id="module-type-U">
+        <a href="#module-type-U" class="anchor"></a>
+        <a href="../src/a.ml.html#module-type-U" class="source_link">Source</a>
   --
-      <div class="spec type anchored" id="type-ext">
-       <a href="#type-ext" class="anchor"></a>
-       <a href="../src/a.ml.html#type-ext" class="source_link">Source</a>
+       <div class="spec type anchored" id="type-ext">
+        <a href="#type-ext" class="anchor"></a>
+        <a href="../src/a.ml.html#type-ext" class="source_link">Source</a>
   --
-      <div class="spec type extension anchored" id="extension-decl-Foo">
-       <a href="#extension-decl-Foo" class="anchor"></a>
-       <a href="../src/a.ml.html#extension-Foo" class="source_link">Source</a>
+       <div class="spec type extension anchored" id="extension-decl-Foo">
+        <a href="#extension-decl-Foo" class="anchor"></a>
+        <a href="../src/a.ml.html#extension-Foo" class="source_link">Source</a>
   --
-      <div class="spec exception anchored" id="exception-Exn">
-       <a href="#exception-Exn" class="anchor"></a>
-       <a href="../src/a.ml.html#exception-Exn" class="source_link">Source</a>
+       <div class="spec exception anchored" id="exception-Exn">
+        <a href="#exception-Exn" class="anchor"></a>
+        <a href="../src/a.ml.html#exception-Exn" class="source_link">Source</a>
   --
-      <div class="spec class anchored" id="class-cls">
-       <a href="#class-cls" class="anchor"></a>
-       <a href="../src/a.ml.html#class-cls" class="source_link">Source</a>
+       <div class="spec class anchored" id="class-cls">
+        <a href="#class-cls" class="anchor"></a>
+        <a href="../src/a.ml.html#class-cls" class="source_link">Source</a>
   --
-      <div class="spec class anchored" id="class-cls'">
-       <a href="#class-cls'" class="anchor"></a>
-       <a href="../src/a.ml.html#class-cls'" class="source_link">Source</a>
+       <div class="spec class anchored" id="class-cls'">
+        <a href="#class-cls'" class="anchor"></a>
+        <a href="../src/a.ml.html#class-cls'" class="source_link">Source</a>
   --
-      <div class="spec class-type anchored" id="class-type-ct">
-       <a href="#class-type-ct" class="anchor"></a>
-       <a href="../src/a.ml.html#class-type-ct" class="source_link">Source</a>
+       <div class="spec class-type anchored" id="class-type-ct">
+        <a href="#class-type-ct" class="anchor"></a>
+        <a href="../src/a.ml.html#class-type-ct" class="source_link">Source</a>
   --
-      <div class="spec module anchored" id="module-X">
-       <a href="#module-X" class="anchor"></a>
-       <a href="../src/a.ml.html#module-X" class="source_link">Source</a>
+       <div class="spec module anchored" id="module-X">
+        <a href="#module-X" class="anchor"></a>
+        <a href="../src/a.ml.html#module-X" class="source_link">Source</a>
   --
-      <div class="spec type anchored" id="type-a1">
-       <a href="#type-a1" class="anchor"></a>
-       <a href="../src/a.ml.html#type-a1" class="source_link">Source</a>
+       <div class="spec type anchored" id="type-a1">
+        <a href="#type-a1" class="anchor"></a>
+        <a href="../src/a.ml.html#type-a1" class="source_link">Source</a>
   --
-      <div class="spec type anchored" id="type-a2">
-       <a href="#type-a2" class="anchor"></a>
-       <a href="../src/a.ml.html#type-a2" class="source_link">Source</a>
+       <div class="spec type anchored" id="type-a2">
+        <a href="#type-a2" class="anchor"></a>
+        <a href="../src/a.ml.html#type-a2" class="source_link">Source</a>
   --
-      <div class="spec module anchored" id="module-F">
-       <a href="#module-F" class="anchor"></a>
-       <a href="../src/a.ml.html#module-F" class="source_link">Source</a>
+       <div class="spec module anchored" id="module-F">
+        <a href="#module-F" class="anchor"></a>
+        <a href="../src/a.ml.html#module-F" class="source_link">Source</a>
   --
-      <div class="spec module anchored" id="module-FM">
-       <a href="#module-FM" class="anchor"></a>
-       <a href="../src/a.ml.html#module-FM" class="source_link">Source</a>
+       <div class="spec module anchored" id="module-FM">
+        <a href="#module-FM" class="anchor"></a>
+        <a href="../src/a.ml.html#module-FM" class="source_link">Source</a>
   --
-      <div class="spec module anchored" id="module-FF">
-       <a href="#module-FF" class="anchor"></a>
-       <a href="../src/a.ml.html#module-FF" class="source_link">Source</a>
+       <div class="spec module anchored" id="module-FF">
+        <a href="#module-FF" class="anchor"></a>
+        <a href="../src/a.ml.html#module-FF" class="source_link">Source</a>
   --
-      <div class="spec module anchored" id="module-FF2">
-       <a href="#module-FF2" class="anchor"></a>
-       <a href="../src/a.ml.html#module-FF2" class="source_link">Source</a>
+       <div class="spec module anchored" id="module-FF2">
+        <a href="#module-FF2" class="anchor"></a>
+        <a href="../src/a.ml.html#module-FF2" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-(*.+%)">
-       <a href="#val-(*.+%)" class="anchor"></a>
-       <a href="../src/a.ml.html#val-(*.+%)" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-(*.+%)">
+        <a href="#val-(*.+%)" class="anchor"></a>
+        <a href="../src/a.ml.html#val-(*.+%)" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-a">
-       <a href="#val-a" class="anchor"></a>
-       <a href="../src/a.ml.html#val-a" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-a">
+        <a href="#val-a" class="anchor"></a>
+        <a href="../src/a.ml.html#val-a" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-c">
-       <a href="#val-c" class="anchor"></a>
-       <a href="../src/a.ml.html#val-c" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-c">
+        <a href="#val-c" class="anchor"></a>
+        <a href="../src/a.ml.html#val-c" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-b">
-       <a href="#val-b" class="anchor"></a>
-       <a href="../src/a.ml.html#val-b" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-b">
+        <a href="#val-b" class="anchor"></a>
+        <a href="../src/a.ml.html#val-b" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-x">
-       <a href="#val-x" class="anchor"></a>
-       <a href="../src/a.ml.html#val-x" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-x">
+        <a href="#val-x" class="anchor"></a>
+        <a href="../src/a.ml.html#val-x" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-list">
-       <a href="#val-list" class="anchor"></a>
-       <a href="../src/a.ml.html#val-list" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-list">
+        <a href="#val-list" class="anchor"></a>
+        <a href="../src/a.ml.html#val-list" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-string">
-       <a href="#val-string" class="anchor"></a>
-       <a href="../src/a.ml.html#val-string" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-string">
+        <a href="#val-string" class="anchor"></a>
+        <a href="../src/a.ml.html#val-string" class="source_link">Source</a>
   --
-      <div class="spec value anchored" id="val-string2">
-       <a href="#val-string2" class="anchor"></a>
-       <a href="../src/a.ml.html#val-string2" class="source_link">Source</a>
+       <div class="spec value anchored" id="val-string2">
+        <a href="#val-string2" class="anchor"></a>
+        <a href="../src/a.ml.html#val-string2" class="source_link">Source</a>
 
 Ids generated in the source code:
 

--- a/test/xref2/canonical_hidden_module.t/run.t
+++ b/test/xref2/canonical_hidden_module.t/run.t
@@ -79,117 +79,119 @@ See the comments on the types at the end of test.mli for the expectation.
     <script>hljs.initHighlightingOnLoad();</script>
    </head>
    <body class="odoc">
-    <header class="odoc-preamble">
-     <h1>Module <code><span>Test</span></code></h1>
-    </header>
-    <div class="odoc-content">
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-A_nonhidden">
-       <a href="#module-A_nonhidden" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> 
-         <a href="A_nonhidden/index.html">A_nonhidden</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
+    <div class="odoc-main">
+     <header class="odoc-preamble">
+      <h1>Module <code><span>Test</span></code></h1>
+     </header>
+     <div class="odoc-content">
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-A_nonhidden">
+        <a href="#module-A_nonhidden" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> 
+          <a href="A_nonhidden/index.html">A_nonhidden</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
       </div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-A">
-       <a href="#module-A" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> <a href="A/index.html">A</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-A">
+        <a href="#module-A" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> <a href="A/index.html">A</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+       <div class="spec-doc"><p>This should not have an expansion</p></div>
       </div>
-      <div class="spec-doc"><p>This should not have an expansion</p></div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-B">
-       <a href="#module-B" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> <a href="B/index.html">B</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
-      </div><div class="spec-doc"><p>This should have an expansion</p></div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-C">
-       <a href="#module-C" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> <a href="C/index.html">C</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
-      </div><div class="spec-doc"><p>This should have an expansion</p></div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-D">
-       <a href="#module-D" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> <a href="D/index.html">D</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-B">
+        <a href="#module-B" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> <a href="B/index.html">B</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div><div class="spec-doc"><p>This should have an expansion</p></div>
       </div>
-      <div class="spec-doc"><p>This also should have an expansion</p></div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-a">
-       <a href="#type-a" class="anchor"></a>
-       <code><span><span class="keyword">type</span> a</span>
-        <span> = <a href="A/index.html#type-t">A.t</a></span>
-       </code>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-C">
+        <a href="#module-C" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> <a href="C/index.html">C</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div><div class="spec-doc"><p>This should have an expansion</p></div>
       </div>
-      <div class="spec-doc">
-       <p>This should render as A.t but link to A_nonhidden/index.html 
-        - since A has no expansion
-       </p>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-D">
+        <a href="#module-D" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> <a href="D/index.html">D</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+       <div class="spec-doc"><p>This also should have an expansion</p></div>
       </div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-b">
-       <a href="#type-b" class="anchor"></a>
-       <code><span><span class="keyword">type</span> b</span></code>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-a">
+        <a href="#type-a" class="anchor"></a>
+        <code><span><span class="keyword">type</span> a</span>
+         <span> = <a href="A/index.html#type-t">A.t</a></span>
+        </code>
+       </div>
+       <div class="spec-doc">
+        <p>This should render as A.t but link to A_nonhidden/index.html
+          - since A has no expansion
+        </p>
+       </div>
       </div>
-      <div class="spec-doc">
-       <p>This should have no RHS as it's hidden and there is no canonical
-         alternative
-       </p>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-b">
+        <a href="#type-b" class="anchor"></a>
+        <code><span><span class="keyword">type</span> b</span></code>
+       </div>
+       <div class="spec-doc">
+        <p>This should have no RHS as it's hidden and there is no canonical
+          alternative
+        </p>
+       </div>
       </div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-c">
-       <a href="#type-c" class="anchor"></a>
-       <code><span><span class="keyword">type</span> c</span>
-        <span> = <a href="C/index.html#type-t">C.t</a></span>
-       </code>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-c">
+        <a href="#type-c" class="anchor"></a>
+        <code><span><span class="keyword">type</span> c</span>
+         <span> = <a href="C/index.html#type-t">C.t</a></span>
+        </code>
+       </div>
+       <div class="spec-doc">
+        <p>This should render as C.t and link to C/index.html</p>
+       </div>
       </div>
-      <div class="spec-doc">
-       <p>This should render as C.t and link to C/index.html</p>
-      </div>
-     </div>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-d">
-       <a href="#type-d" class="anchor"></a>
-       <code><span><span class="keyword">type</span> d</span>
-        <span> = <a href="D/index.html#type-t">D.t</a></span>
-       </code>
-      </div>
-      <div class="spec-doc">
-       <p>This should render as D.t and link to D/index.html</p>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-d">
+        <a href="#type-d" class="anchor"></a>
+        <code><span><span class="keyword">type</span> d</span>
+         <span> = <a href="D/index.html#type-t">D.t</a></span>
+        </code>
+       </div>
+       <div class="spec-doc">
+        <p>This should render as D.t and link to D/index.html</p>
+       </div>
       </div>
      </div>
     </div>

--- a/test/xref2/github_issue_342.t/run.t
+++ b/test/xref2/github_issue_342.t/run.t
@@ -24,13 +24,13 @@ The table of content:
 The rendered headings
 
   $ cat html/Foo/index.html | grep "<h2" -A 3
-     <h2 id="references--and-with-text-in-title">
-      <a href="#references--and-with-text-in-title" class="anchor"></a>
-      References <a href="A/index.html"><code>A</code></a> and 
-      <a href="A/index.html" title="A">with text</a> in title
+      <h2 id="references--and-with-text-in-title">
+       <a href="#references--and-with-text-in-title" class="anchor"></a>
+       References <a href="A/index.html"><code>A</code></a> and 
+       <a href="A/index.html" title="A">with text</a> in title
   --
-     <h2 id="an-url--and-with-text-in-a-title">
-      <a href="#an-url--and-with-text-in-a-title" class="anchor"></a>An
-       url <a href="http://ocaml.org">http://ocaml.org</a> and 
-      <a href="http://ocaml.org">with text</a> in a title
+      <h2 id="an-url--and-with-text-in-a-title">
+       <a href="#an-url--and-with-text-in-a-title" class="anchor"></a>An
+        url <a href="http://ocaml.org">http://ocaml.org</a> and 
+       <a href="http://ocaml.org">with text</a> in a title
 

--- a/test/xref2/github_issue_447.t/run.t
+++ b/test/xref2/github_issue_447.t/run.t
@@ -17,10 +17,10 @@ Let's now check that the reference point to the right page/anchor:
   $ odoc html-generate --output-dir html --indent a.odocl
 
   $ cat html/A/index.html | grep \# | grep Foo | grep -v anchor
-     <p><a href="#type-u.Foo"><code>Foo</code></a> 
-      <a href="#type-u.Foo"><code>u.Foo</code></a> 
-      <a href="#type-u.Foo"><code>Foo</code></a>
-     <p><a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a> and 
-      <a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a>
-     <p><a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a> and 
-      <a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a>
+      <p><a href="#type-u.Foo"><code>Foo</code></a> 
+       <a href="#type-u.Foo"><code>u.Foo</code></a> 
+       <a href="#type-u.Foo"><code>Foo</code></a>
+      <p><a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a> and
+        <a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a>
+      <p><a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a> and
+        <a href="M/index.html#type-t.Foo"><code>M.t.Foo</code></a>

--- a/test/xref2/github_issue_857.t/run.t
+++ b/test/xref2/github_issue_857.t/run.t
@@ -18,8 +18,8 @@ In latex, labels in subpages should be disambiguated since the subpage is inline
 In html, labels in subpages should not be disambiguated since they won't have the same URL.
 
   $ cat html/A/index.html | grep 'id='
-      <div class="spec module-type anchored" id="module-type-A">
-     <h2 id="first"><a href="#first" class="anchor"></a>First outer section
+       <div class="spec module-type anchored" id="module-type-A">
+      <h2 id="first"><a href="#first" class="anchor"></a>First outer section
 
   $ cat html/A/module-type-A/index.html | grep 'id='
-     <h2 id="first"><a href="#first" class="anchor"></a>First inner section
+      <h2 id="first"><a href="#first" class="anchor"></a>First inner section

--- a/test/xref2/github_issue_932.t/run.t
+++ b/test/xref2/github_issue_932.t/run.t
@@ -10,58 +10,58 @@ A quick test to repro the issue found in #941
 The rendered html
 
   $ cat html/Foo/index.html | grep "extension" -A 3
-      <div class="spec type extension anchored" id="extension-decl-A">
-       <a href="#extension-decl-A" class="anchor"></a>
-       <code>
-        <span><span class="keyword">type</span> <a href="#type-t">t</a> += 
-        </span>
+       <div class="spec type extension anchored" id="extension-decl-A">
+        <a href="#extension-decl-A" class="anchor"></a>
+        <code>
+         <span><span class="keyword">type</span> <a href="#type-t">t</a> += 
+         </span>
   --
-        <li id="extension-A" class="def variant extension anchored">
-         <a href="#extension-A" class="anchor"></a>
-         <code><span>| </span><span><span class="extension">A</span></span>
-         </code>
-        </li>
-        <li id="extension-B" class="def variant extension anchored">
-         <a href="#extension-B" class="anchor"></a>
-         <code><span>| </span><span><span class="extension">B</span></span>
-         </code>
-        </li>
-       </ol>
+         <li id="extension-A" class="def variant extension anchored">
+          <a href="#extension-A" class="anchor"></a>
+          <code><span>| </span><span><span class="extension">A</span></span>
+          </code>
+         </li>
+         <li id="extension-B" class="def variant extension anchored">
+          <a href="#extension-B" class="anchor"></a>
+          <code><span>| </span><span><span class="extension">B</span></span>
+          </code>
+         </li>
+        </ol>
   --
-      <div class="spec type extension anchored" id="extension-decl-C">
-       <a href="#extension-decl-C" class="anchor"></a>
-       <code>
-        <span><span class="keyword">type</span> 
-         <a href="M/index.html#type-t">M.t</a> += 
+       <div class="spec type extension anchored" id="extension-decl-C">
+        <a href="#extension-decl-C" class="anchor"></a>
+        <code>
+         <span><span class="keyword">type</span> 
+          <a href="M/index.html#type-t">M.t</a> += 
   --
-        <li id="extension-C" class="def variant extension anchored">
-         <a href="#extension-C" class="anchor"></a>
-         <code><span>| </span><span><span class="extension">C</span></span>
-         </code>
-        </li>
-       </ol>
+         <li id="extension-C" class="def variant extension anchored">
+          <a href="#extension-C" class="anchor"></a>
+          <code><span>| </span><span><span class="extension">C</span></span>
+          </code>
+         </li>
+        </ol>
   --
-      <li>extension-decl-A : <a href="#extension-decl-A"><code>A</code></a>
-      </li>
-      <li>extension-decl-B : <a href="#extension-decl-A"><code>B</code></a>
-      </li><li>extension-A : <a href="#extension-A"><code>A</code></a></li>
-      <li>extension-B : <a href="#extension-B"><code>B</code></a></li>
-      <li>A : <a href="#extension-A"><code>A</code></a></li>
-     </ul>
-     <ul><li>M.t : <a href="M/index.html#type-t"><code>M.t</code></a></li>
-      <li>M.extension-decl-A : 
-       <a href="M/index.html#extension-decl-A"><code>M.A</code></a>
-      </li>
-      <li>M.extension-decl-B : 
-       <a href="M/index.html#extension-decl-A"><code>M.B</code></a>
-      </li>
-      <li>M.extension-A : 
-       <a href="M/index.html#extension-A"><code>M.A</code></a>
-      </li>
-      <li>M.extension-B : 
-       <a href="M/index.html#extension-B"><code>M.B</code></a>
-      </li>
-      <li>M.A : <a href="M/index.html#extension-A"><code>M.A</code></a></li>
-     </ul>
+       <li>extension-decl-A : <a href="#extension-decl-A"><code>A</code></a>
+       </li>
+       <li>extension-decl-B : <a href="#extension-decl-A"><code>B</code></a>
+       </li><li>extension-A : <a href="#extension-A"><code>A</code></a></li>
+       <li>extension-B : <a href="#extension-B"><code>B</code></a></li>
+       <li>A : <a href="#extension-A"><code>A</code></a></li>
+      </ul>
+      <ul><li>M.t : <a href="M/index.html#type-t"><code>M.t</code></a></li>
+       <li>M.extension-decl-A : 
+        <a href="M/index.html#extension-decl-A"><code>M.A</code></a>
+       </li>
+       <li>M.extension-decl-B : 
+        <a href="M/index.html#extension-decl-A"><code>M.B</code></a>
+       </li>
+       <li>M.extension-A : 
+        <a href="M/index.html#extension-A"><code>M.A</code></a>
+       </li>
+       <li>M.extension-B : 
+        <a href="M/index.html#extension-B"><code>M.B</code></a>
+       </li>
+       <li>M.A : <a href="M/index.html#extension-A"><code>M.A</code></a></li>
+      </ul>
+     </div>
     </div>
-   </body>

--- a/test/xref2/inherit_top_comment.t/run.t
+++ b/test/xref2/inherit_top_comment.t/run.t
@@ -6,14 +6,14 @@
 Module X inherits from X__Hidden's top comment:
 
   $ cat html/File/index.html | grep -B 10 X__Hidden
-      <div class="spec module anchored" id="module-X">
-       <a href="#module-X" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> <a href="X/index.html">X</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
-      </div>
-      <div class="spec-doc"><p>Top comment of <code>X__Hidden</code></p></div>
+       <div class="spec module anchored" id="module-X">
+        <a href="#module-X" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> <a href="X/index.html">X</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+       <div class="spec-doc"><p>Top comment of <code>X__Hidden</code></p></div>

--- a/test/xref2/initially_open.t/run.t
+++ b/test/xref2/initially_open.t/run.t
@@ -25,7 +25,7 @@ Run 'normally', without opening the module 'To_open':
   $ odoc link -I . other.odoc
   $ odoc html-generate -o . other.odocl --indent
   $ grep To_open x/Other/index.html
-        <span> = <a href="../To_open/index.html#type-t">To_open.t</a></span>
+         <span> = <a href="../To_open/index.html#type-t">To_open.t</a></span>
 
 Now try again, this time opening 'To_open', and expect the rendered link to be simplified:
 
@@ -33,5 +33,5 @@ Now try again, this time opening 'To_open', and expect the rendered link to be s
   $ odoc link -I . other.odoc
   $ odoc html-generate -o . other.odocl --indent
   $ grep To_open x/Other/index.html
-        <span> = <a href="../To_open/index.html#type-t">t</a></span>
+         <span> = <a href="../To_open/index.html#type-t">t</a></span>
 

--- a/test/xref2/label_reference_text.t/run.t
+++ b/test/xref2/label_reference_text.t/run.t
@@ -16,12 +16,14 @@ The rendered html
   $ cat html/Foo/index.html | grep "splice_me" -A 3
     <nav class="odoc-toc"><ul><li><a href="#splice_me">Splice me</a></li></ul>
     </nav>
-    <div class="odoc-content">
-     <h3 id="splice_me"><a href="#splice_me" class="anchor"></a>Splice me</h3>
-     <p>Should output only the heading's text: 
-      <a href="#splice_me" title="splice_me">Splice me</a> 
-      <a href="#splice_me" title="splice_me">Splice me</a> 
-      <a href="../page.html#splice_me" title="splice_me">Splice me</a>
-     </p>
+    <div class="odoc-main">
+     <header class="odoc-preamble">
+  --
+      <h3 id="splice_me"><a href="#splice_me" class="anchor"></a>Splice me</h3>
+      <p>Should output only the heading's text: 
+       <a href="#splice_me" title="splice_me">Splice me</a> 
+       <a href="#splice_me" title="splice_me">Splice me</a> 
+       <a href="../page.html#splice_me" title="splice_me">Splice me</a>
+      </p>
+     </div>
     </div>
-   </body>

--- a/test/xref2/labels/labels.t/run.t
+++ b/test/xref2/labels/labels.t/run.t
@@ -55,17 +55,20 @@ There are two references in N, one should point to a local label and the other t
      <a href="../../index.html">test</a> &#x00BB; 
      <a href="../index.html">Test</a> &#x00BB; N
     </nav>
-    <header class="odoc-preamble">
-     <h1>Module <code><span>Test.N</span></code></h1>
-    </header>
     <nav class="odoc-toc">
      <ul><li><a href="#B">An other conflicting label</a></li></ul>
     </nav>
-    <div class="odoc-content">
-     <h2 id="B"><a href="#B" class="anchor"></a>An other conflicting label</h2>
-     <p><a href="#B" title="B">An other conflicting label</a> 
-      <a href="../M/index.html#B" title="B">Potentially conflicting label</a>
-     </p>
+    <div class="odoc-main">
+     <header class="odoc-preamble">
+      <h1>Module <code><span>Test.N</span></code></h1>
+     </header>
+     <div class="odoc-content">
+      <h2 id="B"><a href="#B" class="anchor"></a>An other conflicting label
+      </h2>
+      <p><a href="#B" title="B">An other conflicting label</a> 
+       <a href="../M/index.html#B" title="B">Potentially conflicting label</a>
+      </p>
+     </div>
     </div>
    </body>
   </html>
@@ -87,51 +90,53 @@ The second occurence of 'B' in the main page should be disambiguated
     <nav class="odoc-nav"><a href="../index.html">Up</a> – 
      <a href="../index.html">test</a> &#x00BB; Test
     </nav>
-    <header class="odoc-preamble">
-     <h1>Module <code><span>Test</span></code></h1>
-    </header>
     <nav class="odoc-toc">
      <ul><li><a href="#A">First label</a></li>
       <li><a href="#B">Floating label</a></li>
       <li><a href="#B_2">Dupplicate B</a></li>
      </ul>
     </nav>
-    <div class="odoc-content">
-     <h2 id="A"><a href="#A" class="anchor"></a>First label</h2>
-     <h2 id="B"><a href="#B" class="anchor"></a>Floating label</h2>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-M">
-       <a href="#module-M" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> <a href="M/index.html">M</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
+    <div class="odoc-main">
+     <header class="odoc-preamble">
+      <h1>Module <code><span>Test</span></code></h1>
+     </header>
+     <div class="odoc-content">
+      <h2 id="A"><a href="#A" class="anchor"></a>First label</h2>
+      <h2 id="B"><a href="#B" class="anchor"></a>Floating label</h2>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-M">
+        <a href="#module-M" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> <a href="M/index.html">M</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
       </div>
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-N">
+        <a href="#module-N" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> <a href="N/index.html">N</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+      </div><h2 id="B_2"><a href="#B_2" class="anchor"></a>Dupplicate B</h2>
+      <p>Define <code>B</code> again in the same scope.</p>
+      <p>References to the labels:</p>
+      <p><a href="#A" title="A">First label</a> 
+       <a href="#B" title="B">Dupplicate B</a> 
+       <a href="M/index.html#C" title="C">First label of M</a> 
+       <a href="M/index.html#D" title="D">Floating label in M</a> 
+       <a href="M/index.html#B" title="B">Potentially conflicting label</a>
+        <a href="N/index.html#B" title="B">An other conflicting label</a>
+      </p>
      </div>
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-N">
-       <a href="#module-N" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> <a href="N/index.html">N</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
-      </div>
-     </div><h2 id="B_2"><a href="#B_2" class="anchor"></a>Dupplicate B</h2>
-     <p>Define <code>B</code> again in the same scope.</p>
-     <p>References to the labels:</p>
-     <p><a href="#A" title="A">First label</a> 
-      <a href="#B" title="B">Dupplicate B</a> 
-      <a href="M/index.html#C" title="C">First label of M</a> 
-      <a href="M/index.html#D" title="D">Floating label in M</a> 
-      <a href="M/index.html#B" title="B">Potentially conflicting label</a>
-       <a href="N/index.html#B" title="B">An other conflicting label</a>
-     </p>
     </div>
    </body>
   </html>

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -42,22 +42,24 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
     <nav class="odoc-nav"><a href="../index.html">Up</a> – 
      <a href="../index.html">test</a> &#x00BB; A
     </nav>
-    <header class="odoc-preamble"><h1>Module <code><span>A</span></code></h1>
-     <p>Module A.</p>
-    </header>
-    <div class="odoc-content">
-     <div class="odoc-spec">
-      <div class="spec module anchored" id="module-B">
-       <a href="#module-B" class="anchor"></a>
-       <code>
-        <span><span class="keyword">module</span> <a href="B/index.html">B</a>
-        </span>
-        <span> : <span class="keyword">sig</span> ... 
-         <span class="keyword">end</span>
-        </span>
-       </code>
-      </div>
-      <div class="spec-doc"><p>Module B. This paragraph is the synopsis.</p>
+    <div class="odoc-main">
+     <header class="odoc-preamble"><h1>Module <code><span>A</span></code></h1>
+      <p>Module A.</p>
+     </header>
+     <div class="odoc-content">
+      <div class="odoc-spec">
+       <div class="spec module anchored" id="module-B">
+        <a href="#module-B" class="anchor"></a>
+        <code>
+         <span><span class="keyword">module</span> <a href="B/index.html">B</a>
+         </span>
+         <span> : <span class="keyword">sig</span> ... 
+          <span class="keyword">end</span>
+         </span>
+        </code>
+       </div>
+       <div class="spec-doc"><p>Module B. This paragraph is the synopsis.</p>
+       </div>
       </div>
      </div>
     </div>
@@ -81,23 +83,26 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
      <a href="../../index.html">test</a> &#x00BB; <a href="../index.html">A</a>
       &#x00BB; B
     </nav>
-    <header class="odoc-preamble"><h1>Module <code><span>A.B</span></code></h1>
-     <p>Module B. This paragraph is the synopsis.</p>
-     <p>This paragraph and the previous are part of the preamble.</p>
-    </header>
     <nav class="odoc-toc">
      <ul><li><a href="#an-heading">An heading</a></li></ul>
     </nav>
-    <div class="odoc-content">
-     <h3 id="an-heading"><a href="#an-heading" class="anchor"></a>An heading
-     </h3>
-     <p>This paragraph is not part of the preamble. It'll be rendered in
-       the &quot;content&quot;.
-     </p>
-     <div class="odoc-spec">
-      <div class="spec type anchored" id="type-t">
-       <a href="#type-t" class="anchor"></a>
-       <code><span><span class="keyword">type</span> t</span></code>
+    <div class="odoc-main">
+     <header class="odoc-preamble">
+      <h1>Module <code><span>A.B</span></code></h1>
+      <p>Module B. This paragraph is the synopsis.</p>
+      <p>This paragraph and the previous are part of the preamble.</p>
+     </header>
+     <div class="odoc-content">
+      <h3 id="an-heading"><a href="#an-heading" class="anchor"></a>An heading
+      </h3>
+      <p>This paragraph is not part of the preamble. It'll be rendered 
+       in the &quot;content&quot;.
+      </p>
+      <div class="odoc-spec">
+       <div class="spec type anchored" id="type-t">
+        <a href="#type-t" class="anchor"></a>
+        <code><span><span class="keyword">type</span> t</span></code>
+       </div>
       </div>
      </div>
     </div>
@@ -120,8 +125,10 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
     <nav class="odoc-nav"><a href="../index.html">Up</a> – 
      <a href="../index.html">test</a> &#x00BB; A__b
     </nav>
-    <header class="odoc-preamble">
-     <h1>Module <code><span>A__b</span></code></h1>
-    </header><div class="odoc-content"><p>This module is hidden.</p></div>
+    <div class="odoc-main">
+     <header class="odoc-preamble">
+      <h1>Module <code><span>A__b</span></code></h1>
+     </header><div class="odoc-content"><p>This module is hidden.</p></div>
+    </div>
    </body>
   </html>

--- a/test/xref2/ocaml_stdlib.t/run.t
+++ b/test/xref2/ocaml_stdlib.t/run.t
@@ -19,4 +19,4 @@ Imitate the way the stdlib is built and how its documentation should be built.
 The page for Main should include the synopsis from X:
 
   $ cat html/ocaml/Main/index.html | grep "Synopsis"
-      </div><div class="spec-doc"><p>Synopsis</p></div>
+       </div><div class="spec-doc"><p>Synopsis</p></div>


### PR DESCRIPTION
Fix #1111 (alternative to #1143).

Since the introduction of the grid system (#999), [margin collapse](https://www.joshwcomeau.com/css/rules-of-margin-collapse/) did [not work](https://www.w3.org/TR/css-grid-1/#item-margins) between the preamble and content, creating [gaps on which people fell](https://github.com/ocaml/odoc/issues/1111):

> the margins of adjacent grid items do not collapse

This PR slightly changes the html layout, putting the `odoc-preamble` and `odoc-content` in an `odoc-main` element, which in my opinion make more sense than previously:
Previously, they were separated by the nav bar. I wonder if this was a deliberate choice, eg for accessibility reasons, or if it just happened to be like that?

This does not affects ocaml.org (which uses the json output), and from my tests it does not seem to affect odig (let's ping its author, @dbuenzli, so he's aware of the potential layout change!).