### PR TITLE
Remove margin of first child of odoc-content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
   select a result, and enter to follow the selected link. (@EmileTrotignon, #1088)
 - OCaml 5.2.0 compatibility (@Octachron, #1094, #1112)
 - New driver package (@jonludlam, #1121)
+- Fix a big gap between the preamble and the content of a page (@EmileTrotignon, #1147)
 
 ### Changed
 

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -300,7 +300,6 @@ body.odoc {
   display: grid;
   grid-template-columns: min-content 1fr;
   column-gap: 4ex;
-  row-gap: 2ex;
 }
 
 body.odoc-src {
@@ -310,6 +309,10 @@ body.odoc-src {
 .odoc-content {
   grid-row: 4;
   grid-column: 2;
+}
+
+.odoc-content > *:first-child {
+  margin-top: 0;
 }
 
 .odoc-preamble > *:first-child {
@@ -334,6 +337,7 @@ nav {
 nav.odoc-nav {
   grid-column: 2;
   grid-row: 2;
+  margin-bottom: 2ex;
 }
 
 /* Basic markup elements */


### PR DESCRIPTION
This fixes the gap in between the preamble and the content without changing other margins, or changing the structure of the HTML.