### PR TITLE
Path-references lookup to pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 - OCaml 5.2.0 compatibility (@Octachron, #1094, #1112)
 - New driver package (@jonludlam, #1121)
 - Fix a big gap between the preamble and the content of a page (@EmileTrotignon, #1147)
-- Path-references to hierarchical pages and modules (@Julow, #1142, #1151)
+- Path-references to hierarchical pages and modules (@Julow, #1142, #1150, #1151)
   Absolute (`{!/foo}`), relative (`{!./foo}`) and package-local (`{!//foo}`)
   are added.
 - Add a marshalled search index consumable by sherlodoc (@EmileTrotignon, @panglesd, #1084)

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -725,8 +725,16 @@ end = struct
     (if is_page then current_package_of_page ~current_package page_roots output
      else validate_current_package page_roots current_package)
     >>= fun current_package ->
+    let current_dir = Fs.File.dirname output in
     let roots =
-      Some { Resolver.page_roots; lib_roots; current_lib; current_package }
+      Some
+        {
+          Resolver.page_roots;
+          lib_roots;
+          current_lib;
+          current_package;
+          current_dir;
+        }
     in
     let resolver =
       Resolver.create ~important_digests:false ~directories ~open_modules ~roots

--- a/src/odoc/fs.ml
+++ b/src/odoc/fs.ml
@@ -94,6 +94,15 @@ module File = struct
 
   let exists file = Sys.file_exists (Fpath.to_string file)
 
+  let rec of_segs_tl acc = function
+    | [] -> acc
+    | hd :: tl -> of_segs_tl (Fpath.( / ) acc hd) tl
+
+  let of_segs = function
+    | [] -> invalid_arg "Fs.File.of_segs"
+    | "" :: rest -> of_segs_tl (Fpath.v "/") rest
+    | first :: rest -> of_segs_tl (Fpath.v first) rest
+
   module Table = Hashtbl.Make (struct
     type nonrec t = t
 

--- a/src/odoc/fs.ml
+++ b/src/odoc/fs.ml
@@ -103,6 +103,8 @@ module File = struct
     | "" :: rest -> of_segs_tl (Fpath.v "/") rest
     | first :: rest -> of_segs_tl (Fpath.v first) rest
 
+  let append_segs path segs = of_segs_tl path segs
+
   module Table = Hashtbl.Make (struct
     type nonrec t = t
 
@@ -136,6 +138,8 @@ module Directory = struct
           invalid_arg "Odoc.Fs.Directory.create: not a directory";
         path
 
+  let contains ~parentdir f = Fpath.is_rooted ~root:parentdir f
+
   let mkdir_p dir =
     let mkdir d =
       try Unix.mkdir (Fpath.to_string d) 0o755 with
@@ -156,6 +160,8 @@ module Directory = struct
     match Fpath.of_string s with
     | Result.Error (`Msg e) -> invalid_arg ("Odoc.Fs.Directory.of_string: " ^ e)
     | Result.Ok p -> Fpath.to_dir_path p
+
+  let of_file f = Fpath.to_dir_path f
 
   let fold_files_rec ?(ext = "") f acc d =
     let fold_non_dirs ext f acc files =

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -89,5 +89,9 @@ module File : sig
 
   val exists : t -> bool
 
+  val of_segs : string list -> t
+  (** [of_segs segs] Returns an absolute path if [segs] starts with an empty
+      segment. Raises [Invalid_argument] if [segs] is empty. *)
+
   module Table : Hashtbl.S with type key = t
 end

--- a/src/odoc/fs.mli
+++ b/src/odoc/fs.mli
@@ -36,7 +36,11 @@ module Directory : sig
   val reach_from : dir:t -> string -> t
   (** @raises Invalid_argument if [parent/name] exists but is not a directory. *)
 
+  val contains : parentdir:t -> file -> bool
+
   val mkdir_p : t -> unit
+
+  val of_file : file -> t
 
   val of_string : string -> t
 
@@ -92,6 +96,9 @@ module File : sig
   val of_segs : string list -> t
   (** [of_segs segs] Returns an absolute path if [segs] starts with an empty
       segment. Raises [Invalid_argument] if [segs] is empty. *)
+
+  val append_segs : t -> string list -> t
+  (** Append a list of segments to a path. Do not raise. *)
 
   module Table : Hashtbl.S with type key = t
 end

--- a/src/odoc/indexing.ml
+++ b/src/odoc/indexing.ml
@@ -114,13 +114,20 @@ open Odoc_model.Lang.Sidebar
 
 let compile out_format ~output ~warnings_options ~lib_roots ~page_roots
     ~inputs_in_file ~odocls =
+  let current_dir = Fs.File.dirname output in
   parse_input_files inputs_in_file >>= fun files ->
   let files = List.rev_append odocls files in
   let resolver =
     Resolver.create ~important_digests:false ~directories:[]
       ~roots:
         (Some
-           { page_roots; lib_roots; current_lib = None; current_package = None })
+           {
+             page_roots;
+             lib_roots;
+             current_lib = None;
+             current_package = None;
+             current_dir;
+           })
       ~open_modules:[]
   in
   (* if files = [] && then Error (`Msg "No .odocl files were included") *)

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -375,7 +375,7 @@ let add_unit_to_cache u =
 
 let lookup_path _ap ~pages ~libs:_ ~hierarchy (kind, tag, path) =
   let module Env = Odoc_xref2.Env in
-  let ( >>= ) x f = match x with Some x' -> f x' | None -> None in
+  let open Odoc_utils.OptionMonad in
   let page_path_to_path path =
     (* Turn [foo/bar] into [foo/page-bar.odoc]. *)
     let segs =

--- a/src/odoc/resolver.mli
+++ b/src/odoc/resolver.mli
@@ -24,8 +24,10 @@ type t
 type roots = {
   page_roots : (string * Fs.Directory.t) list;
   lib_roots : (string * Fs.Directory.t) list;
-  current_lib : string option;
-  current_package : string option;
+  current_lib : string option;  (** Name of the current [-L]. *)
+  current_package : string option;  (** Name of the current [-P]. *)
+  current_dir : Fs.Directory.t;
+      (** Directory containing the output for the current unit. *)
 }
 
 val create :

--- a/src/utils/odoc_utils.ml
+++ b/src/utils/odoc_utils.ml
@@ -1,3 +1,6 @@
+(** Re-export for compatibility with 4.02. *)
+type ('a, 'b) result = ('a, 'b) Result.result = Ok of 'a | Error of 'b
+
 (** The [result] type and a bind operator. This module is meant to be opened. *)
 module ResultMonad = struct
   (** Re-export for compat *)
@@ -43,6 +46,8 @@ module EitherMonad = struct
 end
 
 module List = struct
+  include List
+
   let rec concat_map ?sep ~f = function
     | [] -> []
     | [ x ] -> f x

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -12,15 +12,24 @@ type lookup_page_result = Lang.Page.t option
 
 type lookup_impl_result = Lang.Implementation.t option
 
+type lookup_path_result =
+  | Path_unit of Lang.Compilation_unit.t
+  | Path_page of Lang.Page.t
+  | Path_directory
+  | Path_not_found
+
 type root =
   | Resolved of (Odoc_model.Root.t * Identifier.Module.t * Component.Module.t)
   | Forward
+
+type path_query = [ `Page | `Unit ] * Reference.tag_hierarchy * string list
 
 type resolver = {
   open_units : string list;
   lookup_unit : string -> lookup_unit_result;
   lookup_impl : string -> lookup_impl_result;
   lookup_page : string -> lookup_page_result;
+  lookup_path : path_query -> lookup_path_result;
 }
 
 let unique_id =
@@ -436,6 +445,11 @@ let lookup_unit name env =
 
 let lookup_impl name env =
   match env.resolver with None -> None | Some r -> r.lookup_impl name
+
+let lookup_path query env =
+  match env.resolver with
+  | None -> Path_not_found
+  | Some r -> r.lookup_path query
 
 type 'a scope = {
   filter : Component.Element.any -> ([< Component.Element.any ] as 'a) option;

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -2,6 +2,7 @@
 open Odoc_model
 open Odoc_model.Names
 open Odoc_model.Paths
+open Odoc_utils
 
 type lookup_unit_result = Forward_reference | Found of Lang.Compilation_unit.t
 

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -12,16 +12,24 @@ type lookup_page_result = Lang.Page.t option
 
 type lookup_impl_result = Lang.Implementation.t option
 
+type lookup_path_result =
+  | Path_unit of Lang.Compilation_unit.t
+  | Path_page of Lang.Page.t
+  | Path_directory
+  | Path_not_found
+
 type root =
-  | Resolved of
-      (Root.t * Odoc_model.Paths.Identifier.Module.t * Component.Module.t)
+  | Resolved of (Root.t * Identifier.Module.t * Component.Module.t)
   | Forward
+
+type path_query = [ `Page | `Unit ] * Reference.tag_hierarchy * string list
 
 type resolver = {
   open_units : string list;
   lookup_unit : string -> lookup_unit_result;
   lookup_impl : string -> lookup_impl_result;
   lookup_page : string -> lookup_page_result;
+  lookup_path : path_query -> lookup_path_result;
 }
 
 type lookup_type =
@@ -103,6 +111,8 @@ val lookup_unit : string -> t -> lookup_unit_result option
 val module_of_unit : Lang.Compilation_unit.t -> Component.Module.t
 
 val lookup_root_module : string -> t -> root option
+
+val lookup_path : path_query -> t -> lookup_path_result
 
 type 'a scope constraint 'a = [< Component.Element.any ]
 (** Target of a lookup *)

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -2,6 +2,7 @@
 
 open Odoc_model
 open Odoc_model.Paths
+open Odoc_utils
 
 type lookup_unit_result = Forward_reference | Found of Lang.Compilation_unit.t
 

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -3,34 +3,22 @@
 open Odoc_model
 open Odoc_model.Paths
 
-type lookup_unit_result =
-  | Forward_reference
-  | Found of Lang.Compilation_unit.t
-  | Not_found
+type lookup_unit_result = Forward_reference | Found of Lang.Compilation_unit.t
 
-type lookup_page_result = Lang.Page.t option
+type path_query = [ `Path of Reference.Hierarchy.t | `Name of string ]
 
-type lookup_impl_result = Lang.Implementation.t option
+type lookup_error = [ `Not_found ]
 
-type lookup_path_result =
-  | Path_unit of Lang.Compilation_unit.t
-  | Path_page of Lang.Page.t
-  | Path_directory
-  | Path_not_found
+type resolver = {
+  open_units : string list;
+  lookup_unit : path_query -> (lookup_unit_result, lookup_error) result;
+  lookup_page : path_query -> (Lang.Page.t, lookup_error) result;
+  lookup_impl : string -> Lang.Implementation.t option;
+}
 
 type root =
   | Resolved of (Root.t * Identifier.Module.t * Component.Module.t)
   | Forward
-
-type path_query = [ `Page | `Unit ] * Reference.tag_hierarchy * string list
-
-type resolver = {
-  open_units : string list;
-  lookup_unit : string -> lookup_unit_result;
-  lookup_impl : string -> lookup_impl_result;
-  lookup_page : string -> lookup_page_result;
-  lookup_path : path_query -> lookup_path_result;
-}
 
 type lookup_type =
   | Module of Identifier.Path.Module.t
@@ -102,17 +90,20 @@ val add_module_type_functor_args :
 
 val lookup_fragment_root : t -> (int * Component.Signature.t) option
 
-val lookup_page : string -> t -> Lang.Page.t option
+val lookup_page_by_name : string -> t -> (Lang.Page.t, lookup_error) result
+val lookup_page_by_path :
+  Reference.Hierarchy.t -> t -> (Lang.Page.t, lookup_error) result
 
 val lookup_impl : string -> t -> Lang.Implementation.t option
 
-val lookup_unit : string -> t -> lookup_unit_result option
+val lookup_unit_by_name :
+  string -> t -> (lookup_unit_result, lookup_error) result
+val lookup_unit_by_path :
+  Reference.Hierarchy.t -> t -> (lookup_unit_result, lookup_error) result
 
 val module_of_unit : Lang.Compilation_unit.t -> Component.Module.t
 
 val lookup_root_module : string -> t -> root option
-
-val lookup_path : path_query -> t -> lookup_path_result
 
 type 'a scope constraint 'a = [< Component.Element.any ]
 (** Target of a lookup *)

--- a/src/xref2/errors.ml
+++ b/src/xref2/errors.ml
@@ -22,6 +22,8 @@ module Tools_error = struct
     | `Module_path
     | `Any_path ]
 
+  type path_kind = [ `Page | `Unit ]
+
   type expansion_of_module_error =
     [ `OpaqueModule (* The module does not have an expansion *)
     | `UnresolvedForwardPath
@@ -114,6 +116,10 @@ module Tools_error = struct
     [ `Wrong_kind of reference_kind list * reference_kind (* Expected, got *)
     | `Lookup_by_name of [ reference_kind | `Any ] * string
     | `Find_by_name of [ reference_kind | `Any ] * string
+    | `Path_error of
+      [ `Not_found | `Is_directory | `Wrong_kind of path_kind list * path_kind ]
+      * Reference.tag_hierarchy
+      * string list
     | `Parent of parent_lookup_error ]
 
   type any =
@@ -141,6 +147,41 @@ module Tools_error = struct
       | `Any_path -> "path"
     in
     Format.pp_print_string fmt k
+
+  let fpf = Format.fprintf
+
+  let pp_human_list pp_a fmt lst =
+    match List.rev lst with
+    | [] -> ()
+    | [ one ] -> pp_a fmt one
+    | last :: rev_tl ->
+        let pp_sep fmt () = fpf fmt ", " in
+        fpf fmt "%a and %a" (Format.pp_print_list ~pp_sep pp_a) rev_tl pp_a last
+
+  let pp_path fmt (tag, p) =
+    let tag =
+      match tag with
+      | `TRelativePath -> ""
+      | `TAbsolutePath -> "/"
+      | `TCurrentPackage -> "//"
+    in
+    let pp_sep fmt () = fpf fmt "/" in
+    fpf fmt "%s%a" tag (Format.pp_print_list ~pp_sep Format.pp_print_string) p
+
+  let pp_path_kind fmt = function
+    | `Unit -> fpf fmt "module"
+    | `Page -> fpf fmt "page"
+
+  let pp_path_error fmt err tag path =
+    match err with
+    | `Not_found -> fpf fmt "Path '%a' not found" pp_path (tag, path)
+    | `Is_directory ->
+        fpf fmt "Path '%a' points to directory" pp_path (tag, path)
+    | `Wrong_kind (expected, got) ->
+        fpf fmt "Path '%a' is of kind %a but was expected %a" pp_path
+          (tag, path) pp_path_kind got
+          (pp_human_list pp_path_kind)
+          expected
 
   let rec pp : Format.formatter -> any -> unit =
    fun fmt err ->
@@ -207,6 +248,7 @@ module Tools_error = struct
         | #reference_kind as kind ->
             Format.fprintf fmt "Couldn't find %a %S" pp_reference_kind kind name
         )
+    | `Path_error (err, tag, path) -> pp_path_error fmt err tag path
     | `Parent e -> pp fmt (e :> any)
 end
 

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -1108,18 +1108,17 @@ let page env page =
   let () =
     List.iter
       (fun child ->
-        let check_resolves ~what f name =
-          match f name env with
-          | Some _ -> ()
-          | None -> Errors.report ~what `Lookup
-        in
         match child with
         | Page.Asset_child _ | Page.Source_tree_child _ -> ()
-        | Page.Page_child page ->
-            check_resolves ~what:(`Child_page page) Env.lookup_page page
-        | Page.Module_child mod_ ->
-            check_resolves ~what:(`Child_module mod_) Env.lookup_root_module
-              mod_)
+        | Page.Page_child page -> (
+            match Env.lookup_page_by_name page env with
+            | Ok _ -> ()
+            | Error `Not_found -> Errors.report ~what:(`Child_page page) `Lookup
+            )
+        | Page.Module_child mod_ -> (
+            match Env.lookup_root_module mod_ env with
+            | Some _ -> ()
+            | None -> Errors.report ~what:(`Child_module mod_) `Lookup))
       page.Lang.Page.children
   in
   {

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -192,7 +192,8 @@ module Path = struct
     | `Page p -> Ok p
 
   let page_in_env env (tag, path) : page_lookup_result ref_result =
-    handle_lookup_errors ~tag ~path (Env.lookup_path (`Page, tag, path) env)
+    Env.lookup_path (`Page, tag, path) env
+    |> handle_lookup_errors ~tag ~path
     >>= expect_page ~tag ~path
     >>= fun p -> Ok (`Identifier p.name, p)
 

--- a/test/integration/dune
+++ b/test/integration/dune
@@ -6,3 +6,8 @@
  (applies_to json_expansion_with_sources)
  (enabled_if
   (> %{ocaml_version} 4.14.0)))
+
+(cram
+ (applies_to html_support_files)
+ (enabled_if
+  (> %{ocaml_version} 4.14.0)))

--- a/test/parent_id/parent_id.t/file.mld
+++ b/test/parent_id/parent_id.t/file.mld
@@ -1,4 +1,3 @@
 {0 File}
 
-{!page-"#my_page"}
-{!page-"#/pkg/dir1/my_page"}
+{!/pkg/dir1/my_page}

--- a/test/parent_id/parent_id.t/run.t
+++ b/test/parent_id/parent_id.t/run.t
@@ -64,18 +64,11 @@ Testing detection of package:
   $ odoc link -P pkg:_odoc/pkg/doc/ _odoc/pkg/doc/page-file.odoc
  Cannot detect due to wrong input:
   $ odoc link -P pkg2:_odoc/pkg/doc/ _odoc/pkg/doc/page-file.odoc
-  Not found by nameError during find by path: no package was found with this name
-  File "file.mld", line 4, characters 0-28:
-  Warning: Failed to resolve reference unresolvedroot(#/pkg/dir1/my_page) Couldn't find page "#/pkg/dir1/my_page"
-  File "file.mld", line 3, characters 0-18:
-  Warning: Failed to resolve reference unresolvedroot(#my_page) Couldn't find page "#my_page"
+  File "file.mld", line 3, characters 0-20:
+  Warning: Failed to resolve reference /pkg/dir1/my_page Path '/pkg/dir1/my_page' not found
 
 Testing missing file:
   $ rm _odoc/pkg/doc/dir1/page-my_page.odoc*
   $ odoc link -P pkg:_odoc/pkg/doc/ _odoc/pkg/doc/page-file.odoc
-  Page not found by name: 0
-  Error during find by path: no file was found with this path: dir1/page-my_page.odoc
-  File "file.mld", line 4, characters 0-28:
-  Warning: Failed to resolve reference unresolvedroot(#/pkg/dir1/my_page) Couldn't find page "#/pkg/dir1/my_page"
-  File "file.mld", line 3, characters 0-18:
-  Warning: Failed to resolve reference unresolvedroot(#my_page) Couldn't find page "#my_page"
+  File "file.mld", line 3, characters 0-20:
+  Warning: Failed to resolve reference /pkg/dir1/my_page Path '/pkg/dir1/my_page' not found

--- a/test/parent_id/sidebar.t/file.mld
+++ b/test/parent_id/sidebar.t/file.mld
@@ -1,4 +1,3 @@
 {0 File}
 
-{!page-"#my_page"}
-{!page-"#/pkg/dir1/my_page"}
+{!/pkg/dir1/my_page}

--- a/test/xref2/path_references.t/doc/dup.mld
+++ b/test/xref2/path_references.t/doc/dup.mld
@@ -1,0 +1,1 @@
+{0 Title for dup}

--- a/test/xref2/path_references.t/doc/foo.mld
+++ b/test/xref2/path_references.t/doc/foo.mld
@@ -1,0 +1,12 @@
+{0 Title for foo}
+
+{1 Page foo}
+{!//foo} {!/pkg/foo} {!foo} {!./foo}
+{1 Page subdir/bar}
+{!//subdir/bar} {!/pkg/subdir/bar} {!bar} {!subdir/bar} {!./subdir/bar}
+{1 Page dup}
+{!//dup} {!/pkg/dup} {!./dup}
+{1 Page subdir/dup}
+{!//subdir/dup} {!/pkg/subdir/dup} {!subdir/dup}
+{1 Module Test}
+{!//libname/Test} {!/pkg/libname/Test} {!./Test} {!Test}

--- a/test/xref2/path_references.t/doc/subdir/bar.mld
+++ b/test/xref2/path_references.t/doc/subdir/bar.mld
@@ -1,0 +1,12 @@
+{0 Title for subdir/bar}
+
+{1 Page foo}
+{!//foo} {!/pkg/foo} {!foo}
+{1 Page subdir/bar}
+{!//subdir/bar} {!/pkg/subdir/bar} {!bar} {!./bar}
+{1 Page dup}
+{!//dup} {!/pkg/dup}
+{1 Page subdir/dup}
+{!//subdir/dup} {!/pkg/subdir/dup} {!./dup}
+{1 Module Test}
+{!//libname/Test} {!/pkg/libname/Test} {!./Test} {!Test}

--- a/test/xref2/path_references.t/doc/subdir/dup.mld
+++ b/test/xref2/path_references.t/doc/subdir/dup.mld
@@ -1,0 +1,1 @@
+{0 Title for subdir/dup}

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -45,29 +45,19 @@
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
   File "doc/foo.mld", line 4, characters 28-36:
   Warning: Failed to resolve reference ./foo Path 'foo' not found
-  $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/lib/libname/test.odoc
+  $ odoc link --current-package pkg -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/lib/libname/test.odoc
   File "test.ml", line 12, characters 42-51:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
   File "test.ml", line 12, characters 21-41:
   Warning: Failed to resolve reference /pkg/libname/Test Path '/pkg/libname/Test' not found
   File "test.ml", line 12, characters 3-20:
   Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
-  File "test.ml", line 10, characters 3-18:
-  Warning: Failed to resolve reference //subdir/dup Path '//subdir/dup' not found
-  File "test.ml", line 8, characters 3-11:
-  Warning: Failed to resolve reference //dup Path '//dup' not found
   File "test.ml", line 6, characters 38-44:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
-  File "test.ml", line 6, characters 3-18:
-  Warning: Failed to resolve reference //subdir/bar Path '//subdir/bar' not found
   File "test.ml", line 4, characters 34-45:
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find page "foo"
-  File "test.ml", line 4, characters 3-16:
-  Warning: Failed to resolve reference //foo Path '//foo' not found
   File "test.ml", line 3, characters 24-30:
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
-  File "test.ml", line 3, characters 3-11:
-  Warning: Failed to resolve reference //foo Path '//foo' not found
 
 Helper that extracts references in a compact way. Headings help to interpret the result.
 
@@ -126,21 +116,21 @@ Helper that extracts references in a compact way. Headings help to interpret the
 
   $ odoc_print ./h/pkg/lib/libname/test.odocl | jq_references
   ["Page","foo"]
-  {"`Reference":[{"`Any_path":["`TCurrentPackage",["foo"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}
-  {"`Reference":[{"`Page_path":["`TCurrentPackage",["foo"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Root":["foo","`TPage"]},[]]}
   ["Page","subdir/bar"]
-  {"`Reference":[{"`Any_path":["`TCurrentPackage",["subdir","bar"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Root":["bar","`TUnknown"]},[]]}
   ["Page","dup"]
-  {"`Reference":[{"`Any_path":["`TCurrentPackage",["dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
   ["Page","subdir/dup"]
-  {"`Reference":[{"`Any_path":["`TCurrentPackage",["subdir","dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   ["Module","Test"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -19,18 +19,10 @@
   Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
   File "doc/subdir/bar.mld", line 10, characters 35-43:
   Warning: Failed to resolve reference ./dup Path 'dup' not found
-  File "doc/subdir/bar.mld", line 10, characters 16-34:
-  Warning: Failed to resolve reference /pkg/subdir/dup Path '/pkg/subdir/dup' not found
-  File "doc/subdir/bar.mld", line 8, characters 9-20:
-  Warning: Failed to resolve reference /pkg/dup Path '/pkg/dup' not found
   File "doc/subdir/bar.mld", line 6, characters 42-50:
   Warning: Failed to resolve reference ./bar Path 'bar' not found
-  File "doc/subdir/bar.mld", line 6, characters 16-34:
-  Warning: Failed to resolve reference /pkg/subdir/bar Path '/pkg/subdir/bar' not found
   File "doc/subdir/bar.mld", line 4, characters 21-27:
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
-  File "doc/subdir/bar.mld", line 4, characters 9-20:
-  Warning: Failed to resolve reference /pkg/foo Path '/pkg/foo' not found
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-foo.odoc
   File "doc/foo.mld", line 12, characters 49-56:
@@ -43,24 +35,16 @@
   Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
   File "doc/foo.mld", line 10, characters 35-48:
   Warning: Failed to resolve reference ./subdir/dup Path 'subdir/dup' not found
-  File "doc/foo.mld", line 10, characters 16-34:
-  Warning: Failed to resolve reference /pkg/subdir/dup Path '/pkg/subdir/dup' not found
   File "doc/foo.mld", line 8, characters 21-29:
   Warning: Failed to resolve reference ./dup Path 'dup' not found
-  File "doc/foo.mld", line 8, characters 9-20:
-  Warning: Failed to resolve reference /pkg/dup Path '/pkg/dup' not found
   File "doc/foo.mld", line 6, characters 56-71:
   Warning: Failed to resolve reference ./subdir/bar Path 'subdir/bar' not found
   File "doc/foo.mld", line 6, characters 42-55:
   Warning: Failed to resolve reference ./subdir/bar Path 'subdir/bar' not found
   File "doc/foo.mld", line 6, characters 35-41:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
-  File "doc/foo.mld", line 6, characters 16-34:
-  Warning: Failed to resolve reference /pkg/subdir/bar Path '/pkg/subdir/bar' not found
   File "doc/foo.mld", line 4, characters 28-36:
   Warning: Failed to resolve reference ./foo Path 'foo' not found
-  File "doc/foo.mld", line 4, characters 9-20:
-  Warning: Failed to resolve reference /pkg/foo Path '/pkg/foo' not found
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/lib/libname/test.odoc
   File "test.ml", line 12, characters 42-51:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
@@ -68,30 +52,20 @@
   Warning: Failed to resolve reference /pkg/libname/Test Path '/pkg/libname/Test' not found
   File "test.ml", line 12, characters 3-20:
   Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
-  File "test.ml", line 10, characters 19-37:
-  Warning: Failed to resolve reference /pkg/subdir/dup Path '/pkg/subdir/dup' not found
   File "test.ml", line 10, characters 3-18:
   Warning: Failed to resolve reference //subdir/dup Path '//subdir/dup' not found
-  File "test.ml", line 8, characters 12-23:
-  Warning: Failed to resolve reference /pkg/dup Path '/pkg/dup' not found
   File "test.ml", line 8, characters 3-11:
   Warning: Failed to resolve reference //dup Path '//dup' not found
   File "test.ml", line 6, characters 38-44:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
-  File "test.ml", line 6, characters 19-37:
-  Warning: Failed to resolve reference /pkg/subdir/bar Path '/pkg/subdir/bar' not found
   File "test.ml", line 6, characters 3-18:
   Warning: Failed to resolve reference //subdir/bar Path '//subdir/bar' not found
   File "test.ml", line 4, characters 34-45:
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find page "foo"
-  File "test.ml", line 4, characters 17-33:
-  Warning: Failed to resolve reference /pkg/foo Path '/pkg/foo' not found
   File "test.ml", line 4, characters 3-16:
   Warning: Failed to resolve reference //foo Path '//foo' not found
   File "test.ml", line 3, characters 24-30:
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
-  File "test.ml", line 3, characters 12-23:
-  Warning: Failed to resolve reference /pkg/foo Path '/pkg/foo' not found
   File "test.ml", line 3, characters 3-11:
   Warning: Failed to resolve reference //foo Path '//foo' not found
 
@@ -103,22 +77,22 @@ Helper that extracts references in a compact way. Headings help to interpret the
   ["Title","for","foo"]
   ["Page","foo"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","foo"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["foo"]]},[]]}
   ["Page","subdir/bar"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","bar"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Root":["bar","`TUnknown"]},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["subdir","bar"]]},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["subdir","bar"]]},[]]}
   ["Page","dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["dup"]]},[]]}
   ["Page","subdir/dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["subdir","dup"]]},[]]}
   ["Module","Test"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
@@ -130,19 +104,19 @@ Helper that extracts references in a compact way. Headings help to interpret the
   ["Title","for","subdir/bar"]
   ["Page","foo"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","foo"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}
   ["Page","subdir/bar"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","bar"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["bar"]]},[]]}
   ["Page","dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
   ["Page","subdir/dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["dup"]]},[]]}
   ["Module","Test"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
@@ -153,21 +127,21 @@ Helper that extracts references in a compact way. Headings help to interpret the
   $ odoc_print ./h/pkg/lib/libname/test.odocl | jq_references
   ["Page","foo"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["foo"]]},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","foo"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}
   {"`Reference":[{"`Page_path":["`TCurrentPackage",["foo"]]},[]]}
-  {"`Reference":[{"`Page_path":["`TAbsolutePath",["pkg","foo"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Root":["foo","`TPage"]},[]]}
   ["Page","subdir/bar"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["subdir","bar"]]},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","bar"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Root":["bar","`TUnknown"]},[]]}
   ["Page","dup"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["dup"]]},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
   ["Page","subdir/dup"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["subdir","dup"]]},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   ["Module","Test"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -1,0 +1,191 @@
+  $ ocamlc -bin-annot test.ml
+
+  $ mkdir h
+  $ odoc compile --output-dir h --parent-id pkg/doc doc/foo.mld
+  $ odoc compile --output-dir h --parent-id pkg/doc doc/dup.mld
+  $ odoc compile --output-dir h --parent-id pkg/doc/subdir doc/subdir/bar.mld
+  $ odoc compile --output-dir h --parent-id pkg/doc/subdir doc/subdir/dup.mld
+  $ odoc compile --output-dir h --parent-id pkg/lib/libname test.cmt
+
+  $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-dup.odoc
+  $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-bar.odoc
+  File "doc/subdir/bar.mld", line 12, characters 49-56:
+  Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
+  File "doc/subdir/bar.mld", line 12, characters 39-48:
+  Warning: Failed to resolve reference ./Test is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 12, characters 18-38:
+  Warning: Failed to resolve reference /pkg/libname/Test is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 12, characters 0-17:
+  Warning: Failed to resolve reference //libname/Test is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 10, characters 35-43:
+  Warning: Failed to resolve reference ./dup is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 10, characters 16-34:
+  Warning: Failed to resolve reference /pkg/subdir/dup is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 10, characters 0-15:
+  Warning: Failed to resolve reference //subdir/dup is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 8, characters 9-20:
+  Warning: Failed to resolve reference /pkg/dup is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 8, characters 0-8:
+  Warning: Failed to resolve reference //dup is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 6, characters 42-50:
+  Warning: Failed to resolve reference ./bar is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 6, characters 16-34:
+  Warning: Failed to resolve reference /pkg/subdir/bar is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 6, characters 0-15:
+  Warning: Failed to resolve reference //subdir/bar is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 4, characters 21-27:
+  Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
+  File "doc/subdir/bar.mld", line 4, characters 9-20:
+  Warning: Failed to resolve reference /pkg/foo is of kind page path but expected signature or page
+  File "doc/subdir/bar.mld", line 4, characters 0-8:
+  Warning: Failed to resolve reference //foo is of kind page path but expected signature or page
+  $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-dup.odoc
+  $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-foo.odoc
+  File "doc/foo.mld", line 12, characters 49-56:
+  Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
+  File "doc/foo.mld", line 12, characters 39-48:
+  Warning: Failed to resolve reference ./Test is of kind page path but expected signature or page
+  File "doc/foo.mld", line 12, characters 18-38:
+  Warning: Failed to resolve reference /pkg/libname/Test is of kind page path but expected signature or page
+  File "doc/foo.mld", line 12, characters 0-17:
+  Warning: Failed to resolve reference //libname/Test is of kind page path but expected signature or page
+  File "doc/foo.mld", line 10, characters 35-48:
+  Warning: Failed to resolve reference ./subdir/dup is of kind page path but expected signature or page
+  File "doc/foo.mld", line 10, characters 16-34:
+  Warning: Failed to resolve reference /pkg/subdir/dup is of kind page path but expected signature or page
+  File "doc/foo.mld", line 10, characters 0-15:
+  Warning: Failed to resolve reference //subdir/dup is of kind page path but expected signature or page
+  File "doc/foo.mld", line 8, characters 21-29:
+  Warning: Failed to resolve reference ./dup is of kind page path but expected signature or page
+  File "doc/foo.mld", line 8, characters 9-20:
+  Warning: Failed to resolve reference /pkg/dup is of kind page path but expected signature or page
+  File "doc/foo.mld", line 8, characters 0-8:
+  Warning: Failed to resolve reference //dup is of kind page path but expected signature or page
+  File "doc/foo.mld", line 6, characters 56-71:
+  Warning: Failed to resolve reference ./subdir/bar is of kind page path but expected signature or page
+  File "doc/foo.mld", line 6, characters 42-55:
+  Warning: Failed to resolve reference ./subdir/bar is of kind page path but expected signature or page
+  File "doc/foo.mld", line 6, characters 35-41:
+  Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
+  File "doc/foo.mld", line 6, characters 16-34:
+  Warning: Failed to resolve reference /pkg/subdir/bar is of kind page path but expected signature or page
+  File "doc/foo.mld", line 6, characters 0-15:
+  Warning: Failed to resolve reference //subdir/bar is of kind page path but expected signature or page
+  File "doc/foo.mld", line 4, characters 28-36:
+  Warning: Failed to resolve reference ./foo is of kind page path but expected signature or page
+  File "doc/foo.mld", line 4, characters 9-20:
+  Warning: Failed to resolve reference /pkg/foo is of kind page path but expected signature or page
+  File "doc/foo.mld", line 4, characters 0-8:
+  Warning: Failed to resolve reference //foo is of kind page path but expected signature or page
+  $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/lib/libname/test.odoc
+  File "test.ml", line 12, characters 42-51:
+  Warning: Failed to resolve reference ./Test is of kind page path but expected signature or page
+  File "test.ml", line 12, characters 21-41:
+  Warning: Failed to resolve reference /pkg/libname/Test is of kind page path but expected signature or page
+  File "test.ml", line 12, characters 3-20:
+  Warning: Failed to resolve reference //libname/Test is of kind page path but expected signature or page
+  File "test.ml", line 10, characters 19-37:
+  Warning: Failed to resolve reference /pkg/subdir/dup is of kind page path but expected signature or page
+  File "test.ml", line 10, characters 3-18:
+  Warning: Failed to resolve reference //subdir/dup is of kind page path but expected signature or page
+  File "test.ml", line 8, characters 12-23:
+  Warning: Failed to resolve reference /pkg/dup is of kind page path but expected signature or page
+  File "test.ml", line 8, characters 3-11:
+  Warning: Failed to resolve reference //dup is of kind page path but expected signature or page
+  File "test.ml", line 6, characters 38-44:
+  Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
+  File "test.ml", line 6, characters 19-37:
+  Warning: Failed to resolve reference /pkg/subdir/bar is of kind page path but expected signature or page
+  File "test.ml", line 6, characters 3-18:
+  Warning: Failed to resolve reference //subdir/bar is of kind page path but expected signature or page
+  File "test.ml", line 4, characters 34-45:
+  Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find page "foo"
+  File "test.ml", line 4, characters 17-33:
+  Warning: Failed to resolve reference /pkg/foo is of kind page path but expected signature or page
+  File "test.ml", line 4, characters 3-16:
+  Warning: Failed to resolve reference //foo is of kind page path but expected signature or page
+  File "test.ml", line 3, characters 24-30:
+  Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
+  File "test.ml", line 3, characters 12-23:
+  Warning: Failed to resolve reference /pkg/foo is of kind page path but expected signature or page
+  File "test.ml", line 3, characters 3-11:
+  Warning: Failed to resolve reference //foo is of kind page path but expected signature or page
+
+Helper that extracts references in a compact way. Headings help to interpret the result.
+
+  $ jq_references() { jq -c '.. | objects | if has("`Reference") then . elif has("`Heading") then [ .. | .["`Word"]? | select(.) ] else empty end'; }
+
+  $ odoc_print ./h/pkg/doc/page-foo.odocl | jq_references
+  ["Title","for","foo"]
+  ["Page","foo"]
+  {"`Reference":[{"`Page_path":{"`Root":["foo","`TCurrentPackage"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"foo"]}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
+  {"`Reference":[{"`Page_path":{"`Root":["foo","`TRelativePath"]}},[]]}
+  ["Page","subdir/bar"]
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"bar"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"bar"]}},[]]}
+  {"`Reference":[{"`Root":["bar","`TUnknown"]},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TRelativePath"]},"bar"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TRelativePath"]},"bar"]}},[]]}
+  ["Page","dup"]
+  {"`Reference":[{"`Page_path":{"`Root":["dup","`TCurrentPackage"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"dup"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Root":["dup","`TRelativePath"]}},[]]}
+  ["Page","subdir/dup"]
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"dup"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"dup"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TRelativePath"]},"dup"]}},[]]}
+  ["Module","Test"]
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["libname","`TCurrentPackage"]},"Test"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"libname"]},"Test"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Root":["Test","`TRelativePath"]}},[]]}
+  {"`Reference":[{"`Root":["Test","`TUnknown"]},[]]}
+
+  $ odoc_print ./h/pkg/doc/subdir/page-bar.odocl | jq_references
+  ["Title","for","subdir/bar"]
+  ["Page","foo"]
+  {"`Reference":[{"`Page_path":{"`Root":["foo","`TCurrentPackage"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"foo"]}},[]]}
+  {"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}
+  ["Page","subdir/bar"]
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"bar"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"bar"]}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
+  {"`Reference":[{"`Page_path":{"`Root":["bar","`TRelativePath"]}},[]]}
+  ["Page","dup"]
+  {"`Reference":[{"`Page_path":{"`Root":["dup","`TCurrentPackage"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"dup"]}},[]]}
+  ["Page","subdir/dup"]
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"dup"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"dup"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Root":["dup","`TRelativePath"]}},[]]}
+  ["Module","Test"]
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["libname","`TCurrentPackage"]},"Test"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"libname"]},"Test"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Root":["Test","`TRelativePath"]}},[]]}
+  {"`Reference":[{"`Root":["Test","`TUnknown"]},[]]}
+
+  $ odoc_print ./h/pkg/lib/libname/test.odocl | jq_references
+  ["Page","foo"]
+  {"`Reference":[{"`Page_path":{"`Root":["foo","`TCurrentPackage"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"foo"]}},[]]}
+  {"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}
+  {"`Reference":[{"`Page_path":{"`Root":["foo","`TCurrentPackage"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"foo"]}},[]]}
+  {"`Reference":[{"`Root":["foo","`TPage"]},[]]}
+  ["Page","subdir/bar"]
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"bar"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"bar"]}},[]]}
+  {"`Reference":[{"`Root":["bar","`TUnknown"]},[]]}
+  ["Page","dup"]
+  {"`Reference":[{"`Page_path":{"`Root":["dup","`TCurrentPackage"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"dup"]}},[]]}
+  ["Page","subdir/dup"]
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"dup"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"dup"]}},[]]}
+  ["Module","Test"]
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["libname","`TCurrentPackage"]},"Test"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"libname"]},"Test"]}},[]]}
+  {"`Reference":[{"`Page_path":{"`Root":["Test","`TRelativePath"]}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -9,6 +9,8 @@
 
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-bar.odoc
+  File "h/pkg/doc/subdir/page-Test.odoc":
+  File does not exist
   File "doc/subdir/bar.mld", line 12, characters 49-56:
   Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/subdir/bar.mld", line 12, characters 39-48:
@@ -17,14 +19,12 @@
   Warning: Failed to resolve reference /pkg/libname/Test Path '/pkg/libname/Test' not found
   File "doc/subdir/bar.mld", line 12, characters 0-17:
   Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
-  File "doc/subdir/bar.mld", line 10, characters 35-43:
-  Warning: Failed to resolve reference ./dup Path 'dup' not found
-  File "doc/subdir/bar.mld", line 6, characters 42-50:
-  Warning: Failed to resolve reference ./bar Path 'bar' not found
   File "doc/subdir/bar.mld", line 4, characters 21-27:
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-foo.odoc
+  File "h/pkg/doc/page-Test.odoc":
+  File does not exist
   File "doc/foo.mld", line 12, characters 49-56:
   Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/foo.mld", line 12, characters 39-48:
@@ -33,18 +33,8 @@
   Warning: Failed to resolve reference /pkg/libname/Test Path '/pkg/libname/Test' not found
   File "doc/foo.mld", line 12, characters 0-17:
   Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
-  File "doc/foo.mld", line 10, characters 35-48:
-  Warning: Failed to resolve reference ./subdir/dup Path 'subdir/dup' not found
-  File "doc/foo.mld", line 8, characters 21-29:
-  Warning: Failed to resolve reference ./dup Path 'dup' not found
-  File "doc/foo.mld", line 6, characters 56-71:
-  Warning: Failed to resolve reference ./subdir/bar Path 'subdir/bar' not found
-  File "doc/foo.mld", line 6, characters 42-55:
-  Warning: Failed to resolve reference ./subdir/bar Path 'subdir/bar' not found
   File "doc/foo.mld", line 6, characters 35-41:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
-  File "doc/foo.mld", line 4, characters 28-36:
-  Warning: Failed to resolve reference ./foo Path 'foo' not found
   $ odoc link --current-package pkg -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/lib/libname/test.odoc
   File "test.ml", line 12, characters 42-51:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
@@ -69,21 +59,21 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TRelativePath",["foo"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
   ["Page","subdir/bar"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Root":["bar","`TUnknown"]},[]]}
-  {"`Reference":[{"`Any_path":["`TRelativePath",["subdir","bar"]]},[]]}
-  {"`Reference":[{"`Any_path":["`TRelativePath",["subdir","bar"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   ["Page","dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TRelativePath",["dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
   ["Page","subdir/dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TRelativePath",["subdir","dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   ["Module","Test"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}
@@ -100,14 +90,14 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TRelativePath",["bar"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
   ["Page","dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
   ["Page","subdir/dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TRelativePath",["dup"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   ["Module","Test"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -12,104 +12,88 @@
   File "doc/subdir/bar.mld", line 12, characters 49-56:
   Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/subdir/bar.mld", line 12, characters 39-48:
-  Warning: Failed to resolve reference ./Test is of kind page path but expected signature or page
+  Warning: Failed to resolve reference ./Test Path 'Test' not found
   File "doc/subdir/bar.mld", line 12, characters 18-38:
-  Warning: Failed to resolve reference /pkg/libname/Test is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/libname/Test Path '/pkg/libname/Test' not found
   File "doc/subdir/bar.mld", line 12, characters 0-17:
-  Warning: Failed to resolve reference //libname/Test is of kind page path but expected signature or page
+  Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
   File "doc/subdir/bar.mld", line 10, characters 35-43:
-  Warning: Failed to resolve reference ./dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference ./dup Path 'dup' not found
   File "doc/subdir/bar.mld", line 10, characters 16-34:
-  Warning: Failed to resolve reference /pkg/subdir/dup is of kind page path but expected signature or page
-  File "doc/subdir/bar.mld", line 10, characters 0-15:
-  Warning: Failed to resolve reference //subdir/dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/subdir/dup Path '/pkg/subdir/dup' not found
   File "doc/subdir/bar.mld", line 8, characters 9-20:
-  Warning: Failed to resolve reference /pkg/dup is of kind page path but expected signature or page
-  File "doc/subdir/bar.mld", line 8, characters 0-8:
-  Warning: Failed to resolve reference //dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/dup Path '/pkg/dup' not found
   File "doc/subdir/bar.mld", line 6, characters 42-50:
-  Warning: Failed to resolve reference ./bar is of kind page path but expected signature or page
+  Warning: Failed to resolve reference ./bar Path 'bar' not found
   File "doc/subdir/bar.mld", line 6, characters 16-34:
-  Warning: Failed to resolve reference /pkg/subdir/bar is of kind page path but expected signature or page
-  File "doc/subdir/bar.mld", line 6, characters 0-15:
-  Warning: Failed to resolve reference //subdir/bar is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/subdir/bar Path '/pkg/subdir/bar' not found
   File "doc/subdir/bar.mld", line 4, characters 21-27:
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
   File "doc/subdir/bar.mld", line 4, characters 9-20:
-  Warning: Failed to resolve reference /pkg/foo is of kind page path but expected signature or page
-  File "doc/subdir/bar.mld", line 4, characters 0-8:
-  Warning: Failed to resolve reference //foo is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/foo Path '/pkg/foo' not found
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-foo.odoc
   File "doc/foo.mld", line 12, characters 49-56:
   Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/foo.mld", line 12, characters 39-48:
-  Warning: Failed to resolve reference ./Test is of kind page path but expected signature or page
+  Warning: Failed to resolve reference ./Test Path 'Test' not found
   File "doc/foo.mld", line 12, characters 18-38:
-  Warning: Failed to resolve reference /pkg/libname/Test is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/libname/Test Path '/pkg/libname/Test' not found
   File "doc/foo.mld", line 12, characters 0-17:
-  Warning: Failed to resolve reference //libname/Test is of kind page path but expected signature or page
+  Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
   File "doc/foo.mld", line 10, characters 35-48:
-  Warning: Failed to resolve reference ./subdir/dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference ./subdir/dup Path 'subdir/dup' not found
   File "doc/foo.mld", line 10, characters 16-34:
-  Warning: Failed to resolve reference /pkg/subdir/dup is of kind page path but expected signature or page
-  File "doc/foo.mld", line 10, characters 0-15:
-  Warning: Failed to resolve reference //subdir/dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/subdir/dup Path '/pkg/subdir/dup' not found
   File "doc/foo.mld", line 8, characters 21-29:
-  Warning: Failed to resolve reference ./dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference ./dup Path 'dup' not found
   File "doc/foo.mld", line 8, characters 9-20:
-  Warning: Failed to resolve reference /pkg/dup is of kind page path but expected signature or page
-  File "doc/foo.mld", line 8, characters 0-8:
-  Warning: Failed to resolve reference //dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/dup Path '/pkg/dup' not found
   File "doc/foo.mld", line 6, characters 56-71:
-  Warning: Failed to resolve reference ./subdir/bar is of kind page path but expected signature or page
+  Warning: Failed to resolve reference ./subdir/bar Path 'subdir/bar' not found
   File "doc/foo.mld", line 6, characters 42-55:
-  Warning: Failed to resolve reference ./subdir/bar is of kind page path but expected signature or page
+  Warning: Failed to resolve reference ./subdir/bar Path 'subdir/bar' not found
   File "doc/foo.mld", line 6, characters 35-41:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
   File "doc/foo.mld", line 6, characters 16-34:
-  Warning: Failed to resolve reference /pkg/subdir/bar is of kind page path but expected signature or page
-  File "doc/foo.mld", line 6, characters 0-15:
-  Warning: Failed to resolve reference //subdir/bar is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/subdir/bar Path '/pkg/subdir/bar' not found
   File "doc/foo.mld", line 4, characters 28-36:
-  Warning: Failed to resolve reference ./foo is of kind page path but expected signature or page
+  Warning: Failed to resolve reference ./foo Path 'foo' not found
   File "doc/foo.mld", line 4, characters 9-20:
-  Warning: Failed to resolve reference /pkg/foo is of kind page path but expected signature or page
-  File "doc/foo.mld", line 4, characters 0-8:
-  Warning: Failed to resolve reference //foo is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/foo Path '/pkg/foo' not found
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/lib/libname/test.odoc
   File "test.ml", line 12, characters 42-51:
-  Warning: Failed to resolve reference ./Test is of kind page path but expected signature or page
+  Warning: Failed to resolve reference ./Test Path 'Test' not found
   File "test.ml", line 12, characters 21-41:
-  Warning: Failed to resolve reference /pkg/libname/Test is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/libname/Test Path '/pkg/libname/Test' not found
   File "test.ml", line 12, characters 3-20:
-  Warning: Failed to resolve reference //libname/Test is of kind page path but expected signature or page
+  Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
   File "test.ml", line 10, characters 19-37:
-  Warning: Failed to resolve reference /pkg/subdir/dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/subdir/dup Path '/pkg/subdir/dup' not found
   File "test.ml", line 10, characters 3-18:
-  Warning: Failed to resolve reference //subdir/dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference //subdir/dup Path '//subdir/dup' not found
   File "test.ml", line 8, characters 12-23:
-  Warning: Failed to resolve reference /pkg/dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/dup Path '/pkg/dup' not found
   File "test.ml", line 8, characters 3-11:
-  Warning: Failed to resolve reference //dup is of kind page path but expected signature or page
+  Warning: Failed to resolve reference //dup Path '//dup' not found
   File "test.ml", line 6, characters 38-44:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
   File "test.ml", line 6, characters 19-37:
-  Warning: Failed to resolve reference /pkg/subdir/bar is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/subdir/bar Path '/pkg/subdir/bar' not found
   File "test.ml", line 6, characters 3-18:
-  Warning: Failed to resolve reference //subdir/bar is of kind page path but expected signature or page
+  Warning: Failed to resolve reference //subdir/bar Path '//subdir/bar' not found
   File "test.ml", line 4, characters 34-45:
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find page "foo"
   File "test.ml", line 4, characters 17-33:
-  Warning: Failed to resolve reference /pkg/foo is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/foo Path '/pkg/foo' not found
   File "test.ml", line 4, characters 3-16:
-  Warning: Failed to resolve reference //foo is of kind page path but expected signature or page
+  Warning: Failed to resolve reference //foo Path '//foo' not found
   File "test.ml", line 3, characters 24-30:
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
   File "test.ml", line 3, characters 12-23:
-  Warning: Failed to resolve reference /pkg/foo is of kind page path but expected signature or page
+  Warning: Failed to resolve reference /pkg/foo Path '/pkg/foo' not found
   File "test.ml", line 3, characters 3-11:
-  Warning: Failed to resolve reference //foo is of kind page path but expected signature or page
+  Warning: Failed to resolve reference //foo Path '//foo' not found
 
 Helper that extracts references in a compact way. Headings help to interpret the result.
 
@@ -118,74 +102,74 @@ Helper that extracts references in a compact way. Headings help to interpret the
   $ odoc_print ./h/pkg/doc/page-foo.odocl | jq_references
   ["Title","for","foo"]
   ["Page","foo"]
-  {"`Reference":[{"`Page_path":{"`Root":["foo","`TCurrentPackage"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"foo"]}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
-  {"`Reference":[{"`Page_path":{"`Root":["foo","`TRelativePath"]}},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","foo"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
+  {"`Reference":[{"`Any_path":["`TRelativePath",["foo"]]},[]]}
   ["Page","subdir/bar"]
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"bar"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"bar"]}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","bar"]]},[]]}
   {"`Reference":[{"`Root":["bar","`TUnknown"]},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TRelativePath"]},"bar"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TRelativePath"]},"bar"]}},[]]}
+  {"`Reference":[{"`Any_path":["`TRelativePath",["subdir","bar"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TRelativePath",["subdir","bar"]]},[]]}
   ["Page","dup"]
-  {"`Reference":[{"`Page_path":{"`Root":["dup","`TCurrentPackage"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"dup"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Root":["dup","`TRelativePath"]}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","dup"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TRelativePath",["dup"]]},[]]}
   ["Page","subdir/dup"]
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"dup"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"dup"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TRelativePath"]},"dup"]}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","dup"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TRelativePath",["subdir","dup"]]},[]]}
   ["Module","Test"]
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["libname","`TCurrentPackage"]},"Test"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"libname"]},"Test"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Root":["Test","`TRelativePath"]}},[]]}
+  {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
   {"`Reference":[{"`Root":["Test","`TUnknown"]},[]]}
 
   $ odoc_print ./h/pkg/doc/subdir/page-bar.odocl | jq_references
   ["Title","for","subdir/bar"]
   ["Page","foo"]
-  {"`Reference":[{"`Page_path":{"`Root":["foo","`TCurrentPackage"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"foo"]}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"foo"]}}},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","foo"]]},[]]}
   {"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}
   ["Page","subdir/bar"]
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"bar"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"bar"]}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
-  {"`Reference":[{"`Page_path":{"`Root":["bar","`TRelativePath"]}},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","bar"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"bar"]}}},[]]}
+  {"`Reference":[{"`Any_path":["`TRelativePath",["bar"]]},[]]}
   ["Page","dup"]
-  {"`Reference":[{"`Page_path":{"`Root":["dup","`TCurrentPackage"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"dup"]}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"dup"]}}},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","dup"]]},[]]}
   ["Page","subdir/dup"]
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"dup"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"dup"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Root":["dup","`TRelativePath"]}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","dup"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TRelativePath",["dup"]]},[]]}
   ["Module","Test"]
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["libname","`TCurrentPackage"]},"Test"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"libname"]},"Test"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Root":["Test","`TRelativePath"]}},[]]}
+  {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
   {"`Reference":[{"`Root":["Test","`TUnknown"]},[]]}
 
   $ odoc_print ./h/pkg/lib/libname/test.odocl | jq_references
   ["Page","foo"]
-  {"`Reference":[{"`Page_path":{"`Root":["foo","`TCurrentPackage"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"foo"]}},[]]}
+  {"`Reference":[{"`Any_path":["`TCurrentPackage",["foo"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","foo"]]},[]]}
   {"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}
-  {"`Reference":[{"`Page_path":{"`Root":["foo","`TCurrentPackage"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"foo"]}},[]]}
+  {"`Reference":[{"`Page_path":["`TCurrentPackage",["foo"]]},[]]}
+  {"`Reference":[{"`Page_path":["`TAbsolutePath",["pkg","foo"]]},[]]}
   {"`Reference":[{"`Root":["foo","`TPage"]},[]]}
   ["Page","subdir/bar"]
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"bar"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"bar"]}},[]]}
+  {"`Reference":[{"`Any_path":["`TCurrentPackage",["subdir","bar"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","bar"]]},[]]}
   {"`Reference":[{"`Root":["bar","`TUnknown"]},[]]}
   ["Page","dup"]
-  {"`Reference":[{"`Page_path":{"`Root":["dup","`TCurrentPackage"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"dup"]}},[]]}
+  {"`Reference":[{"`Any_path":["`TCurrentPackage",["dup"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","dup"]]},[]]}
   ["Page","subdir/dup"]
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["subdir","`TCurrentPackage"]},"dup"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"subdir"]},"dup"]}},[]]}
+  {"`Reference":[{"`Any_path":["`TCurrentPackage",["subdir","dup"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","subdir","dup"]]},[]]}
   ["Module","Test"]
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Root":["libname","`TCurrentPackage"]},"Test"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Slash":[{"`Slash":[{"`Root":["pkg","`TAbsolutePath"]},"libname"]},"Test"]}},[]]}
-  {"`Reference":[{"`Page_path":{"`Root":["Test","`TRelativePath"]}},[]]}
+  {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}

--- a/test/xref2/path_references.t/test.ml
+++ b/test/xref2/path_references.t/test.ml
@@ -1,0 +1,15 @@
+(**
+   {1 Page foo}
+   {!//foo} {!/pkg/foo} {!foo}
+   {!//page-foo} {!/pkg/page-foo} {!page-foo}
+   {1 Page subdir/bar}
+   {!//subdir/bar} {!/pkg/subdir/bar} {!bar}
+   {1 Page dup}
+   {!//dup} {!/pkg/dup}
+   {1 Page subdir/dup}
+   {!//subdir/dup} {!/pkg/subdir/dup}
+   {1 Module Test}
+   {!//libname/Test} {!/pkg/libname/Test} {!./Test} {!Test}
+*)
+
+type t


### PR DESCRIPTION
This implements the resolving of some path-references using the new `Named_roots` mechanism recently added.

This is work in progress. Currently, current-package and absolute references are resolved from pages. On top of https://github.com/ocaml/odoc/pull/1142