### PR TITLE
add odoc package as a link deps to the driver

### DIFF
--- a/src/driver/dune
+++ b/src/driver/dune
@@ -1,6 +1,8 @@
 (executable
  (public_name odoc_driver)
  (package odoc-driver)
+ (link_deps
+  (package odoc))
  (libraries
   cmdliner
   bos


### PR DESCRIPTION
Add the odoc package as a deps to the driver, because it is one.

Now when you do `dune exec odoc_driver -- -p ...` before doing `dune build`, it works anyway !