### PR TITLE
Fix interaction between search and side bars

### DIFF
--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -863,7 +863,7 @@ td.def-doc *:first-child {
 /* When a search bar is present, we need the sticky sidebar to be a bit lower,
    so `top` is higher  */
 
-.odoc-search + * + .odoc-tocs .odoc-toc {
+body.odoc:has( .odoc-search) .odoc-toc {
   --toc-top: calc(var(--search-bar-height) + 2 * var(--search-padding-top));
   max-height: calc(100vh - 2 * var(--toc-top));
   top: var(--toc-top)
@@ -1249,86 +1249,75 @@ td.def-doc *:first-child {
   body.odoc {
     max-width: 132ex;
     grid-template-areas:
-    "search-bar nav"
-    "sidebar    preamble"
-    "sidebar    content";
-  }
-
-  body.odoc:has(> .odoc-search:focus-within) {
-    grid-template-areas:
-    "search-bar search-bar"
-    ".          nav"
-    "sidebar    preamble"
-    "sidebar    content" !important;
-  }
-
-  .odoc-tocs {
+      "search-bar nav"
+      "sidebar    preamble"
+      "sidebar    content";
+    .odoc-tocs {
       display: flex;
       grid-area: sidebar;
       flex-direction : column;
       gap: 20px;
-  }
-  .odoc-toc {
-      position: unset;
-      max-height: unset !important;
+      .odoc-toc {
+        position: unset;
+        max-height: unset;
+      }
+    }
+    &:has(.odoc-search:focus-within) {
+      grid-template-areas:
+        "search-bar search-bar"
+        ".          nav"
+        "sidebar    preamble"
+        "sidebar    content";
+    }
   }
 }
 
 @media only screen and (max-width: 110ex) {
-  body {
+  body.odoc {
     margin: 2em;
     padding: 0;
-  }
-
-  body.odoc {
     grid-template-areas:
       "search-bar"
       "nav"
       "preamble"
       "toc-local"
       "content"
-      "toc-global" !important;
-    grid-template-columns: 1fr !important;
-  }
-
-  body.odoc:has(> .odoc-search:focus-within) {
-    /* This is the same as when there is no focus on the search bar, this is
-    just to prevent the full screen rule from changing anything. */
-    grid-template-areas:
-      "search-bar"
-      "nav"
-      "preamble"
-      "toc-local"
-      "content"
-      "toc-global" !important;
-    grid-template-columns: 1fr !important;
-  }
-
-
-  .odoc-search {
-    position: relative;
-    height: calc(var(--search-bar-height) + 2 * var(--search-padding-top));
-  }
-
-  .odoc-tocs {
+      "toc-global";
+    grid-template-columns: 1fr;
+    &:has(> .odoc-search:focus-within) {
+      /* This is the same as when there is no focus on the search bar, this is
+      just to prevent the full screen rule from changing anything. */
+      grid-template-areas:
+        "search-bar"
+        "nav"
+        "preamble"
+        "toc-local"
+        "content"
+        "toc-global";
+      grid-template-columns: 1fr;
+    }
+    .odoc-search {
+      position: relative;
+      height: calc(var(--search-bar-height) + 2 * var(--search-padding-top));
+    }
+    nav.odoc-nav {
+      padding-top: 0;
+      padding-bottom: var(--search-padding-top);
+    }
+    .odoc-tocs {
       display: contents;
-  }
-
-  .odoc-toc {
-    position: static;
-    width: auto;
-    min-width: unset;
-    max-width: unset;
-    max-height: unset;
-    border: none;
-    padding: 0.2em 1em;
-    border-radius: 5px;
-    margin-bottom: 2em;
-  }
-
-  nav.odoc-nav {
-    padding-top: 0 !important;
-    padding-bottom: var(--search-padding-top);
+      .odoc-toc {
+        position: static;
+        width: auto;
+        min-width: unset;
+        max-width: unset;
+        max-height: unset;
+        border: none;
+        padding: 0.2em 1em;
+        border-radius: 5px;
+        margin-bottom: 2em;
+      }
+    }
   }
 }
 

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -324,9 +324,13 @@ body.odoc:not(:has(> .odoc-tocs .odoc-global-toc)) {
   "content    toc-local";
   grid-template-columns: 1fr min-content;
 }
+
+/* When there is no global sidebar */
 body.odoc:not(:has(> .odoc-tocs .odoc-global-toc)) nav.odoc-nav {
   padding-top: 0;
 }
+
+/* When there is no global sidebbar and the searchbar is focused */
 body.odoc:not(:has(> .odoc-tocs .odoc-global-toc)) nav.odoc-nav:has(+ .odoc-search:focus-within) {
   padding-top: var(--search-padding-top);
 }

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -323,13 +323,12 @@ body.odoc:not(:has(> .odoc-tocs .odoc-global-toc)) {
   "preamble   toc-local"
   "content    toc-local";
   grid-template-columns: 1fr min-content;
-
-  nav.odoc-nav {
-    padding-top: 0;
-  }
-  nav.odoc-nav:has(+ .odoc-search:focus-within) {
-    padding-top: var(--search-padding-top);
-  }
+}
+body.odoc:not(:has(> .odoc-tocs .odoc-global-toc)) nav.odoc-nav {
+  padding-top: 0;
+}
+body.odoc:not(:has(> .odoc-tocs .odoc-global-toc)) nav.odoc-nav:has(+ .odoc-search:focus-within) {
+  padding-top: var(--search-padding-top);
 }
 
 nav.odoc-nav:has(+ .odoc-search:focus-within) {
@@ -1252,23 +1251,23 @@ body.odoc:has( .odoc-search) .odoc-toc {
       "search-bar nav"
       "sidebar    preamble"
       "sidebar    content";
-    .odoc-tocs {
+  }
+  body.odoc .odoc-tocs {
       display: flex;
       grid-area: sidebar;
       flex-direction : column;
       gap: 20px;
-      .odoc-toc {
-        position: unset;
-        max-height: unset;
-      }
-    }
-    &:has(.odoc-search:focus-within) {
-      grid-template-areas:
-        "search-bar search-bar"
-        ".          nav"
-        "sidebar    preamble"
-        "sidebar    content";
-    }
+  }
+  body.odoc .odoc-tocs .odoc-toc {
+    position: unset;
+    max-height: unset;
+  }
+  body.odoc:has(.odoc-search:focus-within) {
+    grid-template-areas:
+      "search-bar search-bar"
+      ".          nav"
+      "sidebar    preamble"
+      "sidebar    content";
   }
 }
 
@@ -1284,40 +1283,40 @@ body.odoc:has( .odoc-search) .odoc-toc {
       "content"
       "toc-global";
     grid-template-columns: 1fr;
-    &:has(> .odoc-search:focus-within) {
-      /* This is the same as when there is no focus on the search bar, this is
-      just to prevent the full screen rule from changing anything. */
-      grid-template-areas:
-        "search-bar"
-        "nav"
-        "preamble"
-        "toc-local"
-        "content"
-        "toc-global";
-      grid-template-columns: 1fr;
-    }
-    .odoc-search {
-      position: relative;
-      height: calc(var(--search-bar-height) + 2 * var(--search-padding-top));
-    }
-    nav.odoc-nav {
-      padding-top: 0;
-      padding-bottom: var(--search-padding-top);
-    }
-    .odoc-tocs {
-      display: contents;
-      .odoc-toc {
-        position: static;
-        width: auto;
-        min-width: unset;
-        max-width: unset;
-        max-height: unset;
-        border: none;
-        padding: 0.2em 1em;
-        border-radius: 5px;
-        margin-bottom: 2em;
-      }
-    }
+  }
+  body.odoc:has(> .odoc-search:focus-within) {
+    /* This is the same as when there is no focus on the search bar, this is
+    just to prevent the default "wide layout" rule from changing anything. */
+    grid-template-areas:
+      "search-bar"
+      "nav"
+      "preamble"
+      "toc-local"
+      "content"
+      "toc-global";
+    grid-template-columns: 1fr;
+  }
+  body.odoc .odoc-search {
+    position: relative;
+    height: calc(var(--search-bar-height) + 2 * var(--search-padding-top));
+  }
+  body.odoc nav.odoc-nav {
+    padding-top: 0;
+    padding-bottom: var(--search-padding-top);
+  }
+  body.odoc .odoc-tocs {
+    display: contents;
+  }
+  body.odoc .odoc-tocs .odoc-toc {
+    position: static;
+    width: auto;
+    min-width: unset;
+    max-width: unset;
+    max-height: unset;
+    border: none;
+    padding: 0.2em 1em;
+    border-radius: 5px;
+    margin-bottom: 2em;
   }
 }
 

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -325,7 +325,7 @@ body.odoc:not(:has(> .odoc-tocs .odoc-global-toc)) {
   grid-template-columns: 1fr min-content;
 
   nav.odoc-nav {
-    padding-bottom: 0;
+    padding-top: 0;
   }
   nav.odoc-nav:has(+ .odoc-search:focus-within) {
     padding-top: var(--search-padding-top);

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -1256,14 +1256,10 @@ td.def-doc *:first-child {
 
   body.odoc:has(> .odoc-search:focus-within) {
     grid-template-areas:
-    "nav        nav"
     "search-bar search-bar"
+    ".          nav"
     "sidebar    preamble"
-    "sidebar    content";
-  }
-
-  nav.odoc-nav:has(+ .odoc-search:focus-within) {
-    padding-bottom: 0;
+    "sidebar    content" !important;
   }
 
   .odoc-tocs {
@@ -1291,8 +1287,8 @@ td.def-doc *:first-child {
       "preamble"
       "toc-local"
       "content"
-      "toc-global";
-    grid-template-columns: 1fr;
+      "toc-global" !important;
+    grid-template-columns: 1fr !important;
   }
 
   body.odoc:has(> .odoc-search:focus-within) {
@@ -1304,15 +1300,14 @@ td.def-doc *:first-child {
       "preamble"
       "toc-local"
       "content"
-      "toc-global";
-    grid-template-columns: 1fr;
+      "toc-global" !important;
+    grid-template-columns: 1fr !important;
   }
 
 
   .odoc-search {
     position: relative;
-    padding-bottom: 0;
-    height: calc(var(--search-bar-height) + var(--search-padding-top));
+    height: calc(var(--search-bar-height) + 2 * var(--search-padding-top));
   }
 
   .odoc-tocs {
@@ -1329,6 +1324,11 @@ td.def-doc *:first-child {
     padding: 0.2em 1em;
     border-radius: 5px;
     margin-bottom: 2em;
+  }
+
+  nav.odoc-nav {
+    padding-top: 0 !important;
+    padding-bottom: var(--search-padding-top);
   }
 }
 

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -302,8 +302,8 @@ body.odoc {
   grid-template-columns: min-content 1fr min-content;
   grid-template-areas:
     "search-bar nav      ."
-    "toc-local  preamble toc-global"
-    "toc-local  content  toc-global";
+    "toc-global  preamble toc-local"
+    "toc-global  content  toc-local";
   column-gap: 4ex;
   grid-template-rows: auto auto 1fr;
 }

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -310,9 +310,30 @@ body.odoc {
 
 body.odoc:has(> .odoc-search:focus-within) {
   grid-template-areas:
-  "search-bar search-bar nav"
-  "toc-local  preamble   toc-global"
-  "toc-local  content    toc-global";
+  "search-bar search-bar search-bar"
+  ".          nav        ."
+  "toc-global  preamble   toc-local"
+  "toc-global  content    toc-local";
+}
+
+body.odoc:not(:has(> .odoc-tocs .odoc-global-toc)) {
+  grid-template-areas:
+  "search-bar search-bar"
+  "nav        ."
+  "preamble   toc-local"
+  "content    toc-local";
+  grid-template-columns: 1fr min-content;
+
+  nav.odoc-nav {
+    padding-bottom: 0;
+  }
+  nav.odoc-nav:has(+ .odoc-search:focus-within) {
+    padding-top: var(--search-padding-top);
+  }
+}
+
+nav.odoc-nav:has(+ .odoc-search:focus-within) {
+  padding-top: 0;
 }
 
 body.odoc-src {
@@ -1253,7 +1274,7 @@ td.def-doc *:first-child {
   }
   .odoc-toc {
       position: unset;
-      max-height: unset;
+      max-height: unset !important;
   }
 }
 

--- a/test/parent_id/sidebar.t/run.t
+++ b/test/parent_id/sidebar.t/run.t
@@ -56,4 +56,4 @@
       </ul>
 
   $ odoc support-files -o html
-  $ cp -r html /tmp/html
+$ cp -r html /tmp/html


### PR DESCRIPTION
There are now a lot of bars in odoc, which can be side, search or absent or present.

This fixes weird css interactions in with some combinations in that were merged before we had a chance to fix them in the sidebar pr.
