### PR TITLE
Disable "big search path" test.

### DIFF
--- a/test/xref2/big_search_path.t/run.t
+++ b/test/xref2/big_search_path.t/run.t
@@ -1,7 +1,10 @@
+WARNING: DISABLED in the dune file.
+Was too brittle (it had too many false positive in CI.). Kept for reference
+until the test is integrated in a benchmark. (TODO)
+
 Testing our timeout (timeout is not available on mac):
 
   $ ./timeout.sh 0.01 "sleep 2" 2> /dev/null
-
 
 We create a lot of directories
 

--- a/test/xref2/dune
+++ b/test/xref2/dune
@@ -60,3 +60,10 @@
  (applies_to lookup_def shadow3 to_remove_test)
  (enabled_if
   (>= %{ocaml_version} 4.14.0)))
+
+; Disable the big_search_path test, as it had too many false positive in CI.
+; Kept for reference until the test is integrated in a benchmark. (TODO)
+
+(cram
+ (applies_to big_search_path)
+ (enabled_if false))


### PR DESCRIPTION
Was too brittle: too many false positive in CI...
(I rebuilded the debian-12-5.2_s390x_opam-2.1 ocaml-CI job on several PR).

I kept the test as a reminder to add it as part of a potential benchmark CI.