### PR TITLE
Resolve path references to modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 - OCaml 5.2.0 compatibility (@Octachron, #1094, #1112)
 - New driver package (@jonludlam, #1121)
 - Fix a big gap between the preamble and the content of a page (@EmileTrotignon, #1147)
-- Path-references to hierarchical pages and modules (@Julow, #1142, #1150, #1151)
+- Path-references to hierarchical pages and modules (@Julow, #1142, #1150, #1151, #1164)
   Absolute (`{!/foo}`), relative (`{!./foo}`) and package-local (`{!//foo}`)
   are added.
 - Add a marshalled search index consumable by sherlodoc (@EmileTrotignon, @panglesd, #1084)

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -245,7 +245,6 @@ let unit_name
     | Source_tree_content { root; _ } ) =
   root_name root
 
-(** Returns [None] if the file is not found or failed to load for any reason. *)
 let load_unit_from_file path = Odoc_file.load path >>= fun u -> Ok u.content
 
 let unit_cache = Hashtbl.create 42

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -448,10 +448,8 @@ let lookup_page_by_path ~pages ~hierarchy path =
 
 let lookup_unit_by_path ~libs ~hierarchy path =
   let possible_unit_names name =
-    [
-      String.capitalize_ascii name ^ ".odoc";
-      String.uncapitalize_ascii name ^ ".odoc";
-    ]
+    Astring.String.Ascii.
+      [ capitalize name ^ ".odoc"; uncapitalize name ^ ".odoc" ]
   in
   match lookup_path ~possible_unit_names ~named_roots:libs ~hierarchy path with
   | Ok (Odoc_file.Unit_content u) -> Ok (Odoc_xref2.Env.Found u)

--- a/src/utils/odoc_utils.ml
+++ b/src/utils/odoc_utils.ml
@@ -63,6 +63,12 @@ module List = struct
     | [] -> List.rev acc
 
   let filter_map f x = filter_map [] f x
+
+  (** @raise [Failure] if the list is empty. *)
+  let rec last = function
+    | [] -> failwith "Odoc_utils.List.last"
+    | [ x ] -> x
+    | _ :: tl -> last tl
 end
 
 module Option = struct

--- a/src/utils/odoc_utils.ml
+++ b/src/utils/odoc_utils.ml
@@ -69,6 +69,12 @@ module List = struct
     | [] -> failwith "Odoc_utils.List.last"
     | [ x ] -> x
     | _ :: tl -> last tl
+
+  (* From ocaml/ocaml *)
+  let rec find_map f = function
+    | [] -> None
+    | x :: l -> (
+        match f x with Some _ as result -> result | None -> find_map f l)
 end
 
 module Option = struct

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -442,8 +442,13 @@ let lookup_impl name env =
 let lookup_page_by_name n env = lookup_page (`Name n) env
 let lookup_page_by_path p env = lookup_page (`Path p) env
 
-let lookup_unit_by_name n env = lookup_unit (`Name n) env
-let lookup_unit_by_path p env = lookup_unit (`Path p) env
+let lookup_unit_by_path p env =
+  match lookup_unit (`Path p) env with
+  | Ok (Found u) ->
+      let m = Component.Delayed.put_val (module_of_unit u) in
+      Ok (`Module ((u.id :> Identifier.Path.Module.t), m))
+  | Ok Forward_reference -> Error `Not_found (* TODO: Remove this case *)
+  | Error _ as e -> e
 
 type 'a scope = {
   filter : Component.Element.any -> ([< Component.Element.any ] as 'a) option;

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -97,10 +97,8 @@ val lookup_page_by_path :
 
 val lookup_impl : string -> t -> Lang.Implementation.t option
 
-val lookup_unit_by_name :
-  string -> t -> (lookup_unit_result, lookup_error) result
 val lookup_unit_by_path :
-  Reference.Hierarchy.t -> t -> (lookup_unit_result, lookup_error) result
+  Reference.Hierarchy.t -> t -> (Component.Element.module_, lookup_error) result
 
 val module_of_unit : Lang.Compilation_unit.t -> Component.Module.t
 

--- a/test/xref2/path_references.t/doc/foo.mld
+++ b/test/xref2/path_references.t/doc/foo.mld
@@ -9,4 +9,4 @@
 {1 Page subdir/dup}
 {!//subdir/dup} {!/pkg/subdir/dup} {!subdir/dup}
 {1 Module Test}
-{!//libname/Test} {!/pkg/libname/Test} {!./Test} {!Test}
+{!//Test} {!/libname/Test} {!./Test} {!Test}

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -30,8 +30,6 @@
   File "doc/foo.mld", line 6, characters 35-41:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
   $ odoc link --current-package pkg -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/lib/libname/test.odoc
-  File "test.ml", line 12, characters 30-39:
-  Warning: Failed to resolve reference ./Test Path 'Test' not found
   File "test.ml", line 6, characters 38-44:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
   File "test.ml", line 4, characters 34-45:
@@ -115,5 +113,5 @@ Helper that extracts references in a compact way. Headings help to interpret the
   ["Module","Test"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
-  {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -25,23 +25,23 @@
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-foo.odoc
   File "h/pkg/doc/page-Test.odoc":
   File does not exist
-  File "doc/foo.mld", line 12, characters 49-56:
+  File "doc/foo.mld", line 12, characters 37-44:
   Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
-  File "doc/foo.mld", line 12, characters 39-48:
+  File "doc/foo.mld", line 12, characters 27-36:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
-  File "doc/foo.mld", line 12, characters 18-38:
-  Warning: Failed to resolve reference /pkg/libname/Test Path '/pkg/libname/Test' not found
-  File "doc/foo.mld", line 12, characters 0-17:
-  Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
+  File "doc/foo.mld", line 12, characters 10-26:
+  Warning: Failed to resolve reference /libname/Test Path '/libname/Test' not found
+  File "doc/foo.mld", line 12, characters 0-9:
+  Warning: Failed to resolve reference //Test Path '//Test' not found
   File "doc/foo.mld", line 6, characters 35-41:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
   $ odoc link --current-package pkg -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/lib/libname/test.odoc
-  File "test.ml", line 12, characters 42-51:
+  File "test.ml", line 12, characters 30-39:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
-  File "test.ml", line 12, characters 21-41:
-  Warning: Failed to resolve reference /pkg/libname/Test Path '/pkg/libname/Test' not found
-  File "test.ml", line 12, characters 3-20:
-  Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
+  File "test.ml", line 12, characters 13-29:
+  Warning: Failed to resolve reference /libname/Test Path '/libname/Test' not found
+  File "test.ml", line 12, characters 3-12:
+  Warning: Failed to resolve reference //Test Path '//Test' not found
   File "test.ml", line 6, characters 38-44:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
   File "test.ml", line 4, characters 34-45:
@@ -75,8 +75,8 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   ["Module","Test"]
-  {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TCurrentPackage",["Test"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
   {"`Reference":[{"`Root":["Test","`TUnknown"]},[]]}
 
@@ -123,7 +123,7 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   ["Module","Test"]
-  {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TCurrentPackage",["Test"]]},[]]}
+  {"`Reference":[{"`Any_path":["`TAbsolutePath",["libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -9,7 +9,19 @@
 
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-bar.odoc
+  File "h/pkg/doc/subdir/Bar.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/bar.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/Dup.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/dup.odoc":
+  File does not exist
   File "h/pkg/doc/subdir/page-Test.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/Test.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/test.odoc":
   File does not exist
   File "doc/subdir/bar.mld", line 12, characters 49-56:
   Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
@@ -23,14 +35,36 @@
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-foo.odoc
+  File "h/pkg/doc/Foo.odoc":
+  File does not exist
+  File "h/pkg/doc/foo.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/Bar.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/bar.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/Bar.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/bar.odoc":
+  File does not exist
+  File "h/pkg/doc/Dup.odoc":
+  File does not exist
+  File "h/pkg/doc/dup.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/Dup.odoc":
+  File does not exist
+  File "h/pkg/doc/subdir/dup.odoc":
+  File does not exist
   File "h/pkg/doc/page-Test.odoc":
+  File does not exist
+  File "h/pkg/doc/Test.odoc":
+  File does not exist
+  File "h/pkg/doc/test.odoc":
   File does not exist
   File "doc/foo.mld", line 12, characters 37-44:
   Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/foo.mld", line 12, characters 27-36:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
-  File "doc/foo.mld", line 12, characters 10-26:
-  Warning: Failed to resolve reference /libname/Test Path '/libname/Test' not found
   File "doc/foo.mld", line 12, characters 0-9:
   Warning: Failed to resolve reference //Test Path '//Test' not found
   File "doc/foo.mld", line 6, characters 35-41:
@@ -38,10 +72,6 @@
   $ odoc link --current-package pkg -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/lib/libname/test.odoc
   File "test.ml", line 12, characters 30-39:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
-  File "test.ml", line 12, characters 13-29:
-  Warning: Failed to resolve reference /libname/Test Path '/libname/Test' not found
-  File "test.ml", line 12, characters 3-12:
-  Warning: Failed to resolve reference //Test Path '//Test' not found
   File "test.ml", line 6, characters 38-44:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
   File "test.ml", line 4, characters 34-45:
@@ -76,7 +106,7 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   ["Module","Test"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["Test"]]},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["libname","Test"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
   {"`Reference":[{"`Root":["Test","`TUnknown"]},[]]}
 
@@ -123,7 +153,7 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]}},"subdir"]}},"dup"]}}},[]]}
   ["Module","Test"]
-  {"`Reference":[{"`Any_path":["`TCurrentPackage",["Test"]]},[]]}
-  {"`Reference":[{"`Any_path":["`TAbsolutePath",["libname","Test"]]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -9,20 +9,6 @@
 
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-bar.odoc
-  File "h/pkg/doc/subdir/Bar.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/bar.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/Dup.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/dup.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/page-Test.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/Test.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/test.odoc":
-  File does not exist
   File "doc/subdir/bar.mld", line 12, characters 49-56:
   Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/subdir/bar.mld", line 12, characters 39-48:
@@ -35,32 +21,6 @@
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-foo.odoc
-  File "h/pkg/doc/Foo.odoc":
-  File does not exist
-  File "h/pkg/doc/foo.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/Bar.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/bar.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/Bar.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/bar.odoc":
-  File does not exist
-  File "h/pkg/doc/Dup.odoc":
-  File does not exist
-  File "h/pkg/doc/dup.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/Dup.odoc":
-  File does not exist
-  File "h/pkg/doc/subdir/dup.odoc":
-  File does not exist
-  File "h/pkg/doc/page-Test.odoc":
-  File does not exist
-  File "h/pkg/doc/Test.odoc":
-  File does not exist
-  File "h/pkg/doc/test.odoc":
-  File does not exist
   File "doc/foo.mld", line 12, characters 37-44:
   Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/foo.mld", line 12, characters 27-36:

--- a/test/xref2/path_references.t/test.ml
+++ b/test/xref2/path_references.t/test.ml
@@ -9,7 +9,7 @@
    {1 Page subdir/dup}
    {!//subdir/dup} {!/pkg/subdir/dup}
    {1 Module Test}
-   {!//libname/Test} {!/pkg/libname/Test} {!./Test} {!Test}
+   {!//Test} {!/libname/Test} {!./Test} {!Test}
 *)
 
 type t


### PR DESCRIPTION
The code for resolving path-references is factorized into the `lookup_path` function. The `Named_roots` for libraries is used to locate modules. `Env`'s API is changed to make the `Ref_tools` part easier to write.

Unprefixed references are resolved both as pages and modules concurrently and a warning is generated if the reference is ambiguous.
