### PR TITLE
Voodoo odoc driver

### DIFF
--- a/odoc-driver.opam
+++ b/odoc-driver.opam
@@ -33,6 +33,7 @@ documentation for installed packages.
 
 
 depends: [
+  "ocaml" {>= "5.1.0"}
   "odoc" {= version}
   "bos"
   "fpath"

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -17,7 +17,7 @@ type compiled = {
   include_dirs : Fpath.Set.t;
   impl : impl option;
   pkg_args : pkg_args;
-  pkgdir : Packages.pkgdir;
+  pkgname : Packages.pkgname;
 }
 
 let mk_byhash (pkgs : Packages.t Util.StringMap.t) =
@@ -197,7 +197,7 @@ let compile ?partial ~output_dir ?linked_dir all =
             include_dirs = includes;
             impl;
             pkg_args;
-            pkgdir = modty.m_pkg;
+            pkgname = modty.m_pkgname;
           }
   in
 
@@ -225,7 +225,7 @@ let compile ?partial ~output_dir ?linked_dir all =
     Util.StringMap.fold
       (fun _pkgname (pkg : Packages.t) acc ->
         Logs.debug (fun m ->
-            m "Package %s mlds: [%a]" pkg.name
+            m "Package %s mlds: [%a]" pkg.pkgname.p_name
               Fmt.(list ~sep:sp Packages.pp_mld)
               pkg.mlds);
         List.fold_left
@@ -252,7 +252,7 @@ let compile ?partial ~output_dir ?linked_dir all =
               include_dirs;
               impl = None;
               pkg_args;
-              pkgdir = mld.mld_pkg;
+              pkgname = mld.mld_pkgname;
             }
             :: acc)
           acc pkg.mlds)
@@ -267,7 +267,7 @@ let compile ?partial ~output_dir ?linked_dir all =
 type linked = {
   output_file : Fpath.t;
   src : Fpath.t option;
-  pkgdir : Packages.pkgdir;
+  pkgname : Packages.pkgname;
 }
 
 let link : compiled list -> _ =
@@ -276,9 +276,9 @@ let link : compiled list -> _ =
    fun c ->
     let includes = Fpath.Set.add c.odoc_output_dir c.include_dirs in
     let link input_file output_file =
-      let { pkg_args = { libs; docs }; pkgdir = current_package, _; _ } = c in
-      Odoc.link ~input_file ~output_file ~includes ~libs ~docs ~current_package
-        ()
+      let { pkg_args = { libs; docs }; pkgname; _ } = c in
+      Odoc.link ~input_file ~output_file ~includes ~libs ~docs
+        ~current_package:pkgname.p_name ()
     in
     let impl =
       match c.impl with
@@ -287,7 +287,7 @@ let link : compiled list -> _ =
               m "Linking impl: %a -> %a" Fpath.pp impl_odoc Fpath.pp impl_odocl);
           link impl_odoc impl_odocl;
           Atomic.incr Stats.stats.linked_impls;
-          [ { pkgdir = c.pkgdir; output_file = impl_odocl; src = Some src } ]
+          [ { pkgname = c.pkgname; output_file = impl_odocl; src = Some src } ]
       | None -> []
     in
     match c.m with
@@ -300,13 +300,14 @@ let link : compiled list -> _ =
         (match c.m with
         | Module _ -> Atomic.incr Stats.stats.linked_units
         | Mld _ -> Atomic.incr Stats.stats.linked_mlds);
-        { output_file = c.odocl_file; src = None; pkgdir = c.pkgdir } :: impl
+        { output_file = c.odocl_file; src = None; pkgname = c.pkgname } :: impl
   in
   Fiber.List.map link compiled |> List.concat
 
 let index_one ~odocl_dir pkgname pkg =
-  let _, dir = pkg.Packages.pkgdir in
-  let output_file = Fpath.(odocl_dir // dir / Odoc.index_filename) in
+  let output_file =
+    Fpath.(odocl_dir // pkg.Packages.pkgname.p_dir / Odoc.index_filename)
+  in
   let libs =
     List.map
       (fun lib -> (lib.Packages.lib_name, Fpath.(odocl_dir // lib.odoc_dir)))
@@ -319,7 +320,7 @@ let index_one ~odocl_dir pkgname pkg =
 let index ~odocl_dir pkgs = Util.StringMap.iter (index_one ~odocl_dir) pkgs
 
 let sherlodoc_index_one ~html_dir ~odocl_dir _ pkg_content =
-  let _, pkg_dir = pkg_content.Packages.pkgdir in
+  let pkg_dir = pkg_content.Packages.pkgname.p_dir in
   let inputs = [ Fpath.(odocl_dir // pkg_dir / Odoc.index_filename) ] in
   let dst = Fpath.(html_dir // Sherlodoc.db_js_file pkg_dir) in
   let dst_dir, _ = Fpath.split_base dst in
@@ -337,15 +338,14 @@ let sherlodoc ~html_dir ~odocl_dir pkgs =
   let inputs =
     pkgs |> Util.StringMap.bindings
     |> List.map (fun (_pkgname, pkg) ->
-           let _, pkg_dir = pkg.Packages.pkgdir in
-           Fpath.(odocl_dir // pkg_dir / Odoc.index_filename))
+           Fpath.(odocl_dir // pkg.Packages.pkgname.p_dir / Odoc.index_filename))
   in
   Sherlodoc.index ~format ~inputs ~dst ()
 
 let html_generate output_dir ~odocl_dir linked =
   let html_generate : linked -> unit =
    fun l ->
-    let _, pkg_dir = l.pkgdir in
+    let pkg_dir = l.pkgname.p_dir in
     let search_uris = [ Sherlodoc.db_js_file pkg_dir; Sherlodoc.js_file ] in
     let index = Some Fpath.(odocl_dir // pkg_dir / Odoc.index_filename) in
     Odoc.html_generate ~search_uris ?index

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -135,7 +135,7 @@ let compile partial ~output_dir ?linked_dir all =
         let odoc_file = Fpath.(output_dir // modty.m_intf.mif_odoc_file) in
         let odocl_file = Fpath.(linked_dir // modty.m_intf.mif_odocl_file) in
         let fibers =
-          List.map
+          Fiber.List.map
             (fun (n, h) ->
               match compile_other h with
               | Ok r -> Some r
@@ -202,7 +202,7 @@ let compile partial ~output_dir ?linked_dir all =
         result
   in
   let to_build = Util.StringMap.bindings hashes |> List.map fst in
-  let mod_results = List.map compile to_build in
+  let mod_results = Fiber.List.map compile to_build in
   let zipped_res = List.map2 (fun a b -> (a,b)) to_build mod_results in
   let zipped = List.filter_map (function (a, Ok b) -> Some (a,b) | _ -> None) zipped_res in
   let mods =

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -17,17 +17,18 @@ type compiled = {
   include_dirs : Fpath.Set.t;
   impl : impl option;
   pkg_args : pkg_args;
-  pkgdir : Packages.pkgdir;
+  pkg_name : string;
+  pkg_dir : Fpath.t;
 }
 
 let mk_byhash (pkgs : Packages.t Util.StringMap.t) =
   Util.StringMap.fold
-    (fun _pkgname pkg acc ->
+    (fun pkgname pkg acc ->
       List.fold_left
         (fun acc (lib : Packages.libty) ->
           List.fold_left
             (fun acc (m : Packages.modulety) ->
-              Util.StringMap.add m.m_intf.mif_hash m acc)
+              Util.StringMap.add m.m_intf.mif_hash (pkgname, m) acc)
             acc lib.modules)
         acc pkg.Packages.libraries)
     pkgs Util.StringMap.empty
@@ -68,7 +69,8 @@ let init_stats (pkgs : Packages.t Util.StringMap.t) =
 
 open Eio.Std
 
-type partial = (string * compiled) list * Packages.modulety Util.StringMap.t
+type partial =
+  (string * compiled) list * (string * Packages.modulety) Util.StringMap.t
 
 let unmarshal filename : partial =
   let ic = open_in_bin (Fpath.to_string filename) in
@@ -140,7 +142,7 @@ let compile ?partial ~output_dir ?linked_dir all =
     | None ->
         Logs.debug (fun m -> m "Error locating hash: %s" hash);
         Error Not_found
-    | Some modty ->
+    | Some (package_name, modty) ->
         let deps = modty.m_intf.mif_deps in
         let odoc_file = Fpath.(output_dir // modty.m_intf.mif_odoc_file) in
         let odocl_file = Fpath.(linked_dir // modty.m_intf.mif_odocl_file) in
@@ -200,7 +202,8 @@ let compile ?partial ~output_dir ?linked_dir all =
             include_dirs = includes;
             impl;
             pkg_args;
-            pkgdir = modty.m_pkg;
+            pkg_dir = modty.m_pkg_dir;
+            pkg_name = package_name;
           }
   in
 
@@ -226,7 +229,7 @@ let compile ?partial ~output_dir ?linked_dir all =
   in
   let result =
     Util.StringMap.fold
-      (fun _pkgname (pkg : Packages.t) acc ->
+      (fun package_name (pkg : Packages.t) acc ->
         Logs.debug (fun m ->
             m "Package %s mlds: [%a]" pkg.name
               Fmt.(list ~sep:sp Packages.pp_mld)
@@ -255,7 +258,8 @@ let compile ?partial ~output_dir ?linked_dir all =
               include_dirs;
               impl = None;
               pkg_args;
-              pkgdir = mld.mld_pkg;
+              pkg_dir = mld.mld_pkg_dir;
+              pkg_name = package_name;
             }
             :: acc)
           acc pkg.mlds)
@@ -267,11 +271,7 @@ let compile ?partial ~output_dir ?linked_dir all =
   | None -> ());
   result
 
-type linked = {
-  output_file : Fpath.t;
-  src : Fpath.t option;
-  pkgdir : Packages.pkgdir;
-}
+type linked = { output_file : Fpath.t; src : Fpath.t option; pkg_dir : Fpath.t }
 
 let link : compiled list -> _ =
  fun compiled ->
@@ -279,9 +279,9 @@ let link : compiled list -> _ =
    fun c ->
     let includes = Fpath.Set.add c.odoc_output_dir c.include_dirs in
     let link input_file output_file =
-      let { pkg_args = { libs; docs }; pkgdir = current_package, _; _ } = c in
-      Odoc.link ~input_file ~output_file ~includes ~libs ~docs ~current_package
-        ()
+      let { pkg_args = { libs; docs }; pkg_name; _ } = c in
+      Odoc.link ~input_file ~output_file ~includes ~libs ~docs
+        ~current_package:pkg_name ()
     in
     let impl =
       match c.impl with
@@ -290,7 +290,7 @@ let link : compiled list -> _ =
               m "Linking impl: %a -> %a" Fpath.pp impl_odoc Fpath.pp impl_odocl);
           link impl_odoc impl_odocl;
           Atomic.incr Stats.stats.linked_impls;
-          [ { pkgdir = c.pkgdir; output_file = impl_odocl; src = Some src } ]
+          [ { pkg_dir = c.pkg_dir; output_file = impl_odocl; src = Some src } ]
       | None -> []
     in
     match c.m with
@@ -303,12 +303,12 @@ let link : compiled list -> _ =
         (match c.m with
         | Module _ -> Atomic.incr Stats.stats.linked_units
         | Mld _ -> Atomic.incr Stats.stats.linked_mlds);
-        { output_file = c.odocl_file; src = None; pkgdir = c.pkgdir } :: impl
+        { output_file = c.odocl_file; src = None; pkg_dir = c.pkg_dir } :: impl
   in
   Fiber.List.map link compiled |> List.concat
 
 let index_one ~odocl_dir pkgname pkg =
-  let _, dir = pkg.Packages.pkgdir in
+  let dir = pkg.Packages.pkg_dir in
   let output_file = Fpath.(odocl_dir // dir / Odoc.index_filename) in
   let libs =
     List.map
@@ -322,9 +322,10 @@ let index_one ~odocl_dir pkgname pkg =
 let index ~odocl_dir pkgs = Util.StringMap.iter (index_one ~odocl_dir) pkgs
 
 let sherlodoc_index_one ~html_dir ~odocl_dir _ pkg_content =
-  let _, pkg_dir = pkg_content.Packages.pkgdir in
-  let inputs = [ Fpath.(odocl_dir // pkg_dir / Odoc.index_filename) ] in
-  let dst = Fpath.(html_dir // Sherlodoc.db_js_file pkg_dir) in
+  let inputs =
+    [ Fpath.(odocl_dir // pkg_content.Packages.pkg_dir / Odoc.index_filename) ]
+  in
+  let dst = Fpath.(html_dir // Sherlodoc.db_js_file pkg_content.pkg_dir) in
   let dst_dir, _ = Fpath.split_base dst in
   Util.mkdir_p dst_dir;
   Sherlodoc.index ~format:`js ~inputs ~dst ()
@@ -340,17 +341,15 @@ let sherlodoc ~html_dir ~odocl_dir pkgs =
   let inputs =
     pkgs |> Util.StringMap.bindings
     |> List.map (fun (_pkgname, pkg) ->
-           let _, pkg_dir = pkg.Packages.pkgdir in
-           Fpath.(odocl_dir // pkg_dir / Odoc.index_filename))
+           Fpath.(odocl_dir // pkg.Packages.pkg_dir / Odoc.index_filename))
   in
   Sherlodoc.index ~format ~inputs ~dst ()
 
 let html_generate output_dir ~odocl_dir linked =
   let html_generate : linked -> unit =
    fun l ->
-    let _, pkg_dir = l.pkgdir in
-    let search_uris = [ Sherlodoc.db_js_file pkg_dir; Sherlodoc.js_file ] in
-    let index = Some Fpath.(odocl_dir // pkg_dir / Odoc.index_filename) in
+    let search_uris = [ Sherlodoc.db_js_file l.pkg_dir; Sherlodoc.js_file ] in
+    let index = Some Fpath.(odocl_dir // l.pkg_dir / Odoc.index_filename) in
     Odoc.html_generate ~search_uris ?index
       ~output_dir:(Fpath.to_string output_dir)
       ~input_file:l.output_file ?source:l.src ();

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -2,7 +2,7 @@
 
 type ty = Module of Packages.modulety | Mld of Packages.mld
 
-type impl = { impl : Fpath.t; src : Fpath.t }
+type impl = { impl_odoc : Fpath.t; impl_odocl: Fpath.t; src : Fpath.t }
 
 type pkg_args = {
   docs : (string * Fpath.t) list;
@@ -11,12 +11,14 @@ type pkg_args = {
 
 type compiled = {
   m : ty;
-  output_dir : Fpath.t;
-  output_file : Fpath.t;
+  odoc_output_dir : Fpath.t; (* e.g. "_odoc/base/lib/base/" *)
+  odoc_file : Fpath.t; (* Full path to odoc file *)
+  odocl_file : Fpath.t;
   include_dirs : Fpath.Set.t;
   impl : impl option;
   pkg_args : pkg_args;
-  package_name : string;
+  pkg_name : string;
+  pkg_dir : Fpath.t;
 }
 
 let mk_byhash (pkgs : Packages.t Util.StringMap.t) =
@@ -67,20 +69,53 @@ let init_stats (pkgs : Packages.t Util.StringMap.t) =
 
 open Eio.Std
 
-let compile output_dir all =
+type partial = 
+  (string * compiled) list * (string * Packages.modulety) Util.StringMap.t
+
+let unmarshal filename =
+  let ic = open_in_bin (Fpath.to_string filename) in
+  let (v : partial) = Marshal.from_channel ic in
+  close_in ic;
+  v
+
+let marshal (v : partial) filename =
+  let p = Fpath.parent filename in
+  Util.mkdir_p p;
+  let oc = open_out_bin (Fpath.to_string filename) in
+  Marshal.to_channel oc v [];
+  close_out oc
+
+let find_partials odoc_dir =
+  let tbl = Hashtbl.create 1000 in
+  let hashes_result = Bos.OS.Dir.fold_contents ~dotfiles:false
+  (fun p hashes ->
+    if Fpath.filename p = "index.m"
+    then
+      let (tbl', hashes') = unmarshal p in
+      List.iter (fun (k,v) -> Hashtbl.replace tbl k (Promise.create_resolved (Ok v))) tbl';
+      Util.StringMap.union (fun _x o1 _o2 -> Some o1) hashes hashes'
+    else hashes) Util.StringMap.empty odoc_dir in
+  match hashes_result with
+  | Ok h -> h, tbl
+  | Error _ -> (* odoc_dir doesn't exist...? *) Util.StringMap.empty, tbl
+
+let compile partial ~output_dir ?linked_dir all =
+  let linked_dir = Option.value linked_dir ~default:output_dir in
   let hashes = mk_byhash all in
-  let tbl = Hashtbl.create 10 in
+  let other_hashes, tbl =
+    match partial with
+    | Some _ -> find_partials output_dir
+    | None -> Util.StringMap.empty, Hashtbl.create 10 in
+  let all_hashes = Util.StringMap.union (fun _x o1 _o2 -> Some o1) hashes other_hashes in
   let pkg_args =
     let docs, libs =
       Util.StringMap.fold
-        (fun pkgname pkg (docs, libs) ->
-          let ( / ) = Fpath.( / ) in
-          let doc = (pkgname, output_dir / pkgname / "doc") in
+        (fun pkgname (pkg : Packages.t) (docs, libs) ->
+          let doc = (pkgname, Fpath.(output_dir // pkg.mld_odoc_dir)) in
           let lib =
             List.map
               (fun lib ->
-                ( lib.Packages.lib_name,
-                  output_dir / pkgname / "lib" / lib.lib_name ))
+                ( lib.Packages.lib_name, Fpath.(output_dir // lib.Packages.odoc_dir )))
               pkg.Packages.libraries
           in
           let docs = doc :: docs and libs = List.rev_append lib libs in
@@ -91,15 +126,16 @@ let compile output_dir all =
   in
 
   let compile_one compile_other hash =
-    match Util.StringMap.find_opt hash hashes with
+    match Util.StringMap.find_opt hash all_hashes with
     | None ->
         Logs.debug (fun m -> m "Error locating hash: %s" hash);
         Error Not_found
     | Some (package_name, modty) ->
         let deps = modty.m_intf.mif_deps in
-        let output_file = Fpath.(output_dir // modty.m_intf.mif_odoc_file) in
+        let odoc_file = Fpath.(output_dir // modty.m_intf.mif_odoc_file) in
+        let odocl_file = Fpath.(linked_dir // modty.m_intf.mif_odocl_file) in
         let fibers =
-          Fiber.List.map
+          List.map
             (fun (n, h) ->
               match compile_other h with
               | Ok r -> Some r
@@ -114,7 +150,7 @@ let compile output_dir all =
           List.fold_left
             (fun acc opt ->
               match opt with
-              | Some s -> Fpath.(Set.add s.output_dir acc)
+              | Some s -> Fpath.(Set.add s.odoc_output_dir acc)
               | _ -> acc)
             Fpath.Set.empty fibers
         in
@@ -124,11 +160,12 @@ let compile output_dir all =
           | Some impl -> (
               match impl.mip_src_info with
               | Some si ->
-                  let output_file = Fpath.(output_dir // impl.mip_odoc_file) in
+                  let odoc_file = Fpath.(output_dir // impl.mip_odoc_file) in
+                  let odocl_file = Fpath.(linked_dir // impl.mip_odocl_file) in
                   Odoc.compile_impl ~output_dir ~input_file:impl.mip_path
                     ~includes ~parent_id:impl.mip_parent_id ~source_id:si.src_id;
                   Atomic.incr Stats.stats.compiled_impls;
-                  Some { impl = output_file; src = si.src_path }
+                  Some { impl_odoc = odoc_file; impl_odocl=odocl_file; src = si.src_path }
               | None -> None)
           | None -> None
         in
@@ -137,36 +174,41 @@ let compile output_dir all =
           ~parent_id:modty.m_intf.mif_parent_id;
         Atomic.incr Stats.stats.compiled_units;
 
-        let output_dir = Fpath.split_base output_file |> fst in
+        let odoc_output_dir = Fpath.split_base odoc_file |> fst in
+
         Ok
           {
             m = Module modty;
-            output_dir;
-            output_file;
+            odoc_output_dir;
+            odoc_file;
+            odocl_file;
             include_dirs = includes;
             impl;
             pkg_args;
-            package_name;
+            pkg_dir = modty.m_pkg_dir;
+            pkg_name = package_name;
           }
   in
 
   let rec compile : string -> (compiled, exn) Result.t =
    fun hash ->
     match Hashtbl.find_opt tbl hash with
-    | Some p -> Promise.await_exn p
+    | Some p -> Promise.await p
     | None ->
         let p, r = Promise.create () in
         Hashtbl.add tbl hash p;
         let result = compile_one compile hash in
-        Promise.resolve_ok r result;
+        Promise.resolve r result;
         result
   in
-  let all_hashes = Util.StringMap.bindings hashes |> List.map fst in
-  let mod_results = Fiber.List.map compile all_hashes in
+  let to_build = Util.StringMap.bindings hashes |> List.map fst in
+  let mod_results = List.map compile to_build in
+  let zipped_res = List.map2 (fun a b -> (a,b)) to_build mod_results in
+  let zipped = List.filter_map (function (a, Ok b) -> Some (a,b) | _ -> None) zipped_res in
   let mods =
     List.filter_map (function Ok x -> Some x | Error _ -> None) mod_results
   in
-  Util.StringMap.fold
+  let result = Util.StringMap.fold
     (fun package_name (pkg : Packages.t) acc ->
       Logs.debug (fun m ->
           m "Package %s mlds: [%a]" pkg.name
@@ -174,8 +216,9 @@ let compile output_dir all =
             pkg.mlds);
       List.fold_left
         (fun acc (mld : Packages.mld) ->
-          let output_file = Fpath.(output_dir // mld.Packages.mld_odoc_file) in
-          let odoc_output_dir = Fpath.split_base output_file |> fst in
+          let odoc_file = Fpath.(output_dir // mld.Packages.mld_odoc_file) in
+          let odocl_file = Fpath.(linked_dir // mld.Packages.mld_odocl_file) in
+          let odoc_output_dir = Fpath.split_base odoc_file |> fst in
           Odoc.compile ~output_dir ~input_file:mld.mld_path
             ~includes:Fpath.Set.empty ~parent_id:mld.mld_parent_id;
           Atomic.incr Stats.stats.compiled_mlds;
@@ -184,46 +227,54 @@ let compile output_dir all =
             |> Fpath.Set.of_list
           in
           let include_dirs = Fpath.Set.add odoc_output_dir include_dirs in
+          let odoc_output_dir = Fpath.split_base odoc_file |> fst in
           {
             m = Mld mld;
-            output_dir;
-            output_file;
+            odoc_output_dir;
+            odoc_file;
+            odocl_file;
             include_dirs;
             impl = None;
             pkg_args;
-            package_name;
+            pkg_dir = mld.mld_pkg_dir;
+            pkg_name = package_name;
           }
           :: acc)
         acc pkg.mlds)
-    all mods
+    all mods in
+
+  (match partial with
+  | Some l -> marshal (zipped, hashes) Fpath.(l / "index.m")
+  | None -> ());
+  result
 
 type linked = {
   output_file : Fpath.t;
   src : Fpath.t option;
-  package_name : string;
+  pkg_dir : Fpath.t;
 }
 
 let link : compiled list -> _ =
  fun compiled ->
   let link : compiled -> linked list =
    fun c ->
-    let includes = Fpath.Set.add c.output_dir c.include_dirs in
-    let link input_file =
-      let { pkg_args = { libs; docs }; package_name = current_package; _ } =
+    let includes = Fpath.Set.add c.odoc_output_dir c.include_dirs in
+    let link input_file output_file =
+      let { pkg_args = { libs; docs }; pkg_name; _ } =
         c
       in
-      Odoc.link ~input_file ~includes ~libs ~docs ~current_package ()
+      Odoc.link ~input_file ~output_file ~includes ~libs ~docs ~current_package:pkg_name ()
     in
     let impl =
       match c.impl with
-      | Some { impl; src } ->
-          Logs.debug (fun m -> m "Linking impl: %a" Fpath.pp impl);
-          link impl;
+      | Some { impl_odoc; impl_odocl; src } ->
+          Logs.debug (fun m -> m "Linking impl: %a -> %a" Fpath.pp impl_odoc Fpath.pp impl_odocl);
+          link impl_odoc impl_odocl;
           Atomic.incr Stats.stats.linked_impls;
           [
             {
-              package_name = c.package_name;
-              output_file = Fpath.(set_ext "odocl" impl);
+              pkg_dir = c.pkg_dir;
+              output_file = impl_odocl;
               src = Some src;
             };
           ]
@@ -231,81 +282,69 @@ let link : compiled list -> _ =
     in
     match c.m with
     | Module m when m.m_hidden ->
-        Logs.debug (fun m -> m "not linking %a" Fpath.pp c.output_file);
+        Logs.debug (fun m -> m "not linking %a" Fpath.pp c.odoc_file);
         impl
     | _ ->
-        Logs.debug (fun m -> m "linking %a" Fpath.pp c.output_file);
-        link c.output_file;
+        Logs.debug (fun m -> m "linking %a" Fpath.pp c.odoc_file);
+        link c.odoc_file c.odocl_file;
         (match c.m with
         | Module _ -> Atomic.incr Stats.stats.linked_units
         | Mld _ -> Atomic.incr Stats.stats.linked_mlds);
         {
-          output_file = Fpath.(set_ext "odocl" c.output_file);
+          output_file = c.odocl_file;
           src = None;
-          package_name = c.package_name;
+          pkg_dir = c.pkg_dir;
         }
         :: impl
   in
   Fiber.List.map link compiled |> List.concat
 
-let odoc_index_path ~odoc_dir pkgname =
-  Fpath.(odoc_dir / pkgname / "index.odoc-index")
-let sherlodoc_js_index_path_relative_to_html pkgname =
-  Fpath.(v pkgname / "sherlodoc_db.js")
-
-let sherlodoc_js_path_relative_to_html = Fpath.v "sherlodoc.js"
-let sherlodoc_js_index_path ~html_dir pkgname =
-  Fpath.(html_dir // sherlodoc_js_index_path_relative_to_html pkgname)
-
-let sherlodoc_js_path ~html_dir =
-  Fpath.(html_dir // sherlodoc_js_path_relative_to_html)
-
-let sherlodoc_marshall_path ~html_dir =
-  Fpath.(html_dir / "sherlodoc_db.marshal")
-let index_one output_dir pkgname pkg =
-  let dir = Fpath.(output_dir / pkgname) in
-  let output_file = odoc_index_path ~odoc_dir:output_dir pkgname in
-  let ( / ) = Fpath.( / ) in
+let index_one ~odocl_dir pkgname pkg =
+  let dir = pkg.Packages.pkg_dir in
+  let output_file = Fpath.(odocl_dir // dir / Odoc.index_filename) in
   let libs =
     List.map
-      (fun lib -> (lib.Packages.lib_name, dir / "lib" / lib.lib_name))
+      (fun lib ->
+        (lib.Packages.lib_name, Fpath.(odocl_dir // lib.odoc_dir)))
       pkg.Packages.libraries
   in
   Odoc.compile_index ~json:false ~output_file ~libs
-    ~docs:[ (pkgname, dir / "doc") ]
+    ~docs:[ (pkgname, Fpath.(odocl_dir // pkg.mld_odoc_dir)) ]
     ()
 
-let index odoc_dir pkgs = Util.StringMap.iter (index_one odoc_dir) pkgs
+let index ~odocl_dir pkgs = Util.StringMap.iter (index_one ~odocl_dir) pkgs
 
-let sherlodoc_index_one ~html_dir ~odoc_dir pkgname _pkg_content =
-  ignore @@ Bos.OS.Dir.create Fpath.(html_dir / pkgname);
-  let format = `js in
-  let inputs = [ odoc_index_path ~odoc_dir pkgname ] in
-  let dst = sherlodoc_js_index_path ~html_dir pkgname in
-  Sherlodoc.index ~format ~inputs ~dst ()
+let sherlodoc_index_one ~html_dir ~odocl_dir _ pkg_content =
+  let inputs = [ Fpath.(odocl_dir // pkg_content.Packages.pkg_dir / Odoc.index_filename) ] in
+  let dst = Fpath.(html_dir // Sherlodoc.db_js_file pkg_content.pkg_dir) in
+  let dst_dir, _ = Fpath.split_base dst in
+  Util.mkdir_p dst_dir;
+  Sherlodoc.index ~format:`js ~inputs ~dst ()
 
-let sherlodoc ~html_dir ~odoc_dir pkgs =
+let sherlodoc ~html_dir ~odocl_dir pkgs =
   ignore @@ Bos.OS.Dir.create html_dir;
-  Sherlodoc.js (sherlodoc_js_path ~html_dir);
-  Util.StringMap.iter (sherlodoc_index_one ~html_dir ~odoc_dir) pkgs;
+  Sherlodoc.js Fpath.(html_dir // Sherlodoc.js_file);
+  Util.StringMap.iter (sherlodoc_index_one ~html_dir ~odocl_dir) pkgs;
   let format = `marshal in
-  let dst = sherlodoc_marshall_path ~html_dir in
+  let dst = Fpath.(html_dir // Sherlodoc.db_marshal_file) in
+  let dst_dir, _ = Fpath.split_base dst in
+  Util.mkdir_p dst_dir;
   let inputs =
     pkgs |> Util.StringMap.bindings
-    |> List.map (fun (pkgname, _pkg) -> odoc_index_path ~odoc_dir pkgname)
+    |> List.map (fun (_pkgname, pkg) -> Fpath.(odocl_dir // pkg.Packages.pkg_dir / Odoc.index_filename))
   in
   Sherlodoc.index ~format ~inputs ~dst ()
 
-let html_generate output_dir ~odoc_dir linked =
+let html_generate output_dir ~odocl_dir linked =
   let html_generate : linked -> unit =
    fun l ->
     let search_uris =
       [
-        sherlodoc_js_index_path_relative_to_html l.package_name;
-        sherlodoc_js_path_relative_to_html;
+        Sherlodoc.db_js_file l.pkg_dir;
+        Sherlodoc.js_file;
       ]
     in
-    let index = Some (odoc_index_path ~odoc_dir l.package_name) in
+    let index = Some (Fpath.(odocl_dir // l.pkg_dir / Odoc.index_filename)) in
     Odoc.html_generate ~search_uris ?index
       ~output_dir:(Fpath.to_string output_dir)
       ~input_file:l.output_file ?source:l.src ();

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -104,7 +104,7 @@ let find_partials odoc_dir =
   | Ok h -> (h, tbl)
   | Error _ -> (* odoc_dir doesn't exist...? *) (Util.StringMap.empty, tbl)
 
-let compile partial ~output_dir ?linked_dir all =
+let compile ?partial ~output_dir ?linked_dir all =
   let linked_dir = Option.value linked_dir ~default:output_dir in
   let hashes = mk_byhash all in
   let other_hashes, tbl =

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -23,12 +23,12 @@ type compiled = {
 
 let mk_byhash (pkgs : Packages.t Util.StringMap.t) =
   Util.StringMap.fold
-    (fun pkgname pkg acc ->
+    (fun pkg_name pkg acc ->
       List.fold_left
         (fun acc (lib : Packages.libty) ->
           List.fold_left
             (fun acc (m : Packages.modulety) ->
-              Util.StringMap.add m.m_intf.mif_hash (pkgname, m) acc)
+              Util.StringMap.add m.m_intf.mif_hash (pkg_name, m) acc)
             acc lib.modules)
         acc pkg.Packages.libraries)
     pkgs Util.StringMap.empty
@@ -121,8 +121,8 @@ let compile ?partial ~output_dir ?linked_dir all =
   let pkg_args =
     let docs, libs =
       Util.StringMap.fold
-        (fun pkgname (pkg : Packages.t) (docs, libs) ->
-          let doc = (pkgname, Fpath.(output_dir // pkg.mld_odoc_dir)) in
+        (fun pkg_name (pkg : Packages.t) (docs, libs) ->
+          let doc = (pkg_name, Fpath.(output_dir // pkg.mld_odoc_dir)) in
           let lib =
             List.map
               (fun lib ->
@@ -307,7 +307,7 @@ let link : compiled list -> _ =
   in
   Fiber.List.map link compiled |> List.concat
 
-let index_one ~odocl_dir pkgname pkg =
+let index_one ~odocl_dir pkg_name pkg =
   let dir = pkg.Packages.pkg_dir in
   let output_file = Fpath.(odocl_dir // dir / Odoc.index_filename) in
   let libs =
@@ -316,7 +316,7 @@ let index_one ~odocl_dir pkgname pkg =
       pkg.Packages.libraries
   in
   Odoc.compile_index ~json:false ~output_file ~libs
-    ~docs:[ (pkgname, Fpath.(odocl_dir // pkg.mld_odoc_dir)) ]
+    ~docs:[ (pkg_name, Fpath.(odocl_dir // pkg.mld_odoc_dir)) ]
     ()
 
 let index ~odocl_dir pkgs = Util.StringMap.iter (index_one ~odocl_dir) pkgs

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -2,7 +2,12 @@ type compiled
 
 val init_stats : Packages.set -> unit
 
-val compile : Fpath.t option -> output_dir:Fpath.t -> ?linked_dir:Fpath.t -> Packages.set -> compiled list
+val compile :
+  Fpath.t option ->
+  output_dir:Fpath.t ->
+  ?linked_dir:Fpath.t ->
+  Packages.set ->
+  compiled list
 
 type linked
 

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -2,15 +2,15 @@ type compiled
 
 val init_stats : Packages.set -> unit
 
-val compile : Fpath.t -> Packages.set -> compiled list
+val compile : Fpath.t option -> output_dir:Fpath.t -> ?linked_dir:Fpath.t -> Packages.set -> compiled list
 
 type linked
 
 val link : compiled list -> linked list
 
-val index : Fpath.t -> Packages.set -> unit
+val index : odocl_dir:Fpath.t -> Packages.set -> unit
 
-val sherlodoc : html_dir:Fpath.t -> odoc_dir:Fpath.t -> Packages.set -> unit
+val sherlodoc : html_dir:Fpath.t -> odocl_dir:Fpath.t -> Packages.set -> unit
 
 (* val compile_sidebars : *)
 (*   odoc_dir:Fpath.t -> *)
@@ -18,4 +18,4 @@ val sherlodoc : html_dir:Fpath.t -> odoc_dir:Fpath.t -> Packages.set -> unit
 (*   Packages.set -> *)
 (*   Fpath.t Util.StringMap.t *)
 
-val html_generate : Fpath.t -> odoc_dir:Fpath.t -> linked list -> unit
+val html_generate : Fpath.t -> odocl_dir:Fpath.t -> linked list -> unit

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -17,10 +17,4 @@ val index : odocl_dir:Fpath.t -> Packages.set -> unit
 
 val sherlodoc : html_dir:Fpath.t -> odocl_dir:Fpath.t -> Packages.set -> unit
 
-(* val compile_sidebars : *)
-(*   odoc_dir:Fpath.t -> *)
-(*   output_dir:Fpath.t -> *)
-(*   Packages.set -> *)
-(*   Fpath.t Util.StringMap.t *)
-
 val html_generate : Fpath.t -> odocl_dir:Fpath.t -> linked list -> unit

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -3,11 +3,16 @@ type compiled
 val init_stats : Packages.set -> unit
 
 val compile :
-  Fpath.t option ->
+  ?partial:Fpath.t ->
   output_dir:Fpath.t ->
   ?linked_dir:Fpath.t ->
   Packages.set ->
   compiled list
+(** Use [partial] to reuse the output of a previous call to [compile]. Useful in
+    the voodoo context.
+
+    [output_dir] is the directory for [odoc] file, [linked_dir] is the one for
+    [odocl] files (defaulting to [output_dir] when absent). *)
 
 type linked
 

--- a/src/driver/dune
+++ b/src/driver/dune
@@ -13,4 +13,5 @@
   opam-format
   logs
   logs.fmt
+  result
   eio_main))

--- a/src/driver/dune
+++ b/src/driver/dune
@@ -13,5 +13,4 @@
   opam-format
   logs
   logs.fmt
-  result
   eio_main))

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -36,9 +36,9 @@ let of_dune_build dir =
             in
             let pkg_dir = Fpath.rem_prefix dir path |> Option.get in
             ( pkg_dir,
-              Packages.Lib.v pkg_dir
-                (Util.StringMap.singleton libname libname)
-                libname path (Some cmtidir) ))
+              Packages.Lib.v ~pkg_dir
+                ~libname_of_archive:(Util.StringMap.singleton libname libname)
+                ~pkg_name:libname ~dir:path ~cmtidir:(Some cmtidir) ))
           libs
       in
       let packages =

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -2,10 +2,7 @@
 
 let of_dune_build dir =
   let contents =
-    Bos.OS.Dir.fold_contents ~dotfiles:true
-      (fun p acc -> p :: acc)
-      []
-      Fpath.(v dir)
+    Bos.OS.Dir.fold_contents ~dotfiles:true (fun p acc -> p :: acc) [] dir
   in
   match contents with
   | Error _ -> Util.StringMap.empty
@@ -37,7 +34,7 @@ let of_dune_build dir =
             let cmtidir =
               Fpath.(path / Printf.sprintf ".%s.objs" libname / "byte")
             in
-            match Fpath.rem_prefix (Fpath.v dir) path with
+            match Fpath.rem_prefix dir path with
             | Some pkg_dir ->
                 ( pkg_dir,
                   Packages.Lib.v pkg_dir

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -1,42 +1,68 @@
 (* Dune build tree *)
 
 let of_dune_build dir =
-  let contents = Bos.OS.Dir.fold_contents ~dotfiles:true
-    (fun p acc ->
-      p::acc
-    ) [] Fpath.(v dir) in
+  let contents =
+    Bos.OS.Dir.fold_contents ~dotfiles:true
+      (fun p acc -> p :: acc)
+      []
+      Fpath.(v dir)
+  in
   match contents with
   | Error _ -> Util.StringMap.empty
-  | Ok c -> 
-    let sorted = List.sort (fun p1 p2 -> Fpath.compare p1 p2) c in
-    let libs = List.filter_map (fun x ->
-      match Fpath.segs x |> List.rev with
-      | "byte" :: libname :: path ->
-        let sz = String.length ".objs" in
-        if Astring.String.is_suffix ~affix:".objs" libname && String.length libname > sz + 1 && libname.[0] = '.'
-        then
-          let libname = String.sub libname 1 (String.length libname - sz - 1) in
-          Some (libname, Fpath.(v (String.concat dir_sep (List.rev path))))
-        else None
-      | _ -> None) sorted in
-    let libs = List.map (fun (libname, path) ->
-      let cmtidir = Fpath.(path / Printf.sprintf ".%s.objs" libname / "byte") in
-      match Fpath.rem_prefix (Fpath.v dir) path with
-      | Some pkg_dir ->
-          (pkg_dir, Packages.Lib.v pkg_dir (Util.StringMap.singleton libname libname) libname path (Some cmtidir))
-      | None -> failwith "Error") libs
-    in
-    let packages = List.filter_map (fun (pkg_dir, lib) ->
-      match lib with
-      | [lib] ->
-        Some (lib.Packages.lib_name, {
-        Packages.name = lib.Packages.lib_name;
-        version="1.0";
-        libraries=[lib];
-        mlds = [];
-        mld_odoc_dir = Fpath.v lib.Packages.lib_name;
-        pkg_dir;
-        other_docs = Fpath.Set.empty;
-        })
-      | _ -> None) libs in
-    Util.StringMap.of_list packages
+  | Ok c ->
+      let sorted = List.sort (fun p1 p2 -> Fpath.compare p1 p2) c in
+      let libs =
+        List.filter_map
+          (fun x ->
+            match Fpath.segs x |> List.rev with
+            | "byte" :: libname :: path ->
+                let sz = String.length ".objs" in
+                if
+                  Astring.String.is_suffix ~affix:".objs" libname
+                  && String.length libname > sz + 1
+                  && libname.[0] = '.'
+                then
+                  let libname =
+                    String.sub libname 1 (String.length libname - sz - 1)
+                  in
+                  Some
+                    (libname, Fpath.(v (String.concat dir_sep (List.rev path))))
+                else None
+            | _ -> None)
+          sorted
+      in
+      let libs =
+        List.map
+          (fun (libname, path) ->
+            let cmtidir =
+              Fpath.(path / Printf.sprintf ".%s.objs" libname / "byte")
+            in
+            match Fpath.rem_prefix (Fpath.v dir) path with
+            | Some pkg_dir ->
+                ( pkg_dir,
+                  Packages.Lib.v pkg_dir
+                    (Util.StringMap.singleton libname libname)
+                    libname path (Some cmtidir) )
+            | None -> failwith "Error")
+          libs
+      in
+      let packages =
+        List.filter_map
+          (fun (pkg_dir, lib) ->
+            match lib with
+            | [ lib ] ->
+                Some
+                  ( lib.Packages.lib_name,
+                    {
+                      Packages.name = lib.Packages.lib_name;
+                      version = "1.0";
+                      libraries = [ lib ];
+                      mlds = [];
+                      mld_odoc_dir = Fpath.v lib.Packages.lib_name;
+                      pkg_dir;
+                      other_docs = Fpath.Set.empty;
+                    } )
+            | _ -> None)
+          libs
+      in
+      Util.StringMap.of_list packages

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -1,10 +1,5 @@
 (* Dune build tree *)
 
-(* Map lib names to package names. *)
-let mk_pkgname ~dir libname path =
-  let p_dir = Fpath.rem_prefix dir path |> Option.get in
-  { Packages.p_name = libname; p_dir }
-
 let of_dune_build dir =
   let contents =
     Bos.OS.Dir.fold_contents ~dotfiles:true (fun p acc -> p :: acc) [] dir
@@ -39,27 +34,28 @@ let of_dune_build dir =
             let cmtidir =
               Fpath.(path / Printf.sprintf ".%s.objs" libname / "byte")
             in
-            let pkgname = mk_pkgname ~dir libname path in
-            ( pkgname,
-              Packages.Lib.v ~pkgname
+            (* Map lib names to package names. *)
+            let pkgdir = (libname, Fpath.rem_prefix dir path |> Option.get) in
+            ( pkgdir,
+              Packages.Lib.v ~pkgdir
                 ~libname_of_archive:(Util.StringMap.singleton libname libname)
                 ~dir:path ~cmtidir:(Some cmtidir) ))
           libs
       in
       let packages =
         List.filter_map
-          (fun (pkgname, lib) ->
+          (fun (pkgdir, lib) ->
             match lib with
             | [ lib ] ->
-                (* Accept only one library per package for now. *)
                 Some
                   ( lib.Packages.lib_name,
                     {
-                      Packages.version = "1.0";
+                      Packages.name = lib.Packages.lib_name;
+                      version = "1.0";
                       libraries = [ lib ];
                       mlds = [];
                       mld_odoc_dir = Fpath.v lib.Packages.lib_name;
-                      pkgname;
+                      pkgdir;
                       other_docs = Fpath.Set.empty;
                     } )
             | _ -> None)

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -1,0 +1,42 @@
+(* Dune build tree *)
+
+let of_dune_build dir =
+  let contents = Bos.OS.Dir.fold_contents ~dotfiles:true
+    (fun p acc ->
+      p::acc
+    ) [] Fpath.(v dir) in
+  match contents with
+  | Error _ -> Util.StringMap.empty
+  | Ok c -> 
+    let sorted = List.sort (fun p1 p2 -> Fpath.compare p1 p2) c in
+    let libs = List.filter_map (fun x ->
+      match Fpath.segs x |> List.rev with
+      | "byte" :: libname :: path ->
+        let sz = String.length ".objs" in
+        if Astring.String.is_suffix ~affix:".objs" libname && String.length libname > sz + 1 && libname.[0] = '.'
+        then
+          let libname = String.sub libname 1 (String.length libname - sz - 1) in
+          Some (libname, Fpath.(v (String.concat dir_sep (List.rev path))))
+        else None
+      | _ -> None) sorted in
+    let libs = List.map (fun (libname, path) ->
+      let cmtidir = Fpath.(path / Printf.sprintf ".%s.objs" libname / "byte") in
+      match Fpath.rem_prefix (Fpath.v dir) path with
+      | Some pkg_dir ->
+          (pkg_dir, Packages.Lib.v pkg_dir (Util.StringMap.singleton libname libname) libname path (Some cmtidir))
+      | None -> failwith "Error") libs
+    in
+    let packages = List.filter_map (fun (pkg_dir, lib) ->
+      match lib with
+      | [lib] ->
+        Some (lib.Packages.lib_name, {
+        Packages.name = lib.Packages.lib_name;
+        version="1.0";
+        libraries=[lib];
+        mlds = [];
+        mld_odoc_dir = Fpath.v lib.Packages.lib_name;
+        pkg_dir;
+        other_docs = Fpath.Set.empty;
+        })
+      | _ -> None) libs in
+    Util.StringMap.of_list packages

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -34,16 +34,17 @@ let of_dune_build dir =
             let cmtidir =
               Fpath.(path / Printf.sprintf ".%s.objs" libname / "byte")
             in
-            let pkg_dir = Fpath.rem_prefix dir path |> Option.get in
-            ( pkg_dir,
-              Packages.Lib.v ~pkg_dir
+            (* Map lib names to package names. *)
+            let pkgdir = (libname, Fpath.rem_prefix dir path |> Option.get) in
+            ( pkgdir,
+              Packages.Lib.v ~pkgdir
                 ~libname_of_archive:(Util.StringMap.singleton libname libname)
-                ~pkg_name:libname ~dir:path ~cmtidir:(Some cmtidir) ))
+                ~dir:path ~cmtidir:(Some cmtidir) ))
           libs
       in
       let packages =
         List.filter_map
-          (fun (pkg_dir, lib) ->
+          (fun (pkgdir, lib) ->
             match lib with
             | [ lib ] ->
                 Some
@@ -54,7 +55,7 @@ let of_dune_build dir =
                       libraries = [ lib ];
                       mlds = [];
                       mld_odoc_dir = Fpath.v lib.Packages.lib_name;
-                      pkg_dir;
+                      pkgdir;
                       other_docs = Fpath.Set.empty;
                     } )
             | _ -> None)

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -34,13 +34,11 @@ let of_dune_build dir =
             let cmtidir =
               Fpath.(path / Printf.sprintf ".%s.objs" libname / "byte")
             in
-            match Fpath.rem_prefix dir path with
-            | Some pkg_dir ->
-                ( pkg_dir,
-                  Packages.Lib.v pkg_dir
-                    (Util.StringMap.singleton libname libname)
-                    libname path (Some cmtidir) )
-            | None -> failwith "Error")
+            let pkg_dir = Fpath.rem_prefix dir path |> Option.get in
+            ( pkg_dir,
+              Packages.Lib.v pkg_dir
+                (Util.StringMap.singleton libname libname)
+                libname path (Some cmtidir) ))
           libs
       in
       let packages =

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -34,17 +34,16 @@ let of_dune_build dir =
             let cmtidir =
               Fpath.(path / Printf.sprintf ".%s.objs" libname / "byte")
             in
-            (* Map lib names to package names. *)
-            let pkgdir = (libname, Fpath.rem_prefix dir path |> Option.get) in
-            ( pkgdir,
-              Packages.Lib.v ~pkgdir
+            let pkg_dir = Fpath.rem_prefix dir path |> Option.get in
+            ( pkg_dir,
+              Packages.Lib.v ~pkg_dir
                 ~libname_of_archive:(Util.StringMap.singleton libname libname)
-                ~dir:path ~cmtidir:(Some cmtidir) ))
+                ~pkg_name:libname ~dir:path ~cmtidir:(Some cmtidir) ))
           libs
       in
       let packages =
         List.filter_map
-          (fun (pkgdir, lib) ->
+          (fun (pkg_dir, lib) ->
             match lib with
             | [ lib ] ->
                 Some
@@ -55,7 +54,7 @@ let of_dune_build dir =
                       libraries = [ lib ];
                       mlds = [];
                       mld_odoc_dir = Fpath.v lib.Packages.lib_name;
-                      pkgdir;
+                      pkg_dir;
                       other_docs = Fpath.Set.empty;
                     } )
             | _ -> None)

--- a/src/driver/dune_style.mli
+++ b/src/driver/dune_style.mli
@@ -1,0 +1,1 @@
+val of_dune_build : Fpath.t -> Packages.set

--- a/src/driver/indexes.ml
+++ b/src/driver/indexes.ml
@@ -1,5 +1,5 @@
 let package fmt (pkg : Packages.t) =
-  Format.fprintf fmt "{0 Package %s}\n" pkg.name;
+  Format.fprintf fmt "{0 Package %s}\n" pkg.pkgname.p_name;
   Format.fprintf fmt "{1 Libraries}\n";
   List.iter
     (fun (lib : Packages.libty) ->

--- a/src/driver/indexes.ml
+++ b/src/driver/indexes.ml
@@ -1,5 +1,5 @@
 let package fmt (pkg : Packages.t) =
-  Format.fprintf fmt "{0 Package %s}\n" pkg.pkgname.p_name;
+  Format.fprintf fmt "{0 Package %s}\n" pkg.name;
   Format.fprintf fmt "{1 Libraries}\n";
   List.iter
     (fun (lib : Packages.libty) ->

--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -1,0 +1,153 @@
+(** To extract the library names for a given package, without using dune, we
+
+    1. parse the META file of the package with ocamlfind to see which libraries
+    exist and what their archive name (.cma filename) is.
+
+    2. use ocamlobjinfo to get a list of all modules within the archives.
+
+    This code assumes that the META file lists for every library an archive
+    [archive_name], and that for this cma archive exists a corresponsing
+    [archive_name].ocamlobjinfo file. *)
+
+type library = {
+  name : string;
+  archive_name : string;
+  mutable modules : string list;
+  dir : string option;
+}
+
+type t = { libraries : library list }
+
+let read_libraries_from_pkg_defs ~library_name pkg_defs =
+  try
+    let cma_filename = Fl_metascanner.lookup "archive" [ "byte" ] pkg_defs in
+    let dir = List.find_opt (fun d -> d.Fl_metascanner.def_var = "directory") pkg_defs in
+    let dir = Option.map (fun d -> d.Fl_metascanner.def_value) dir in 
+    let archive_name =
+      let file_name_len = String.length cma_filename in
+      if file_name_len > 0 then String.sub cma_filename 0 (file_name_len - 4)
+      else cma_filename
+    in
+    if String.length archive_name > 0 then
+      [ { name = library_name; archive_name; modules = []; dir } ]
+    else []
+  with Not_found -> []
+
+let process_meta_file file =
+  let _ = Format.eprintf "process_meta_file: %s\n%!" (Fpath.to_string file) in
+  let ic = open_in (Fpath.to_string file) in
+  let meta = Fl_metascanner.parse ic in
+  let base_library_name =
+    if Fpath.basename file = "META" then Fpath.parent file |> Fpath.basename
+    else Fpath.get_ext file
+  in
+  let rec extract_name_and_archive ~prefix
+      ((name, pkg_expr) : string * Fl_metascanner.pkg_expr) =
+    let library_name = prefix ^ "." ^ name in
+    let libraries =
+      read_libraries_from_pkg_defs ~library_name pkg_expr.pkg_defs
+    in
+    let child_libraries =
+      pkg_expr.pkg_children
+      |> List.map (extract_name_and_archive ~prefix:library_name)
+      |> List.flatten
+    in
+    libraries @ child_libraries
+  in
+  let libraries =
+    read_libraries_from_pkg_defs ~library_name:base_library_name meta.pkg_defs
+  in
+  let is_not_private (lib : library) =
+    not
+      (String.split_on_char '.' lib.name
+      |> List.exists (fun x -> x = "__private__"))
+  in
+  let libraries =
+    libraries
+    @ (meta.pkg_children
+      |> List.map (extract_name_and_archive ~prefix:base_library_name)
+      |> List.flatten)
+    |> List.filter is_not_private
+  in
+  libraries
+
+let process_ocamlobjinfo_file ~(libraries : library list) file =
+  let _ =
+    Format.eprintf "process_ocamlobjinfo_file: %s\n%!" (Fpath.to_string file)
+  in
+  let ic = open_in (Fpath.to_string file) in
+  let lines = Util.lines_of_channel ic in
+  let affix = "Unit name: " in
+  let len = String.length affix in
+  close_in ic;
+  let units =
+    List.concat_map
+      (fun line ->
+        if Astring.String.is_prefix ~affix line then
+          [ String.sub line len (String.length line - len) ]
+        else [])
+      lines
+  in
+  let _, archive_name = Fpath.split_base file in
+  let archive_name = archive_name |> Fpath.rem_ext |> Fpath.to_string in
+  let _ =
+    Format.eprintf "trying to look up archive_name: %s\nunits: %s\n%!"
+      archive_name (String.concat "," units)
+  in
+  try
+    let library =
+      List.find (fun l -> l.archive_name = archive_name) libraries
+    in
+    library.modules <- library.modules @ units
+  with Not_found ->
+    Format.eprintf "failed to find archive_name: %s\n%!" archive_name;
+    ()
+
+(* let get_libraries package =
+  let path =  package in
+  let maybe_meta_files =
+    Bos.OS.Dir.fold_contents ~dotfiles:true
+      (fun p acc ->
+        let is_meta = p |> Fpath.basename = "META" in
+        if is_meta then p :: acc else acc)
+      [] path
+  in
+
+  match maybe_meta_files with
+  | Error (`Msg msg) ->
+      failwith
+        ("FIXME: error traversing directories to find the META files: " ^ msg)
+  | Ok meta_files -> (
+      let libraries =
+        meta_files |> List.map process_meta_file |> List.flatten
+      in
+
+      let _ =
+        Format.eprintf "found archive_names: [%s]\n%!"
+          (String.concat ", "
+             (List.map (fun (l : library) -> l.archive_name) libraries))
+      in
+
+      let maybe_ocamlobjinfo_files =
+        Bos.OS.Dir.fold_contents ~dotfiles:true
+          (fun p acc ->
+            let is_ocamlobjinfo = Fpath.get_ext p = ".ocamlobjinfo" in
+            if is_ocamlobjinfo then p :: acc else acc)
+          [] path
+      in
+      match maybe_ocamlobjinfo_files with
+      | Error (`Msg msg) ->
+          failwith
+            ("FIXME: error traversing directories to find the ocamlobjinfo \
+              files: " ^ msg)
+      | Ok ocamlobjinfo_files ->
+          List.iter (process_ocamlobjinfo_file ~libraries) ocamlobjinfo_files;
+          let _ =
+            Format.eprintf "found archive_names: [%s]\n%!"
+              (String.concat ", "
+                 (List.map
+                    (fun (l : library) ->
+                      l.archive_name ^ "/" ^ String.concat "," l.modules)
+                    libraries))
+          in
+          { libraries }) *)

--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -21,8 +21,10 @@ type t = { libraries : library list }
 let read_libraries_from_pkg_defs ~library_name pkg_defs =
   try
     let cma_filename = Fl_metascanner.lookup "archive" [ "byte" ] pkg_defs in
-    let dir = List.find_opt (fun d -> d.Fl_metascanner.def_var = "directory") pkg_defs in
-    let dir = Option.map (fun d -> d.Fl_metascanner.def_value) dir in 
+    let dir =
+      List.find_opt (fun d -> d.Fl_metascanner.def_var = "directory") pkg_defs
+    in
+    let dir = Option.map (fun d -> d.Fl_metascanner.def_value) dir in
     let archive_name =
       let file_name_len = String.length cma_filename in
       if file_name_len > 0 then String.sub cma_filename 0 (file_name_len - 4)
@@ -104,50 +106,50 @@ let process_ocamlobjinfo_file ~(libraries : library list) file =
     ()
 
 (* let get_libraries package =
-  let path =  package in
-  let maybe_meta_files =
-    Bos.OS.Dir.fold_contents ~dotfiles:true
-      (fun p acc ->
-        let is_meta = p |> Fpath.basename = "META" in
-        if is_meta then p :: acc else acc)
-      [] path
-  in
+   let path =  package in
+   let maybe_meta_files =
+     Bos.OS.Dir.fold_contents ~dotfiles:true
+       (fun p acc ->
+         let is_meta = p |> Fpath.basename = "META" in
+         if is_meta then p :: acc else acc)
+       [] path
+   in
 
-  match maybe_meta_files with
-  | Error (`Msg msg) ->
-      failwith
-        ("FIXME: error traversing directories to find the META files: " ^ msg)
-  | Ok meta_files -> (
-      let libraries =
-        meta_files |> List.map process_meta_file |> List.flatten
-      in
+   match maybe_meta_files with
+   | Error (`Msg msg) ->
+       failwith
+         ("FIXME: error traversing directories to find the META files: " ^ msg)
+   | Ok meta_files -> (
+       let libraries =
+         meta_files |> List.map process_meta_file |> List.flatten
+       in
 
-      let _ =
-        Format.eprintf "found archive_names: [%s]\n%!"
-          (String.concat ", "
-             (List.map (fun (l : library) -> l.archive_name) libraries))
-      in
+       let _ =
+         Format.eprintf "found archive_names: [%s]\n%!"
+           (String.concat ", "
+              (List.map (fun (l : library) -> l.archive_name) libraries))
+       in
 
-      let maybe_ocamlobjinfo_files =
-        Bos.OS.Dir.fold_contents ~dotfiles:true
-          (fun p acc ->
-            let is_ocamlobjinfo = Fpath.get_ext p = ".ocamlobjinfo" in
-            if is_ocamlobjinfo then p :: acc else acc)
-          [] path
-      in
-      match maybe_ocamlobjinfo_files with
-      | Error (`Msg msg) ->
-          failwith
-            ("FIXME: error traversing directories to find the ocamlobjinfo \
-              files: " ^ msg)
-      | Ok ocamlobjinfo_files ->
-          List.iter (process_ocamlobjinfo_file ~libraries) ocamlobjinfo_files;
-          let _ =
-            Format.eprintf "found archive_names: [%s]\n%!"
-              (String.concat ", "
-                 (List.map
-                    (fun (l : library) ->
-                      l.archive_name ^ "/" ^ String.concat "," l.modules)
-                    libraries))
-          in
-          { libraries }) *)
+       let maybe_ocamlobjinfo_files =
+         Bos.OS.Dir.fold_contents ~dotfiles:true
+           (fun p acc ->
+             let is_ocamlobjinfo = Fpath.get_ext p = ".ocamlobjinfo" in
+             if is_ocamlobjinfo then p :: acc else acc)
+           [] path
+       in
+       match maybe_ocamlobjinfo_files with
+       | Error (`Msg msg) ->
+           failwith
+             ("FIXME: error traversing directories to find the ocamlobjinfo \
+               files: " ^ msg)
+       | Ok ocamlobjinfo_files ->
+           List.iter (process_ocamlobjinfo_file ~libraries) ocamlobjinfo_files;
+           let _ =
+             Format.eprintf "found archive_names: [%s]\n%!"
+               (String.concat ", "
+                  (List.map
+                     (fun (l : library) ->
+                       l.archive_name ^ "/" ^ String.concat "," l.modules)
+                     libraries))
+           in
+           { libraries }) *)

--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -3,20 +3,14 @@
     1. parse the META file of the package with ocamlfind to see which libraries
     exist and what their archive name (.cma filename) is.
 
-    2. use ocamlobjinfo to get a list of all modules within the archives.
+    2. use ocamlobjinfo to get a list of all modules within the archives. EDIT:
+    it seems this step is now skipped.
 
     This code assumes that the META file lists for every library an archive
     [archive_name], and that for this cma archive exists a corresponsing
     [archive_name].ocamlobjinfo file. *)
 
-type library = {
-  name : string;
-  archive_name : string;
-  mutable modules : string list;
-  dir : string option;
-}
-
-type t = { libraries : library list }
+type library = { name : string; archive_name : string; dir : string option }
 
 let read_libraries_from_pkg_defs ~library_name pkg_defs =
   try
@@ -31,12 +25,12 @@ let read_libraries_from_pkg_defs ~library_name pkg_defs =
       else cma_filename
     in
     if String.length archive_name > 0 then
-      [ { name = library_name; archive_name; modules = []; dir } ]
+      [ { name = library_name; archive_name; dir } ]
     else []
   with Not_found -> []
 
 let process_meta_file file =
-  let _ = Format.eprintf "process_meta_file: %s\n%!" (Fpath.to_string file) in
+  let () = Format.eprintf "process_meta_file: %s\n%!" (Fpath.to_string file) in
   let ic = open_in (Fpath.to_string file) in
   let meta = Fl_metascanner.parse ic in
   let base_library_name =
@@ -72,84 +66,3 @@ let process_meta_file file =
     |> List.filter is_not_private
   in
   libraries
-
-let process_ocamlobjinfo_file ~(libraries : library list) file =
-  let _ =
-    Format.eprintf "process_ocamlobjinfo_file: %s\n%!" (Fpath.to_string file)
-  in
-  let ic = open_in (Fpath.to_string file) in
-  let lines = Util.lines_of_channel ic in
-  let affix = "Unit name: " in
-  let len = String.length affix in
-  close_in ic;
-  let units =
-    List.concat_map
-      (fun line ->
-        if Astring.String.is_prefix ~affix line then
-          [ String.sub line len (String.length line - len) ]
-        else [])
-      lines
-  in
-  let _, archive_name = Fpath.split_base file in
-  let archive_name = archive_name |> Fpath.rem_ext |> Fpath.to_string in
-  let _ =
-    Format.eprintf "trying to look up archive_name: %s\nunits: %s\n%!"
-      archive_name (String.concat "," units)
-  in
-  try
-    let library =
-      List.find (fun l -> l.archive_name = archive_name) libraries
-    in
-    library.modules <- library.modules @ units
-  with Not_found ->
-    Format.eprintf "failed to find archive_name: %s\n%!" archive_name;
-    ()
-
-(* let get_libraries package =
-   let path =  package in
-   let maybe_meta_files =
-     Bos.OS.Dir.fold_contents ~dotfiles:true
-       (fun p acc ->
-         let is_meta = p |> Fpath.basename = "META" in
-         if is_meta then p :: acc else acc)
-       [] path
-   in
-
-   match maybe_meta_files with
-   | Error (`Msg msg) ->
-       failwith
-         ("FIXME: error traversing directories to find the META files: " ^ msg)
-   | Ok meta_files -> (
-       let libraries =
-         meta_files |> List.map process_meta_file |> List.flatten
-       in
-
-       let _ =
-         Format.eprintf "found archive_names: [%s]\n%!"
-           (String.concat ", "
-              (List.map (fun (l : library) -> l.archive_name) libraries))
-       in
-
-       let maybe_ocamlobjinfo_files =
-         Bos.OS.Dir.fold_contents ~dotfiles:true
-           (fun p acc ->
-             let is_ocamlobjinfo = Fpath.get_ext p = ".ocamlobjinfo" in
-             if is_ocamlobjinfo then p :: acc else acc)
-           [] path
-       in
-       match maybe_ocamlobjinfo_files with
-       | Error (`Msg msg) ->
-           failwith
-             ("FIXME: error traversing directories to find the ocamlobjinfo \
-               files: " ^ msg)
-       | Ok ocamlobjinfo_files ->
-           List.iter (process_ocamlobjinfo_file ~libraries) ocamlobjinfo_files;
-           let _ =
-             Format.eprintf "found archive_names: [%s]\n%!"
-               (String.concat ", "
-                  (List.map
-                     (fun (l : library) ->
-                       l.archive_name ^ "/" ^ String.concat "," l.modules)
-                     libraries))
-           in
-           { libraries }) *)

--- a/src/driver/library_names.mli
+++ b/src/driver/library_names.mli
@@ -1,0 +1,5 @@
+type library = { name : string; archive_name : string; dir : string option }
+
+val process_meta_file : Fpath.t -> library list
+(** From a path to a [Meta] file, returns the list of libraries defined in this
+    file. *)

--- a/src/driver/ocamlfind.ml
+++ b/src/driver/ocamlfind.ml
@@ -1,17 +1,22 @@
-let init () =
-  let prefix = Opam.prefix () in
-  let env_camllib = Fpath.(v prefix / "lib" / "ocaml" |> to_string) in
-  let config = Fpath.(v prefix / "lib" / "findlib.conf" |> to_string) in
-  Findlib.init ~config ~env_camllib ()
 
-let () = init ()
+
+let init =
+  let initialized = ref false in
+  fun () ->
+    if !initialized then () else
+    let prefix = Opam.prefix () in
+    let env_camllib = Fpath.(v prefix / "lib" / "ocaml" |> to_string) in
+    let config = Fpath.(v prefix / "lib" / "findlib.conf" |> to_string) in
+    Findlib.init ~config ~env_camllib ()
 
 let all () =
+  init ();
   Fl_package_base.list_packages ()
 
 
 let get_dir lib =
   try
+    init ();
     Fl_package_base.query lib |> fun x ->
     Logs.debug (fun m -> m "Package %s is in directory %s@." lib x.package_dir);
     Ok Fpath.(v x.package_dir |> to_dir_path)
@@ -20,6 +25,7 @@ let get_dir lib =
     Error (`Msg "Error getting directory")
 
 let archives pkg =
+  init ();
   let package = Fl_package_base.query pkg in
   let get_1 preds =
     try
@@ -39,6 +45,7 @@ let archives pkg =
       |> List.sort_uniq String.compare
 
 let sub_libraries top =
+  init ();
   let packages = Fl_package_base.list_packages () in
   List.fold_left
     (fun acc lib ->
@@ -47,6 +54,7 @@ let sub_libraries top =
     Util.StringSet.empty packages
 
 let deps pkgs =
+  init ();
   try
     let packages =
       Fl_package_base.requires_deeply ~preds:[ "ppx_driver" ] pkgs

--- a/src/driver/ocamlfind.ml
+++ b/src/driver/ocamlfind.ml
@@ -6,6 +6,10 @@ let init () =
 
 let () = init ()
 
+let all () =
+  Fl_package_base.list_packages ()
+
+
 let get_dir lib =
   try
     Fl_package_base.query lib |> fun x ->

--- a/src/driver/ocamlfind.ml
+++ b/src/driver/ocamlfind.ml
@@ -1,18 +1,16 @@
-
-
 let init =
   let initialized = ref false in
   fun () ->
-    if !initialized then () else
-    let prefix = Opam.prefix () in
-    let env_camllib = Fpath.(v prefix / "lib" / "ocaml" |> to_string) in
-    let config = Fpath.(v prefix / "lib" / "findlib.conf" |> to_string) in
-    Findlib.init ~config ~env_camllib ()
+    if !initialized then ()
+    else
+      let prefix = Opam.prefix () in
+      let env_camllib = Fpath.(v prefix / "lib" / "ocaml" |> to_string) in
+      let config = Fpath.(v prefix / "lib" / "findlib.conf" |> to_string) in
+      Findlib.init ~config ~env_camllib ()
 
 let all () =
   init ();
   Fl_package_base.list_packages ()
-
 
 let get_dir lib =
   try

--- a/src/driver/ocamlfind.mli
+++ b/src/driver/ocamlfind.mli
@@ -1,6 +1,9 @@
 val get_dir : string -> (Fpath.t, [> `Msg of string ]) result
 (** [get_dir libname] returns the path where [libname] is installed *)
 
+val all : unit -> string list
+(** [all ()] returns a list of all packages *)
+
 val archives : string -> string list
 (** Returns the list of archive file names of a given library *)
 

--- a/src/driver/ocamlobjinfo.ml
+++ b/src/driver/ocamlobjinfo.ml
@@ -44,10 +44,13 @@ let get_source file srcdirs =
           in
           let name = Fpath.(filename (v name)) in
           let possibilities =
-            List.map (fun dir ->
-              List.map
-                (fun poss -> Fpath.(dir / poss))
-                (source_possibilities name)) srcdirs |> List.flatten
+            List.map
+              (fun dir ->
+                List.map
+                  (fun poss -> Fpath.(dir / poss))
+                  (source_possibilities name))
+              srcdirs
+            |> List.flatten
           in
           List.find_opt
             (fun f ->

--- a/src/driver/ocamlobjinfo.mli
+++ b/src/driver/ocamlobjinfo.mli
@@ -1,3 +1,3 @@
-val get_source : Fpath.t -> Fpath.t option
+val get_source : Fpath.t -> Fpath.t list -> Fpath.t option
 (** use [ocamlobjinfo] binary to read the input compiled file and try to find
     the source file *)

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -182,10 +182,10 @@ let source_tree ?(ignore_output = false) ~parent ~output file =
     Cmd_outputs.(
       add_prefixed_output cmd source_tree_output (Fpath.to_string file) lines)
 
-let classify dir =
+let classify dirs =
   let open Cmd in
-  let cmd = !odoc % "classify" % p dir in
-  let desc = Printf.sprintf "Classifying %s" (Fpath.to_string dir) in
+  let cmd = List.fold_left (fun cmd d -> cmd % p d) (!odoc % "classify") dirs in
+  let desc = Format.asprintf "Classifying [%a]" (Fmt.(list ~sep:sp) Fpath.pp) dirs in
   let lines =
     Cmd_outputs.submit desc cmd None |> List.filter (fun l -> l <> "")
   in

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -70,8 +70,8 @@ let compile_impl ~output_dir ~input_file:file ~includes ~parent_id ~source_id =
 let doc_args docs =
   let open Cmd in
   List.fold_left
-    (fun acc (pkgname, path) ->
-      let s = Format.asprintf "%s:%a" pkgname Fpath.pp path in
+    (fun acc (pkg_name, path) ->
+      let s = Format.asprintf "%s:%a" pkg_name Fpath.pp path in
       v "-P" % s %% acc)
     Cmd.empty docs
 

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -7,7 +7,6 @@ let id_of_fpath id = id
 
 let index_filename = "index.odoc-index"
 
-
 type compile_deps = { digest : Digest.t; deps : (string * Digest.t) list }
 
 (* This is the just-built odoc binary *)
@@ -53,14 +52,13 @@ let compile_impl ~output_dir ~input_file:file ~includes ~parent_id ~source_id =
       includes Cmd.empty
   in
   let cmd =
-    !odoc % "compile-impl" % Fpath.to_string file % "--output-dir" % p output_dir
-    %% includes % "--enable-missing-root-warning"
+    !odoc % "compile-impl" % Fpath.to_string file % "--output-dir"
+    % p output_dir %% includes % "--enable-missing-root-warning"
   in
   let output_file =
-      let _, f = Fpath.split_base file in
-      Some
-        Fpath.(
-          output_dir // parent_id / ("impl-" ^ to_string (set_ext "odoc" f)))
+    let _, f = Fpath.split_base file in
+    Some
+      Fpath.(output_dir // parent_id / ("impl-" ^ to_string (set_ext "odoc" f)))
   in
   let cmd = cmd % "--parent-id" % Fpath.to_string parent_id in
   let cmd = cmd % "--source-id" % Fpath.to_string source_id in
@@ -87,13 +85,12 @@ let lib_args libs =
       v "-L" % s %% acc)
     Cmd.empty libs
 
-let link ?(ignore_output = false) ~input_file:file ?output_file ~includes ~docs ~libs
-    ~current_package () =
+let link ?(ignore_output = false) ~input_file:file ?output_file ~includes ~docs
+    ~libs ~current_package () =
   let open Cmd in
   let output_file =
-    match output_file with
-    | Some f -> f
-    | None -> Fpath.set_ext "odocl" file in
+    match output_file with Some f -> f | None -> Fpath.set_ext "odocl" file
+  in
   let includes =
     Fpath.Set.fold
       (fun path acc -> Cmd.(acc % "-I" % p path))
@@ -185,7 +182,9 @@ let source_tree ?(ignore_output = false) ~parent ~output file =
 let classify dirs =
   let open Cmd in
   let cmd = List.fold_left (fun cmd d -> cmd % p d) (!odoc % "classify") dirs in
-  let desc = Format.asprintf "Classifying [%a]" (Fmt.(list ~sep:sp) Fpath.pp) dirs in
+  let desc =
+    Format.asprintf "Classifying [%a]" (Fmt.(list ~sep:sp) Fpath.pp) dirs
+  in
   let lines =
     Cmd_outputs.submit desc cmd None |> List.filter (fun l -> l <> "")
   in

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -9,9 +9,7 @@ let index_filename = "index.odoc-index"
 
 type compile_deps = { digest : Digest.t; deps : (string * Digest.t) list }
 
-(* This is the just-built odoc binary *)
-let default = "./_build/default/src/odoc/bin/main.exe"
-let odoc = ref (Cmd.v default)
+let odoc = ref (Cmd.v "odoc")
 
 let compile_deps f =
   let cmd = Cmd.(!odoc % "compile-deps" % Fpath.to_string f) in

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -8,7 +8,6 @@ val index_filename : string
 val default : string
 val odoc : Bos.Cmd.t ref
 
-
 type compile_deps = { digest : Digest.t; deps : (string * Digest.t) list }
 val compile_deps : Fpath.t -> (compile_deps, [> `Msg of string ]) result
 val classify : Fpath.t list -> (string * string list) list

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -11,7 +11,7 @@ val odoc : Bos.Cmd.t ref
 
 type compile_deps = { digest : Digest.t; deps : (string * Digest.t) list }
 val compile_deps : Fpath.t -> (compile_deps, [> `Msg of string ]) result
-val classify : Fpath.t -> (string * string list) list
+val classify : Fpath.t list -> (string * string list) list
 val compile_impl :
   output_dir:Fpath.t ->
   input_file:Fpath.t ->

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -5,7 +5,6 @@ val id_of_fpath : Fpath.t -> id
 
 val index_filename : string
 
-val default : string
 val odoc : Bos.Cmd.t ref
 
 type compile_deps = { digest : Digest.t; deps : (string * Digest.t) list }

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -1,3 +1,14 @@
+type id
+
+val fpath_of_id : id -> Fpath.t
+val id_of_fpath : Fpath.t -> id
+
+val index_filename : string
+
+val default : string
+val odoc : Bos.Cmd.t ref
+
+
 type compile_deps = { digest : Digest.t; deps : (string * Digest.t) list }
 val compile_deps : Fpath.t -> (compile_deps, [> `Msg of string ]) result
 val classify : Fpath.t -> (string * string list) list
@@ -5,19 +16,20 @@ val compile_impl :
   output_dir:Fpath.t ->
   input_file:Fpath.t ->
   includes:Fpath.set ->
-  parent_id:string ->
-  source_id:string ->
+  parent_id:id ->
+  source_id:id ->
   unit
 val compile :
   output_dir:Fpath.t ->
   input_file:Fpath.t ->
   includes:Fpath.set ->
-  parent_id:string ->
+  parent_id:id ->
   unit
 
 val link :
   ?ignore_output:bool ->
   input_file:Fpath.t ->
+  ?output_file:Fpath.t ->
   includes:Fpath.set ->
   docs:(string * Fpath.t) list ->
   libs:(string * Fpath.t) list ->

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -558,13 +558,8 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
   ignore indexes
 
 let fpath_arg =
-  let parse s =
-    match Fpath.of_string s with
-    | Ok v -> Ok v
-    | Error (`Msg m) -> Error (`Msg m)
-  in
   let print ppf v = Fpath.pp ppf v in
-  Arg.conv (parse, print)
+  Arg.conv (Fpath.of_string, print)
 
 let odoc_dir =
   let doc = "Directory in which the intermediate odoc files go" in
@@ -617,7 +612,7 @@ let blessed =
 
 let dune_style =
   let doc = "Dune style" in
-  Arg.(value & opt (some string) None & info [ "dune-style" ] ~doc)
+  Arg.(value & opt (some fpath_arg) None & info [ "dune-style" ] ~doc)
 
 let cmd =
   let doc = "Generate odoc documentation" in

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -497,7 +497,7 @@ let render_stats env nprocs =
       in
       inner (0, 0, 0, 0, 0, 0, 0, 0))
 
-let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers odoc_bin voodoo package_name blessed =
+let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers odoc_bin voodoo package_name blessed dune_style =
   Odoc.odoc := Bos.Cmd.v odoc_bin;
   let _ = Voodoo.find_universe_and_version "foo" in
   Eio_main.run @@ fun env ->
@@ -511,7 +511,10 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers o
       match package_name with
       | Some p -> Voodoo.of_voodoo p blessed
       | None -> failwith "Need a package name for voodoo"
-    else
+    else match dune_style with
+    | Some dir ->
+      Dune_style.of_dune_build dir
+     | None ->
       let libs =
         if libs = [] then Ocamlfind.all ()
         else libs
@@ -623,13 +626,16 @@ let blessed =
   let doc = "Blessed" in
   Arg.(value & flag & info ["blessed"] ~doc)
 
+let dune_style =
+  let doc = "Dune style" in
+  Arg.(value & opt (some string) None & info ["dune-style"] ~doc)
   
 let cmd =
   let doc = "Generate odoc documentation" in
   let info = Cmd.info "odoc_driver" ~doc in
   Cmd.v info
     Term.(
-      const run $ packages $ verbose $ packages_dir $ odoc_dir $ odocl_dir $ html_dir $ stats $ nb_workers $ odoc_bin $ voodoo $ package_name $ blessed)
+      const run $ packages $ verbose $ packages_dir $ odoc_dir $ odocl_dir $ html_dir $ stats $ nb_workers $ odoc_bin $ voodoo $ package_name $ blessed $ dune_style)
 
 (* let map = Ocamlfind.package_to_dir_map () in
    let _dirs = List.map (fun lib -> List.assoc lib map) deps in

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -509,7 +509,7 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
 
   let all =
     match (voodoo, package_name, dune_style, packages_dir) with
-    | true, Some p, None, None -> Voodoo.of_voodoo p blessed
+    | true, Some p, None, None -> Voodoo.of_voodoo p ~blessed
     | false, None, Some dir, None -> Dune_style.of_dune_build dir
     | false, None, None, packages_dir ->
         let libs = if libs = [] then Ocamlfind.all () else libs in
@@ -517,7 +517,7 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
           List.map Ocamlfind.sub_libraries libs
           |> List.fold_left Util.StringSet.union Util.StringSet.empty
         in
-        Packages.of_libs packages_dir libs
+        Packages.of_libs ~packages_dir libs
     | true, None, _, _ -> failwith "--voodoo requires --package-name"
     | false, Some _, _, _ -> failwith "--package-name requires --voodoo"
     | true, _, _, Some _ | false, _, Some _, Some _ ->

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -503,22 +503,24 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers o
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   if verbose then Logs.set_level (Some Logs.Debug);
-  let libs =
-    if libs = [] then Ocamlfind.all ()
-    else libs
-  in
   Logs.set_reporter (Logs_fmt.reporter ());
   let () = Worker_pool.start_workers env sw nb_workers in
-  let libs =
-    List.map Ocamlfind.sub_libraries libs
-    |> List.fold_left Util.StringSet.union Util.StringSet.empty
-  in
+ 
   let all =
     if voodoo then
       match package_name with
       | Some p -> Voodoo.of_voodoo p blessed
       | None -> failwith "Need a package name for voodoo"
-    else Packages.of_libs packages_dir libs in
+    else
+      let libs =
+        if libs = [] then Ocamlfind.all ()
+        else libs
+      in    
+      let libs =
+        List.map Ocamlfind.sub_libraries libs
+        |> List.fold_left Util.StringSet.union Util.StringSet.empty
+      in
+      Packages.of_libs packages_dir libs in
   let partial =
     if voodoo
     then

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -499,7 +499,7 @@ let render_stats env nprocs =
 
 let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
     odoc_bin voodoo package_name blessed dune_style =
-  Odoc.odoc := Bos.Cmd.v odoc_bin;
+  Option.iter (fun odoc_bin -> Odoc.odoc := Bos.Cmd.v odoc_bin) odoc_bin;
   let _ = Voodoo.find_universe_and_version "foo" in
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -594,7 +594,7 @@ let nb_workers =
 
 let odoc_bin =
   let doc = "Odoc binary to use" in
-  Arg.(value & opt string Odoc.default & info [ "odoc" ] ~doc)
+  Arg.(value & opt (some string) None & info [ "odoc" ] ~doc)
 
 let packages_dir =
   let doc = "Packages directory under which packages should be output." in

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -537,7 +537,8 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
     Eio.Fiber.both
       (fun () ->
         let compiled =
-          Compile.compile partial ~output_dir:odoc_dir ?linked_dir:odocl_dir all
+          Compile.compile ?partial ~output_dir:odoc_dir ?linked_dir:odocl_dir
+            all
         in
         let linked = Compile.link compiled in
         let odocl_dir = match odocl_dir with Some l -> l | None -> odoc_dir in

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -543,14 +543,7 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
         let odocl_dir = match odocl_dir with Some l -> l | None -> odoc_dir in
         let () = Compile.index ~odocl_dir all in
         let () = Compile.sherlodoc ~html_dir ~odocl_dir all in
-        (* let sidebars = *)
-        (*   Compile.compile_sidebars ~odoc_dir *)
-        (*     ~output_dir:(Fpath.( / ) odoc_dir "sidebars") *)
-        (*     all *)
-        (* in *)
-        let () =
-          Compile.html_generate html_dir ~odocl_dir (* sidebars *) linked
-        in
+        let () = Compile.html_generate html_dir ~odocl_dir linked in
         let _ = Odoc.support_files html_dir in
         ())
       (fun () -> render_stats env nb_workers)

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -72,7 +72,7 @@ let pkg_dir top_dir pkg_name = maybe_prepend_top top_dir Fpath.(v pkg_name)
 
 let parent_of_lib pkg_dir lib_name = Fpath.(pkg_dir / "lib" / lib_name)
 
-let parent_of_pkg pkg_dir = Fpath.(pkg_dir / "doc")
+let parent_of_pages pkg_dir = Fpath.(pkg_dir / "doc")
 
 let parent_of_src pkg_dir lib_name = Fpath.(pkg_dir / "src" / lib_name)
 
@@ -336,7 +336,7 @@ let of_libs ~packages_dir libs =
         | None -> acc
         | Some rel_path ->
             let pkg_dir = pkg_dir packages_dir pkg_name in
-            let id = Fpath.(parent_of_pkg pkg_dir // rel_path) in
+            let id = Fpath.(parent_of_pages pkg_dir // rel_path) in
             let mld_parent_id = id |> Fpath.parent |> Fpath.rem_empty_seg in
             let page_name = Fpath.(rem_ext mld_path |> filename) in
             let odoc_file =
@@ -404,7 +404,7 @@ let of_libs ~packages_dir libs =
                       mlds = update_mlds pkg.mlds libraries;
                     }
               | None ->
-                  let mld_odoc_dir = parent_of_pkg pkg_dir in
+                  let mld_odoc_dir = parent_of_pages pkg_dir in
                   Some
                     {
                       name = pkg.name;

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -184,7 +184,7 @@ module Module = struct
 end
 
 module Lib = struct
-  let v pkg_dir libname_of_archive pkg_name dir cmtidir =
+  let v ~pkg_dir ~libname_of_archive ~pkg_name ~dir ~cmtidir =
     Logs.debug (fun m ->
         m "Classifying dir %a for package %s" Fpath.pp dir pkg_name);
     let dirs =
@@ -233,7 +233,7 @@ let pp ppf t =
     Fmt.(list ~sep:sp Lib.pp)
     t.libraries
 
-let of_libs packages_dir libs =
+let of_libs ~packages_dir libs =
   let libs = Util.StringSet.to_seq libs |> List.of_seq in
   let results = List.map (fun x -> (x, Ocamlfind.deps [ x ])) libs in
   let all_libs_set =
@@ -371,7 +371,10 @@ let of_libs packages_dir libs =
       | Some pkg ->
           let pkg_dir = pkg_dir packages_dir pkg.name in
 
-          let libraries = Lib.v pkg_dir libname_of_archive pkg.name dir None in
+          let libraries =
+            Lib.v ~pkg_dir ~libname_of_archive ~pkg_name:pkg.name ~dir
+              ~cmtidir:None
+          in
           let libraries =
             List.filter
               (fun l -> Util.StringSet.mem l.archive_name archives)

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -1,5 +1,7 @@
 (* Packages *)
 
+type pkgdir = string * Fpath.t
+
 type dep = string * Digest.t
 
 type id = Odoc.id
@@ -32,7 +34,7 @@ type modulety = {
   m_intf : intf;
   m_impl : impl option;
   m_hidden : bool;
-  m_pkg_dir : Fpath.t;
+  m_pkg : pkgdir;
       (* The 'top dir' of a package, relative to [_odoc] or [_html] *)
 }
 
@@ -42,7 +44,7 @@ type mld = {
   mld_parent_id : id;
   mld_path : Fpath.t; (* Absolute or relative to cwd *)
   mld_deps : Fpath.t list;
-  mld_pkg_dir : Fpath.t;
+  mld_pkg : pkgdir;
       (* The 'top dir' of a package, relative to [_odoc] or [_html] *)
 }
 
@@ -61,20 +63,21 @@ type t = {
   libraries : libty list;
   mlds : mld list;
   mld_odoc_dir : Fpath.t; (* Relative to [odoc] dir *)
-  pkg_dir : Fpath.t;
+  pkgdir : pkgdir;
   other_docs : Fpath.Set.t;
 }
 
 let maybe_prepend_top top_dir dir =
   match top_dir with None -> dir | Some d -> Fpath.(d // dir)
 
-let pkg_dir top_dir pkg_name = maybe_prepend_top top_dir Fpath.(v pkg_name)
+let find_pkg top_dir pkg_name =
+  (pkg_name, maybe_prepend_top top_dir Fpath.(v pkg_name))
 
-let parent_of_lib pkg_dir lib_name = Fpath.(pkg_dir / "lib" / lib_name)
+let parent_of_lib (_, pkg_dir) lib_name = Fpath.(pkg_dir / "lib" / lib_name)
 
-let parent_of_pages pkg_dir = Fpath.(pkg_dir / "doc")
+let parent_of_pages (_, pkg_dir) = Fpath.(pkg_dir / "doc")
 
-let parent_of_src pkg_dir lib_name = Fpath.(pkg_dir / "src" / lib_name)
+let parent_of_src (_, pkg_dir) lib_name = Fpath.(pkg_dir / "src" / lib_name)
 
 module Module = struct
   type t = modulety
@@ -85,7 +88,7 @@ module Module = struct
 
   let is_hidden name = Astring.String.is_infix ~affix:"__" name
 
-  let vs pkg_dir lib_name libsdir cmtidir modules =
+  let vs pkgdir lib_name libsdir cmtidir modules =
     let dir = match cmtidir with None -> libsdir | Some dir -> dir in
     let mk m_name =
       let exists ext =
@@ -105,7 +108,7 @@ module Module = struct
             | _ -> None)
       in
       let mk_intf mif_path =
-        let mif_parent_id = parent_of_lib pkg_dir lib_name in
+        let mif_parent_id = parent_of_lib pkgdir lib_name in
         let mif_odoc_file =
           Fpath.(
             mif_parent_id
@@ -125,7 +128,7 @@ module Module = struct
         | Error _ -> failwith "bad deps"
       in
       let mk_impl mip_path =
-        let mip_parent_id = parent_of_lib pkg_dir lib_name in
+        let mip_parent_id = parent_of_lib pkgdir lib_name in
         let mip_odoc_file =
           Fpath.(
             mip_parent_id
@@ -148,7 +151,7 @@ module Module = struct
                   m "Found source file %a for %s" Fpath.pp src_path m_name);
               let src_name = Fpath.filename src_path in
               let src_id =
-                Fpath.(parent_of_src pkg_dir lib_name / src_name)
+                Fpath.(parent_of_src pkgdir lib_name / src_name)
                 |> Odoc.id_of_fpath
               in
               Some { src_path; src_id }
@@ -166,7 +169,7 @@ module Module = struct
       let m_hidden = is_hidden m_name in
       try
         let r (m_intf, m_impl) =
-          Some { m_name; m_intf; m_impl; m_hidden; m_pkg_dir = pkg_dir }
+          Some { m_name; m_intf; m_impl; m_hidden; m_pkg = pkgdir }
         in
         match state with
         | Some cmt, Some cmti -> r (mk_intf cmti, Some (mk_impl cmt))
@@ -184,7 +187,8 @@ module Module = struct
 end
 
 module Lib = struct
-  let v ~pkg_dir ~libname_of_archive ~pkg_name ~dir ~cmtidir =
+  let v ~pkgdir ~libname_of_archive ~dir ~cmtidir =
+    let pkg_name, _ = pkgdir in
     Logs.debug (fun m ->
         m "Classifying dir %a for package %s" Fpath.pp dir pkg_name);
     let dirs =
@@ -211,8 +215,8 @@ module Lib = struct
                   m "Defaulting to name of library: %s" archive_name);
               archive_name
           in
-          let modules = Module.vs pkg_dir lib_name dir cmtidir modules in
-          let odoc_dir = parent_of_lib pkg_dir lib_name in
+          let modules = Module.vs pkgdir lib_name dir cmtidir modules in
+          let odoc_dir = parent_of_lib pkgdir lib_name in
           Some { lib_name; odoc_dir; archive_name; modules }
         with _ ->
           Logs.err (fun m ->
@@ -335,8 +339,8 @@ let of_libs ~packages_dir libs =
         match rel_path with
         | None -> acc
         | Some rel_path ->
-            let pkg_dir = pkg_dir packages_dir pkg_name in
-            let id = Fpath.(parent_of_pages pkg_dir // rel_path) in
+            let pkgdir = find_pkg packages_dir pkg_name in
+            let id = Fpath.(parent_of_pages pkgdir // rel_path) in
             let mld_parent_id = id |> Fpath.parent |> Fpath.rem_empty_seg in
             let page_name = Fpath.(rem_ext mld_path |> filename) in
             let odoc_file =
@@ -350,7 +354,7 @@ let of_libs ~packages_dir libs =
               mld_parent_id = Odoc.id_of_fpath mld_parent_id;
               mld_path;
               mld_deps;
-              mld_pkg_dir = pkg_dir;
+              mld_pkg = pkgdir;
             }
             :: acc)
       odoc_pages []
@@ -369,11 +373,10 @@ let of_libs ~packages_dir libs =
           Logs.debug (fun m -> m "No package for dir %a\n%!" Fpath.pp dir);
           acc
       | Some pkg ->
-          let pkg_dir = pkg_dir packages_dir pkg.name in
+          let pkgdir = find_pkg packages_dir pkg.name in
 
           let libraries =
-            Lib.v ~pkg_dir ~libname_of_archive ~pkg_name:pkg.name ~dir
-              ~cmtidir:None
+            Lib.v ~pkgdir ~libname_of_archive ~dir ~cmtidir:None
           in
           let libraries =
             List.filter
@@ -404,7 +407,7 @@ let of_libs ~packages_dir libs =
                       mlds = update_mlds pkg.mlds libraries;
                     }
               | None ->
-                  let mld_odoc_dir = parent_of_pages pkg_dir in
+                  let mld_odoc_dir = parent_of_pages pkgdir in
                   Some
                     {
                       name = pkg.name;
@@ -413,7 +416,7 @@ let of_libs ~packages_dir libs =
                       mlds;
                       mld_odoc_dir;
                       other_docs;
-                      pkg_dir;
+                      pkgdir;
                     })
             acc)
     dirs Util.StringMap.empty

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -1,6 +1,6 @@
 (* Packages *)
 
-type pkgdir = string * Fpath.t
+type pkgname = { p_name : string; p_dir : Fpath.t }
 
 type dep = string * Digest.t
 
@@ -34,7 +34,7 @@ type modulety = {
   m_intf : intf;
   m_impl : impl option;
   m_hidden : bool;
-  m_pkg : pkgdir;
+  m_pkgname : pkgname;
       (* The 'top dir' of a package, relative to [_odoc] or [_html] *)
 }
 
@@ -44,7 +44,7 @@ type mld = {
   mld_parent_id : id;
   mld_path : Fpath.t; (* Absolute or relative to cwd *)
   mld_deps : Fpath.t list;
-  mld_pkg : pkgdir;
+  mld_pkgname : pkgname;
       (* The 'top dir' of a package, relative to [_odoc] or [_html] *)
 }
 
@@ -58,26 +58,26 @@ type libty = {
 }
 
 type t = {
-  name : string;
+  pkgname : pkgname;
   version : string;
   libraries : libty list;
   mlds : mld list;
   mld_odoc_dir : Fpath.t; (* Relative to [odoc] dir *)
-  pkgdir : pkgdir;
   other_docs : Fpath.Set.t;
 }
 
 let maybe_prepend_top top_dir dir =
   match top_dir with None -> dir | Some d -> Fpath.(d // dir)
 
-let find_pkg top_dir pkg_name =
-  (pkg_name, maybe_prepend_top top_dir Fpath.(v pkg_name))
+let mk_pkgname top_dir p_name =
+  let p_dir = maybe_prepend_top top_dir Fpath.(v p_name) in
+  { p_name; p_dir }
 
-let parent_of_lib (_, pkg_dir) lib_name = Fpath.(pkg_dir / "lib" / lib_name)
+let parent_of_lib pkgname lib_name = Fpath.(pkgname.p_dir / "lib" / lib_name)
 
-let parent_of_pages (_, pkg_dir) = Fpath.(pkg_dir / "doc")
+let parent_of_pages pkgname = Fpath.(pkgname.p_dir / "doc")
 
-let parent_of_src (_, pkg_dir) lib_name = Fpath.(pkg_dir / "src" / lib_name)
+let parent_of_src pkgname lib_name = Fpath.(pkgname.p_dir / "src" / lib_name)
 
 module Module = struct
   type t = modulety
@@ -88,7 +88,7 @@ module Module = struct
 
   let is_hidden name = Astring.String.is_infix ~affix:"__" name
 
-  let vs pkgdir lib_name libsdir cmtidir modules =
+  let vs pkgname lib_name libsdir cmtidir modules =
     let dir = match cmtidir with None -> libsdir | Some dir -> dir in
     let mk m_name =
       let exists ext =
@@ -108,7 +108,7 @@ module Module = struct
             | _ -> None)
       in
       let mk_intf mif_path =
-        let mif_parent_id = parent_of_lib pkgdir lib_name in
+        let mif_parent_id = parent_of_lib pkgname lib_name in
         let mif_odoc_file =
           Fpath.(
             mif_parent_id
@@ -128,7 +128,7 @@ module Module = struct
         | Error _ -> failwith "bad deps"
       in
       let mk_impl mip_path =
-        let mip_parent_id = parent_of_lib pkgdir lib_name in
+        let mip_parent_id = parent_of_lib pkgname lib_name in
         let mip_odoc_file =
           Fpath.(
             mip_parent_id
@@ -151,7 +151,7 @@ module Module = struct
                   m "Found source file %a for %s" Fpath.pp src_path m_name);
               let src_name = Fpath.filename src_path in
               let src_id =
-                Fpath.(parent_of_src pkgdir lib_name / src_name)
+                Fpath.(parent_of_src pkgname lib_name / src_name)
                 |> Odoc.id_of_fpath
               in
               Some { src_path; src_id }
@@ -169,7 +169,7 @@ module Module = struct
       let m_hidden = is_hidden m_name in
       try
         let r (m_intf, m_impl) =
-          Some { m_name; m_intf; m_impl; m_hidden; m_pkg = pkgdir }
+          Some { m_name; m_intf; m_impl; m_hidden; m_pkgname = pkgname }
         in
         match state with
         | Some cmt, Some cmti -> r (mk_intf cmti, Some (mk_impl cmt))
@@ -187,10 +187,10 @@ module Module = struct
 end
 
 module Lib = struct
-  let v ~pkgdir ~libname_of_archive ~dir ~cmtidir =
-    let pkg_name, _ = pkgdir in
+  let v ~pkgname ~libname_of_archive ~dir ~cmtidir =
+    let { p_name; _ } = pkgname in
     Logs.debug (fun m ->
-        m "Classifying dir %a for package %s" Fpath.pp dir pkg_name);
+        m "Classifying dir %a for package %s" Fpath.pp dir p_name);
     let dirs =
       match cmtidir with None -> [ dir ] | Some dir2 -> [ dir; dir2 ]
     in
@@ -206,7 +206,7 @@ module Lib = struct
                   m
                     "Unable to determine library in package '%s' to which \
                      archive '%s' belongs"
-                    pkg_name archive_name);
+                    p_name archive_name);
               Logs.debug (fun m ->
                   m "These are the archives I know about: [%a]"
                     Fmt.(list ~sep:sp string)
@@ -215,8 +215,8 @@ module Lib = struct
                   m "Defaulting to name of library: %s" archive_name);
               archive_name
           in
-          let modules = Module.vs pkgdir lib_name dir cmtidir modules in
-          let odoc_dir = parent_of_lib pkgdir lib_name in
+          let modules = Module.vs pkgname lib_name dir cmtidir modules in
+          let odoc_dir = parent_of_lib pkgname lib_name in
           Some { lib_name; odoc_dir; archive_name; modules }
         with _ ->
           Logs.err (fun m ->
@@ -232,8 +232,8 @@ module Lib = struct
 end
 
 let pp ppf t =
-  Fmt.pf ppf "name: %s@.version: %s@.libraries: [@[<hov 2>@,%a@]@,]" t.name
-    t.version
+  Fmt.pf ppf "name: %s@.version: %s@.libraries: [@[<hov 2>@,%a@]@,]"
+    t.pkgname.p_name t.version
     Fmt.(list ~sep:sp Lib.pp)
     t.libraries
 
@@ -339,8 +339,8 @@ let of_libs ~packages_dir libs =
         match rel_path with
         | None -> acc
         | Some rel_path ->
-            let pkgdir = find_pkg packages_dir pkg_name in
-            let id = Fpath.(parent_of_pages pkgdir // rel_path) in
+            let pkgname = mk_pkgname packages_dir pkg_name in
+            let id = Fpath.(parent_of_pages pkgname // rel_path) in
             let mld_parent_id = id |> Fpath.parent |> Fpath.rem_empty_seg in
             let page_name = Fpath.(rem_ext mld_path |> filename) in
             let odoc_file =
@@ -354,7 +354,7 @@ let of_libs ~packages_dir libs =
               mld_parent_id = Odoc.id_of_fpath mld_parent_id;
               mld_path;
               mld_deps;
-              mld_pkg = pkgdir;
+              mld_pkgname = pkgname;
             }
             :: acc)
       odoc_pages []
@@ -373,10 +373,10 @@ let of_libs ~packages_dir libs =
           Logs.debug (fun m -> m "No package for dir %a\n%!" Fpath.pp dir);
           acc
       | Some pkg ->
-          let pkgdir = find_pkg packages_dir pkg.name in
+          let pkgname = mk_pkgname packages_dir pkg.name in
 
           let libraries =
-            Lib.v ~pkgdir ~libname_of_archive ~dir ~cmtidir:None
+            Lib.v ~pkgname ~libname_of_archive ~dir ~cmtidir:None
           in
           let libraries =
             List.filter
@@ -407,16 +407,15 @@ let of_libs ~packages_dir libs =
                       mlds = update_mlds pkg.mlds libraries;
                     }
               | None ->
-                  let mld_odoc_dir = parent_of_pages pkgdir in
+                  let mld_odoc_dir = parent_of_pages pkgname in
                   Some
                     {
-                      name = pkg.name;
+                      pkgname;
                       version = pkg.version;
                       libraries;
                       mlds;
                       mld_odoc_dir;
                       other_docs;
-                      pkgdir;
                     })
             acc)
     dirs Util.StringMap.empty

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -1,8 +1,5 @@
 (** {1 OCaml compilation unit} *)
 
-type pkgdir = string * Fpath.t
-(** A package's name and path. *)
-
 (** {2 Interface part} *)
 
 type dep = string * Digest.t
@@ -41,7 +38,7 @@ type modulety = {
   m_intf : intf;
   m_impl : impl option;
   m_hidden : bool;
-  m_pkg : pkgdir;
+  m_pkg_dir : Fpath.t;
 }
 
 (** {1 Standalone pages units} *)
@@ -52,7 +49,7 @@ type mld = {
   mld_parent_id : id;
   mld_path : Fpath.t;
   mld_deps : Fpath.t list;
-  mld_pkg : pkgdir;
+  mld_pkg_dir : Fpath.t;
 }
 
 val pp_mld : Format.formatter -> mld -> unit
@@ -70,13 +67,14 @@ type libty = {
   modules : modulety list;
 }
 
-val parent_of_pages : pkgdir -> Fpath.t
-(** Given a [pkgdir], returns a [mld_odoc_dir]. *)
+val parent_of_pages : Fpath.t -> Fpath.t
+(** Given a [pkg_dir], returns a [mld_odoc_dir]. *)
 
 module Lib : sig
   val v :
-    pkgdir:pkgdir ->
+    pkg_dir:Fpath.t ->
     libname_of_archive:string Util.StringMap.t ->
+    pkg_name:string ->
     dir:Fpath.t ->
     cmtidir:Fpath.t option ->
     libty list
@@ -89,7 +87,7 @@ type t = {
   mlds : mld list;
   mld_odoc_dir : Fpath.t;
       (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
-  pkgdir : pkgdir;
+  pkg_dir : Fpath.t;
   other_docs : Fpath.Set.t;
 }
 

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -67,6 +67,18 @@ type libty = {
   modules : modulety list;
 }
 
+val parent_of_pkg : Fpath.t -> Fpath.t
+
+module Lib : sig
+  val v :
+    pkg_dir:Fpath.t ->
+    libname_of_archive:string Util.StringMap.t ->
+    pkg_name:string ->
+    dir:Fpath.t ->
+    cmtidir:Fpath.t option ->
+    libty list
+end
+
 type t = {
   name : string;
   version : string;
@@ -82,17 +94,5 @@ val pp : Format.formatter -> t -> unit
 
 type set = t Util.StringMap.t
 
-val of_libs : Fpath.t option -> Util.StringSet.t -> set
 (** Turns a set of libraries into a map from library name to package *)
-
-val parent_of_pkg : Fpath.t -> Fpath.t
-
-module Lib : sig
-  val v :
-    Fpath.t ->
-    string Util.StringMap.t ->
-    string ->
-    Fpath.t ->
-    Fpath.t option ->
-    libty list
-end
+val of_libs : packages_dir:Fpath.t option -> Util.StringSet.t -> set

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -67,7 +67,8 @@ type libty = {
   modules : modulety list;
 }
 
-val parent_of_pkg : Fpath.t -> Fpath.t
+val parent_of_pages : Fpath.t -> Fpath.t
+(** Given a [pkg_dir], returns a [mld_odoc_dir]. *)
 
 module Lib : sig
   val v :

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -95,5 +95,5 @@ val pp : Format.formatter -> t -> unit
 
 type set = t Util.StringMap.t
 
-(** Turns a set of libraries into a map from library name to package *)
 val of_libs : packages_dir:Fpath.t option -> Util.StringSet.t -> set
+(** Turns a set of libraries into a map from package name to package *)

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -61,7 +61,8 @@ val pp_mld : Format.formatter -> mld -> unit
 
 type libty = {
   lib_name : string;
-  odoc_dir : Fpath.t; (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
+  odoc_dir : Fpath.t;
+      (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
   archive_name : string;
   modules : modulety list;
 }
@@ -71,7 +72,8 @@ type t = {
   version : string;
   libraries : libty list;
   mlds : mld list;
-  mld_odoc_dir : Fpath.t; (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
+  mld_odoc_dir : Fpath.t;
+      (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
   pkg_dir : Fpath.t;
   other_docs : Fpath.Set.t;
 }
@@ -86,6 +88,11 @@ val of_libs : Fpath.t option -> Util.StringSet.t -> set
 val parent_of_pkg : Fpath.t -> Fpath.t
 
 module Lib : sig
-
-  val v : Fpath.t -> string Util.StringMap.t -> string -> Fpath.t -> Fpath.t option -> libty list
+  val v :
+    Fpath.t ->
+    string Util.StringMap.t ->
+    string ->
+    Fpath.t ->
+    Fpath.t option ->
+    libty list
 end

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -1,5 +1,8 @@
 (** {1 OCaml compilation unit} *)
 
+type pkgdir = string * Fpath.t
+(** A package's name and path. *)
+
 (** {2 Interface part} *)
 
 type dep = string * Digest.t
@@ -38,7 +41,7 @@ type modulety = {
   m_intf : intf;
   m_impl : impl option;
   m_hidden : bool;
-  m_pkg_dir : Fpath.t;
+  m_pkg : pkgdir;
 }
 
 (** {1 Standalone pages units} *)
@@ -49,7 +52,7 @@ type mld = {
   mld_parent_id : id;
   mld_path : Fpath.t;
   mld_deps : Fpath.t list;
-  mld_pkg_dir : Fpath.t;
+  mld_pkg : pkgdir;
 }
 
 val pp_mld : Format.formatter -> mld -> unit
@@ -67,14 +70,13 @@ type libty = {
   modules : modulety list;
 }
 
-val parent_of_pages : Fpath.t -> Fpath.t
-(** Given a [pkg_dir], returns a [mld_odoc_dir]. *)
+val parent_of_pages : pkgdir -> Fpath.t
+(** Given a [pkgdir], returns a [mld_odoc_dir]. *)
 
 module Lib : sig
   val v :
-    pkg_dir:Fpath.t ->
+    pkgdir:pkgdir ->
     libname_of_archive:string Util.StringMap.t ->
-    pkg_name:string ->
     dir:Fpath.t ->
     cmtidir:Fpath.t option ->
     libty list
@@ -87,7 +89,7 @@ type t = {
   mlds : mld list;
   mld_odoc_dir : Fpath.t;
       (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
-  pkg_dir : Fpath.t;
+  pkgdir : pkgdir;
   other_docs : Fpath.Set.t;
 }
 

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -1,6 +1,6 @@
 (** {1 OCaml compilation unit} *)
 
-type pkgname = { p_name : string; p_dir : Fpath.t }
+type pkgdir = string * Fpath.t
 (** A package's name and path. *)
 
 (** {2 Interface part} *)
@@ -41,7 +41,7 @@ type modulety = {
   m_intf : intf;
   m_impl : impl option;
   m_hidden : bool;
-  m_pkgname : pkgname;
+  m_pkg : pkgdir;
 }
 
 (** {1 Standalone pages units} *)
@@ -52,7 +52,7 @@ type mld = {
   mld_parent_id : id;
   mld_path : Fpath.t;
   mld_deps : Fpath.t list;
-  mld_pkgname : pkgname;
+  mld_pkg : pkgdir;
 }
 
 val pp_mld : Format.formatter -> mld -> unit
@@ -70,12 +70,12 @@ type libty = {
   modules : modulety list;
 }
 
-val parent_of_pages : pkgname -> Fpath.t
-(** Given a [pkgname], returns a [mld_odoc_dir]. *)
+val parent_of_pages : pkgdir -> Fpath.t
+(** Given a [pkgdir], returns a [mld_odoc_dir]. *)
 
 module Lib : sig
   val v :
-    pkgname:pkgname ->
+    pkgdir:pkgdir ->
     libname_of_archive:string Util.StringMap.t ->
     dir:Fpath.t ->
     cmtidir:Fpath.t option ->
@@ -83,12 +83,13 @@ module Lib : sig
 end
 
 type t = {
-  pkgname : pkgname;
+  name : string;
   version : string;
   libraries : libty list;
   mlds : mld list;
   mld_odoc_dir : Fpath.t;
       (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
+  pkgdir : pkgdir;
   other_docs : Fpath.Set.t;
 }
 

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -61,7 +61,6 @@ val pp_mld : Format.formatter -> mld -> unit
 
 type libty = {
   lib_name : string;
-  dir : Fpath.t;
   odoc_dir : Fpath.t; (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
   archive_name : string;
   modules : modulety list;
@@ -88,5 +87,5 @@ val parent_of_pkg : Fpath.t -> Fpath.t
 
 module Lib : sig
 
-  val v : Fpath.t -> string Util.StringMap.t -> string -> Fpath.t -> libty list
+  val v : Fpath.t -> string Util.StringMap.t -> string -> Fpath.t -> Fpath.t option -> libty list
 end

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -4,10 +4,12 @@
 
 type dep = string * Digest.t
 
+type id = Odoc.id
+
 type intf = {
   mif_odoc_file : Fpath.t;
   mif_odocl_file : Fpath.t;
-  mif_parent_id : string;
+  mif_parent_id : id;
   mif_hash : string;
   mif_path : Fpath.t;
   mif_deps : dep list;
@@ -17,12 +19,12 @@ val pp_intf : Format.formatter -> intf -> unit
 
 (** {2 Implementation part} *)
 
-type src_info = { src_path : Fpath.t; src_id : string }
+type src_info = { src_path : Fpath.t; src_id : id }
 
 type impl = {
   mip_odoc_file : Fpath.t;
   mip_odocl_file : Fpath.t;
-  mip_parent_id : string;
+  mip_parent_id : id;
   mip_path : Fpath.t;
   mip_src_info : src_info option;
 }
@@ -36,6 +38,7 @@ type modulety = {
   m_intf : intf;
   m_impl : impl option;
   m_hidden : bool;
+  m_pkg_dir : Fpath.t;
 }
 
 (** {1 Standalone pages units} *)
@@ -43,9 +46,10 @@ type modulety = {
 type mld = {
   mld_odoc_file : Fpath.t;
   mld_odocl_file : Fpath.t;
-  mld_parent_id : string;
+  mld_parent_id : id;
   mld_path : Fpath.t;
   mld_deps : Fpath.t list;
+  mld_pkg_dir : Fpath.t;
 }
 
 val pp_mld : Format.formatter -> mld -> unit
@@ -58,7 +62,7 @@ val pp_mld : Format.formatter -> mld -> unit
 type libty = {
   lib_name : string;
   dir : Fpath.t;
-  odoc_dir : Fpath.t;
+  odoc_dir : Fpath.t; (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
   archive_name : string;
   modules : modulety list;
 }
@@ -68,6 +72,8 @@ type t = {
   version : string;
   libraries : libty list;
   mlds : mld list;
+  mld_odoc_dir : Fpath.t; (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
+  pkg_dir : Fpath.t;
   other_docs : Fpath.Set.t;
 }
 
@@ -75,5 +81,12 @@ val pp : Format.formatter -> t -> unit
 
 type set = t Util.StringMap.t
 
-val of_libs : Util.StringSet.t -> set
+val of_libs : Fpath.t option -> Util.StringSet.t -> set
 (** Turns a set of libraries into a map from library name to package *)
+
+val parent_of_pkg : Fpath.t -> Fpath.t
+
+module Lib : sig
+
+  val v : Fpath.t -> string Util.StringMap.t -> string -> Fpath.t -> libty list
+end

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -1,6 +1,6 @@
 (** {1 OCaml compilation unit} *)
 
-type pkgdir = string * Fpath.t
+type pkgname = { p_name : string; p_dir : Fpath.t }
 (** A package's name and path. *)
 
 (** {2 Interface part} *)
@@ -41,7 +41,7 @@ type modulety = {
   m_intf : intf;
   m_impl : impl option;
   m_hidden : bool;
-  m_pkg : pkgdir;
+  m_pkgname : pkgname;
 }
 
 (** {1 Standalone pages units} *)
@@ -52,7 +52,7 @@ type mld = {
   mld_parent_id : id;
   mld_path : Fpath.t;
   mld_deps : Fpath.t list;
-  mld_pkg : pkgdir;
+  mld_pkgname : pkgname;
 }
 
 val pp_mld : Format.formatter -> mld -> unit
@@ -70,12 +70,12 @@ type libty = {
   modules : modulety list;
 }
 
-val parent_of_pages : pkgdir -> Fpath.t
-(** Given a [pkgdir], returns a [mld_odoc_dir]. *)
+val parent_of_pages : pkgname -> Fpath.t
+(** Given a [pkgname], returns a [mld_odoc_dir]. *)
 
 module Lib : sig
   val v :
-    pkgdir:pkgdir ->
+    pkgname:pkgname ->
     libname_of_archive:string Util.StringMap.t ->
     dir:Fpath.t ->
     cmtidir:Fpath.t option ->
@@ -83,13 +83,12 @@ module Lib : sig
 end
 
 type t = {
-  name : string;
+  pkgname : pkgname;
   version : string;
   libraries : libty list;
   mlds : mld list;
   mld_odoc_dir : Fpath.t;
       (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
-  pkgdir : pkgdir;
   other_docs : Fpath.Set.t;
 }
 

--- a/src/driver/run.ml
+++ b/src/driver/run.ml
@@ -25,6 +25,7 @@ let commands = ref []
 (** Return the list of executed commands where the first argument was [cmd]. *)
 let run env cmd output_file =
   let cmd = Bos.Cmd.to_list cmd in
+  Logs.debug (fun m -> m "Executing: %s" (String.concat " " cmd));
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let t_start = Unix.gettimeofday () in
   let env =
@@ -60,7 +61,7 @@ let filter_commands cmd =
       (fun c -> match c.cmd with _ :: cmd' :: _ -> cmd = cmd' | _ -> false)
       !commands
   with
-  | [] -> failwith ("No commands run for " ^ cmd)
+  | [] -> []
   | _ :: _ as cmds -> cmds
 
 let print_cmd c =

--- a/src/driver/sherlodoc.ml
+++ b/src/driver/sherlodoc.ml
@@ -3,20 +3,16 @@ open Cmd_outputs
 
 let sherlodoc = Cmd.v "sherlodoc"
 
-
 (* All paths relative to the html output dir *)
 
 (* Per-package sherlodoc db for javascript search*)
-let db_js_file pkg_dir =
-  Fpath.(pkg_dir / "sherlodoc_db.js")
+let db_js_file pkg_dir = Fpath.(pkg_dir / "sherlodoc_db.js")
 
 (* Global sherlodoc marshal file for server-side global search *)
-let db_marshal_file =
-  Fpath.v "sherlodoc_db.marshal"
+let db_marshal_file = Fpath.v "sherlodoc_db.marshal"
 
 (* Global static sherlodoc support file for javascript search *)
-let js_file =
-  Fpath.v "sherlodoc.js"
+let js_file = Fpath.v "sherlodoc.js"
 
 let index ?(ignore_output = false) ~format ~inputs ~dst ?favored_prefixes () =
   let desc = Printf.sprintf "Sherlodoc indexing at %s" (Fpath.to_string dst) in

--- a/src/driver/sherlodoc.ml
+++ b/src/driver/sherlodoc.ml
@@ -3,6 +3,21 @@ open Cmd_outputs
 
 let sherlodoc = Cmd.v "sherlodoc"
 
+
+(* All paths relative to the html output dir *)
+
+(* Per-package sherlodoc db for javascript search*)
+let db_js_file pkg_dir =
+  Fpath.(pkg_dir / "sherlodoc_db.js")
+
+(* Global sherlodoc marshal file for server-side global search *)
+let db_marshal_file =
+  Fpath.v "sherlodoc_db.marshal"
+
+(* Global static sherlodoc support file for javascript search *)
+let js_file =
+  Fpath.v "sherlodoc.js"
+
 let index ?(ignore_output = false) ~format ~inputs ~dst ?favored_prefixes () =
   let desc = Printf.sprintf "Sherlodoc indexing at %s" (Fpath.to_string dst) in
   let format =

--- a/src/driver/stats.ml
+++ b/src/driver/stats.ml
@@ -85,26 +85,27 @@ let compute_metric_int prefix suffix description values =
   match compute_min_max_avg values with
   | None -> []
   | Some (min, max, avg, count) ->
-    let min = int_of_float min in
-    let max = int_of_float max in
-    let avg = int_of_float avg in
-    [
-      `Assoc
-        [
-          ("name", `String (prefix ^ "-total-" ^ suffix));
-          ("value", `Int count);
-          ("description", `String ("Number of " ^ description));
-        ];
-      `Assoc
-        [
-          ("name", `String (prefix ^ "-size-" ^ suffix));
-          ( "value",
-            `Assoc [ ("min", `Int min); ("max", `Int max); ("avg", `Int avg) ] );
-          ("units", `String "b");
-          ("description", `String ("Size of " ^ description));
-          ("trend", `String "lower-is-better");
-        ];
-    ]
+      let min = int_of_float min in
+      let max = int_of_float max in
+      let avg = int_of_float avg in
+      [
+        `Assoc
+          [
+            ("name", `String (prefix ^ "-total-" ^ suffix));
+            ("value", `Int count);
+            ("description", `String ("Number of " ^ description));
+          ];
+        `Assoc
+          [
+            ("name", `String (prefix ^ "-size-" ^ suffix));
+            ( "value",
+              `Assoc [ ("min", `Int min); ("max", `Int max); ("avg", `Int avg) ]
+            );
+            ("units", `String "b");
+            ("description", `String ("Size of " ^ description));
+            ("trend", `String "lower-is-better");
+          ];
+      ]
 
 let compute_metric_cmd cmd =
   let open Run in
@@ -112,24 +113,28 @@ let compute_metric_cmd cmd =
   let times = List.map (fun c -> c.Run.time) cmds in
   match compute_min_max_avg times with
   | None -> []
-  | Some (min, max, avg, count) -> [
-    `Assoc
+  | Some (min, max, avg, count) ->
       [
-        ("name", `String ("total-" ^ cmd));
-        ("value", `Int count);
-        ("description", `String ("Number of time 'odoc " ^ cmd ^ "' has run."));
-      ];
-    `Assoc
-      [
-        ("name", `String ("time-" ^ cmd));
-        ( "value",
-          `Assoc
-            [ ("min", `Float min); ("max", `Float max); ("avg", `Float avg) ] );
-        ("units", `String "s");
-        ("description", `String ("Time taken by 'odoc " ^ cmd ^ "'"));
-        ("trend", `String "lower-is-better");
-      ];
-  ]
+        `Assoc
+          [
+            ("name", `String ("total-" ^ cmd));
+            ("value", `Int count);
+            ( "description",
+              `String ("Number of time 'odoc " ^ cmd ^ "' has run.") );
+          ];
+        `Assoc
+          [
+            ("name", `String ("time-" ^ cmd));
+            ( "value",
+              `Assoc
+                [
+                  ("min", `Float min); ("max", `Float max); ("avg", `Float avg);
+                ] );
+            ("units", `String "s");
+            ("description", `String ("Time taken by 'odoc " ^ cmd ^ "'"));
+            ("trend", `String "lower-is-better");
+          ];
+      ]
 
 (** Analyze the size of files produced by a command. *)
 let compute_produced_cmd cmd =
@@ -165,21 +170,23 @@ let compute_longest_cmd cmd =
   match compute_min_max_avg times with
   | None -> []
   | Some (min, max, avg, _count) ->
-  [
-    `Assoc
       [
-        ("name", `String ("longest-" ^ cmd));
-        ( "value",
-          `Assoc
-            [ ("min", `Float min); ("max", `Float max); ("avg", `Float avg) ] );
-        ("units", `String "s");
-        ( "description",
-          `String
-            (Printf.sprintf "Time taken by the %d longest calls to 'odoc %s'" k
-               cmd) );
-        ("trend", `String "lower-is-better");
-      ];
-  ]
+        `Assoc
+          [
+            ("name", `String ("longest-" ^ cmd));
+            ( "value",
+              `Assoc
+                [
+                  ("min", `Float min); ("max", `Float max); ("avg", `Float avg);
+                ] );
+            ("units", `String "s");
+            ( "description",
+              `String
+                (Printf.sprintf
+                   "Time taken by the %d longest calls to 'odoc %s'" k cmd) );
+            ("trend", `String "lower-is-better");
+          ];
+      ]
 
 let all_metrics html_dir =
   compute_metric_cmd "compile"

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -96,7 +96,13 @@ let process_package pkg =
         Fpath.Set.add meta_dir acc
       | Some x ->
         let dir = Fpath.(meta_dir // v x) in
-        Fpath.Set.add dir acc)) Fpath.Set.empty libs
+        (* NB. topkg installs a META file that points to a ../topkg-care directory
+           that is installed by the topkg-care package. We filter that out here,
+           though I've not thought of a good way to sort out the `topkg-care` package *)
+        match Bos.OS.Dir.exists dir with
+        | Ok true ->
+          Fpath.Set.add dir acc
+        | _ -> acc)) Fpath.Set.empty libs
       in
     let libname_of_archive =
       List.fold_left (fun acc x ->

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -117,7 +117,7 @@ let process_package pkg =
       Logs.debug (fun m -> m "%s,%s\n%!" k v)) libname_of_archive;
     Some (List.map (fun directory ->
       Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
-      Packages.Lib.v (top_dir pkg) libname_of_archive pkg.name directory) Fpath.(Set.to_list directories)))
+      Packages.Lib.v (top_dir pkg) libname_of_archive pkg.name directory None) Fpath.(Set.to_list directories)))
   metas in
 (* Check the main package lib directory even if there's no meta file *)
 let extra_libraries =
@@ -131,7 +131,7 @@ let extra_libraries =
   in
   List.map (fun libdir ->
     Logs.debug (fun m -> m "Processing directory without META: %a" Fpath.pp libdir);
-    Packages.Lib.v (top_dir pkg) Util.StringMap.empty pkg.name Fpath.(pkg_path // libdir)) libdirs_without_meta
+    Packages.Lib.v (top_dir pkg) Util.StringMap.empty pkg.name Fpath.(pkg_path // libdir) None) libdirs_without_meta
 in
 Printf.eprintf "Found %d metas" (List.length metas);
 let mld_odoc_dir = Packages.parent_of_pkg (top_dir pkg) in

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -38,9 +38,6 @@ let find_universe_and_version pkg_name =
   | _ :: _ :: u :: _, [ version ] -> Ok (u, Fpath.to_string version)
   | _ -> Error (`Msg (Format.sprintf "Failed to find package %s" pkg_name))
 
-(* let read_package universe pkg version =
-   () *)
-
 let process_package pkg =
   let metas =
     List.filter

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -185,6 +185,8 @@ let pp ppf v =
   List.iter (fun fp -> Format.fprintf ppf "%a\n" Fpath.pp fp) v.files;
   Format.fprintf ppf "]\n%!"
 
+let () = ignore pp
+
 let of_voodoo pkg_name blessed =
   let contents =
     Bos.OS.Dir.fold_contents ~dotfiles:true

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -71,7 +71,7 @@ let process_package pkg =
               | None -> None
               | Some rel_path ->
                   let id =
-                    Fpath.(Packages.parent_of_pkg (top_dir pkg) // rel_path)
+                    Fpath.(Packages.parent_of_pages (top_dir pkg) // rel_path)
                   in
                   let mld_parent_id =
                     id |> Fpath.parent |> Fpath.rem_empty_seg
@@ -168,7 +168,7 @@ let process_package pkg =
       libdirs_without_meta
   in
   Printf.eprintf "Found %d metas" (List.length metas);
-  let mld_odoc_dir = Packages.parent_of_pkg (top_dir pkg) in
+  let mld_odoc_dir = Packages.parent_of_pages (top_dir pkg) in
   let libraries = List.flatten libraries in
   let libraries = List.flatten extra_libraries @ libraries in
   {

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -12,12 +12,9 @@ type pkg = {
 
 let prep_path = ref "prep"
 
-let mk_pkgname pkg : Packages.pkgname =
-  let p_dir =
-    if pkg.blessed then Fpath.(v "p" / pkg.name / pkg.version)
-    else Fpath.(v "u" / pkg.universe / pkg.name / pkg.version)
-  in
-  { Packages.p_name = pkg.name; p_dir }
+let pkgdir pkg : Packages.pkgdir =
+  if pkg.blessed then (pkg.name, Fpath.(v "p" / pkg.name / pkg.version))
+  else (pkg.name, Fpath.(v "u" / pkg.universe / pkg.name / pkg.version))
 
 (* Use output from Voodoo Prep as input *)
 
@@ -50,7 +47,7 @@ let process_package pkg =
       pkg.files
   in
 
-  let pkgname = mk_pkgname pkg in
+  let pkgdir = pkgdir pkg in
   let pkg_path =
     Fpath.(v "prep" / "universes" / pkg.universe / pkg.name / pkg.version)
   in
@@ -75,7 +72,7 @@ let process_package pkg =
               | None -> None
               | Some rel_path ->
                   let id =
-                    Fpath.(Packages.parent_of_pages pkgname // rel_path)
+                    Fpath.(Packages.parent_of_pages pkgdir // rel_path)
                   in
                   let mld_parent_id =
                     id |> Fpath.parent |> Fpath.rem_empty_seg
@@ -93,7 +90,7 @@ let process_package pkg =
                       mld_parent_id = Odoc.id_of_fpath mld_parent_id;
                       mld_path = Fpath.(pkg_path // p);
                       mld_deps;
-                      mld_pkgname = pkgname;
+                      mld_pkg = pkgdir;
                     })
         | _ -> None)
       pkg.files
@@ -141,7 +138,7 @@ let process_package pkg =
           (List.concat_map
              (fun directory ->
                Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
-               Packages.Lib.v ~pkgname ~libname_of_archive ~dir:directory
+               Packages.Lib.v ~pkgdir ~libname_of_archive ~dir:directory
                  ~cmtidir:None)
              Fpath.(Set.to_list directories)))
       metas
@@ -165,22 +162,23 @@ let process_package pkg =
       (fun libdir ->
         Logs.debug (fun m ->
             m "Processing directory without META: %a" Fpath.pp libdir);
-        Packages.Lib.v ~pkgname ~libname_of_archive:Util.StringMap.empty
+        Packages.Lib.v ~pkgdir ~libname_of_archive:Util.StringMap.empty
           ~dir:Fpath.(pkg_path // libdir)
           ~cmtidir:None)
       libdirs_without_meta
   in
   Printf.eprintf "Found %d metas" (List.length metas);
-  let mld_odoc_dir = Packages.parent_of_pages pkgname in
+  let mld_odoc_dir = Packages.parent_of_pages pkgdir in
   let libraries = List.flatten libraries in
   let libraries = List.flatten extra_libraries @ libraries in
   {
-    Packages.pkgname;
+    Packages.name = pkg.name;
     version = pkg.version;
     mld_odoc_dir;
     libraries;
     mlds;
     other_docs = Fpath.Set.empty;
+    pkgdir;
   }
 
 let pp ppf v =

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -134,7 +134,7 @@ let process_package pkg =
           (fun k v -> Logs.debug (fun m -> m "%s,%s\n%!" k v))
           libname_of_archive;
         Some
-          (List.map
+          (List.concat_map
              (fun directory ->
                Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
                Packages.Lib.v (top_dir pkg) libname_of_archive pkg.name
@@ -168,7 +168,7 @@ let process_package pkg =
   in
   Printf.eprintf "Found %d metas" (List.length metas);
   let mld_odoc_dir = Packages.parent_of_pkg (top_dir pkg) in
-  let libraries = List.flatten (List.flatten libraries) in
+  let libraries = List.flatten libraries in
   let libraries = List.flatten extra_libraries @ libraries in
   {
     Packages.name = pkg.name;

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -137,8 +137,8 @@ let process_package pkg =
           (List.concat_map
              (fun directory ->
                Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
-               Packages.Lib.v (top_dir pkg) libname_of_archive pkg.name
-                 directory None)
+               Packages.Lib.v ~pkg_dir:(top_dir pkg) ~libname_of_archive
+                 ~pkg_name:pkg.name ~dir:directory ~cmtidir:None)
              Fpath.(Set.to_list directories)))
       metas
   in
@@ -161,9 +161,10 @@ let process_package pkg =
       (fun libdir ->
         Logs.debug (fun m ->
             m "Processing directory without META: %a" Fpath.pp libdir);
-        Packages.Lib.v (top_dir pkg) Util.StringMap.empty pkg.name
-          Fpath.(pkg_path // libdir)
-          None)
+        Packages.Lib.v ~pkg_dir:(top_dir pkg)
+          ~libname_of_archive:Util.StringMap.empty ~pkg_name:pkg.name
+          ~dir:Fpath.(pkg_path // libdir)
+          ~cmtidir:None)
       libdirs_without_meta
   in
   Printf.eprintf "Found %d metas" (List.length metas);
@@ -187,7 +188,7 @@ let pp ppf v =
 
 let () = ignore pp
 
-let of_voodoo pkg_name blessed =
+let of_voodoo pkg_name ~blessed =
   let contents =
     Bos.OS.Dir.fold_contents ~dotfiles:true
       (fun p acc -> p :: acc)

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -12,9 +12,9 @@ type pkg = {
 
 let prep_path = ref "prep"
 
-let top_dir pkg =
-  if pkg.blessed then Fpath.(v "p" / pkg.name / pkg.version)
-  else Fpath.(v "u" / pkg.universe / pkg.name / pkg.version)
+let pkgdir pkg : Packages.pkgdir =
+  if pkg.blessed then (pkg.name, Fpath.(v "p" / pkg.name / pkg.version))
+  else (pkg.name, Fpath.(v "u" / pkg.universe / pkg.name / pkg.version))
 
 (* Use output from Voodoo Prep as input *)
 
@@ -47,6 +47,7 @@ let process_package pkg =
       pkg.files
   in
 
+  let pkgdir = pkgdir pkg in
   let pkg_path =
     Fpath.(v "prep" / "universes" / pkg.universe / pkg.name / pkg.version)
   in
@@ -71,7 +72,7 @@ let process_package pkg =
               | None -> None
               | Some rel_path ->
                   let id =
-                    Fpath.(Packages.parent_of_pages (top_dir pkg) // rel_path)
+                    Fpath.(Packages.parent_of_pages pkgdir // rel_path)
                   in
                   let mld_parent_id =
                     id |> Fpath.parent |> Fpath.rem_empty_seg
@@ -89,7 +90,7 @@ let process_package pkg =
                       mld_parent_id = Odoc.id_of_fpath mld_parent_id;
                       mld_path = Fpath.(pkg_path // p);
                       mld_deps;
-                      mld_pkg_dir = top_dir pkg;
+                      mld_pkg = pkgdir;
                     })
         | _ -> None)
       pkg.files
@@ -137,8 +138,8 @@ let process_package pkg =
           (List.concat_map
              (fun directory ->
                Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
-               Packages.Lib.v ~pkg_dir:(top_dir pkg) ~libname_of_archive
-                 ~pkg_name:pkg.name ~dir:directory ~cmtidir:None)
+               Packages.Lib.v ~pkgdir ~libname_of_archive ~dir:directory
+                 ~cmtidir:None)
              Fpath.(Set.to_list directories)))
       metas
   in
@@ -161,14 +162,13 @@ let process_package pkg =
       (fun libdir ->
         Logs.debug (fun m ->
             m "Processing directory without META: %a" Fpath.pp libdir);
-        Packages.Lib.v ~pkg_dir:(top_dir pkg)
-          ~libname_of_archive:Util.StringMap.empty ~pkg_name:pkg.name
+        Packages.Lib.v ~pkgdir ~libname_of_archive:Util.StringMap.empty
           ~dir:Fpath.(pkg_path // libdir)
           ~cmtidir:None)
       libdirs_without_meta
   in
   Printf.eprintf "Found %d metas" (List.length metas);
-  let mld_odoc_dir = Packages.parent_of_pages (top_dir pkg) in
+  let mld_odoc_dir = Packages.parent_of_pages pkgdir in
   let libraries = List.flatten libraries in
   let libraries = List.flatten extra_libraries @ libraries in
   {
@@ -178,7 +178,7 @@ let process_package pkg =
     libraries;
     mlds;
     other_docs = Fpath.Set.empty;
-    pkg_dir = top_dir pkg;
+    pkgdir;
   }
 
 let pp ppf v =

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -1,0 +1,164 @@
+(* Voodoo *)
+
+let (>>=) = Result.bind
+
+type pkg = {
+  name : string;
+  version : string;
+  universe : string;
+  blessed : bool;
+  files : Fpath.t list;
+}
+
+let prep_path = ref "prep"
+
+let top_dir pkg =
+  if pkg.blessed
+  then Fpath.(v "p" / pkg.name / pkg.version)
+  else Fpath.(v "u" / pkg.universe / pkg.name / pkg.version)
+
+(* Use output from Voodoo Prep as input *)
+
+let find_universe_and_version pkg_name =
+  Bos.OS.Dir.contents Fpath.(v !prep_path / "universes") >>= fun universes ->
+  let universe =
+    match
+      List.find_opt
+        (fun u ->
+          match Bos.OS.Dir.exists Fpath.(u / pkg_name) with
+          | Ok b -> b
+          | Error _ -> false)
+        universes
+    with
+    | Some u -> Ok u
+    | None -> Error (`Msg (Format.sprintf "Failed to find package %s" pkg_name))
+  in
+  universe >>= fun u ->
+  Bos.OS.Dir.contents ~rel:true Fpath.(u / pkg_name) >>= fun version ->
+  match (Fpath.segs u, version) with
+  | _ :: _ :: u :: _, [ version ] -> Ok (u, Fpath.to_string version)
+  | _ -> Error (`Msg (Format.sprintf "Failed to find package %s" pkg_name))
+
+(* let read_package universe pkg version =
+  () *)
+
+
+let process_package pkg =
+  let metas = List.filter (fun p ->
+    let filename = Fpath.filename p in
+    filename = "META") pkg.files
+  in
+
+  let pkg_path = Fpath.(v "prep" / "universes" / pkg.universe / pkg.name / pkg.version) in
+
+  let mlds = List.filter_map (fun p ->
+    let prefix = Fpath.(v "doc" / pkg.name / "odoc-pages") in
+
+    match Fpath.segs p with
+    | "doc" :: pkg_name :: "odoc-pages" :: _ :: _ -> begin
+      if pkg_name <> pkg.name 
+      then begin
+        Logs.err (fun k -> k "Error: name in 'doc' dir does not match package name: %s <> %s" pkg_name pkg.name);
+        None
+      end else begin
+        let rel_path = Fpath.rem_prefix prefix p in
+        match rel_path with
+        | None -> None
+        | Some rel_path ->
+          let id = Fpath.(Packages.parent_of_pkg (top_dir pkg) // rel_path) in
+          let mld_parent_id =
+            (id |> Fpath.parent |> Fpath.rem_empty_seg)
+          in
+          let page_name = Fpath.(rem_ext p |> filename) in
+          let odoc_file =
+            Fpath.(mld_parent_id / ("page-" ^ page_name ^ ".odoc"))
+          in
+          let odocl_file = Fpath.(set_ext "odocl" odoc_file) in
+          let mld_deps = [] in
+          Some { Packages.mld_odoc_file = odoc_file;
+            mld_odocl_file = odocl_file;
+            mld_parent_id = Odoc.id_of_fpath mld_parent_id;
+            mld_path = Fpath.(pkg_path // p);
+            mld_deps; mld_pkg_dir = (top_dir pkg)}
+        end
+      end
+    | _ -> None
+    ) pkg.files in
+
+
+  let libraries = List.filter_map (fun meta_file ->
+    let full_meta_path = Fpath.(pkg_path // meta_file) in
+    let libs = Library_names.process_meta_file full_meta_path in
+    let meta_dir = Fpath.parent full_meta_path in
+    let directories = List.fold_left (fun acc x ->
+      (match x.Library_names.dir with 
+      | None ->
+        Fpath.Set.add meta_dir acc
+      | Some x ->
+        let dir = Fpath.(meta_dir // v x) in
+        Fpath.Set.add dir acc)) Fpath.Set.empty libs
+      in
+    let libname_of_archive =
+      List.fold_left (fun acc x ->
+        Util.StringMap.update x.Library_names.archive_name (function
+          | None -> Some (x.Library_names.name)
+          | Some y -> Logs.err (fun m ->
+              m "Multiple libraries for archive %s: %s and %s."
+                x.archive_name x.name y);
+              Some y
+        ) acc) Util.StringMap.empty libs in
+    Util.StringMap.iter (fun k v ->
+      Logs.debug (fun m -> m "%s,%s\n%!" k v)) libname_of_archive;
+    Some (List.map (fun directory ->
+      Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
+      Packages.Lib.v (top_dir pkg) libname_of_archive pkg.name directory) Fpath.(Set.to_list directories)))
+  metas in
+(* Check the main package lib directory even if there's no meta file *)
+let extra_libraries =
+  let libdirs_without_meta = List.filter (fun p ->
+    match Fpath.segs p with
+    | "lib" :: _ :: _ when Sys.is_directory Fpath.(pkg_path // p |> to_string) ->
+      not (List.exists (fun p2 ->
+        Fpath.parent p2 = Fpath.to_dir_path p
+        ) metas)
+    | _ -> false) pkg.files
+  in
+  List.map (fun libdir ->
+    Logs.debug (fun m -> m "Processing directory without META: %a" Fpath.pp libdir);
+    Packages.Lib.v (top_dir pkg) Util.StringMap.empty pkg.name Fpath.(pkg_path // libdir)) libdirs_without_meta
+in
+Printf.eprintf "Found %d metas" (List.length metas);
+let mld_odoc_dir = Packages.parent_of_pkg (top_dir pkg) in
+let libraries = List.flatten (List.flatten libraries) in
+let libraries = List.flatten extra_libraries @ libraries in
+{ Packages.name = pkg.name; version = pkg.version; mld_odoc_dir; libraries; mlds = mlds; other_docs=Fpath.Set.empty; pkg_dir = (top_dir pkg) }
+
+let pp ppf v =
+  Format.fprintf ppf "n: %s v: %s u: %s [\n" v.name v.version v.universe;
+  List.iter (fun fp -> Format.fprintf ppf "%a\n" Fpath.pp fp) v.files;
+  Format.fprintf ppf "]\n%!"
+
+let of_voodoo pkg_name blessed =
+  let contents = Bos.OS.Dir.fold_contents ~dotfiles:true
+    (fun p acc ->
+      p::acc
+    ) [] Fpath.(v !prep_path) in
+  match contents with
+  | Error _ -> Util.StringMap.empty
+  | Ok c -> 
+    let sorted = List.sort (fun p1 p2 -> Fpath.compare p1 p2) c in
+    let last, packages = List.fold_left (fun (cur_opt, acc) file ->
+      match Fpath.segs file with
+      | "prep" :: "universes" :: u :: p :: v :: (_ :: _ as rest) when p = pkg_name ->
+        let file = Fpath.v (Astring.String.concat ~sep:"/" rest) in
+        (match cur_opt with
+        | Some cur when cur.name = p && cur.version = v && cur.universe = u -> 
+          (Some {cur with files = file :: cur.files}, acc)
+        | _ ->
+          Some { name = p; version = v; universe = u; blessed; files = [file]}, cur_opt :: acc)
+      | _ -> (cur_opt, acc))
+         (None, []) sorted
+    in
+    let packages = List.filter_map (fun x -> x) (last :: packages) in
+    let packages = List.map process_package packages in
+    Util.StringMap.singleton pkg_name (List.hd packages)

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -1,6 +1,6 @@
 (* Voodoo *)
 
-let (>>=) = Result.bind
+let ( >>= ) = Result.bind
 
 type pkg = {
   name : string;
@@ -13,8 +13,7 @@ type pkg = {
 let prep_path = ref "prep"
 
 let top_dir pkg =
-  if pkg.blessed
-  then Fpath.(v "p" / pkg.name / pkg.version)
+  if pkg.blessed then Fpath.(v "p" / pkg.name / pkg.version)
   else Fpath.(v "u" / pkg.universe / pkg.name / pkg.version)
 
 (* Use output from Voodoo Prep as input *)
@@ -40,104 +39,149 @@ let find_universe_and_version pkg_name =
   | _ -> Error (`Msg (Format.sprintf "Failed to find package %s" pkg_name))
 
 (* let read_package universe pkg version =
-  () *)
-
+   () *)
 
 let process_package pkg =
-  let metas = List.filter (fun p ->
-    let filename = Fpath.filename p in
-    filename = "META") pkg.files
+  let metas =
+    List.filter
+      (fun p ->
+        let filename = Fpath.filename p in
+        filename = "META")
+      pkg.files
   in
 
-  let pkg_path = Fpath.(v "prep" / "universes" / pkg.universe / pkg.name / pkg.version) in
-
-  let mlds = List.filter_map (fun p ->
-    let prefix = Fpath.(v "doc" / pkg.name / "odoc-pages") in
-
-    match Fpath.segs p with
-    | "doc" :: pkg_name :: "odoc-pages" :: _ :: _ -> begin
-      if pkg_name <> pkg.name 
-      then begin
-        Logs.err (fun k -> k "Error: name in 'doc' dir does not match package name: %s <> %s" pkg_name pkg.name);
-        None
-      end else begin
-        let rel_path = Fpath.rem_prefix prefix p in
-        match rel_path with
-        | None -> None
-        | Some rel_path ->
-          let id = Fpath.(Packages.parent_of_pkg (top_dir pkg) // rel_path) in
-          let mld_parent_id =
-            (id |> Fpath.parent |> Fpath.rem_empty_seg)
-          in
-          let page_name = Fpath.(rem_ext p |> filename) in
-          let odoc_file =
-            Fpath.(mld_parent_id / ("page-" ^ page_name ^ ".odoc"))
-          in
-          let odocl_file = Fpath.(set_ext "odocl" odoc_file) in
-          let mld_deps = [] in
-          Some { Packages.mld_odoc_file = odoc_file;
-            mld_odocl_file = odocl_file;
-            mld_parent_id = Odoc.id_of_fpath mld_parent_id;
-            mld_path = Fpath.(pkg_path // p);
-            mld_deps; mld_pkg_dir = (top_dir pkg)}
-        end
-      end
-    | _ -> None
-    ) pkg.files in
-
-
-  let libraries = List.filter_map (fun meta_file ->
-    let full_meta_path = Fpath.(pkg_path // meta_file) in
-    let libs = Library_names.process_meta_file full_meta_path in
-    let meta_dir = Fpath.parent full_meta_path in
-    let directories = List.fold_left (fun acc x ->
-      (match x.Library_names.dir with 
-      | None ->
-        Fpath.Set.add meta_dir acc
-      | Some x ->
-        let dir = Fpath.(meta_dir // v x) in
-        (* NB. topkg installs a META file that points to a ../topkg-care directory
-           that is installed by the topkg-care package. We filter that out here,
-           though I've not thought of a good way to sort out the `topkg-care` package *)
-        match Bos.OS.Dir.exists dir with
-        | Ok true ->
-          Fpath.Set.add dir acc
-        | _ -> acc)) Fpath.Set.empty libs
-      in
-    let libname_of_archive =
-      List.fold_left (fun acc x ->
-        Util.StringMap.update x.Library_names.archive_name (function
-          | None -> Some (x.Library_names.name)
-          | Some y -> Logs.err (fun m ->
-              m "Multiple libraries for archive %s: %s and %s."
-                x.archive_name x.name y);
-              Some y
-        ) acc) Util.StringMap.empty libs in
-    Util.StringMap.iter (fun k v ->
-      Logs.debug (fun m -> m "%s,%s\n%!" k v)) libname_of_archive;
-    Some (List.map (fun directory ->
-      Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
-      Packages.Lib.v (top_dir pkg) libname_of_archive pkg.name directory None) Fpath.(Set.to_list directories)))
-  metas in
-(* Check the main package lib directory even if there's no meta file *)
-let extra_libraries =
-  let libdirs_without_meta = List.filter (fun p ->
-    match Fpath.segs p with
-    | "lib" :: _ :: _ when Sys.is_directory Fpath.(pkg_path // p |> to_string) ->
-      not (List.exists (fun p2 ->
-        Fpath.parent p2 = Fpath.to_dir_path p
-        ) metas)
-    | _ -> false) pkg.files
+  let pkg_path =
+    Fpath.(v "prep" / "universes" / pkg.universe / pkg.name / pkg.version)
   in
-  List.map (fun libdir ->
-    Logs.debug (fun m -> m "Processing directory without META: %a" Fpath.pp libdir);
-    Packages.Lib.v (top_dir pkg) Util.StringMap.empty pkg.name Fpath.(pkg_path // libdir) None) libdirs_without_meta
-in
-Printf.eprintf "Found %d metas" (List.length metas);
-let mld_odoc_dir = Packages.parent_of_pkg (top_dir pkg) in
-let libraries = List.flatten (List.flatten libraries) in
-let libraries = List.flatten extra_libraries @ libraries in
-{ Packages.name = pkg.name; version = pkg.version; mld_odoc_dir; libraries; mlds = mlds; other_docs=Fpath.Set.empty; pkg_dir = (top_dir pkg) }
+
+  let mlds =
+    List.filter_map
+      (fun p ->
+        let prefix = Fpath.(v "doc" / pkg.name / "odoc-pages") in
+
+        match Fpath.segs p with
+        | "doc" :: pkg_name :: "odoc-pages" :: _ :: _ -> (
+            if pkg_name <> pkg.name then (
+              Logs.err (fun k ->
+                  k
+                    "Error: name in 'doc' dir does not match package name: %s \
+                     <> %s"
+                    pkg_name pkg.name);
+              None)
+            else
+              let rel_path = Fpath.rem_prefix prefix p in
+              match rel_path with
+              | None -> None
+              | Some rel_path ->
+                  let id =
+                    Fpath.(Packages.parent_of_pkg (top_dir pkg) // rel_path)
+                  in
+                  let mld_parent_id =
+                    id |> Fpath.parent |> Fpath.rem_empty_seg
+                  in
+                  let page_name = Fpath.(rem_ext p |> filename) in
+                  let odoc_file =
+                    Fpath.(mld_parent_id / ("page-" ^ page_name ^ ".odoc"))
+                  in
+                  let odocl_file = Fpath.(set_ext "odocl" odoc_file) in
+                  let mld_deps = [] in
+                  Some
+                    {
+                      Packages.mld_odoc_file = odoc_file;
+                      mld_odocl_file = odocl_file;
+                      mld_parent_id = Odoc.id_of_fpath mld_parent_id;
+                      mld_path = Fpath.(pkg_path // p);
+                      mld_deps;
+                      mld_pkg_dir = top_dir pkg;
+                    })
+        | _ -> None)
+      pkg.files
+  in
+
+  let libraries =
+    List.filter_map
+      (fun meta_file ->
+        let full_meta_path = Fpath.(pkg_path // meta_file) in
+        let libs = Library_names.process_meta_file full_meta_path in
+        let meta_dir = Fpath.parent full_meta_path in
+        let directories =
+          List.fold_left
+            (fun acc x ->
+              match x.Library_names.dir with
+              | None -> Fpath.Set.add meta_dir acc
+              | Some x -> (
+                  let dir = Fpath.(meta_dir // v x) in
+                  (* NB. topkg installs a META file that points to a ../topkg-care directory
+                     that is installed by the topkg-care package. We filter that out here,
+                     though I've not thought of a good way to sort out the `topkg-care` package *)
+                  match Bos.OS.Dir.exists dir with
+                  | Ok true -> Fpath.Set.add dir acc
+                  | _ -> acc))
+            Fpath.Set.empty libs
+        in
+        let libname_of_archive =
+          List.fold_left
+            (fun acc x ->
+              Util.StringMap.update x.Library_names.archive_name
+                (function
+                  | None -> Some x.Library_names.name
+                  | Some y ->
+                      Logs.err (fun m ->
+                          m "Multiple libraries for archive %s: %s and %s."
+                            x.archive_name x.name y);
+                      Some y)
+                acc)
+            Util.StringMap.empty libs
+        in
+        Util.StringMap.iter
+          (fun k v -> Logs.debug (fun m -> m "%s,%s\n%!" k v))
+          libname_of_archive;
+        Some
+          (List.map
+             (fun directory ->
+               Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
+               Packages.Lib.v (top_dir pkg) libname_of_archive pkg.name
+                 directory None)
+             Fpath.(Set.to_list directories)))
+      metas
+  in
+  (* Check the main package lib directory even if there's no meta file *)
+  let extra_libraries =
+    let libdirs_without_meta =
+      List.filter
+        (fun p ->
+          match Fpath.segs p with
+          | "lib" :: _ :: _
+            when Sys.is_directory Fpath.(pkg_path // p |> to_string) ->
+              not
+                (List.exists
+                   (fun p2 -> Fpath.parent p2 = Fpath.to_dir_path p)
+                   metas)
+          | _ -> false)
+        pkg.files
+    in
+    List.map
+      (fun libdir ->
+        Logs.debug (fun m ->
+            m "Processing directory without META: %a" Fpath.pp libdir);
+        Packages.Lib.v (top_dir pkg) Util.StringMap.empty pkg.name
+          Fpath.(pkg_path // libdir)
+          None)
+      libdirs_without_meta
+  in
+  Printf.eprintf "Found %d metas" (List.length metas);
+  let mld_odoc_dir = Packages.parent_of_pkg (top_dir pkg) in
+  let libraries = List.flatten (List.flatten libraries) in
+  let libraries = List.flatten extra_libraries @ libraries in
+  {
+    Packages.name = pkg.name;
+    version = pkg.version;
+    mld_odoc_dir;
+    libraries;
+    mlds;
+    other_docs = Fpath.Set.empty;
+    pkg_dir = top_dir pkg;
+  }
 
 let pp ppf v =
   Format.fprintf ppf "n: %s v: %s u: %s [\n" v.name v.version v.universe;
@@ -145,26 +189,40 @@ let pp ppf v =
   Format.fprintf ppf "]\n%!"
 
 let of_voodoo pkg_name blessed =
-  let contents = Bos.OS.Dir.fold_contents ~dotfiles:true
-    (fun p acc ->
-      p::acc
-    ) [] Fpath.(v !prep_path) in
+  let contents =
+    Bos.OS.Dir.fold_contents ~dotfiles:true
+      (fun p acc -> p :: acc)
+      []
+      Fpath.(v !prep_path)
+  in
   match contents with
   | Error _ -> Util.StringMap.empty
-  | Ok c -> 
-    let sorted = List.sort (fun p1 p2 -> Fpath.compare p1 p2) c in
-    let last, packages = List.fold_left (fun (cur_opt, acc) file ->
-      match Fpath.segs file with
-      | "prep" :: "universes" :: u :: p :: v :: (_ :: _ as rest) when p = pkg_name ->
-        let file = Fpath.v (Astring.String.concat ~sep:"/" rest) in
-        (match cur_opt with
-        | Some cur when cur.name = p && cur.version = v && cur.universe = u -> 
-          (Some {cur with files = file :: cur.files}, acc)
-        | _ ->
-          Some { name = p; version = v; universe = u; blessed; files = [file]}, cur_opt :: acc)
-      | _ -> (cur_opt, acc))
-         (None, []) sorted
-    in
-    let packages = List.filter_map (fun x -> x) (last :: packages) in
-    let packages = List.map process_package packages in
-    Util.StringMap.singleton pkg_name (List.hd packages)
+  | Ok c ->
+      let sorted = List.sort (fun p1 p2 -> Fpath.compare p1 p2) c in
+      let last, packages =
+        List.fold_left
+          (fun (cur_opt, acc) file ->
+            match Fpath.segs file with
+            | "prep" :: "universes" :: u :: p :: v :: (_ :: _ as rest)
+              when p = pkg_name -> (
+                let file = Fpath.v (Astring.String.concat ~sep:"/" rest) in
+                match cur_opt with
+                | Some cur
+                  when cur.name = p && cur.version = v && cur.universe = u ->
+                    (Some { cur with files = file :: cur.files }, acc)
+                | _ ->
+                    ( Some
+                        {
+                          name = p;
+                          version = v;
+                          universe = u;
+                          blessed;
+                          files = [ file ];
+                        },
+                      cur_opt :: acc ))
+            | _ -> (cur_opt, acc))
+          (None, []) sorted
+      in
+      let packages = List.filter_map (fun x -> x) (last :: packages) in
+      let packages = List.map process_package packages in
+      Util.StringMap.singleton pkg_name (List.hd packages)

--- a/src/driver/voodoo.mli
+++ b/src/driver/voodoo.mli
@@ -1,4 +1,4 @@
 val find_universe_and_version :
   string -> (string * string, [> `Msg of string ]) result
 
-val of_voodoo : string -> bool -> Packages.set
+val of_voodoo : string -> blessed:bool -> Packages.set

--- a/src/driver/voodoo.mli
+++ b/src/driver/voodoo.mli
@@ -1,0 +1,4 @@
+val find_universe_and_version :
+  string -> (string * string, [> `Msg of string ]) result
+
+val of_voodoo : string -> bool -> Packages.set

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -136,11 +136,12 @@ let read_cmt ~make_root ~parent ~filename () =
       in
       let interface = cmt_info.cmt_interface_digest in
       (match cmt_info.cmt_interface_digest with
-      | None ->
-        (match cmt_info.cmt_source_digest with
-        | Some x -> (try Odoc_model.Names.set_unique_ident (Digest.to_hex x) with _ -> ())
-        | None ->
-          (try Odoc_model.Names.set_unique_ident name with _ -> ()))
+      | None -> (
+          match cmt_info.cmt_source_digest with
+          | Some x -> (
+              try Odoc_model.Names.set_unique_ident (Digest.to_hex x)
+              with _ -> ())
+          | None -> ( try Odoc_model.Names.set_unique_ident name with _ -> ()))
       | Some digest -> (
           try Odoc_model.Names.set_unique_ident (Digest.to_hex digest)
           with _ -> ()));

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -136,7 +136,11 @@ let read_cmt ~make_root ~parent ~filename () =
       in
       let interface = cmt_info.cmt_interface_digest in
       (match cmt_info.cmt_interface_digest with
-      | None -> raise Corrupted
+      | None ->
+        (match cmt_info.cmt_source_digest with
+        | Some x -> (try Odoc_model.Names.set_unique_ident (Digest.to_hex x) with _ -> ())
+        | None ->
+          (try Odoc_model.Names.set_unique_ident name with _ -> ()))
       | Some digest -> (
           try Odoc_model.Names.set_unique_ident (Digest.to_hex digest)
           with _ -> ()));

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -646,7 +646,7 @@ end = struct
   open Or_error
 
   (** Find the package/library name the output is part of *)
-  let find_root_of_output l o =
+  let find_root_of_input l o =
     let l =
       List.map
         ~f:(fun (x, p) ->
@@ -673,7 +673,7 @@ end = struct
         | None -> Error `Not_found)
 
   let current_library_of_input lib_roots input =
-    match find_root_of_output lib_roots input with
+    match find_root_of_input lib_roots input with
     | Ok _ as ok -> ok
     | Error `Not_found ->
         Error (`Msg "The output file must be part of a directory passed as -L")
@@ -703,8 +703,8 @@ end = struct
           | _ -> Ok current_package)
     | None -> Ok detected_package
 
-  let current_package_of_page ~current_package page_roots output =
-    match find_root_of_output page_roots output with
+  let current_package_of_page ~current_package page_roots input =
+    match find_root_of_input page_roots input with
     | Ok detected_package ->
         validate_current_package ?detected_package page_roots current_package
     | Error `Not_found ->
@@ -729,7 +729,7 @@ end = struct
     let is_page = is_page input in
     (if is_page then Ok None else current_library_of_input lib_roots input)
     >>= fun current_lib ->
-    (if is_page then current_package_of_page ~current_package page_roots output
+    (if is_page then current_package_of_page ~current_package page_roots input
      else validate_current_package page_roots current_package)
     >>= fun current_package ->
     let current_dir = Fs.File.dirname output in

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -672,8 +672,8 @@ end = struct
         | Some _ as r -> Ok r
         | None -> Error `Not_found)
 
-  let current_library_of_output lib_roots output =
-    match find_root_of_output lib_roots output with
+  let current_library_of_input lib_roots input =
+    match find_root_of_output lib_roots input with
     | Ok _ as ok -> ok
     | Error `Not_found ->
         Error (`Msg "The output file must be part of a directory passed as -L")
@@ -727,7 +727,7 @@ end = struct
      else Ok ())
     >>= fun () ->
     let is_page = is_page input in
-    (if is_page then Ok None else current_library_of_output lib_roots output)
+    (if is_page then Ok None else current_library_of_input lib_roots input)
     >>= fun current_lib ->
     (if is_page then current_package_of_page ~current_package page_roots output
      else validate_current_package page_roots current_package)

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -1519,11 +1519,11 @@ module Odoc_error = struct
 end
 
 module Classify = struct
-  let libdir =
-    let doc = "The directory containing the libraries" in
-    Arg.(required & pos 0 (some string) None & info ~doc ~docv:"DIR" [])
+  let libdirs =
+    let doc = "The directories containing the libraries" in
+    Arg.(value & pos_all string [] & info ~doc ~docv:"DIR" [])
 
-  let cmd = Term.(const handle_error $ (const Classify.classify $ libdir))
+  let cmd = Term.(const handle_error $ (const Classify.classify $ libdirs))
 
   let info ~docs =
     Term.info "classify" ~docs


### PR DESCRIPTION
adds two new modes to the driver for different inputs - one to handle voodoo-style layout, and the second to handle dune `_build` style layout.