### PR TITLE
Fix the type_expr loader in OCaml 4.14 and later

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,9 @@
 - Fix wrong links to standalone comments in search results (#1118, @panglesd)
 - Remove duplicated or unwanted comments (@Julow, #1133)
   This could happen with inline includes.
+- Fix misprinting of type variables from ml files for OCaml 4.14 and later
+  (multiple occurences of the same type variable could be named differently)
+  (@octachron, #1173)
 
 
 # 2.4.0

--- a/test/generators/cases/bugs.ml
+++ b/test/generators/cases/bugs.ml
@@ -3,3 +3,5 @@ let foo (type a) ?(bar : a opt) () = ()
 (** Triggers an assertion failure when
     {:https://github.com/ocaml/odoc/issues/101} is not fixed. *)
 
+let repeat x y = (x, y, x, y)
+(** Renders as [val repeat : 'a -> 'b -> 'c * 'd * 'e * 'f] before https://github.com/ocaml/odoc/pull/1173 *)

--- a/test/generators/html/Bugs.html
+++ b/test/generators/html/Bugs.html
@@ -40,6 +40,29 @@
      </p>
     </div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-repeat">
+     <a href="#val-repeat" class="anchor"></a>
+     <code>
+      <span><span class="keyword">val</span> repeat : 
+       <span><span class="type-var">'a</span> 
+        <span class="arrow">&#45;&gt;</span>
+       </span> 
+       <span><span class="type-var">'b</span> 
+        <span class="arrow">&#45;&gt;</span>
+       </span> <span class="type-var">'a</span> * 
+       <span class="type-var">'b</span> * <span class="type-var">'a</span>
+        * <span class="type-var">'b</span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>Renders as 
+      <code>val repeat : 'a -&gt; 'b -&gt; 'c * 'd * 'e * 'f</code> before
+       https://github.com/ocaml/odoc/pull/1173
+     </p>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/latex/Bugs.tex
+++ b/test/generators/latex/Bugs.tex
@@ -2,5 +2,7 @@
 \label{module-Bugs-type-opt}\ocamlcodefragment{\ocamltag{keyword}{type} 'a opt = \ocamltag{type-var}{'a} option}\\
 \label{module-Bugs-val-foo}\ocamlcodefragment{\ocamltag{keyword}{val} foo : \ocamltag{optlabel}{?bar}:\ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} unit \ocamltag{arrow}{$\rightarrow$} unit}\begin{ocamlindent}Triggers an assertion failure when \href{https://github.com/ocaml/odoc/issues/101}{https://github.com/ocaml/odoc/issues/101}\footnote{\url{https://github.com/ocaml/odoc/issues/101}} is not fixed.\end{ocamlindent}%
 \medbreak
+\label{module-Bugs-val-repeat}\ocamlcodefragment{\ocamltag{keyword}{val} repeat : \ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'b} \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a} * \ocamltag{type-var}{'b} * \ocamltag{type-var}{'a} * \ocamltag{type-var}{'b}}\begin{ocamlindent}Renders as \ocamlinlinecode{val repeat : 'a -> 'b -> 'c * 'd * 'e * 'f} before https://github.com/ocaml/odoc/pull/1173\end{ocamlindent}%
+\medbreak
 
 

--- a/test/generators/man/Bugs.3o
+++ b/test/generators/man/Bugs.3o
@@ -23,4 +23,11 @@ https://github\.com/ocaml/odoc/issues/101
 .UE 
  is not fixed\.
 .nf 
+.sp 
+\f[CB]val\fR repeat : \f[CB]'a\fR \f[CB]\->\fR \f[CB]'b\fR \f[CB]\->\fR \f[CB]'a\fR * \f[CB]'b\fR * \f[CB]'a\fR * \f[CB]'b\fR
+.fi 
+.br 
+.ti +2
+Renders as val repeat : 'a -> 'b -> 'c * 'd * 'e * 'f before https://github\.com/ocaml/odoc/pull/1173
+.nf 
 


### PR DESCRIPTION
Currently, generating documentation from ml files
```ocaml
(* test.ml *)
let repeat x y = x ,y, x, y
```
makes odoc misprint equal type variables as distinc type variables:
```ocaml
val repeat : 'a -> 'b -> 'c * 'd * 'e * 'f
```
starting from OCaml 4.14 .

This issue stems from the uses of physical equalities on non-representative type expressions in the name map of the type expression loader of odoc. Consequently, different type nodes are attributed different names by odoc, even if they belong to the same class of equal-after-unification type nodes. 

This issue typically doesn't arise when using mli files, because then we read source type expressions directly, without doing any unification (in most cases?).

This PR fixes this issue by ensuring that the naming maps only use representative type expressions.
Fortunately, this requires mostly tweaks to the  `Compat` module.
