### PR TITLE
Driver: Separate types for "package" and "odoc unit".

### DIFF
--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -149,7 +149,7 @@ let compile ?partial ~partial_dir ?linked_dir:_ (all : Odoc_unit.t list) =
       ~includes ~parent_id:unit.parent_id;
     Atomic.incr Stats.stats.compiled_mlds
   in
-  let _compiled_mlds = Fiber.List.map compile_mld mld_units in
+  let () = Fiber.List.iter compile_mld mld_units in
   let compile_impl (unit : Odoc_unit.impl Odoc_unit.unit) =
     let includes = Fpath.Set.of_list unit.include_dirs in
     let source_id = match unit.kind with `Impl src -> src.src_id in
@@ -157,7 +157,7 @@ let compile ?partial ~partial_dir ?linked_dir:_ (all : Odoc_unit.t list) =
       ~includes ~parent_id:unit.parent_id ~source_id;
     Atomic.incr Stats.stats.compiled_impls
   in
-  let _compiled_impls = Fiber.List.map compile_impl impl_units in
+  let () = Fiber.List.iter compile_impl impl_units in
   let zipped_res =
     List.map2
       (fun Odoc_unit.{ kind = `Intf { hash; _ }; _ } b -> (hash, b))

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -1,37 +1,13 @@
 (* compile *)
 
-type ty = Module of Packages.modulety | Mld of Packages.mld
+type compiled = Odoc_unit.t
 
-type impl = { impl_odoc : Fpath.t; impl_odocl : Fpath.t; src : Fpath.t }
-
-type pkg_args = {
-  docs : (string * Fpath.t) list;
-  libs : (string * Fpath.t) list;
-}
-
-type compiled = {
-  m : ty;
-  odoc_output_dir : Fpath.t; (* e.g. "_odoc/base/lib/base/" *)
-  odoc_file : Fpath.t; (* Full path to odoc file *)
-  odocl_file : Fpath.t;
-  include_dirs : Fpath.Set.t;
-  impl : impl option;
-  pkg_args : pkg_args;
-  pkg_name : string;
-  pkg_dir : Fpath.t;
-}
-
-let mk_byhash (pkgs : Packages.t Util.StringMap.t) =
-  Util.StringMap.fold
-    (fun pkg_name pkg acc ->
-      List.fold_left
-        (fun acc (lib : Packages.libty) ->
-          List.fold_left
-            (fun acc (m : Packages.modulety) ->
-              Util.StringMap.add m.m_intf.mif_hash (pkg_name, m) acc)
-            acc lib.modules)
-        acc pkg.Packages.libraries)
-    pkgs Util.StringMap.empty
+let mk_byhash (pkgs : Odoc_unit.intf Odoc_unit.unit list) =
+  List.fold_left
+    (fun acc (u : Odoc_unit.intf Odoc_unit.unit) ->
+      match u.Odoc_unit.kind with
+      | `Intf { hash; _ } -> Util.StringMap.add hash u acc)
+    Util.StringMap.empty pkgs
 
 let init_stats (pkgs : Packages.t Util.StringMap.t) =
   let total, total_impl, non_hidden, mlds =
@@ -70,7 +46,8 @@ let init_stats (pkgs : Packages.t Util.StringMap.t) =
 open Eio.Std
 
 type partial =
-  (string * compiled) list * (string * Packages.modulety) Util.StringMap.t
+  (string * Odoc_unit.intf Odoc_unit.unit) list
+  * Odoc_unit.intf Odoc_unit.unit Util.StringMap.t
 
 let unmarshal filename : partial =
   let ic = open_in_bin (Fpath.to_string filename) in
@@ -86,7 +63,8 @@ let marshal (v : partial) filename =
     ~finally:(fun () -> close_out oc)
     (fun () -> Marshal.to_channel oc v [])
 
-let find_partials odoc_dir =
+let find_partials odoc_dir : Odoc_unit.intf Odoc_unit.unit Util.StringMap.t * _
+    =
   let tbl = Hashtbl.create 1000 in
   let hashes_result =
     Bos.OS.Dir.fold_contents ~dotfiles:false ~elements:`Dirs
@@ -107,9 +85,21 @@ let find_partials odoc_dir =
   | Ok h -> (h, tbl)
   | Error _ -> (* odoc_dir doesn't exist...? *) (Util.StringMap.empty, tbl)
 
-let compile ?partial ~output_dir ?linked_dir all =
-  let linked_dir = Option.value linked_dir ~default:output_dir in
-  let hashes = mk_byhash all in
+let compile ?partial ~output_dir ?linked_dir:_ (all : Odoc_unit.t list) =
+  (* let linked_dir = Option.value linked_dir ~default:output_dir in *)
+  let intf_units, impl_units, mld_units =
+    List.fold_left
+      (fun (intf_units, impl_units, page_units) (unit : Odoc_unit.t) ->
+        match unit with
+        | { kind = `Intf _; _ } as intf ->
+            (intf :: intf_units, impl_units, page_units)
+        | { kind = `Impl; _ } as impl ->
+            (intf_units, impl :: impl_units, page_units)
+        | { kind = `Mld; _ } as mld ->
+            (intf_units, impl_units, mld :: page_units))
+      ([], [], []) all
+  in
+  let hashes = mk_byhash intf_units in
   let other_hashes, tbl =
     match partial with
     | Some _ -> find_partials output_dir
@@ -118,241 +108,176 @@ let compile ?partial ~output_dir ?linked_dir all =
   let all_hashes =
     Util.StringMap.union (fun _x o1 _o2 -> Some o1) hashes other_hashes
   in
-  let pkg_args =
-    let docs, libs =
-      Util.StringMap.fold
-        (fun pkg_name (pkg : Packages.t) (docs, libs) ->
-          let doc = (pkg_name, Fpath.(output_dir // pkg.mld_odoc_dir)) in
-          let lib =
-            List.map
-              (fun lib ->
-                ( lib.Packages.lib_name,
-                  Fpath.(output_dir // lib.Packages.odoc_dir) ))
-              pkg.Packages.libraries
-          in
-          let docs = doc :: docs and libs = List.rev_append lib libs in
-          (docs, libs))
-        all ([], [])
-    in
-    { docs; libs }
-  in
-
   let compile_one compile_other hash =
     match Util.StringMap.find_opt hash all_hashes with
     | None ->
         Logs.debug (fun m -> m "Error locating hash: %s" hash);
         Error Not_found
-    | Some (package_name, modty) ->
-        let deps = modty.m_intf.mif_deps in
-        let odoc_file = Fpath.(output_dir // modty.m_intf.mif_odoc_file) in
-        let odocl_file = Fpath.(linked_dir // modty.m_intf.mif_odocl_file) in
-        let fibers =
+    | Some unit ->
+        let deps = match unit.kind with `Intf { deps; _ } -> deps in
+        let _fibers =
           Fiber.List.map
-            (fun (n, h) ->
-              match compile_other h with
+            (fun other_unit ->
+              match compile_other other_unit with
               | Ok r -> Some r
               | Error _exn ->
                   Logs.debug (fun m ->
-                      m "Missing module %s (hash %s, required by %s)" n h
-                        modty.m_name);
+                      m "Missing module %s (hash %s, required by %s)" "TODO"
+                        (* n h *) "TODO" "TODO" (* unit.m_name *));
                   None)
             deps
         in
-        let includes =
-          List.fold_left
-            (fun acc opt ->
-              match opt with
-              | Some s -> Fpath.(Set.add s.odoc_output_dir acc)
-              | _ -> acc)
-            Fpath.Set.empty fibers
-        in
-        let includes = Fpath.Set.add output_dir includes in
-        let impl =
-          match modty.m_impl with
-          | Some impl -> (
-              match impl.mip_src_info with
-              | Some si ->
-                  let odoc_file = Fpath.(output_dir // impl.mip_odoc_file) in
-                  let odocl_file = Fpath.(linked_dir // impl.mip_odocl_file) in
-                  Odoc.compile_impl ~output_dir ~input_file:impl.mip_path
-                    ~includes ~parent_id:impl.mip_parent_id ~source_id:si.src_id;
-                  Atomic.incr Stats.stats.compiled_impls;
-                  Some
-                    {
-                      impl_odoc = odoc_file;
-                      impl_odocl = odocl_file;
-                      src = si.src_path;
-                    }
-              | None -> None)
-          | None -> None
-        in
 
-        Odoc.compile ~output_dir ~input_file:modty.m_intf.mif_path ~includes
-          ~parent_id:modty.m_intf.mif_parent_id;
+        (* let includes = Fpath.Set.add output_dir includes in ?????????? *)
+
+        (* TOOOODOOOOO *)
+        (* let impl = *)
+        (*   match modty.m_impl with *)
+        (*   | Some impl -> ( *)
+        (*       match impl.mip_src_info with *)
+        (*       | Some si -> *)
+        (*           let odoc_file = Fpath.(output_dir // impl.mip_odoc_file) in *)
+        (*           let odocl_file = Fpath.(linked_dir // impl.mip_odocl_file) in *)
+        (*           Odoc.compile_impl ~output_dir ~input_file:impl.mip_path *)
+        (*             ~includes ~parent_id:impl.mip_parent_id ~source_id:si.src_id; *)
+        (*           Atomic.incr Stats.stats.compiled_impls; *)
+        (*           Some *)
+        (*             { *)
+        (*               impl_odoc = odoc_file; *)
+        (*               impl_odocl = odocl_file; *)
+        (*               src = si.src_path; *)
+        (*             } *)
+        (*       | None -> None) *)
+        (*   | None -> None *)
+        (* in *)
+        let includes = Fpath.Set.of_list unit.include_dirs in
+        Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
+          ~includes ~parent_id:unit.parent_id;
         Atomic.incr Stats.stats.compiled_units;
 
-        let odoc_output_dir = Fpath.split_base odoc_file |> fst in
-
-        Ok
-          {
-            m = Module modty;
-            odoc_output_dir;
-            odoc_file;
-            odocl_file;
-            include_dirs = includes;
-            impl;
-            pkg_args;
-            pkg_dir = modty.m_pkg_dir;
-            pkg_name = package_name;
-          }
+        Ok unit
   in
 
-  let rec compile : string -> (compiled, exn) Result.t =
-   fun hash ->
+  let rec compile_mod :
+      Odoc_unit.intf Odoc_unit.unit ->
+      (Odoc_unit.intf Odoc_unit.unit, exn) Result.t =
+   fun unit ->
+    let hash = match unit.kind with `Intf { hash; _ } -> hash in
     match Hashtbl.find_opt tbl hash with
     | Some p -> Promise.await p
     | None ->
         let p, r = Promise.create () in
         Hashtbl.add tbl hash p;
-        let result = compile_one compile hash in
+        let result = compile_one compile_mod hash in
         Promise.resolve r result;
         result
   in
-  let to_build = Util.StringMap.bindings hashes |> List.map fst in
-  let mod_results = Fiber.List.map compile to_build in
-  let zipped_res = List.map2 (fun a b -> (a, b)) to_build mod_results in
+  let to_build = Util.StringMap.bindings hashes |> List.map snd in
+  let mod_results = Fiber.List.map compile_mod to_build in
+  let compile_mld (unit : Odoc_unit.mld Odoc_unit.unit) =
+    let includes = Fpath.Set.of_list unit.include_dirs in
+    Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
+      ~includes ~parent_id:unit.parent_id;
+    Atomic.incr Stats.stats.compiled_mlds
+  in
+  let _compiled_mlds = Fiber.List.map compile_mld mld_units in
+  let compile_impl (unit : Odoc_unit.impl Odoc_unit.unit) =
+    let includes = Fpath.Set.of_list unit.include_dirs in
+    Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
+      ~includes ~parent_id:unit.parent_id;
+    Atomic.incr Stats.stats.compiled_impls
+  in
+  let _compiled_impls = Fiber.List.map compile_impl impl_units in
+  let zipped_res =
+    List.map2
+      (fun Odoc_unit.{ kind = `Intf { hash; _ }; _ } b -> (hash, b))
+      to_build mod_results
+  in
   let zipped =
     List.filter_map (function a, Ok b -> Some (a, b) | _ -> None) zipped_res
   in
-  let mods =
-    List.filter_map (function Ok x -> Some x | Error _ -> None) mod_results
-  in
-  let result =
-    Util.StringMap.fold
-      (fun package_name (pkg : Packages.t) acc ->
-        Logs.debug (fun m ->
-            m "Package %s mlds: [%a]" pkg.name
-              Fmt.(list ~sep:sp Packages.pp_mld)
-              pkg.mlds);
-        List.fold_left
-          (fun acc (mld : Packages.mld) ->
-            let odoc_file = Fpath.(output_dir // mld.Packages.mld_odoc_file) in
-            let odocl_file =
-              Fpath.(linked_dir // mld.Packages.mld_odocl_file)
-            in
-            let odoc_output_dir = Fpath.split_base odoc_file |> fst in
-            Odoc.compile ~output_dir ~input_file:mld.mld_path
-              ~includes:Fpath.Set.empty ~parent_id:mld.mld_parent_id;
-            Atomic.incr Stats.stats.compiled_mlds;
-            let include_dirs =
-              List.map (fun f -> Fpath.(output_dir // f)) mld.mld_deps
-              |> Fpath.Set.of_list
-            in
-            let include_dirs = Fpath.Set.add odoc_output_dir include_dirs in
-            let odoc_output_dir = Fpath.split_base odoc_file |> fst in
-            {
-              m = Mld mld;
-              odoc_output_dir;
-              odoc_file;
-              odocl_file;
-              include_dirs;
-              impl = None;
-              pkg_args;
-              pkg_dir = mld.mld_pkg_dir;
-              pkg_name = package_name;
-            }
-            :: acc)
-          acc pkg.mlds)
-      all mods
-  in
-
   (match partial with
   | Some l -> marshal (zipped, hashes) Fpath.(l / "index.m")
   | None -> ());
-  result
+  all
 
-type linked = { output_file : Fpath.t; src : Fpath.t option; pkg_dir : Fpath.t }
+type linked = Odoc_unit.t
 
 let link : compiled list -> _ =
  fun compiled ->
-  let link : compiled -> linked list =
+  let link : compiled -> linked =
    fun c ->
-    let includes = Fpath.Set.add c.odoc_output_dir c.include_dirs in
     let link input_file output_file =
-      let { pkg_args = { libs; docs }; pkg_name; _ } = c in
-      Odoc.link ~input_file ~output_file ~includes ~libs ~docs
-        ~current_package:pkg_name ()
+      let { Odoc_unit.libs; pages } = c.pkg_args in
+      let includes = c.include_dirs |> Fpath.Set.of_list in
+      Odoc.link ~input_file ~output_file ~includes ~libs ~docs:pages
+        ~current_package:c.pkgname ()
     in
-    let impl =
-      match c.impl with
-      | Some { impl_odoc; impl_odocl; src } ->
-          Logs.debug (fun m ->
-              m "Linking impl: %a -> %a" Fpath.pp impl_odoc Fpath.pp impl_odocl);
-          link impl_odoc impl_odocl;
-          Atomic.incr Stats.stats.linked_impls;
-          [ { pkg_dir = c.pkg_dir; output_file = impl_odocl; src = Some src } ]
-      | None -> []
-    in
-    match c.m with
-    | Module m when m.m_hidden ->
+    match c.kind with
+    | `Intf { hidden = true; _ } ->
         Logs.debug (fun m -> m "not linking %a" Fpath.pp c.odoc_file);
-        impl
+        c
     | _ ->
         Logs.debug (fun m -> m "linking %a" Fpath.pp c.odoc_file);
         link c.odoc_file c.odocl_file;
-        (match c.m with
-        | Module _ -> Atomic.incr Stats.stats.linked_units
-        | Mld _ -> Atomic.incr Stats.stats.linked_mlds);
-        { output_file = c.odocl_file; src = None; pkg_dir = c.pkg_dir } :: impl
+        (match c.kind with
+        | `Intf _ -> Atomic.incr Stats.stats.linked_units
+        | `Mld -> Atomic.incr Stats.stats.linked_mlds
+        | `Impl -> Atomic.incr Stats.stats.linked_impls);
+        c
   in
-  Fiber.List.map link compiled |> List.concat
+  Fiber.List.map link compiled
 
-let index_one ~odocl_dir pkg_name pkg =
-  let dir = pkg.Packages.pkg_dir in
-  let output_file = Fpath.(odocl_dir // dir / Odoc.index_filename) in
-  let libs =
-    List.map
-      (fun lib -> (lib.Packages.lib_name, Fpath.(odocl_dir // lib.odoc_dir)))
-      pkg.Packages.libraries
-  in
-  Odoc.compile_index ~json:false ~output_file ~libs
-    ~docs:[ (pkg_name, Fpath.(odocl_dir // pkg.mld_odoc_dir)) ]
-    ()
+(* let index_one ~odocl_dir pkg_name pkg = *)
+(*   let dir = pkg.Packages.pkg_dir in *)
+(*   let output_file = Fpath.(odocl_dir // dir / Odoc.index_filename) in *)
+(*   let libs = *)
+(*     List.map *)
+(*       (fun lib -> (lib.Packages.lib_name, Fpath.(odocl_dir // lib.odoc_dir))) *)
+(*       pkg.Packages.libraries *)
+(*   in *)
+(*   Odoc.compile_index ~json:false ~output_file ~libs *)
+(*     ~docs:[ (pkg_name, Fpath.(odocl_dir // pkg.mld_odoc_dir)) ] *)
+(*     () *)
 
-let index ~odocl_dir pkgs = Util.StringMap.iter (index_one ~odocl_dir) pkgs
+(* let index ~odocl_dir pkgs = Util.StringMap.iter (index_one ~odocl_dir) pkgs *)
 
-let sherlodoc_index_one ~html_dir ~odocl_dir _ pkg_content =
-  let inputs =
-    [ Fpath.(odocl_dir // pkg_content.Packages.pkg_dir / Odoc.index_filename) ]
-  in
-  let dst = Fpath.(html_dir // Sherlodoc.db_js_file pkg_content.pkg_dir) in
-  let dst_dir, _ = Fpath.split_base dst in
-  Util.mkdir_p dst_dir;
-  Sherlodoc.index ~format:`js ~inputs ~dst ()
+(* let sherlodoc_index_one ~html_dir ~odocl_dir _ pkg_content = *)
+(*   let inputs = *)
+(*     [ Fpath.(odocl_dir // pkg_content.Packages.pkg_dir / Odoc.index_filename) ] *)
+(*   in *)
+(*   let dst = Fpath.(html_dir // Sherlodoc.db_js_file pkg_content.pkg_dir) in *)
+(*   let dst_dir, _ = Fpath.split_base dst in *)
+(*   Util.mkdir_p dst_dir; *)
+(*   Sherlodoc.index ~format:`js ~inputs ~dst () *)
 
-let sherlodoc ~html_dir ~odocl_dir pkgs =
-  ignore @@ Bos.OS.Dir.create html_dir;
-  Sherlodoc.js Fpath.(html_dir // Sherlodoc.js_file);
-  Util.StringMap.iter (sherlodoc_index_one ~html_dir ~odocl_dir) pkgs;
-  let format = `marshal in
-  let dst = Fpath.(html_dir // Sherlodoc.db_marshal_file) in
-  let dst_dir, _ = Fpath.split_base dst in
-  Util.mkdir_p dst_dir;
-  let inputs =
-    pkgs |> Util.StringMap.bindings
-    |> List.map (fun (_pkgname, pkg) ->
-           Fpath.(odocl_dir // pkg.Packages.pkg_dir / Odoc.index_filename))
-  in
-  Sherlodoc.index ~format ~inputs ~dst ()
+(* let sherlodoc ~html_dir ~odocl_dir pkgs = *)
+(*   ignore @@ Bos.OS.Dir.create html_dir; *)
+(*   Sherlodoc.js Fpath.(html_dir // Sherlodoc.js_file); *)
+(*   Util.StringMap.iter (sherlodoc_index_one ~html_dir ~odocl_dir) pkgs; *)
+(*   let format = `marshal in *)
+(*   let dst = Fpath.(html_dir // Sherlodoc.db_marshal_file) in *)
+(*   let dst_dir, _ = Fpath.split_base dst in *)
+(*   Util.mkdir_p dst_dir; *)
+(*   let inputs = *)
+(*     pkgs |> Util.StringMap.bindings *)
+(*     |> List.map (fun (_pkgname, pkg) -> *)
+(*            Fpath.(odocl_dir // pkg.Packages.pkg_dir / Odoc.index_filename)) *)
+(*   in *)
+(*   Sherlodoc.index ~format ~inputs ~dst () *)
 
-let html_generate output_dir ~odocl_dir linked =
+let html_generate output_dir (* ~odocl_dir *) linked =
   let html_generate : linked -> unit =
    fun l ->
-    let search_uris = [ Sherlodoc.db_js_file l.pkg_dir; Sherlodoc.js_file ] in
-    let index = Some Fpath.(odocl_dir // l.pkg_dir / Odoc.index_filename) in
-    Odoc.html_generate ~search_uris ?index
-      ~output_dir:(Fpath.to_string output_dir)
-      ~input_file:l.output_file ?source:l.src ();
-    Atomic.incr Stats.stats.generated_units
+    match l.kind with
+    | `Intf { hidden = true; _ } -> ()
+    | _ ->
+        (* let pkg_dir = l. in *)
+        (* let search_uris = [ Sherlodoc.db_js_file pkg_dir; Sherlodoc.js_file ] in *)
+        (* let index = Some Fpath.(odocl_dir // pkg_dir / Odoc.index_filename) in *)
+        Odoc.html_generate ~search_uris:[] ?index:None
+          ~output_dir:(Fpath.to_string output_dir)
+          ~input_file:l.odocl_file ?source:None (* l.src *) ();
+        Atomic.incr Stats.stats.generated_units
   in
   Fiber.List.iter html_generate linked

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -1,6 +1,6 @@
 type compiled
 
-val init_stats : Packages.set -> unit
+val init_stats : Odoc_unit.t list -> unit
 
 val compile :
   ?partial:Fpath.t ->

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -4,9 +4,9 @@ val init_stats : Packages.set -> unit
 
 val compile :
   ?partial:Fpath.t ->
-  output_dir:Fpath.t ->
+  partial_dir:Fpath.t ->
   ?linked_dir:Fpath.t ->
-  (* Packages.set *) Odoc_unit.t list (* Util.StringMap.t *) ->
+  Odoc_unit.t list ->
   compiled list
 (** Use [partial] to reuse the output of a previous call to [compile]. Useful in
     the voodoo context.
@@ -18,8 +18,4 @@ type linked
 
 val link : compiled list -> linked list
 
-(* val index : odocl_dir:Fpath.t -> Packages.set -> unit *)
-
-(* val sherlodoc : html_dir:Fpath.t -> odocl_dir:Fpath.t -> Packages.set -> unit *)
-
-val html_generate : Fpath.t (* -> odocl_dir:Fpath.t *) -> linked list -> unit
+val html_generate : Fpath.t -> linked list -> unit

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -6,7 +6,7 @@ val compile :
   ?partial:Fpath.t ->
   output_dir:Fpath.t ->
   ?linked_dir:Fpath.t ->
-  Packages.set ->
+  (* Packages.set *) Odoc_unit.t list (* Util.StringMap.t *) ->
   compiled list
 (** Use [partial] to reuse the output of a previous call to [compile]. Useful in
     the voodoo context.
@@ -18,8 +18,8 @@ type linked
 
 val link : compiled list -> linked list
 
-val index : odocl_dir:Fpath.t -> Packages.set -> unit
+(* val index : odocl_dir:Fpath.t -> Packages.set -> unit *)
 
-val sherlodoc : html_dir:Fpath.t -> odocl_dir:Fpath.t -> Packages.set -> unit
+(* val sherlodoc : html_dir:Fpath.t -> odocl_dir:Fpath.t -> Packages.set -> unit *)
 
-val html_generate : Fpath.t -> odocl_dir:Fpath.t -> linked list -> unit
+val html_generate : Fpath.t (* -> odocl_dir:Fpath.t *) -> linked list -> unit

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -36,7 +36,7 @@ let of_dune_build dir =
             in
             let pkg_dir = Fpath.rem_prefix dir path |> Option.get in
             ( pkg_dir,
-              Packages.Lib.v ~pkg_dir
+              Packages.Lib.v
                 ~libname_of_archive:(Util.StringMap.singleton libname libname)
                 ~pkg_name:libname ~dir:path ~cmtidir:(Some cmtidir) ))
           libs
@@ -53,7 +53,6 @@ let of_dune_build dir =
                       version = "1.0";
                       libraries = [ lib ];
                       mlds = [];
-                      mld_odoc_dir = Fpath.v lib.Packages.lib_name;
                       pkg_dir;
                       other_docs = Fpath.Set.empty;
                     } )

--- a/src/driver/indexes.ml
+++ b/src/driver/indexes.ml
@@ -1,7 +1,0 @@
-let package fmt (pkg : Packages.t) =
-  Format.fprintf fmt "{0 Package %s}\n" pkg.name;
-  Format.fprintf fmt "{1 Libraries}\n";
-  List.iter
-    (fun (lib : Packages.libty) ->
-      Format.fprintf fmt "{2 %s}\n" lib.archive_name)
-    pkg.libraries

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -3,7 +3,10 @@ open Bos
 type id = Fpath.t
 
 let fpath_of_id id = id
-let id_of_fpath id = id
+
+let id_of_fpath id =
+  id |> Fpath.normalize
+  |> Fpath.rem_empty_seg (* If an odoc path ends with a [/] everything breaks *)
 
 let index_filename = "index.odoc-index"
 

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -451,6 +451,7 @@ let render_stats env nprocs =
   let total = Atomic.get Stats.stats.total_units in
   let total_impls = Atomic.get Stats.stats.total_impls in
   let total_mlds = Atomic.get Stats.stats.total_mlds in
+  let total_indexes = Atomic.get Stats.stats.total_indexes in
   let bar message total =
     let open Progress.Line in
     list [ lpad 16 (const message); bar total; count_to total ]
@@ -476,7 +477,7 @@ let render_stats env nprocs =
       ++ dline "Linking" non_hidden
       ++ dline "Linking impls" total_impls
       ++ dline "Linking mlds" total_mlds
-      ++ dline "Indexes" 10000 (* TODO *)
+      ++ dline "Indexes" total_indexes
       ++ dline "HTML" (total_impls + non_hidden + total_mlds)
       ++ line (procs nprocs)
       ++ descriptions)

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -470,7 +470,7 @@ let render_stats env nprocs =
       ++ dline "Linking" non_hidden
       ++ dline "Linking impls" total_impls
       ++ dline "Linking mlds" total_mlds
-      ++ dline "Indexes" 10000
+      ++ dline "Indexes" 10000 (* TODO *)
       ++ dline "HTML" (total_impls + non_hidden + total_mlds)
       ++ line (procs nprocs))
     (fun comp compimpl compmld link linkimpl linkmld indexes html procs ->
@@ -537,7 +537,6 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
       | _ -> failwith "Error, expecting singleton library in voodoo mode"
     else None
   in
-  Compile.init_stats all;
   let () =
     Eio.Fiber.both
       (fun () ->
@@ -546,6 +545,7 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
           Odoc_unit.of_packages ~output_dir:odoc_dir ~linked_dir:odocl_dir
             ~index_dir:None all
         in
+        Compile.init_stats all;
         let compiled =
           Compile.compile ?partial ~partial_dir:odoc_dir ?linked_dir:odocl_dir
             all
@@ -559,10 +559,7 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
 
   Format.eprintf "Final stats: %a@.%!" Stats.pp_stats Stats.stats;
   Format.eprintf "Total time: %f@.%!" (Stats.total_time ());
-  if stats then Stats.bench_results html_dir;
-  let indexes = Util.StringMap.map (fun _i pkg -> Indexes.package pkg) all in
-
-  ignore indexes
+  if stats then Stats.bench_results html_dir
 
 let fpath_arg =
   let print ppf v = Fpath.pp ppf v in

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -529,7 +529,7 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
     if voodoo then
       match Util.StringMap.to_list all with
       | [ (_, p) ] ->
-          let output_path = Fpath.(odoc_dir // p.mld_odoc_dir) in
+          let output_path = Fpath.(odoc_dir // p.pkg_dir / "doc") in
           Some output_path
       | _ -> failwith "Error, expecting singleton library in voodoo mode"
     else None
@@ -538,15 +538,19 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
   let () =
     Eio.Fiber.both
       (fun () ->
+        let all =
+          let all = Util.StringMap.bindings all |> List.map snd in
+          Odoc_unit.of_packages ~output_dir:odoc_dir ~linked_dir:odocl_dir all
+        in
         let compiled =
           Compile.compile ?partial ~output_dir:odoc_dir ?linked_dir:odocl_dir
             all
         in
         let linked = Compile.link compiled in
-        let odocl_dir = match odocl_dir with Some l -> l | None -> odoc_dir in
-        let () = Compile.index ~odocl_dir all in
-        let () = Compile.sherlodoc ~html_dir ~odocl_dir all in
-        let () = Compile.html_generate html_dir ~odocl_dir linked in
+        (* let odocl_dir = match odocl_dir with Some l -> l | None -> odoc_dir in *)
+        (* let () = Compile.index ~odocl_dir all in *)
+        (* let () = Compile.sherlodoc ~html_dir ~odocl_dir all in *)
+        let () = Compile.html_generate html_dir (* ~odocl_dir *) linked in
         let _ = Odoc.support_files html_dir in
         ())
       (fun () -> render_stats env nb_workers)

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -1,0 +1,190 @@
+type pkg_args = {
+  pages : (string * Fpath.t) list;
+  libs : (string * Fpath.t) list;
+}
+
+type 'a unit = {
+  parent_id : Odoc.id;
+  odoc_dir : Fpath.t;
+  input_file : Fpath.t;
+  output_dir : Fpath.t;
+  odoc_file : Fpath.t;
+  odocl_file : Fpath.t;
+  pkg_args : pkg_args;
+  pkgname : string;
+  include_dirs : Fpath.t list;
+  kind : 'a;
+}
+
+type intf_extra = { hidden : bool; hash : string; deps : intf unit list }
+and intf = [ `Intf of intf_extra ]
+
+type impl = [ `Impl ]
+
+type mld = [ `Mld ]
+
+type t = [ impl | intf | mld ] unit
+
+let of_packages ~output_dir ~linked_dir (pkgs : Packages.t list) : t list =
+  let linked_dir =
+    match linked_dir with None -> output_dir | Some dir -> dir
+  in
+  (* This isn't a hashtable, but a table of hashes! Yay! *)
+  let hashtable =
+    let open Packages in
+    let h = Util.StringMap.empty in
+    List.fold_left
+      (fun h pkg ->
+        List.fold_left
+          (fun h lib ->
+            List.fold_left
+              (fun h mod_ ->
+                Util.StringMap.add mod_.m_intf.mif_hash
+                  (pkg, lib.lib_name, mod_) h)
+              h lib.modules)
+          h pkg.libraries)
+      h pkgs
+  in
+  (* This one is a hashtable *)
+  let cache = Hashtbl.create 10 in
+  let pkg_args : pkg_args =
+    let pages, libs =
+      List.fold_left
+        (fun (pages, libs) pkg ->
+          let page =
+            ( pkg.Packages.name,
+              Fpath.(output_dir // pkg.Packages.pkg_dir / "doc") )
+          in
+          let new_libs =
+            List.map
+              (fun lib ->
+                ( lib.Packages.lib_name,
+                  Fpath.(
+                    output_dir // pkg.Packages.pkg_dir / "lib" / lib.lib_name)
+                ))
+              pkg.libraries
+          in
+          (page :: pages, new_libs :: libs))
+        ([], []) pkgs
+    in
+    let libs = List.concat libs in
+    { pages; libs }
+  in
+  let rec of_intf hidden pkg libname (intf : Packages.intf) : intf unit =
+    match Hashtbl.find_opt cache intf.mif_hash with
+    | Some unit -> unit
+    | None ->
+        let open Fpath in
+        let rel_dir = pkg.Packages.pkg_dir / "lib" / libname in
+        let odoc_dir = output_dir // rel_dir in
+        let parent_id = rel_dir |> Odoc.id_of_fpath in
+        let filename = intf.mif_path |> Fpath.rem_ext |> Fpath.basename in
+        let odoc_file = odoc_dir / (filename ^ ".odoc") in
+        let odocl_file = linked_dir // rel_dir / (filename ^ ".odocl") in
+        let input_file = intf.mif_path in
+        let deps =
+          List.filter_map
+            (fun (_name, hash) ->
+              match Util.StringMap.find_opt hash hashtable with
+              | None -> None
+              | Some (pkg, lib, mod_) ->
+                  let result = of_intf mod_.m_hidden pkg lib mod_.m_intf in
+                  Hashtbl.add cache mod_.m_intf.mif_hash result;
+                  Some result)
+            intf.mif_deps
+        in
+        let include_dirs = List.map (fun u -> u.odoc_dir) deps in
+        let kind = `Intf { hidden; hash = intf.mif_hash; deps } in
+        {
+          output_dir;
+          pkgname = pkg.name;
+          pkg_args;
+          parent_id;
+          odoc_dir;
+          input_file;
+          odoc_file;
+          odocl_file;
+          include_dirs;
+          kind;
+        }
+  in
+  let of_impl pkg libname (impl : Packages.impl) : impl unit option =
+    let open Fpath in
+    match impl.mip_src_info with
+    | None -> None
+    | Some _ ->
+        let rel_dir = pkg.Packages.pkg_dir / "lib" / libname in
+        let odoc_dir = output_dir // rel_dir in
+        let parent_id = rel_dir |> Odoc.id_of_fpath in
+        let filename = impl.mip_path |> Fpath.rem_ext |> Fpath.basename in
+        let odoc_file = odoc_dir / (filename ^ ".odoc") in
+        let odocl_file = linked_dir // rel_dir / (filename ^ ".odocl") in
+        let input_file = impl.mip_path in
+        let kind = `Impl in
+        Some
+          {
+            output_dir;
+            pkgname = pkg.name;
+            parent_id;
+            odoc_dir;
+            input_file;
+            odoc_file;
+            odocl_file;
+            pkg_args;
+            include_dirs = [];
+            kind;
+          }
+  in
+
+  let of_module pkg libname (m : Packages.modulety) : [ impl | intf ] unit list
+      =
+    let i :> [ impl | intf ] unit = of_intf m.m_hidden pkg libname m.m_intf in
+    let m :> [ impl | intf ] unit list =
+      Option.bind m.m_impl (of_impl pkg libname) |> Option.to_list
+    in
+    i :: m
+  in
+  let of_lib pkg (lib : Packages.libty) : [ impl | intf ] unit list =
+    List.concat_map (of_module pkg lib.lib_name) lib.modules
+  in
+  let of_mld pkg (mld : Packages.mld) : mld unit list =
+    let open Fpath in
+    let { Packages.mld_path; mld_rel_path } = mld in
+    let rel_dir =
+      pkg.Packages.pkg_dir / "doc" // Fpath.parent mld_rel_path
+      |> Fpath.normalize
+    in
+    let odoc_dir = output_dir // rel_dir in
+    let filename = mld_path |> Fpath.rem_ext |> Fpath.basename in
+    let odoc_file = odoc_dir / ("page-" ^ filename ^ ".odoc") in
+    let odocl_file = linked_dir // rel_dir / ("page-" ^ filename ^ ".odocl") in
+    let parent_id = rel_dir |> Odoc.id_of_fpath in
+    let include_dirs =
+      List.map
+        (fun (lib : Packages.libty) ->
+          Fpath.(output_dir // pkg.pkg_dir / "lib" / lib.lib_name))
+        pkg.libraries
+    in
+    let include_dirs = odoc_dir :: include_dirs in
+    let kind = `Mld in
+    [
+      {
+        output_dir;
+        pkgname = pkg.name;
+        parent_id;
+        odoc_dir;
+        input_file = mld_path;
+        odoc_file;
+        odocl_file;
+        kind;
+        pkg_args;
+        include_dirs;
+      };
+    ]
+  in
+  let of_package (pkg : Packages.t) : t list =
+    let lib_units :> t list list = List.map (of_lib pkg) pkg.libraries in
+    let mld_units :> t list list = List.map (of_mld pkg) pkg.mlds in
+    List.concat (List.rev_append lib_units mld_units)
+  in
+  List.concat_map of_package pkgs

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -19,7 +19,8 @@ type 'a unit = {
 type intf_extra = { hidden : bool; hash : string; deps : intf unit list }
 and intf = [ `Intf of intf_extra ]
 
-type impl = [ `Impl ]
+type impl_extra = { src_id : Odoc.id; src_path : Fpath.t }
+type impl = [ `Impl of impl_extra ]
 
 type mld = [ `Mld ]
 

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -3,6 +3,13 @@ type pkg_args = {
   libs : (string * Fpath.t) list;
 }
 
+type index = {
+  pkg_args : pkg_args;
+  output_file : Fpath.t;
+  json : bool;
+  search_dir : Fpath.t;
+}
+
 type 'a unit = {
   parent_id : Odoc.id;
   odoc_dir : Fpath.t;
@@ -13,6 +20,7 @@ type 'a unit = {
   pkg_args : pkg_args;
   pkgname : string;
   include_dirs : Fpath.t list;
+  index : index;
   kind : 'a;
 }
 
@@ -27,4 +35,8 @@ type mld = [ `Mld ]
 type t = [ impl | intf | mld ] unit
 
 val of_packages :
-  output_dir:Fpath.t -> linked_dir:Fpath.t option -> Packages.t list -> t list
+  output_dir:Fpath.t ->
+  linked_dir:Fpath.t option ->
+  index_dir:Fpath.t option ->
+  Packages.t list ->
+  t list

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -1,0 +1,29 @@
+type pkg_args = {
+  pages : (string * Fpath.t) list;
+  libs : (string * Fpath.t) list;
+}
+
+type 'a unit = {
+  parent_id : Odoc.id;
+  odoc_dir : Fpath.t;
+  input_file : Fpath.t;
+  output_dir : Fpath.t;
+  odoc_file : Fpath.t;
+  odocl_file : Fpath.t;
+  pkg_args : pkg_args;
+  pkgname : string;
+  include_dirs : Fpath.t list;
+  kind : 'a;
+}
+
+type intf_extra = { hidden : bool; hash : string; deps : intf unit list }
+and intf = [ `Intf of intf_extra ]
+
+type impl = [ `Impl ]
+
+type mld = [ `Mld ]
+
+type t = [ impl | intf | mld ] unit
+
+val of_packages :
+  output_dir:Fpath.t -> linked_dir:Fpath.t option -> Packages.t list -> t list

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -10,7 +10,11 @@ let pp_intf fmt i = Format.fprintf fmt "intf: %a" Fpath.pp i.mif_path
 
 type src_info = { src_path : Fpath.t }
 
-type impl = { mip_path : Fpath.t; mip_src_info : src_info option }
+type impl = {
+  mip_path : Fpath.t;
+  mip_src_info : src_info option;
+  mip_deps : dep list;
+}
 
 let pp_impl fmt i = Format.fprintf fmt "impl: %a" Fpath.pp i.mip_path
 
@@ -101,7 +105,12 @@ module Module = struct
                   m "Found source file %a for %s" Fpath.pp src_path m_name);
               Some { src_path }
         in
-        { mip_src_info; mip_path }
+        let mip_deps =
+          match Odoc.compile_deps mip_path with
+          | Ok { digest = _; deps } -> deps
+          | Error _ -> failwith "bad deps"
+        in
+        { mip_src_info; mip_path; mip_deps }
       in
       let state = (exists "cmt", exists "cmti") in
 

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -4,30 +4,15 @@
 
 type dep = string * Digest.t
 
-type id = Odoc.id
-
-type intf = {
-  mif_odoc_file : Fpath.t;
-  mif_odocl_file : Fpath.t;
-  mif_parent_id : id;
-  mif_hash : string;
-  mif_path : Fpath.t;
-  mif_deps : dep list;
-}
+type intf = { mif_hash : string; mif_path : Fpath.t; mif_deps : dep list }
 
 val pp_intf : Format.formatter -> intf -> unit
 
 (** {2 Implementation part} *)
 
-type src_info = { src_path : Fpath.t; src_id : id }
+type src_info = { src_path : Fpath.t }
 
-type impl = {
-  mip_odoc_file : Fpath.t;
-  mip_odocl_file : Fpath.t;
-  mip_parent_id : id;
-  mip_path : Fpath.t;
-  mip_src_info : src_info option;
-}
+type impl = { mip_path : Fpath.t; mip_src_info : src_info option }
 
 val pp_impl : Format.formatter -> impl -> unit
 
@@ -38,19 +23,11 @@ type modulety = {
   m_intf : intf;
   m_impl : impl option;
   m_hidden : bool;
-  m_pkg_dir : Fpath.t;
 }
 
 (** {1 Standalone pages units} *)
 
-type mld = {
-  mld_odoc_file : Fpath.t;
-  mld_odocl_file : Fpath.t;
-  mld_parent_id : id;
-  mld_path : Fpath.t;
-  mld_deps : Fpath.t list;
-  mld_pkg_dir : Fpath.t;
-}
+type mld = { mld_path : Fpath.t; mld_rel_path : Fpath.t }
 
 val pp_mld : Format.formatter -> mld -> unit
 
@@ -61,8 +38,6 @@ val pp_mld : Format.formatter -> mld -> unit
 
 type libty = {
   lib_name : string;
-  odoc_dir : Fpath.t;
-      (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
   archive_name : string;
   modules : modulety list;
 }
@@ -72,7 +47,6 @@ val parent_of_pages : Fpath.t -> Fpath.t
 
 module Lib : sig
   val v :
-    pkg_dir:Fpath.t ->
     libname_of_archive:string Util.StringMap.t ->
     pkg_name:string ->
     dir:Fpath.t ->
@@ -85,10 +59,8 @@ type t = {
   version : string;
   libraries : libty list;
   mlds : mld list;
-  mld_odoc_dir : Fpath.t;
-      (** Relative to dir where all odoc files are, e.g. [_odoc/] by default *)
-  pkg_dir : Fpath.t;
   other_docs : Fpath.Set.t;
+  pkg_dir : Fpath.t;
 }
 
 val pp : Format.formatter -> t -> unit

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -12,7 +12,11 @@ val pp_intf : Format.formatter -> intf -> unit
 
 type src_info = { src_path : Fpath.t }
 
-type impl = { mip_path : Fpath.t; mip_src_info : src_info option }
+type impl = {
+  mip_path : Fpath.t;
+  mip_src_info : src_info option;
+  mip_deps : dep list;
+}
 
 val pp_impl : Format.formatter -> impl -> unit
 

--- a/src/driver/stats.ml
+++ b/src/driver/stats.ml
@@ -6,6 +6,7 @@ type stats = {
   mutable total_units : int Atomic.t;
   mutable total_impls : int Atomic.t;
   mutable total_mlds : int Atomic.t;
+  mutable total_indexes : int Atomic.t;
   mutable non_hidden_units : int Atomic.t;
   mutable compiled_units : int Atomic.t;
   mutable compiled_impls : int Atomic.t;
@@ -24,6 +25,7 @@ let stats =
     total_units = Atomic.make 0;
     total_impls = Atomic.make 0;
     total_mlds = Atomic.make 0;
+    total_indexes = Atomic.make 0;
     non_hidden_units = Atomic.make 0;
     compiled_units = Atomic.make 0;
     compiled_impls = Atomic.make 0;

--- a/src/driver/stats.ml
+++ b/src/driver/stats.ml
@@ -13,6 +13,7 @@ type stats = {
   mutable linked_units : int Atomic.t;
   mutable linked_impls : int Atomic.t;
   mutable linked_mlds : int Atomic.t;
+  mutable generated_indexes : int Atomic.t;
   mutable generated_units : int Atomic.t;
   mutable processes : int Atomic.t;
 }
@@ -30,6 +31,7 @@ let stats =
     linked_impls = Atomic.make 0;
     linked_mlds = Atomic.make 0;
     generated_units = Atomic.make 0;
+    generated_indexes = Atomic.make 0;
     processes = Atomic.make 0;
   }
 

--- a/src/driver/stats.ml
+++ b/src/driver/stats.ml
@@ -16,6 +16,7 @@ type stats = {
   mutable generated_indexes : int Atomic.t;
   mutable generated_units : int Atomic.t;
   mutable processes : int Atomic.t;
+  mutable process_activity : string Atomic.t Array.t;
 }
 
 let stats =
@@ -33,7 +34,11 @@ let stats =
     generated_units = Atomic.make 0;
     generated_indexes = Atomic.make 0;
     processes = Atomic.make 0;
+    process_activity = [||];
   }
+
+let init_nprocs nprocs =
+  stats.process_activity <- Array.init nprocs (fun _ -> Atomic.make "idle")
 
 let pp_stats fmt stats =
   Fmt.pf fmt


### PR DESCRIPTION
The original reason for this is to allow adding odoc units that are not part of a package (eg pages that list packages, ...).

But I think it also makes it more readable:
- It factors path computations from the various "package extractors"[^1], in the end they have less things to do,
- The paths for an odoc unit are computed once, all at the same place, in a place which does nothing else,
- Understanding the code that runs commands is much simpler, since it has less things to do (run every command once and in the right order).

Indexes yet have to be implemented, so this PR is not finished yet.

[^1]: By "package extractors" I mean the `of_libs` function (creating packages from the opam switch), the `of_dune_build` function (creating packages from `_build/default/...`) and the `of_voodoo` function.