### PR TITLE
Driver: generate "external" pages

### DIFF
--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -227,6 +227,7 @@ let sherlodoc_index_one ~output_dir (index : Odoc_unit.index) =
 
 let html_generate output_dir linked =
   let tbl = Hashtbl.create 10 in
+  let _ = OS.Dir.create output_dir |> Result.get_ok in
   Sherlodoc.js Fpath.(output_dir // Sherlodoc.js_file);
   let compile_index : Odoc_unit.index -> _ =
    fun index ->

--- a/src/driver/dune
+++ b/src/driver/dune
@@ -13,4 +13,5 @@
   opam-format
   logs
   logs.fmt
-  eio_main))
+  eio_main
+  odoc_utils))

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -1,13 +1,12 @@
 open Packages
 open Odoc_unit
-let write_file file content = Bos.OS.File.write file content |> Result.get_ok
 
 let make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir rel_path ~content
     ?(include_dirs = []) ~pkgname ~pkg_args () =
   let input_file = Fpath.(mld_dir // rel_path / "index.mld") in
   let odoc_file = Fpath.(odoc_dir // rel_path / "page-index.odoc") in
   let odocl_file = Fpath.(odocl_dir // rel_path / "page-index.odocl") in
-  let () = write_file input_file content in
+  let () = Util.write_file input_file (String.split_on_char '\n' content) in
   let parent_id = rel_path |> Odoc.Id.of_fpath in
   {
     parent_id;

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -43,7 +43,9 @@ let list_packages_content all =
     all |> List.sort (fun n1 n2 -> String.compare n1.name n2.name)
   in
   let title = "{0 List of all packages}\n" in
-  let s_of_pkg pkg = Format.sprintf "- {{!/%s/index}%s}" pkg.name pkg.name in
+  let s_of_pkg pkg =
+    Format.sprintf "- {{!/__driver/%s/index}%s}" pkg.name pkg.name
+  in
   let pkg_ul = sorted_packages |> List.map s_of_pkg |> String.concat "\n" in
   title ^ pkg_ul
 
@@ -55,7 +57,7 @@ let of_package ~mld_dir ~odoc_dir ~odocl_dir ~output_dir pkg =
     let odoc_file = Fpath.(odoc_dir // rel_path / "page-index.odoc") in
     let odocl_file = Fpath.(odocl_dir // rel_path / "page-index.odocl") in
     let () = write_file input_file content in
-    let parent_id = rel_path |> Odoc.id_of_fpath in
+    let parent_id = rel_path |> Odoc.Id.of_fpath in
     let open Odoc_unit in
     {
       parent_id;
@@ -106,17 +108,17 @@ let of_package ~mld_dir ~odoc_dir ~odocl_dir ~output_dir pkg =
 
 let of_packages ~mld_dir ~odoc_dir ~odocl_dir ~output_dir all =
   let content = list_packages_content all in
-  let rel_path = Fpath.v "a" in
+  let rel_path = Fpath.v "./" in
   let input_file = Fpath.(mld_dir // rel_path / "index.mld") in
   let () = write_file input_file content in
   let open Odoc_unit in
-  let parent_id = rel_path |> Odoc.id_of_fpath in
+  let parent_id = rel_path |> Odoc.Id.of_fpath in
   let pkgname = "__driver" in
   let pkg_args =
     {
       pages =
-        (pkgname, Fpath.(odoc_dir // rel_path))
-        :: List.map (fun pkg -> (pkg.name, Fpath.(odoc_dir / pkg.name))) all;
+        (pkgname, Fpath.(odoc_dir // rel_path)) :: []
+        (* List.map (fun pkg -> (pkg.name, Fpath.(odoc_dir / pkg.name))) all *);
       libs = [];
     }
   in

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -1,0 +1,252 @@
+open Packages
+
+let pkg_landing_page_content pkg =
+  let title = Format.sprintf "{0 %s}\n" pkg.name in
+  let documentation =
+    match pkg.mlds with
+    | _ :: _ ->
+        Format.sprintf
+          "{1 Documentation pages}\n\n{{!/%s/doc/index}Documentation for %s}\n"
+          pkg.name pkg.name
+    | [] -> ""
+  in
+  let libraries =
+    match pkg.libraries with
+    | [] -> ""
+    | _ :: _ ->
+        Format.sprintf "{1 Libraries}\n\n{{!/%s/lib/index}Libraries for %s}\n"
+          pkg.name pkg.name
+  in
+  title ^ documentation ^ libraries
+
+let library_landing_page_content lib =
+  let title = Format.sprintf "{0 %s}\n" lib.lib_name in
+  let s_of_module m =
+    if m.m_hidden then None
+    else Some (Format.sprintf "- {!%s}" m.Packages.m_name)
+  in
+  let modules =
+    lib.modules |> List.filter_map s_of_module |> String.concat "\n"
+  in
+  title ^ modules
+
+let libraries_landing_page_content pkg =
+  let title = Format.sprintf "{0 %s}\n" pkg.name in
+  let s_of_lib (lib : Packages.libty) =
+    Format.sprintf "- {{!/%s/%s/index}%s}" pkg.name lib.lib_name lib.lib_name
+  in
+  let libraries = pkg.libraries |> List.map s_of_lib |> String.concat "\n" in
+  title ^ libraries
+
+let list_packages_content all =
+  let sorted_packages =
+    all |> List.sort (fun n1 n2 -> String.compare n1.name n2.name)
+  in
+  let title = "{0 List of all packages}\n" in
+  let s_of_pkg pkg = Format.sprintf "- {{!/%s/index}%s}" pkg.name pkg.name in
+  let pkg_ul = sorted_packages |> List.map s_of_pkg |> String.concat "\n" in
+  title ^ pkg_ul
+
+let write_file file content = Bos.OS.File.write file content |> Result.get_ok
+
+let of_package ~mld_dir ~odoc_dir ~odocl_dir ~output_dir pkg =
+  let make_unit rel_path ~content ?(include_dirs = []) ~pkgname ~pkg_args () =
+    let input_file = Fpath.(mld_dir // rel_path / "index.mld") in
+    let odoc_file = Fpath.(odoc_dir // rel_path / "page-index.odoc") in
+    let odocl_file = Fpath.(odocl_dir // rel_path / "page-index.odocl") in
+    let () = write_file input_file content in
+    let parent_id = rel_path |> Odoc.id_of_fpath in
+    let open Odoc_unit in
+    {
+      parent_id;
+      odoc_dir;
+      input_file;
+      output_dir;
+      odoc_file;
+      odocl_file;
+      pkg_args;
+      pkgname;
+      include_dirs;
+      index = None;
+      kind = `Mld;
+    }
+  in
+  let library_list_page =
+    let open Odoc_unit in
+    let content = libraries_landing_page_content pkg in
+    let rel_path = Fpath.(v pkg.name / "lib") in
+    let pkg_args =
+      { pages = [ (pkg.name, Fpath.( // ) odoc_dir rel_path) ]; libs = [] }
+    in
+    make_unit rel_path ~content ~pkgname:pkg.name ~pkg_args ()
+  in
+  let library_landing_pages =
+    let do_ lib =
+      let open Odoc_unit in
+      let content = library_landing_page_content lib in
+      let rel_path = Fpath.(v pkg.name / "lib" / lib.lib_name) in
+      let pkg_args =
+        { pages = [ (pkg.name, Fpath.( // ) odoc_dir rel_path) ]; libs = [] }
+      in
+      let include_dirs = [ Fpath.(odoc_dir // rel_path) ] in
+      make_unit rel_path ~content ~pkgname:pkg.name ~include_dirs ~pkg_args ()
+    in
+    List.map do_ pkg.libraries
+  in
+  let package_landing_page =
+    let open Odoc_unit in
+    let content = pkg_landing_page_content pkg in
+    let rel_path = Fpath.v pkg.name in
+    let pkg_args =
+      { pages = [ (pkg.name, Fpath.( // ) odoc_dir rel_path) ]; libs = [] }
+    in
+    make_unit rel_path ~content ~pkgname:pkg.name ~pkg_args ()
+  in
+  package_landing_page :: library_list_page :: library_landing_pages
+
+let of_packages ~mld_dir ~odoc_dir ~odocl_dir ~output_dir all =
+  let content = list_packages_content all in
+  let rel_path = Fpath.v "a" in
+  let input_file = Fpath.(mld_dir // rel_path / "index.mld") in
+  let () = write_file input_file content in
+  let open Odoc_unit in
+  let parent_id = rel_path |> Odoc.id_of_fpath in
+  let pkgname = "__driver" in
+  let pkg_args =
+    {
+      pages =
+        (pkgname, Fpath.(odoc_dir // rel_path))
+        :: List.map (fun pkg -> (pkg.name, Fpath.(odoc_dir / pkg.name))) all;
+      libs = [];
+    }
+  in
+  {
+    parent_id;
+    odoc_dir;
+    input_file;
+    output_dir;
+    pkg_args;
+    pkgname;
+    odoc_file = Fpath.(odoc_dir // rel_path / "page-index.odoc");
+    odocl_file = Fpath.(odocl_dir // rel_path / "page-index.odocl");
+    include_dirs = [];
+    index = None;
+    kind = `Mld;
+  }
+  :: List.concat_map (of_package ~mld_dir ~odoc_dir ~odocl_dir ~output_dir) all
+
+(* let compile_list_packages odoc_dir all : compiled = *)
+(*   let sorted_packages = *)
+(*     all |> Util.StringMap.to_list *)
+(*     |> List.sort (fun (n1, _) (n2, _) -> String.compare n1 n2) *)
+(*   in *)
+(*   let title = "{0 List of all packages}\n" in *)
+(*   let s_of_pkg (name, _) = Format.sprintf "- {{!%s/index}%s}" name name in *)
+(*   let pkg_ul = sorted_packages |> List.map s_of_pkg |> String.concat "\n" in *)
+(*   let content = title ^ pkg_ul in *)
+(*   let input_file = Fpath.( / ) odoc_dir "index.mld" in *)
+(*   let () = Bos.OS.File.write input_file content |> Result.get_ok in *)
+(*   Odoc.compile ~output_dir:odoc_dir ~input_file ~includes:Fpath.Set.empty *)
+(*     ~parent_id:(Odoc.id_of_fpath (Fpath.v "./")); *)
+(*   Atomic.incr Stats.stats.compiled_mlds; *)
+(*   { *)
+(*     m = Mld; *)
+(*     odoc_output_dir = odoc_dir; *)
+(*     odoc_file = Fpath.(odoc_dir / "page-index.odoc"); *)
+(*     odocl_file = Fpath.(odoc_dir / "page-index.odocl"); *)
+(*     include_dirs = Fpath.Set.empty; *)
+(*     impl = None; *)
+(*     pkg_args = { docs = [ ("_driver_pkg", odoc_dir) ]; libs = [] }; *)
+(*     pkgname = { p_name = "_driver_pkg"; p_dir = Fpath.v "./" }; *)
+(*   } *)
+
+(* let compile_landing_pages odoc_dir pkg : compiled list = *)
+(*   let pkgname = pkg.Packages.pkgname in *)
+(*   let driver_page ~odoc_file ~odocl_file ?(include_dirs = Fpath.Set.empty) () = *)
+(*     let pkg_args = *)
+(*       { *)
+(*         docs = [ (pkgname.p_name, Fpath.( / ) odoc_dir pkgname.p_name) ]; *)
+(*         libs = []; *)
+(*       } *)
+(*     in *)
+(*     { *)
+(*       m = Mld; *)
+(*       odoc_output_dir = odoc_dir; *)
+(*       odoc_file; *)
+(*       odocl_file; *)
+(*       include_dirs; *)
+(*       impl = None; *)
+(*       pkg_args; *)
+(*       pkgname; *)
+(*     } *)
+(*   in *)
+(*   let title = Format.sprintf "{0 %s}\n" in *)
+(*   let compile ~content ~input_file ?(include_dirs = Fpath.Set.empty) ~parent_id *)
+(*       () = *)
+(*     let () = Bos.OS.File.write input_file content |> Result.get_ok in *)
+(*     Odoc.compile ~output_dir:odoc_dir ~input_file ~includes:include_dirs *)
+(*       ~parent_id; *)
+(*     Atomic.incr Stats.stats.compiled_mlds; *)
+(*     ( Fpath.(odoc_dir // Odoc.fpath_of_id parent_id / "page-index.odoc"), *)
+(*       Fpath.(odoc_dir // Odoc.fpath_of_id parent_id / "page-index.odocl") ) *)
+(*   in *)
+
+(*   let library_landing_page pkgname (lib : Packages.libty) : compiled = *)
+(*     let libname = lib.lib_name in *)
+(*     let parent_id = *)
+(*       Fpath.(v pkgname.Packages.p_name / "lib" / libname) |> Odoc.id_of_fpath *)
+(*     in *)
+(*     let input_file = *)
+(*       Fpath.(odoc_dir // Odoc.fpath_of_id parent_id / "index.mld") *)
+(*     in *)
+(*     let s_of_module m = Format.sprintf "- {!%s}" m.Packages.m_name in *)
+(*     let modules = lib.modules |> List.map s_of_module |> String.concat "\n" in *)
+(*     let content = title libname ^ modules in *)
+(*     let include_dirs = *)
+(*       Fpath.(Set.empty |> Set.add (odoc_dir // Odoc.fpath_of_id parent_id)) *)
+(*     in *)
+(*     let odoc_file, odocl_file = *)
+(*       compile ~content ~input_file ~include_dirs ~parent_id () *)
+(*     in *)
+(*     driver_page ~odoc_file ~odocl_file ~include_dirs () *)
+(*   in *)
+
+(*   let libraries_landing_page pkg : compiled list = *)
+(*     let pkgname = pkg.Packages.pkgname in *)
+(*     let parent_id = Fpath.(v pkgname.p_name / "lib") |> Odoc.id_of_fpath in *)
+(*     let input_file = *)
+(*       Fpath.(odoc_dir // Odoc.fpath_of_id parent_id / "index.mld") *)
+(*     in *)
+(*     let s_of_lib (lib : Packages.libty) = *)
+(*       Format.sprintf "- {{!%s/index}%s}" lib.lib_name lib.lib_name *)
+(*     in *)
+(*     let libraries = pkg.libraries |> List.map s_of_lib |> String.concat "\n" in *)
+(*     let content = title pkgname.p_name ^ libraries in *)
+(*     let odoc_file, odocl_file = compile ~content ~input_file ~parent_id () in *)
+(*     driver_page ~odoc_file ~odocl_file () *)
+(*     :: List.map (library_landing_page pkgname) pkg.libraries *)
+(*   in *)
+
+(*   let package_landing_page = *)
+(*     let input_file = Fpath.(odoc_dir // v pkgname.p_name / "index.mld") in *)
+(*     let documentation = *)
+(*       match pkg.mlds with *)
+(*       | _ :: _ -> *)
+(*           Format.sprintf *)
+(*             "{1 Documentation pages}\n\n{{!doc/index}Documentation for %s}" *)
+(*             pkgname.p_name *)
+(*       | [] -> "" *)
+(*     in *)
+(*     let libraries = *)
+(*       match pkg.libraries with *)
+(*       | [] -> "" *)
+(*       | _ :: _ -> *)
+(*           Format.sprintf "{1 Libraries}\n\n{{!lib/index}Libraries for %s}" *)
+(*             pkgname.p_name *)
+(*     in *)
+(*     let content = title pkgname.p_name ^ documentation ^ libraries in *)
+(*     let parent_id = Odoc.id_of_fpath (Fpath.v pkgname.p_name) in *)
+(*     let odoc_file, odocl_file = compile ~content ~input_file ~parent_id () in *)
+(*     driver_page ~odoc_file ~odocl_file () *)
+(*   in *)
+(*   package_landing_page :: libraries_landing_page pkg *)

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -1,254 +1,137 @@
 open Packages
-
-let pkg_landing_page_content pkg =
-  let title = Format.sprintf "{0 %s}\n" pkg.name in
-  let documentation =
-    match pkg.mlds with
-    | _ :: _ ->
-        Format.sprintf
-          "{1 Documentation pages}\n\n{{!/%s/doc/index}Documentation for %s}\n"
-          pkg.name pkg.name
-    | [] -> ""
-  in
-  let libraries =
-    match pkg.libraries with
-    | [] -> ""
-    | _ :: _ ->
-        Format.sprintf "{1 Libraries}\n\n{{!/%s/lib/index}Libraries for %s}\n"
-          pkg.name pkg.name
-  in
-  title ^ documentation ^ libraries
-
-let library_landing_page_content lib =
-  let title = Format.sprintf "{0 %s}\n" lib.lib_name in
-  let s_of_module m =
-    if m.m_hidden then None
-    else Some (Format.sprintf "- {!%s}" m.Packages.m_name)
-  in
-  let modules =
-    lib.modules |> List.filter_map s_of_module |> String.concat "\n"
-  in
-  title ^ modules
-
-let libraries_landing_page_content pkg =
-  let title = Format.sprintf "{0 %s}\n" pkg.name in
-  let s_of_lib (lib : Packages.libty) =
-    Format.sprintf "- {{!/%s/%s/index}%s}" pkg.name lib.lib_name lib.lib_name
-  in
-  let libraries = pkg.libraries |> List.map s_of_lib |> String.concat "\n" in
-  title ^ libraries
-
-let list_packages_content all =
-  let sorted_packages =
-    all |> List.sort (fun n1 n2 -> String.compare n1.name n2.name)
-  in
-  let title = "{0 List of all packages}\n" in
-  let s_of_pkg pkg =
-    Format.sprintf "- {{!/__driver/%s/index}%s}" pkg.name pkg.name
-  in
-  let pkg_ul = sorted_packages |> List.map s_of_pkg |> String.concat "\n" in
-  title ^ pkg_ul
-
+open Odoc_unit
 let write_file file content = Bos.OS.File.write file content |> Result.get_ok
 
-let of_package ~mld_dir ~odoc_dir ~odocl_dir ~output_dir pkg =
-  let make_unit rel_path ~content ?(include_dirs = []) ~pkgname ~pkg_args () =
-    let input_file = Fpath.(mld_dir // rel_path / "index.mld") in
-    let odoc_file = Fpath.(odoc_dir // rel_path / "page-index.odoc") in
-    let odocl_file = Fpath.(odocl_dir // rel_path / "page-index.odocl") in
-    let () = write_file input_file content in
-    let parent_id = rel_path |> Odoc.Id.of_fpath in
-    let open Odoc_unit in
-    {
-      parent_id;
-      odoc_dir;
-      input_file;
-      output_dir;
-      odoc_file;
-      odocl_file;
-      pkg_args;
-      pkgname;
-      include_dirs;
-      index = None;
-      kind = `Mld;
-    }
-  in
-  let library_list_page =
-    let open Odoc_unit in
-    let content = libraries_landing_page_content pkg in
-    let rel_path = Fpath.(v pkg.name / "lib") in
-    let pkg_args =
-      { pages = [ (pkg.name, Fpath.( // ) odoc_dir rel_path) ]; libs = [] }
-    in
-    make_unit rel_path ~content ~pkgname:pkg.name ~pkg_args ()
-  in
-  let library_landing_pages =
-    let do_ lib =
-      let open Odoc_unit in
-      let content = library_landing_page_content lib in
-      let rel_path = Fpath.(v pkg.name / "lib" / lib.lib_name) in
-      let pkg_args =
-        { pages = [ (pkg.name, Fpath.( // ) odoc_dir rel_path) ]; libs = [] }
-      in
-      let include_dirs = [ Fpath.(odoc_dir // rel_path) ] in
-      make_unit rel_path ~content ~pkgname:pkg.name ~include_dirs ~pkg_args ()
-    in
-    List.map do_ pkg.libraries
-  in
-  let package_landing_page =
-    let open Odoc_unit in
-    let content = pkg_landing_page_content pkg in
-    let rel_path = Fpath.v pkg.name in
-    let pkg_args =
-      { pages = [ (pkg.name, Fpath.( // ) odoc_dir rel_path) ]; libs = [] }
-    in
-    make_unit rel_path ~content ~pkgname:pkg.name ~pkg_args ()
-  in
-  package_landing_page :: library_list_page :: library_landing_pages
-
-let of_packages ~mld_dir ~odoc_dir ~odocl_dir ~output_dir all =
-  let content = list_packages_content all in
-  let rel_path = Fpath.v "./" in
+let make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir rel_path ~content
+    ?(include_dirs = []) ~pkgname ~pkg_args () =
   let input_file = Fpath.(mld_dir // rel_path / "index.mld") in
+  let odoc_file = Fpath.(odoc_dir // rel_path / "page-index.odoc") in
+  let odocl_file = Fpath.(odocl_dir // rel_path / "page-index.odocl") in
   let () = write_file input_file content in
-  let open Odoc_unit in
   let parent_id = rel_path |> Odoc.Id.of_fpath in
-  let pkgname = "__driver" in
-  let pkg_args =
-    {
-      pages =
-        (pkgname, Fpath.(odoc_dir // rel_path)) :: []
-        (* List.map (fun pkg -> (pkg.name, Fpath.(odoc_dir / pkg.name))) all *);
-      libs = [];
-    }
-  in
   {
     parent_id;
     odoc_dir;
     input_file;
     output_dir;
+    odoc_file;
+    odocl_file;
     pkg_args;
     pkgname;
-    odoc_file = Fpath.(odoc_dir // rel_path / "page-index.odoc");
-    odocl_file = Fpath.(odocl_dir // rel_path / "page-index.odocl");
-    include_dirs = [];
+    include_dirs;
     index = None;
     kind = `Mld;
   }
+
+module PackageLanding = struct
+  let content pkg =
+    let title = Format.sprintf "{0 %s}\n" pkg.name in
+    let documentation =
+      match pkg.mlds with
+      | _ :: _ ->
+          Format.sprintf
+            "{1 Documentation pages}\n\n\
+             {{!/%s/doc/index}Documentation for %s}\n"
+            pkg.name pkg.name
+      | [] -> ""
+    in
+    let libraries =
+      match pkg.libraries with
+      | [] -> ""
+      | _ :: _ ->
+          Format.sprintf "{1 Libraries}\n\n{{!/%s/lib/index}Libraries for %s}\n"
+            pkg.name pkg.name
+    in
+    title ^ documentation ^ libraries
+
+  let page ~odoc_dir ~odocl_dir ~mld_dir ~output_dir ~pkg =
+    let content = content pkg in
+    let rel_path = Fpath.v pkg.name in
+    let pkg_args =
+      { pages = [ (pkg.name, Fpath.( // ) odoc_dir rel_path) ]; libs = [] }
+    in
+    make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir rel_path ~content
+      ~pkgname:pkg.name ~pkg_args ()
+end
+
+module PackageList = struct
+  let content all =
+    let sorted_packages =
+      all |> List.sort (fun n1 n2 -> String.compare n1.name n2.name)
+    in
+    let title = "{0 List of all packages}\n" in
+    let s_of_pkg pkg =
+      Format.sprintf "- {{!/__driver/%s/index}%s}" pkg.name pkg.name
+    in
+    let pkg_ul = sorted_packages |> List.map s_of_pkg |> String.concat "\n" in
+    title ^ pkg_ul
+
+  let page ~mld_dir ~odoc_dir ~odocl_dir ~output_dir all =
+    let content = content all in
+    let rel_path = Fpath.v "./" in
+    let pkgname = "__driver" in
+    let pkg_args =
+      { pages = [ (pkgname, Fpath.(odoc_dir // rel_path)) ]; libs = [] }
+    in
+    make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir ~content ~pkgname
+      ~pkg_args rel_path ()
+end
+
+module LibraryLanding = struct
+  let content lib =
+    let title = Format.sprintf "{0 %s}\n" lib.lib_name in
+    let s_of_module m =
+      if m.m_hidden then None
+      else Some (Format.sprintf "- {!%s}" m.Packages.m_name)
+    in
+    let modules =
+      lib.modules |> List.filter_map s_of_module |> String.concat "\n"
+    in
+    title ^ modules
+  let page ~pkg ~odoc_dir ~odocl_dir ~mld_dir ~output_dir lib =
+    let content = content lib in
+    let rel_path = Fpath.(v pkg.name / "lib" / lib.lib_name) in
+    let pkg_args =
+      { pages = [ (pkg.name, Fpath.( // ) odoc_dir rel_path) ]; libs = [] }
+    in
+    let include_dirs = [ Fpath.(odoc_dir // rel_path) ] in
+    make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir rel_path ~content
+      ~pkgname:pkg.name ~include_dirs ~pkg_args ()
+end
+
+module PackageLibLanding = struct
+  let content pkg =
+    let title = Format.sprintf "{0 %s}\n" pkg.name in
+    let s_of_lib (lib : Packages.libty) =
+      Format.sprintf "- {{!/%s/%s/index}%s}" pkg.name lib.lib_name lib.lib_name
+    in
+    let libraries = pkg.libraries |> List.map s_of_lib |> String.concat "\n" in
+    title ^ libraries
+
+  let page ~pkg ~odoc_dir ~odocl_dir ~mld_dir ~output_dir =
+    let content = content pkg in
+    let rel_path = Fpath.(v pkg.name / "lib") in
+    let pkg_args =
+      { pages = [ (pkg.name, Fpath.( // ) odoc_dir rel_path) ]; libs = [] }
+    in
+    make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir rel_path ~content
+      ~pkgname:pkg.name ~pkg_args ()
+end
+
+let of_package ~mld_dir ~odoc_dir ~odocl_dir ~output_dir pkg =
+  let library_pages =
+    List.map
+      (LibraryLanding.page ~pkg ~odoc_dir ~odocl_dir ~mld_dir ~output_dir)
+      pkg.libraries
+  in
+  let package_landing_page =
+    PackageLanding.page ~odoc_dir ~odocl_dir ~mld_dir ~output_dir ~pkg
+  in
+  let library_list_page =
+    PackageLibLanding.page ~odoc_dir ~odocl_dir ~mld_dir ~output_dir ~pkg
+  in
+  package_landing_page :: library_list_page :: library_pages
+
+let of_packages ~mld_dir ~odoc_dir ~odocl_dir ~output_dir all =
+  PackageList.page ~mld_dir ~odoc_dir ~odocl_dir ~output_dir all
   :: List.concat_map (of_package ~mld_dir ~odoc_dir ~odocl_dir ~output_dir) all
-
-(* let compile_list_packages odoc_dir all : compiled = *)
-(*   let sorted_packages = *)
-(*     all |> Util.StringMap.to_list *)
-(*     |> List.sort (fun (n1, _) (n2, _) -> String.compare n1 n2) *)
-(*   in *)
-(*   let title = "{0 List of all packages}\n" in *)
-(*   let s_of_pkg (name, _) = Format.sprintf "- {{!%s/index}%s}" name name in *)
-(*   let pkg_ul = sorted_packages |> List.map s_of_pkg |> String.concat "\n" in *)
-(*   let content = title ^ pkg_ul in *)
-(*   let input_file = Fpath.( / ) odoc_dir "index.mld" in *)
-(*   let () = Bos.OS.File.write input_file content |> Result.get_ok in *)
-(*   Odoc.compile ~output_dir:odoc_dir ~input_file ~includes:Fpath.Set.empty *)
-(*     ~parent_id:(Odoc.id_of_fpath (Fpath.v "./")); *)
-(*   Atomic.incr Stats.stats.compiled_mlds; *)
-(*   { *)
-(*     m = Mld; *)
-(*     odoc_output_dir = odoc_dir; *)
-(*     odoc_file = Fpath.(odoc_dir / "page-index.odoc"); *)
-(*     odocl_file = Fpath.(odoc_dir / "page-index.odocl"); *)
-(*     include_dirs = Fpath.Set.empty; *)
-(*     impl = None; *)
-(*     pkg_args = { docs = [ ("_driver_pkg", odoc_dir) ]; libs = [] }; *)
-(*     pkgname = { p_name = "_driver_pkg"; p_dir = Fpath.v "./" }; *)
-(*   } *)
-
-(* let compile_landing_pages odoc_dir pkg : compiled list = *)
-(*   let pkgname = pkg.Packages.pkgname in *)
-(*   let driver_page ~odoc_file ~odocl_file ?(include_dirs = Fpath.Set.empty) () = *)
-(*     let pkg_args = *)
-(*       { *)
-(*         docs = [ (pkgname.p_name, Fpath.( / ) odoc_dir pkgname.p_name) ]; *)
-(*         libs = []; *)
-(*       } *)
-(*     in *)
-(*     { *)
-(*       m = Mld; *)
-(*       odoc_output_dir = odoc_dir; *)
-(*       odoc_file; *)
-(*       odocl_file; *)
-(*       include_dirs; *)
-(*       impl = None; *)
-(*       pkg_args; *)
-(*       pkgname; *)
-(*     } *)
-(*   in *)
-(*   let title = Format.sprintf "{0 %s}\n" in *)
-(*   let compile ~content ~input_file ?(include_dirs = Fpath.Set.empty) ~parent_id *)
-(*       () = *)
-(*     let () = Bos.OS.File.write input_file content |> Result.get_ok in *)
-(*     Odoc.compile ~output_dir:odoc_dir ~input_file ~includes:include_dirs *)
-(*       ~parent_id; *)
-(*     Atomic.incr Stats.stats.compiled_mlds; *)
-(*     ( Fpath.(odoc_dir // Odoc.fpath_of_id parent_id / "page-index.odoc"), *)
-(*       Fpath.(odoc_dir // Odoc.fpath_of_id parent_id / "page-index.odocl") ) *)
-(*   in *)
-
-(*   let library_landing_page pkgname (lib : Packages.libty) : compiled = *)
-(*     let libname = lib.lib_name in *)
-(*     let parent_id = *)
-(*       Fpath.(v pkgname.Packages.p_name / "lib" / libname) |> Odoc.id_of_fpath *)
-(*     in *)
-(*     let input_file = *)
-(*       Fpath.(odoc_dir // Odoc.fpath_of_id parent_id / "index.mld") *)
-(*     in *)
-(*     let s_of_module m = Format.sprintf "- {!%s}" m.Packages.m_name in *)
-(*     let modules = lib.modules |> List.map s_of_module |> String.concat "\n" in *)
-(*     let content = title libname ^ modules in *)
-(*     let include_dirs = *)
-(*       Fpath.(Set.empty |> Set.add (odoc_dir // Odoc.fpath_of_id parent_id)) *)
-(*     in *)
-(*     let odoc_file, odocl_file = *)
-(*       compile ~content ~input_file ~include_dirs ~parent_id () *)
-(*     in *)
-(*     driver_page ~odoc_file ~odocl_file ~include_dirs () *)
-(*   in *)
-
-(*   let libraries_landing_page pkg : compiled list = *)
-(*     let pkgname = pkg.Packages.pkgname in *)
-(*     let parent_id = Fpath.(v pkgname.p_name / "lib") |> Odoc.id_of_fpath in *)
-(*     let input_file = *)
-(*       Fpath.(odoc_dir // Odoc.fpath_of_id parent_id / "index.mld") *)
-(*     in *)
-(*     let s_of_lib (lib : Packages.libty) = *)
-(*       Format.sprintf "- {{!%s/index}%s}" lib.lib_name lib.lib_name *)
-(*     in *)
-(*     let libraries = pkg.libraries |> List.map s_of_lib |> String.concat "\n" in *)
-(*     let content = title pkgname.p_name ^ libraries in *)
-(*     let odoc_file, odocl_file = compile ~content ~input_file ~parent_id () in *)
-(*     driver_page ~odoc_file ~odocl_file () *)
-(*     :: List.map (library_landing_page pkgname) pkg.libraries *)
-(*   in *)
-
-(*   let package_landing_page = *)
-(*     let input_file = Fpath.(odoc_dir // v pkgname.p_name / "index.mld") in *)
-(*     let documentation = *)
-(*       match pkg.mlds with *)
-(*       | _ :: _ -> *)
-(*           Format.sprintf *)
-(*             "{1 Documentation pages}\n\n{{!doc/index}Documentation for %s}" *)
-(*             pkgname.p_name *)
-(*       | [] -> "" *)
-(*     in *)
-(*     let libraries = *)
-(*       match pkg.libraries with *)
-(*       | [] -> "" *)
-(*       | _ :: _ -> *)
-(*           Format.sprintf "{1 Libraries}\n\n{{!lib/index}Libraries for %s}" *)
-(*             pkgname.p_name *)
-(*     in *)
-(*     let content = title pkgname.p_name ^ documentation ^ libraries in *)
-(*     let parent_id = Odoc.id_of_fpath (Fpath.v pkgname.p_name) in *)
-(*     let odoc_file, odocl_file = compile ~content ~input_file ~parent_id () in *)
-(*     driver_page ~odoc_file ~odocl_file () *)
-(*   in *)
-(*   package_landing_page :: libraries_landing_page pkg *)

--- a/src/driver/landing_pages.mli
+++ b/src/driver/landing_pages.mli
@@ -1,0 +1,7 @@
+val of_packages :
+  mld_dir:Fpath.t ->
+  odoc_dir:Fpath.t ->
+  odocl_dir:Fpath.t ->
+  output_dir:Fpath.t ->
+  Packages.t list ->
+  [> `Mld ] Odoc_unit.unit list

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -1,12 +1,20 @@
 open Bos
 
-type id = Fpath.t
+module Id : sig
+  type t
+  val to_fpath : t -> Fpath.t
+  val of_fpath : Fpath.t -> t
+  val to_string : t -> string
+end = struct
+  type t = Fpath.t
 
-let fpath_of_id id = id
+  let to_fpath id = id
 
-let id_of_fpath id =
-  id |> Fpath.normalize
-  |> Fpath.rem_empty_seg (* If an odoc path ends with a [/] everything breaks *)
+  let of_fpath id = id |> Fpath.normalize |> Fpath.rem_empty_seg
+  (* If an odoc path ends with a [/] everything breaks *)
+
+  let to_string id = match Fpath.to_string id with "." -> "" | v -> v
+end
 
 let index_filename = "index.odoc-index"
 
@@ -33,13 +41,13 @@ let compile ~output_dir ~input_file:file ~includes ~parent_id =
   in
   let output_file =
     let _, f = Fpath.split_base file in
-    Some Fpath.(output_dir // parent_id // set_ext "odoc" f)
+    Some Fpath.(output_dir // Id.to_fpath parent_id // set_ext "odoc" f)
   in
   let cmd =
     !odoc % "compile" % Fpath.to_string file % "--output-dir" % p output_dir
     %% includes % "--enable-missing-root-warning"
   in
-  let cmd = cmd % "--parent-id" % Fpath.to_string parent_id in
+  let cmd = cmd % "--parent-id" % Id.to_string parent_id in
   let desc = Printf.sprintf "Compiling %s" (Fpath.to_string file) in
   let lines = Cmd_outputs.submit desc cmd output_file in
   Cmd_outputs.(
@@ -48,13 +56,14 @@ let compile ~output_dir ~input_file:file ~includes ~parent_id =
 let compile_asset ~output_dir ~name ~parent_id =
   let open Cmd in
   let output_file =
-    Some Fpath.(output_dir // parent_id / ("asset-" ^ name ^ ".odoc"))
+    Some
+      Fpath.(output_dir // Id.to_fpath parent_id / ("asset-" ^ name ^ ".odoc"))
   in
   let cmd =
     !odoc % "compile-asset" % "--name" % name % "--output-dir" % p output_dir
   in
 
-  let cmd = cmd % "--parent-id" % Fpath.to_string parent_id in
+  let cmd = cmd % "--parent-id" % Id.to_string parent_id in
   let desc = Printf.sprintf "Compiling %s" name in
   let lines = Cmd_outputs.submit desc cmd output_file in
   Cmd_outputs.(add_prefixed_output cmd compile_output name lines)
@@ -73,10 +82,12 @@ let compile_impl ~output_dir ~input_file:file ~includes ~parent_id ~source_id =
   let output_file =
     let _, f = Fpath.split_base file in
     Some
-      Fpath.(output_dir // parent_id / ("impl-" ^ to_string (set_ext "odoc" f)))
+      Fpath.(
+        output_dir // Id.to_fpath parent_id
+        / ("impl-" ^ to_string (set_ext "odoc" f)))
   in
-  let cmd = cmd % "--parent-id" % Fpath.to_string parent_id in
-  let cmd = cmd % "--source-id" % Fpath.to_string source_id in
+  let cmd = cmd % "--parent-id" % Id.to_string parent_id in
+  let cmd = cmd % "--source-id" % Id.to_string source_id in
   let desc =
     Printf.sprintf "Compiling implementation %s" (Fpath.to_string file)
   in

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -1,7 +1,9 @@
-type id
-
-val fpath_of_id : id -> Fpath.t
-val id_of_fpath : Fpath.t -> id
+module Id : sig
+  type t
+  val to_fpath : t -> Fpath.t
+  val of_fpath : Fpath.t -> t
+  val to_string : t -> string
+end
 
 val index_filename : string
 
@@ -14,17 +16,17 @@ val compile_impl :
   output_dir:Fpath.t ->
   input_file:Fpath.t ->
   includes:Fpath.set ->
-  parent_id:id ->
-  source_id:id ->
+  parent_id:Id.t ->
+  source_id:Id.t ->
   unit
 val compile :
   output_dir:Fpath.t ->
   input_file:Fpath.t ->
   includes:Fpath.set ->
-  parent_id:id ->
+  parent_id:Id.t ->
   unit
 
-val compile_asset : output_dir:Fpath.t -> name:string -> parent_id:id -> unit
+val compile_asset : output_dir:Fpath.t -> name:string -> parent_id:Id.t -> unit
 
 val link :
   ?ignore_output:bool ->

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -582,15 +582,6 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
       (fun () -> render_stats env nb_workers)
   in
 
-  (* List.iter *)
-  (*   (fun l -> *)
-  (*     if Astring.String.is_infix ~affix:"_odoc/./index.mld" l then *)
-  (*       Format.printf "%s\n" l) *)
-  (*   !Cmd_outputs.compile_output; *)
-  (* List.iter *)
-  (*   (fun l -> *)
-  (*     if Astring.String.is_infix ~affix:"__driver" l then Format.printf "%s\n" l) *)
-  (*   !Cmd_outputs.link_output; *)
   Format.eprintf "Final stats: %a@.%!" Stats.pp_stats Stats.stats;
   Format.eprintf "Total time: %f@.%!" (Stats.total_time ());
   if stats then Stats.bench_results html_dir

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -584,9 +584,13 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
 
   (* List.iter *)
   (*   (fun l -> *)
-  (*     if Astring.String.is_infix ~affix:"index.mld" l then *)
+  (*     if Astring.String.is_infix ~affix:"_odoc/./index.mld" l then *)
   (*       Format.printf "%s\n" l) *)
   (*   !Cmd_outputs.compile_output; *)
+  (* List.iter *)
+  (*   (fun l -> *)
+  (*     if Astring.String.is_infix ~affix:"__driver" l then Format.printf "%s\n" l) *)
+  (*   !Cmd_outputs.link_output; *)
   Format.eprintf "Final stats: %a@.%!" Stats.pp_stats Stats.stats;
   Format.eprintf "Total time: %f@.%!" (Stats.total_time ());
   if stats then Stats.bench_results html_dir

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -558,8 +558,17 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
       (fun () ->
         let all =
           let all = Util.StringMap.bindings all |> List.map snd in
-          Odoc_unit.of_packages ~output_dir:odoc_dir ~linked_dir:odocl_dir
-            ~index_dir:None all
+          let internal =
+            Odoc_unit.of_packages ~output_dir:odoc_dir ~linked_dir:odocl_dir
+              ~index_dir:None all
+          in
+          let external_ =
+            let mld_dir = odoc_dir in
+            let odocl_dir = Option.value odocl_dir ~default:odoc_dir in
+            Landing_pages.of_packages ~mld_dir ~odoc_dir ~odocl_dir
+              ~output_dir:odoc_dir all
+          in
+          internal @ external_
         in
         Compile.init_stats all;
         let compiled =
@@ -573,6 +582,11 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
       (fun () -> render_stats env nb_workers)
   in
 
+  (* List.iter *)
+  (*   (fun l -> *)
+  (*     if Astring.String.is_infix ~affix:"index.mld" l then *)
+  (*       Format.printf "%s\n" l) *)
+  (*   !Cmd_outputs.compile_output; *)
   Format.eprintf "Final stats: %a@.%!" Stats.pp_stats Stats.stats;
   Format.eprintf "Total time: %f@.%!" (Stats.total_time ());
   if stats then Stats.bench_results html_dir

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -20,7 +20,7 @@ type 'a unit = {
   pkg_args : pkg_args;
   pkgname : string;
   include_dirs : Fpath.t list;
-  index : index;
+  index : index option;
   kind : 'a;
 }
 
@@ -110,7 +110,7 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
       odocl_file;
       include_dirs;
       kind;
-      index = index_of pkg;
+      index = Some (index_of pkg);
     }
   in
   let rec build_deps deps =

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -11,7 +11,7 @@ type index = {
 }
 
 type 'a unit = {
-  parent_id : Odoc.id;
+  parent_id : Odoc.Id.t;
   odoc_dir : Fpath.t;
   input_file : Fpath.t;
   output_dir : Fpath.t;
@@ -27,7 +27,7 @@ type 'a unit = {
 type intf_extra = { hidden : bool; hash : string; deps : intf unit list }
 and intf = [ `Intf of intf_extra ]
 
-type impl_extra = { src_id : Odoc.id; src_path : Fpath.t }
+type impl_extra = { src_id : Odoc.Id.t; src_path : Fpath.t }
 type impl = [ `Impl of impl_extra ]
 
 type mld = [ `Mld ]
@@ -96,7 +96,7 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
     let ( // ) = Fpath.( // ) in
     let ( / ) = Fpath.( / ) in
     let odoc_dir = output_dir // rel_dir in
-    let parent_id = rel_dir |> Odoc.id_of_fpath in
+    let parent_id = rel_dir |> Odoc.Id.of_fpath in
     let odoc_file = odoc_dir / (name ^ ".odoc") in
     let odocl_file = linked_dir // rel_dir / (name ^ ".odocl") in
     {
@@ -152,7 +152,7 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
         let kind =
           let src_name = Fpath.filename src_path in
           let src_id =
-            Fpath.(pkg.pkg_dir / "src" / libname / src_name) |> Odoc.id_of_fpath
+            Fpath.(pkg.pkg_dir / "src" / libname / src_name) |> Odoc.Id.of_fpath
           in
           `Impl { src_id; src_path }
         in

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -11,7 +11,7 @@ type index = {
 }
 
 type 'a unit = {
-  parent_id : Odoc.id;
+  parent_id : Odoc.Id.t;
   odoc_dir : Fpath.t;
   input_file : Fpath.t;
   output_dir : Fpath.t;
@@ -27,7 +27,7 @@ type 'a unit = {
 type intf_extra = { hidden : bool; hash : string; deps : intf unit list }
 and intf = [ `Intf of intf_extra ]
 
-type impl_extra = { src_id : Odoc.id; src_path : Fpath.t }
+type impl_extra = { src_id : Odoc.Id.t; src_path : Fpath.t }
 type impl = [ `Impl of impl_extra ]
 
 type mld = [ `Mld ]

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -20,7 +20,7 @@ type 'a unit = {
   pkg_args : pkg_args;
   pkgname : string;
   include_dirs : Fpath.t list;
-  index : index;
+  index : index option;
   kind : 'a;
 }
 

--- a/src/driver/util.ml
+++ b/src/driver/util.ml
@@ -1,3 +1,4 @@
+open Odoc_utils
 open Bos
 
 module StringSet = Set.Make (String)
@@ -17,29 +18,17 @@ let lines_of_process cmd =
   | Ok x -> x
   | Error (`Msg e) -> failwith ("Error: " ^ e)
 
-let mkdir_p d =
-  let segs =
-    Fpath.segs (Fpath.normalize d) |> List.filter (fun s -> String.length s > 0)
-  in
-  let _ =
-    List.fold_left
-      (fun path seg ->
-        let d = Fpath.(path // v seg) in
-        try
-          Unix.mkdir (Fpath.to_string d) 0o755;
-          d
-        with
-        | Unix.Unix_error (Unix.EEXIST, _, _) -> d
-        | exn -> raise exn)
-      (Fpath.v ".") segs
-  in
-  ()
-
-let write_file filename lines =
-  let dir = fst (Fpath.split_base filename) in
-  mkdir_p dir;
-  let oc = open_out (Fpath.to_string filename) in
-  List.iter (fun line -> Printf.fprintf oc "%s\n" line) lines;
-  close_out oc
+(** Opens a file for writing and calls [f]. The destination directory is created
+    if needed. *)
+let with_out_to filename f =
+  let open ResultMonad in
+  OS.Dir.create (Fpath.parent filename) >>= fun _ ->
+  OS.File.with_oc filename
+    (fun oc () ->
+      f oc;
+      Ok ())
+    ()
+  |> Result.join
+  >>= fun () -> Ok ()
 
 let cp src dst = assert (lines_of_process Cmd.(v "cp" % src % dst) = [])

--- a/src/html/link.ml
+++ b/src/html/link.ml
@@ -37,11 +37,7 @@ module Path = struct
 
   let as_filename ~is_flat (url : Url.Path.t) =
     let url_segs = for_linking ~is_flat url in
-    let filename =
-      match url_segs with
-      | [] -> Fpath.v "./"
-      | url_segs -> Fpath.(v @@ String.concat Fpath.dir_sep @@ url_segs)
-    in
+    let filename = Fpath.(v @@ String.concat Fpath.dir_sep @@ url_segs) in
     filename
 end
 

--- a/src/html/link.ml
+++ b/src/html/link.ml
@@ -36,7 +36,13 @@ module Path = struct
     dir @ [ file ]
 
   let as_filename ~is_flat (url : Url.Path.t) =
-    Fpath.(v @@ String.concat Fpath.dir_sep @@ for_linking ~is_flat url)
+    let url_segs = for_linking ~is_flat url in
+    let filename =
+      match url_segs with
+      | [] -> Fpath.v "./"
+      | url_segs -> Fpath.(v @@ String.concat Fpath.dir_sep @@ url_segs)
+    in
+    filename
 end
 
 type resolve = Current of Url.Path.t | Base of string

--- a/src/odoc/asset.ml
+++ b/src/odoc/asset.ml
@@ -1,12 +1,20 @@
+open Or_error
+
 let compile ~parent_id ~name ~output_dir =
   let open Odoc_model in
-  let parent_id = Compile.mk_id parent_id in
+  let parent_id =
+    match Compile.mk_id parent_id with
+    | Some s -> Ok s
+    | None ->
+        Error (`Msg "parent-id cannot be empty when compiling implementations.")
+  in
+  parent_id >>= fun parent_id ->
   let id =
     Paths.Identifier.Mk.asset_file
       ((parent_id :> Paths.Identifier.Page.t), Names.AssetName.make_std name)
   in
   let directory =
-    Compile.path_of_id output_dir parent_id
+    Compile.path_of_id output_dir (Some parent_id)
     |> Fpath.to_string |> Fs.Directory.of_string
   in
   let name = "asset-" ^ name ^ ".odoc" in
@@ -21,4 +29,4 @@ let compile ~parent_id ~name ~output_dir =
       }
   in
   let asset = Lang.Asset.{ name = id; root } in
-  Odoc_file.save_asset output ~warnings:[] asset
+  Ok (Odoc_file.save_asset output ~warnings:[] asset)

--- a/src/odoc/asset.ml
+++ b/src/odoc/asset.ml
@@ -5,8 +5,7 @@ let compile ~parent_id ~name ~output_dir =
   let parent_id =
     match Compile.mk_id parent_id with
     | Some s -> Ok s
-    | None ->
-        Error (`Msg "parent-id cannot be empty when compiling implementations.")
+    | None -> Error (`Msg "parent-id cannot be empty when compiling assets.")
   in
   parent_id >>= fun parent_id ->
   let id =

--- a/src/odoc/asset.mli
+++ b/src/odoc/asset.mli
@@ -1,1 +1,7 @@
-val compile : parent_id:string -> name:string -> output_dir:string -> unit
+open Or_error
+
+val compile :
+  parent_id:string ->
+  name:string ->
+  output_dir:string ->
+  (unit, [> msg ]) result

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -353,7 +353,9 @@ module Compile_asset = struct
         & opt (some string) None
         & info ~docs ~docv:"PARENT" ~doc [ "parent-id" ])
     in
-    Term.(const compile_asset $ parent_id $ asset_name $ output_dir)
+    Term.(
+      const handle_error
+      $ (const compile_asset $ parent_id $ asset_name $ output_dir))
 
   let info ~docs =
     let man =

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -42,11 +42,13 @@ type spec = {
 }
 
 let rec path_of_id output_dir id =
-  match (id : Paths.Identifier.ContainerPage.t).iv with
-  | `Page (None, p) -> Fpath.(v output_dir / PageName.to_string p)
-  | `Page (Some parent, p) ->
-      let d = path_of_id output_dir parent in
-      Fpath.(d / PageName.to_string p)
+  match id with
+  | None -> Fpath.v output_dir
+  | Some id -> (
+      match (id : Paths.Identifier.ContainerPage.t).iv with
+      | `Page (parent, p) ->
+          let d = path_of_id output_dir parent in
+          Fpath.(d / PageName.to_string p))
 
 let check_is_empty msg = function [] -> Ok () | _ :: _ -> Error (`Msg msg)
 
@@ -95,13 +97,17 @@ let resolve_parent_page resolver f =
   extract_parent page.name >>= fun parent -> Ok (parent, page.children)
 
 let mk_id str =
-  let l = String.cuts ~sep:"/" str in
-  List.fold_left
-    (fun acc id -> Some (Paths.Identifier.Mk.page (acc, PageName.make_std id)))
-    None l
-  |> function
-  | Some x -> x
-  | None -> failwith "Failed to create ID"
+  match str with
+  | "" -> None
+  | str -> (
+      let l = String.cuts ~sep:"/" str in
+      List.fold_left
+        (fun acc id ->
+          Some (Paths.Identifier.Mk.page (acc, PageName.make_std id)))
+        None l
+      |> function
+      | Some x -> Some x
+      | None -> failwith "Failed to create ID")
 
 let resolve_imports resolver imports =
   List.map
@@ -300,13 +306,7 @@ let resolve_spec ~input resolver cli_spec =
         else name |> Fpath.to_string |> String.Ascii.uncapitalize
       in
       let output = Fs.File.create ~directory ~name in
-      Ok
-        {
-          parent_id = Some parent_id;
-          output;
-          parents_children = None;
-          children = [];
-        }
+      Ok { parent_id; output; parents_children = None; children = [] }
   | CliNoParent output ->
       Ok { output; parent_id = None; parents_children = None; children = [] }
 

--- a/src/odoc/compile.mli
+++ b/src/odoc/compile.mli
@@ -49,8 +49,9 @@ val resolve_parent_page :
 (** Parse and resolve a parent reference. Returns the identifier of the parent
     and its children as a list of reference. *)
 
-val mk_id : string -> Identifier.ContainerPage.t
-val path_of_id : string -> Comment.Identifier.Id.container_page -> Fpath.t
+val mk_id : string -> Identifier.ContainerPage.t option
+val path_of_id :
+  string -> Comment.Identifier.Id.container_page option -> Fpath.t
 
 val compile :
   resolver:Resolver.t ->

--- a/src/odoc/source.ml
+++ b/src/odoc/source.ml
@@ -31,8 +31,14 @@ let compile ~resolver ~output ~warnings_options ~source_id input =
           Error (`Msg "Source id cannot be in the root directory")
         else
           let parent =
-            Compile.mk_id Fpath.(to_string (rem_empty_seg parent_id))
+            match Compile.mk_id Fpath.(to_string (rem_empty_seg parent_id)) with
+            | Some s -> Ok s
+            | None ->
+                Error
+                  (`Msg
+                    "parent-id cannot be empty when compiling implementations.")
           in
+          parent >>= fun parent ->
           let source_id =
             Paths.Identifier.Mk.source_page (parent, Fpath.to_string name)
           in

--- a/test/parent_id/dune
+++ b/test/parent_id/dune
@@ -1,2 +1,7 @@
+(env
+ (_
+  (binaries
+   (../odoc_print/odoc_print.exe as odoc_print))))
+
 (cram
- (deps %{bin:odoc}))
+ (deps %{bin:odoc} %{bin:odoc_print}))

--- a/test/parent_id/empty_parent_id.t/run.t
+++ b/test/parent_id/empty_parent_id.t/run.t
@@ -1,0 +1,15 @@
+  $ echo "{0 Test}" > file.mld
+
+It is possible to have pages with no parent, even with the odoc 3 "parent-id"
+argument. In this case, an empty string is passed as argument.
+
+  $ odoc compile --parent-id "" --output-dir _odoc file.mld
+  $ ls _odoc
+  page-file.odoc
+  $ odoc_print _odoc/page-file.odoc | jq ".name"
+  {
+    "`LeafPage": [
+      "None",
+      "file"
+    ]
+  }


### PR DESCRIPTION
This adds generation of (basic) pages for:
- A "list of all packages" page (at the root of the doc)
- A landing page for each package (in the `<pkgname>/` folder)
- A landing page for the list of libraries (in the `<pkgname>/lib/` folder)
- A landing page for each library (in the `<pkgname>/lib/<libname>` folder)

This PR does not touch only the driver: I had to add the possibility of an empty `--parent-id` for the "list of all packages" page.

I also had to avoid "relative references" in the generated pages as they are did not resolve. I used `rooted absolute references instead, and I will investigate the bug.

This will hopefully be useful to test various ideas for the breadcrumbs.