### PR TITLE
Add a frontmatter to mld pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 - Added a `compile-asset` command (@EmileTrotignon, @panglesd, #1170)
 - Allow referencing assets (@panglesd, #1171)
 - Added a `--asset-path` arg to `html-generate` (@panglesd, #1185)
+- Add a frontmatter syntax for mld pages (@panglesd, #1187)
 
 ### Changed
 

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -145,19 +145,16 @@ let extract_frontmatter docs : _ =
       (fun line -> Astring.String.cut ~sep:":" line)
       lines
   in
-  let extracted =
-    let rec aux acc = function
-      | [] -> None
-      | doc :: l -> (
+  let fm, content =
+    let fm, rev_content =
+      List.fold_left
+        (fun (fm_acc, content_acc) doc ->
           match doc.Location_.value with
           | `Code_block (Some "frontmatter", content, None) ->
-              Some
-                ( parse_frontmatter content.Location_.value,
-                  List.rev_append acc l )
-          | _ -> aux (doc :: acc) l)
+              (parse_frontmatter content.Location_.value :: fm_acc, content_acc)
+          | _ -> (fm_acc, doc :: content_acc))
+        ([], []) docs
     in
-    aux [] docs
+    (List.concat fm, List.rev rev_content)
   in
-  match extracted with
-  | None -> (None, docs)
-  | Some (fm, docs) -> (Some fm, docs)
+  (fm, content)

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -150,7 +150,7 @@ let extract_frontmatter docs : _ =
       List.fold_left
         (fun (fm_acc, content_acc) doc ->
           match doc.Location_.value with
-          | `Code_block (Some "frontmatter", content, None) ->
+          | `Code_block (Some "meta", content, None) ->
               (parse_frontmatter content.Location_.value :: fm_acc, content_acc)
           | _ -> (fm_acc, doc :: content_acc))
         ([], []) docs

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -1,3 +1,5 @@
+open Odoc_utils
+
 module Path = Paths.Path
 module Reference = Paths.Reference
 module Identifier = Paths.Identifier
@@ -130,7 +132,7 @@ and link_content_of_inline_elements l =
   l |> List.map link_content_of_inline_element |> List.concat
 
 let find_zero_heading docs : link_content option =
-  Odoc_utils.List.find_map
+  List.find_map
     (fun doc ->
       match doc.Location_.value with
       | `Heading ({ heading_level = `Title; _ }, _, h_content) ->
@@ -141,9 +143,7 @@ let find_zero_heading docs : link_content option =
 let extract_frontmatter docs : _ =
   let parse_frontmatter s =
     let lines = Astring.String.cuts ~sep:"\n" s in
-    Odoc_utils.List.filter_map
-      (fun line -> Astring.String.cut ~sep:":" line)
-      lines
+    List.filter_map (fun line -> Astring.String.cut ~sep:":" line) lines
   in
   let fm, content =
     let fm, rev_content =

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -130,15 +130,34 @@ and link_content_of_inline_elements l =
   l |> List.map link_content_of_inline_element |> List.concat
 
 let find_zero_heading docs : link_content option =
-  let rec find_map f = function
-    | [] -> None
-    | x :: l -> (
-        match f x with Some _ as result -> result | None -> find_map f l)
-  in
-  find_map
+  Odoc_utils.List.find_map
     (fun doc ->
       match doc.Location_.value with
       | `Heading ({ heading_level = `Title; _ }, _, h_content) ->
           Some (link_content_of_inline_elements h_content)
       | _ -> None)
     docs
+
+let extract_frontmatter docs : _ =
+  let parse_frontmatter s =
+    let lines = Astring.String.cuts ~sep:"\n" s in
+    Odoc_utils.List.filter_map
+      (fun line -> Astring.String.cut ~sep:":" line)
+      lines
+  in
+  let extracted =
+    let rec aux acc = function
+      | [] -> None
+      | doc :: l -> (
+          match doc.Location_.value with
+          | `Code_block (Some "frontmatter", content, None) ->
+              Some
+                ( parse_frontmatter content.Location_.value,
+                  List.rev_append acc l )
+          | _ -> aux (doc :: acc) l)
+    in
+    aux [] docs
+  in
+  match extracted with
+  | None -> (None, docs)
+  | Some (fm, docs) -> (Some fm, docs)

--- a/src/model/dune
+++ b/src/model/dune
@@ -16,4 +16,4 @@
   (backend landmarks --auto))
  (instrumentation
   (backend bisect_ppx))
- (libraries result compiler-libs.common odoc-parser))
+ (libraries result compiler-libs.common odoc-parser odoc_utils))

--- a/src/model/frontmatter.ml
+++ b/src/model/frontmatter.ml
@@ -1,0 +1,1 @@
+type t = (string * string) list

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -527,10 +527,6 @@ end =
 module rec Page : sig
   type child = Page_child of string | Module_child of string
 
-  module Frontmatter : sig
-    type t = (string * string) list
-  end
-
   type t = {
     name : Identifier.Page.t;
     root : Root.t;

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -527,11 +527,16 @@ end =
 module rec Page : sig
   type child = Page_child of string | Module_child of string
 
+  module Frontmatter : sig
+    type t = (string * string) list
+  end
+
   type t = {
     name : Identifier.Page.t;
     root : Root.t;
     content : Comment.docs;
     children : child list;
+    frontmatter : Frontmatter.t option;
     digest : Digest.t;
     linked : bool;
   }

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -532,7 +532,7 @@ module rec Page : sig
     root : Root.t;
     content : Comment.docs;
     children : child list;
-    frontmatter : Frontmatter.t option;
+    frontmatter : Frontmatter.t;
     digest : Digest.t;
     linked : bool;
   }

--- a/src/model/root.ml
+++ b/src/model/root.ml
@@ -29,7 +29,11 @@ end
 module Odoc_file = struct
   type compilation_unit = { name : string; hidden : bool }
 
-  type page = { name : string; title : Comment.link_content option }
+  type page = {
+    name : string;
+    title : Comment.link_content option;
+    frontmatter : Frontmatter.t option;
+  }
 
   type t =
     | Page of page
@@ -41,7 +45,7 @@ module Odoc_file = struct
     let hidden = force_hidden || Names.contains_double_underscore name in
     Compilation_unit { name; hidden }
 
-  let create_page name title = Page { name; title }
+  let create_page name title frontmatter = Page { name; title; frontmatter }
 
   let create_impl name = Impl name
 

--- a/src/model/root.ml
+++ b/src/model/root.ml
@@ -32,7 +32,7 @@ module Odoc_file = struct
   type page = {
     name : string;
     title : Comment.link_content option;
-    frontmatter : Frontmatter.t option;
+    frontmatter : Frontmatter.t;
   }
 
   type t =

--- a/src/model/root.mli
+++ b/src/model/root.mli
@@ -28,7 +28,11 @@ end
 module Odoc_file : sig
   type compilation_unit = { name : string; hidden : bool }
 
-  type page = { name : string; title : Comment.link_content option }
+  type page = {
+    name : string;
+    title : Comment.link_content option;
+    frontmatter : Frontmatter.t option;
+  }
 
   type t =
     | Page of page
@@ -38,7 +42,8 @@ module Odoc_file : sig
 
   val create_unit : force_hidden:bool -> string -> t
 
-  val create_page : string -> Comment.link_content option -> t
+  val create_page :
+    string -> Comment.link_content option -> Frontmatter.t option -> t
 
   val create_impl : string -> t
 

--- a/src/model/root.mli
+++ b/src/model/root.mli
@@ -31,7 +31,7 @@ module Odoc_file : sig
   type page = {
     name : string;
     title : Comment.link_content option;
-    frontmatter : Frontmatter.t option;
+    frontmatter : Frontmatter.t;
   }
 
   type t =
@@ -42,8 +42,7 @@ module Odoc_file : sig
 
   val create_unit : force_hidden:bool -> string -> t
 
-  val create_page :
-    string -> Comment.link_content option -> Frontmatter.t option -> t
+  val create_page : string -> Comment.link_content option -> Frontmatter.t -> t
 
   val create_impl : string -> t
 

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -697,6 +697,10 @@ and page_t =
     [
       F ("name", (fun t -> t.name), identifier);
       F ("root", (fun t -> t.root), root);
+      F
+        ( "frontmatter",
+          (fun t -> t.frontmatter),
+          Option (List (Pair (string, string))) );
       F ("content", (fun t -> t.content), docs);
       F ("digest", (fun t -> t.digest), Digest.t);
     ]

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -697,10 +697,7 @@ and page_t =
     [
       F ("name", (fun t -> t.name), identifier);
       F ("root", (fun t -> t.root), root);
-      F
-        ( "frontmatter",
-          (fun t -> t.frontmatter),
-          Option (List (Pair (string, string))) );
+      F ("frontmatter", (fun t -> t.frontmatter), List (Pair (string, string)));
       F ("content", (fun t -> t.content), docs);
       F ("digest", (fun t -> t.digest), Digest.t);
     ]

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -238,12 +238,14 @@ let mld ~parent_id ~parents_children ~output ~children ~warnings_options input =
   >>= fun name ->
   let resolve content =
     let zero_heading = Comment.find_zero_heading content in
+    let frontmatter, content = Comment.extract_frontmatter content in
     let root =
       let file = Root.Odoc_file.create_page root_name zero_heading in
       { Root.id = (name :> Paths.Identifier.OdocId.t); file; digest }
     in
     let page =
-      Lang.Page.{ name; root; children; content; digest; linked = false }
+      Lang.Page.
+        { name; root; children; content; digest; linked = false; frontmatter }
     in
     Odoc_file.save_page output ~warnings:[] page;
     Ok ()

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -240,7 +240,9 @@ let mld ~parent_id ~parents_children ~output ~children ~warnings_options input =
     let zero_heading = Comment.find_zero_heading content in
     let frontmatter, content = Comment.extract_frontmatter content in
     let root =
-      let file = Root.Odoc_file.create_page root_name zero_heading in
+      let file =
+        Root.Odoc_file.create_page root_name zero_heading frontmatter
+      in
       { Root.id = (name :> Paths.Identifier.OdocId.t); file; digest }
     in
     let page =

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -15,9 +15,18 @@ let from_mld ~xref_base_uri ~resolver ~output ~warnings_options input =
   in
   let to_html content =
     (* This is a mess. *)
+    let frontmatter, content = Odoc_model.Comment.extract_frontmatter content in
     let page =
       Odoc_model.Lang.Page.
-        { name = id; root; content; children = []; digest; linked = false }
+        {
+          name = id;
+          root;
+          content;
+          children = [];
+          digest;
+          linked = false;
+          frontmatter;
+        }
     in
     let env = Resolver.build_env_for_page resolver page in
     Odoc_xref2.Link.resolve_page ~filename:input_s env page

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -9,13 +9,15 @@ let from_mld ~xref_base_uri ~resolver ~output ~warnings_options input =
   in
   let input_s = Fs.File.to_string input in
   let digest = Digest.file input_s in
-  let root =
-    let file = Odoc_model.Root.Odoc_file.create_page page_name None in
-    { Odoc_model.Root.id; file; digest }
-  in
   let to_html content =
     (* This is a mess. *)
     let frontmatter, content = Odoc_model.Comment.extract_frontmatter content in
+    let root =
+      let file =
+        Odoc_model.Root.Odoc_file.create_page page_name None frontmatter
+      in
+      { Odoc_model.Root.id; file; digest }
+    in
     let page =
       Odoc_model.Lang.Page.
         {

--- a/test/pages/frontmatter.t/one_frontmatter.mld
+++ b/test/pages/frontmatter.t/one_frontmatter.mld
@@ -1,0 +1,6 @@
+{0 Title}
+
+{@frontmatter[
+bli1: bloblobloblo1
+bli2: bloblobloblo2
+]}

--- a/test/pages/frontmatter.t/one_frontmatter.mld
+++ b/test/pages/frontmatter.t/one_frontmatter.mld
@@ -1,6 +1,6 @@
-{0 Title}
+{0 One frontmatter}
 
-{@frontmatter[
+{@meta[
 bli1: bloblobloblo1
 bli2: bloblobloblo2
 ]}

--- a/test/pages/frontmatter.t/run.t
+++ b/test/pages/frontmatter.t/run.t
@@ -1,0 +1,101 @@
+When there is no frontmatter, everything is normal
+
+  $ odoc compile zero_frontmatter.mld
+  $ odoc_print page-zero_frontmatter.odoc | jq '.frontmatter'
+  "None"
+
+When there is one frontmatter, it is extracted from the content:
+
+  $ odoc compile one_frontmatter.mld
+  $ odoc_print page-one_frontmatter.odoc | jq '.frontmatter'
+  {
+    "Some": [
+      [
+        "bli1",
+        " bloblobloblo1"
+      ],
+      [
+        "bli2",
+        " bloblobloblo2"
+      ]
+    ]
+  }
+  $ odoc_print page-one_frontmatter.odoc | jq '.content'
+  [
+    {
+      "`Heading": [
+        {
+          "heading_level": "`Title",
+          "heading_label_explicit": "false"
+        },
+        {
+          "`Label": [
+            {
+              "`LeafPage": [
+                "None",
+                "one_frontmatter"
+              ]
+            },
+            "title"
+          ]
+        },
+        [
+          {
+            "`Word": "Title"
+          }
+        ]
+      ]
+    }
+  ]
+
+When there is more than one frontmatter, they are all extracted from the content:
+
+  $ odoc compile two_frontmatters.mld
+  $ odoc_print page-two_frontmatters.odoc | jq '.frontmatter'
+  {
+    "Some": [
+      [
+        "bli1",
+        " bloblobloblo1"
+      ],
+      [
+        "bli2",
+        " bloblobloblo2"
+      ]
+    ]
+  }
+  $ odoc_print page-two_frontmatters.odoc | jq '.content'
+  [
+    {
+      "`Heading": [
+        {
+          "heading_level": "`Title",
+          "heading_label_explicit": "false"
+        },
+        {
+          "`Label": [
+            {
+              "`LeafPage": [
+                "None",
+                "two_frontmatters"
+              ]
+            },
+            "title"
+          ]
+        },
+        [
+          {
+            "`Word": "Title"
+          }
+        ]
+      ]
+    },
+    {
+      "`Code_block": [
+        {
+          "Some": "frontmatter"
+        },
+        "bli3: bloblobloblo1"
+      ]
+    }
+  ]

--- a/test/pages/frontmatter.t/run.t
+++ b/test/pages/frontmatter.t/run.t
@@ -34,12 +34,16 @@ When there is one frontmatter, it is extracted from the content:
                 "one_frontmatter"
               ]
             },
-            "title"
+            "one-frontmatter"
           ]
         },
         [
           {
-            "`Word": "Title"
+            "`Word": "One"
+          },
+          "`Space",
+          {
+            "`Word": "frontmatter"
           }
         ]
       ]
@@ -80,12 +84,16 @@ When there is more than one frontmatter, they are all extracted from the content
                 "two_frontmatters"
               ]
             },
-            "title"
+            "two-frontmatters"
           ]
         },
         [
           {
-            "`Word": "Title"
+            "`Word": "Two"
+          },
+          "`Space",
+          {
+            "`Word": "frontmatters"
           }
         ]
       ]

--- a/test/pages/frontmatter.t/run.t
+++ b/test/pages/frontmatter.t/run.t
@@ -2,24 +2,22 @@ When there is no frontmatter, everything is normal
 
   $ odoc compile zero_frontmatter.mld
   $ odoc_print page-zero_frontmatter.odoc | jq '.frontmatter'
-  "None"
+  []
 
 When there is one frontmatter, it is extracted from the content:
 
   $ odoc compile one_frontmatter.mld
   $ odoc_print page-one_frontmatter.odoc | jq '.frontmatter'
-  {
-    "Some": [
-      [
-        "bli1",
-        " bloblobloblo1"
-      ],
-      [
-        "bli2",
-        " bloblobloblo2"
-      ]
+  [
+    [
+      "bli1",
+      " bloblobloblo1"
+    ],
+    [
+      "bli2",
+      " bloblobloblo2"
     ]
-  }
+  ]
   $ odoc_print page-one_frontmatter.odoc | jq '.content'
   [
     {
@@ -52,18 +50,20 @@ When there is more than one frontmatter, they are all extracted from the content
 
   $ odoc compile two_frontmatters.mld
   $ odoc_print page-two_frontmatters.odoc | jq '.frontmatter'
-  {
-    "Some": [
-      [
-        "bli1",
-        " bloblobloblo1"
-      ],
-      [
-        "bli2",
-        " bloblobloblo2"
-      ]
+  [
+    [
+      "bli3",
+      " bloblobloblo1"
+    ],
+    [
+      "bli1",
+      " bloblobloblo1"
+    ],
+    [
+      "bli2",
+      " bloblobloblo2"
     ]
-  }
+  ]
   $ odoc_print page-two_frontmatters.odoc | jq '.content'
   [
     {
@@ -88,14 +88,6 @@ When there is more than one frontmatter, they are all extracted from the content
             "`Word": "Title"
           }
         ]
-      ]
-    },
-    {
-      "`Code_block": [
-        {
-          "Some": "frontmatter"
-        },
-        "bli3: bloblobloblo1"
       ]
     }
   ]

--- a/test/pages/frontmatter.t/two_frontmatters.mld
+++ b/test/pages/frontmatter.t/two_frontmatters.mld
@@ -1,0 +1,10 @@
+{0 Title}
+
+{@frontmatter[
+bli1: bloblobloblo1
+bli2: bloblobloblo2
+]}
+
+{@frontmatter[
+bli3: bloblobloblo1
+]}

--- a/test/pages/frontmatter.t/two_frontmatters.mld
+++ b/test/pages/frontmatter.t/two_frontmatters.mld
@@ -1,10 +1,10 @@
-{0 Title}
+{0 Two frontmatters}
 
-{@frontmatter[
+{@meta[
 bli1: bloblobloblo1
 bli2: bloblobloblo2
 ]}
 
-{@frontmatter[
+{@meta[
 bli3: bloblobloblo1
 ]}

--- a/test/pages/frontmatter.t/zero_frontmatter.mld
+++ b/test/pages/frontmatter.t/zero_frontmatter.mld
@@ -1,0 +1,1 @@
+{0 No frontmatter}


### PR DESCRIPTION
This PR adds a frontmatter to mld pages.

The frontmatter consists in this PR to a list of string key values. Code blocks of the form:
```
{@meta[
key1: value1
key2: value2
]}
```
are removed from the content and the key-value pairs are added to the frontmatter of the page.

The frontmatter is added to the odoc file, including the page's "root", allowing to access it quickly without loading the whole content.

---

The idea of having a frontmatter originates from https://github.com/ocaml/odoc/discussions/1097 (see the "Metadata block" section).
In this discussion, the metadata provided by the frontmatter is:
- The package and library dependencies of the page (to be able to do cross-package referencing)
- The order in the table of content, for index pages.

The parsing of the data is not included in this PR. (Also, I am not sure which other data than the two items above could fit in the metadata block.)

About this: @dbuenzli wrote:

> As a driver author I don't want to parse this metadata block. If the driver will need that info odoc should be able to extract it for me in a simple from like e.g. we have for deps (I don't mind lines based, json or sexp).

I agree. However, this is not part of this PR (it will be in the PR defining the syntax for libs and pkgs dependencies, I guess).