### PR TITLE
Careful library deps

### DIFF
--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -196,7 +196,12 @@ let link : compiled list -> _ =
    fun c ->
     let link input_file output_file =
       let { Odoc_unit.libs; pages } = c.pkg_args in
-      let includes = c.include_dirs |> Fpath.Set.of_list in
+      let lib_includes =
+        List.fold_left
+          (fun acc (_, lib) -> Fpath.Set.add lib acc)
+          Fpath.Set.empty libs
+      in
+      let includes = List.fold_left (fun acc lib -> Fpath.Set.add lib acc)lib_includes  c.include_dirs in
       Odoc.link ~input_file ~output_file ~includes ~libs ~docs:pages
         ~current_package:c.pkgname ()
     in

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -196,12 +196,7 @@ let link : compiled list -> _ =
    fun c ->
     let link input_file output_file =
       let { Odoc_unit.libs; pages } = c.pkg_args in
-      let lib_includes =
-        List.fold_left
-          (fun acc (_, lib) -> Fpath.Set.add lib acc)
-          Fpath.Set.empty libs
-      in
-      let includes = List.fold_left (fun acc lib -> Fpath.Set.add lib acc)lib_includes  c.include_dirs in
+      let includes = Fpath.Set.of_list c.include_dirs in
       Odoc.link ~input_file ~output_file ~includes ~libs ~docs:pages
         ~current_package:c.pkgname ()
     in

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -34,11 +34,14 @@ let of_dune_build dir =
             let cmtidir =
               Fpath.(path / Printf.sprintf ".%s.objs" libname / "byte")
             in
+            let all_lib_deps = Util.StringMap.empty in
+            (* TODO *)
             let pkg_dir = Fpath.rem_prefix dir path |> Option.get in
             ( pkg_dir,
               Packages.Lib.v
                 ~libname_of_archive:(Util.StringMap.singleton libname libname)
-                ~pkg_name:libname ~dir:path ~cmtidir:(Some cmtidir) ))
+                ~pkg_name:libname ~dir:path ~cmtidir:(Some cmtidir)
+                ~all_lib_deps ))
           libs
       in
       let packages =

--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -10,11 +10,13 @@
     [archive_name], and that for this cma archive exists a corresponsing
     [archive_name].ocamlobjinfo file. *)
 
-type library = { name : string; archive_name : string; dir : string option }
+type library = { name : string; archive_name : string; dir : string option; deps : string list }
 
 let read_libraries_from_pkg_defs ~library_name pkg_defs =
   try
     let cma_filename = Fl_metascanner.lookup "archive" [ "byte" ] pkg_defs in
+    let deps_str = Fl_metascanner.lookup "requires" [] pkg_defs in
+    let deps = Astring.String.fields deps_str in
     let dir =
       List.find_opt (fun d -> d.Fl_metascanner.def_var = "directory") pkg_defs
     in
@@ -25,7 +27,7 @@ let read_libraries_from_pkg_defs ~library_name pkg_defs =
       else cma_filename
     in
     if String.length archive_name > 0 then
-      [ { name = library_name; archive_name; dir } ]
+      [ { name = library_name; archive_name; dir; deps } ]
     else []
   with Not_found -> []
 

--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -10,7 +10,12 @@
     [archive_name], and that for this cma archive exists a corresponsing
     [archive_name].ocamlobjinfo file. *)
 
-type library = { name : string; archive_name : string; dir : string option; deps : string list }
+type library = {
+  name : string;
+  archive_name : string;
+  dir : string option;
+  deps : string list;
+}
 
 let read_libraries_from_pkg_defs ~library_name pkg_defs =
   try

--- a/src/driver/library_names.mli
+++ b/src/driver/library_names.mli
@@ -1,4 +1,4 @@
-type library = { name : string; archive_name : string; dir : string option }
+type library = { name : string; archive_name : string; dir : string option; deps : string list }
 
 val process_meta_file : Fpath.t -> library list
 (** From a path to a [Meta] file, returns the list of libraries defined in this

--- a/src/driver/library_names.mli
+++ b/src/driver/library_names.mli
@@ -1,4 +1,9 @@
-type library = { name : string; archive_name : string; dir : string option; deps : string list }
+type library = {
+  name : string;
+  archive_name : string;
+  dir : string option;
+  deps : string list;
+}
 
 val process_meta_file : Fpath.t -> library list
 (** From a path to a [Meta] file, returns the list of libraries defined in this

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -49,6 +49,7 @@ val pp_asset : Format.formatter -> asset -> unit
 type libty = {
   lib_name : string;
   archive_name : string;
+  lib_deps : string list;
   modules : modulety list;
 }
 
@@ -61,6 +62,7 @@ module Lib : sig
     pkg_name:string ->
     dir:Fpath.t ->
     cmtidir:Fpath.t option ->
+    all_lib_deps:string list Util.StringMap.t ->
     libty list
 end
 

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -47,6 +47,9 @@ let process_package pkg =
       pkg.files
   in
 
+  let all_lib_deps = Util.StringMap.empty in
+
+  (* TODO *)
   let pkg_path =
     Fpath.(v "prep" / "universes" / pkg.universe / pkg.name / pkg.version)
   in
@@ -137,10 +140,11 @@ let process_package pkg =
              (fun directory ->
                Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
                Packages.Lib.v ~libname_of_archive ~pkg_name:pkg.name
-                 ~dir:directory ~cmtidir:None)
+                 ~dir:directory ~cmtidir:None ~all_lib_deps)
              Fpath.(Set.to_list directories)))
       metas
   in
+
   (* Check the main package lib directory even if there's no meta file *)
   let extra_libraries =
     let libdirs_without_meta =
@@ -163,7 +167,7 @@ let process_package pkg =
         Packages.Lib.v ~libname_of_archive:Util.StringMap.empty
           ~pkg_name:pkg.name
           ~dir:Fpath.(pkg_path // libdir)
-          ~cmtidir:None)
+          ~cmtidir:None ~all_lib_deps)
       libdirs_without_meta
   in
   Printf.eprintf "Found %d metas" (List.length metas);

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -688,6 +688,7 @@ end = struct
           current_dir;
         }
     in
+    let directories = directories @ List.map ~f:snd lib_roots in
     let resolver =
       Resolver.create ~important_digests:false ~directories ~open_modules ~roots
     in

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -10,8 +10,6 @@
 
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-bar.odoc
-  File "doc/subdir/bar.mld", line 12, characters 49-56:
-  Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/subdir/bar.mld", line 12, characters 39-48:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
   File "doc/subdir/bar.mld", line 12, characters 18-38:
@@ -22,8 +20,6 @@
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-foo.odoc
-  File "doc/foo.mld", line 12, characters 37-44:
-  Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/foo.mld", line 12, characters 27-36:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
   File "doc/foo.mld", line 12, characters 0-9:
@@ -67,7 +63,7 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["Test"]]},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
-  {"`Reference":[{"`Root":["Test","`TUnknown"]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
   ["Asset"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`AssetFile":[{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]},"img.png"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`AssetFile":[{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]},"img.png"]}}},[]]}
@@ -95,7 +91,7 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
-  {"`Reference":[{"`Root":["Test","`TUnknown"]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
 
   $ odoc_print ./h/pkg/lib/libname/test.odocl | jq_references
   ["Page","foo"]


### PR DESCRIPTION
Make sure the set of libraries provided during linking only comes from the dependency libraries of the library being linked.

Also ensure that the modules in the libraries passed are in the normal include path.