### PR TITLE
Specify children order in frontmatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 - Add a 'remap' option to HTML generation for partial docsets (@jonludlam, #1189)
 - Added an `html-generate-asset` command (@panglesd, #1185)
 - Added syntax for images, videos, audio (@panglesd, #1184)
+- Added the ability to order pages in the table of content (@panglesd, #1193)
 
 ### Changed
 

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -75,10 +75,10 @@ let of_lang (v : Odoc_model.Lang.Sidebar.t) =
     let page_hierarchy { Odoc_model.Lang.Sidebar.page_name; pages } =
       if pages = [] then None
       else
-        let prepare_for_hierarchy (link_content, id) =
+        let prepare_for_hierarchy { Odoc_model.Lang.Sidebar.title; id } =
           let path = Url.Path.from_identifier id in
           let payload =
-            let content = Comment.link_content link_content in
+            let content = Comment.link_content title in
             (path, sidebar_toc_entry id content)
           in
           (payload, path |> Url.Path.to_list |> List.map snd)

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -1,91 +1,91 @@
 open Types
 
-module Hierarchy : sig
-  type 'a dir
-  (** Directory in a filesystem-like abstraction, where files have a ['a]
-      payload and directory can also have a ['a] payload. *)
+let sidebar_toc_entry id content =
+  let href = id |> Url.Path.from_identifier |> Url.from_path in
+  let target = Target.Internal (Resolved href) in
+  inline @@ Inline.Link { target; content; tooltip = None }
 
-  val make : ('a * string list) list -> 'a dir
-  (** Create a directory from a list of payload and file path (given as a
-      string list). Files named ["index"] give their payload to their
-      containing directory. *)
+module Toc : sig
+  type t
 
-  val remove_common_root : 'a dir -> 'a dir
+  val of_lang : Odoc_model.Sidebar.toc -> t
+
+  val remove_common_root : t -> t
   (** Returns the deepest subdir containing all files. *)
 
-  val to_sidebar : ?fallback:string -> ('a -> Block.one) -> 'a dir -> Block.t
+  val to_sidebar :
+    ?fallback:string -> (Url.Path.t * Inline.one -> Block.one) -> t -> Block.t
 end = struct
-  type 'a dir = 'a option * (string * 'a t) list
-  and 'a t = Leaf of 'a | Dir of 'a dir
+  type t = Item of (Url.Path.t * Inline.one) option * t list
 
-  let rec add_entry_to_dir (dir : 'a dir) payload path =
-    match (path, dir) with
-    | [], _ -> assert false
-    | [ "index" ], (None, l) -> (Some payload, l)
-    | [ name ], (p, l) -> (p, (name, Leaf payload) :: l)
-    | name :: rest, (p, l) ->
-        let rec add_to_dir (l : (string * 'a t) list) =
-          match l with
-          | [] -> [ (name, Dir (add_entry_to_dir (None, []) payload rest)) ]
-          | (name2, Dir d) :: q when name = name2 ->
-              (name2, Dir (add_entry_to_dir d payload rest)) :: q
-          | d :: q -> d :: add_to_dir q
-        in
-        (p, add_to_dir l)
+  open Odoc_model.Sidebar
+  open Odoc_model.Paths.Identifier
 
-  let make l =
-    let empty = (None, []) in
-    let add_entry_to_dir acc (path, payload) =
-      add_entry_to_dir acc path payload
+  let of_lang (dir : toc) =
+    let rec of_lang ~parent_id (dir : toc) =
+      let title, parent_id =
+        match PageToc.dir_payload dir with
+        | Some (title, index_id) -> (Some title, Some (index_id :> Page.t))
+        | None -> (None, (parent_id :> Page.t option))
+      in
+      let children_order = PageToc.contents dir in
+      let entries =
+        List.filter_map
+          (fun id ->
+            match id with
+            | id, PageToc.Entry title ->
+                (* TODO warn on non empty children order if not index page somewhere *)
+                let payload =
+                  let path = Url.Path.from_identifier id in
+                  let content = Comment.link_content title in
+                  Some (path, sidebar_toc_entry id content)
+                in
+                Some (Item (payload, []))
+            | id, PageToc.Dir dir -> Some (of_lang ~parent_id:(Some id) dir))
+          children_order
+      in
+      let payload =
+        match (title, parent_id) with
+        | None, _ | _, None -> None
+        | Some title, Some parent_id ->
+            let path = Url.Path.from_identifier parent_id in
+            let content = Comment.link_content title in
+            Some (path, sidebar_toc_entry parent_id content)
+      in
+      Item (payload, entries)
     in
-    List.fold_left add_entry_to_dir empty l
+
+    of_lang ~parent_id:None dir
 
   let rec remove_common_root = function
-    | None, [ (_, Dir d) ] -> remove_common_root d
+    | Item (_, [ d ]) -> remove_common_root d
     | x -> x
 
-  let rec to_sidebar ?(fallback = "root") convert (name, content) =
+  let rec to_sidebar ?(fallback = "root") convert (Item (name, content)) =
     let name =
       match name with
       | Some v -> convert v
       | None -> block (Block.Inline [ inline (Text fallback) ])
     in
     let content =
-      let content = List.map (t_to_sidebar convert) content in
-      block (Block.List (Block.Unordered, content))
+      match content with
+      | [] -> []
+      | _ :: _ ->
+          let content = List.map (to_sidebar convert) content in
+          [ block (Block.List (Block.Unordered, content)) ]
     in
-    [ name; content ]
-
-  and t_to_sidebar convert = function
-    | _, Leaf payload -> [ convert payload ]
-    | fallback, Dir d -> to_sidebar ~fallback convert d
+    name :: content
 end
-type pages = { name : string; pages : (Url.Path.t * Inline.one) Hierarchy.dir }
+type pages = { name : string; pages : Toc.t }
 type library = { name : string; units : (Url.Path.t * Inline.one) list }
 
 type t = { pages : pages list; libraries : library list }
 
-let of_lang (v : Odoc_model.Lang.Sidebar.t) =
-  let sidebar_toc_entry id content =
-    let href = id |> Url.Path.from_identifier |> Url.from_path in
-    let target = Target.Internal (Resolved href) in
-    inline @@ Inline.Link { target; content; tooltip = None }
-  in
+let of_lang (v : Odoc_model.Sidebar.t) =
   let pages =
-    let page_hierarchy { Odoc_model.Lang.Sidebar.page_name; pages } =
-      if pages = [] then None
-      else
-        let prepare_for_hierarchy { Odoc_model.Lang.Sidebar.title; id } =
-          let path = Url.Path.from_identifier id in
-          let payload =
-            let content = Comment.link_content title in
-            (path, sidebar_toc_entry id content)
-          in
-          (payload, path |> Url.Path.to_list |> List.map snd)
-        in
-        let pages = List.map prepare_for_hierarchy pages in
-        let hierarchy = Hierarchy.make pages |> Hierarchy.remove_common_root in
-        Some { name = page_name; pages = hierarchy }
+    let page_hierarchy { Odoc_model.Sidebar.hierarchy_name; pages } =
+      let hierarchy = Toc.of_lang pages |> Toc.remove_common_root in
+      Some { name = hierarchy_name; pages = hierarchy }
     in
     Odoc_utils.List.filter_map page_hierarchy v.pages
   in
@@ -96,7 +96,7 @@ let of_lang (v : Odoc_model.Lang.Sidebar.t) =
     in
     let units =
       List.map
-        (fun { Odoc_model.Lang.Sidebar.units; name } ->
+        (fun { Odoc_model.Sidebar.units; name } ->
           let units = List.map item units in
           { name; units })
         v.libraries
@@ -121,7 +121,7 @@ let to_block (sidebar : t) url =
   let pages =
     Odoc_utils.List.concat_map
       ~f:(fun (p : pages) ->
-        let pages = Hierarchy.to_sidebar render_entry p.pages in
+        let pages = Toc.to_sidebar render_entry p.pages in
         let pages = [ block (Block.List (Block.Unordered, [ pages ])) ] in
         let pages = [ title @@ p.name ^ "'s Pages" ] @ pages in
         pages)

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -1,3 +1,4 @@
+open Odoc_utils
 open Types
 
 let sidebar_toc_entry id content =

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -9,7 +9,7 @@ let sidebar_toc_entry id content =
 module Toc : sig
   type t
 
-  val of_lang : Odoc_model.Sidebar.toc -> t
+  val of_lang : Odoc_model.Sidebar.PageToc.t -> t
 
   val remove_common_root : t -> t
   (** Returns the deepest subdir containing all files. *)
@@ -22,8 +22,8 @@ end = struct
   open Odoc_model.Sidebar
   open Odoc_model.Paths.Identifier
 
-  let of_lang (dir : toc) =
-    let rec of_lang ~parent_id (dir : toc) =
+  let of_lang (dir : PageToc.t) =
+    let rec of_lang ~parent_id (dir : PageToc.t) =
       let title, parent_id =
         match PageToc.dir_payload dir with
         | Some (title, index_id) -> (Some title, Some (index_id :> Page.t))
@@ -55,7 +55,6 @@ end = struct
       in
       Item (payload, entries)
     in
-
     of_lang ~parent_id:None dir
 
   let rec remove_common_root = function

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -11,9 +11,6 @@ module Toc : sig
 
   val of_lang : Odoc_model.Sidebar.PageToc.t -> t
 
-  val remove_common_root : t -> t
-  (** Returns the deepest subdir containing all files. *)
-
   val to_sidebar :
     ?fallback:string -> (Url.Path.t * Inline.one -> Block.one) -> t -> Block.t
 end = struct
@@ -56,10 +53,6 @@ end = struct
     in
     of_lang ~parent_id:None dir
 
-  let rec remove_common_root = function
-    | Item (_, [ d ]) -> remove_common_root d
-    | x -> x
-
   let rec to_sidebar ?(fallback = "root") convert (Item (name, content)) =
     let name =
       match name with
@@ -83,7 +76,7 @@ type t = { pages : pages list; libraries : library list }
 let of_lang (v : Odoc_model.Sidebar.t) =
   let pages =
     let page_hierarchy { Odoc_model.Sidebar.hierarchy_name; pages } =
-      let hierarchy = Toc.of_lang pages |> Toc.remove_common_root in
+      let hierarchy = Toc.of_lang pages in
       Some { name = hierarchy_name; pages = hierarchy }
     in
     Odoc_utils.List.filter_map page_hierarchy v.pages

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -23,13 +23,12 @@ end = struct
   open Odoc_model.Paths.Identifier
 
   let of_lang (dir : PageToc.t) =
-    let rec of_lang ~parent_id (dir : PageToc.t) =
+    let rec of_lang ~parent_id ((content, index) : PageToc.t) =
       let title, parent_id =
-        match PageToc.dir_payload dir with
+        match index with
         | Some (index_id, title) -> (Some title, Some (index_id :> Page.t))
         | None -> (None, (parent_id :> Page.t option))
       in
-      let ordered_children = PageToc.contents dir in
       let entries =
         List.filter_map
           (fun id ->
@@ -43,7 +42,7 @@ end = struct
                 in
                 Some (Item (payload, []))
             | id, PageToc.Dir dir -> Some (of_lang ~parent_id:(Some id) dir))
-          ordered_children
+          content
       in
       let payload =
         match (title, parent_id) with

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -26,10 +26,10 @@ end = struct
     let rec of_lang ~parent_id (dir : PageToc.t) =
       let title, parent_id =
         match PageToc.dir_payload dir with
-        | Some (title, index_id) -> (Some title, Some (index_id :> Page.t))
+        | Some (index_id, title) -> (Some title, Some (index_id :> Page.t))
         | None -> (None, (parent_id :> Page.t option))
       in
-      let children_order = PageToc.contents dir in
+      let ordered_children = PageToc.contents dir in
       let entries =
         List.filter_map
           (fun id ->
@@ -43,7 +43,7 @@ end = struct
                 in
                 Some (Item (payload, []))
             | id, PageToc.Dir dir -> Some (of_lang ~parent_id:(Some id) dir))
-          children_order
+          ordered_children
       in
       let payload =
         match (title, parent_id) with

--- a/src/document/sidebar.mli
+++ b/src/document/sidebar.mli
@@ -1,6 +1,6 @@
 type t
 
-val of_lang : Odoc_model.Lang.Sidebar.t -> t
+val of_lang : Odoc_model.Sidebar.t -> t
 
 val to_block : t -> Url.Path.t -> Types.Block.t
 (** Generates the sidebar document given a global sidebar and the path at which

--- a/src/driver/cmd_outputs.ml
+++ b/src/driver/cmd_outputs.ml
@@ -11,6 +11,8 @@ let link_output = ref [ "" ]
 
 let generate_output = ref [ "" ]
 
+let index_output = ref [ "" ]
+
 let source_tree_output = ref [ "" ]
 
 let add_prefixed_output cmd list prefix lines =

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -152,7 +152,7 @@ let compile_index ?(ignore_output = false) ~output_file ~json ~docs ~libs () =
   let lines = Cmd_outputs.submit desc cmd (Some output_file) in
   if not ignore_output then
     Cmd_outputs.(
-      add_prefixed_output cmd link_output (Fpath.to_string output_file) lines)
+      add_prefixed_output cmd index_output (Fpath.to_string output_file) lines)
 
 let html_generate ~output_dir ?index ?(ignore_output = false)
     ?(search_uris = []) ~input_file:file () =

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -147,20 +147,16 @@ let find_zero_heading docs : link_content option =
     docs
 
 let extract_frontmatter docs : _ =
-  let parse_frontmatter s =
-    let lines = Astring.String.cuts ~sep:"\n" s in
-    List.filter_map (fun line -> Astring.String.cut ~sep:":" line) lines
-  in
   let fm, content =
     let fm, rev_content =
       List.fold_left
         (fun (fm_acc, content_acc) doc ->
           match doc.Location_.value with
           | `Code_block (Some "meta", content, None) ->
-              (parse_frontmatter content.Location_.value :: fm_acc, content_acc)
+              (content.Location_.value :: fm_acc, content_acc)
           | _ -> (fm_acc, doc :: content_acc))
         ([], []) docs
     in
-    (List.concat fm, List.rev rev_content)
+    (fm |> String.concat "\n" |> Frontmatter.parse, List.rev rev_content)
   in
   (fm, content)

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -147,16 +147,13 @@ let find_zero_heading docs : link_content option =
     docs
 
 let extract_frontmatter docs : _ =
-  let fm, content =
-    let fm, rev_content =
-      List.fold_left
-        (fun (fm_acc, content_acc) doc ->
-          match doc.Location_.value with
-          | `Code_block (Some "meta", content, None) ->
-              (content.Location_.value :: fm_acc, content_acc)
-          | _ -> (fm_acc, doc :: content_acc))
-        ([], []) docs
-    in
-    (fm |> String.concat "\n" |> Frontmatter.parse, List.rev rev_content)
+  let fm, rev_content =
+    List.fold_left
+      (fun (fm_acc, content_acc) doc ->
+        match doc.Location_.value with
+        | `Code_block (Some "meta", content, None) ->
+            (Frontmatter.parse content, content_acc)
+        | _ -> (fm_acc, doc :: content_acc))
+      (Frontmatter.empty, []) docs
   in
-  (fm, content)
+  (fm, List.rev rev_content)

--- a/src/model/frontmatter.ml
+++ b/src/model/frontmatter.ml
@@ -22,7 +22,8 @@ let parse_child c =
 
 let parse s =
   let entries =
-    s |> String.split_on_char '\n'
+    s
+    |> Astring.String.cuts ~sep:"\n"
     |> List.map (fun l ->
            l |> fun x ->
            Astring.String.cut ~sep:":" x |> function

--- a/src/model/frontmatter.ml
+++ b/src/model/frontmatter.ml
@@ -1,1 +1,33 @@
-type t = (string * string) list
+type line =
+  | Children_order of Paths.Reference.Page.t list
+  | KV of string * string
+  | V of string
+
+type t = { children_order : Paths.Reference.Page.t list }
+
+let empty = { children_order = [] }
+
+let apply fm line =
+  match (line, fm) with
+  | Children_order children_order, { children_order = [] } -> { children_order }
+  | Children_order _, { children_order = _ :: _ } ->
+      (* TODO raise warning about duplicate children field *) fm
+  | KV _, _ | V _, _ -> (* TODO raise warning *) fm
+
+let parse s =
+  let entries =
+    s |> String.split_on_char '\n'
+    |> List.map (fun l ->
+           l |> fun x ->
+           Astring.String.cut ~sep:":" x |> function
+           | Some ("children", v) ->
+               let refs =
+                 Astring.String.fields v
+                 |> List.map (fun name : Paths.Reference.Page.t ->
+                        `Page_path (`TRelativePath, [ name ]))
+               in
+               Children_order refs
+           | Some (k, v) -> KV (k, v)
+           | None -> V x)
+  in
+  List.fold_left apply empty entries

--- a/src/model/frontmatter.ml
+++ b/src/model/frontmatter.ml
@@ -27,7 +27,9 @@ let parse s =
            l |> fun x ->
            Astring.String.cut ~sep:":" x |> function
            | Some ("children", v) ->
-               let refs = Astring.String.fields v |> List.map parse_child in
+               let refs =
+                 v |> Astring.String.fields ~empty:false |> List.map parse_child
+               in
                Children_order refs
            | Some (k, v) -> KV (k, v)
            | None -> V x)

--- a/src/model/frontmatter.ml
+++ b/src/model/frontmatter.ml
@@ -3,14 +3,15 @@ type line =
   | KV of string * string
   | V of string
 
-type t = { children_order : Paths.Reference.Page.t list }
+type t = { children_order : Paths.Reference.Page.t list option }
 
-let empty = { children_order = [] }
+let empty = { children_order = None }
 
 let apply fm line =
   match (line, fm) with
-  | Children_order children_order, { children_order = [] } -> { children_order }
-  | Children_order _, { children_order = _ :: _ } ->
+  | Children_order children_order, { children_order = None } ->
+      { children_order = Some children_order }
+  | Children_order _, { children_order = Some _ } ->
       (* TODO raise warning about duplicate children field *) fm
   | KV _, _ | V _, _ -> (* TODO raise warning *) fm
 

--- a/src/model/frontmatter.ml
+++ b/src/model/frontmatter.ml
@@ -1,8 +1,13 @@
 type child = Page of string | Dir of string
 
-type line = Children_order of child list | KV of string * string | V of string
+type line =
+  | Children_order of child Location_.with_location list
+  | KV of string * string
+  | V of string
 
-type t = { children_order : child list Location_.with_location option }
+type children_order = child Location_.with_location list Location_.with_location
+
+type t = { children_order : children_order option }
 
 let empty = { children_order = None }
 
@@ -32,6 +37,7 @@ let parse s =
                    v
                    |> Astring.String.fields ~empty:false
                    |> List.map parse_child
+                   |> List.map (Location_.same s)
                  in
                  Children_order refs
              | Some (k, v) -> KV (k, v)

--- a/src/model/frontmatter.mli
+++ b/src/model/frontmatter.mli
@@ -1,5 +1,7 @@
 type child = Page of string | Dir of string
 
-type t = { children_order : child list option }
+type t = { children_order : child list Location_.with_location option }
 
-val parse : string -> t
+val empty : t
+
+val parse : string Location_.with_location -> t

--- a/src/model/frontmatter.mli
+++ b/src/model/frontmatter.mli
@@ -1,0 +1,7 @@
+type child = Page of string | Dir of string
+
+type line = Children_order of child list | KV of string * string | V of string
+
+type t = { children_order : child list option }
+
+val parse : string -> t

--- a/src/model/frontmatter.mli
+++ b/src/model/frontmatter.mli
@@ -1,7 +1,5 @@
 type child = Page of string | Dir of string
 
-type line = Children_order of child list | KV of string * string | V of string
-
 type t = { children_order : child list option }
 
 val parse : string -> t

--- a/src/model/frontmatter.mli
+++ b/src/model/frontmatter.mli
@@ -1,6 +1,8 @@
 type child = Page of string | Dir of string
 
-type t = { children_order : child list Location_.with_location option }
+type children_order = child Location_.with_location list Location_.with_location
+
+type t = { children_order : children_order option }
 
 val empty : t
 

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -539,26 +539,15 @@ module rec Page : sig
 end =
   Page
 
-module rec Sidebar : sig
-  type library = { name : string; units : Paths.Identifier.RootModule.t list }
-
-  type page = { title : Comment.link_content; id : Paths.Identifier.Page.t }
-
-  type pages = { page_name : string; pages : page list }
-
-  type t = { pages : pages list; libraries : library list }
-end =
-  Sidebar
-
-module rec Index : sig
-  type 'a t = Sidebar.t * 'a Paths.Identifier.Hashtbl.Any.t
-end =
-  Index
-
 module rec Asset : sig
   type t = { name : Identifier.AssetFile.t; root : Root.t }
 end =
   Asset
+
+module rec Index : sig
+  type 'a t = { sidebar : Sidebar.t; index : 'a Paths.Identifier.Hashtbl.Any.t }
+end =
+  Index
 
 let umty_of_mty : ModuleType.expr -> ModuleType.U.expr option = function
   | Signature sg -> Some (Signature sg)

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -542,10 +542,9 @@ end =
 module rec Sidebar : sig
   type library = { name : string; units : Paths.Identifier.RootModule.t list }
 
-  type pages = {
-    page_name : string;
-    pages : (Comment.link_content * Paths.Identifier.Page.t) list;
-  }
+  type page = { title : Comment.link_content; id : Paths.Identifier.Page.t }
+
+  type pages = { page_name : string; pages : page list }
 
   type t = { pages : pages list; libraries : library list }
 end =

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -539,15 +539,15 @@ module rec Page : sig
 end =
   Page
 
-module rec Asset : sig
-  type t = { name : Identifier.AssetFile.t; root : Root.t }
-end =
-  Asset
-
 module rec Index : sig
   type 'a t = { sidebar : Sidebar.t; index : 'a Paths.Identifier.Hashtbl.Any.t }
 end =
   Index
+
+module rec Asset : sig
+  type t = { name : Identifier.AssetFile.t; root : Root.t }
+end =
+  Asset
 
 let umty_of_mty : ModuleType.expr -> ModuleType.U.expr option = function
   | Signature sg -> Some (Signature sg)

--- a/src/model/odoc_model.ml
+++ b/src/model/odoc_model.ml
@@ -10,3 +10,4 @@ module Location_ = Location_
 module Compat = Compat
 module Semantics = Semantics
 module Reference = Reference
+module Frontmatter = Frontmatter

--- a/src/model/odoc_model.ml
+++ b/src/model/odoc_model.ml
@@ -1,4 +1,5 @@
 module Lang = Lang
+module Sidebar = Sidebar
 module Fold = Fold
 module Comment = Comment
 module Paths = Paths

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -363,14 +363,27 @@ module Identifier = struct
     type t_pv = Id.page_pv
   end
 
+  module LeafPage = struct
+    type t = Id.leaf_page
+    type t_pv = Id.leaf_page_pv
+    let equal = equal
+    let hash = hash
+  end
+
   module ContainerPage = struct
     type t = Id.container_page
     type t_pv = Id.container_page_pv
+    let equal = equal
+    let hash = hash
   end
 
   module NonSrc = struct
     type t = Paths_types.Identifier.non_src
     type t_pv = Paths_types.Identifier.non_src_pv
+
+    let equal x y = x.ihash = y.ihash && x.ikey = y.ikey
+
+    let hash x = x.ihash
   end
 
   module SourcePage = struct
@@ -623,6 +636,8 @@ module Identifier = struct
 
   module Hashtbl = struct
     module Any = Hashtbl.Make (Any)
+    module ContainerPage = Hashtbl.Make (ContainerPage)
+    module LeafPage = Hashtbl.Make (LeafPage)
   end
 end
 

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -139,6 +139,11 @@ module Identifier : sig
     type t_pv = Id.page_pv
   end
 
+  module LeafPage : sig
+    type t = Id.leaf_page
+    type t_pv = Id.leaf_page_pv
+  end
+
   module ContainerPage : sig
     type t = Id.container_page
     type t_pv = Id.container_page_pv
@@ -147,6 +152,8 @@ module Identifier : sig
   module NonSrc : sig
     type t = Id.non_src
     type t_pv = Id.non_src_pv
+    val hash : t -> int
+    val equal : ([< t_pv ] id as 'a) -> 'a -> bool
   end
 
   module SourcePage : sig
@@ -235,6 +242,8 @@ module Identifier : sig
 
   module Hashtbl : sig
     module Any : Hashtbl.S with type key = Any.t
+    module ContainerPage : Hashtbl.S with type key = ContainerPage.t
+    module LeafPage : Hashtbl.S with type key = LeafPage.t
   end
 
   module Mk : sig

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -756,7 +756,6 @@ module rec Reference : sig
   type page =
     [ `Resolved of Resolved_reference.page
     | `Root of string * [ `TPage | `TUnknown ]
-    | `Dot of label_parent * string
     | `Page_path of hierarchy ]
   (** @canonical Odoc_model.Paths.Reference.Page.t *)
 

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -11,8 +11,13 @@ module Identifier = struct
   and container_page = container_page_pv id
   (** @canonical Odoc_model.Paths.Identifier.ContainerPage.t *)
 
-  type page_pv =
-    [ container_page_pv | `LeafPage of container_page option * PageName.t ]
+  type leaf_page_pv = [ `LeafPage of container_page option * PageName.t ]
+  (** @canonical Odoc_model.Paths.Identifier.LeafPage.t_pv *)
+
+  and leaf_page = leaf_page_pv id
+  (** @canonical Odoc_model.Paths.Identifier.LeafPage.t *)
+
+  type page_pv = [ container_page_pv | leaf_page_pv ]
   (** @canonical Odoc_model.Paths.Identifier.Page.t_pv *)
 
   and page = page_pv id

--- a/src/model/sidebar.ml
+++ b/src/model/sidebar.ml
@@ -1,0 +1,142 @@
+open Paths.Identifier
+
+module CPH = Hashtbl.ContainerPage
+module LPH = Hashtbl.LeafPage
+
+type page = Page.t
+type leaf_page = LeafPage.t
+type container_page = ContainerPage.t
+
+module PageToc = struct
+  type title = Comment.link_content
+  type children_order = Paths.Identifier.Page.t list
+
+  type payload = { title : title; children_order : children_order option }
+
+  type dir_content = { leafs : payload LPH.t; dirs : t CPH.t }
+  and t = container_page option * dir_content
+
+  let empty_t dir_id = (dir_id, { leafs = LPH.create 10; dirs = CPH.create 10 })
+
+  let get_parent id : container_page option =
+    let id :> page = id in
+    match id.iv with
+    | `Page (Some parent, _) -> Some parent
+    | `LeafPage (Some parent, _) -> Some parent
+    | `Page (None, _) | `LeafPage (None, _) -> None
+
+  let find_leaf ((_, dir_content) : t) leaf_page =
+    try Some (LPH.find dir_content.leafs leaf_page) with Not_found -> None
+
+  let find_dir (_, dir_content) container_page =
+    try Some (CPH.find dir_content.dirs container_page) with Not_found -> None
+
+  type content = Entry of title | Dir of t
+
+  type c_or_l = Container of ContainerPage.t | Leaf of LeafPage.t
+
+  let classify = function
+    | { iv = `LeafPage _; _ } as id -> Leaf id
+    | { iv = `Page _; _ } as id -> Container id
+
+  let find dir id =
+    let open Odoc_utils.OptionMonad in
+    match classify id with
+    | Leaf id -> find_leaf dir id >>= fun x -> Some (Entry x.title)
+    | Container id -> find_dir dir id >>= fun x -> Some (Dir x)
+
+  let leafs (_, dir_content) =
+    LPH.fold
+      (fun id { title = payload; _ } acc ->
+        if String.equal "index" (Paths.Identifier.name id) then acc
+        else (id, payload) :: acc)
+      dir_content.leafs []
+
+  let dir_payload ((parent_id, _) as dir) =
+    let index_id =
+      Paths.Identifier.Mk.leaf_page (parent_id, Names.PageName.make_std "index")
+    in
+    match find_leaf dir index_id with
+    | Some payload -> Some (payload, index_id)
+    | None -> None
+
+  let dirs (_, dir_content) =
+    CPH.fold (fun id payload acc -> (id, payload) :: acc) dir_content.dirs []
+
+  let contents dir =
+    let children_order =
+      match dir_payload dir with
+      | Some ({ children_order; _ }, _) -> children_order
+      | None -> None
+    in
+    let children_order =
+      match children_order with
+      | None ->
+          let contents =
+            let leafs =
+              leafs dir
+              |> List.map (fun (id, payload) -> ((id :> Page.t), Entry payload))
+            in
+            let dirs =
+              dirs dir
+              |> List.map (fun (id, payload) -> ((id :> Page.t), Dir payload))
+            in
+            leafs @ dirs
+          in
+          List.sort
+            (fun (x, _) (y, _) ->
+              String.compare (Paths.Identifier.name x) (Paths.Identifier.name y))
+            contents
+      | Some ch ->
+          let open Odoc_utils.OptionMonad in
+          List.filter_map
+            (fun id -> find dir id >>= fun content -> Some (id, content))
+            ch
+    in
+    children_order
+
+  let dir_payload ((parent_id, _) as dir) =
+    let index_id =
+      Paths.Identifier.Mk.leaf_page (parent_id, Names.PageName.make_std "index")
+    in
+    match find_leaf dir index_id with
+    | Some payload -> Some (payload.title, index_id)
+    | None -> None
+
+  let rec get_or_create (dir : t) (id : container_page) : t =
+    let _, { dirs = parent_dirs; _ } =
+      match get_parent id with
+      | Some parent -> get_or_create dir parent
+      | None -> dir
+    in
+    let current_item =
+      try Some (CPH.find parent_dirs id) with Not_found -> None
+    in
+    match current_item with
+    | Some item -> item
+    | None ->
+        let new_ = empty_t (Some id) in
+        CPH.add parent_dirs id new_;
+        new_
+
+  let add (dir : t) ((id : leaf_page), title, children_order) =
+    let _, dir_content =
+      match get_parent id with
+      | Some parent -> get_or_create dir parent
+      | None -> dir
+    in
+    LPH.replace dir_content.leafs id { title; children_order }
+
+  let of_list l =
+    let dir = empty_t None in
+    List.iter (add dir) l;
+    dir
+end
+
+type toc = PageToc.t
+
+type library = { name : string; units : Paths.Identifier.RootModule.t list }
+
+type page_hierarchy = { hierarchy_name : string; pages : toc }
+
+type t = { pages : page_hierarchy list; libraries : library list }

--- a/src/model/sidebar.ml
+++ b/src/model/sidebar.ml
@@ -1,3 +1,4 @@
+open Odoc_utils
 open Paths.Identifier
 
 module CPH = Hashtbl.ContainerPage
@@ -48,7 +49,7 @@ module PageToc = struct
   let leafs (_, dir_content) =
     LPH.fold
       (fun id { title = payload; _ } acc ->
-        if String.equal "index" (Paths.Identifier.name id) then acc
+        if Astring.String.equal "index" (Paths.Identifier.name id) then acc
         else (id, payload) :: acc)
       dir_content.leafs []
 
@@ -88,7 +89,7 @@ module PageToc = struct
               String.compare (Paths.Identifier.name x) (Paths.Identifier.name y))
             contents
       | Some ch ->
-          let open Odoc_utils.OptionMonad in
+          let open OptionMonad in
           List.filter_map
             (fun c ->
               let id =

--- a/src/model/sidebar.ml
+++ b/src/model/sidebar.ml
@@ -105,7 +105,7 @@ module PageToc = struct
       Paths.Identifier.Mk.leaf_page (parent_id, Names.PageName.make_std "index")
     in
     match find_leaf dir index_id with
-    | Some payload -> Some (payload.title, index_id)
+    | Some payload -> Some (index_id, payload.title)
     | None -> None
 
   let rec get_or_create (dir : t) (id : container_page) : t =

--- a/src/model/sidebar.ml
+++ b/src/model/sidebar.ml
@@ -70,38 +70,35 @@ module PageToc = struct
       | Some ({ children_order; _ }, _) -> children_order
       | None -> None
     in
-    let children_order =
-      match children_order with
-      | None ->
-          let contents =
-            let leafs =
-              leafs dir
-              |> List.map (fun (id, payload) -> ((id :> Page.t), Entry payload))
-            in
-            let dirs =
-              dirs dir
-              |> List.map (fun (id, payload) -> ((id :> Page.t), Dir payload))
-            in
-            leafs @ dirs
+    match children_order with
+    | None ->
+        let contents =
+          let leafs =
+            leafs dir
+            |> List.map (fun (id, payload) -> ((id :> Page.t), Entry payload))
           in
-          List.sort
-            (fun (x, _) (y, _) ->
-              String.compare (Paths.Identifier.name x) (Paths.Identifier.name y))
-            contents
-      | Some ch ->
-          let open OptionMonad in
-          List.filter_map
-            (fun c ->
-              let id =
-                match c with
-                | Frontmatter.Page name ->
-                    Mk.leaf_page (dir_id, Names.PageName.make_std name)
-                | Dir name -> Mk.page (dir_id, Names.PageName.make_std name)
-              in
-              find dir id >>= fun content -> Some (id, content))
-            ch
-    in
-    children_order
+          let dirs =
+            dirs dir
+            |> List.map (fun (id, payload) -> ((id :> Page.t), Dir payload))
+          in
+          leafs @ dirs
+        in
+        List.sort
+          (fun (x, _) (y, _) ->
+            String.compare (Paths.Identifier.name x) (Paths.Identifier.name y))
+          contents
+    | Some ch ->
+        let open OptionMonad in
+        List.filter_map
+          (fun c ->
+            let id =
+              match c with
+              | Frontmatter.Page name ->
+                  Mk.leaf_page (dir_id, Names.PageName.make_std name)
+              | Dir name -> Mk.page (dir_id, Names.PageName.make_std name)
+            in
+            find dir id >>= fun content -> Some (id, content))
+          ch
 
   let dir_payload ((parent_id, _) as dir) =
     let index_id =

--- a/src/model/sidebar.ml
+++ b/src/model/sidebar.ml
@@ -1,12 +1,12 @@
 open Odoc_utils
-open Paths.Identifier
+module Id = Paths.Identifier
 
-module CPH = Hashtbl.ContainerPage
-module LPH = Hashtbl.LeafPage
+module CPH = Id.Hashtbl.ContainerPage
+module LPH = Id.Hashtbl.LeafPage
 
-type page = Page.t
-type leaf_page = LeafPage.t
-type container_page = ContainerPage.t
+type page = Id.Page.t
+type leaf_page = Id.LeafPage.t
+type container_page = Id.ContainerPage.t
 
 module PageToc = struct
   type title = Comment.link_content
@@ -74,8 +74,8 @@ module PageToc = struct
     | Some payload -> Some (payload, index_id, payload.title)
     | None -> None
 
-  type index = Page.t * title
-  type t = (Page.t * content) list * index option
+  type index = Id.Page.t * title
+  type t = (Id.Page.t * content) list * index option
   and content = Entry of title | Dir of t
 
   let rec t_of_in_progress (dir : in_progress) =
@@ -86,7 +86,7 @@ module PageToc = struct
       | None -> (None, None)
     in
     let pp_content fmt (id, _) =
-      match id.iv with
+      match id.Id.iv with
       | `LeafPage (_, name) ->
           Format.fprintf fmt "'%s'" (Names.PageName.to_string name)
       | `Page (_, name) ->
@@ -101,12 +101,12 @@ module PageToc = struct
       let contents =
         let leafs =
           leafs dir
-          |> List.map (fun (id, payload) -> ((id :> Page.t), Entry payload))
+          |> List.map (fun (id, payload) -> ((id :> Id.Page.t), Entry payload))
         in
         let dirs =
           dirs dir
           |> List.map (fun (id, payload) ->
-                 ((id :> Page.t), Dir (t_of_in_progress payload)))
+                 ((id :> Id.Page.t), Dir (t_of_in_progress payload)))
         in
         leafs @ dirs
       in
@@ -117,7 +117,7 @@ module PageToc = struct
             List.mapi (fun i x -> (i, x)) children_order.value
           in
           let equal id ch =
-            match (ch, id.iv) with
+            match (ch, id.Id.iv) with
             | (_, { Location_.value = Frontmatter.Dir c; _ }), `Page (_, name)
               ->
                 String.equal (Names.PageName.to_string name) c
@@ -128,7 +128,7 @@ module PageToc = struct
           let children_indexes, indexed_content, unindexed_content =
             List.fold_left
               (fun (children_indexes, indexed_content, unindexed_content)
-                   (((id : Page.t), _) as entry) ->
+                   (((id : Id.Page.t), _) as entry) ->
                 let indexes_for_entry, children_indexes =
                   List.partition (equal id) children_indexes
                 in
@@ -168,8 +168,7 @@ module PageToc = struct
     in
     let ordered =
       ordered
-      |> List.sort (fun (i, _) (j, _) ->
-             (Stdlib.compare : int -> int -> int) i j)
+      |> List.sort (fun (i, _) (j, _) -> (compare : int -> int -> int) i j)
       |> List.map snd
     in
     let unordered =

--- a/src/model/sidebar.ml
+++ b/src/model/sidebar.ml
@@ -8,6 +8,8 @@ type page = Id.Page.t
 type leaf_page = Id.LeafPage.t
 type container_page = Id.ContainerPage.t
 
+open Astring
+
 module PageToc = struct
   type title = Comment.link_content
 
@@ -34,7 +36,7 @@ module PageToc = struct
   let leafs (_, dir_content) =
     LPH.fold
       (fun id { title = payload; _ } acc ->
-        if Astring.String.equal "index" (Paths.Identifier.name id) then acc
+        if String.equal "index" (Paths.Identifier.name id) then acc
         else (id, payload) :: acc)
       dir_content.leafs []
 

--- a/src/model/sidebar.ml
+++ b/src/model/sidebar.ml
@@ -168,7 +168,8 @@ module PageToc = struct
     in
     let ordered =
       ordered
-      |> List.sort (fun (i, _) (j, _) -> Int.compare i j)
+      |> List.sort (fun (i, _) (j, _) ->
+             (Stdlib.compare : int -> int -> int) i j)
       |> List.map snd
     in
     let unordered =

--- a/src/model/sidebar.ml
+++ b/src/model/sidebar.ml
@@ -182,10 +182,13 @@ module PageToc = struct
     let contents = ordered @ unordered in
     (contents, index)
 
+  let rec remove_common_root (v : t) =
+    match v with [ (_, Dir v) ], None -> remove_common_root v | _ -> v
+
   let of_list l =
     let dir = empty_t None in
     List.iter (add dir) l;
-    t_of_in_progress dir
+    t_of_in_progress dir |> remove_common_root
 end
 
 type toc = PageToc.t

--- a/src/model/sidebar.mli
+++ b/src/model/sidebar.mli
@@ -1,0 +1,27 @@
+open Paths.Identifier
+
+module PageToc : sig
+  type title = Comment.link_content
+  type children_order = Paths.Identifier.Page.t list
+
+  type t
+  type content = Entry of title | Dir of t
+
+  val of_list : (LeafPage.t * title * children_order option) list -> t
+  (** Uses the convention that the [index] children passes its payload to the
+      container directory to output a payload *)
+
+  val find : t -> Page.t -> content option
+  val contents : t -> (Page.t * content) list
+
+  val dir_payload : t -> (title * LeafPage.t) option
+  (** Gets a title and the ID from a potential [index] page *)
+end
+
+type toc = PageToc.t
+
+type library = { name : string; units : RootModule.t list }
+
+type page_hierarchy = { hierarchy_name : string; pages : toc }
+
+type t = { pages : page_hierarchy list; libraries : library list }

--- a/src/model/sidebar.mli
+++ b/src/model/sidebar.mli
@@ -2,7 +2,7 @@ open Paths.Identifier
 
 module PageToc : sig
   type title = Comment.link_content
-  type children_order = Paths.Identifier.Page.t list
+  type children_order = Frontmatter.child list
 
   type t
   type content = Entry of title | Dir of t

--- a/src/model/sidebar.mli
+++ b/src/model/sidebar.mli
@@ -13,7 +13,7 @@ module PageToc : sig
 
   val contents : t -> (Page.t * content) list
 
-  val dir_payload : t -> (title * LeafPage.t) option
+  val dir_payload : t -> (LeafPage.t * title) option
   (** Gets a title and the ID from a potential [index] page *)
 end
 

--- a/src/model/sidebar.mli
+++ b/src/model/sidebar.mli
@@ -2,13 +2,13 @@ open Paths.Identifier
 
 module PageToc : sig
   type title = Comment.link_content
-  type children_order = Frontmatter.child list Location_.with_location
 
   type index = Page.t * title
   type t = (Page.t * content) list * index option
   and content = Entry of title | Dir of t
 
-  val of_list : (LeafPage.t * title * children_order option) list -> t
+  val of_list :
+    (LeafPage.t * title * Frontmatter.children_order option) list -> t
   (** Uses the convention that the [index] children passes its payload to the
       container directory to output a payload *)
 end

--- a/src/model/sidebar.mli
+++ b/src/model/sidebar.mli
@@ -4,17 +4,13 @@ module PageToc : sig
   type title = Comment.link_content
   type children_order = Frontmatter.child list
 
-  type t
-  type content = Entry of title | Dir of t
+  type index = Page.t * title
+  type t = (Page.t * content) list * index option
+  and content = Entry of title | Dir of t
 
   val of_list : (LeafPage.t * title * children_order option) list -> t
   (** Uses the convention that the [index] children passes its payload to the
       container directory to output a payload *)
-
-  val contents : t -> (Page.t * content) list
-
-  val dir_payload : t -> (LeafPage.t * title) option
-  (** Gets a title and the ID from a potential [index] page *)
 end
 
 type library = { name : string; units : RootModule.t list }

--- a/src/model/sidebar.mli
+++ b/src/model/sidebar.mli
@@ -11,17 +11,14 @@ module PageToc : sig
   (** Uses the convention that the [index] children passes its payload to the
       container directory to output a payload *)
 
-  val find : t -> Page.t -> content option
   val contents : t -> (Page.t * content) list
 
   val dir_payload : t -> (title * LeafPage.t) option
   (** Gets a title and the ID from a potential [index] page *)
 end
 
-type toc = PageToc.t
-
 type library = { name : string; units : RootModule.t list }
 
-type page_hierarchy = { hierarchy_name : string; pages : toc }
+type page_hierarchy = { hierarchy_name : string; pages : PageToc.t }
 
 type t = { pages : page_hierarchy list; libraries : library list }

--- a/src/model/sidebar.mli
+++ b/src/model/sidebar.mli
@@ -2,7 +2,7 @@ open Paths.Identifier
 
 module PageToc : sig
   type title = Comment.link_content
-  type children_order = Frontmatter.child list
+  type children_order = Frontmatter.child list Location_.with_location
 
   type index = Page.t * title
   type t = (Page.t * content) list * index option

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -704,14 +704,12 @@ and page_t =
 
 and frontmatter =
   let open Odoc_model.Frontmatter in
-  Record
-    [
-      F
-        ( "children",
-          (fun t ->
-            (t.children_order :> Odoc_model.Paths.Reference.t list option)),
-          Option (List reference) );
-    ]
+  Record [ F ("children", (fun t -> t.children_order), Option (List child)) ]
+
+and child =
+  let open Odoc_model.Frontmatter in
+  Variant
+    (function Page s -> C ("Page", s, string) | Dir s -> C ("Dir", s, string))
 
 and implementation_t =
   let open Lang.Implementation in

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -697,9 +697,19 @@ and page_t =
     [
       F ("name", (fun t -> t.name), identifier);
       F ("root", (fun t -> t.root), root);
-      F ("frontmatter", (fun t -> t.frontmatter), List (Pair (string, string)));
+      F ("frontmatter", (fun t -> t.frontmatter), frontmatter);
       F ("content", (fun t -> t.content), docs);
       F ("digest", (fun t -> t.digest), Digest.t);
+    ]
+
+and frontmatter =
+  let open Odoc_model.Frontmatter in
+  Record
+    [
+      F
+        ( "children",
+          (fun t -> (t.children_order :> Odoc_model.Paths.Reference.t list)),
+          List reference );
     ]
 
 and implementation_t =

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -708,8 +708,9 @@ and frontmatter =
     [
       F
         ( "children",
-          (fun t -> (t.children_order :> Odoc_model.Paths.Reference.t list)),
-          List reference );
+          (fun t ->
+            (t.children_order :> Odoc_model.Paths.Reference.t list option)),
+          Option (List reference) );
     ]
 
 and implementation_t =

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -1,5 +1,6 @@
 open Type_desc
 open Odoc_model
+open Odoc_utils
 open Paths_desc
 open Comment_desc
 module T = Type_desc

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -704,7 +704,14 @@ and page_t =
 
 and frontmatter =
   let open Odoc_model.Frontmatter in
-  Record [ F ("children", (fun t -> t.children_order), Option (List child)) ]
+  let ignore_loc x = x.Location_.value in
+  Record
+    [
+      F
+        ( "children",
+          (fun t -> Option.map ignore_loc t.children_order),
+          Option (List child) );
+    ]
 
 and child =
   let open Odoc_model.Frontmatter in

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -716,7 +716,9 @@ and frontmatter =
 and child =
   let open Odoc_model.Frontmatter in
   Variant
-    (function Page s -> C ("Page", s, string) | Dir s -> C ("Dir", s, string))
+    (function
+    | { Location_.value = Page s; _ } -> C ("Page", s, string)
+    | { Location_.value = Dir s; _ } -> C ("Dir", s, string))
 
 and implementation_t =
   let open Lang.Implementation in

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -2,6 +2,7 @@ open Astring
 open Odoc_model
 open Odoc_model.Names
 open Or_error
+open Odoc_utils
 
 (*
  * Copyright (c) 2014 Leo White <leo@lpw25.net>

--- a/src/odoc/indexing.ml
+++ b/src/odoc/indexing.ml
@@ -159,16 +159,7 @@ let compile out_format ~output ~warnings_options ~occurrences ~lib_roots
                       ]
                   | Some x -> x
                 in
-                let children_order =
-                  match fm.Frontmatter.children_order with
-                  | None -> None
-                  | Some co ->
-                      Some
-                        (List.filter_map
-                           (function
-                             | `Resolved (`Identifier id) -> Some id | _ -> None)
-                           co)
-                in
+                let children_order = fm.Frontmatter.children_order in
                 (id, title, children_order))
               (List.filter_map
                  (function

--- a/src/odoc/indexing.ml
+++ b/src/odoc/indexing.ml
@@ -1,3 +1,4 @@
+open Odoc_utils
 open Astring
 open Odoc_json_index
 open Or_error
@@ -162,9 +163,9 @@ let compile out_format ~output ~warnings_options ~occurrences ~lib_roots
                 let children_order = fm.Frontmatter.children_order in
                 (id, title, children_order))
               (List.filter_map
-                 (function
-                   | Paths.Identifier.(
-                       ({ iv = #LeafPage.t_pv; _ } as id), pl, fm) ->
+                 Paths.Identifier.(
+                   function
+                   | ({ iv = #LeafPage.t_pv; _ } as id), pl, fm ->
                        Some (id, pl, fm)
                    | _ -> None)
                  pages)

--- a/src/odoc/indexing.ml
+++ b/src/odoc/indexing.ml
@@ -148,18 +148,18 @@ let compile out_format ~output ~warnings_options ~occurrences ~lib_roots
         let pages = Resolver.all_pages ~root:page_root resolver in
         let pages =
           List.map
-            (fun (page_id, title) ->
+            (fun (id, title) ->
               let title =
                 match title with
                 | None ->
                     [
                       Odoc_model.Location_.at
                         (Odoc_model.Location_.span [])
-                        (`Word (Odoc_model.Paths.Identifier.name page_id));
+                        (`Word (Odoc_model.Paths.Identifier.name id));
                     ]
                 | Some x -> x
               in
-              (title, page_id))
+              { title; id })
             pages
         in
         { page_name = page_root; pages })

--- a/src/odoc/indexing.ml
+++ b/src/odoc/indexing.ml
@@ -8,7 +8,7 @@ module H = Odoc_model.Paths.Identifier.Hashtbl.Any
 let handle_file file ~unit ~page ~occ =
   match Fpath.basename file with
   | s when String.is_prefix ~affix:"index-" s ->
-      Odoc_file.load_index file >>= fun (_sidebar, index) -> Ok (occ index)
+      Odoc_file.load_index file >>= fun { index; _ } -> Ok (occ index)
   | _ -> (
       Odoc_file.load file >>= fun unit' ->
       match unit' with
@@ -108,14 +108,14 @@ let compile_to_marshall ~output ~warnings_options sidebar files =
   in
   let result = Error.catch_warnings index in
   result |> Error.handle_warnings ~warnings_options >>= fun () ->
-  Ok (Odoc_file.save_index output (sidebar, final_index))
+  Ok (Odoc_file.save_index output { index = final_index; sidebar })
 
 let read_occurrences file =
   let ic = open_in_bin file in
   let htbl : Odoc_occurrences.Table.t = Marshal.from_channel ic in
   htbl
 
-open Odoc_model.Lang.Sidebar
+open Odoc_model.Sidebar
 
 let compile out_format ~output ~warnings_options ~occurrences ~lib_roots
     ~page_roots ~inputs_in_file ~odocls =
@@ -147,22 +147,40 @@ let compile out_format ~output ~warnings_options ~occurrences ~lib_roots
       (fun (page_root, _) ->
         let pages = Resolver.all_pages ~root:page_root resolver in
         let pages =
-          List.map
-            (fun (id, title) ->
-              let title =
-                match title with
-                | None ->
-                    [
-                      Odoc_model.Location_.at
-                        (Odoc_model.Location_.span [])
-                        (`Word (Odoc_model.Paths.Identifier.name id));
-                    ]
-                | Some x -> x
-              in
-              { title; id })
-            pages
+          let pages =
+            List.map
+              (fun (id, title, fm) ->
+                let title =
+                  match title with
+                  | None ->
+                      [
+                        Location_.at (Location_.span [])
+                          (`Word (Paths.Identifier.name id));
+                      ]
+                  | Some x -> x
+                in
+                let children_order =
+                  match fm.Frontmatter.children_order with
+                  | None -> None
+                  | Some co ->
+                      Some
+                        (List.filter_map
+                           (function
+                             | `Resolved (`Identifier id) -> Some id | _ -> None)
+                           co)
+                in
+                (id, title, children_order))
+              (List.filter_map
+                 (function
+                   | Paths.Identifier.(
+                       ({ iv = #LeafPage.t_pv; _ } as id), pl, fm) ->
+                       Some (id, pl, fm)
+                   | _ -> None)
+                 pages)
+          in
+          PageToc.of_list pages
         in
-        { page_name = page_root; pages })
+        { hierarchy_name = page_root; pages })
       page_roots
   in
   let libraries =

--- a/src/odoc/indexing.ml
+++ b/src/odoc/indexing.ml
@@ -149,26 +149,25 @@ let compile out_format ~output ~warnings_options ~occurrences ~lib_roots
         let pages = Resolver.all_pages ~root:page_root resolver in
         let pages =
           let pages =
-            List.map
-              (fun (id, title, fm) ->
-                let title =
-                  match title with
-                  | None ->
-                      [
-                        Location_.at (Location_.span [])
-                          (`Word (Paths.Identifier.name id));
-                      ]
-                  | Some x -> x
-                in
-                let children_order = fm.Frontmatter.children_order in
-                (id, title, children_order))
-              (List.filter_map
+            pages
+            |> List.filter_map
                  Paths.Identifier.(
                    function
                    | ({ iv = #LeafPage.t_pv; _ } as id), pl, fm ->
                        Some (id, pl, fm)
                    | _ -> None)
-                 pages)
+            |> List.map (fun (id, title, fm) ->
+                   let title =
+                     match title with
+                     | None ->
+                         [
+                           Location_.at (Location_.span [])
+                             (`Word (Paths.Identifier.name id));
+                         ]
+                     | Some x -> x
+                   in
+                   let children_order = fm.Frontmatter.children_order in
+                   (id, title, children_order))
           in
           PageToc.of_list pages
         in

--- a/src/odoc/rendering.ml
+++ b/src/odoc/rendering.ml
@@ -79,7 +79,7 @@ let generate_odoc ~syntax ~warnings_options:_ ~renderer ~output ~extra_suffix
   (match sidebar with
   | None -> Ok None
   | Some x ->
-      Odoc_file.load_index x >>= fun (sidebar, _) ->
+      Odoc_file.load_index x >>= fun { sidebar; index = _ } ->
       Ok (Some (Odoc_document.Sidebar.of_lang sidebar)))
   >>= fun sidebar ->
   document_of_odocl ~syntax file >>= fun doc ->

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -84,7 +84,8 @@ end = struct
       match current_root with
       | Some root ->
           List.fold_left
-            (fun acc (x, dir) -> if String.equal x root then Some dir else acc)
+            (fun acc (x, dir) ->
+              if Astring.String.equal x root then Some dir else acc)
             None pkglist
       | None -> None
     in

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -82,8 +82,10 @@ end = struct
       pkglist;
     let current_root_dir =
       match current_root with
-      | Some root -> (
-          try Some (List.assq root pkglist) with Not_found -> None)
+      | Some root ->
+          List.fold_left
+            (fun acc (x, dir) -> if String.equal x root then Some dir else acc)
+            None pkglist
       | None -> None
     in
     { current_root; table = cache; current_root_dir }
@@ -499,11 +501,11 @@ let all_pages ?root ({ pages; _ } : t) =
   let filter (root : Odoc_model.Root.t) =
     match root with
     | {
-     file = Page { title; _ };
+     file = Page { title; frontmatter; _ };
      id = { iv = #Odoc_model.Paths.Identifier.Page.t_pv; _ } as id;
      _;
     } ->
-        Some (id, title)
+        Some (id, title, frontmatter)
     | _ -> None
   in
   match pages with

--- a/src/odoc/resolver.mli
+++ b/src/odoc/resolver.mli
@@ -47,7 +47,9 @@ val lookup_page : t -> string -> Odoc_model.Lang.Page.t option
 val all_pages :
   ?root:string ->
   t ->
-  (Odoc_model.Paths.Identifier.Page.t * Odoc_model.Comment.link_content option)
+  (Odoc_model.Paths.Identifier.Page.t
+  * Odoc_model.Comment.link_content option
+  * Odoc_model.Frontmatter.t)
   list
 
 val all_units :

--- a/src/odoc/resolver.mli
+++ b/src/odoc/resolver.mli
@@ -19,6 +19,8 @@
     This is the module which does the link between packages, directories and
     {!Odoc_xref2}'s needs. *)
 
+open Odoc_model
+
 type t
 
 type roots = {
@@ -42,15 +44,12 @@ val create :
     @param important_digests indicate whether digests should be compared when
     odoc_xref2 tries to lookup or fetch a unit. It defaults to [true]. *)
 
-val lookup_page : t -> string -> Odoc_model.Lang.Page.t option
+val lookup_page : t -> string -> Lang.Page.t option
 
 val all_pages :
   ?root:string ->
   t ->
-  (Odoc_model.Paths.Identifier.Page.t
-  * Odoc_model.Comment.link_content option
-  * Odoc_model.Frontmatter.t)
-  list
+  (Paths.Identifier.Page.t * Comment.link_content option * Frontmatter.t) list
 
 val all_units :
   library:string -> t -> Odoc_model.Paths.Identifier.RootModule.t list
@@ -58,28 +57,25 @@ val all_units :
 (** Helpers for creating xref2 env. *)
 
 val build_compile_env_for_unit :
-  t -> Odoc_model.Lang.Compilation_unit.t -> Odoc_xref2.Env.t
+  t -> Lang.Compilation_unit.t -> Odoc_xref2.Env.t
 (** Initialize the environment for compiling the given module. *)
 
-val build_link_env_for_unit :
-  t -> Odoc_model.Lang.Compilation_unit.t -> Odoc_xref2.Env.t
+val build_link_env_for_unit : t -> Lang.Compilation_unit.t -> Odoc_xref2.Env.t
 (** Initialize the environment for linking the given module. *)
 
-val build_env_for_page : t -> Odoc_model.Lang.Page.t -> Odoc_xref2.Env.t
+val build_env_for_page : t -> Lang.Page.t -> Odoc_xref2.Env.t
 (** Initialize the environment for the given page. *)
 
-val build_compile_env_for_impl :
-  t -> Odoc_model.Lang.Implementation.t -> Odoc_xref2.Env.t
+val build_compile_env_for_impl : t -> Lang.Implementation.t -> Odoc_xref2.Env.t
 (** Initialize the environment for the given implementation. *)
 
-val build_link_env_for_impl :
-  t -> Odoc_model.Lang.Implementation.t -> Odoc_xref2.Env.t
+val build_link_env_for_impl : t -> Lang.Implementation.t -> Odoc_xref2.Env.t
 (** Initialize the environment for the given implementation. *)
 
 val build_env_for_reference : t -> Odoc_xref2.Env.t
 (** Initialize the environment for a reference. *)
 
-val resolve_import : t -> string -> Odoc_model.Root.t option
+val resolve_import : t -> string -> Root.t option
 (** Similar to {!Odoc_xref2.Env.lookup_root_module} but save work by loading
     only the root. Only used when resolving imports, which are needed for the
     [link-deps] command. *)

--- a/src/utils/odoc_utils.ml
+++ b/src/utils/odoc_utils.ml
@@ -75,20 +75,18 @@ module List = struct
     | [] -> None
     | x :: l -> (
         match f x with Some _ as result -> result | None -> find_map f l)
-
-  let partition_map p l =
-    let rec part left right = function
-      | [] -> (rev left, rev right)
-      | x :: l -> (
-          match p x with
-          | `Left v -> part (v :: left) right l
-          | `Right v -> part left (v :: right) l)
-    in
-    part [] [] l
 end
 
 module Option = struct
   let map f = function None -> None | Some x -> Some (f x)
+
+  let is_some = function None -> false | Some _ -> true
+end
+
+module Result = struct
+  include Result
+
+  let join = function Ok r -> r | Error _ as e -> e
 end
 
 module Fun = struct

--- a/src/utils/odoc_utils.ml
+++ b/src/utils/odoc_utils.ml
@@ -75,6 +75,16 @@ module List = struct
     | [] -> None
     | x :: l -> (
         match f x with Some _ as result -> result | None -> find_map f l)
+
+  let partition_map p l =
+    let rec part left right = function
+      | [] -> (rev left, rev right)
+      | x :: l -> (
+          match p x with
+          | `Left v -> part (v :: left) right l
+          | `Right v -> part left (v :: right) l)
+    in
+    part [] [] l
 end
 
 module Option = struct

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -1145,11 +1145,17 @@ let page env page =
     in
     {
       Frontmatter.children_order =
-        List.map resolve page.frontmatter.children_order;
+        Option.map (List.map resolve) page.frontmatter.children_order;
     }
+  in
+  let root =
+    match page.root.file with
+    | Page p -> { page.root with file = Page { p with frontmatter } }
+    | _ -> assert false
   in
   {
     page with
+    root;
     Page.content = comment_docs env page.Page.name page.content;
     linked = true;
     frontmatter;

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -1133,10 +1133,26 @@ let page env page =
             | None -> Errors.report ~what:(`Child_module mod_) `Lookup))
       page.Lang.Page.children
   in
+  let frontmatter =
+    let resolve r =
+      match Ref_tools.resolve_page_reference env r |> Error.raise_warnings with
+      | Ok (ref_, _c) -> `Resolved ref_
+      | Error e ->
+          Errors.report
+            ~what:(`Reference (r :> Paths.Reference.t))
+            ~tools_error:(`Reference e) `Resolve;
+          r
+    in
+    {
+      Frontmatter.children_order =
+        List.map resolve page.frontmatter.children_order;
+    }
+  in
   {
     page with
     Page.content = comment_docs env page.Page.name page.content;
     linked = true;
+    frontmatter;
   }
 
 let source_info env infos =

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -1133,32 +1133,10 @@ let page env page =
             | None -> Errors.report ~what:(`Child_module mod_) `Lookup))
       page.Lang.Page.children
   in
-  let frontmatter =
-    let resolve r =
-      match Ref_tools.resolve_page_reference env r |> Error.raise_warnings with
-      | Ok (ref_, _c) -> `Resolved ref_
-      | Error e ->
-          Errors.report
-            ~what:(`Reference (r :> Paths.Reference.t))
-            ~tools_error:(`Reference e) `Resolve;
-          r
-    in
-    {
-      Frontmatter.children_order =
-        Option.map (List.map resolve) page.frontmatter.children_order;
-    }
-  in
-  let root =
-    match page.root.file with
-    | Page p -> { page.root with file = Page { p with frontmatter } }
-    | _ -> assert false
-  in
   {
     page with
-    root;
     Page.content = comment_docs env page.Page.name page.content;
     linked = true;
-    frontmatter;
   }
 
 let source_info env infos =

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -816,13 +816,6 @@ and resolve_module_reference env (r : Module.t) : M.t ref_result =
   | `Root (name, _) -> M.in_env env name
   | `Module_path p -> Path.module_in_env env p
 
-let resolve_page_reference env (r : Reference.Page.t) :
-    page_lookup_result ref_result =
-  match r with
-  | `Resolved _r -> failwith "What's going on!?"
-  | `Page_path p -> Path.page_in_env env p
-  | `Root (name, _) -> Page.in_env env name
-
 let resolve_class_signature_reference env (r : ClassSignature.t) =
   (* Casting from ClassSignature to LabelParent.
      TODO: Add [resolve_class_signature_reference] when it's easier to implement. *)
@@ -1010,9 +1003,6 @@ let resolve_reference :
 
 let resolve_module_reference env m =
   Odoc_model.Error.catch_warnings (fun () -> resolve_module_reference env m)
-
-let resolve_page_reference env m =
-  Odoc_model.Error.catch_warnings (fun () -> resolve_page_reference env m)
 
 let resolve_asset_reference env m =
   Odoc_model.Error.catch_warnings (fun () -> resolve_asset_reference env m)

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -816,6 +816,13 @@ and resolve_module_reference env (r : Module.t) : M.t ref_result =
   | `Root (name, _) -> M.in_env env name
   | `Module_path p -> Path.module_in_env env p
 
+let resolve_page_reference env (r : Reference.Page.t) :
+    page_lookup_result ref_result =
+  match r with
+  | `Resolved _r -> failwith "What's going on!?"
+  | `Page_path p -> Path.page_in_env env p
+  | `Root (name, _) -> Page.in_env env name
+
 let resolve_class_signature_reference env (r : ClassSignature.t) =
   (* Casting from ClassSignature to LabelParent.
      TODO: Add [resolve_class_signature_reference] when it's easier to implement. *)
@@ -1003,6 +1010,9 @@ let resolve_reference :
 
 let resolve_module_reference env m =
   Odoc_model.Error.catch_warnings (fun () -> resolve_module_reference env m)
+
+let resolve_page_reference env m =
+  Odoc_model.Error.catch_warnings (fun () -> resolve_page_reference env m)
 
 let resolve_asset_reference env m =
   Odoc_model.Error.catch_warnings (fun () -> resolve_asset_reference env m)

--- a/src/xref2/ref_tools.mli
+++ b/src/xref2/ref_tools.mli
@@ -14,11 +14,6 @@ val resolve_module_reference :
   Module.t ->
   module_lookup_result ref_result Odoc_model.Error.with_warnings
 
-val resolve_page_reference :
-  Env.t ->
-  Page.t ->
-  page_lookup_result ref_result Odoc_model.Error.with_warnings
-
 val resolve_asset_reference :
   Env.t ->
   Asset.t ->

--- a/src/xref2/ref_tools.mli
+++ b/src/xref2/ref_tools.mli
@@ -2,6 +2,7 @@ open Odoc_model.Paths.Reference
 
 type module_lookup_result =
   Resolved.Module.t * Cpath.Resolved.module_ * Component.Module.t
+type page_lookup_result = Resolved.Page.t * Odoc_model.Lang.Page.t
 
 type asset_lookup_result = Resolved.Asset.t
 
@@ -12,6 +13,11 @@ val resolve_module_reference :
   Env.t ->
   Module.t ->
   module_lookup_result ref_result Odoc_model.Error.with_warnings
+
+val resolve_page_reference :
+  Env.t ->
+  Page.t ->
+  page_lookup_result ref_result Odoc_model.Error.with_warnings
 
 val resolve_asset_reference :
   Env.t ->

--- a/src/xref2/ref_tools.mli
+++ b/src/xref2/ref_tools.mli
@@ -2,7 +2,6 @@ open Odoc_model.Paths.Reference
 
 type module_lookup_result =
   Resolved.Module.t * Cpath.Resolved.module_ * Component.Module.t
-type page_lookup_result = Resolved.Page.t * Odoc_model.Lang.Page.t
 
 type asset_lookup_result = Resolved.Asset.t
 

--- a/test/pages/frontmatter.t/one_frontmatter.mld
+++ b/test/pages/frontmatter.t/one_frontmatter.mld
@@ -1,6 +1,5 @@
 {0 One frontmatter}
 
 {@meta[
-bli1: bloblobloblo1
-bli2: bloblobloblo2
+children: page1 page2
 ]}

--- a/test/pages/frontmatter.t/run.t
+++ b/test/pages/frontmatter.t/run.t
@@ -3,7 +3,7 @@ When there is no frontmatter, everything is normal
   $ odoc compile zero_frontmatter.mld
   $ odoc_print page-zero_frontmatter.odoc | jq '.frontmatter'
   {
-    "children": []
+    "children": "None"
   }
 
 When there is one frontmatter, it is extracted from the content:
@@ -11,32 +11,19 @@ When there is one frontmatter, it is extracted from the content:
   $ odoc compile one_frontmatter.mld
   $ odoc_print page-one_frontmatter.odoc | jq '.frontmatter'
   {
-    "children": [
-      {
-        "`Page_path": [
-          "`TRelativePath",
-          [
-            ""
-          ]
-        ]
-      },
-      {
-        "`Page_path": [
-          "`TRelativePath",
-          [
-            "page1"
-          ]
-        ]
-      },
-      {
-        "`Page_path": [
-          "`TRelativePath",
-          [
-            "page2"
-          ]
-        ]
-      }
-    ]
+    "children": {
+      "Some": [
+        {
+          "Page": ""
+        },
+        {
+          "Page": "page1"
+        },
+        {
+          "Page": "page2"
+        }
+      ]
+    }
   }
   $ odoc_print page-one_frontmatter.odoc | jq '.content'
   [
@@ -75,7 +62,7 @@ When there is more than one frontmatter, they are all extracted from the content
   $ odoc compile two_frontmatters.mld
   $ odoc_print page-two_frontmatters.odoc | jq '.frontmatter'
   {
-    "children": []
+    "children": "None"
   }
   $ odoc_print page-two_frontmatters.odoc | jq '.content'
   [

--- a/test/pages/frontmatter.t/run.t
+++ b/test/pages/frontmatter.t/run.t
@@ -14,9 +14,6 @@ When there is one frontmatter, it is extracted from the content:
     "children": {
       "Some": [
         {
-          "Page": ""
-        },
-        {
           "Page": "page1"
         },
         {

--- a/test/pages/frontmatter.t/run.t
+++ b/test/pages/frontmatter.t/run.t
@@ -2,22 +2,42 @@ When there is no frontmatter, everything is normal
 
   $ odoc compile zero_frontmatter.mld
   $ odoc_print page-zero_frontmatter.odoc | jq '.frontmatter'
-  []
+  {
+    "children": []
+  }
 
 When there is one frontmatter, it is extracted from the content:
 
   $ odoc compile one_frontmatter.mld
   $ odoc_print page-one_frontmatter.odoc | jq '.frontmatter'
-  [
-    [
-      "bli1",
-      " bloblobloblo1"
-    ],
-    [
-      "bli2",
-      " bloblobloblo2"
+  {
+    "children": [
+      {
+        "`Page_path": [
+          "`TRelativePath",
+          [
+            ""
+          ]
+        ]
+      },
+      {
+        "`Page_path": [
+          "`TRelativePath",
+          [
+            "page1"
+          ]
+        ]
+      },
+      {
+        "`Page_path": [
+          "`TRelativePath",
+          [
+            "page2"
+          ]
+        ]
+      }
     ]
-  ]
+  }
   $ odoc_print page-one_frontmatter.odoc | jq '.content'
   [
     {
@@ -54,20 +74,9 @@ When there is more than one frontmatter, they are all extracted from the content
 
   $ odoc compile two_frontmatters.mld
   $ odoc_print page-two_frontmatters.odoc | jq '.frontmatter'
-  [
-    [
-      "bli3",
-      " bloblobloblo1"
-    ],
-    [
-      "bli1",
-      " bloblobloblo1"
-    ],
-    [
-      "bli2",
-      " bloblobloblo2"
-    ]
-  ]
+  {
+    "children": []
+  }
   $ odoc_print page-two_frontmatters.odoc | jq '.content'
   [
     {

--- a/test/pages/frontmatter.t/run.t
+++ b/test/pages/frontmatter.t/run.t
@@ -9,6 +9,8 @@ When there is no frontmatter, everything is normal
 When there is one frontmatter, it is extracted from the content:
 
   $ odoc compile one_frontmatter.mld
+  File "one_frontmatter.mld":
+  Warning: Non-index page cannot specify (children _) in the frontmatter.
   $ odoc_print page-one_frontmatter.odoc | jq '.frontmatter'
   {
     "children": {

--- a/test/pages/toc_order.t/content.mld
+++ b/test/pages/toc_order.t/content.mld
@@ -1,0 +1,1 @@
+{0 Ten reasons why}

--- a/test/pages/toc_order.t/content.mld
+++ b/test/pages/toc_order.t/content.mld
@@ -1,1 +1,1 @@
-{0 Ten reasons why}
+{0 This is top level content}

--- a/test/pages/toc_order.t/dir1/content_in_dir.mld
+++ b/test/pages/toc_order.t/dir1/content_in_dir.mld
@@ -1,0 +1,1 @@
+{0 This is some content}

--- a/test/pages/toc_order.t/dir1/content_in_dir.mld
+++ b/test/pages/toc_order.t/dir1/content_in_dir.mld
@@ -1,1 +1,1 @@
-{0 This is some content}
+{0 This is some content in dir1}

--- a/test/pages/toc_order.t/dir1/dontent.mld
+++ b/test/pages/toc_order.t/dir1/dontent.mld
@@ -1,0 +1,1 @@
+{0 The name is dontent}

--- a/test/pages/toc_order.t/dir1/index.mld
+++ b/test/pages/toc_order.t/dir1/index.mld
@@ -1,5 +1,1 @@
-{0 Check this out}
-
-{@meta[
-children:content_in_dir
-]}
+{0 This is dir1's index}

--- a/test/pages/toc_order.t/dir1/index.mld
+++ b/test/pages/toc_order.t/dir1/index.mld
@@ -1,0 +1,5 @@
+{0 Check this out}
+
+{@meta[
+children:content_in_dir
+]}

--- a/test/pages/toc_order.t/index.mld
+++ b/test/pages/toc_order.t/index.mld
@@ -1,0 +1,7 @@
+{0 This index has a name}
+
+Hello
+
+{@meta[
+children: content dir1/
+]}

--- a/test/pages/toc_order.t/index.mld
+++ b/test/pages/toc_order.t/index.mld
@@ -1,7 +1,7 @@
-{0 This index has a name}
+{0 This is the main index}
 
 Hello
 
 {@meta[
-children: content dir1/
+children: content dir1/ typo
 ]}

--- a/test/pages/toc_order.t/index.mld
+++ b/test/pages/toc_order.t/index.mld
@@ -3,5 +3,5 @@
 Hello
 
 {@meta[
-children: content dir1/ typo
+children: content dir1/ dir1/ typo
 ]}

--- a/test/pages/toc_order.t/omitted.mld
+++ b/test/pages/toc_order.t/omitted.mld
@@ -1,0 +1,1 @@
+{0 This one is omitted}

--- a/test/pages/toc_order.t/run.t
+++ b/test/pages/toc_order.t/run.t
@@ -1,19 +1,25 @@
   $ odoc compile --parent-id pkg/doc --output-dir _odoc index.mld
   $ odoc compile --parent-id pkg/doc --output-dir _odoc content.mld
+  $ odoc compile --parent-id pkg/doc --output-dir _odoc omitted.mld
   $ odoc compile --parent-id pkg/doc/dir1 --output-dir _odoc dir1/index.mld
   $ odoc compile --parent-id pkg/doc/dir1 --output-dir _odoc dir1/content_in_dir.mld
+  $ odoc compile --parent-id pkg/doc/dir1 --output-dir _odoc dir1/dontent.mld
 
   $ odoc link _odoc/pkg/doc/page-index.odoc
   $ odoc link _odoc/pkg/doc/page-content.odoc
+  $ odoc link _odoc/pkg/doc/page-omitted.odoc
   $ odoc link _odoc/pkg/doc/dir1/page-index.odoc
   $ odoc link _odoc/pkg/doc/dir1/page-content_in_dir.odoc
+  $ odoc link _odoc/pkg/doc/dir1/page-dontent.odoc
 
   $ odoc compile-index -P test:_odoc/pkg/doc
 
-  $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/page-index.odocl
+  $ odoc html-generate --indent --index index.odoc-index -o _html  _odoc/pkg/doc/page-index.odocl
   $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/page-content.odocl
+  $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/page-omitted.odocl
   $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/dir1/page-index.odocl
   $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/dir1/page-content_in_dir.odocl
+  $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/dir1/page-dontent.odocl
   $ odoc support-files -o _html
 
   $ odoc_print _odoc/pkg/doc/page-index.odocl | jq .frontmatter
@@ -25,10 +31,33 @@
         },
         {
           "Dir": "dir1"
+        },
+        {
+          "Page": "typo"
         }
       ]
     }
   }
 
 
-  $ cp -r _html /tmp/html
+$ cp -r _html /tmp/html
+
+The order in toplevel should be as given by the children field, and by
+alphabetical order on the filename in dir1.
+Omitted has been omitted in the children of index, so it does not appear.
+Typo is in the children field of index, but does not exist. It is omitted to,
+but this should be a warning!
+
+  $ cat _html/pkg/doc/index.html | grep odoc-global-toc -A 11
+     <nav class="odoc-toc odoc-global-toc"><b>test's Pages</b>
+      <ul>
+       <li><a href="#" class="current_unit">This is the main index</a>
+        <ul><li><a href="content.html">This is top level content</a></li>
+         <li><a href="dir1/index.html">This is dir1's index</a>
+          <ul>
+           <li>
+            <a href="dir1/content_in_dir.html">This is some content in dir1</a>
+           </li><li><a href="dir1/dontent.html">The name is dontent</a></li>
+          </ul>
+         </li>
+        </ul>

--- a/test/pages/toc_order.t/run.t
+++ b/test/pages/toc_order.t/run.t
@@ -10,74 +10,24 @@
 
   $ odoc compile-index -P test:_odoc/pkg/doc
 
-  $ ls
-  _odoc
-  content.mld
-  dir1
-  index.mld
-  index.odoc-index
-
   $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/page-index.odocl
   $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/page-content.odocl
   $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/dir1/page-index.odocl
   $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/dir1/page-content_in_dir.odocl
   $ odoc support-files -o _html
 
-  $ odoc_print _odoc/pkg/doc/page-index.odocl
+  $ odoc_print _odoc/pkg/doc/page-index.odocl | jq .frontmatter
   {
-    "name": {
-      "`LeafPage": [
+    "children": {
+      "Some": [
         {
-          "Some": {
-            "`Page": [ { "Some": { "`Page": [ "None", "pkg" ] } }, "doc" ]
-          }
+          "Page": "content"
         },
-        "index"
+        {
+          "Dir": "dir1"
+        }
       ]
-    },
-    "root": "<root>",
-    "frontmatter": {
-      "children": {
-        "Some": [ { "Page": "" }, { "Page": "content" }, { "Dir": "dir1" } ]
-      }
-    },
-    "content": [
-      {
-        "`Heading": [
-          { "heading_level": "`Title", "heading_label_explicit": "false" },
-          {
-            "`Label": [
-              {
-                "`LeafPage": [
-                  {
-                    "Some": {
-                      "`Page": [
-                        { "Some": { "`Page": [ "None", "pkg" ] } }, "doc"
-                      ]
-                    }
-                  },
-                  "index"
-                ]
-              },
-              "this-index-has-a-name"
-            ]
-          },
-          [
-            { "`Word": "This" },
-            "`Space",
-            { "`Word": "index" },
-            "`Space",
-            { "`Word": "has" },
-            "`Space",
-            { "`Word": "a" },
-            "`Space",
-            { "`Word": "name" }
-          ]
-        ]
-      },
-      { "`Paragraph": [ { "`Word": "Hello" } ] }
-    ],
-    "digest": "<digest>"
+    }
   }
 
 

--- a/test/pages/toc_order.t/run.t
+++ b/test/pages/toc_order.t/run.t
@@ -1,0 +1,84 @@
+  $ odoc compile --parent-id pkg/doc --output-dir _odoc index.mld
+  $ odoc compile --parent-id pkg/doc --output-dir _odoc content.mld
+  $ odoc compile --parent-id pkg/doc/dir1 --output-dir _odoc dir1/index.mld
+  $ odoc compile --parent-id pkg/doc/dir1 --output-dir _odoc dir1/content_in_dir.mld
+
+  $ odoc link _odoc/pkg/doc/page-index.odoc
+  $ odoc link _odoc/pkg/doc/page-content.odoc
+  $ odoc link _odoc/pkg/doc/dir1/page-index.odoc
+  $ odoc link _odoc/pkg/doc/dir1/page-content_in_dir.odoc
+
+  $ odoc compile-index -P test:_odoc/pkg/doc
+
+  $ ls
+  _odoc
+  content.mld
+  dir1
+  index.mld
+  index.odoc-index
+
+  $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/page-index.odocl
+  $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/page-content.odocl
+  $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/dir1/page-index.odocl
+  $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/dir1/page-content_in_dir.odocl
+  $ odoc support-files -o _html
+
+  $ odoc_print _odoc/pkg/doc/page-index.odocl
+  {
+    "name": {
+      "`LeafPage": [
+        {
+          "Some": {
+            "`Page": [ { "Some": { "`Page": [ "None", "pkg" ] } }, "doc" ]
+          }
+        },
+        "index"
+      ]
+    },
+    "root": "<root>",
+    "frontmatter": {
+      "children": {
+        "Some": [ { "Page": "" }, { "Page": "content" }, { "Dir": "dir1" } ]
+      }
+    },
+    "content": [
+      {
+        "`Heading": [
+          { "heading_level": "`Title", "heading_label_explicit": "false" },
+          {
+            "`Label": [
+              {
+                "`LeafPage": [
+                  {
+                    "Some": {
+                      "`Page": [
+                        { "Some": { "`Page": [ "None", "pkg" ] } }, "doc"
+                      ]
+                    }
+                  },
+                  "index"
+                ]
+              },
+              "this-index-has-a-name"
+            ]
+          },
+          [
+            { "`Word": "This" },
+            "`Space",
+            { "`Word": "index" },
+            "`Space",
+            { "`Word": "has" },
+            "`Space",
+            { "`Word": "a" },
+            "`Space",
+            { "`Word": "name" }
+          ]
+        ]
+      },
+      { "`Paragraph": [ { "`Word": "Hello" } ] }
+    ],
+    "digest": "<digest>"
+  }
+
+
+  $ cp -r _html /tmp/html

--- a/test/pages/toc_order.t/run.t
+++ b/test/pages/toc_order.t/run.t
@@ -44,7 +44,7 @@ $ cp -r _html /tmp/html
 
 The order in toplevel should be as given by the children field, and by
 alphabetical order on the filename in dir1.
-Omitted has been omitted in the children of index, so it does not appear.
+Omitted has been added in the children of index, after the ones that were ordered.
 Typo is in the children field of index, but does not exist. It is omitted to,
 but this should be a warning!
 
@@ -59,5 +59,5 @@ but this should be a warning!
             <a href="dir1/content_in_dir.html">This is some content in dir1</a>
            </li><li><a href="dir1/dontent.html">The name is dontent</a></li>
           </ul>
-         </li>
+         </li><li><a href="omitted.html">This one is omitted</a></li>
         </ul>

--- a/test/pages/toc_order.t/run.t
+++ b/test/pages/toc_order.t/run.t
@@ -14,6 +14,10 @@
 
   $ odoc compile-index -P test:_odoc/pkg/doc
   File "index.mld", line 5, character 7 to line 7, character 0:
+  Warning: Duplicate 'dir1/' in (children).
+  File "index.mld", line 5, character 7 to line 7, character 0:
+  Warning: 'typo' in (children) does not correspond to anything.
+  File "index.mld", line 5, character 7 to line 7, character 0:
   Warning: (children) doesn't include 'omitted'.
 
   $ odoc html-generate --indent --index index.odoc-index -o _html  _odoc/pkg/doc/page-index.odocl
@@ -30,6 +34,9 @@
       "Some": [
         {
           "Page": "content"
+        },
+        {
+          "Dir": "dir1"
         },
         {
           "Dir": "dir1"

--- a/test/pages/toc_order.t/run.t
+++ b/test/pages/toc_order.t/run.t
@@ -13,6 +13,8 @@
   $ odoc link _odoc/pkg/doc/dir1/page-dontent.odoc
 
   $ odoc compile-index -P test:_odoc/pkg/doc
+  File "index.mld", line 5, character 7 to line 7, character 0:
+  Warning: (children) doesn't include 'omitted'.
 
   $ odoc html-generate --indent --index index.odoc-index -o _html  _odoc/pkg/doc/page-index.odocl
   $ odoc html-generate --index index.odoc-index -o _html  _odoc/pkg/doc/page-content.odocl

--- a/test/parent_id/sidebar.t/run.t
+++ b/test/parent_id/sidebar.t/run.t
@@ -23,10 +23,10 @@
      <nav class="odoc-toc odoc-global-toc"><b>pkg's Pages</b>
       <ul>
        <li><a href="#" class="current_unit">Package <code>pkg</code></a>
-        <ul><li><a href="file.html">File</a></li>
+        <ul>
          <li><a href="dir1/index.html">A directory</a>
           <ul><li><a href="dir1/my_page.html">My page</a></li></ul>
-         </li>
+         </li><li><a href="file.html">File</a></li>
         </ul>
        </li>
       </ul><b>Libraries</b>
@@ -41,11 +41,11 @@
      <nav class="odoc-toc odoc-global-toc"><b>pkg's Pages</b>
       <ul>
        <li><a href="../../../doc/index.html">Package <code>pkg</code></a>
-        <ul><li><a href="../../../doc/file.html">File</a></li>
+        <ul>
          <li><a href="../../../doc/dir1/index.html">A directory</a>
           <ul><li><a href="../../../doc/dir1/my_page.html">My page</a></li>
           </ul>
-         </li>
+         </li><li><a href="../../../doc/file.html">File</a></li>
         </ul>
        </li>
       </ul><b>Libraries</b>


### PR DESCRIPTION
Now that we have a convention for hierarchical pages, we need a way for the author to specify the order.

This PR does that by using the frontmatter, using this syntax:

```
children: child1 dir1/ child2 dir2/
```

The trailing `/` for directories is needed to distinguish them from files.

This PR is mostly ready, but:
- TODO warnings:
  - [x] warn when a children field is given in the frontmatter of a non index page,
  - [x] warn when an entry of the `children` list is not found (should it happen during `linking` of the page or during the `compile-index` command?)
  - [x] Test those warnings
- Decide what to do when a children is omitted from the list: 
   - :x: do not include it in the toc (I'm in favor, this is what is implemented)? 
   - [X] :heavy_check_mark:  Include it at the end of the list (I'm not in favor)?
   - [X] :heavy_check_mark: Warn the user?
-  Decide what to do when there is no `children` list in an index page:
   - :x: Warn the user? (not in favor!)
   - [X] :heavy_check_mark: Use alphabetical order on unit names (in favor, this is what the current PR does)
   - :x: Use the alphabetical order on page main title (not in favor!)
- [x] Clean up/factor the implementation of `PageToc`.
- [x] Fix compat CI