### PR TITLE
CI: Run the driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           opam-pin: false
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-local-packages: |
-            odoc.opam
+            odoc-parser.opam odoc.opam
 
       - name: Install dependencies
         run: opam install -y --deps-only -t ./odoc.opam ./odoc-parser.opam

--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -1,0 +1,37 @@
+name: "Driver"
+
+on:
+  - pull_request
+
+jobs:
+  build: # Check build on various OSes
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 5.2.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Clone the project
+      - uses: actions/checkout@v2
+
+      # Setup
+      - name: Setup OCaml ${{ matrix.ocaml-version }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-local-packages: odoc-parser.opam odoc.opam odoc-driver.opam
+
+      - name: Install dependencies
+        run: |
+          opam install -y --deps-only -t ./odoc-parser.opam ./odoc.opam ./odoc-driver.opam
+          opam install -y base # Input to the driver
+
+      - name: Run the driver
+        run: |
+          opam exec -- dune exec -- odoc_driver -p base
+          echo "Generated $(find _html -name '*.html' | wc -l) pages"


### PR DESCRIPTION
This builds the doc of `base` in CI to ensure that the driver works. This will also check that the pinned version of sherlodoc is compatible.