### PR TITLE
Revert "driver depend on sherlodoc"

### DIFF
--- a/odoc-driver.opam
+++ b/odoc-driver.opam
@@ -44,7 +44,6 @@ depends: [
   "eio_main"
   "progress"
   "cmdliner"
-  "sherlodoc"
 ]
 
 build: [
@@ -60,7 +59,4 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-]
-pin-depends: [
-  [ "sherlodoc.dev" "git+https://github.com/art-w/sherlodoc#0357233acf56936db6760cba573f7e77750b5428"]
 ]


### PR DESCRIPTION
This reverts https://github.com/ocaml/odoc/pull/1197 as it breaks the CI and fixing it requires quite a bit of technology. The way ocaml-ci installs dependencies seems to be incompatible with having dependency of the form `local package -> other package -> local package`.