### PR TITLE
Fix using `odoc_driver` to build `odoc`

### DIFF
--- a/src/driver/ocamlfind.ml
+++ b/src/driver/ocamlfind.ml
@@ -6,7 +6,7 @@ let init =
       let prefix = Opam.prefix () in
       let env_camllib = Fpath.(v prefix / "lib" / "ocaml" |> to_string) in
       let config = Fpath.(v prefix / "lib" / "findlib.conf" |> to_string) in
-      Findlib.init ~config ~env_camllib ()
+      Findlib.init ~env_ocamlpath:"" ~config ~env_camllib ()
 
 let all () =
   init ();


### PR DESCRIPTION
Quoting the docs of the Findlib library:

> * Furthermore, the environment variables OCAMLPATH, OCAMLFIND_DESTDIR,
> * OCAMLFIND_COMMANDS, OCAMLFIND_IGNORE_DUPS_IN, and CAMLLIB are interpreted.
> * By default, the function takes
> * the values found in the environment, but you can pass different values
> * using the [env_*] arguments. By setting these values to empty strings
> * they are no longer considered.

So when we do

```
dune exec -- odoc_driver -p odoc
```

findlib finds the `odoc` library in `_build/install` in some part of the codebase[^1], in `<opam switch>/lib/odoc` in some other parts of the code, which results in the docs for `odoc` not being built.

This changes to consistently find the `<opam switch>/lib/odoc`.

[^1]: ~because the `ocamlpath` of _compile time_ was used!~ Missread...