### PR TITLE
Vendor sherlodoc as a submodule and run the driver in CI

### DIFF
--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -1,0 +1,39 @@
+name: "Driver"
+
+on:
+  - pull_request
+
+jobs:
+  build: # Check build on various OSes
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 5.2.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Clone the project
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # Setup
+      - name: Setup OCaml ${{ matrix.ocaml-version }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-local-packages: odoc-parser.opam odoc.opam odoc-driver.opam sherlodoc/sherlodoc.opam
+
+      - name: Install dependencies
+        run: |
+          opam install -y --deps-only -t ./odoc-parser.opam ./odoc.opam ./odoc-driver.opam sherlodoc/sherlodoc.opam
+          opam install -y base # Input to the driver
+
+      - name: Run the driver
+        run: |
+          opam exec -- dune exec -- odoc_driver -p base
+          echo "Generated $(find _html -name '*.html' | wc -l) pages"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "sherlodoc"]
+	path = sherlodoc
+	url = https://github.com/Julow/sherlodoc
+	branch = odoc3_compat

--- a/dune
+++ b/dune
@@ -23,3 +23,5 @@
   (progn
    (bash "diff doc/driver.mld doc/driver.mld.corrected >&2 || true")
    (cat doc/driver-benchmarks.json))))
+
+(vendored_dirs sherlodoc)

--- a/odoc-driver.opam
+++ b/odoc-driver.opam
@@ -45,6 +45,7 @@ depends: [
   "progress"
   "cmdliner"
   "sexplib"
+  "sherlodoc"
 ]
 
 build: [

--- a/src/driver/dune
+++ b/src/driver/dune
@@ -2,7 +2,8 @@
  (public_name odoc_driver)
  (package odoc-driver)
  (link_deps
-  (package odoc))
+  (package odoc)
+  (package sherlodoc))
  (libraries
   cmdliner
   bos


### PR DESCRIPTION
This vendors Sherlodoc as a submodule to make running the driver easier locally and in CI.
This allows the CI to check that the driver runs without errors and that sherlodoc continues to build.
Currently, it's checked out to <https://github.com/EmileTrotignon/sherlodoc/pull/1>. It's expected that the remote and branch of the submodule is changed often.
When testing the driver, make sure to have sherlodoc in the workspace with `git submodule update --init`.
