### PR TITLE
Docs CI compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,8 @@
 - Fix misprinting of type variables from ml files for OCaml 4.14 and later
   (multiple occurences of the same type variable could be named differently)
   (@octachron, #1173)
+- Fix bug where source rendering would cause odoc to fail completely if it
+  encounters invalid syntax (@jonludlam #1208)
 
 
 # 2.4.0

--- a/odoc-driver.opam
+++ b/odoc-driver.opam
@@ -45,6 +45,7 @@ depends: [
   "progress"
   "cmdliner"
   "sexplib"
+  "ppx_sexp_conv"
 ]
 
 build: [

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -8,7 +8,11 @@ let mk_byhash (pkgs : Odoc_unit.t list) =
   List.fold_left
     (fun acc (u : Odoc_unit.t) ->
       match u.Odoc_unit.kind with
-      | `Intf { hash; _ } as kind -> Util.StringMap.add hash { u with kind } acc
+      | `Intf { hash; _ } as kind ->
+          let elt = { u with kind } in
+          Util.StringMap.update hash
+            (function None -> Some [ elt ] | Some x -> Some (elt :: x))
+            acc
       | _ -> acc)
     Util.StringMap.empty pkgs
 
@@ -50,8 +54,8 @@ let init_stats (units : Odoc_unit.t list) =
 open Eio.Std
 
 type partial =
-  (string * Odoc_unit.intf Odoc_unit.unit) list
-  * Odoc_unit.intf Odoc_unit.unit Util.StringMap.t
+  (string * Odoc_unit.intf Odoc_unit.unit list) list
+  * Odoc_unit.intf Odoc_unit.unit list Util.StringMap.t
 
 let unmarshal filename : partial =
   let ic = open_in_bin (Fpath.to_string filename) in
@@ -66,8 +70,8 @@ let marshal (v : partial) filename =
     ~finally:(fun () -> close_out oc)
     (fun () -> Marshal.to_channel oc v [])
 
-let find_partials odoc_dir : Odoc_unit.intf Odoc_unit.unit Util.StringMap.t * _
-    =
+let find_partials odoc_dir :
+    Odoc_unit.intf Odoc_unit.unit list Util.StringMap.t * _ =
   let tbl = Hashtbl.create 1000 in
   let hashes_result =
     OS.Dir.fold_contents ~dotfiles:false ~elements:`Dirs
@@ -100,42 +104,47 @@ let compile ?partial ~partial_dir ?linked_dir:_ (all : Odoc_unit.t list) =
       | None -> (Util.StringMap.empty, Hashtbl.create 10)
     in
     let all_hashes =
-      Util.StringMap.union (fun _x o1 _o2 -> Some o1) hashes other_hashes
+      Util.StringMap.union (fun _x o1 o2 -> Some (o1 @ o2)) hashes other_hashes
     in
     let compile_one compile_other hash =
       match Util.StringMap.find_opt hash all_hashes with
       | None ->
           Logs.debug (fun m -> m "Error locating hash: %s" hash);
           Error Not_found
-      | Some unit ->
-          let deps = match unit.kind with `Intf { deps; _ } -> deps in
-          let _fibers =
-            Fiber.List.map
-              (fun (other_unit : Odoc_unit.intf Odoc_unit.unit) ->
-                match compile_other other_unit with
-                | Ok r -> Some r
-                | Error _exn ->
-                    Logs.debug (fun m ->
-                        m
-                          "Error during compilation of module %s (hash %s, \
-                           required by %s)"
-                          (Fpath.filename other_unit.input_file)
-                          (match other_unit.kind with
-                          | `Intf { hash; _ } -> hash)
-                          (Fpath.filename unit.input_file));
-                    None)
-              deps
-          in
-          let includes = unit.include_dirs in
-          Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
-            ~includes ~parent_id:unit.parent_id;
-          Atomic.incr Stats.stats.compiled_units;
+      | Some units ->
+          Ok
+            (List.map
+               (fun (unit : Odoc_unit.intf Odoc_unit.unit) ->
+                 let deps = match unit.kind with `Intf { deps; _ } -> deps in
+                 let _fibers =
+                   Fiber.List.map
+                     (fun (other_unit : Odoc_unit.intf Odoc_unit.unit) ->
+                       match compile_other other_unit with
+                       | Ok r -> Some r
+                       | Error _exn ->
+                           Logs.debug (fun m ->
+                               m
+                                 "Error during compilation of module %s (hash \
+                                  %s, required by %s)"
+                                 (Fpath.filename other_unit.input_file)
+                                 (match other_unit.kind with
+                                 | `Intf { hash; _ } -> hash)
+                                 (Fpath.filename unit.input_file));
+                           None)
+                     deps
+                 in
+                 let includes = unit.include_dirs in
+                 Odoc.compile ~output_dir:unit.output_dir
+                   ~input_file:unit.input_file ~includes
+                   ~parent_id:unit.parent_id;
+                 Atomic.incr Stats.stats.compiled_units;
 
-          Ok unit
+                 unit)
+               units)
     in
     let rec compile_mod :
         Odoc_unit.intf Odoc_unit.unit ->
-        (Odoc_unit.intf Odoc_unit.unit, exn) Result.t =
+        (Odoc_unit.intf Odoc_unit.unit list, exn) Result.t =
      fun unit ->
       let hash = match unit.kind with `Intf { hash; _ } -> hash in
       match Hashtbl.find_opt tbl hash with
@@ -153,7 +162,7 @@ let compile ?partial ~partial_dir ?linked_dir:_ (all : Odoc_unit.t list) =
   let compile (unit : Odoc_unit.t) =
     match unit.kind with
     | `Intf _ as kind ->
-        (compile_mod { unit with kind } :> (Odoc_unit.t, _) Result.t)
+        (compile_mod { unit with kind } :> (Odoc_unit.t list, _) Result.t)
     | `Impl src ->
         let includes = unit.include_dirs in
         let source_id = src.src_id in
@@ -161,25 +170,35 @@ let compile ?partial ~partial_dir ?linked_dir:_ (all : Odoc_unit.t list) =
           ~input_file:unit.input_file ~includes ~parent_id:unit.parent_id
           ~source_id;
         Atomic.incr Stats.stats.compiled_impls;
-        Ok unit
+        Ok [ unit ]
     | `Asset ->
         Odoc.compile_asset ~output_dir:unit.output_dir ~parent_id:unit.parent_id
           ~name:(Fpath.filename unit.input_file);
         Atomic.incr Stats.stats.compiled_assets;
-        Ok unit
+        Ok [ unit ]
     | `Mld ->
         let includes = unit.include_dirs in
         Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
           ~includes ~parent_id:unit.parent_id;
         Atomic.incr Stats.stats.compiled_mlds;
-        Ok unit
+        Ok [ unit ]
   in
   let res = Fiber.List.map compile all in
   (* For voodoo mode, we need to keep which modules successfully compiled *)
   let zipped =
     List.filter_map
       (function
-        | Ok (Odoc_unit.{ kind = `Intf { hash; _ }; _ } as b) -> Some (hash, b)
+        | Ok (Odoc_unit.{ kind = `Intf { hash; _ }; _ } :: _ as b) ->
+            let l =
+              List.filter_map
+                (function
+                  | Odoc_unit.{ kind = `Intf { hash = hash'; _ }; _ } as x
+                    when hash' = hash ->
+                      Some x
+                  | _ -> None)
+                b
+            in
+            Some (hash, l)
         | _ -> None)
       res
   in

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -195,7 +195,7 @@ let link : compiled list -> _ =
   let link : compiled -> linked =
    fun c ->
     let link input_file output_file =
-      let { Odoc_unit.libs; pages } = c.pkg_args in
+      let { Odoc_unit.libs; pages; _ } = c.pkg_args in
       let includes = c.include_dirs in
       Odoc.link ~input_file ~output_file ~includes ~libs ~docs:pages
         ~current_package:c.pkgname ()
@@ -232,12 +232,16 @@ let html_generate ~occurrence_file output_dir linked =
   let compile_index : Odoc_unit.index -> _ =
    fun index ->
     let compile_index_one
-        ({ pkg_args = { pages; libs }; output_file; json; search_dir = _ } as
-         index :
+        ({
+           pkg_args = { pages_linked; libs_linked; _ };
+           output_file;
+           json;
+           search_dir = _;
+         } as index :
           Odoc_unit.index) =
       let () =
-        Odoc.compile_index ~json ~occurrence_file ~output_file ~libs ~docs:pages
-          ()
+        Odoc.compile_index ~json ~occurrence_file ~output_file ~libs:libs_linked
+          ~docs:pages_linked ()
       in
       sherlodoc_index_one ~output_dir index
     in

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -126,7 +126,7 @@ let compile ?partial ~partial_dir ?linked_dir:_ (all : Odoc_unit.t list) =
                     None)
               deps
           in
-          let includes = Fpath.Set.of_list unit.include_dirs in
+          let includes = unit.include_dirs in
           Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
             ~includes ~parent_id:unit.parent_id;
           Atomic.incr Stats.stats.compiled_units;
@@ -155,7 +155,7 @@ let compile ?partial ~partial_dir ?linked_dir:_ (all : Odoc_unit.t list) =
     | `Intf _ as kind ->
         (compile_mod { unit with kind } :> (Odoc_unit.t, _) Result.t)
     | `Impl src ->
-        let includes = Fpath.Set.of_list unit.include_dirs in
+        let includes = unit.include_dirs in
         let source_id = src.src_id in
         Odoc.compile_impl ~output_dir:unit.output_dir
           ~input_file:unit.input_file ~includes ~parent_id:unit.parent_id
@@ -168,7 +168,7 @@ let compile ?partial ~partial_dir ?linked_dir:_ (all : Odoc_unit.t list) =
         Atomic.incr Stats.stats.compiled_assets;
         Ok unit
     | `Mld ->
-        let includes = Fpath.Set.of_list unit.include_dirs in
+        let includes = unit.include_dirs in
         Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
           ~includes ~parent_id:unit.parent_id;
         Atomic.incr Stats.stats.compiled_mlds;
@@ -196,7 +196,7 @@ let link : compiled list -> _ =
    fun c ->
     let link input_file output_file =
       let { Odoc_unit.libs; pages } = c.pkg_args in
-      let includes = c.include_dirs |> Fpath.Set.of_list in
+      let includes = c.include_dirs in
       Odoc.link ~input_file ~output_file ~includes ~libs ~docs:pages
         ~current_package:c.pkgname ()
     in

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -264,6 +264,8 @@ let html_generate ~occurrence_file output_dir linked =
     | `Impl { src_path; _ } ->
         Odoc.html_generate_source ~search_uris:[] ~output_dir ~input_file
           ~source:src_path ();
+        Odoc.html_generate_source ~search_uris:[] ~output_dir ~input_file
+          ~source:src_path ~as_json:true ();
         Atomic.incr Stats.stats.generated_units
     | `Asset ->
         Odoc.html_generate_asset ~output_dir ~input_file:l.odoc_file
@@ -279,6 +281,8 @@ let html_generate ~occurrence_file output_dir linked =
               (Some search_uris, Some index)
         in
         Odoc.html_generate ?search_uris ?index ~output_dir ~input_file ();
+        Odoc.html_generate ?search_uris ?index ~output_dir ~input_file
+          ~as_json:true ();
         Atomic.incr Stats.stats.generated_units
   in
   Fiber.List.iter html_generate linked

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -214,7 +214,8 @@ let link : compiled list -> _ =
   let link : compiled -> linked =
    fun c ->
     let link input_file output_file =
-      let { Odoc_unit.libs; pages; _ } = c.pkg_args in
+      let libs = Odoc_unit.Pkg_args.compiled_libs c.pkg_args in
+      let pages = Odoc_unit.Pkg_args.compiled_pages c.pkg_args in
       let includes = c.include_dirs in
       Odoc.link ~input_file ~output_file ~includes ~libs ~docs:pages
         ~current_package:c.pkgname ()
@@ -251,13 +252,10 @@ let html_generate ~occurrence_file output_dir linked =
   let compile_index : Odoc_unit.index -> _ =
    fun index ->
     let compile_index_one
-        ({
-           pkg_args = { pages_linked; libs_linked; _ };
-           output_file;
-           json;
-           search_dir = _;
-         } as index :
+        ({ pkg_args; output_file; json; search_dir = _ } as index :
           Odoc_unit.index) =
+      let libs_linked = Odoc_unit.Pkg_args.linked_libs pkg_args in
+      let pages_linked = Odoc_unit.Pkg_args.linked_pages pkg_args in
       let () =
         Odoc.compile_index ~json ~occurrence_file ~output_file ~libs:libs_linked
           ~docs:pages_linked ()

--- a/src/driver/dune
+++ b/src/driver/dune
@@ -3,6 +3,8 @@
  (package odoc-driver)
  (link_deps
   (package odoc))
+ (preprocess
+  (pps ppx_sexp_conv))
  (libraries
   cmdliner
   bos

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -103,7 +103,7 @@ let of_dune_build dir =
                 ~libname_of_archive:
                   (Fpath.Map.singleton Fpath.(path / libname) libname)
                 ~pkg_name:libname ~dir:path ~cmtidir:(Some cmtidir)
-                ~all_lib_deps ))
+                ~all_lib_deps ~cmi_only_libs:[] ))
           libs
       in
       let packages =

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -39,7 +39,8 @@ let of_dune_build dir =
             let pkg_dir = Fpath.rem_prefix dir path |> Option.get in
             ( pkg_dir,
               Packages.Lib.v
-                ~libname_of_archive:(Util.StringMap.singleton libname libname)
+                ~libname_of_archive:
+                  (Fpath.Map.singleton Fpath.(path / libname) libname)
                 ~pkg_name:libname ~dir:path ~cmtidir:(Some cmtidir)
                 ~all_lib_deps ))
           libs

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -34,11 +34,14 @@ let of_dune_build dir =
             let cmtidir =
               Fpath.(path / Printf.sprintf ".%s.objs" libname / "byte")
             in
+            let all_lib_deps = Util.StringMap.empty in
+            (* TODO *)
             let pkg_dir = Fpath.rem_prefix dir path |> Option.get in
             ( pkg_dir,
               Packages.Lib.v
                 ~libname_of_archive:(Util.StringMap.singleton libname libname)
-                ~pkg_name:libname ~dir:path ~cmtidir:(Some cmtidir) ))
+                ~pkg_name:libname ~dir:path ~cmtidir:(Some cmtidir)
+                ~all_lib_deps ))
           libs
       in
       let packages =

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -3,8 +3,6 @@ open Odoc_unit
 
 let fpf = Format.fprintf
 
-let make_rel dir l = List.map (fun (x, y) -> (x, Fpath.(dir // y))) l
-
 let make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir rel_path ~content
     ?(include_dirs = Fpath.Set.empty) ~pkgname ~pkg_args () =
   let input_file = Fpath.(mld_dir // rel_path / "index.mld") in
@@ -45,10 +43,10 @@ module PackageLanding = struct
     let pages_rel = [ (pkg.name, rel_path) ] in
     let pkg_args =
       {
-        pages = make_rel output_dir pages_rel;
+        Pkg_args.pages = pages_rel;
         libs = [];
-        pages_linked = make_rel odocl_dir pages_rel;
-        libs_linked = [];
+        compile_dir = output_dir;
+        link_dir = odocl_dir;
       }
     in
     make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir rel_path ~content
@@ -73,10 +71,10 @@ module PackageList = struct
     let pages_rel = [ (pkgname, rel_path) ] in
     let pkg_args =
       {
-        pages = make_rel odoc_dir pages_rel;
+        Pkg_args.pages = pages_rel;
         libs = [];
-        pages_linked = make_rel odocl_dir pages_rel;
-        libs_linked = [];
+        compile_dir = output_dir;
+        link_dir = odocl_dir;
       }
     in
     make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir ~content ~pkgname
@@ -97,10 +95,10 @@ module LibraryLanding = struct
     let pages_rel = [ (pkg.name, rel_path) ] in
     let pkg_args =
       {
-        pages = make_rel odoc_dir pages_rel;
+        Pkg_args.pages = pages_rel;
         libs = [];
-        pages_linked = make_rel odocl_dir pages_rel;
-        libs_linked = [];
+        link_dir = odocl_dir;
+        compile_dir = output_dir;
       }
     in
     let include_dirs = Fpath.Set.singleton Fpath.(odoc_dir // rel_path) in
@@ -122,10 +120,10 @@ module PackageLibLanding = struct
     let pages_rel = [ (pkg.name, rel_path) ] in
     let pkg_args =
       {
-        pages = make_rel odoc_dir pages_rel;
+        Pkg_args.pages = pages_rel;
         libs = [];
-        pages_linked = make_rel odocl_dir pages_rel;
-        libs_linked = [];
+        compile_dir = output_dir;
+        link_dir = odocl_dir;
       }
     in
     make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir rel_path ~content

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -4,7 +4,7 @@ open Odoc_unit
 let fpf = Format.fprintf
 
 let make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir rel_path ~content
-    ?(include_dirs = []) ~pkgname ~pkg_args () =
+    ?(include_dirs = Fpath.Set.empty) ~pkgname ~pkg_args () =
   let input_file = Fpath.(mld_dir // rel_path / "index.mld") in
   let odoc_file = Fpath.(odoc_dir // rel_path / "page-index.odoc") in
   let odocl_file = Fpath.(odocl_dir // rel_path / "page-index.odocl") in
@@ -83,7 +83,7 @@ module LibraryLanding = struct
     let pkg_args =
       { pages = [ (pkg.name, Fpath.( // ) odoc_dir rel_path) ]; libs = [] }
     in
-    let include_dirs = [ Fpath.(odoc_dir // rel_path) ] in
+    let include_dirs = Fpath.Set.singleton Fpath.(odoc_dir // rel_path) in
     make_unit ~odoc_dir ~odocl_dir ~mld_dir ~output_dir rel_path ~content
       ~pkgname:pkg.name ~include_dirs ~pkg_args ()
 end

--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -10,11 +10,18 @@
     [archive_name], and that for this cma archive exists a corresponsing
     [archive_name].ocamlobjinfo file. *)
 
-type library = { name : string; archive_name : string; dir : string option }
+type library = {
+  name : string;
+  archive_name : string;
+  dir : string option;
+  deps : string list;
+}
 
 let read_libraries_from_pkg_defs ~library_name pkg_defs =
   try
     let cma_filename = Fl_metascanner.lookup "archive" [ "byte" ] pkg_defs in
+    let deps_str = Fl_metascanner.lookup "requires" [] pkg_defs in
+    let deps = Astring.String.fields deps_str in
     let dir =
       List.find_opt (fun d -> d.Fl_metascanner.def_var = "directory") pkg_defs
     in
@@ -25,7 +32,7 @@ let read_libraries_from_pkg_defs ~library_name pkg_defs =
       else cma_filename
     in
     if String.length archive_name > 0 then
-      [ { name = library_name; archive_name; dir } ]
+      [ { name = library_name; archive_name; dir; deps } ]
     else []
   with Not_found -> []
 

--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -17,10 +17,7 @@ type library = {
   deps : string list;
 }
 
-type t = {
-  meta_dir : Fpath.t;
-  libraries : library list;
-}
+type t = { meta_dir : Fpath.t; libraries : library list }
 
 let read_libraries_from_pkg_defs ~library_name pkg_defs =
   try
@@ -85,29 +82,28 @@ let process_meta_file file =
   { meta_dir; libraries }
 
 let libname_of_archive v =
-  let {meta_dir; libraries} = v in
+  let { meta_dir; libraries } = v in
   List.fold_left
-  (fun acc (x : library) ->
-    match x.archive_name with
-    | None -> acc
-    | Some archive_name ->
-        let dir =
-          match x.dir with
-          | None -> meta_dir
-          | Some x -> Fpath.(meta_dir // v x)
-        in
-        Fpath.Map.update
-          Fpath.(dir / archive_name)
-          (function
-            | None -> Some x.name
-            | Some y ->
-                Logs.err (fun m ->
-                    m "Multiple libraries for archive %s: %s and %s."
-                      archive_name x.name y);
-                Some y)
-          acc)
-  Fpath.Map.empty libraries
-  
+    (fun acc (x : library) ->
+      match x.archive_name with
+      | None -> acc
+      | Some archive_name ->
+          let dir =
+            match x.dir with
+            | None -> meta_dir
+            | Some x -> Fpath.(meta_dir // v x)
+          in
+          Fpath.Map.update
+            Fpath.(dir / archive_name)
+            (function
+              | None -> Some x.name
+              | Some y ->
+                  Logs.err (fun m ->
+                      m "Multiple libraries for archive %s: %s and %s."
+                        archive_name x.name y);
+                  Some y)
+            acc)
+    Fpath.Map.empty libraries
 
 let directories v =
   let { meta_dir; libraries } = v in

--- a/src/driver/library_names.mli
+++ b/src/driver/library_names.mli
@@ -1,6 +1,6 @@
 type library = {
   name : string;
-  archive_name : string;
+  archive_name : string option;
   dir : string option;
   deps : string list;
 }

--- a/src/driver/library_names.mli
+++ b/src/driver/library_names.mli
@@ -5,10 +5,7 @@ type library = {
   deps : string list;
 }
 
-type t = {
-  meta_dir : Fpath.t;
-  libraries : library list;
-}
+type t = { meta_dir : Fpath.t; libraries : library list }
 
 val process_meta_file : Fpath.t -> t
 (** From a path to a [Meta] file, returns the list of libraries defined in this

--- a/src/driver/library_names.mli
+++ b/src/driver/library_names.mli
@@ -5,6 +5,22 @@ type library = {
   deps : string list;
 }
 
-val process_meta_file : Fpath.t -> library list
+type t = {
+  meta_dir : Fpath.t;
+  libraries : library list;
+}
+
+val process_meta_file : Fpath.t -> t
 (** From a path to a [Meta] file, returns the list of libraries defined in this
     file. *)
+
+val libname_of_archive : t -> string Fpath.map
+(** [libname_of_archive meta_dir libraries] computes a map from the fully-qualified
+    archive path to the name of the library. [meta_path] is the path of the 
+    directory where the META file is found, and [libraries] are the libraries
+    defined in that META file. *)
+
+val directories : t -> Fpath.set
+(** [directories meta_dir libraries] computes a set of directories
+    containing the libraries in [libraries] defined in the META file
+    found in [meta_path]. *)

--- a/src/driver/library_names.mli
+++ b/src/driver/library_names.mli
@@ -1,4 +1,9 @@
-type library = { name : string; archive_name : string; dir : string option }
+type library = {
+  name : string;
+  archive_name : string;
+  dir : string option;
+  deps : string list;
+}
 
 val process_meta_file : Fpath.t -> library list
 (** From a path to a [Meta] file, returns the list of libraries defined in this

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -162,7 +162,7 @@ let compile_index ?(ignore_output = false) ~output_file ?occurrence_file ~json
       add_prefixed_output cmd index_output (Fpath.to_string output_file) lines)
 
 let html_generate ~output_dir ?index ?(ignore_output = false)
-    ?(search_uris = []) ~input_file:file () =
+    ?(search_uris = []) ?(as_json = false) ~input_file:file () =
   let open Cmd in
   let index =
     match index with None -> empty | Some idx -> v "--index" % p idx
@@ -175,6 +175,7 @@ let html_generate ~output_dir ?index ?(ignore_output = false)
   let cmd =
     !odoc % "html-generate" % p file %% index %% search_uris % "-o" % output_dir
   in
+  let cmd = if as_json then cmd % "--as-json" else cmd in
   let desc = Printf.sprintf "Generating HTML for %s" (Fpath.to_string file) in
   let lines = Cmd_outputs.submit desc cmd None in
   if not ignore_output then
@@ -195,7 +196,7 @@ let html_generate_asset ~output_dir ?(ignore_output = false) ~input_file:file
       add_prefixed_output cmd generate_output (Fpath.to_string file) lines)
 
 let html_generate_source ~output_dir ?(ignore_output = false) ~source
-    ?(search_uris = []) ~input_file:file () =
+    ?(search_uris = []) ?(as_json = false) ~input_file:file () =
   let open Cmd in
   let file = v "--impl" % p file in
   let search_uris =
@@ -207,6 +208,8 @@ let html_generate_source ~output_dir ?(ignore_output = false) ~source
     !odoc % "html-generate-source" %% file % p source %% search_uris % "-o"
     % output_dir
   in
+  let cmd = if as_json then cmd % "--as-json" else cmd in
+
   let desc = Printf.sprintf "Generating HTML for %s" (Fpath.to_string source) in
   let lines = Cmd_outputs.submit desc cmd None in
   if not ignore_output then

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -54,6 +54,7 @@ val html_generate :
   ?index:Fpath.t ->
   ?ignore_output:bool ->
   ?search_uris:Fpath.t list ->
+  ?as_json:bool ->
   input_file:Fpath.t ->
   unit ->
   unit
@@ -71,6 +72,7 @@ val html_generate_source :
   ?ignore_output:bool ->
   source:Fpath.t ->
   ?search_uris:Fpath.t list ->
+  ?as_json:bool ->
   input_file:Fpath.t ->
   unit ->
   unit

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -571,6 +571,8 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
             Odoc_unit.of_packages ~output_dir:odoc_dir ~linked_dir:odocl_dir
               ~index_dir:None ~extra_libs_paths all
           in
+          Format.eprintf "All units:\n%!";
+          Format.eprintf "%a" Fmt.(list ~sep:Fmt.semi Odoc_unit.pp) internal;
           let external_ =
             let mld_dir = odoc_dir in
             let odocl_dir = Option.value odocl_dir ~default:odoc_dir in

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -532,10 +532,6 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
     | true, Some p, None, None ->
         let all = Voodoo.of_voodoo p ~blessed in
         let extra_libs_paths = Voodoo.extra_libs_paths odoc_dir in
-        Format.eprintf "extra_libs_paths:\n%!";
-        Util.StringMap.iter
-          (fun lib path -> Format.eprintf "%s -> %a\n%!" lib Fpath.pp path)
-          extra_libs_paths;
         (all, extra_libs_paths)
     | false, None, Some dir, None ->
         (Dune_style.of_dune_build dir, Util.StringMap.empty)
@@ -571,8 +567,6 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
             Odoc_unit.of_packages ~output_dir:odoc_dir ~linked_dir:odocl_dir
               ~index_dir:None ~extra_libs_paths all
           in
-          Format.eprintf "All units:\n%!";
-          Format.eprintf "%a" Fmt.(list ~sep:Fmt.semi Odoc_unit.pp) internal;
           let external_ =
             let mld_dir = odoc_dir in
             let odocl_dir = Option.value odocl_dir ~default:odoc_dir in

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -139,8 +139,11 @@ let of_packages ~output_dir ~linked_dir ~index_dir ~extra_libs_paths
     let pkg_args = args_of pkg lib_deps in
     let odoc_dir = output_dir // rel_dir in
     let parent_id = rel_dir |> Odoc.Id.of_fpath in
-    let odoc_file = odoc_dir / (name ^ ".odoc") in
-    let odocl_file = linked_dir // rel_dir / (name ^ ".odocl") in
+    let odoc_file = odoc_dir / (String.uncapitalize_ascii name ^ ".odoc") in
+    (* odoc will uncapitalise the output filename *)
+    let odocl_file =
+      linked_dir // rel_dir / (String.uncapitalize_ascii name ^ ".odocl")
+    in
     {
       output_dir;
       pkgname = pkg.Packages.name;
@@ -211,7 +214,8 @@ let of_packages ~output_dir ~linked_dir ~index_dir ~extra_libs_paths
           `Impl { src_id; src_path }
         in
         let name =
-          impl.mip_path |> Fpath.rem_ext |> Fpath.basename |> ( ^ ) "impl-"
+          impl.mip_path |> Fpath.rem_ext |> Fpath.basename
+          |> String.uncapitalize_ascii |> ( ^ ) "impl-"
         in
         let unit =
           make_unit ~name ~kind ~rel_dir ~input_file:impl.mip_path ~pkg

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -241,12 +241,15 @@ let of_packages ~output_dir ~linked_dir ~index_dir ~extra_libs_paths
       index = Some (index_of pkg);
     }
   in
+  let missing = ref Util.StringSet.empty in
 
   let rec build_deps deps =
     List.filter_map
       (fun (_name, hash) ->
         match Util.StringMap.find_opt hash module_of_hash with
-        | None -> None
+        | None ->
+            missing := Util.StringSet.add hash !missing;
+            None
         | Some (pkg, lib, mod_) ->
             let lib_deps = Util.StringSet.add lib.lib_name lib.lib_deps in
             let result =

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -19,12 +19,13 @@ type 'a unit = {
   odocl_file : Fpath.t;
   pkg_args : pkg_args;
   pkgname : string;
-  include_dirs : Fpath.t list;
+  include_dirs : Fpath.Set.t;
   index : index option;
   kind : 'a;
 }
 
 type intf_extra = { hidden : bool; hash : string; deps : intf unit list }
+
 and intf = [ `Intf of intf_extra ]
 
 type impl_extra = { src_id : Odoc.Id.t; src_path : Fpath.t }
@@ -43,51 +44,55 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
   in
   let index_dir = match index_dir with None -> output_dir | Some dir -> dir in
 
-  (* Maps a hash to the corresponding [Package.t], library name and
-     [Packages.modulety]. *)
-  let module_of_hash =
+  let doc_dir pkg = Fpath.(pkg.Packages.pkg_dir / "doc") in
+
+  let lib_dir pkg libname = Fpath.(pkg.Packages.pkg_dir / "lib" / libname) in
+
+  let make_absolute = Fpath.( // ) output_dir in
+
+  (* [module_of_hash] Maps a hash to the corresponding [Package.t], library name and
+     [Packages.modulety]. [lib_dirs] maps a library name to the odoc dir containing its
+     odoc files. *)
+  let module_of_hash, lib_dirs =
     let open Packages in
     let h = Util.StringMap.empty in
+    let lds = Util.StringMap.empty in
     List.fold_left
-      (fun h pkg ->
+      (fun (h, lds) pkg ->
         List.fold_left
-          (fun h lib ->
-            List.fold_left
-              (fun h mod_ ->
-                Util.StringMap.add mod_.m_intf.mif_hash
-                  (pkg, lib.lib_name, mod_) h)
-              h lib.modules)
-          h pkg.libraries)
-      h pkgs
+          (fun (h, lds) lib ->
+            let h' =
+              List.fold_left
+                (fun h mod_ ->
+                  Util.StringMap.add mod_.m_intf.mif_hash (pkg, lib, mod_) h)
+                h lib.modules
+            in
+            let lib_dir = lib_dir pkg lib.lib_name in
+            let lds' = Util.StringMap.add lib.lib_name lib_dir lds in
+            (h', lds'))
+          (h, lds) pkg.libraries)
+      (h, lds) pkgs
   in
   let pkg_map =
     Util.StringMap.of_list (List.map (fun pkg -> (pkg.Packages.name, pkg)) pkgs)
   in
 
-  let lib_map =
-    Util.StringMap.of_list
-      (List.concat_map
-         (fun pkg ->
-           List.map
-             (fun lib -> (lib.Packages.lib_name, (pkg, lib)))
-             pkg.Packages.libraries)
-         pkgs)
-  in
-  let doc_dir pkg = Fpath.(pkg.Packages.pkg_dir / "doc") in
-  let lib_dir pkg libname = Fpath.(pkg.Packages.pkg_dir / "lib" / libname) in
-  let make_absolute = Fpath.( // ) output_dir in
-
   let dash_p pkg = (pkg.Packages.name, doc_dir pkg |> make_absolute) in
-  let dash_l pkg lib =
-    (lib.Packages.lib_name, lib_dir pkg lib.lib_name |> make_absolute)
+
+  let dash_l lib_name =
+    match Util.StringMap.find_opt lib_name lib_dirs with
+    | Some dir -> [ (lib_name, make_absolute dir) ]
+    | None ->
+        Logs.err (fun m -> m "Library %s not found" lib_name);
+        []
   in
   (* Given a pkg,  *)
-  let pkg_args_of_pkg pkg : pkg_args =
+  let base_args pkg lib_deps : pkg_args =
     let own_page = dash_p pkg in
-    let own_libs = List.map (dash_l pkg) pkg.libraries in
+    let own_libs = List.concat_map dash_l (Util.StringSet.to_list lib_deps) in
     { pages = [ own_page ]; libs = own_libs }
   in
-  let pkg_args_of_config config : pkg_args =
+  let args_of_config config : pkg_args =
     let { Global_config.deps = { packages; libraries } } = config in
     let pages =
       List.filter_map
@@ -97,38 +102,41 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
           | Some pkg -> Some (dash_p pkg))
         packages
     in
-    let libs =
-      List.filter_map
-        (fun libname ->
-          match Util.StringMap.find_opt libname lib_map with
-          | None -> None
-          | Some (pkg, lib) -> Some (dash_l pkg lib))
-        libraries
-    in
+    let libs = List.concat_map dash_l libraries in
     { pages; libs }
   in
-  let pkg_args =
+  let args_of =
     let cache = Hashtbl.create 10 in
-    fun pkg : pkg_args ->
-      match Hashtbl.find_opt cache pkg with
+    fun pkg lib_deps : pkg_args ->
+      match Hashtbl.find_opt cache (pkg, lib_deps) with
       | Some res -> res
       | None ->
-          let { pages = own_page; libs = own_libs } = pkg_args_of_pkg pkg in
+          let { pages = own_page; libs = own_libs } = base_args pkg lib_deps in
           let { pages = config_pages; libs = config_libs } =
-            pkg_args_of_config pkg.Packages.config
+            args_of_config pkg.Packages.config
           in
-          { pages = own_page @ config_pages; libs = own_libs @ config_libs }
+          let result =
+            { pages = own_page @ config_pages; libs = own_libs @ config_libs }
+          in
+          Hashtbl.add cache (pkg, lib_deps) result;
+          result
   in
 
   let index_of pkg =
-    let pkg_args = pkg_args_of_pkg pkg in
+    let pkg_libs =
+      List.map (fun l -> l.Packages.lib_name) pkg.Packages.libraries
+      |> Util.StringSet.of_list
+    in
+    let pkg_args = base_args pkg pkg_libs in
     let output_file = Fpath.(index_dir / pkg.name / Odoc.index_filename) in
     { pkg_args; output_file; json = false; search_dir = pkg.pkg_dir }
   in
 
-  let make_unit ~name ~kind ~rel_dir ~input_file ~pkg ~include_dirs : _ unit =
+  let make_unit ~name ~kind ~rel_dir ~input_file ~pkg ~include_dirs ~lib_deps :
+      _ unit =
     let ( // ) = Fpath.( // ) in
     let ( / ) = Fpath.( / ) in
+    let pkg_args = args_of pkg lib_deps in
     let odoc_dir = output_dir // rel_dir in
     let parent_id = rel_dir |> Odoc.Id.of_fpath in
     let odoc_file = odoc_dir / (name ^ ".odoc") in
@@ -136,7 +144,7 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
     {
       output_dir;
       pkgname = pkg.Packages.name;
-      pkg_args = pkg_args pkg;
+      pkg_args;
       parent_id;
       odoc_dir;
       input_file;
@@ -154,43 +162,46 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
         match Util.StringMap.find_opt hash module_of_hash with
         | None -> None
         | Some (pkg, lib, mod_) ->
-            let result = of_intf mod_.m_hidden pkg lib mod_.m_intf in
+            let lib_deps = Util.StringSet.add lib.lib_name lib.lib_deps in
+            let result =
+              of_intf mod_.m_hidden pkg lib.lib_name lib_deps mod_.m_intf
+            in
             Some result)
       deps
   and of_intf =
     (* Memoize (using the hash as the key) the creation of interface units, to
        avoid creating them twice *)
     let intf_cache : (string, intf unit) Hashtbl.t = Hashtbl.create 10 in
-
-    fun hidden pkg libname (intf : Packages.intf) : intf unit ->
+    fun hidden pkg libname lib_deps (intf : Packages.intf) : intf unit ->
       let do_ () : intf unit =
         let rel_dir = lib_dir pkg libname in
         let include_dirs, kind =
           let deps = build_deps intf.mif_deps in
-          let include_dirs = List.map (fun u -> u.odoc_dir) deps in
+          let include_dirs =
+            List.map (fun u -> u.odoc_dir) deps |> Fpath.Set.of_list
+          in
           let kind = `Intf { hidden; hash = intf.mif_hash; deps } in
           (include_dirs, kind)
         in
         let name = intf.mif_path |> Fpath.rem_ext |> Fpath.basename in
         make_unit ~name ~kind ~rel_dir ~input_file:intf.mif_path ~pkg
-          ~include_dirs
+          ~include_dirs ~lib_deps
       in
       match Hashtbl.find_opt intf_cache intf.mif_hash with
       | Some unit -> unit
       | None ->
-          let result = do_ () in
-          Hashtbl.add intf_cache intf.mif_hash result;
-          result
+          let unit = do_ () in
+          Hashtbl.add intf_cache intf.mif_hash unit;
+          unit
   in
-
-  let of_impl pkg libname (impl : Packages.impl) : impl unit option =
+  let of_impl pkg libname lib_deps (impl : Packages.impl) : impl unit option =
     match impl.mip_src_info with
     | None -> None
     | Some { src_path } ->
         let rel_dir = lib_dir pkg libname in
         let include_dirs =
           let deps = build_deps impl.mip_deps in
-          List.map (fun u -> u.odoc_dir) deps
+          List.map (fun u -> u.odoc_dir) deps |> Fpath.Set.of_list
         in
         let kind =
           let src_name = Fpath.filename src_path in
@@ -204,21 +215,24 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
         in
         let unit =
           make_unit ~name ~kind ~rel_dir ~input_file:impl.mip_path ~pkg
-            ~include_dirs
+            ~include_dirs ~lib_deps
         in
         Some unit
   in
 
-  let of_module pkg libname (m : Packages.modulety) : [ impl | intf ] unit list
-      =
-    let i :> [ impl | intf ] unit = of_intf m.m_hidden pkg libname m.m_intf in
+  let of_module pkg libname lib_deps (m : Packages.modulety) :
+      [ impl | intf ] unit list =
+    let i :> [ impl | intf ] unit =
+      of_intf m.m_hidden pkg libname lib_deps m.m_intf
+    in
     let m :> [ impl | intf ] unit list =
-      Option.bind m.m_impl (of_impl pkg libname) |> Option.to_list
+      Option.bind m.m_impl (of_impl pkg libname lib_deps) |> Option.to_list
     in
     i :: m
   in
   let of_lib pkg (lib : Packages.libty) : [ impl | intf ] unit list =
-    List.concat_map (of_module pkg lib.lib_name) lib.modules
+    let lib_deps = Util.StringSet.add lib.lib_name lib.lib_deps in
+    List.concat_map (of_module pkg lib.lib_name lib_deps) lib.modules
   in
   let of_mld pkg (mld : Packages.mld) : mld unit list =
     let open Fpath in
@@ -229,11 +243,14 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
         (fun (lib : Packages.libty) -> lib_dir pkg lib.lib_name)
         pkg.libraries
     in
-    let include_dirs = (output_dir // rel_dir) :: include_dirs in
+    let include_dirs =
+      (output_dir // rel_dir) :: include_dirs |> Fpath.Set.of_list
+    in
     let kind = `Mld in
     let name = mld_path |> Fpath.rem_ext |> Fpath.basename |> ( ^ ) "page-" in
     let unit =
       make_unit ~name ~kind ~rel_dir ~input_file:mld_path ~pkg ~include_dirs
+        ~lib_deps:Util.StringSet.empty
     in
     [ unit ]
   in
@@ -243,11 +260,12 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
     let rel_dir =
       doc_dir pkg // Fpath.parent asset_rel_path |> Fpath.normalize
     in
-    let include_dirs = [] in
+    let include_dirs = Fpath.Set.empty in
     let kind = `Asset in
     let unit =
       let name = asset_path |> Fpath.basename |> ( ^ ) "asset-" in
       make_unit ~name ~kind ~rel_dir ~input_file:asset_path ~pkg ~include_dirs
+        ~lib_deps:Util.StringSet.empty
     in
     [ unit ]
   in

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -37,8 +37,8 @@ type asset = [ `Asset ]
 
 type t = [ impl | intf | mld | asset ] unit
 
-let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
-    t list =
+let of_packages ~output_dir ~linked_dir ~index_dir ~extra_libs_paths
+    (pkgs : Packages.t list) : t list =
   let linked_dir =
     match linked_dir with None -> output_dir | Some dir -> dir
   in
@@ -56,7 +56,7 @@ let of_packages ~output_dir ~linked_dir ~index_dir (pkgs : Packages.t list) :
   let module_of_hash, lib_dirs =
     let open Packages in
     let h = Util.StringMap.empty in
-    let lds = Util.StringMap.empty in
+    let lds = extra_libs_paths in
     List.fold_left
       (fun (h, lds) pkg ->
         List.fold_left

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -1,6 +1,8 @@
 type pkg_args = {
   pages : (string * Fpath.t) list;
   libs : (string * Fpath.t) list;
+  pages_linked : (string * Fpath.t) list;
+  libs_linked : (string * Fpath.t) list;
 }
 
 type index = {

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -19,7 +19,7 @@ type 'a unit = {
   odocl_file : Fpath.t;
   pkg_args : pkg_args;
   pkgname : string;
-  include_dirs : Fpath.t list;
+  include_dirs : Fpath.Set.t;
   index : index option;
   kind : 'a;
 }

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -1,12 +1,23 @@
-type pkg_args = {
-  pages : (string * Fpath.t) list;
-  libs : (string * Fpath.t) list;
-  pages_linked : (string * Fpath.t) list;
-  libs_linked : (string * Fpath.t) list;
-}
+module Pkg_args : sig
+  type t = {
+    compile_dir : Fpath.t;
+    link_dir : Fpath.t;
+    pages : (string * Fpath.t) list;
+    libs : (string * Fpath.t) list;
+  }
+
+  val compiled_pages : t -> (string * Fpath.t) list
+  val compiled_libs : t -> (string * Fpath.t) list
+  val linked_pages : t -> (string * Fpath.t) list
+  val linked_libs : t -> (string * Fpath.t) list
+
+  val combine : t -> t -> t
+
+  val pp : t Fmt.t
+end
 
 type index = {
-  pkg_args : pkg_args;
+  pkg_args : Pkg_args.t;
   output_file : Fpath.t;
   json : bool;
   search_dir : Fpath.t;
@@ -19,7 +30,7 @@ type 'a unit = {
   output_dir : Fpath.t;
   odoc_file : Fpath.t;
   odocl_file : Fpath.t;
-  pkg_args : pkg_args;
+  pkg_args : Pkg_args.t;
   pkgname : string;
   include_dirs : Fpath.Set.t;
   index : index option;

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -40,5 +40,6 @@ val of_packages :
   output_dir:Fpath.t ->
   linked_dir:Fpath.t option ->
   index_dir:Fpath.t option ->
+  extra_libs_paths:Fpath.t Util.StringMap.t ->
   Packages.t list ->
   t list

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -36,6 +36,8 @@ type asset = [ `Asset ]
 
 type t = [ impl | intf | mld | asset ] unit
 
+val pp : t Fmt.t
+
 val of_packages :
   output_dir:Fpath.t ->
   linked_dir:Fpath.t option ->

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -171,7 +171,6 @@ module Lib = struct
       Fmt.(list ~sep:sp Module.pp)
       t.modules
 end
-
 let pp ppf t =
   Fmt.pf ppf "name: %s@.version: %s@.libraries: [@[<hov 2>@,%a@]@,]" t.name
     t.version

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -162,6 +162,10 @@ module Lib = struct
         | None ->
             Logs.err (fun m ->
                 m "Error processing library %s: Ignoring." archive_name);
+            Logs.err (fun m ->
+                m "Known libraries: [%a]"
+                  Fmt.(list ~sep:sp string)
+                  (Fpath.Map.bindings libname_of_archive |> List.map snd));
             None)
       results
 

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -35,6 +35,7 @@ let pp_asset fmt m = Format.fprintf fmt "%a" Fpath.pp m.asset_path
 
 type libty = {
   lib_name : string;
+  dir : Fpath.t;
   archive_name : string;
   lib_deps : Util.StringSet.t;
   modules : modulety list;
@@ -157,7 +158,7 @@ module Lib = struct
             try Util.StringMap.find lib_name all_lib_deps
             with _ -> Util.StringSet.empty
           in
-          Some { lib_name; archive_name; modules; lib_deps }
+          Some { lib_name; archive_name; modules; lib_deps; dir }
         with e ->
           Logs.err (fun m ->
               m "Error processing library %s: %s Ignoring." archive_name

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -59,7 +59,7 @@ val parent_of_pages : Fpath.t -> Fpath.t
 
 module Lib : sig
   val v :
-    libname_of_archive:string Util.StringMap.t ->
+    libname_of_archive:string Fpath.Map.t ->
     pkg_name:string ->
     dir:Fpath.t ->
     cmtidir:Fpath.t option ->

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -49,7 +49,7 @@ val pp_asset : Format.formatter -> asset -> unit
 type libty = {
   lib_name : string;
   dir : Fpath.t;
-  archive_name : string;
+  archive_name : string option;
   lib_deps : Util.StringSet.t;
   modules : modulety list;
 }
@@ -64,6 +64,7 @@ module Lib : sig
     dir:Fpath.t ->
     cmtidir:Fpath.t option ->
     all_lib_deps:Util.StringSet.t Util.StringMap.t ->
+    cmi_only_libs:(Fpath.t * string) list ->
     libty list
 
   val pp : Format.formatter -> libty -> unit

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -49,6 +49,7 @@ val pp_asset : Format.formatter -> asset -> unit
 type libty = {
   lib_name : string;
   archive_name : string;
+  lib_deps : Util.StringSet.t;
   modules : modulety list;
 }
 
@@ -61,6 +62,7 @@ module Lib : sig
     pkg_name:string ->
     dir:Fpath.t ->
     cmtidir:Fpath.t option ->
+    all_lib_deps:Util.StringSet.t Util.StringMap.t ->
     libty list
 end
 

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -48,6 +48,7 @@ val pp_asset : Format.formatter -> asset -> unit
 
 type libty = {
   lib_name : string;
+  dir : Fpath.t;
   archive_name : string;
   lib_deps : Util.StringSet.t;
   modules : modulety list;

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -64,6 +64,8 @@ module Lib : sig
     cmtidir:Fpath.t option ->
     all_lib_deps:Util.StringSet.t Util.StringMap.t ->
     libty list
+
+  val pp : Format.formatter -> libty -> unit
 end
 
 type t = {

--- a/src/driver/run.ml
+++ b/src/driver/run.ml
@@ -42,7 +42,7 @@ let run env cmd output_file =
     |> Array.of_list
   in
   (* Logs.debug (fun m -> m "Running cmd %a" Fmt.(list ~sep:sp string) cmd); *)
-  let (r, errors) =
+  let r, errors =
     Eio.Switch.run ~name:"Process.parse_out" @@ fun sw ->
     let r, w = Eio.Process.pipe proc_mgr ~sw in
     let re, we = Eio.Process.pipe proc_mgr ~sw in

--- a/src/driver/run.ml
+++ b/src/driver/run.ml
@@ -42,7 +42,7 @@ let run env cmd output_file =
     |> Array.of_list
   in
   (* Logs.debug (fun m -> m "Running cmd %a" Fmt.(list ~sep:sp string) cmd); *)
-  let r =
+  let (r, errors) =
     Eio.Switch.run ~name:"Process.parse_out" @@ fun sw ->
     let r, w = Eio.Process.pipe proc_mgr ~sw in
     let re, we = Eio.Process.pipe proc_mgr ~sw in
@@ -62,7 +62,7 @@ let run env cmd output_file =
       Eio.Flow.close r;
       Eio.Flow.close re;
       match Eio.Process.await child with
-      | `Exited 0 -> output
+      | `Exited 0 -> (output, err)
       | `Exited n ->
           Logs.err (fun m -> m "%d - Process exitted %d: stderr=%s" myn n err);
           failwith "Error"
@@ -79,7 +79,6 @@ let run env cmd output_file =
   let t_end = Unix.gettimeofday () in
   let r = String.split_on_char '\n' r in
   let time = t_end -. t_start in
-  let errors = "" in
   commands := { cmd; time; output_file; errors } :: !commands;
   r
 

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -47,6 +47,9 @@ let process_package pkg =
       pkg.files
   in
 
+  let all_lib_deps = Util.StringMap.empty in
+
+  (* TODO *)
   let pkg_path =
     Fpath.(v "prep" / "universes" / pkg.universe / pkg.name / pkg.version)
   in
@@ -143,10 +146,11 @@ let process_package pkg =
              (fun directory ->
                Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
                Packages.Lib.v ~libname_of_archive ~pkg_name:pkg.name
-                 ~dir:directory ~cmtidir:None)
+                 ~dir:directory ~cmtidir:None ~all_lib_deps)
              Fpath.(Set.to_list directories)))
       metas
   in
+
   (* Check the main package lib directory even if there's no meta file *)
   let extra_libraries =
     let libdirs_without_meta =
@@ -169,7 +173,7 @@ let process_package pkg =
         Packages.Lib.v ~libname_of_archive:Util.StringMap.empty
           ~pkg_name:pkg.name
           ~dir:Fpath.(pkg_path // libdir)
-          ~cmtidir:None)
+          ~cmtidir:None ~all_lib_deps)
       libdirs_without_meta
   in
   Printf.eprintf "Found %d metas" (List.length metas);

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -162,7 +162,8 @@ let process_package pkg =
         Some
           (List.concat_map
              (fun directory ->
-               Format.eprintf "Processing directory: %a\n%!" Fpath.pp directory;
+               Logs.debug (fun m ->
+                   m "Processing directory: %a\n%!" Fpath.pp directory);
                Packages.Lib.v ~libname_of_archive ~pkg_name:pkg.name
                  ~dir:directory ~cmtidir:None ~all_lib_deps)
              Fpath.(Set.to_list directories)))
@@ -187,12 +188,17 @@ let process_package pkg =
           | _ -> false)
         pkg.files
     in
-    Format.eprintf "libdirs_without_meta: %a\n%!"
-      Fmt.(list ~sep:comma Fpath.pp)
-      (List.map (fun p -> Fpath.(pkg_path // p)) libdirs_without_meta);
-    Format.eprintf "lib dirs: %a\n%!"
-      Fmt.(list ~sep:comma Fpath.pp)
-      (List.map (fun (lib : Packages.libty) -> lib.dir) libraries);
+
+    Logs.debug (fun m ->
+        m "libdirs_without_meta: %a\n%!"
+          Fmt.(list ~sep:comma Fpath.pp)
+          (List.map (fun p -> Fpath.(pkg_path // p)) libdirs_without_meta));
+
+    Logs.debug (fun m ->
+        m "lib dirs: %a\n%!"
+          Fmt.(list ~sep:comma Fpath.pp)
+          (List.map (fun (lib : Packages.libty) -> lib.dir) libraries));
+
     List.map
       (fun libdir ->
         let libname_of_archive =
@@ -218,7 +224,6 @@ let process_package pkg =
           ~cmtidir:None ~all_lib_deps)
       libdirs_without_meta
   in
-  Logs.debug (fun m -> m "Found %d METAs" (List.length metas));
   let libraries = List.flatten extra_libraries @ libraries in
   let result =
     {
@@ -232,7 +237,6 @@ let process_package pkg =
       config;
     }
   in
-  Format.eprintf "%a\n%!" Packages.pp result;
   result
 
 let pp ppf v =

--- a/src/driver/voodoo.mli
+++ b/src/driver/voodoo.mli
@@ -2,3 +2,5 @@ val find_universe_and_version :
   string -> (string * string, [> `Msg of string ]) result
 
 val of_voodoo : string -> blessed:bool -> Packages.set
+
+val extra_libs_paths : Fpath.t -> Fpath.t Util.StringMap.t

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -688,6 +688,7 @@ end = struct
           current_dir;
         }
     in
+    let directories = directories @ List.map ~f:snd lib_roots in
     let resolver =
       Resolver.create ~important_digests:false ~directories ~open_modules ~roots
     in

--- a/src/odoc/classify.cppo.ml
+++ b/src/odoc/classify.cppo.ml
@@ -118,6 +118,8 @@ module Deps = struct
           inner acc rest
     in
     let eq (l1 : t) (l2 : t) =
+      (* Note that the keys in l1 and l2 never change, only the values, so it's
+         safe to iterate over the keys of just one of l1 or l2 *)
       List.for_all
         (fun (x, deps) ->
           try

--- a/src/odoc/classify.cppo.ml
+++ b/src/odoc/classify.cppo.ml
@@ -101,6 +101,8 @@ module Cmi = struct
 end
 
 module Deps = struct
+  type t = (string * StringSet.t) list
+
   let closure deps =
     let rec inner acc l =
       match l with
@@ -115,9 +117,18 @@ module Deps = struct
           in
           inner acc rest
     in
+    let eq (l1 : t) (l2 : t) =
+      List.for_all
+        (fun (x, deps) ->
+          try
+            let deps' = List.assoc x l2 in
+            StringSet.equal deps deps'
+          with Not_found -> false)
+        l1
+    in
     let rec loop acc =
       let acc' = inner acc deps in
-      if acc = acc' then acc else loop acc'
+      if eq acc acc' then acc else loop acc'
     in
     loop deps
 

--- a/src/odoc/fs.ml
+++ b/src/odoc/fs.ml
@@ -31,7 +31,7 @@ let mkdir_p dir =
     if Sys.file_exists (Fpath.to_string p) then acc
     else dirs_to_create (Fpath.parent p) (p :: acc)
   in
-  List.iter (dirs_to_create dir []) ~f:mkdir
+  List.iter (dirs_to_create (Fpath.normalize dir) []) ~f:mkdir
 
 module File = struct
   type t = file

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -10,8 +10,6 @@
 
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/subdir/page-bar.odoc
-  File "doc/subdir/bar.mld", line 12, characters 49-56:
-  Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/subdir/bar.mld", line 12, characters 39-48:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
   File "doc/subdir/bar.mld", line 12, characters 18-38:
@@ -22,8 +20,6 @@
   Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-dup.odoc
   $ odoc link -P pkg:h/pkg/doc -L libname:h/pkg/lib/libname h/pkg/doc/page-foo.odoc
-  File "doc/foo.mld", line 12, characters 37-44:
-  Warning: Failed to resolve reference unresolvedroot(Test) Couldn't find "Test"
   File "doc/foo.mld", line 12, characters 27-36:
   Warning: Failed to resolve reference ./Test Path 'Test' not found
   File "doc/foo.mld", line 12, characters 0-9:
@@ -67,7 +63,7 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["Test"]]},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
-  {"`Reference":[{"`Root":["Test","`TUnknown"]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
   ["Asset"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`AssetFile":[{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]},"img.png"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`AssetFile":[{"`Page":[{"Some":{"`Page":["None","pkg"]}},"doc"]},"img.png"]}}},[]]}
@@ -95,7 +91,7 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
-  {"`Reference":[{"`Root":["Test","`TUnknown"]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"lib"]}},"libname"]}},"Test"]}}},[]]}
 
   $ odoc_print ./h/pkg/lib/libname/test.odocl | jq_references
   ["Page","foo"]


### PR DESCRIPTION
This PR contains the contents of #1192 as well as a few more bugfixes and improvements required to ensure we can use `odoc_driver` in place of voodoo for building the docs for ocaml.org. 

Best reviewed commit-by-commit.