### PR TITLE
opam: Update lower bounds on yojson

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -51,7 +51,7 @@ depends: [
   "fmt"
 
   "ocamlfind" {with-test}
-  "yojson" {>= "1.6.0" & with-test}
+  "yojson" {>= "2.1.0" & with-test}
   ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
   "conf-jq" {with-test}
 


### PR DESCRIPTION
The output format of older yojson was unstable in some cases.