### PR TITLE
Standalone markdown support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 - Added an `html-generate-asset` command (@panglesd, #1185)
 - Added syntax for images, videos, audio (@panglesd, #1184)
 - Added the ability to order pages in the table of content (@panglesd, #1193)
+- Added `odoc-md` to process standalone Markdown pages (@jonludlam, #1234)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # **[odoc](https://ocaml.github.io/odoc/) : OCaml Documentation Generator**
-</p>
 
 <p align="center">
   <a href="https://ocaml.ci.dev/github/ocaml/odoc">

--- a/README.md
+++ b/README.md
@@ -1,11 +1,4 @@
-<h1 align="center">
-  <a href="https://ocaml.github.io/odoc/">
-    odoc
-  </a>
-</h1>
-
-<p align="center">
-  <strong>OCaml Documentation Generator.</strong>
+# **[odoc](https://ocaml.github.io/odoc/) : OCaml Documentation Generator**
 </p>
 
 <p align="center">

--- a/odoc-md.opam
+++ b/odoc-md.opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+
+version: "dev"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+maintainer: [
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Jon Ludlam <jon@recoil.org>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator - Markdown support"
+description: """
+Odoc-md is part of the odoc suite of tools for generating documentation for OCaml packages.
+
+This package provides support for generating documentation from Markdown files.
+"""
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "odoc" {= version}
+  "cmarkit"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -124,7 +124,7 @@ let of_dune_build dir =
                         (* When dune has a notion of doc assets, do something *);
                       enable_warnings = false;
                       pkg_dir;
-                      other_docs = Fpath.Set.empty;
+                      other_docs = [];
                       config = Global_config.empty;
                     } )
             | _ -> None)

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -62,12 +62,15 @@ let compile_md ~output_dir ~input_file:file ~parent_id =
     let _, f = Fpath.split_base file in
     Some Fpath.(output_dir // Id.to_fpath parent_id // set_ext "odoc" f)
   in
-  let cmd = !odoc_md % Fpath.to_string file % "--output-dir" % p output_dir in
+  let cmd = !odoc_md % p file % "--output-dir" % p output_dir in
   let cmd = cmd % "--parent-id" % Id.to_string parent_id in
   let desc = Printf.sprintf "Compiling Markdown %s" (Fpath.to_string file) in
-  let lines = Cmd_outputs.submit desc cmd output_file in
-  Cmd_outputs.(
-    add_prefixed_output cmd compile_output (Fpath.to_string file) lines)
+  let _lines =
+    Cmd_outputs.submit
+      (Some (`Compile, Fpath.to_string file))
+      desc cmd output_file
+  in
+  ()
 
 let compile_asset ~output_dir ~name ~parent_id =
   let open Cmd in

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -62,16 +62,13 @@ let compile_md ~output_dir ~input_file:file ~parent_id =
     let _, f = Fpath.split_base file in
     Some Fpath.(output_dir // Id.to_fpath parent_id // set_ext "odoc" f)
   in
-  let cmd =
-    !odoc_md % Fpath.to_string file % "--output-dir" % p output_dir
-  in
+  let cmd = !odoc_md % Fpath.to_string file % "--output-dir" % p output_dir in
   let cmd = cmd % "--parent-id" % Id.to_string parent_id in
   let desc = Printf.sprintf "Compiling Markdown %s" (Fpath.to_string file) in
   let lines = Cmd_outputs.submit desc cmd output_file in
   Cmd_outputs.(
     add_prefixed_output cmd compile_output (Fpath.to_string file) lines)
 
-        
 let compile_asset ~output_dir ~name ~parent_id =
   let open Cmd in
   let output_file =

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -22,6 +22,8 @@ type compile_deps = { digest : Digest.t; deps : (string * Digest.t) list }
 
 let odoc = ref (Cmd.v "odoc")
 
+let odoc_md = ref (Cmd.v "odoc-md")
+
 let compile_deps f =
   let cmd = Cmd.(!odoc % "compile-deps" % Fpath.to_string f) in
   let desc = Printf.sprintf "Compile deps for %s" (Fpath.to_string f) in
@@ -54,6 +56,22 @@ let compile ~output_dir ~input_file:file ~includes ~parent_id =
        (Some (`Compile, Fpath.to_string file))
        desc cmd output_file
 
+let compile_md ~output_dir ~input_file:file ~parent_id =
+  let open Cmd in
+  let output_file =
+    let _, f = Fpath.split_base file in
+    Some Fpath.(output_dir // Id.to_fpath parent_id // set_ext "odoc" f)
+  in
+  let cmd =
+    !odoc_md % Fpath.to_string file % "--output-dir" % p output_dir
+  in
+  let cmd = cmd % "--parent-id" % Id.to_string parent_id in
+  let desc = Printf.sprintf "Compiling Markdown %s" (Fpath.to_string file) in
+  let lines = Cmd_outputs.submit desc cmd output_file in
+  Cmd_outputs.(
+    add_prefixed_output cmd compile_output (Fpath.to_string file) lines)
+
+        
 let compile_asset ~output_dir ~name ~parent_id =
   let open Cmd in
   let output_file =

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -25,6 +25,7 @@ val compile :
   includes:Fpath.set ->
   parent_id:Id.t ->
   unit
+val compile_md : output_dir:Fpath.t -> input_file:Fpath.t -> parent_id:Id.t -> unit
 
 val compile_asset : output_dir:Fpath.t -> name:string -> parent_id:Id.t -> unit
 

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -25,7 +25,8 @@ val compile :
   includes:Fpath.set ->
   parent_id:Id.t ->
   unit
-val compile_md : output_dir:Fpath.t -> input_file:Fpath.t -> parent_id:Id.t -> unit
+val compile_md :
+  output_dir:Fpath.t -> input_file:Fpath.t -> parent_id:Id.t -> unit
 
 val compile_asset : output_dir:Fpath.t -> name:string -> parent_id:Id.t -> unit
 

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -70,10 +70,10 @@ type impl_extra = { src_id : Odoc.Id.t; src_path : Fpath.t }
 type impl = [ `Impl of impl_extra ]
 
 type mld = [ `Mld ]
-
+type md = [ `Md ]
 type asset = [ `Asset ]
 
-type all_kinds = [ impl | intf | mld | asset ]
+type all_kinds = [ impl | intf | mld | asset | md ]
 type t = all_kinds unit
 
 let rec pp_kind : all_kinds Fmt.t =
@@ -82,6 +82,7 @@ let rec pp_kind : all_kinds Fmt.t =
   | `Intf x -> Format.fprintf fmt "`Intf %a" pp_intf_extra x
   | `Impl x -> Format.fprintf fmt "`Impl %a" pp_impl_extra x
   | `Mld -> Format.fprintf fmt "`Mld"
+  | `Md -> Format.fprintf fmt "`Md"
   | `Asset -> Format.fprintf fmt "`Asset"
 
 and pp_intf_extra fmt x =

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -44,10 +44,10 @@ type impl_extra = { src_id : Odoc.Id.t; src_path : Fpath.t }
 type impl = [ `Impl of impl_extra ]
 
 type mld = [ `Mld ]
-
+type md = [`Md]
 type asset = [ `Asset ]
 
-type t = [ impl | intf | mld | asset ] unit
+type t = [ impl | intf | mld | asset | md ] unit
 
 val pp : t Fmt.t
 

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -44,7 +44,7 @@ type impl_extra = { src_id : Odoc.Id.t; src_path : Fpath.t }
 type impl = [ `Impl of impl_extra ]
 
 type mld = [ `Mld ]
-type md = [`Md]
+type md = [ `Md ]
 type asset = [ `Asset ]
 
 type t = [ impl | intf | mld | asset | md ] unit

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -214,19 +214,23 @@ let packages ~dirs ~extra_libs_paths (pkgs : Packages.t list) : t list =
     in
     [ unit ]
   in
-  let of_md pkg (md :Fpath.t) : md unit list =
+  let of_md pkg (md : Fpath.t) : md unit list =
     let ext = Fpath.get_ext md in
     match ext with
     | ".md" ->
-      let rel_dir = doc_dir pkg in
-      let kind = `Md in
-      let name = md |> Fpath.rem_ext |> Fpath.basename |> ( ^ ) "page-" in
-      let lib_deps = Util.StringSet.empty in
-      let unit = make_unit ~name ~kind ~rel_dir ~input_file:md ~pkg ~include_dirs:Fpath.Set.empty ~lib_deps in
-      [ unit ]
+        let rel_dir = doc_dir pkg in
+        let kind = `Md in
+        let name = md |> Fpath.rem_ext |> Fpath.basename |> ( ^ ) "page-" in
+        let lib_deps = Util.StringSet.empty in
+        let unit =
+          make_unit ~name ~kind ~rel_dir ~input_file:md ~pkg
+            ~include_dirs:Fpath.Set.empty ~lib_deps
+            ~enable_warnings:pkg.enable_warnings
+        in
+        [ unit ]
     | _ ->
-      Logs.debug (fun m -> m "Skipping non-markdown doc file %a" Fpath.pp md);
-      []
+        Logs.debug (fun m -> m "Skipping non-markdown doc file %a" Fpath.pp md);
+        []
   in
   let of_asset pkg (asset : Packages.asset) : asset unit list =
     let open Fpath in
@@ -248,7 +252,7 @@ let packages ~dirs ~extra_libs_paths (pkgs : Packages.t list) : t list =
     let lib_units :> t list list = List.map (of_lib pkg) pkg.libraries in
     let mld_units :> t list list = List.map (of_mld pkg) pkg.mlds in
     let asset_units :> t list list = List.map (of_asset pkg) pkg.assets in
-    let md_units :> t list list = Fpath.Set.fold (fun md acc -> of_md pkg md :: acc) pkg.other_docs [] in
+    let md_units :> t list list = List.map (of_md pkg) pkg.other_docs in
     let pkg_index :> t list =
       let has_index_page =
         List.exists

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -87,7 +87,7 @@ type t = {
   mlds : mld list;
   assets : asset list;
   enable_warnings : bool;
-  other_docs : Fpath.Set.t;
+  other_docs : Fpath.t list;
   pkg_dir : Fpath.t;
   config : Global_config.t;
 }
@@ -106,9 +106,7 @@ let pp fmt t =
      }@]"
     t.name t.version (Fmt.Dump.list pp_libty) t.libraries (Fmt.Dump.list pp_mld)
     t.mlds (Fmt.Dump.list pp_asset) t.assets t.enable_warnings
-    (Fmt.Dump.list Fpath.pp)
-    (Fpath.Set.elements t.other_docs)
-    Fpath.pp t.pkg_dir
+    (Fmt.Dump.list Fpath.pp) t.other_docs Fpath.pp t.pkg_dir
 
 let maybe_prepend_top top_dir dir =
   match top_dir with None -> dir | Some d -> Fpath.(d // dir)
@@ -405,6 +403,7 @@ let of_libs ~packages_dir libs =
                         docs
                       |> Fpath.Set.of_list
                     in
+                    let other_docs = Fpath.Set.elements other_docs in
                     Some
                       {
                         name = pkg.name;
@@ -470,8 +469,8 @@ let of_packages ~packages_dir packages =
             files.docs
           |> Fpath.Set.of_list
         in
-
         let enable_warnings = List.mem pkg.name packages in
+        let other_docs = Fpath.Set.elements other_docs in
         Util.StringMap.add pkg.name
           {
             name = pkg.name;

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -74,7 +74,7 @@ type t = {
   mlds : mld list;
   assets : asset list;
   enable_warnings : bool;
-  other_docs : Fpath.Set.t;
+  other_docs : Fpath.t list;
   pkg_dir : Fpath.t;
   config : Global_config.t;
 }

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -209,7 +209,7 @@ let process_package pkg =
       mlds;
       assets;
       enable_warnings = false;
-      other_docs = Fpath.Set.empty;
+      other_docs = [];
       pkg_dir = top_dir pkg;
       config;
     }

--- a/src/markdown/doc_of_md.ml
+++ b/src/markdown/doc_of_md.ml
@@ -86,6 +86,13 @@ let meta_to_loc ~locator meta = textloc_to_loc ~locator (Meta.textloc meta)
    about the nature of data they apply to. E.g. most assume the
    textloc is on the same line. *)
 
+let chop_end_of_meta_textloc ~count meta =
+  let textloc = Meta.textloc meta in
+  let last_line = Textloc.last_line textloc in
+  let last_byte = Textloc.last_byte textloc - count in
+  let textloc = Textloc.set_last textloc ~last_byte ~last_line in
+  Meta.with_textloc ~keep_id:true meta textloc
+
 let split_info_string_locs ~left_count ~right_count m =
   if right_count = 0 then (Meta.textloc m, Textloc.none)
   else
@@ -296,6 +303,67 @@ and inline_to_inline_elements ~locator defs acc i : inlines_acc =
       inline_to_inline_elements ~locator defs acc i
   | _ -> assert false
 
+(* Heading label support - CommonMark extension. Parses a potential
+   final {#id} in heading inlines. In [id] braces must be escaped
+   otherwise parsing fails; if the rightmost brace is escaped it's
+   not a heading label. The parse runs from right to left *)
+
+let parse_heading_label s =
+  let rec loop s max prev i =
+    if i < 0 then None
+    else
+      match s.[i] with
+      | '{' as c ->
+          if i > 0 && s.[i - 1] = '\\' then loop s max c (i - 1)
+          else if prev = '#' then Some i
+          else None
+      | '}' as c ->
+          if i > 0 && s.[i - 1] = '\\' then loop s max c (i - 1) else None
+      | c -> loop s max c (i - 1)
+  in
+  let max = String.length s - 1 in
+  let last =
+    (* [last] is rightmost non blank, if any. *)
+    let k = ref max in
+    while (not (!k < 0)) && is_blank s.[!k] do
+      decr k
+    done;
+    !k
+  in
+  if last < 1 || s.[last] <> '}' || s.[last - 1] = '\\' then None
+  else
+    match loop s max s.[last] (last - 1) with
+    | None -> None
+    | Some first ->
+        let chop = max - first + 1 in
+        let text = String.sub s 0 first in
+        let first = first + 2 and last = last - 1 in
+        (* remove delims *)
+        let label = String.sub s first (last - first + 1) in
+        Some (text, chop, label)
+
+let heading_inline_and_label h =
+  (* cmarkit claims it's already normalized but let's be defensive :-) *)
+  match Inline.normalize (Block.Heading.inline h) with
+  | Inline.Text (t, m) as inline -> (
+      match parse_heading_label t with
+      | None -> (inline, None)
+      | Some (t, chop, label) ->
+          let m = chop_end_of_meta_textloc ~count:chop m in
+          (Inline.Text (t, m), Some label))
+  | Inline.Inlines (is, m0) as inline -> (
+      match List.rev is with
+      | Inline.Text (t, m1) :: ris -> (
+          match parse_heading_label t with
+          | None -> (inline, None)
+          | Some (t, chop, label) ->
+              let m0 = chop_end_of_meta_textloc ~count:chop m0 in
+              let m1 = chop_end_of_meta_textloc ~count:chop m1 in
+              ( Inline.Inlines (List.rev (Inline.Text (t, m1) :: ris), m0),
+                Some label ))
+      | _ -> (inline, None))
+  | inline -> (inline, None)
+
 (* Block translations *)
 
 let raw_paragraph ~loc ~raw_loc backend raw =
@@ -381,14 +449,11 @@ let heading_to_block_element ~locator defs h m (bs, warns) =
     | 6 -> (5, warn ~loc warn_heading_level_6 warns)
     | level -> (level, warns)
   in
-  let inline =
-    (* cmarkit claims it's already normalized but let's be defensive :-) *)
-    Inline.normalize (Block.Heading.inline h)
-  in
+  let inline, label = heading_inline_and_label h in
   let inlines, warns =
     inline_to_inline_elements ~locator defs ([], warns) inline
   in
-  (Loc.at loc (`Heading (level, None, inlines)) :: bs, warns)
+  (Loc.at loc (`Heading (level, label, inlines)) :: bs, warns)
 
 let paragraph_to_nestable_block_element ~locator defs p m (bs, warns) =
   (* TODO Parse inlines for @tags support. *)

--- a/src/markdown/doc_of_md.ml
+++ b/src/markdown/doc_of_md.ml
@@ -1,0 +1,454 @@
+let strf = Printf.sprintf
+
+(* ocamlmark parsing *)
+
+open Odoc_parser
+open Cmarkit
+
+(* Text location and comment massaging.
+
+   One slight annoyance is that CommonMark is sensitive to leading
+   blanks on lines and ocamldoc comments are usually indented by [n]
+   spaces up the … of (** … *). So we can't just feed it the comment
+   text: we would mostly get CommonMark indented code blocks.
+
+   So we massage the comment to trim up to [n] initial spaces after
+   newlines. [n] being the number of columns until … in (** … *). We
+   need to remember how much we trimmed on each line in order to patch
+   the locations reported by cmarkit. Below we keep pass that info
+   around using the [~locator] argument.
+
+   This is not needed in [md] files, but the code is kept in case we
+   add support for markdown in docstrings. *)
+
+let comment_col ~location = location.Lexing.pos_cnum - location.Lexing.pos_bol
+
+let massage_comment ~location b s =
+  let rec next_non_space s ~max i =
+    if i > max || not (s.[i] = ' ') then i else next_non_space s ~max (i + 1)
+  in
+  let rec find_after_trim ~max_trim s max ~start i =
+    if i - start + 1 > max_trim || i > max || s.[i] <> ' ' then i
+    else find_after_trim ~max_trim s max ~start (i + 1)
+  in
+  let flush b s start last =
+    Buffer.add_substring b s start (last - start + 1)
+  in
+  let rec loop b s acc ~max_trim max start k =
+    if k > max then (
+      flush b s start max;
+      ((location, Array.of_list (List.rev acc)), Buffer.contents b))
+    else if not (s.[k] = '\n' || s.[k] = '\r') then
+      loop b s acc ~max_trim max start (k + 1)
+    else
+      let next = k + 1 in
+      let next =
+        if s.[k] = '\r' && next <= max && s.[next] = '\n' then next + 1
+        else next
+      in
+      let after_trim = find_after_trim ~max_trim s max ~start:next next in
+      let trim = after_trim - next in
+      flush b s start (next - 1);
+      loop b s (trim :: acc) ~max_trim max after_trim after_trim
+  in
+  if s = "" then ((location, [| 0 |]), s)
+  else
+    let max = String.length s - 1 in
+    let nsp = next_non_space s ~max 0 in
+    let max_trim = comment_col ~location + nsp in
+    loop b s [ nsp (* trim *) ] ~max_trim max nsp nsp
+
+let textloc_to_loc ~locator textloc =
+  (* Note: if you get an [Invalid_argument] from this function suspect a bug
+     in cmarkit's location computation. *)
+  let point_of_line_and_byte_pos ~locator:(location, line_trim_counts) l pos =
+    let line_num, line_pos = l in
+    let line = location.Lexing.pos_lnum + line_num - 1 in
+    let column = line_trim_counts.(line_num - 1) + (pos - line_pos) in
+    let column =
+      match line_num with 1 -> comment_col ~location + column | _ -> column
+    in
+    { Loc.line; column }
+  in
+  let file = Textloc.file textloc in
+  let first_line = Textloc.first_line textloc in
+  let first_byte = Textloc.first_byte textloc in
+  let last_line = Textloc.last_line textloc in
+  let last_byte = Textloc.last_byte textloc + 1 in
+  let start = point_of_line_and_byte_pos ~locator first_line first_byte in
+  let end_ = point_of_line_and_byte_pos ~locator last_line last_byte in
+  { Loc.file; start; end_ }
+
+let meta_to_loc ~locator meta = textloc_to_loc ~locator (Meta.textloc meta)
+
+(* Sometimes we need to munge a bit the cmarkit metas and textlocs.
+   These function do that. They are not general and make assumptions
+   about the nature of data they apply to. E.g. most assume the
+   textloc is on the same line. *)
+
+let split_info_string_locs ~left_count ~right_count m =
+  if right_count = 0 then (Meta.textloc m, Textloc.none)
+  else
+    let textloc = Meta.textloc m in
+    let line = Textloc.first_line textloc in
+    let last_byte = Textloc.first_byte textloc + left_count - 1 in
+    let first_byte = Textloc.last_byte textloc - right_count + 1 in
+    ( Textloc.set_last textloc ~last_byte ~last_line:line,
+      Textloc.set_first textloc ~first_byte ~first_line:line )
+
+let textloc_of_sub textloc ~first ~last (* in textloc relative space *) =
+  let file = Textloc.file textloc in
+  let line = Textloc.first_line textloc in
+  let first_byte = Textloc.first_byte textloc + first in
+  let last_byte = Textloc.first_byte textloc + last in
+  Textloc.v ~file ~first_byte ~last_byte ~first_line:line ~last_line:line
+
+(* Warnings *)
+
+let warn_unsupported_hard_break =
+  "Hard breaks are unsupported in ocamlmark, using a soft break."
+
+let warn_unsupported_header_nesting =
+  "Headers in list items are unsupported in ocamlmark, dropped."
+
+let warn_heading_level_6 =
+  "Heading level 6 is unsupported in ocamlmark, using 5."
+
+let warn_unsupported_list_start_number start =
+  strf "List start numbers are unsupported in ocamlmark, replacing %d with 1."
+    start
+
+let warn_unsupported_cmark kind =
+  strf "%s are unsupported in ocamlmark, dropped." kind
+
+let warn_unsupported_link_title =
+  "Link titles are unsupported in ocamlmark, dropped."
+
+let warn ~loc:location message warns = { Warning.location; message } :: warns
+
+let warn_unsupported_cmark ~locator kind meta (acc, warns) =
+  let msg = warn_unsupported_cmark kind in
+  (acc, warn ~loc:(meta_to_loc ~locator meta) msg warns)
+
+let warn_unsupported_header_nesting ~locator meta (acc, warns) =
+  let msg = warn_unsupported_header_nesting in
+  (acc, warn ~loc:(meta_to_loc ~locator meta) msg warns)
+
+let is_blank = function ' ' | '\t' -> true | _ -> false
+let rec next_blank s ~max i =
+  if i > max || is_blank s.[i] then i else next_blank s ~max (i + 1)
+
+let rec next_nonblank s ~max i =
+  if i > max || not (is_blank s.[i]) then i else next_nonblank s ~max (i + 1)
+
+(* Translating blocks and inlines. *)
+
+(* A few type definitions for better variant typing. *)
+
+type inlines_acc = Ast.inline_element Ast.with_location list * Warning.t list
+type ast_acc = Ast.t * Warning.t list
+type nestable_ast_acc =
+  Ast.nestable_block_element Ast.with_location list * Warning.t list
+
+(* Inline translations *)
+
+let link_definition defs l =
+  match Inline.Link.reference_definition defs l with
+  | Some (Link_definition.Def (ld, _)) -> ld
+  | Some _ -> assert false (* if we parse without cmarkit extensions *)
+  | None -> assert false (* assert [l]'s referenced label is not synthetic *)
+
+let autolink_to_inline_element ~locator a m (is, warns) =
+  let loc = meta_to_loc ~locator m in
+  let link, link_loc = Inline.Autolink.link a in
+  let link_loc = meta_to_loc ~locator link_loc in
+  let text = [ Loc.at link_loc (`Word link) ] in
+  (Loc.at loc (`Link (link, text)) :: is, warns)
+
+let break_to_inline_element ~locator br m (is, warns) =
+  let loc = meta_to_loc ~locator m in
+  let warns =
+    match Inline.Break.type' br with
+    | `Soft -> warns
+    | `Hard -> warn ~loc warn_unsupported_hard_break warns
+  in
+  (Loc.at loc (`Space "\n") :: is, warns)
+
+let code_span_to_inline_element ~locator cs m (is, warns) =
+  let loc = meta_to_loc ~locator m in
+  let code = Inline.Code_span.code cs in
+  (Loc.at loc (`Code_span code) :: is, warns)
+
+let raw_html_to_inline_element ~locator html m (is, warns) =
+  let loc = meta_to_loc ~locator m in
+  let html = String.concat "\n" (List.map Block_line.tight_to_string html) in
+  (Loc.at loc (`Raw_markup (Some "html", html)) :: is, warns)
+
+let image_to_inline_element ~locator defs i m (is, warns) =
+  (* We map to raw html, ocamldoc's ast should have a case for that. *)
+  let escape esc b s =
+    Buffer.clear b;
+    esc b s;
+    Buffer.contents b
+  in
+  let pct_esc = escape Cmarkit_html.buffer_add_pct_encoded_string in
+  let html_esc = escape Cmarkit_html.buffer_add_html_escaped_string in
+  let loc = meta_to_loc ~locator m in
+  let b = Buffer.create 255 in
+  let ld = link_definition defs i in
+  let link =
+    match Link_definition.dest ld with
+    | None -> ""
+    | Some (link, _) -> pct_esc b link
+  in
+  let title =
+    match Link_definition.title ld with
+    | None -> ""
+    | Some title ->
+        let title = List.map Block_line.tight_to_string title in
+        html_esc b (String.concat "\n" title)
+  in
+  let alt =
+    let ls = Inline.to_plain_text ~break_on_soft:false (Inline.Link.text i) in
+    html_esc b (String.concat "\n" (List.map (String.concat "") ls))
+  in
+  let img =
+    String.concat ""
+      [ {|<img src="|}; link; {|" alt="|}; alt; {|" title="|}; title; {|" >"|} ]
+  in
+  (Loc.at loc (`Raw_markup (Some "html", img)) :: is, warns)
+
+let text_to_inline_elements ~locator s meta ((is, warns) as acc) =
+  (* [s] is on a single source line (but may have newlines because of
+     character references) we need to tokenize it for ocamldoc's ast. *)
+  let flush_tok s meta acc is_space first last =
+    let textloc = textloc_of_sub (Meta.textloc meta) ~first ~last in
+    let loc = textloc_to_loc ~locator textloc in
+    let s = String.sub s first (last - first + 1) in
+    Loc.at loc (if is_space then `Space s else `Word s) :: acc
+  in
+  let rec tokenize s meta acc max start is_space =
+    if start > max then (List.rev_append acc is, warns)
+    else
+      let next_start =
+        if is_space then next_nonblank s ~max start else next_blank s ~max start
+      in
+      let acc = flush_tok s meta acc is_space start (next_start - 1) in
+      tokenize s meta acc max next_start (not is_space)
+  in
+  let max = String.length s - 1 in
+  if max < 0 then acc else tokenize s meta [] max 0 (is_blank s.[0])
+
+let rec link_reference_to_inline_element ~locator defs l m (is, warns) =
+  let loc = meta_to_loc ~locator m in
+  let ld = link_definition defs l in
+  let link =
+    match Link_definition.dest ld with None -> "" | Some (l, _) -> l
+  in
+  let warns =
+    match Link_definition.title ld with
+    | None -> warns
+    | Some title ->
+        let textloc = Block_line.tight_list_textloc title in
+        let loc = textloc_to_loc ~locator textloc in
+        warn ~loc warn_unsupported_link_title warns
+  in
+  let text, warns =
+    inline_to_inline_elements ~locator defs ([], warns) (Inline.Link.text l)
+  in
+  (Loc.at loc (`Link (link, text)) :: is, warns)
+
+and link_to_inline_element ~locator defs l m acc =
+  link_reference_to_inline_element ~locator defs l m acc
+
+and emphasis_to_inline_element ~locator defs style e m (is, warns) =
+  let loc = meta_to_loc ~locator m in
+  let i = Inline.Emphasis.inline e in
+  let inlines, warns = inline_to_inline_elements ~locator defs ([], warns) i in
+  (Loc.at loc (`Styled (style, inlines)) :: is, warns)
+
+and inline_to_inline_elements ~locator defs acc i : inlines_acc =
+  match i with
+  | Inline.Autolink (a, m) -> autolink_to_inline_element ~locator a m acc
+  | Inline.Break (b, m) -> break_to_inline_element ~locator b m acc
+  | Inline.Code_span (cs, m) -> code_span_to_inline_element ~locator cs m acc
+  | Inline.Emphasis (e, m) ->
+      emphasis_to_inline_element ~locator defs `Emphasis e m acc
+  | Inline.Image (i, m) -> image_to_inline_element ~locator defs i m acc
+  | Inline.Inlines (is, _m) ->
+      let inline = inline_to_inline_elements ~locator defs in
+      List.fold_left inline acc (List.rev is)
+  | Inline.Link (l, m) -> link_to_inline_element ~locator defs l m acc
+  | Inline.Raw_html (html, m) -> raw_html_to_inline_element ~locator html m acc
+  | Inline.Strong_emphasis (e, m) ->
+      emphasis_to_inline_element ~locator defs `Bold e m acc
+  | Inline.Text (t, m) -> text_to_inline_elements ~locator t m acc
+  | _ -> assert false
+
+(* Block translations *)
+
+let raw_paragraph ~loc ~raw_loc backend raw =
+  Loc.at loc (`Paragraph [ Loc.at raw_loc (`Raw_markup (Some backend, raw)) ])
+
+let code_block_to_nestable_block_element ~locator cb m (bs, warns) =
+  let loc = meta_to_loc ~locator m in
+  let code = Block.Code_block.code cb in
+  let code_loc = textloc_to_loc ~locator (Block_line.list_textloc code) in
+  let code = String.concat "\n" (List.map Block_line.to_string code) in
+  match Block.Code_block.info_string cb with
+  | None ->
+      let code_block =
+        {
+          Ast.meta = None;
+          delimiter = None;
+          content = Loc.at code_loc code;
+          output = None;
+        }
+        (* (None, Loc.at code_loc code) *)
+      in
+      (Loc.at loc (`Code_block code_block) :: bs, warns)
+  | Some (info, im) -> (
+      match Block.Code_block.language_of_info_string info with
+      | None ->
+          let code_block =
+            {
+              Ast.meta = None;
+              delimiter = None;
+              content = Loc.at code_loc code;
+              output = None;
+            }
+          in
+          (* (None, Loc.at code_loc code) *)
+          (Loc.at loc (`Code_block code_block) :: bs, warns)
+      | Some ("verb", _) -> (Loc.at loc (`Verbatim code) :: bs, warns)
+      | Some ("=html", _) ->
+          (raw_paragraph ~loc ~raw_loc:code_loc "html" code :: bs, warns)
+      | Some ("=latex", _) ->
+          (raw_paragraph ~loc ~raw_loc:code_loc "latex" code :: bs, warns)
+      | Some ("=texi", _) ->
+          (raw_paragraph ~loc ~raw_loc:code_loc "texi" code :: bs, warns)
+      | Some ("=man", _) ->
+          (raw_paragraph ~loc ~raw_loc:code_loc "man" code :: bs, warns)
+      | Some (lang, env) ->
+          let left_count = String.length lang in
+          let right_count = String.length env in
+          let lang_loc, env_loc =
+            split_info_string_locs ~left_count ~right_count im
+          in
+          let env =
+            if env = "" then None
+            else Some (Loc.at (textloc_to_loc ~locator env_loc) env)
+          in
+          let lang = Loc.at (textloc_to_loc ~locator lang_loc) lang in
+          let metadata = Some { Ast.language = lang; tags = env } in
+          let code_block =
+            {
+              Ast.meta = metadata;
+              delimiter = None;
+              content = Loc.at code_loc code;
+              output = None;
+            }
+            (* (metadata, Loc.at code_loc code) *)
+          in
+          (Loc.at loc (`Code_block code_block) :: bs, warns))
+
+let html_block_to_nestable_block_element ~locator html m (bs, warns) =
+  let loc = meta_to_loc ~locator m in
+  let html = String.concat "\n" (List.map fst html) in
+  (raw_paragraph ~loc ~raw_loc:loc "html" html :: bs, warns)
+
+let heading_to_block_element ~locator defs h m (bs, warns) =
+  let loc = meta_to_loc ~locator m in
+  let level, warns =
+    match Block.Heading.level h with
+    | 6 -> (5, warn ~loc warn_heading_level_6 warns)
+    | level -> (level, warns)
+  in
+  let inline =
+    (* cmarkit claims it's already normalized but let's be defensive :-) *)
+    Inline.normalize (Block.Heading.inline h)
+  in
+  let inlines, warns =
+    inline_to_inline_elements ~locator defs ([], warns) inline
+  in
+  (Loc.at loc (`Heading (level, None, inlines)) :: bs, warns)
+
+let paragraph_to_nestable_block_element ~locator defs p m (bs, warns) =
+  (* TODO Parse inlines for @tags support. *)
+  let loc = meta_to_loc ~locator m in
+  let i = Block.Paragraph.inline p in
+  let is, warns = inline_to_inline_elements ~locator defs ([], warns) i in
+  (Loc.at loc (`Paragraph is) :: bs, warns)
+
+let thematic_break_to_nestable_block_element ~locator m (bs, warns) =
+  let loc = meta_to_loc ~locator m in
+  (raw_paragraph ~loc ~raw_loc:loc "html" "<hr>" :: bs, warns)
+
+let rec list_to_nestable_block_element ~locator defs l m (bs, warns) =
+  let loc = meta_to_loc ~locator m in
+  let style = `Heavy (* Note this is a layout property of ocamldoc *) in
+  let kind, warns =
+    match Block.List'.type' l with
+    | `Unordered _ -> (`Unordered, warns)
+    | `Ordered (start, _) ->
+        ( `Ordered,
+          if start = 1 then warns
+          else warn ~loc (warn_unsupported_list_start_number start) warns )
+  in
+  let add_item ~locator (acc, warns) (i, _meta) =
+    let b = Block.List_item.block i in
+    let bs, warns =
+      block_to_nestable_block_elements ~locator defs ([], warns) b
+    in
+    (bs :: acc, warns)
+  in
+  let ritems = List.rev (Block.List'.items l) in
+  let items, warns = List.fold_left (add_item ~locator) ([], warns) ritems in
+  (Loc.at loc (`List (kind, style, items)) :: bs, warns)
+
+and block_to_nestable_block_elements ~locator defs acc b : nestable_ast_acc =
+  match b with
+  | Block.Blocks (bs, _) ->
+      let block = block_to_nestable_block_elements ~locator defs in
+      List.fold_left block acc (List.rev bs)
+  | Block.Code_block (c, m) ->
+      code_block_to_nestable_block_element ~locator c m acc
+  | Block.Heading (_, m) -> warn_unsupported_header_nesting ~locator m acc
+  | Block.Html_block (html, m) ->
+      html_block_to_nestable_block_element ~locator html m acc
+  | Block.List (l, m) -> list_to_nestable_block_element ~locator defs l m acc
+  | Block.Paragraph (p, m) ->
+      paragraph_to_nestable_block_element ~locator defs p m acc
+  | Block.Block_quote (_, m) ->
+      warn_unsupported_cmark ~locator "Block quotes" m acc
+  | Block.Thematic_break (_, m) ->
+      thematic_break_to_nestable_block_element ~locator m acc
+  | Block.Blank_line _ | Block.Link_reference_definition _ ->
+      (* layout cases *) acc
+  | _ -> assert false
+
+let rec block_to_ast ~locator defs acc b : ast_acc =
+  match b with
+  | Block.Heading (h, m) -> heading_to_block_element ~locator defs h m acc
+  | Block.Blocks (bs, _) ->
+      List.fold_left (block_to_ast ~locator defs) acc (List.rev bs)
+  | b ->
+      (* We can't go directy with acc because of nestable typing. *)
+      let bs, ws = acc in
+      let bs', ws = block_to_nestable_block_elements ~locator defs ([], ws) b in
+      (List.rev_append (List.rev (bs' :> Ast.t)) bs, ws)
+
+(* Parsing comments *)
+
+let parse_comment ?buffer:b ~location ~text:s () : Ast.t * Warning.t list =
+  let b =
+    match b with
+    | None -> Buffer.create (String.length s)
+    | Some b ->
+        Buffer.reset b;
+        b
+  in
+  let locator, text = massage_comment ~location b s in
+  let warns = ref [] and file = location.Lexing.pos_fname in
+  let doc = Doc.of_string ~file ~locs:true ~strict:true text in
+  block_to_ast ~locator (Doc.defs doc) ([], !warns) (Doc.block doc)

--- a/src/markdown/doc_of_md.mli
+++ b/src/markdown/doc_of_md.mli
@@ -1,0 +1,12 @@
+(** [ocamlmark] support. *)
+
+(** {1:parsing ocamlmark parsing} *)
+
+val parse_comment :
+  ?buffer:Buffer.t ->
+  location:Lexing.position ->
+  text:string ->
+  unit ->
+  Odoc_parser.Ast.t * Odoc_parser.Warning.t list
+(** [parse_comment ~location ~text] parses the ocamlmark [text] assuming it
+    corresponds to [location]. [buffer] is used as a scratch buffer. *)

--- a/src/markdown/dune
+++ b/src/markdown/dune
@@ -3,4 +3,3 @@
  (name odoc_md)
  (package odoc-md)
  (libraries cmarkit odoc.model odoc.odoc cmdliner))
-

--- a/src/markdown/dune
+++ b/src/markdown/dune
@@ -1,0 +1,6 @@
+(executable
+ (public_name odoc-md)
+ (name odoc_md)
+ (package odoc-md)
+ (libraries cmarkit odoc.model odoc.odoc cmdliner))
+

--- a/src/markdown/odoc_md.ml
+++ b/src/markdown/odoc_md.ml
@@ -1,0 +1,74 @@
+(* This exe will compile a markdown file, outputting a compiled `page-x.odoc` file. 
+   This is tightly coupled with the internal representation of odoc files and thus needs
+   to be run with the exact same version of odoc that it is compiled with. *)
+
+open Odoc_model
+
+let parse id input_s =
+  let location =
+    Lexing.{ pos_fname = input_s; pos_lnum = 1; pos_cnum = 0; pos_bol = 0 }
+  in
+  let str = In_channel.(with_open_bin input_s input_all) in
+  let content, _warnings = Doc_of_md.parse_comment ~location ~text:str () in
+  let (content, ()) = Semantics.ast_to_comment ~internal_tags:Expect_none
+  ~sections_allowed:`All ~tags_allowed:true
+  ~parent_of_sections:(id :> Paths.Identifier.LabelParent.t) content []
+  |> Error.raise_warnings in
+  content
+
+let mk_page input_s id content =
+  (* Construct the output file representation *)
+  let zero_heading = Comment.find_zero_heading content in
+  let frontmatter, content = Comment.extract_frontmatter content in
+  let digest = Digest.file input_s in
+  let root =
+    let file =
+      Root.Odoc_file.create_page input_s zero_heading frontmatter
+    in
+    { Root.id = (id :> Paths.Identifier.OdocId.t); file; digest }
+  in
+  let children=[] in
+  { Lang.Page.name=id; root; children; content; digest; linked = false; frontmatter }
+
+let run input_s parent_id_str odoc_dir =
+  (* Construct the id of this page *)
+  let page_name =
+    Filename.basename input_s |> Filename.chop_extension
+  in
+  let parent_id = Odoc_odoc.Compile.mk_id parent_id_str in
+  let id = Odoc_model.Paths.Identifier.Mk.leaf_page (parent_id, Odoc_model.Names.PageName.make_std page_name) in
+
+  let content = parse id input_s in
+  let page = mk_page input_s id content in
+
+  let output = Fpath.(v odoc_dir // v parent_id_str / ("page-" ^ page_name ^ ".odoc")) in
+  Odoc_odoc.Odoc_file.save_page output ~warnings:[] page
+
+open Cmdliner
+
+let input =
+  let doc = "Input markdown file." in
+  Arg.(required & pos 0 (some file) None & info ~doc ~docv:"FILE" [])
+
+let parent_id =
+  let doc = "Parent id. This defines both the location of the resulting odoc file as well as the \
+    location of the eventual html or other file." in
+  Arg.(
+    required
+    & opt (some string) None
+    & info ~docv:"PARENT" ~doc [ "parent-id" ])
+
+let output_dir =
+  let doc = "Output file directory. The output file will be put in the parent-id path below this." in
+  Arg.(
+    required
+    & opt (some string) None
+    & info ~docv:"PATH" ~doc [ "output-dir" ])
+    
+let cmd =
+  let doc = "Compile a markdown file to an odoc page-*.odoc file." in
+  let info = Cmd.info "odoc-md" ~doc in
+  Cmd.v info
+    Term.(const run $ input $ parent_id $ output_dir)
+
+let () = Cmdliner.(exit @@ Cmd.eval cmd)

--- a/src/markdown/odoc_md.ml
+++ b/src/markdown/odoc_md.ml
@@ -1,4 +1,4 @@
-(* This exe will compile a markdown file, outputting a compiled `page-x.odoc` file. 
+(* This exe will compile a markdown file, outputting a compiled `page-x.odoc` file.
    This is tightly coupled with the internal representation of odoc files and thus needs
    to be run with the exact same version of odoc that it is compiled with. *)
 
@@ -10,10 +10,13 @@ let parse id input_s =
   in
   let str = In_channel.(with_open_bin input_s input_all) in
   let content, _warnings = Doc_of_md.parse_comment ~location ~text:str () in
-  let (content, ()) = Semantics.ast_to_comment ~internal_tags:Expect_none
-  ~sections_allowed:`All ~tags_allowed:true
-  ~parent_of_sections:(id :> Paths.Identifier.LabelParent.t) content []
-  |> Error.raise_warnings in
+  let content, () =
+    Semantics.ast_to_comment ~internal_tags:Expect_none ~sections_allowed:`All
+      ~tags_allowed:true
+      ~parent_of_sections:(id :> Paths.Identifier.LabelParent.t)
+      content []
+    |> Error.raise_warnings
+  in
   content
 
 let mk_page input_s id content =
@@ -22,26 +25,35 @@ let mk_page input_s id content =
   let frontmatter, content = Comment.extract_frontmatter content in
   let digest = Digest.file input_s in
   let root =
-    let file =
-      Root.Odoc_file.create_page input_s zero_heading frontmatter
-    in
+    let file = Root.Odoc_file.create_page input_s zero_heading frontmatter in
     { Root.id = (id :> Paths.Identifier.OdocId.t); file; digest }
   in
-  let children=[] in
-  { Lang.Page.name=id; root; children; content; digest; linked = false; frontmatter }
+  let children = [] in
+  {
+    Lang.Page.name = id;
+    root;
+    children;
+    content;
+    digest;
+    linked = false;
+    frontmatter;
+  }
 
 let run input_s parent_id_str odoc_dir =
   (* Construct the id of this page *)
-  let page_name =
-    Filename.basename input_s |> Filename.chop_extension
-  in
+  let page_name = Filename.basename input_s |> Filename.chop_extension in
   let parent_id = Odoc_odoc.Compile.mk_id parent_id_str in
-  let id = Odoc_model.Paths.Identifier.Mk.leaf_page (parent_id, Odoc_model.Names.PageName.make_std page_name) in
+  let id =
+    Odoc_model.Paths.Identifier.Mk.leaf_page
+      (parent_id, Odoc_model.Names.PageName.make_std page_name)
+  in
 
   let content = parse id input_s in
   let page = mk_page input_s id content in
 
-  let output = Fpath.(v odoc_dir // v parent_id_str / ("page-" ^ page_name ^ ".odoc")) in
+  let output =
+    Fpath.(v odoc_dir // v parent_id_str / ("page-" ^ page_name ^ ".odoc"))
+  in
   Odoc_odoc.Odoc_file.save_page output ~warnings:[] page
 
 open Cmdliner
@@ -51,24 +63,24 @@ let input =
   Arg.(required & pos 0 (some file) None & info ~doc ~docv:"FILE" [])
 
 let parent_id =
-  let doc = "Parent id. This defines both the location of the resulting odoc file as well as the \
-    location of the eventual html or other file." in
+  let doc =
+    "Parent id. This defines both the location of the resulting odoc file as \
+     well as the location of the eventual html or other file."
+  in
   Arg.(
-    required
-    & opt (some string) None
-    & info ~docv:"PARENT" ~doc [ "parent-id" ])
+    required & opt (some string) None & info ~docv:"PARENT" ~doc [ "parent-id" ])
 
 let output_dir =
-  let doc = "Output file directory. The output file will be put in the parent-id path below this." in
+  let doc =
+    "Output file directory. The output file will be put in the parent-id path \
+     below this."
+  in
   Arg.(
-    required
-    & opt (some string) None
-    & info ~docv:"PATH" ~doc [ "output-dir" ])
-    
+    required & opt (some string) None & info ~docv:"PATH" ~doc [ "output-dir" ])
+
 let cmd =
   let doc = "Compile a markdown file to an odoc page-*.odoc file." in
   let info = Cmd.info "odoc-md" ~doc in
-  Cmd.v info
-    Term.(const run $ input $ parent_id $ output_dir)
+  Cmd.v info Term.(const run $ input $ parent_id $ output_dir)
 
 let () = Cmdliner.(exit @@ Cmd.eval cmd)

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -244,11 +244,11 @@ let mld ~parent_id ~parents_children ~output ~children ~warnings_options input =
          Ok (Paths.Identifier.Mk.page (parent_id, page_name))
      | None -> Ok (Paths.Identifier.Mk.page (parent_id, page_name)))
      >>= fun id -> Ok (id :> Paths.Identifier.Page.t))
-  >>= fun name ->
+  >>= fun id ->
   let resolve content =
     let zero_heading = Comment.find_zero_heading content in
     let frontmatter, content = Comment.extract_frontmatter content in
-    if (not (is_index_page name)) && has_children_order frontmatter then
+    if (not (is_index_page id)) && has_children_order frontmatter then
       Error.raise_warning
         (Error.filename_only
            "Non-index page cannot specify (children _) in the frontmatter."
@@ -257,11 +257,11 @@ let mld ~parent_id ~parents_children ~output ~children ~warnings_options input =
       let file =
         Root.Odoc_file.create_page root_name zero_heading frontmatter
       in
-      { Root.id = (name :> Paths.Identifier.OdocId.t); file; digest }
+      { Root.id = (id :> Paths.Identifier.OdocId.t); file; digest }
     in
     let page =
       Lang.Page.
-        { name; root; children; content; digest; linked = false; frontmatter }
+        { name=id; root; children; content; digest; linked = false; frontmatter }
     in
     Odoc_file.save_page output ~warnings:[] page;
     ()
@@ -270,11 +270,12 @@ let mld ~parent_id ~parents_children ~output ~children ~warnings_options input =
   Error.handle_errors_and_warnings ~warnings_options
   @@ Error.catch_errors_and_warnings
   @@ fun () ->
-  Odoc_loader.read_string (name :> Paths.Identifier.LabelParent.t) input_s str
+  Odoc_loader.read_string (id :> Paths.Identifier.LabelParent.t) input_s str
   |> Error.raise_errors_and_warnings
   |> function
   | `Stop -> resolve [] (* TODO: Error? *)
   | `Docs content -> resolve content
+      
 
 let handle_file_ext ext =
   match ext with

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -261,7 +261,15 @@ let mld ~parent_id ~parents_children ~output ~children ~warnings_options input =
     in
     let page =
       Lang.Page.
-        { name=id; root; children; content; digest; linked = false; frontmatter }
+        {
+          name = id;
+          root;
+          children;
+          content;
+          digest;
+          linked = false;
+          frontmatter;
+        }
     in
     Odoc_file.save_page output ~warnings:[] page;
     ()
@@ -275,7 +283,6 @@ let mld ~parent_id ~parents_children ~output ~children ~warnings_options input =
   |> function
   | `Stop -> resolve [] (* TODO: Error? *)
   | `Docs content -> resolve content
-      
 
 let handle_file_ext ext =
   match ext with


### PR DESCRIPTION
This PR adds a new package, `odoc-md`, that can process markdown files and output `page-*.odoc` files to be linked and then turned into HTML/man/whatever by `odoc`. It's based on previous work by @dbuenzli and @panglesd, but is more limited in scope. There is no support for odoc-style references in markdown, as the main intent is to be able to render the various markdown-formatted files that `voodoo` currently does for ocaml.org (e.g. https://ocaml.org/p/odoc/latest/README.md.html).

`odoc-md` is based on [cmarkit](https://erratique.ch/software/cmarkit), which has an OCaml lower bound of 4.14, which is why this is a new package rather than part of the odoc package.