### PR TITLE
Driver: uniformize names for directories

### DIFF
--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -92,7 +92,7 @@ let find_partials odoc_dir :
   | Ok h -> (h, tbl)
   | Error _ -> (* odoc_dir doesn't exist...? *) (Util.StringMap.empty, tbl)
 
-let compile ?partial ~partial_dir ?linked_dir:_ (all : Odoc_unit.t list) =
+let compile ?partial ~partial_dir (all : Odoc_unit.t list) =
   let hashes = mk_byhash all in
   let compile_mod =
     (* Modules have a more complicated compilation because:

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -3,11 +3,7 @@ type compiled
 val init_stats : Odoc_unit.t list -> unit
 
 val compile :
-  ?partial:Fpath.t ->
-  partial_dir:Fpath.t ->
-  ?linked_dir:Fpath.t ->
-  Odoc_unit.t list ->
-  compiled list
+  ?partial:Fpath.t -> partial_dir:Fpath.t -> Odoc_unit.t list -> compiled list
 (** Use [partial] to reuse the output of a previous call to [compile]. Useful in
     the voodoo context.
 

--- a/src/driver/landing_pages.mli
+++ b/src/driver/landing_pages.mli
@@ -2,6 +2,5 @@ val of_packages :
   mld_dir:Fpath.t ->
   odoc_dir:Fpath.t ->
   odocl_dir:Fpath.t ->
-  output_dir:Fpath.t ->
   Packages.t list ->
   [> `Mld ] Odoc_unit.unit list

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -625,22 +625,18 @@ let run libs verbose packages_dir odoc_dir odocl_dir html_dir stats nb_workers
         let all =
           let all = Util.StringMap.bindings all |> List.map snd in
           let internal =
-            Odoc_unit.of_packages ~output_dir:odoc_dir ~linked_dir:odocl_dir
-              ~index_dir:None ~extra_libs_paths all
+            Odoc_unit.of_packages ~odoc_dir ~odocl_dir ~index_dir:None
+              ~extra_libs_paths all
           in
           let external_ =
             let mld_dir = odoc_dir in
             let odocl_dir = Option.value odocl_dir ~default:odoc_dir in
-            Landing_pages.of_packages ~mld_dir ~odoc_dir ~odocl_dir
-              ~output_dir:odoc_dir all
+            Landing_pages.of_packages ~mld_dir ~odoc_dir ~odocl_dir all
           in
           internal @ external_
         in
         Compile.init_stats all;
-        let compiled =
-          Compile.compile ?partial ~partial_dir:odoc_dir ?linked_dir:odocl_dir
-            all
-        in
+        let compiled = Compile.compile ?partial ~partial_dir:odoc_dir all in
         let linked = Compile.link compiled in
         let occurrence_file =
           let output =

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -1,7 +1,7 @@
 module Pkg_args : sig
   type t = {
-    compile_dir : Fpath.t;
-    link_dir : Fpath.t;
+    odoc_dir : Fpath.t;
+    odocl_dir : Fpath.t;
     pages : (string * Fpath.t) list;
     libs : (string * Fpath.t) list;
   }
@@ -25,7 +25,6 @@ type index = {
 
 type 'a unit = {
   parent_id : Odoc.Id.t;
-  odoc_dir : Fpath.t;
   input_file : Fpath.t;
   output_dir : Fpath.t;
   odoc_file : Fpath.t;
@@ -55,8 +54,8 @@ val lib_dir : Packages.t -> Packages.libty -> Fpath.t
 val doc_dir : Packages.t -> Fpath.t
 
 val of_packages :
-  output_dir:Fpath.t ->
-  linked_dir:Fpath.t option ->
+  odoc_dir:Fpath.t ->
+  odocl_dir:Fpath.t option ->
   index_dir:Fpath.t option ->
   extra_libs_paths:Fpath.t Util.StringMap.t ->
   Packages.t list ->


### PR DESCRIPTION
`odoc_dir` was sometimes used to refer to the root of the directory containing .odoc files (`_odoc` by default), and sometimes used to refer to the direct parent of a `.odoc` file.

The root of the directory containing `.odoc` files was referred as `odoc_dir`, `output_dir`.

The root of the directory containing `.odocl` files was referred as `odocl_dir`, `link_dir`, `linked_dir`.

This commit cleans that. The root of the directory for `.odoc` files is consistently named `odoc_dir`, the root for `.odocl` files is `odocl_dir`.

It has the nice effect of removing code with punning working, and fixing some misunderstanding wrt to this in the `Landing_page` module.