### PR TITLE
Voodoo fixes following the change in layout

### DIFF
--- a/src/driver/cmd_outputs.ml
+++ b/src/driver/cmd_outputs.ml
@@ -25,3 +25,12 @@ let submit log_dest desc cmd output_file =
       maybe_log log_dest x;
       String.split_on_char '\n' x.output
   | Error exn -> raise exn
+
+let submit_ignore_failures log_dest desc cmd output_file =
+  match Worker_pool.submit desc cmd output_file with
+  | Ok x ->
+      maybe_log log_dest x;
+      ()
+  | Error exn ->
+      Logs.err (fun m -> m "Error: %s" (Printexc.to_string exn));
+      ()

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -4,6 +4,8 @@ open Bos
 
 type compiled = Odoc_unit.t
 
+let odoc_partial_filename = "__odoc_partial.m"
+
 let mk_byhash (pkgs : Odoc_unit.t list) =
   List.fold_left
     (fun acc (u : Odoc_unit.t) ->
@@ -76,7 +78,7 @@ let find_partials odoc_dir :
   let hashes_result =
     OS.Dir.fold_contents ~dotfiles:false ~elements:`Dirs
       (fun p hashes ->
-        let index_m = Fpath.( / ) p "index.m" in
+        let index_m = Fpath.( / ) p odoc_partial_filename in
         match OS.File.exists index_m with
         | Ok true ->
             let tbl', hashes' = unmarshal index_m in
@@ -208,7 +210,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.t list) =
       res
   in
   (match partial with
-  | Some l -> marshal (zipped, hashes) Fpath.(l / "index.m")
+  | Some l -> marshal (zipped, hashes) Fpath.(l / odoc_partial_filename)
   | None -> ());
   all
 

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -135,7 +135,12 @@ let compile ?partial ~partial_dir (all : Odoc_unit.t list) =
                            None)
                      deps
                  in
-                 let includes = unit.include_dirs in
+                 let includes =
+                   List.fold_left
+                     (fun acc (_lib, path) -> Fpath.Set.add path acc)
+                     Fpath.Set.empty
+                     (Odoc_unit.Pkg_args.compiled_libs unit.pkg_args)
+                 in
                  Odoc.compile ~output_dir:unit.output_dir
                    ~input_file:unit.input_file ~includes
                    ~parent_id:unit.parent_id;
@@ -166,7 +171,12 @@ let compile ?partial ~partial_dir (all : Odoc_unit.t list) =
     | `Intf _ as kind ->
         (compile_mod { unit with kind } :> (Odoc_unit.t list, _) Result.t)
     | `Impl src ->
-        let includes = unit.include_dirs in
+        let includes =
+          List.fold_left
+            (fun acc (_lib, path) -> Fpath.Set.add path acc)
+            Fpath.Set.empty
+            (Odoc_unit.Pkg_args.compiled_libs unit.pkg_args)
+        in
         let source_id = src.src_id in
         Odoc.compile_impl ~output_dir:unit.output_dir
           ~input_file:unit.input_file ~includes ~parent_id:unit.parent_id
@@ -179,7 +189,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.t list) =
         Atomic.incr Stats.stats.compiled_assets;
         Ok [ unit ]
     | `Mld ->
-        let includes = unit.include_dirs in
+        let includes = Fpath.Set.empty in
         Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
           ~includes ~parent_id:unit.parent_id;
         Atomic.incr Stats.stats.compiled_mlds;
@@ -223,8 +233,7 @@ let link : compiled list -> _ =
     let link input_file output_file enable_warnings =
       let libs = Odoc_unit.Pkg_args.compiled_libs c.pkg_args in
       let pages = Odoc_unit.Pkg_args.compiled_pages c.pkg_args in
-      let includes = c.include_dirs in
-      Odoc.link ~input_file ~output_file ~includes ~libs ~docs:pages
+      Odoc.link ~input_file ~output_file ~libs ~docs:pages
         ~ignore_output:(not enable_warnings) ?current_package:c.pkgname ()
     in
     match c.kind with

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -1,4 +1,4 @@
-type compiled
+type compiled = Odoc_unit.t
 
 val init_stats : Odoc_unit.t list -> unit
 

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -17,7 +17,6 @@ let make_index ~dirs ~rel_dir ?index ~content () =
     input_file;
     odoc_file;
     odocl_file;
-    include_dirs = Fpath.Set.empty;
     enable_warnings = false;
     kind = `Mld;
     index;

--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -29,8 +29,7 @@ let read_libraries_from_pkg_defs ~library_name pkg_defs =
     in
 
     let deps_str = Fl_metascanner.lookup "requires" [] pkg_defs in
-    let deps = Astring.String.fields deps_str in
-    let deps = List.filter (fun x -> String.length x > 0) deps in
+    let deps = Astring.String.fields ~empty:false deps_str in
     let dir =
       List.find_opt (fun d -> d.Fl_metascanner.def_var = "directory") pkg_defs
     in

--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -30,6 +30,7 @@ let read_libraries_from_pkg_defs ~library_name pkg_defs =
 
     let deps_str = Fl_metascanner.lookup "requires" [] pkg_defs in
     let deps = Astring.String.fields deps_str in
+    let deps = List.filter (fun x -> String.length x > 0) deps in
     let dir =
       List.find_opt (fun d -> d.Fl_metascanner.def_var = "directory") pkg_defs
     in

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -130,16 +130,11 @@ let lib_args libs =
       v "-L" % s %% acc)
     Cmd.empty libs
 
-let link ?(ignore_output = false) ~input_file:file ?output_file ~includes ~docs
-    ~libs ?current_package () =
+let link ?(ignore_output = false) ~input_file:file ?output_file ~docs ~libs
+    ?current_package () =
   let open Cmd in
   let output_file =
     match output_file with Some f -> f | None -> Fpath.set_ext "odocl" file
-  in
-  let includes =
-    Fpath.Set.fold
-      (fun path acc -> Cmd.(acc % "-I" % p path))
-      includes Cmd.empty
   in
   let docs = doc_args docs in
   let libs = lib_args libs in
@@ -149,7 +144,7 @@ let link ?(ignore_output = false) ~input_file:file ?output_file ~includes ~docs
     | Some c -> Cmd.(v "--current-package" % c)
   in
   let cmd =
-    !odoc % "link" % p file % "-o" % p output_file %% includes %% docs %% libs
+    !odoc % "link" % p file % "-o" % p output_file %% docs %% libs
     %% current_package % "--enable-missing-root-warning"
   in
   let cmd =

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -34,7 +34,6 @@ val link :
   ?ignore_output:bool ->
   input_file:Fpath.t ->
   ?output_file:Fpath.t ->
-  includes:Fpath.set ->
   docs:(string * Fpath.t) list ->
   libs:(string * Fpath.t) list ->
   ?current_package:string ->

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -149,12 +149,16 @@ let run mode
         let all = Voodoo.of_voodoo p ~blessed in
         let extra_paths = Voodoo.extra_paths odoc_dir in
         (all, extra_paths, actions)
-    | Dune { path } -> (Dune_style.of_dune_build path, Voodoo.empty_extra_paths, All)
+    | Dune { path } ->
+        (Dune_style.of_dune_build path, Voodoo.empty_extra_paths, All)
     | OpamLibs { libs } ->
         ( Packages.of_libs ~packages_dir:None (Util.StringSet.of_list libs),
-          Voodoo.empty_extra_paths, All )
+          Voodoo.empty_extra_paths,
+          All )
     | OpamPackages { packages } ->
-        (Packages.of_packages ~packages_dir:None packages, Voodoo.empty_extra_paths, All)
+        ( Packages.of_packages ~packages_dir:None packages,
+          Voodoo.empty_extra_paths,
+          All )
   in
 
   let virtual_check =

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -216,7 +216,7 @@ let run mode
         let () =
           match mode with
           | Voodoo _ -> Voodoo.write_lib_markers odoc_dir all
-          | Dune _ | Opam _ -> ()
+          | Dune _ | OpamLibs _ | OpamPackages _ -> ()
         in
         match actions with
         | CompileOnly -> ()

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -149,12 +149,12 @@ let run mode
         let all = Voodoo.of_voodoo p ~blessed in
         let extra_paths = Voodoo.extra_paths odoc_dir in
         (all, extra_paths, actions)
-    | Dune { path } -> (Dune_style.of_dune_build path, Util.StringMap.(empty, empty), All)
+    | Dune { path } -> (Dune_style.of_dune_build path, Voodoo.empty_extra_paths, All)
     | OpamLibs { libs } ->
         ( Packages.of_libs ~packages_dir:None (Util.StringSet.of_list libs),
-          Util.StringMap.(empty, empty), All )
+          Voodoo.empty_extra_paths, All )
     | OpamPackages { packages } ->
-        (Packages.of_packages ~packages_dir:None packages, Util.StringMap.(empty, empty), All)
+        (Packages.of_packages ~packages_dir:None packages, Voodoo.empty_extra_paths, All)
   in
 
   let virtual_check =

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -206,14 +206,17 @@ let run mode
         let compiled =
           match actions with
           | LinkAndGen -> units
-          | _ -> Compile.compile ?partial ~partial_dir:odoc_dir units
+          | CompileOnly | All ->
+              Compile.compile ?partial ~partial_dir:odoc_dir units
         in
-        (match mode with
-        | Voodoo _ -> Voodoo.write_lib_markers odoc_dir all
-        | _ -> ());
+        let () =
+          match mode with
+          | Voodoo _ -> Voodoo.write_lib_markers odoc_dir all
+          | Dune _ | Opam _ -> ()
+        in
         match actions with
         | CompileOnly -> ()
-        | _ ->
+        | LinkAndGen | All ->
             let linked = Compile.link compiled in
             let occurrence_file =
               let output =

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -56,7 +56,6 @@ type 'a unit = {
   odocl_file : Fpath.t;
   pkg_args : Pkg_args.t;
   pkgname : string option;
-  include_dirs : Fpath.Set.t;
   index : index option;
   enable_warnings : bool;
   kind : 'a;
@@ -105,15 +104,12 @@ and pp : all_kinds unit Fmt.t =
      odocl_file: %a@;\
      pkg_args: %a@;\
      pkgname: %a@;\
-     include_dirs: [%a]@;\
      index: %a@;\
      kind:%a@;\
      @]"
     (Odoc.Id.to_string x.parent_id)
     Fpath.pp x.input_file Fpath.pp x.output_dir Fpath.pp x.odoc_file Fpath.pp
     x.odocl_file Pkg_args.pp x.pkg_args (Fmt.option Fmt.string) x.pkgname
-    Fmt.(list ~sep:comma Fpath.pp)
-    (Fpath.Set.to_list x.include_dirs)
     (Fmt.option pp_index) x.index pp_kind
     (x.kind :> all_kinds)
 

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -31,7 +31,6 @@ type 'a unit = {
   odocl_file : Fpath.t;
   pkg_args : Pkg_args.t;
   pkgname : string option;
-  include_dirs : Fpath.Set.t;
   index : index option;
   enable_warnings : bool;
   kind : 'a;

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -215,8 +215,7 @@ let packages ~dirs ~extra_paths (pkgs : Packages.t list) : t list =
         let name = md |> Fpath.rem_ext |> Fpath.basename |> ( ^ ) "page-" in
         let lib_deps = Util.StringSet.empty in
         let unit =
-          make_unit ~name ~kind ~rel_dir ~input_file:md ~pkg
-            ~lib_deps
+          make_unit ~name ~kind ~rel_dir ~input_file:md ~pkg ~lib_deps
             ~enable_warnings:pkg.enable_warnings
         in
         [ unit ]

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -87,8 +87,8 @@ let packages ~dirs ~extra_paths (pkgs : Packages.t list) : t list =
     { pkg_args; output_file; json = false; search_dir = pkg.pkg_dir }
   in
 
-  let make_unit ~name ~kind ~rel_dir ~input_file ~pkg ~lib_deps
-      ~enable_warnings : _ unit =
+  let make_unit ~name ~kind ~rel_dir ~input_file ~pkg ~lib_deps ~enable_warnings
+      : _ unit =
     let ( // ) = Fpath.( // ) in
     let ( / ) = Fpath.( / ) in
     let pkg_args = args_of pkg lib_deps in
@@ -141,9 +141,8 @@ let packages ~dirs ~extra_paths (pkgs : Packages.t list) : t list =
           kind
         in
         let name = intf.mif_path |> Fpath.rem_ext |> Fpath.basename in
-        make_unit ~name ~kind ~rel_dir ~input_file:intf.mif_path ~pkg
-         
-          ~lib_deps ~enable_warnings:pkg.enable_warnings
+        make_unit ~name ~kind ~rel_dir ~input_file:intf.mif_path ~pkg ~lib_deps
+          ~enable_warnings:pkg.enable_warnings
       in
       match Hashtbl.find_opt intf_cache intf.mif_hash with
       | Some unit -> unit
@@ -171,8 +170,7 @@ let packages ~dirs ~extra_paths (pkgs : Packages.t list) : t list =
         in
         let unit =
           make_unit ~name ~kind ~rel_dir ~input_file:impl.mip_path ~pkg
-            
-~lib_deps ~enable_warnings:pkg.enable_warnings
+            ~lib_deps ~enable_warnings:pkg.enable_warnings
         in
         Some unit
   in
@@ -203,8 +201,8 @@ let packages ~dirs ~extra_paths (pkgs : Packages.t list) : t list =
       |> Util.StringSet.of_list
     in
     let unit =
-      make_unit ~name ~kind ~rel_dir ~input_file:mld_path ~pkg
-        ~lib_deps ~enable_warnings:pkg.enable_warnings
+      make_unit ~name ~kind ~rel_dir ~input_file:mld_path ~pkg ~lib_deps
+        ~enable_warnings:pkg.enable_warnings
     in
     [ unit ]
   in
@@ -235,7 +233,7 @@ let packages ~dirs ~extra_paths (pkgs : Packages.t list) : t list =
     let kind = `Asset in
     let unit =
       let name = asset_path |> Fpath.basename |> ( ^ ) "asset-" in
-      make_unit ~name ~kind ~rel_dir ~input_file:asset_path ~pkg 
+      make_unit ~name ~kind ~rel_dir ~input_file:asset_path ~pkg
         ~lib_deps:Util.StringSet.empty ~enable_warnings:false
     in
     [ unit ]

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -1,11 +1,13 @@
 open Odoc_unit
 
-let packages ~dirs ~extra_paths:(extra_pkg_paths, extra_libs_paths)
-    (pkgs : Packages.t list) : t list =
+let packages ~dirs ~extra_paths (pkgs : Packages.t list) : t list =
   let { odoc_dir; odocl_dir; index_dir; mld_dir = _ } = dirs in
   (* [module_of_hash] Maps a hash to the corresponding [Package.t], library name and
      [Packages.modulety]. [lib_dirs] maps a library name to the odoc dir containing its
      odoc files. *)
+  let extra_libs_paths = extra_paths.Voodoo.libs in
+  let extra_pkg_paths = extra_paths.Voodoo.pkgs in
+
   let module_of_hash, lib_dirs =
     let open Packages in
     let h = Util.StringMap.empty in

--- a/src/driver/odoc_units_of.mli
+++ b/src/driver/odoc_units_of.mli
@@ -2,6 +2,6 @@ open Odoc_unit
 
 val packages :
   dirs:dirs ->
-  extra_libs_paths:Fpath.t Util.StringMap.t ->
+  extra_paths:Fpath.t Util.StringMap.t * Fpath.t Util.StringMap.t ->
   Packages.t list ->
   t list

--- a/src/driver/odoc_units_of.mli
+++ b/src/driver/odoc_units_of.mli
@@ -1,7 +1,4 @@
 open Odoc_unit
 
 val packages :
-  dirs:dirs ->
-  extra_paths:Fpath.t Util.StringMap.t * Fpath.t Util.StringMap.t ->
-  Packages.t list ->
-  t list
+  dirs:dirs -> extra_paths:Voodoo.extra_paths -> Packages.t list -> t list

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -75,7 +75,8 @@ let pp_libty fmt l =
      }@]"
     l.lib_name Fpath.pp l.dir
     (Fmt.Dump.option Fmt.string)
-    l.archive_name (Fmt.Dump.list Fmt.string)
+    l.archive_name
+    (Fmt.list ~sep:Fmt.comma Fmt.string)
     (Util.StringSet.elements l.lib_deps)
     (Fmt.Dump.list pp_modulety)
     l.modules

--- a/src/driver/sherlodoc.ml
+++ b/src/driver/sherlodoc.ml
@@ -33,10 +33,10 @@ let index ?(ignore_output = false) ~format ~inputs ~dst ?favored_prefixes () =
   let log =
     if ignore_output then None else Some (`Sherlodoc, Fpath.to_string dst)
   in
-  ignore @@ submit log desc cmd (Some dst)
+  ignore @@ submit_ignore_failures log desc cmd (Some dst)
 
 let js dst =
   let cmd = Cmd.(sherlodoc % "js" % p dst) in
   let desc = Printf.sprintf "Sherlodoc js at %s" (Fpath.to_string dst) in
-  let _lines = submit None desc cmd (Some dst) in
+  let _lines = submit_ignore_failures (Some (`Sherlodoc, Fpath.to_string dst))  desc cmd (Some dst) in
   ()

--- a/src/driver/sherlodoc.ml
+++ b/src/driver/sherlodoc.ml
@@ -38,5 +38,9 @@ let index ?(ignore_output = false) ~format ~inputs ~dst ?favored_prefixes () =
 let js dst =
   let cmd = Cmd.(sherlodoc % "js" % p dst) in
   let desc = Printf.sprintf "Sherlodoc js at %s" (Fpath.to_string dst) in
-  let _lines = submit_ignore_failures (Some (`Sherlodoc, Fpath.to_string dst))  desc cmd (Some dst) in
+  let _lines =
+    submit_ignore_failures
+      (Some (`Sherlodoc, Fpath.to_string dst))
+      desc cmd (Some dst)
+  in
   ()

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -124,7 +124,7 @@ let process_package pkg =
         List.fold_left
           (fun acc lib ->
             Util.StringMap.add lib.Library_names.name
-              (Util.StringSet.of_list lib.Library_names.deps)
+              (Util.StringSet.of_list ("stdlib" :: lib.Library_names.deps))
               acc)
           acc m.libraries)
       Util.StringMap.empty metas

--- a/src/driver/voodoo.mli
+++ b/src/driver/voodoo.mli
@@ -3,4 +3,6 @@ val find_universe_and_version :
 
 val of_voodoo : string -> blessed:bool -> Packages.set
 
-val extra_libs_paths : Fpath.t -> Fpath.t Util.StringMap.t
+val extra_paths : Fpath.t -> Fpath.t Util.StringMap.t * Fpath.t Util.StringMap.t
+
+val write_lib_markers : Fpath.t -> Packages.t Util.StringMap.t -> unit

--- a/src/driver/voodoo.mli
+++ b/src/driver/voodoo.mli
@@ -3,6 +3,21 @@ val find_universe_and_version :
 
 val of_voodoo : string -> blessed:bool -> Packages.set
 
-val extra_paths : Fpath.t -> Fpath.t Util.StringMap.t * Fpath.t Util.StringMap.t
+type extra_paths = {
+  pkgs : Fpath.t Util.StringMap.t;
+  libs : Fpath.t Util.StringMap.t;
+}
+
+val empty_extra_paths : extra_paths
+(** When [odoc_driver] is not running in voodoo mode, this value can be passed to 
+    {!Odoc_units_of.packages} *)
+
+val extra_paths : Fpath.t -> extra_paths
+(** [extra_paths odoc_dir] returns the paths to packages and libraries that have previously
+    been compiled by odoc_driver running in voodoo mode. In order to find these, 
+    the previous invocation of odoc_driver will need to have written marker files by
+    calling {!write_lib_markers} *)
 
 val write_lib_markers : Fpath.t -> Packages.t Util.StringMap.t -> unit
+(** [write_lib_markers odoc_dir pkgs] writes marker files to show the locations of the
+    compilation units associated with packages and libraries in [pkgs]. *)

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -70,10 +70,7 @@ end = struct
     omit : Fs.Directory.t list;
   }
 
-  type t = {
-    table : (string, pkg) Hashtbl.t;
-    current_root : named_root option;
-  }
+  type t = { table : (string, pkg) Hashtbl.t; current_root : named_root option }
 
   type input = {
     name : string;
@@ -542,7 +539,6 @@ let all_units ~library ({ libs; _ } : t) =
   | None -> []
   | Some libs ->
       Odoc_utils.List.filter_map filter @@ all_roots ~root:library libs
-
 
 type roots = {
   page_roots : named_root list;

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -34,6 +34,7 @@
 open Odoc_utils
 open Or_error
 
+type named_root = string * Fs.Directory.t
 module Named_roots : sig
   type t
 
@@ -45,7 +46,7 @@ module Named_roots : sig
     omit : Fs.Directory.t list;
   }
 
-  val create : input list -> current_root:(string * Fs.Directory.t) option -> t
+  val create : input list -> current_root:named_root option -> t
 
   val all_of : ?root:string -> ext:string -> t -> (Fs.File.t list, error) result
 
@@ -71,7 +72,7 @@ end = struct
 
   type t = {
     table : (string, pkg) Hashtbl.t;
-    current_root : (string * Fs.Directory.t) option;
+    current_root : named_root option;
   }
 
   type input = {
@@ -542,11 +543,12 @@ let all_units ~library ({ libs; _ } : t) =
   | Some libs ->
       Odoc_utils.List.filter_map filter @@ all_roots ~root:library libs
 
+
 type roots = {
-  page_roots : (string * Fs.Directory.t) list;
-  lib_roots : (string * Fs.Directory.t) list;
-  current_lib : (string * Fs.Directory.t) option;
-  current_package : (string * Fs.Directory.t) option;
+  page_roots : named_root list;
+  lib_roots : named_root list;
+  current_lib : named_root option;
+  current_package : named_root option;
   current_dir : Fs.Directory.t;
 }
 

--- a/src/odoc/resolver.mli
+++ b/src/odoc/resolver.mli
@@ -26,8 +26,10 @@ type t
 type roots = {
   page_roots : (string * Fs.Directory.t) list;
   lib_roots : (string * Fs.Directory.t) list;
-  current_lib : string option;  (** Name of the current [-L]. *)
-  current_package : string option;  (** Name of the current [-P]. *)
+  current_lib : (string * Fs.Directory.t) option;
+      (** Name of the current [-L]. *)
+  current_package : (string * Fs.Directory.t) option;
+      (** Name of the current [-P]. *)
   current_dir : Fs.Directory.t;
       (** Directory containing the output for the current unit. *)
 }

--- a/src/odoc/resolver.mli
+++ b/src/odoc/resolver.mli
@@ -23,13 +23,15 @@ open Odoc_model
 
 type t
 
+type named_root = string * Fs.Directory.t
+
 type roots = {
-  page_roots : (string * Fs.Directory.t) list;
-  lib_roots : (string * Fs.Directory.t) list;
-  current_lib : (string * Fs.Directory.t) option;
-      (** Name of the current [-L]. *)
-  current_package : (string * Fs.Directory.t) option;
-      (** Name of the current [-P]. *)
+  page_roots : named_root list;
+  lib_roots : named_root list;
+  current_lib : named_root option;
+      (** The current [-L]. *)
+  current_package : named_root option;
+      (** The current [-P]. *)
   current_dir : Fs.Directory.t;
       (** Directory containing the output for the current unit. *)
 }

--- a/src/odoc/resolver.mli
+++ b/src/odoc/resolver.mli
@@ -28,10 +28,8 @@ type named_root = string * Fs.Directory.t
 type roots = {
   page_roots : named_root list;
   lib_roots : named_root list;
-  current_lib : named_root option;
-      (** The current [-L]. *)
-  current_package : named_root option;
-      (** The current [-P]. *)
+  current_lib : named_root option;  (** The current [-L]. *)
+  current_package : named_root option;  (** The current [-P]. *)
   current_dir : Fs.Directory.t;
       (** Directory containing the output for the current unit. *)
 }

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -16,8 +16,6 @@
   Warning: Failed to resolve reference /pkg/libname/Test Path '/pkg/libname/Test' not found
   File "doc/subdir/bar.mld", line 12, characters 0-17:
   Warning: Failed to resolve reference //libname/Test Path '//libname/Test' not found
-  File "doc/subdir/bar.mld", line 4, characters 21-27:
-  Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
   $ odoc link -P pkg:h/pkg -L libname:h/pkg/libname h/pkg/page-dup.odoc
   $ odoc link -P pkg:h/pkg -L libname:h/pkg/libname h/pkg/page-foo.odoc
   File "doc/foo.mld", line 12, characters 27-36:
@@ -29,10 +27,6 @@
   $ odoc link -P pkg:h/pkg -L libname:h/pkg/libname h/pkg/libname/test.odoc
   File "test.ml", line 6, characters 38-44:
   Warning: Failed to resolve reference unresolvedroot(bar) Couldn't find "bar"
-  File "test.ml", line 4, characters 34-45:
-  Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find page "foo"
-  File "test.ml", line 3, characters 24-30:
-  Warning: Failed to resolve reference unresolvedroot(foo) Couldn't find "foo"
 
 Helper that extracts references in a compact way. Headings help to interpret the result.
 
@@ -74,7 +68,7 @@ Helper that extracts references in a compact way. Headings help to interpret the
   ["Page","foo"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
-  {"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   ["Page","subdir/bar"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
@@ -97,10 +91,10 @@ Helper that extracts references in a compact way. Headings help to interpret the
   ["Page","foo"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
-  {"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
-  {"`Reference":[{"`Root":["foo","`TPage"]},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
+  {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   ["Page","subdir/bar"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}


### PR DESCRIPTION
Combined with the splitting of the compile/link phases so we can link to more than just the dependencies of your package. This is a building block to allow links in the documentation of package A to go to package B that isn't a direct dependency - or even to package C that depends on package A!
