### PR TITLE
odoc_index: Replace -P/-L with --root arguments

### DIFF
--- a/src/index/page_hierarchy.ml
+++ b/src/index/page_hierarchy.ml
@@ -188,5 +188,24 @@ let rec remove_common_root (v : t) =
 
 let of_list l =
   let dir = empty_t None in
+  let l =
+    List.filter_map
+      (fun (page : Lang.Page.t) ->
+        match page.name with
+        | { iv = #Paths.Identifier.LeafPage.t_pv; _ } as id ->
+            let title =
+              match Odoc_model.Comment.find_zero_heading page.content with
+              | None ->
+                  [
+                    Location_.at (Location_.span [])
+                      (`Word (Paths.Identifier.name id));
+                  ]
+              | Some title -> title
+            in
+            let children_order = page.frontmatter.Frontmatter.children_order in
+            Some (id, title, children_order)
+        | _ -> None)
+      l
+  in
   List.iter (add dir) l;
   t_of_in_progress dir |> remove_common_root

--- a/src/index/page_hierarchy.mli
+++ b/src/index/page_hierarchy.mli
@@ -1,5 +1,4 @@
 open Odoc_model
-open Odoc_model.Paths
 open Odoc_utils
 
 (** Page hierarchies represent a hierarchy of pages. *)
@@ -12,7 +11,6 @@ type index =
 
 type t = index Tree.t
 
-val of_list :
-  (Identifier.LeafPage.t * title * Frontmatter.children_order option) list -> t
+val of_list : Lang.Page.t list -> t
 (** Uses the convention that the [index] children passes its payload to the
       container directory to output a payload *)

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -468,14 +468,12 @@ module Indexing = struct
     | None, `JSON -> Ok (Fs.File.of_string "index.json")
     | None, `Marshall -> Ok (Fs.File.of_string "index.odoc-index")
 
-  let index dst json warnings_options page_roots lib_roots inputs_in_file inputs
-      occurrences =
+  let index dst json warnings_options roots inputs_in_file inputs occurrences =
     let marshall = if json then `JSON else `Marshall in
     output_file ~dst marshall >>= fun output ->
-    Antichain.check (page_roots |> List.map ~f:snd) ~opt:"-P" >>= fun () ->
-    Antichain.check (lib_roots |> List.map ~f:snd) ~opt:"-L" >>= fun () ->
-    Indexing.compile marshall ~output ~warnings_options ~occurrences ~lib_roots
-      ~page_roots ~inputs_in_file ~odocls:inputs
+    Antichain.check (roots |> List.map ~f:snd) ~opt:"--root" >>= fun () ->
+    Indexing.compile marshall ~output ~warnings_options ~occurrences ~roots
+      ~inputs_in_file ~odocls:inputs
   let cmd =
     let dst =
       let doc =
@@ -510,31 +508,20 @@ module Indexing = struct
       let doc = ".odocl file to index" in
       Arg.(value & pos_all convert_fpath [] & info ~doc ~docv:"FILE" [])
     in
-    let page_roots =
+    let roots =
       let doc =
-        "Specifies a directory PATH containing pages that should be included \
-         in the sidebar, under the NAME section."
+        "Specifies a directory PATH containing pages or units that should be \
+         included in the sidebar."
       in
       Arg.(
         value
         & opt_all convert_named_root []
-        & info ~docs ~docv:"NAME:PATH" ~doc [ "P" ])
-    in
-    let lib_roots =
-      let doc =
-        "Specifies a directory PATH containing units that should be included \
-         in the sidebar, as part of the LIBNAME library."
-      in
-
-      Arg.(
-        value
-        & opt_all convert_named_root []
-        & info ~docs ~docv:"LIBNAME:PATH" ~doc [ "L" ])
+        & info ~docs ~docv:"NAME:PATH" ~doc [ "root" ])
     in
     Term.(
       const handle_error
-      $ (const index $ dst $ json $ warnings_options $ page_roots $ lib_roots
-       $ inputs_in_file $ inputs $ occurrences))
+      $ (const index $ dst $ json $ warnings_options $ roots $ inputs_in_file
+       $ inputs $ occurrences))
 
   let info ~docs =
     let doc =

--- a/src/odoc/indexing.mli
+++ b/src/odoc/indexing.mli
@@ -14,8 +14,7 @@ val compile :
   output:Fs.file ->
   warnings_options:Odoc_model.Error.warnings_options ->
   occurrences:Fs.file option ->
-  lib_roots:(string * Fs.directory) list ->
-  page_roots:(string * Fs.directory) list ->
+  roots:(string * Fs.directory) list ->
   inputs_in_file:Fs.file list ->
   odocls:Fs.file list ->
   (unit, [> msg ]) result

--- a/src/utils/odoc_utils.ml
+++ b/src/utils/odoc_utils.ml
@@ -51,6 +51,8 @@ module Option = struct
   let map f = function None -> None | Some x -> Some (f x)
 
   let is_some = function None -> false | Some _ -> true
+
+  let to_list = function None -> [] | Some x -> [ x ]
 end
 
 module Result = struct

--- a/test/frontmatter/toc_order.t/run.t
+++ b/test/frontmatter/toc_order.t/run.t
@@ -12,7 +12,7 @@
   $ odoc link _odoc/pkg/dir1/page-content_in_dir.odoc
   $ odoc link _odoc/pkg/dir1/page-dontent.odoc
 
-  $ odoc compile-index -P test:_odoc/pkg
+  $ odoc compile-index --root test:_odoc/pkg
   File "index.mld", line 1, characters 30-35:
   Warning: Duplicate 'dir1/' in (children).
   File "index.mld", line 1, characters 36-40:

--- a/test/parent_id/missing_indexes.t/run.t
+++ b/test/parent_id/missing_indexes.t/run.t
@@ -7,7 +7,7 @@
   $ odoc link _odoc/page-foo.odoc
   $ odoc link _odoc/page-bar.odoc
   $ odoc link _odoc/baz/page-bli.odoc
-  $ odoc compile-index -P _:_odoc
+  $ odoc compile-index --root _:_odoc
 
   $ odoc html-generate --index index.odoc-index --indent --output-dir _html _odoc/page-foo.odocl
 

--- a/test/roots_and_hierarchy/canonical_hierarchy.t/run.t
+++ b/test/roots_and_hierarchy/canonical_hierarchy.t/run.t
@@ -23,7 +23,7 @@ Let's link it:
 
 Let's html-generate it (with a sidebar):
 
-  $ odoc compile-index -P pkg:_odoc/pkg/ -L libname:_odoc/pkg/libname -o sidebar.odoc-index
+  $ odoc compile-index --root pkg:_odoc/pkg/ -o sidebar.odoc-index
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/page-file.odocl
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/dir1/page-my_page.odocl
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/dir1/page-index.odocl

--- a/test/roots_and_hierarchy/separate_doc_lib_folders.t/run.t
+++ b/test/roots_and_hierarchy/separate_doc_lib_folders.t/run.t
@@ -23,7 +23,7 @@ Let's link it:
 
 Let's html-generate it (with a sidebar):
 
-  $ odoc compile-index -P pkg:_odoc/pkg/doc/ -L libname:_odoc/pkg/lib/libname -o sidebar.odoc-index
+  $ odoc compile-index --root pkg:_odoc/pkg/doc/ --root libname:_odoc/pkg/lib/libname -o sidebar.odoc-index
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/doc/page-file.odocl
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/doc/dir1/page-my_page.odocl
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/doc/dir1/page-index.odocl

--- a/test/roots_and_hierarchy/sidebar.t/run.t
+++ b/test/roots_and_hierarchy/sidebar.t/run.t
@@ -12,7 +12,7 @@
   $ odoc link -P pkg:_odoc/pkg/ _odoc/pkg/page-index.odoc
   $ odoc link -P pkg:_odoc/pkg/ _odoc/pkg/libname/unit.odoc
 
-  $ odoc compile-index -P pkg:_odoc/pkg/ -L libname:_odoc/pkg/libname -o sidebar.odoc-index
+  $ odoc compile-index --root libname:_odoc/pkg/ -o sidebar.odoc-index
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/page-file.odocl
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/dir1/page-my_page.odocl
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/dir1/page-index.odocl

--- a/test/roots_and_hierarchy/sidebar_with_indexes.t/run.t
+++ b/test/roots_and_hierarchy/sidebar_with_indexes.t/run.t
@@ -18,7 +18,7 @@ Since -L subfolders are omitted from -P roots, the index page should not be adde
   $ odoc link -P pkg:_odoc/pkg/ _odoc/pkg/libname/unit.odoc
   $ odoc link -P pkg:_odoc/pkg/ _odoc/pkg/libname/page-index.odoc
 
-  $ odoc compile-index -P pkg:_odoc/pkg/ -L libname:_odoc/pkg/libname -o sidebar.odoc-index
+  $ odoc compile-index --root libname:_odoc/pkg/ -o sidebar.odoc-index
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/page-file.odocl
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/dir1/page-my_page.odocl
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/dir1/page-index.odocl
@@ -26,7 +26,7 @@ Since -L subfolders are omitted from -P roots, the index page should not be adde
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/libname/unit.odocl
   $ odoc html-generate --indent --index sidebar.odoc-index -o html _odoc/pkg/libname/page-index.odocl
 
-  $ cat html/pkg/index.html | grep odoc-global-toc -A 15
+  $ cat html/pkg/index.html | grep odoc-global-toc -A 16
      <nav class="odoc-toc odoc-global-toc">
       <ul class="odoc-modules">
        <li><b>Library <code>libname</code></b>
@@ -39,6 +39,7 @@ Since -L subfolders are omitted from -P roots, the index page should not be adde
          <li><a href="dir1/index.html">A directory</a>
           <ul><li><a href="dir1/my_page.html">My page</a></li></ul>
          </li><li><a href="file.html">File</a></li>
+         <li><a href="libname/index.html">Library landing page</a></li>
         </ul>
        </li>
       </ul>

--- a/test/search/html_search.t/run.t
+++ b/test/search/html_search.t/run.t
@@ -65,9 +65,9 @@ the --marshall flag is passed.  Odocl files can be given either in a list (using
 passing directly the name of the files.
 
   $ printf "main.odocl\npage-page.odocl\nj.odocl\n" > index_map
-  $ odoc compile-index --json -o index.json -P pkgname:.
+  $ odoc compile-index --json -o index.json --root pkgname:.
 
-  $ odoc compile-index -o index-main.odoc-index -P pkgname:.
+  $ odoc compile-index -o index-main.odoc-index --root pkgname:.
 
 The json index file contains a json array, each element of the array corresponding to
 a search entry.
@@ -214,7 +214,7 @@ Testing the warnings/errors for the `compile-index` command:
 
 Passing an inexistent file:
 
-  $ odoc compile-index -P pkgname:babar
+  $ odoc compile-index --root pkgname:babar
   $ odoc compile-index --file-list babar
   odoc: option '--file-list': no 'babar' file or directory
   Usage: odoc compile-index [--file-list=FILE] [--json] [OPTION]… [FILE]…
@@ -224,7 +224,7 @@ Passing an inexistent file:
 Passing an empty folder is allowed:
 
   $ mkdir foo
-  $ odoc compile-index -P pkgname:foo
+  $ odoc compile-index --root pkgname:foo
 
 Wrong file extensions:
 
@@ -241,7 +241,7 @@ Wrong file extensions:
 Passing a file which is not a correctly marshalled one:
 
   $ echo hello > my_file.odocl
-  $ odoc compile-index -P pkgname:.
+  $ odoc compile-index --root pkgname:.
   File "./my_file.odocl":
   Warning: Error while unmarshalling "./my_file.odocl": End_of_file
   

--- a/test/search/id_standalone_comments.t/run.t
+++ b/test/search/id_standalone_comments.t/run.t
@@ -7,7 +7,7 @@ Compile and link the documentation
   $ odoc compile -I . main.cmt
   $ odoc link -I . main.odoc
 
-  $ odoc compile-index --json -P pkgname:./
+  $ odoc compile-index --json --root pkgname:./
 We test that you can also pass a .odocl file directly.
   $ odoc compile-index --json main.odocl -o index2.json
 Indexes should be the same no matter how the inputs were passed.

--- a/test/search/module_aliases.t/run.t
+++ b/test/search/module_aliases.t/run.t
@@ -6,7 +6,7 @@ Compile and link the documentation
 
   $ odoc compile main.cmt
   $ odoc link main.odoc
-  $ odoc compile-index --json -P pkgname:.
+  $ odoc compile-index --json --root pkgname:.
 
 Search results only redirect to their definition point (not the
 expansions). Comments link to the expansion they are in.


### PR DESCRIPTION
Based on #1244 (see [5a79e19](https://github.com/ocaml/odoc/pull/1247/commits/5a79e1933e4d8d217a48f2f4968e9a46163f981c) only)