### PR TITLE
Html remap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,9 @@
   #1187, #1243)
 - Add a `@short_title` tag to specify the short title of a page for use in
   the sidebar / breadcrumbs (@panglesd, #1246)
-- Add a 'remap' option to HTML generation for partial docsets (@jonludlam, #1189)
+- Add a frontmatter syntax for mld pages (@panglesd, #1187)
+- Add 'remap' and 'remap-file' options to HTML generation for partial docsets
+  (@jonludlam, #1189, #1248)
 - Added an `html-generate-asset` command (@panglesd, #1185)
 - Added syntax for images, videos, audio (@panglesd, #1184)
 - Added the ability to order pages in the table of content (@panglesd, #1193)

--- a/src/driver/common_args.ml
+++ b/src/driver/common_args.ml
@@ -52,6 +52,10 @@ let generate_grep =
   let doc = "Show html-generate commands containing the string" in
   Arg.(value & opt (some string) None & info [ "html-grep" ] ~doc)
 
+let remap =
+  let doc = "Remap paths in non-selected packages to ocaml.org" in
+  Arg.(value & flag & info [ "remap" ] ~doc)
+
 type t = {
   verbose : bool;
   odoc_dir : Fpath.t;
@@ -65,6 +69,7 @@ type t = {
   compile_grep : string option;
   link_grep : string option;
   generate_grep : string option;
+  remap : bool;
 }
 
 let term =
@@ -82,7 +87,8 @@ let term =
   and+ odoc_bin = odoc_bin
   and+ compile_grep = compile_grep
   and+ link_grep = link_grep
-  and+ generate_grep = generate_grep in
+  and+ generate_grep = generate_grep
+  and+ remap = remap in
   {
     verbose;
     odoc_dir;
@@ -96,4 +102,5 @@ let term =
     compile_grep;
     link_grep;
     generate_grep;
+    remap;
   }

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -315,7 +315,7 @@ let html_generate ~occurrence_file ~remaps output_dir linked =
                  let index = index.output_file in
                  (Some search_uris, Some index)
            in
-           Odoc.html_generate ?search_uris ?index ~remap:remap_file ~output_dir
+           Odoc.html_generate ?search_uris ?index ?remap:remap_file ~output_dir
              ~input_file ();
            Odoc.html_generate ?search_uris ?index ~output_dir ~input_file
              ~as_json:true ());

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -14,4 +14,9 @@ type linked
 
 val link : compiled list -> linked list
 
-val html_generate : occurrence_file:Fpath.t -> Fpath.t -> linked list -> unit
+val html_generate :
+  occurrence_file:Fpath.t ->
+  remaps:(string * string) list ->
+  Fpath.t ->
+  linked list ->
+  unit

--- a/src/driver/dune_style.ml
+++ b/src/driver/dune_style.ml
@@ -122,7 +122,8 @@ let of_dune_build dir =
                       assets =
                         []
                         (* When dune has a notion of doc assets, do something *);
-                      enable_warnings = false;
+                      selected = false;
+                      remaps = [];
                       pkg_dir;
                       other_docs = [];
                       config = Global_config.empty;

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -18,6 +18,7 @@ let make_index ~dirs ~rel_dir ?index ~content () =
     odoc_file;
     odocl_file;
     enable_warnings = false;
+    to_output = true;
     kind = `Mld;
     index;
   }

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -180,7 +180,7 @@ let compile_index ?(ignore_output = false) ~output_file ?occurrence_file ~json
   ignore @@ Cmd_outputs.submit log desc cmd (Some output_file)
 
 let html_generate ~output_dir ?index ?(ignore_output = false)
-    ?(search_uris = []) ?(as_json = false) ~input_file:file () =
+    ?(search_uris = []) ?(remap = None) ?(as_json = false) ~input_file:file () =
   let open Cmd in
   let index =
     match index with None -> empty | Some idx -> v "--index" % p idx
@@ -192,6 +192,9 @@ let html_generate ~output_dir ?index ?(ignore_output = false)
   in
   let cmd =
     !odoc % "html-generate" % p file %% index %% search_uris % "-o" % output_dir
+  in
+  let cmd =
+    match remap with None -> cmd | Some f -> cmd % "--remap-file" % p f
   in
   let cmd = if as_json then cmd % "--as-json" else cmd in
   let desc = Printf.sprintf "Generating HTML for %s" (Fpath.to_string file) in

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -180,7 +180,7 @@ let compile_index ?(ignore_output = false) ~output_file ?occurrence_file ~json
   ignore @@ Cmd_outputs.submit log desc cmd (Some output_file)
 
 let html_generate ~output_dir ?index ?(ignore_output = false)
-    ?(search_uris = []) ?(remap = None) ?(as_json = false) ~input_file:file () =
+    ?(search_uris = []) ?remap ?(as_json = false) ~input_file:file () =
   let open Cmd in
   let index =
     match index with None -> empty | Some idx -> v "--index" % p idx

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -55,7 +55,7 @@ val html_generate :
   ?index:Fpath.t ->
   ?ignore_output:bool ->
   ?search_uris:Fpath.t list ->
-  ?remap:Fpath.t option ->
+  ?remap:Fpath.t ->
   ?as_json:bool ->
   input_file:Fpath.t ->
   unit ->

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -55,6 +55,7 @@ val html_generate :
   ?index:Fpath.t ->
   ?ignore_output:bool ->
   ?search_uris:Fpath.t list ->
+  ?remap:Fpath.t option ->
   ?as_json:bool ->
   input_file:Fpath.t ->
   unit ->

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -58,6 +58,7 @@ type 'a unit = {
   pkgname : string option;
   index : index option;
   enable_warnings : bool;
+  to_output : bool;
   kind : 'a;
 }
 

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -33,6 +33,7 @@ type 'a unit = {
   pkgname : string option;
   index : index option;
   enable_warnings : bool;
+  to_output : bool;
   kind : 'a;
 }
 

--- a/src/driver/odoc_units_of.mli
+++ b/src/driver/odoc_units_of.mli
@@ -1,4 +1,8 @@
 open Odoc_unit
 
 val packages :
-  dirs:dirs -> extra_paths:Voodoo.extra_paths -> Packages.t list -> t list
+  dirs:dirs ->
+  extra_paths:Voodoo.extra_paths ->
+  remap:bool ->
+  Packages.t list ->
+  t list

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -474,7 +474,7 @@ let of_packages ~packages_dir packages =
         in
         let selected = List.mem pkg.name packages in
         let remaps =
-          if List.mem pkg.name packages then []
+          if selected then []
           else
             let local_pkg_path = Fpath.to_string (Fpath.to_dir_path pkg_dir) in
             let pkg_path =

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -73,7 +73,8 @@ type t = {
   libraries : libty list;
   mlds : mld list;
   assets : asset list;
-  enable_warnings : bool;
+  selected : bool;
+  remaps : (string * string) list;
   other_docs : Fpath.t list;
   pkg_dir : Fpath.t;
   config : Global_config.t;

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -229,7 +229,8 @@ let process_package pkg =
       libraries;
       mlds;
       assets;
-      enable_warnings = false;
+      selected = true;
+      remaps = [];
       other_docs = [];
       pkg_dir = top_dir pkg;
       config;

--- a/src/html/link.ml
+++ b/src/html/link.ml
@@ -13,17 +13,22 @@ module Path = struct
 
   let remap config f =
     let l = String.concat "/" f in
-    try
-      let prefix, replacement =
-        List.find
-          (fun (prefix, _replacement) ->
-            Astring.String.is_prefix ~affix:prefix l)
-          (Config.remap config)
-      in
-      let len = String.length prefix in
-      let l = String.sub l len (String.length l - len) in
-      Some (replacement ^ l)
-    with Not_found -> None
+    let remaps =
+      List.filter
+        (fun (prefix, _replacement) -> Astring.String.is_prefix ~affix:prefix l)
+        (Config.remap config)
+    in
+    let remaps =
+      List.sort
+        (fun (a, _) (b, _) -> compare (String.length b) (String.length a))
+        remaps
+    in
+    match remaps with
+    | [] -> None
+    | (prefix, replacement) :: _ ->
+        let len = String.length prefix in
+        let l = String.sub l len (String.length l - len) in
+        Some (replacement ^ l)
 
   let get_dir_and_file ~config url =
     let l = Url.Path.to_list url in

--- a/test/integration/remap.t/remap.txt
+++ b/test/integration/remap.t/remap.txt
@@ -1,0 +1,3 @@
+prefix/otherpkg/:https://mysite.org/bar/
+prefix/:https://mysite.org/foo/
+

--- a/test/integration/remap.t/run.t
+++ b/test/integration/remap.t/run.t
@@ -18,3 +18,10 @@ This shouldn't stop us from outputting the remapped package though, and the foll
 
   $ odoc html-generate -o _html3 _odoc/prefix/otherpkg/otherlib.odocl -R prefix/otherpkg/:https://mysite.org/p/otherpkg/1.2.3/
 
+The order shouldn't matter, the longest prefix ought to win
+  $ odoc html-generate -o _html3 --indent _odoc/prefix/mypkg/test.odocl -R prefix/:https://mysite.org/foo/ -R prefix/otherpkg/:https://mysite.org/bar/
+  $ odoc html-generate -o _html4 --indent _odoc/prefix/mypkg/test.odocl -R prefix/otherpkg/:https://mysite.org/bar/ -R prefix/:https://mysite.org/foo/ 
+
+  $ grep Otherlib/index.html _html3/prefix/mypkg/Test/index.html _html4/prefix/mypkg/Test/index.html
+  _html3/prefix/mypkg/Test/index.html:       <a href="https://mysite.org/bar/Otherlib/index.html#type-t">Otherlib.t
+  _html4/prefix/mypkg/Test/index.html:       <a href="https://mysite.org/bar/Otherlib/index.html#type-t">Otherlib.t

--- a/test/integration/remap.t/run.t
+++ b/test/integration/remap.t/run.t
@@ -25,3 +25,9 @@ The order shouldn't matter, the longest prefix ought to win
   $ grep Otherlib/index.html _html3/prefix/mypkg/Test/index.html _html4/prefix/mypkg/Test/index.html
   _html3/prefix/mypkg/Test/index.html:       <a href="https://mysite.org/bar/Otherlib/index.html#type-t">Otherlib.t
   _html4/prefix/mypkg/Test/index.html:       <a href="https://mysite.org/bar/Otherlib/index.html#type-t">Otherlib.t
+
+  $ odoc html-generate -o _html5 --indent _odoc/prefix/mypkg/test.odocl --remap-file remap.txt
+  $ grep Otherlib/index.html _html5/prefix/mypkg/Test/index.html
+         <a href="https://mysite.org/bar/Otherlib/index.html#type-t">Otherlib.t
+
+


### PR DESCRIPTION
This adds a mode for publishing your package docs on your own site. It will generate HTML for the packages you select, and rewrite links that would have gone to other local packages to their documentation pages on ocaml.org.