### PR TITLE
Fix dep issue and hard failure

### DIFF
--- a/src/driver/dune
+++ b/src/driver/dune
@@ -2,7 +2,8 @@
  (public_name odoc_driver)
  (package odoc-driver)
  (link_deps
-  (package odoc))
+  (package odoc)
+  (package odoc-md))
  (preprocess
   (pps ppx_sexp_conv))
  (libraries

--- a/src/driver/opam.ml
+++ b/src/driver/opam.ml
@@ -64,10 +64,20 @@ let pkg_contents { name; _ } =
             | None -> assert false
           else str)
         file
-    with _ ->
-      Logs.err (fun m ->
-          m "Error while reading: %s. Considering it empty." changes_file);
-      OpamStd.String.Map.empty
+    with
+    | OpamSystem.File_not_found s ->
+        Logs.err (fun m ->
+            m "File not found: %s.\n%s\nConsidering it empty." changes_file s);
+        OpamStd.String.Map.empty
+    | OpamPp.Bad_version _ ->
+        Logs.err (fun m ->
+            m "Bad version while parsing %s.\nConsidering it empty."
+              changes_file);
+        OpamStd.String.Map.empty
+    | OpamPp.Bad_format _ ->
+        Logs.err (fun m ->
+            m "Bad format while parsing %s.\nConsidering it empty." changes_file);
+        OpamStd.String.Map.empty
   in
   let added =
     OpamStd.String.Map.fold


### PR DESCRIPTION
Packages without the corresponding files (eg installed by `dune install`) do not have the `<packagename>.change` file, making `odoc_driver` fully crash.

Moreover their is a missing dependency on `odoc-md` (which could have been part of the `odoc-driver` package?)
