### PR TITLE
Prepare for 2.4.4 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2.4.4
+
+### Added
+
+- OCaml 5.3.0 compatibility (@Julow, #1202, #1254)
+
 # 2.4.3
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.4.3
 
 ### Fixed
 

--- a/odoc-bench.opam
+++ b/odoc-bench.opam
@@ -25,7 +25,7 @@ authors: [
 ]
 dev-repo: "git+https://github.com/ocaml/odoc.git"
 
-synopsis: "Meta package defining dependencies for the benchmark rule. Not released."
+synopsis: "Meta package defining dependencies for the benchmark rule. Not released"
 
 depends: [
   "astring"

--- a/odoc.opam
+++ b/odoc.opam
@@ -57,7 +57,7 @@ depends: [
 
   "ppx_expect" {with-test}
   "bos" {with-test}
-  "crunch" {> "1.1.0"}
+  "crunch" {> "2.0.0"}
 
   ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
 ]


### PR DESCRIPTION
The first two commits backports changes made in previous 2.4 patch releases.
I suggest that we only tag patch releases on the 2.4 branch to avoid confusion in the future.