### PR TITLE
Add `--suppress-warnings" to avoid inheriting warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- Addded `--suppress-warnings` to the CLI to remove warnings from a unit, even
+  if they end up being raised in another unit through expansion (@jonludlam,
+  #1260)
 - Improve jump to implementation in rendered source code, and add a
   `count-occurrences` flag and command to count occurrences of every identifiers
   (@panglesd, #976)

--- a/doc/examples/resolution.mli
+++ b/doc/examples/resolution.mli
@@ -85,8 +85,6 @@ module Hidden : sig
   (**/**)
 
   type v = T of t
-
-  type w = U of u
 end
 
 module References : sig

--- a/doc/odoc.mld
+++ b/doc/odoc.mld
@@ -59,5 +59,3 @@ The main other pages of this site:
 - {!page-dune} shows how to create docs using Dune.
 - {!page-parent_child_spec} delineates parent/child specifications.
 - {!page-interface} describes [odoc]'s public-facing interface and their support guarantees.
-- {!page-ocamlary} demonstrates the rendering of most of the OCaml constructs.
-- {!page-api_reference} lists [odoc]'s API reference library.

--- a/dune
+++ b/dune
@@ -23,3 +23,8 @@
   (progn
    (bash "diff doc/driver.mld doc/driver.mld.corrected >&2 || true")
    (cat doc/driver-benchmarks.json))))
+
+(install
+ (files odoc-config.sexp)
+ (section doc)
+ (package odoc))

--- a/odoc-config.sexp
+++ b/odoc-config.sexp
@@ -1,0 +1,2 @@
+(libraries fmt)
+

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -413,8 +413,8 @@ let standalone docs =
   Utils.flatmap ~f:item_element
   @@ List.map (fun x -> x.Odoc_model.Location_.value) docs
 
-let to_ir (docs : Comment.docs) =
+let to_ir (docs : Comment.elements) =
   Utils.flatmap ~f:block_element
-  @@ List.map (fun x -> x.Odoc_model.Location_.value) docs.elements
+  @@ List.map (fun x -> x.Odoc_model.Location_.value) docs
 
 let has_doc docs = docs <> []

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -415,6 +415,6 @@ let standalone docs =
 
 let to_ir (docs : Comment.docs) =
   Utils.flatmap ~f:block_element
-  @@ List.map (fun x -> x.Odoc_model.Location_.value) docs
+  @@ List.map (fun x -> x.Odoc_model.Location_.value) docs.elements
 
 let has_doc docs = docs <> []

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -530,10 +530,9 @@ module Make (Syntax : SYNTAX) = struct
                  field fld.mutable_ (fld.id :> Paths.Identifier.t) fld.type_
                in
                let anchor = Some url in
-               let rhs = Comment.to_ir fld.doc in
-               let doc =
-                 if not (Comment.has_doc fld.doc.elements) then [] else rhs
-               in
+               let doc = fld.doc.elements in
+               let rhs = Comment.to_ir doc in
+               let doc = if not (Comment.has_doc doc) then [] else rhs in
                let markers = Syntax.Comment.markers in
                DocumentedSrc.Documented { anchor; attrs; code; doc; markers })
       in
@@ -610,10 +609,9 @@ module Make (Syntax : SYNTAX) = struct
                        cstr.args cstr.res
                    in
                    let anchor = Some url in
-                   let rhs = Comment.to_ir cstr.doc in
-                   let doc =
-                     if not (Comment.has_doc cstr.doc.elements) then [] else rhs
-                   in
+                   let doc = cstr.doc.elements in
+                   let rhs = Comment.to_ir doc in
+                   let doc = if not (Comment.has_doc doc) then [] else rhs in
                    let markers = Syntax.Comment.markers in
                    DocumentedSrc.Nested { anchor; attrs; code; doc; markers })
           in
@@ -625,7 +623,7 @@ module Make (Syntax : SYNTAX) = struct
       let anchor = Some url in
       let attrs = [ "def"; "variant"; Url.Anchor.string_of_kind url.kind ] in
       let code = O.documentedSrc (O.txt "| ") @ constructor id t.args t.res in
-      let doc = Comment.to_ir t.doc in
+      let doc = Comment.to_ir t.doc.elements in
       let markers = Syntax.Comment.markers in
       DocumentedSrc.Nested { anchor; attrs; code; doc; markers }
 
@@ -646,7 +644,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "type"; "extension" ] in
       let anchor = Some (Url.Anchor.extension_decl t) in
-      let doc = Comment.to_ir t.doc in
+      let doc = Comment.to_ir t.doc.elements in
       let source_anchor =
         (* Take the anchor from the first constructor only for consistency with
            regular variants. *)
@@ -666,7 +664,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "exception" ] in
       let anchor = path_to_id t.id in
-      let doc = Comment.to_ir t.doc in
+      let doc = Comment.to_ir t.doc.elements in
       let source_anchor = source_anchor t.source_loc in
       Item.Declaration { attr; anchor; doc; content; source_anchor }
 
@@ -710,7 +708,7 @@ module Make (Syntax : SYNTAX) = struct
                       else O.txt " " ++ O.keyword "of" ++ O.sp ++ params)),
                 match doc with
                 | { elements = []; _ } -> None
-                | _ -> Some (Comment.to_ir doc) ))
+                | _ -> Some (Comment.to_ir doc.elements) ))
         in
         let markers = Syntax.Comment.markers in
         try
@@ -881,7 +879,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = "type" :: (if is_substitution then [ "subst" ] else []) in
       let anchor = path_to_id t.id in
-      let doc = Comment.to_ir t.doc in
+      let doc = Comment.to_ir t.doc.elements in
       let source_anchor = source_anchor t.source_loc in
       Item.Declaration { attr; anchor; doc; content; source_anchor }
   end
@@ -909,7 +907,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "value" ] @ extra_attr in
       let anchor = path_to_id t.id in
-      let doc = Comment.to_ir t.doc in
+      let doc = Comment.to_ir t.doc.elements in
       let source_anchor = source_anchor t.source_loc in
       Item.Declaration { attr; anchor; doc; content; source_anchor }
   end
@@ -1010,7 +1008,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "method" ] in
       let anchor = path_to_id t.id in
-      let doc = Comment.to_ir t.doc in
+      let doc = Comment.to_ir t.doc.elements in
       Item.Declaration { attr; anchor; doc; content; source_anchor = None }
 
     let instance_variable (t : Odoc_model.Lang.InstanceVariable.t) =
@@ -1029,7 +1027,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "value"; "instance-variable" ] in
       let anchor = path_to_id t.id in
-      let doc = Comment.to_ir t.doc in
+      let doc = Comment.to_ir t.doc.elements in
       Item.Declaration { attr; anchor; doc; content; source_anchor = None }
 
     let inherit_ (ih : Lang.ClassSignature.Inherit.t) =
@@ -1043,7 +1041,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "inherit" ] in
       let anchor = None in
-      let doc = Comment.to_ir ih.doc in
+      let doc = Comment.to_ir ih.doc.elements in
       Item.Declaration { attr; anchor; doc; content; source_anchor = None }
 
     let constraint_ (cst : Lang.ClassSignature.Constraint.t) =
@@ -1052,7 +1050,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [] in
       let anchor = None in
-      let doc = Comment.to_ir cst.doc in
+      let doc = Comment.to_ir cst.doc.elements in
       Item.Declaration { attr; anchor; doc; content; source_anchor = None }
 
     let class_signature (c : Lang.ClassSignature.t) =
@@ -1314,7 +1312,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let attr = [ "module-substitution" ] in
       let anchor = path_to_id t.id in
-      let doc = Comment.to_ir t.doc in
+      let doc = Comment.to_ir t.doc.elements in
       Item.Declaration { attr; anchor; doc; content; source_anchor = None }
 
     and module_type_substitution (t : Odoc_model.Lang.ModuleTypeSubstitution.t)
@@ -1724,7 +1722,7 @@ module Make (Syntax : SYNTAX) = struct
            synopsis because no page is generated to render it and we'd loose
            the full documentation.
            The documentation from the expansion is not used. *)
-        Comment.to_ir t.doc
+        Comment.to_ir t.doc.elements
       in
       Item.Include { attr; anchor; doc; content; source_anchor = None }
   end

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -94,7 +94,7 @@ end = struct
             | Page { short_title = None; _ } ->
                 let title =
                   let open Odoc_model in
-                  match Comment.find_zero_heading entry.doc.elements with
+                  match Comment.find_zero_heading entry.doc with
                   | Some t -> t
                   | None ->
                       let name =

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -94,7 +94,7 @@ end = struct
             | Page { short_title = None; _ } ->
                 let title =
                   let open Odoc_model in
-                  match Comment.find_zero_heading entry.doc with
+                  match Comment.find_zero_heading entry.doc.elements with
                   | Some t -> t
                   | None ->
                       let name =

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -143,6 +143,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.t list) =
                  in
                  Odoc.compile ~output_dir:unit.output_dir
                    ~input_file:unit.input_file ~includes
+                   ~suppress_warnings:(not unit.enable_warnings)
                    ~parent_id:unit.parent_id;
                  Atomic.incr Stats.stats.compiled_units;
 
@@ -191,7 +192,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.t list) =
     | `Mld ->
         let includes = Fpath.Set.empty in
         Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
-          ~includes ~parent_id:unit.parent_id;
+          ~includes ~suppress_warnings:false ~parent_id:unit.parent_id;
         Atomic.incr Stats.stats.compiled_mlds;
         Ok [ unit ]
     | `Md ->

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -18,13 +18,14 @@ let make_index ~dirs ?pkg ~rel_dir ?index ~content () =
   let odoc_file = Fpath.(odoc_dir // rel_dir / "page-index.odoc") in
   let odocl_file = Fpath.(odocl_dir // rel_dir / "page-index.odocl") in
   let parent_id = rel_dir |> Odoc.Id.of_fpath in
+  let pkg_args = Pkg_args.v ~pages ~libs ~odoc_dir ~odocl_dir in
   Util.with_out_to input_file (fun oc ->
       fpf (Format.formatter_of_out_channel oc) "%t@?" content)
   |> Result.get_ok;
   {
     output_dir = dirs.odoc_dir;
     pkgname = None;
-    pkg_args = { Pkg_args.pages; libs; odoc_dir; odocl_dir };
+    pkg_args;
     parent_id;
     input_file;
     odoc_file;

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -36,7 +36,8 @@ let compile_deps f =
   | [ (_, digest) ], deps -> Ok { digest; deps }
   | _ -> Error (`Msg "odd")
 
-let compile ~output_dir ~input_file:file ~includes ~parent_id =
+let compile ~output_dir ~input_file:file ~includes ~suppress_warnings ~parent_id
+    =
   let open Cmd in
   let includes =
     Fpath.Set.fold
@@ -52,6 +53,7 @@ let compile ~output_dir ~input_file:file ~includes ~parent_id =
     %% includes % "--enable-missing-root-warning"
   in
   let cmd = cmd % "--parent-id" % Id.to_string parent_id in
+  let cmd = if suppress_warnings then cmd % "--suppress-warnings" else cmd in
   let desc = Printf.sprintf "Compiling %s" (Fpath.to_string file) in
   ignore
   @@ Cmd_outputs.submit

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -24,6 +24,7 @@ val compile :
   output_dir:Fpath.t ->
   input_file:Fpath.t ->
   includes:Fpath.set ->
+  suppress_warnings:bool ->
   parent_id:Id.t ->
   unit
 val compile_md :

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -2,11 +2,16 @@ module Pkg_args = struct
   type t = {
     odoc_dir : Fpath.t;
     odocl_dir : Fpath.t;
-    pages : (string * Fpath.t) list;
-    libs : (string * Fpath.t) list;
+    pages : Fpath.t Util.StringMap.t;
+    libs : Fpath.t Util.StringMap.t;
   }
 
-  let map_rel dir = List.map (fun (a, b) -> (a, Fpath.(dir // b)))
+  let v ~odoc_dir ~odocl_dir ~pages ~libs =
+    let pages, libs = Util.StringMap.(of_list pages, of_list libs) in
+    { odoc_dir; odocl_dir; pages; libs }
+
+  let map_rel dir m =
+    Util.StringMap.fold (fun a b acc -> (a, Fpath.(dir // b)) :: acc) m []
 
   let compiled_pages v = map_rel v.odoc_dir v.pages
   let compiled_libs v = map_rel v.odoc_dir v.libs
@@ -21,8 +26,8 @@ module Pkg_args = struct
     {
       odoc_dir = v1.odoc_dir;
       odocl_dir = v1.odocl_dir;
-      pages = v1.pages @ v2.pages;
-      libs = v1.libs @ v2.libs;
+      pages = Util.StringMap.union (fun _ x _ -> Some x) v1.pages v2.pages;
+      libs = Util.StringMap.union (fun _ x _ -> Some x) v1.libs v2.libs;
     }
 
   let pp fmt x =
@@ -33,7 +38,10 @@ module Pkg_args = struct
     in
     Format.fprintf fmt
       "@[<hov>odoc_dir: %a@;odocl_dir: %a@;pages: [%a]@;libs: [%a]@]" Fpath.pp
-      x.odoc_dir Fpath.pp x.odocl_dir sfp_pp x.pages sfp_pp x.libs
+      x.odoc_dir Fpath.pp x.odocl_dir sfp_pp
+      (Util.StringMap.bindings x.pages)
+      sfp_pp
+      (Util.StringMap.bindings x.libs)
 end
 
 type sidebar = { output_file : Fpath.t; json : bool }

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -1,15 +1,17 @@
 module Pkg_args : sig
-  type t = {
-    odoc_dir : Fpath.t;
-    odocl_dir : Fpath.t;
-    pages : (string * Fpath.t) list;
-    libs : (string * Fpath.t) list;
-  }
+  type t
 
   val compiled_pages : t -> (string * Fpath.t) list
   val compiled_libs : t -> (string * Fpath.t) list
   val linked_pages : t -> (string * Fpath.t) list
   val linked_libs : t -> (string * Fpath.t) list
+
+  val v :
+    odoc_dir:Fpath.t ->
+    odocl_dir:Fpath.t ->
+    pages:(string * Fpath.t) list ->
+    libs:(string * Fpath.t) list ->
+    t
 
   val combine : t -> t -> t
 

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -193,10 +193,13 @@ let packages ~dirs ~extra_paths ~remap (pkgs : Packages.t list) : t list =
   in
   let of_lib pkg (lib : Packages.libty) =
     let lib_deps = Util.StringSet.add lib.lib_name lib.lib_deps in
-    let landing_page :> t =
-      let index = index_of pkg in
-      Landing_pages.library ~dirs ~pkg ~index lib
+    let lib_deps =
+      List.fold_left
+        (fun acc lib -> Util.StringSet.add lib.Packages.lib_name acc)
+        lib_deps pkg.Packages.libraries
     in
+    let index = index_of pkg in
+    let landing_page :> t = Landing_pages.library ~dirs ~pkg ~index lib in
     landing_page :: List.concat_map (of_module pkg lib lib_deps) lib.modules
   in
   let of_mld pkg (mld : Packages.mld) : mld unit list =

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -46,7 +46,7 @@ let packages ~dirs ~extra_paths ~remap (pkgs : Packages.t list) : t list =
   let base_args pkg lib_deps : Pkg_args.t =
     let own_page = dash_p pkg.Packages.name (doc_dir pkg) in
     let own_libs = List.concat_map dash_l (Util.StringSet.to_list lib_deps) in
-    { pages = [ own_page ]; libs = own_libs; odoc_dir; odocl_dir }
+    Pkg_args.v ~pages:[ own_page ] ~libs:own_libs ~odoc_dir ~odocl_dir
   in
   let args_of_config config : Pkg_args.t =
     let { Global_config.deps = { packages; libraries } } = config in
@@ -61,7 +61,7 @@ let packages ~dirs ~extra_paths ~remap (pkgs : Packages.t list) : t list =
         packages
     in
     let libs_rel = List.concat_map dash_l libraries in
-    { pages = pages_rel; libs = libs_rel; odoc_dir; odocl_dir }
+    Pkg_args.v ~pages:pages_rel ~libs:libs_rel ~odoc_dir ~odocl_dir
   in
   let args_of =
     let cache = Hashtbl.create 10 in

--- a/src/index/entry.ml
+++ b/src/index/entry.ml
@@ -62,7 +62,7 @@ type kind =
 
 type t = {
   id : Odoc_model.Paths.Identifier.Any.t;
-  doc : Odoc_model.Comment.docs;
+  doc : Odoc_model.Comment.elements;
   kind : kind;
 }
 

--- a/src/index/entry.mli
+++ b/src/index/entry.mli
@@ -60,12 +60,12 @@ type kind =
 
 type t = {
   id : Odoc_model.Paths.Identifier.Any.t;
-  doc : Odoc_model.Comment.docs;
+  doc : Odoc_model.Comment.elements;
   kind : kind;
 }
 
 val entry :
   id:[< Odoc_model.Paths.Identifier.Any.t_pv ] Odoc_model.Paths.Identifier.id ->
-  doc:Odoc_model.Comment.docs ->
+  doc:Odoc_model.Comment.elements ->
   kind:kind ->
   t

--- a/src/index/skeleton.ml
+++ b/src/index/skeleton.ml
@@ -8,7 +8,12 @@ type t = Entry.t Tree.t
 module Entry = struct
   let of_comp_unit (u : Compilation_unit.t) =
     let has_expansion = true in
-    let doc = match u.content with Pack _ -> [] | Module m -> m.doc in
+    let doc =
+      match u.content with
+      | Pack _ ->
+          { Odoc_model.Comment.elements = []; suppress_warnings = false }
+      | Module m -> m.doc
+    in
     Entry.entry ~id:u.id ~doc ~kind:(Module { has_expansion })
 
   let of_module (m : Module.t) =

--- a/src/index/skeleton.ml
+++ b/src/index/skeleton.ml
@@ -6,13 +6,12 @@ open Odoc_utils
 type t = Entry.t Tree.t
 
 module Entry = struct
+  open Odoc_model.Comment
+
   let of_comp_unit (u : Compilation_unit.t) =
     let has_expansion = true in
     let doc =
-      match u.content with
-      | Pack _ ->
-          { Odoc_model.Comment.elements = []; suppress_warnings = false }
-      | Module m -> m.doc
+      match u.content with Pack _ -> [] | Module m -> m.doc.elements
     in
     Entry.entry ~id:u.id ~doc ~kind:(Module { has_expansion })
 
@@ -20,7 +19,7 @@ module Entry = struct
     let has_expansion =
       match m.type_ with Alias (_, None) -> false | _ -> true
     in
-    Entry.entry ~id:m.id ~doc:m.doc ~kind:(Module { has_expansion })
+    Entry.entry ~id:m.id ~doc:m.doc.elements ~kind:(Module { has_expansion })
 
   let of_module_type (mt : ModuleType.t) =
     let has_expansion =
@@ -35,7 +34,8 @@ module Entry = struct
           | _ -> false)
       | _ -> true
     in
-    Entry.entry ~id:mt.id ~doc:mt.doc ~kind:(ModuleType { has_expansion })
+    Entry.entry ~id:mt.id ~doc:mt.doc.elements
+      ~kind:(ModuleType { has_expansion })
 
   let of_type_decl (td : TypeDecl.t) =
     let kind =
@@ -46,7 +46,7 @@ module Entry = struct
           representation = td.representation;
         }
     in
-    Entry.entry ~id:td.id ~doc:td.doc ~kind
+    Entry.entry ~id:td.id ~doc:td.doc.elements ~kind
 
   let varify_params =
     List.mapi (fun i param ->
@@ -67,7 +67,7 @@ module Entry = struct
               params )
     in
     let kind = Entry.Constructor { args; res } in
-    Entry.entry ~id:c.id ~doc:c.doc ~kind
+    Entry.entry ~id:c.id ~doc:c.doc.elements ~kind
 
   let of_field id_parent params (field : TypeDecl.Field.t) =
     let params = varify_params params in
@@ -81,7 +81,7 @@ module Entry = struct
       Entry.Field
         { mutable_ = field.mutable_; type_ = field.type_; parent_type }
     in
-    Entry.entry ~id:field.id ~doc:field.doc ~kind
+    Entry.entry ~id:field.id ~doc:field.doc.elements ~kind
 
   let of_exception (exc : Exception.t) =
     let res =
@@ -93,11 +93,11 @@ module Entry = struct
       | Some x -> x
     in
     let kind = Entry.Exception { args = exc.args; res } in
-    Entry.entry ~id:exc.id ~doc:exc.doc ~kind
+    Entry.entry ~id:exc.id ~doc:exc.doc.elements ~kind
 
   let of_value (v : Value.t) =
     let kind = Entry.Value { value = v.value; type_ = v.type_ } in
-    Entry.entry ~id:v.id ~doc:v.doc ~kind
+    Entry.entry ~id:v.id ~doc:v.doc.elements ~kind
 
   let of_extension_constructor type_path params (v : Extension.Constructor.t) =
     let res =
@@ -108,26 +108,26 @@ module Entry = struct
           TypeExpr.Constr (type_path, params)
     in
     let kind = Entry.ExtensionConstructor { args = v.args; res } in
-    Entry.entry ~id:v.id ~doc:v.doc ~kind
+    Entry.entry ~id:v.id ~doc:v.doc.elements ~kind
 
   let of_class (cl : Class.t) =
     let kind = Entry.Class { virtual_ = cl.virtual_; params = cl.params } in
-    Entry.entry ~id:cl.id ~doc:cl.doc ~kind
+    Entry.entry ~id:cl.id ~doc:cl.doc.elements ~kind
 
   let of_class_type (ct : ClassType.t) =
     let kind =
       Entry.Class_type { virtual_ = ct.virtual_; params = ct.params }
     in
-    Entry.entry ~id:ct.id ~doc:ct.doc ~kind
+    Entry.entry ~id:ct.id ~doc:ct.doc.elements ~kind
 
   let of_method (m : Method.t) =
     let kind =
       Entry.Method
         { virtual_ = m.virtual_; private_ = m.private_; type_ = m.type_ }
     in
-    Entry.entry ~id:m.id ~doc:m.doc ~kind
+    Entry.entry ~id:m.id ~doc:m.doc.elements ~kind
 
-  let of_docs id doc = Entry.entry ~id ~doc ~kind:Doc
+  let of_docs id doc = Entry.entry ~id ~doc:doc.elements ~kind:Doc
 end
 
 let if_non_hidden id f =

--- a/src/index/skeleton_of.ml
+++ b/src/index/skeleton_of.ml
@@ -39,18 +39,15 @@ let compare_entry (t1 : t) (t2 : t) =
   try_ Astring.String.compare by_name @@ fun () -> 0
 
 let rec t_of_in_progress (dir : In_progress.in_progress) : t =
-  let empty_doc = { Comment.elements = []; suppress_warnings = false } in
-
   let entry_of_page page =
     let kind = Entry.Page page.Lang.Page.frontmatter in
-    let doc = page.content in
+    let doc = page.content.elements in
     let id = page.name in
     Entry.entry ~kind ~doc ~id
   in
   let entry_of_impl id =
     let kind = Entry.Impl in
-    let doc = empty_doc in
-    Entry.entry ~kind ~doc ~id
+    Entry.entry ~kind ~doc:[] ~id
   in
   let children_order, index =
     match In_progress.index dir with
@@ -63,16 +60,14 @@ let rec t_of_in_progress (dir : In_progress.in_progress) : t =
           match In_progress.root_dir dir with
           | Some id ->
               let kind = Entry.Dir in
-              let doc = empty_doc in
-              Entry.entry ~kind ~doc ~id
+              Entry.entry ~kind ~doc:[] ~id
           | None ->
               let id =
                 (* root dir must have an index page *)
                 Id.Mk.leaf_page (None, Names.PageName.make_std "index")
               in
               let kind = Entry.Dir in
-              let doc = empty_doc in
-              Entry.entry ~kind ~doc ~id
+              Entry.entry ~kind ~doc:[] ~id
         in
         (None, entry)
   in

--- a/src/index/skeleton_of.ml
+++ b/src/index/skeleton_of.ml
@@ -39,6 +39,8 @@ let compare_entry (t1 : t) (t2 : t) =
   try_ Astring.String.compare by_name @@ fun () -> 0
 
 let rec t_of_in_progress (dir : In_progress.in_progress) : t =
+  let empty_doc = { Comment.elements = []; suppress_warnings = false } in
+
   let entry_of_page page =
     let kind = Entry.Page page.Lang.Page.frontmatter in
     let doc = page.content in
@@ -47,7 +49,7 @@ let rec t_of_in_progress (dir : In_progress.in_progress) : t =
   in
   let entry_of_impl id =
     let kind = Entry.Impl in
-    let doc = [] in
+    let doc = empty_doc in
     Entry.entry ~kind ~doc ~id
   in
   let children_order, index =
@@ -61,7 +63,7 @@ let rec t_of_in_progress (dir : In_progress.in_progress) : t =
           match In_progress.root_dir dir with
           | Some id ->
               let kind = Entry.Dir in
-              let doc = [] in
+              let doc = empty_doc in
               Entry.entry ~kind ~doc ~id
           | None ->
               let id =
@@ -69,7 +71,7 @@ let rec t_of_in_progress (dir : In_progress.in_progress) : t =
                 Id.Mk.leaf_page (None, Names.PageName.make_std "index")
               in
               let kind = Entry.Dir in
-              let doc = [] in
+              let doc = empty_doc in
               Entry.entry ~kind ~doc ~id
         in
         (None, entry)

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -1171,7 +1171,7 @@ and read_signature env parent (items : Odoc_model.Compat.signature) =
   fst @@ read_signature_noenv env parent items
 
 
-let read_interface root name suppress_warnings intf =
+let read_interface root name ~suppress_warnings intf =
   let id =
     Identifier.Mk.root (root, Odoc_model.Names.ModuleName.make_std name)
   in

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -25,6 +25,14 @@ open Odoc_model.Names
 module Env = Ident_env
 module Paths = Odoc_model.Paths
 
+
+type env = {
+  ident_env : Env.t;
+  suppress_warnings : bool;  (** suppress warnings *)
+}
+
+let empty_doc = { Odoc_model.Comment.elements = []; suppress_warnings = false }
+
 module Compat = struct
 #if OCAML_VERSION >= (4, 14, 0)
 #if OCAML_VERSION >= (5, 3, 0)
@@ -458,7 +466,7 @@ let rec read_type_expr env typ =
           let typs = List.map (read_type_expr env) typs in
             Tuple typs
       | Tconstr(p, params, _) ->
-          let p = Env.Path.read_type env p in
+          let p = Env.Path.read_type env.ident_env p in
           let params = List.map (read_type_expr env) params in
             Constr(p, params)
       | Tvariant row -> read_row env px row
@@ -479,7 +487,7 @@ let rec read_type_expr env typ =
         let eqs = List.combine frags tyl in
 #endif
           let open TypeExpr.Package in
-          let path = Env.Path.read_module_type env p in
+          let path = Env.Path.read_module_type env.ident_env p in
           let substitutions =
             List.map
               (fun (frag,typ) ->
@@ -522,7 +530,7 @@ and read_row env _px row =
   let all_present = List.length present = List.length sorted_fields in
   match Compat.get_row_name row with
   | Some(p, params) when namable_row row ->
-      let p = Env.Path.read_type env p in
+      let p = Env.Path.read_type env.ident_env p in
       let params = List.map (read_type_expr env) params in
       if Compat.row_closed row && all_present then
         Constr (p, params)
@@ -535,15 +543,16 @@ and read_row env _px row =
       let elements =
         List.map
           (fun (name, f) ->
+            let doc = empty_doc in
             match Compat.row_field_repr f with
               | Rpresent None ->
-                Constructor {name; constant = true; arguments = []; doc = []}
+                Constructor {name; constant = true; arguments = []; doc}
               | Rpresent (Some typ) ->
                 Constructor {
                   name;
                   constant = false;
                   arguments = [read_type_expr env typ];
-                  doc = [];
+                  doc;
                 }
 #if OCAML_VERSION >= (4, 14, 0)
               | Reither(constant, typs, _) ->
@@ -553,7 +562,7 @@ and read_row env _px row =
                 let arguments =
                   List.map (read_type_expr env) typs
                 in
-                Constructor {name; constant; arguments; doc = []}
+                Constructor {name; constant; arguments; doc}
               | Rabsent -> assert false)
           sorted_fields
       in
@@ -600,20 +609,20 @@ and read_object env fi nm =
         in
         Object {fields = methods; open_}
     | Some (p, _ :: params) ->
-        let p = Env.Path.read_class_type env p in
+        let p = Env.Path.read_class_type env.ident_env p in
         let params = List.map (read_type_expr env) params in
         Class (p, params)
     | _ -> assert false
   end
 
-let read_value_description env parent id vd =
+let read_value_description ({ident_env ; suppress_warnings} as env) parent id vd =
   let open Signature in
-  let id = Env.find_value_identifier env id in
+  let id = Env.find_value_identifier ident_env id in
   let source_loc = None in
   let container =
     (parent : Identifier.Signature.t :> Identifier.LabelParent.t)
   in
-  let doc = Doc_attr.attached_no_tag container vd.val_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings container vd.val_attributes in
   mark_value_description vd;
   let type_ = read_type_expr env vd.val_type in
   let value =
@@ -635,7 +644,7 @@ let read_label_declaration env parent ld =
   let name = Ident.name ld.ld_id in
   let id = Identifier.Mk.field (parent, Odoc_model.Names.FieldName.make_std name) in
   let doc =
-    Doc_attr.attached_no_tag
+    Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings
       (parent :> Identifier.LabelParent.t) ld.ld_attributes
   in
   let mutable_ = (ld.ld_mutable = Mutable) in
@@ -658,9 +667,9 @@ let read_constructor_declaration_arguments env parent arg =
 
 let read_constructor_declaration env parent cd =
   let open TypeDecl.Constructor in
-  let id = Ident_env.find_constructor_identifier env cd.cd_id in
+  let id = Ident_env.find_constructor_identifier env.ident_env cd.cd_id in
   let container = (parent :> Identifier.LabelParent.t) in
-  let doc = Doc_attr.attached_no_tag container cd.cd_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings container cd.cd_attributes in
   let args =
     read_constructor_declaration_arguments env
       (parent :> Identifier.FieldParent.t) cd.cd_args
@@ -735,15 +744,15 @@ let read_class_constraints env params =
   let open ClassSignature in
   read_type_constraints env params
   |> List.map (fun (left, right) ->
-         Constraint { Constraint.left; right; doc = [] })
+         Constraint { Constraint.left; right; doc = empty_doc })
 
 let read_type_declaration env parent id decl =
   let open TypeDecl in
-  let id = Env.find_type_identifier env id in
+  let id = Env.find_type_identifier env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, canonical =
-    Doc_attr.attached Odoc_model.Semantics.Expect_canonical container decl.type_attributes
+    Doc_attr.attached ~suppress_warnings:env.suppress_warnings Odoc_model.Semantics.Expect_canonical container decl.type_attributes
   in
   let canonical = match canonical with | None -> None | Some s -> Doc_attr.conv_canonical_type s in
   let params = mark_type_declaration decl in
@@ -779,10 +788,10 @@ let read_type_declaration env parent id decl =
 
 let read_extension_constructor env parent id ext =
   let open Extension.Constructor in
-  let id = Env.find_extension_identifier env id in
+  let id = Env.find_extension_identifier env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc = Doc_attr.attached_no_tag container ext.ext_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings container ext.ext_attributes in
   let args =
     read_constructor_declaration_arguments env
       (parent : Identifier.Signature.t :> Identifier.FieldParent.t) ext.ext_args
@@ -792,7 +801,7 @@ let read_extension_constructor env parent id ext =
 
 let read_type_extension env parent id ext rest =
   let open Extension in
-  let type_path = Env.Path.read_type env ext.ext_type_path in
+  let type_path = Env.Path.read_type env.ident_env ext.ext_type_path in
   let doc = Doc_attr.empty in
   let type_params = mark_type_extension' ext rest in
   let first = read_extension_constructor env parent id ext in
@@ -812,10 +821,10 @@ let read_type_extension env parent id ext rest =
 
 let read_exception env parent id ext =
   let open Exception in
-  let id = Env.find_exception_identifier env id in
+  let id = Env.find_exception_identifier env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc = Doc_attr.attached_no_tag container ext.ext_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings container ext.ext_attributes in
     mark_exception ext;
     let args =
       read_constructor_declaration_arguments env
@@ -854,7 +863,7 @@ let rec read_class_signature env parent params =
       || List.exists aliasable params
       then read_class_signature env parent params cty
       else begin
-        let p = Env.Path.read_class_type env p in
+        let p = Env.Path.read_class_type env.ident_env p in
         let params = List.map (read_type_expr env) params in
           Constr(p, params)
       end
@@ -881,7 +890,7 @@ let rec read_class_signature env parent params =
         List.map (read_method env parent (Compat.csig_concr csig)) methods
       in
       let items = constraints @ instance_variables @ methods in
-      Signature {self; items; doc = []}
+      Signature {self; items; doc = empty_doc}
   | Cty_arrow _ -> assert false
 
 let rec read_virtual = function
@@ -906,10 +915,10 @@ let rec read_virtual = function
 
 let read_class_type_declaration env parent id cltd =
   let open ClassType in
-  let id = Env.find_class_type_identifier env id in
+  let id = Env.find_class_type_identifier env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc = Doc_attr.attached_no_tag container cltd.clty_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings container cltd.clty_attributes in
     mark_class_type_declaration cltd;
     let params =
       List.map2
@@ -942,10 +951,10 @@ let rec read_class_type env parent params =
 
 let read_class_declaration env parent id cld =
   let open Class in
-  let id = Env.find_class_identifier env id in
+  let id = Env.find_class_identifier env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc = Doc_attr.attached_no_tag container cld.cty_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings container cld.cty_attributes in
     mark_class_declaration cld;
     let params =
       List.map2
@@ -961,7 +970,7 @@ let read_class_declaration env parent id cld =
 let rec read_module_type env parent (mty : Odoc_model.Compat.module_type) =
   let open ModuleType in
     match mty with
-    | Mty_ident p -> Path {p_path = Env.Path.read_module_type env p; p_expansion=None }
+    | Mty_ident p -> Path {p_path = Env.Path.read_module_type env.ident_env p; p_expansion=None }
     | Mty_signature sg -> Signature (read_signature env parent sg)
     | Mty_functor(parameter, res) ->
         let f_parameter, env =
@@ -970,8 +979,8 @@ let rec read_module_type env parent (mty : Odoc_model.Compat.module_type) =
           | Named (id_opt, arg) ->
               let id, env = match id_opt with
                 | None -> Identifier.Mk.parameter(parent, Odoc_model.Names.ModuleName.make_std "_"), env
-                | Some id -> let env = Env.add_parameter parent id (ModuleName.of_ident id) env in
-                  Ident_env.find_parameter_identifier env id, env
+                | Some id -> let e' = Env.add_parameter parent id (ModuleName.of_ident id) env.ident_env in
+                  Ident_env.find_parameter_identifier e' id, {env with ident_env = e'}
               in
               let arg = read_module_type env (id :> Identifier.Signature.t) arg in
               Odoc_model.Lang.FunctorParameter.Named ({ FunctorParameter. id; expr = arg }), env
@@ -979,30 +988,30 @@ let rec read_module_type env parent (mty : Odoc_model.Compat.module_type) =
         let res = read_module_type env (Identifier.Mk.result parent) res in
         Functor( f_parameter, res)
     | Mty_alias p ->
-        let t_original_path = Env.Path.read_module env p in
+        let t_original_path = Env.Path.read_module env.ident_env p in
         let t_desc = ModPath t_original_path in
         TypeOf { t_desc; t_expansion = None; t_original_path }
 
 and read_module_type_declaration env parent id (mtd : Odoc_model.Compat.modtype_declaration) =
   let open ModuleType in
-  let id = Env.find_module_type env id in
+  let id = Env.find_module_type env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container mtd.mtd_attributes in
+  let doc, canonical = Doc_attr.attached ~suppress_warnings:env.suppress_warnings Odoc_model.Semantics.Expect_canonical container mtd.mtd_attributes in
   let canonical = match canonical with | None -> None | Some s -> Doc_attr.conv_canonical_module_type s in
   let expr = opt_map (read_module_type env (id :> Identifier.Signature.t)) mtd.mtd_type in
   {id; source_loc; doc; canonical; expr }
 
 and read_module_declaration env parent ident (md : Odoc_model.Compat.module_declaration) =
   let open Module in
-  let id = (Env.find_module_identifier env ident :> Identifier.Module.t) in
+  let id = (Env.find_module_identifier env.ident_env ident :> Identifier.Module.t) in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container md.md_attributes in
+  let doc, canonical = Doc_attr.attached ~suppress_warnings:env.suppress_warnings Odoc_model.Semantics.Expect_canonical container md.md_attributes in
   let canonical = match canonical with | None -> None | Some s -> Some (Doc_attr.conv_canonical_module s) in
   let type_ =
     match md.md_type with
-    | Mty_alias p -> Alias (Env.Path.read_module env p, None)
+    | Mty_alias p -> Alias (Env.Path.read_module env.ident_env p, None)
     | _ -> ModuleType (read_module_type env (id :> Identifier.Signature.t) md.md_type)
   in
   let hidden =
@@ -1035,9 +1044,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_value(id, v, _) :: rest ->
         let vd = read_value_description env parent id v in
         let shadowed =
-          if Env.is_shadowed env id
+          if Env.is_shadowed env.ident_env id
           then
-            let identifier = Env.find_value_identifier env id in
+            let identifier = Env.find_value_identifier env.ident_env id in
           match identifier.iv with
           | `Value (_, n) -> { shadowed with s_values = (Odoc_model.Names.parenthesise (Ident.name id), n) :: shadowed.s_values }
           else shadowed
@@ -1049,9 +1058,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_type(id, decl, rec_status, _)::rest ->
         let decl = read_type_declaration env parent id decl in
         let shadowed =
-          if Env.is_shadowed env id
+          if Env.is_shadowed env.ident_env id
           then
-            let identifier = Env.find_type_identifier env id in
+            let identifier = Env.find_type_identifier env.ident_env id in
             let `Type (_, name) = identifier.iv in
             { shadowed with s_types = (Ident.name id, name) :: shadowed.s_types }
           else shadowed
@@ -1077,9 +1086,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_module (id, _, md, rec_status, _)::rest ->
           let md = read_module_declaration env parent id md in
           let shadowed =
-            if Env.is_shadowed env id
+            if Env.is_shadowed env.ident_env id
             then
-              let identifier = Env.find_module_identifier env id in
+              let identifier = Env.find_module_identifier env.ident_env id in
             let name =
               match identifier.iv with
               | `Module (_, n) -> n 
@@ -1093,9 +1102,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_modtype(id, mtd, _) :: rest ->
           let mtd = read_module_type_declaration env parent id mtd in
           let shadowed =
-            if Env.is_shadowed env id
+            if Env.is_shadowed env.ident_env id
             then
-              let identifier = Env.find_module_type env id in
+              let identifier = Env.find_module_type env.ident_env id in
             let name =
               match identifier.iv with
               | `ModuleType (_, n) -> n
@@ -1114,9 +1123,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
 #endif
           let cl = read_class_declaration env parent id cl in
           let shadowed =
-            if Env.is_shadowed env id
+            if Env.is_shadowed env.ident_env id
             then
-              let identifier = Env.find_class_identifier env id in
+              let identifier = Env.find_class_identifier env.ident_env id in
             let name =
               match identifier.iv with
               | `Class (_, n) -> n
@@ -1133,9 +1142,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
 #endif
         let cltyp = read_class_type_declaration env parent id cltyp in
         let shadowed =
-          if Env.is_shadowed env id
+          if Env.is_shadowed env.ident_env id
           then
-            let identifier = Env.find_class_type_identifier env id in
+            let identifier = Env.find_class_type_identifier env.ident_env id in
           let name =
             match identifier.iv with
             | `ClassType (_, n) -> n
@@ -1152,16 +1161,23 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_class_type _ :: _
     | Sig_class _ :: _ -> assert false
 
-    | [] -> ({items = List.rev acc; compiled=false; removed = []; doc = [] }, shadowed)
+    | [] -> ({items = List.rev acc; compiled=false; removed = []; doc = empty_doc }, shadowed)
   in
     loop ([],{s_modules=[]; s_module_types=[]; s_values=[];s_types=[]; s_classes=[]; s_class_types=[]}) items
 
 and read_signature env parent (items : Odoc_model.Compat.signature) =
-  let env = Env.handle_signature_type_items parent items env in
+  let e' = Env.handle_signature_type_items parent items env.ident_env in
+  let env = { env with ident_env = e' } in
   fst @@ read_signature_noenv env parent items
 
 
-let read_interface root name intf =
-  let id = Identifier.Mk.root (root, Odoc_model.Names.ModuleName.make_std name) in
-  let items = read_signature (Env.empty ()) id intf in
+let read_interface root name suppress_warnings intf =
+  let id =
+    Identifier.Mk.root (root, Odoc_model.Names.ModuleName.make_std name)
+  in
+  let items =
+    read_signature
+      { ident_env = Env.empty (); suppress_warnings }
+      id intf
+  in
   (id, items)

--- a/src/loader/cmi.mli
+++ b/src/loader/cmi.mli
@@ -27,7 +27,7 @@ type env = {
 val read_interface :
   Odoc_model.Paths.Identifier.ContainerPage.t option ->
   string ->
-  bool ->
+  suppress_warnings:bool ->
   Odoc_model.Compat.signature ->
   Paths.Identifier.RootModule.t * Odoc_model.Lang.Signature.t
 

--- a/src/loader/cmi.mli
+++ b/src/loader/cmi.mli
@@ -18,9 +18,16 @@
 
 module Paths = Odoc_model.Paths
 
+
+type env = {
+  ident_env : Ident_env.t; (** Environment *)
+  suppress_warnings : bool (** Suppress warnings *)
+}
+
 val read_interface :
   Odoc_model.Paths.Identifier.ContainerPage.t option ->
   string ->
+  bool ->
   Odoc_model.Compat.signature ->
   Paths.Identifier.RootModule.t * Odoc_model.Lang.Signature.t
 
@@ -32,7 +39,7 @@ val read_label : Asttypes.arg_label -> Odoc_model.Lang.TypeExpr.label option
 
 val mark_type_expr : Types.type_expr -> unit
 
-val read_type_expr : Ident_env.t ->
+val read_type_expr : env ->
                      Types.type_expr -> Odoc_model.Lang.TypeExpr.t
 
 val mark_type_extension : Types.type_expr list ->
@@ -46,44 +53,45 @@ val mark_class_declaration : Types.class_declaration -> unit
 
 val read_self_type : Types.type_expr -> Odoc_model.Lang.TypeExpr.t option
 
-val read_type_constraints : Ident_env.t -> Types.type_expr list ->
+val read_type_constraints : env -> Types.type_expr list ->
                             (Odoc_model.Lang.TypeExpr.t
                              * Odoc_model.Lang.TypeExpr.t) list
 
 val read_class_constraints :
-  Ident_env.t ->
+  env ->
   Types.type_expr list ->
   Odoc_model.Lang.ClassSignature.item list
 
-val read_class_signature : Ident_env.t ->
+val read_class_signature : env ->
                            Paths.Identifier.ClassSignature.t ->
                            Types.type_expr list -> Types.class_type ->
                            Odoc_model.Lang.ClassType.expr
 
-val read_class_type : Ident_env.t ->
+val read_class_type : env ->
                       Paths.Identifier.ClassSignature.t ->
                       Types.type_expr list -> Types.class_type ->
                       Odoc_model.Lang.Class.decl
 
-val read_module_type : Ident_env.t ->
+val read_module_type : env ->
                        Paths.Identifier.Signature.t ->
                        Odoc_model.Compat.module_type -> Odoc_model.Lang.ModuleType.expr
 
-val read_signature_noenv : Ident_env.t ->
+val read_signature_noenv : env ->
                        Paths.Identifier.Signature.t ->
                        Odoc_model.Compat.signature ->
                        (Odoc_model.Lang.Signature.t * Odoc_model.Lang.Include.shadowed)
 
-val read_signature : Ident_env.t ->
+val read_signature : env ->
                      Paths.Identifier.Signature.t ->
                      Odoc_model.Compat.signature -> Odoc_model.Lang.Signature.t
 
 
-val read_extension_constructor : Ident_env.t ->
+val read_extension_constructor : env ->
                        Paths.Identifier.Signature.t ->
                        Ident.t -> Types.extension_constructor ->
                        Odoc_model.Lang.Extension.Constructor.t
 
-val read_exception : Ident_env.t ->
+val read_exception : env ->
   Paths.Identifier.Signature.t -> Ident.t ->
   Types.extension_constructor -> Odoc_model.Lang.Exception.t
+ 

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -395,12 +395,13 @@ let rec read_module_expr env parent label_parent mexpr =
         Functor (f_parameter, res)
 #else
     | Tmod_functor(id, _, arg, res) ->
-        let new_env = Env.add_parameter parent id (ModuleName.of_ident id) env in
+        let new_env = Env.add_parameter parent id (ModuleName.of_ident id) env.ident_env in
+        let new_env = {env with ident_env = new_env} in
         let f_parameter =
           match arg with
           | None -> FunctorParameter.Unit
           | Some arg ->
-              let id = Env.find_parameter_identifier new_env id in
+              let id = Env.find_parameter_identifier new_env.ident_env id in
               let arg = Cmti.read_module_type env (id :> Identifier.Signature.t) label_parent arg in
               Named { FunctorParameter. id; expr = arg; }
         in

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -616,7 +616,7 @@ and read_structure :
   | _ ->
     ({ Signature.items = Comment (`Docs doc_post) :: items; compiled=false; removed = []; doc }, tags)
 
-let read_implementation root name suppress_warnings impl =
+let read_implementation root name ~suppress_warnings impl =
   let id =
     Identifier.Mk.root (root, Odoc_model.Names.ModuleName.make_std name)
   in

--- a/src/loader/cmt.mli
+++ b/src/loader/cmt.mli
@@ -17,6 +17,7 @@
 val read_implementation :
   Odoc_model.Paths.Identifier.ContainerPage.t option ->
   string ->
+  bool ->
   Typedtree.structure ->
   Odoc_model.Paths.Identifier.RootModule.t
   * Odoc_model.Lang.Signature.t

--- a/src/loader/cmt.mli
+++ b/src/loader/cmt.mli
@@ -17,7 +17,7 @@
 val read_implementation :
   Odoc_model.Paths.Identifier.ContainerPage.t option ->
   string ->
-  bool ->
+  suppress_warnings:bool ->
   Typedtree.structure ->
   Odoc_model.Paths.Identifier.RootModule.t
   * Odoc_model.Lang.Signature.t

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -815,7 +815,7 @@ and read_signature :
   | _ ->
     ({ Signature.items = Comment (`Docs doc_post) :: items; compiled=false; removed = []; doc }, tags)
 
-let read_interface root name suppress_warnings intf =
+let read_interface root name ~suppress_warnings intf =
   let id =
     Identifier.Mk.root (root, Odoc_model.Names.ModuleName.make_std name)
   in

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -546,12 +546,13 @@ and read_module_type env parent label_parent mty =
         Functor (f_parameter, res)
 #else
     | Tmty_functor(id, _, arg, res) ->
-        let new_env = Env.add_parameter parent id (ModuleName.of_ident id) env in
+        let new_env = Env.add_parameter parent id (ModuleName.of_ident id) env.ident_env in
+        let new_env = {env with ident_env = new_env} in
         let f_parameter =
           match arg with
           | None -> Odoc_model.Lang.FunctorParameter.Unit
           | Some arg ->
-              let id = Ident_env.find_parameter_identifier new_env id in
+              let id = Ident_env.find_parameter_identifier new_env.ident_env id in
               let arg = read_module_type env (id :> Identifier.Signature.t) label_parent arg in
               Named { FunctorParameter. id; expr = arg }
         in

--- a/src/loader/cmti.mli
+++ b/src/loader/cmti.mli
@@ -27,7 +27,7 @@ val read_module_expr :
 val read_interface :
   Odoc_model.Paths.Identifier.ContainerPage.t option ->
   string ->
-  bool ->
+  suppress_warnings:bool ->
   Typedtree.signature ->
   Paths.Identifier.RootModule.t
   * Odoc_model.Lang.Signature.t

--- a/src/loader/cmti.mli
+++ b/src/loader/cmti.mli
@@ -17,7 +17,7 @@
 module Paths = Odoc_model.Paths
 
 val read_module_expr :
-  (Ident_env.t ->
+  (Cmi.env ->
   Paths.Identifier.Signature.t ->
   Paths.Identifier.LabelParent.t ->
   Typedtree.module_expr ->
@@ -27,6 +27,7 @@ val read_module_expr :
 val read_interface :
   Odoc_model.Paths.Identifier.ContainerPage.t option ->
   string ->
+  bool ->
   Typedtree.signature ->
   Paths.Identifier.RootModule.t
   * Odoc_model.Lang.Signature.t
@@ -35,33 +36,33 @@ val read_interface :
     [@canonical] tag. *)
 
 val read_module_type :
-  Ident_env.t ->
+  Cmi.env ->
   Paths.Identifier.Signature.t ->
   Paths.Identifier.LabelParent.t ->
   Typedtree.module_type ->
   Odoc_model.Lang.ModuleType.expr
 
 val read_value_description :
-  Ident_env.t ->
+  Cmi.env ->
   Paths.Identifier.Signature.t ->
   Typedtree.value_description ->
   Odoc_model.Lang.Signature.item
 
 val read_type_declarations :
-  Ident_env.t ->
+  Cmi.env ->
   Paths.Identifier.Signature.t ->
   Odoc_model.Lang.Signature.recursive ->
   Typedtree.type_declaration list ->
   Odoc_model.Lang.Signature.item list
 
 val read_module_type_declaration :
-  Ident_env.t ->
+  Cmi.env ->
   Paths.Identifier.Signature.t ->
   Typedtree.module_type_declaration ->
   Odoc_model.Lang.ModuleType.t
 
 val read_class_type_declarations :
-  Ident_env.t ->
+  Cmi.env ->
   Paths.Identifier.Signature.t ->
   Typedtree.class_type Typedtree.class_infos list ->
   Odoc_model.Lang.Signature.item list

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -22,12 +22,14 @@ val empty : Odoc_model.Comment.docs
 val is_stop_comment : Parsetree.attribute -> bool
 
 val attached :
+  suppress_warnings:bool ->
   'tags Semantics.handle_internal_tags ->
   Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
   Odoc_model.Comment.docs * 'tags
 
 val attached_no_tag :
+  suppress_warnings:bool ->
   Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
   Odoc_model.Comment.docs
@@ -47,11 +49,13 @@ val page :
 
 val standalone :
   Paths.Identifier.LabelParent.t ->
+  suppress_warnings:bool ->
   Parsetree.attribute ->
   Odoc_model.Comment.docs_or_stop option
 
 val standalone_multiple :
   Paths.Identifier.LabelParent.t ->
+  suppress_warnings:bool ->
   Parsetree.attributes ->
   Odoc_model.Comment.docs_or_stop list
 

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -101,7 +101,7 @@ let compilation_unit_of_sig ~make_root ~imports ~interface ?sourcefile ~name ~id
   make_compilation_unit ~make_root ~imports ~interface ?sourcefile ~name ~id
     ?canonical content
 
-let read_cmti ~make_root ~parent ~filename () =
+let read_cmti ~make_root ~parent ~filename ~suppress_warnings () =
   let cmt_info = Cmt_format.read_cmt filename in
   match cmt_info.cmt_annots with
   | Interface intf -> (
@@ -118,12 +118,14 @@ let read_cmti ~make_root ~parent ~filename () =
               cmt_info.cmt_source_digest,
               cmt_info.cmt_builddir )
           in
-          let id, sg, canonical = Cmti.read_interface parent name intf in
+          let id, sg, canonical =
+            Cmti.read_interface parent name suppress_warnings intf
+          in
           compilation_unit_of_sig ~make_root ~imports:cmt_info.cmt_imports
             ~interface ~sourcefile ~name ~id ?canonical sg)
   | _ -> raise Not_an_interface
 
-let read_cmt ~make_root ~parent ~filename () =
+let read_cmt ~make_root ~parent ~filename ~suppress_warnings () =
   match Cmt_format.read_cmt filename with
   | exception Cmi_format.Error (Not_an_interface _) ->
       raise Not_an_implementation
@@ -175,17 +177,19 @@ let read_cmt ~make_root ~parent ~filename () =
           make_compilation_unit ~make_root ~imports ~interface ~sourcefile ~name
             ~id content
       | Implementation impl ->
-          let id, sg, canonical = Cmt.read_implementation parent name impl in
+          let id, sg, canonical =
+            Cmt.read_implementation parent name suppress_warnings impl
+          in
           compilation_unit_of_sig ~make_root ~imports ~interface ~sourcefile
             ~name ~id ?canonical sg
       | _ -> raise Not_an_implementation)
 
-let read_cmi ~make_root ~parent ~filename () =
+let read_cmi ~make_root ~parent ~filename ~suppress_warnings () =
   let cmi_info = Cmi_format.read_cmi filename in
   match cmi_info.cmi_crcs with
   | (name, (Some _ as interface)) :: imports when name = cmi_info.cmi_name ->
       let id, sg =
-        Cmi.read_interface parent name
+        Cmi.read_interface parent name suppress_warnings
           (Odoc_model.Compat.signature cmi_info.cmi_sign)
       in
       compilation_unit_of_sig ~make_root ~imports ~interface ~name ~id sg
@@ -251,16 +255,19 @@ let wrap_errors ~filename f =
       | Not_an_interface -> not_an_interface filename
       | Make_root_error m -> error_msg filename m)
 
-let read_cmti ~make_root ~parent ~filename =
-  wrap_errors ~filename (read_cmti ~make_root ~parent ~filename)
+let read_cmti ~make_root ~parent ~filename ~suppress_warnings =
+  wrap_errors ~filename
+    (read_cmti ~make_root ~parent ~filename ~suppress_warnings)
 
-let read_cmt ~make_root ~parent ~filename =
-  wrap_errors ~filename (read_cmt ~make_root ~parent ~filename)
+let read_cmt ~make_root ~parent ~filename ~suppress_warnings =
+  wrap_errors ~filename
+    (read_cmt ~make_root ~parent ~filename ~suppress_warnings)
 
 let read_impl ~make_root ~filename ~source_id =
   wrap_errors ~filename (read_impl ~make_root ~source_id ~filename)
 
-let read_cmi ~make_root ~parent ~filename =
-  wrap_errors ~filename (read_cmi ~make_root ~parent ~filename)
+let read_cmi ~make_root ~parent ~filename ~suppress_warnings =
+  wrap_errors ~filename
+    (read_cmi ~make_root ~parent ~filename ~suppress_warnings)
 
 let read_location = Doc_attr.read_location

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -119,7 +119,7 @@ let read_cmti ~make_root ~parent ~filename ~suppress_warnings () =
               cmt_info.cmt_builddir )
           in
           let id, sg, canonical =
-            Cmti.read_interface parent name suppress_warnings intf
+            Cmti.read_interface parent name ~suppress_warnings intf
           in
           compilation_unit_of_sig ~make_root ~imports:cmt_info.cmt_imports
             ~interface ~sourcefile ~name ~id ?canonical sg)
@@ -178,7 +178,7 @@ let read_cmt ~make_root ~parent ~filename ~suppress_warnings () =
             ~id content
       | Implementation impl ->
           let id, sg, canonical =
-            Cmt.read_implementation parent name suppress_warnings impl
+            Cmt.read_implementation parent name ~suppress_warnings impl
           in
           compilation_unit_of_sig ~make_root ~imports ~interface ~sourcefile
             ~name ~id ?canonical sg
@@ -189,7 +189,7 @@ let read_cmi ~make_root ~parent ~filename ~suppress_warnings () =
   match cmi_info.cmi_crcs with
   | (name, (Some _ as interface)) :: imports when name = cmi_info.cmi_name ->
       let id, sg =
-        Cmi.read_interface parent name suppress_warnings
+        Cmi.read_interface parent name ~suppress_warnings
           (Odoc_model.Compat.signature cmi_info.cmi_sign)
       in
       compilation_unit_of_sig ~make_root ~imports ~interface ~name ~id sg

--- a/src/loader/odoc_loader.mli
+++ b/src/loader/odoc_loader.mli
@@ -17,12 +17,14 @@ val read_cmti :
   make_root:make_root ->
   parent:Identifier.ContainerPage.t option ->
   filename:string ->
+  suppress_warnings:bool ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_cmt :
   make_root:make_root ->
   parent:Identifier.ContainerPage.t option ->
   filename:string ->
+  suppress_warnings:bool ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_impl :
@@ -35,6 +37,7 @@ val read_cmi :
   make_root:make_root ->
   parent:Identifier.ContainerPage.t option ->
   filename:string ->
+  suppress_warnings:bool ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_location : Location.t -> Location_.span

--- a/src/markdown/odoc_md.ml
+++ b/src/markdown/odoc_md.ml
@@ -20,9 +20,9 @@ let parse id input_s =
   in
   (content, List.map Error.t_of_parser_t parser_warnings @ semantics_warnings)
 
-let mk_page input_s id content =
+let mk_page input_s id elements =
   (* Construct the output file representation *)
-  let zero_heading = Comment.find_zero_heading content in
+  let zero_heading = Comment.find_zero_heading elements in
   let frontmatter = Frontmatter.empty in
   let digest = Digest.file input_s in
   let root =
@@ -34,7 +34,7 @@ let mk_page input_s id content =
     Lang.Page.name = id;
     root;
     children;
-    content;
+    content = { elements; suppress_warnings = false };
     digest;
     linked = false;
     frontmatter;

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -113,7 +113,9 @@ type block_element =
     heading_attrs * Identifier.Label.t * inline_element with_location list
   | `Tag of tag ]
 
-type docs = block_element with_location list
+type elements = block_element with_location list
+
+type docs = { elements : elements; suppress_warnings : bool }
 
 type docs_or_stop = [ `Docs of docs | `Stop ]
 

--- a/src/model/error.ml
+++ b/src/model/error.ml
@@ -101,7 +101,11 @@ let print_error ?prefix t = prerr_endline (_to_string ?prefix t)
 
 let print_errors = List.iter print_error
 
-type warnings_options = { warn_error : bool; print_warnings : bool }
+type warnings_options = {
+  warn_error : bool;
+  print_warnings : bool;
+  suppress_warnings : bool;
+}
 
 let print_warnings ~warnings_options warnings =
   if warnings_options.print_warnings then

--- a/src/model/error.mli
+++ b/src/model/error.mli
@@ -41,6 +41,7 @@ val catch_errors_and_warnings : (unit -> 'a) -> 'a with_errors_and_warnings
 type warnings_options = {
   warn_error : bool;  (** If [true], warnings will result in an error. *)
   print_warnings : bool;  (** Whether to print warnings. *)
+  suppress_warnings : bool;  (** Whether to suppress warnings. *)
 }
 
 val handle_warnings :

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -571,5 +571,6 @@ let extract_signature_doc (s : Signature.t) =
     | { decl = ModuleType expr; _ } -> uexpr_considered_hidden expr
   in
   match (s.doc, s.items) with
-  | [], Include inc :: _ when should_take_top inc -> inc.expansion.content.doc
+  | { elements = []; _ }, Include inc :: _ when should_take_top inc ->
+      inc.expansion.content.doc
   | doc, _ -> doc

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -551,9 +551,9 @@ module rec Reference : sig
   type tag_only_child_module = [ `TChildModule ]
 
   type tag_hierarchy =
-    [ `TRelativePath  (** {!identifier/} *)
-    | `TAbsolutePath  (** {!/identifier} *)
-    | `TCurrentPackage  (** {!//identifier} *) ]
+    [ `TRelativePath  (** [{!identifier/}] *)
+    | `TAbsolutePath  (** [{!/identifier}] *)
+    | `TCurrentPackage  (** [{!//identifier}] *) ]
   (** @canonical Odoc_model.Paths.Reference.tag_hierarchy *)
 
   type tag_any =

--- a/src/model/semantics.ml
+++ b/src/model/semantics.ml
@@ -531,7 +531,7 @@ let append_alerts_to_comment alerts
           comment)
       alerts
   in
-  comment @ (alerts : alerts :> Comment.docs)
+  comment @ (alerts :> Comment.elements)
 
 let handle_internal_tags (type a) tags : a handle_internal_tags -> a = function
   | Expect_status -> (

--- a/src/model/semantics.mli
+++ b/src/model/semantics.mli
@@ -17,7 +17,7 @@ val ast_to_comment :
   parent_of_sections:Paths.Identifier.LabelParent.t ->
   Odoc_parser.Ast.t ->
   alerts ->
-  (Comment.docs * 'tags) Error.with_warnings
+  (Comment.elements * 'tags) Error.with_warnings
 
 val non_link_inline_element :
   context:string ->
@@ -30,6 +30,6 @@ val parse_comment :
   containing_definition:Paths.Identifier.LabelParent.t ->
   location:Lexing.position ->
   text:string ->
-  (Comment.docs * 'tags) Error.with_warnings
+  (Comment.elements * 'tags) Error.with_warnings
 
 val parse_reference : string -> Paths.Reference.t Error.with_errors_and_warnings

--- a/src/model_desc/comment_desc.mli
+++ b/src/model_desc/comment_desc.mli
@@ -1,8 +1,10 @@
 open Odoc_model
 open Odoc_model.Comment
 
-val docs : docs Type_desc.t
-
 val inline_element : inline_element Location_.with_location list Type_desc.t
+
+val elements : elements Type_desc.t
+
+val docs : docs Type_desc.t
 
 val docs_or_stop : docs_or_stop Type_desc.t

--- a/src/ocamlary/ocamlary.mli
+++ b/src/ocamlary/ocamlary.mli
@@ -1068,10 +1068,3 @@ type new_t = ..
 type new_t += C
 
 module type TypeExtPruned = TypeExt with type t := new_t
-
-(** {1 Unresolved references} *)
-
-(** - {!Stdlib.Invalid_argument}
-    - {!Hashtbl.t}
-    - {!Set.S.empty}
-    - {!CollectionModule.InnerModuleA.foo} *)

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -141,12 +141,29 @@ let warnings_options =
     let env = Arg.env_var "ODOC_ENABLE_MISSING_ROOT_WARNING" ~doc in
     Arg.(value & flag & info ~docs ~doc ~env [ "enable-missing-root-warning" ])
   in
+  let suppress_warnings =
+    let doc =
+      "Suppress warnings. This is useful when you want to declare that \
+       warnings that would be generated resolving the references defined in \
+       this unit should be ignored if they end up in expansions in other \
+       units."
+    in
+    let env = Arg.env_var "ODOC_SUPPRESS_WARNINGS" ~doc in
+    Arg.(value & flag & info ~docs ~doc ~env [ "suppress-warnings" ])
+  in
   Term.(
-    const (fun warn_error print_warnings enable_missing_root_warning ->
+    const
+      (fun
+        warn_error
+        print_warnings
+        enable_missing_root_warning
+        suppress_warnings
+      ->
         Odoc_model.Error.enable_missing_root_warning :=
           enable_missing_root_warning;
-        { Odoc_model.Error.warn_error; print_warnings })
-    $ warn_error $ print_warnings $ enable_missing_root_warning)
+        { Odoc_model.Error.warn_error; print_warnings; suppress_warnings })
+    $ warn_error $ print_warnings $ enable_missing_root_warning
+    $ suppress_warnings)
 
 let dst ?create () =
   let doc = "Output directory where the HTML tree is expected to be saved." in
@@ -965,7 +982,11 @@ end = struct
           ~roots:None
       in
       let warnings_options =
-        { Odoc_model.Error.warn_error = false; print_warnings = false }
+        {
+          Odoc_model.Error.warn_error = false;
+          print_warnings = false;
+          suppress_warnings = false;
+        }
       in
       Rendering.targets_odoc ~resolver ~warnings_options ~syntax:OCaml
         ~renderer:R.renderer ~output:output_dir ~extra odoc_file
@@ -1000,7 +1021,11 @@ end = struct
   module Targets_source = struct
     let list_targets output_dir source_file extra odoc_file =
       let warnings_options =
-        { Odoc_model.Error.warn_error = false; print_warnings = false }
+        {
+          Odoc_model.Error.warn_error = false;
+          print_warnings = false;
+          suppress_warnings = false;
+        }
       in
       Rendering.targets_source_odoc ~warnings_options ~syntax:OCaml
         ~renderer:R.renderer ~output:output_dir ~extra ~source_file odoc_file

--- a/src/odoc/html_fragment.ml
+++ b/src/odoc/html_fragment.ml
@@ -34,7 +34,7 @@ let from_mld ~xref_base_uri ~resolver ~output ~warnings_options input =
     Odoc_xref2.Link.resolve_page ~filename:input_s env page
     |> Odoc_model.Error.handle_warnings ~warnings_options
     >>= fun resolved ->
-    let page = Odoc_document.Comment.to_ir resolved.content in
+    let page = Odoc_document.Comment.to_ir resolved.content.elements in
     let config =
       Odoc_html.Config.v ~semantic_uris:false ~indent:false ~flat:false
         ~open_details:false ~as_json:false ~remap:[] ()

--- a/src/odoc/odoc_link.ml
+++ b/src/odoc/odoc_link.ml
@@ -34,7 +34,14 @@ let content_for_hidden_modules =
       `Word "hidden.";
     ]
   in
-  [ Comment (`Docs [ with_loc @@ `Paragraph (List.map with_loc sentence) ]) ]
+  [
+    Comment
+      (`Docs
+        {
+          elements = [ with_loc @@ `Paragraph (List.map with_loc sentence) ];
+          suppress_warnings = true;
+        });
+  ]
 
 let link_unit ~resolver ~filename m =
   let open Odoc_model in
@@ -49,7 +56,7 @@ let link_unit ~resolver ~filename m =
               items = content_for_hidden_modules;
               compiled = false;
               removed = [];
-              doc = [];
+              doc = { elements = []; suppress_warnings = false };
             };
         expansion = None;
       }

--- a/src/odoc/url.ml
+++ b/src/odoc/url.ml
@@ -7,7 +7,13 @@ let resolve url_to_string directories reference =
   in
   let reference =
     let open Odoc_model in
-    let warnings_options = { Error.warn_error = true; print_warnings = true } in
+    let warnings_options =
+      {
+        Error.warn_error = true;
+        print_warnings = true;
+        suppress_warnings = false;
+      }
+    in
     Semantics.parse_reference reference
     |> Error.handle_errors_and_warnings ~warnings_options
   in

--- a/src/search/html.mli
+++ b/src/search/html.mli
@@ -27,11 +27,11 @@ val names_of_id : Paths.Identifier.t -> string * string
     The tuple is intended to be given respectively to the [prefix_name] and
     [name] arguments of {!Odoc_html_frontend.of_strings}. *)
 
-val of_doc : Comment.docs -> html
+val of_doc : Comment.elements -> html
 (** [of_doc d] returns the HTML associated of the documentation comment [d],
     generated correctly for search (no links or anchors). *)
 
-val html_string_of_doc : Comment.docs -> string
+val html_string_of_doc : Comment.elements -> string
 (** [html_string_of_doc d] is the same as {!of_doc} converted to a
     string. *)
 

--- a/src/search/html.mli
+++ b/src/search/html.mli
@@ -9,7 +9,7 @@ val url : Entry.t -> string
 
 (** The below is intended for search engine that do not use the Json output but
     Odoc as a library. Most search engine will use their own representation
-    instead of {!Entry.t}, and may not want to store the whole HTML in their
+    instead of {!Odoc_index.Entry.t}, and may not want to store the whole HTML in their
     database. The following functions help give correct values to store in a
     search database. *)
 

--- a/src/search/json_index/json_search.ml
+++ b/src/search/json_index/json_search.ml
@@ -81,7 +81,7 @@ let rec of_id x =
 
 let of_id n = `Array (List.rev @@ of_id (n :> Odoc_model.Paths.Identifier.t))
 
-let of_doc (doc : Odoc_model.Comment.docs) =
+let of_doc (doc : Odoc_model.Comment.elements) =
   let txt = Text.of_doc doc in
   `String txt
 

--- a/src/search/odoc_html_frontend.mli
+++ b/src/search/odoc_html_frontend.mli
@@ -1,6 +1,6 @@
 (**  This library is intended for search engine that do not use the Json output
     but Odoc as a library. Most search engine will use their own representation
-    instead of {!Entry.t}, and may not want to store the whole HTML in their
+    instead of {!Odoc_index.Entry.t}, and may not want to store the whole HTML in their
     database.
     This library contains functions that are useful for the frontend of such
     search engines.

--- a/src/search/text.ml
+++ b/src/search/text.ml
@@ -41,8 +41,8 @@ module Of_comments = struct
 
   let get_value x = x.Odoc_model.Location_.value
 
-  let rec string_of_doc (doc : Odoc_model.Comment.docs) =
-    doc.elements |> List.map get_value
+  let rec string_of_doc (doc : Odoc_model.Comment.elements) =
+    doc |> List.map get_value
     |> List.map s_of_block_element
     |> String.concat "\n"
 

--- a/src/search/text.ml
+++ b/src/search/text.ml
@@ -42,7 +42,7 @@ module Of_comments = struct
   let get_value x = x.Odoc_model.Location_.value
 
   let rec string_of_doc (doc : Odoc_model.Comment.docs) =
-    doc |> List.map get_value
+    doc.elements |> List.map get_value
     |> List.map s_of_block_element
     |> String.concat "\n"
 

--- a/src/search/text.mli
+++ b/src/search/text.mli
@@ -4,6 +4,6 @@
 
 val of_type : Odoc_model.Lang.TypeExpr.t -> string
 
-val of_doc : Odoc_model.Comment.docs -> string
+val of_doc : Odoc_model.Comment.elements -> string
 
 val of_record : Odoc_model.Lang.TypeDecl.Field.t list -> string

--- a/src/utils/odoc_list.ml
+++ b/src/utils/odoc_list.ml
@@ -16,7 +16,7 @@ let rec filter_map acc f = function
 
 let filter_map f x = filter_map [] f x
 
-(** @raise [Failure] if the list is empty. *)
+(** @raise Failure if the list is empty. *)
 let rec last = function
   | [] -> failwith "Odoc_utils.List.last"
   | [ x ] -> x

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -253,7 +253,11 @@ and signature_items : Env.t -> Id.Signature.t -> Signature.item list -> _ =
                 Component.Delayed.(
                   put (fun () -> Component.Of_Lang.(module_ (empty ()) m)))
               in
-              Env.add_module (m.id :> Paths.Identifier.Path.Module.t) ty [] env
+              Env.add_module
+                (m.id :> Paths.Identifier.Path.Module.t)
+                ty
+                { elements = []; suppress_warnings = false }
+                env
             in
             let env =
               match r with

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -433,7 +433,10 @@ and CComment : sig
     | `Media of
       Odoc_model.Comment.media_href * Odoc_model.Comment.media * string ]
 
-  type docs = block_element Odoc_model.Comment.with_location list
+  type docs = {
+    elements : block_element Odoc_model.Comment.with_location list;
+    suppress_warnings : bool;
+  }
 
   type docs_or_stop = [ `Docs of docs | `Stop ]
 end

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -273,7 +273,7 @@ let add_docs (docs : Comment.docs) env =
           let label = Ident.Of_Identifier.label id in
           add_label id { Component.Label.attrs; label; text; location } env
       | _ -> env)
-    env docs
+    env docs.elements
 
 let add_comment (com : Comment.docs_or_stop) env =
   match com with `Docs doc -> add_docs doc env | `Stop -> env
@@ -289,7 +289,7 @@ let add_cdocs p (docs : Component.CComment.docs) env =
           in
           add_label label h env
       | _ -> env)
-    env docs
+    env docs.elements
 
 let add_module identifier m docs env =
   let env' = add_to_elts Kind_Module identifier (`Module (identifier, m)) env in
@@ -373,7 +373,7 @@ let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
           {
             id;
             source_loc = None;
-            doc = [];
+            doc = { elements = []; suppress_warnings = false };
             type_ = ModuleType (Signature s);
             canonical = unit.canonical;
             hidden = unit.hidden;
@@ -387,11 +387,16 @@ let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
           {
             id;
             source_loc = None;
-            doc = [];
+            doc = { elements = []; suppress_warnings = false };
             type_ =
               ModuleType
                 (Signature
-                   { items = []; compiled = true; removed = []; doc = [] });
+                   {
+                     items = [];
+                     compiled = true;
+                     removed = [];
+                     doc = { elements = []; suppress_warnings = false };
+                   });
             canonical = unit.canonical;
             hidden = unit.hidden;
           }
@@ -644,7 +649,13 @@ let lookup_fragment_root env =
 let mk_functor_parameter module_type =
   let type_ = Component.Module.ModuleType module_type in
   Component.Module.
-    { source_loc = None; doc = []; type_; canonical = None; hidden = false }
+    {
+      source_loc = None;
+      doc = { elements = []; suppress_warnings = false };
+      type_;
+      canonical = None;
+      hidden = false;
+    }
 
 let add_functor_parameter : Lang.FunctorParameter.t -> t -> t =
  fun p t ->
@@ -656,7 +667,10 @@ let add_functor_parameter : Lang.FunctorParameter.t -> t -> t =
         let open Component.Of_Lang in
         mk_functor_parameter (module_type_expr (empty ()) n.expr)
       in
-      add_module id (Component.Delayed.put_val m) [] t
+      add_module id
+        (Component.Delayed.put_val m)
+        { elements = []; suppress_warnings = false }
+        t
 
 let add_functor_args' :
     Paths.Identifier.Signature.t -> Component.ModuleType.expr -> t -> t =

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -271,7 +271,7 @@ let any_in_sig sg name =
         | Some r -> Some (`In_type (N.typed_type id, typ, r))
         | None -> None)
     | TypExt typext -> any_in_typext typext name
-    | Comment (`Docs d) -> any_in_comment d (LabelName.make_std name)
+    | Comment (`Docs d) -> any_in_comment d.elements (LabelName.make_std name)
     | _ -> None)
 
 let signature_in_sig sg name =
@@ -303,7 +303,7 @@ let value_in_sig sg name =
 
 let label_in_sig sg name =
   filter_in_sig sg (function
-    | Signature.Comment (`Docs d) -> any_in_comment d name
+    | Signature.Comment (`Docs d) -> any_in_comment d.elements name
     | _ -> None)
 
 let exception_in_sig sg name =

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -1092,7 +1092,12 @@ and docs :
     Identifier.LabelParent.t ->
     Component.CComment.docs ->
     Odoc_model.Comment.docs =
- fun parent ds -> List.rev_map (fun d -> block_element parent d) ds |> List.rev
+ fun parent ds ->
+  {
+    elements =
+      List.rev_map (fun d -> block_element parent d) ds.elements |> List.rev;
+    suppress_warnings = ds.suppress_warnings;
+  }
 
 and docs_or_stop parent (d : Component.CComment.docs_or_stop) =
   match d with `Docs d -> `Docs (docs parent d) | `Stop -> `Stop

--- a/src/xref2/paths.md
+++ b/src/xref2/paths.md
@@ -434,7 +434,9 @@ val sg : Odoc_model.Lang.Signature.t =
               ihash = 818126955; ikey = "r_Root.p_None"},
              ARG);
          ihash = 379411454; ikey = "mt_ARG.r_Root.p_None"};
-       source_loc = None; doc = []; canonical = None;
+       source_loc = None;
+       doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+       canonical = None;
        expr =
         Some
          (Odoc_model.Lang.ModuleType.Signature
@@ -457,8 +459,14 @@ val sg : Odoc_model.Lang.Signature.t =
                        ihash = 379411454; ikey = "mt_ARG.r_Root.p_None"},
                       S);
                   ihash = 208722936; ikey = "mt_S.mt_ARG.r_Root.p_None"};
-                source_loc = None; doc = []; canonical = None; expr = None}];
-            compiled = true; removed = []; doc = []})};
+                source_loc = None;
+                doc =
+                 {Odoc_model__.Comment.elements = [];
+                  suppress_warnings = false};
+                canonical = None; expr = None}];
+            compiled = true; removed = [];
+            doc =
+             {Odoc_model__.Comment.elements = []; suppress_warnings = false}})};
      Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
       {Odoc_model.Lang.Module.id =
         {Odoc_model__Paths_types.iv =
@@ -472,7 +480,8 @@ val sg : Odoc_model.Lang.Signature.t =
               ihash = 818126955; ikey = "r_Root.p_None"},
              F);
          ihash = 748202139; ikey = "m_F.r_Root.p_None"};
-       source_loc = None; doc = [];
+       source_loc = None;
+       doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
        type_ =
         Odoc_model.Lang.Module.ModuleType
          (Odoc_model.Lang.ModuleType.Functor
@@ -527,9 +536,15 @@ val sg : Odoc_model.Lang.Signature.t =
                                 S);
                             ihash = 313393860;
                             ikey = "mt_S.p_X.m_F.r_Root.p_None"};
-                          source_loc = None; doc = []; canonical = None;
-                          expr = None}];
-                      compiled = true; removed = []; doc = []});
+                          source_loc = None;
+                          doc =
+                           {Odoc_model__.Comment.elements = [];
+                            suppress_warnings = false};
+                          canonical = None; expr = None}];
+                      compiled = true; removed = [];
+                      doc =
+                       {Odoc_model__.Comment.elements = [];
+                        suppress_warnings = false}});
                  p_path =
                   `Resolved
                     (`Identifier
@@ -565,25 +580,19 @@ val sg : Odoc_model.Lang.Signature.t =
                                      Root);
                                  ihash = 818126955;
                                  ikey =
-                                  "r_Root.p_Non"... (* string length 13; truncated *)},
-                                F);
-                            ihash = 748202139;
-                            ikey =
-                             "m_F.r_Roo"... (* string length 17; truncated *)};
-                        ihash = 709672416;
-                        ikey =
-                         "___resul"... (* string length 29; truncated *)},
-                       N);
-                   ihash = 837385364;
-                   ikey = "m_N.___r"... (* string length 33; truncated *)};
-                 source_loc = None; doc = [];
-                 type_ = Odoc_model.Lang.Module.ModuleType ...;
-                  canonical = ...; hidden = ...});
-                ...];
-              compiled = ...; removed = ...; doc = ...}));
-        canonical = ...; hidden = ...});
-      ...];
-    compiled = ...; removed = ...; doc = ...}
+                                  "r_Root.p"... (* string length 13; truncated *)},
+                                ...);
+                            ihash = ...; ikey = ...};
+                        ihash = ...; ikey = ...},
+                       ...);
+                   ihash = ...; ikey = ...};
+                 source_loc = ...; doc = ...; type_ = ...; canonical = ...;
+                 hidden = ...});
+               ...];
+             compiled = ...; removed = ...; doc = ...}));
+       canonical = ...; hidden = ...});
+     ...];
+   compiled = ...; removed = ...; doc = ...}
 ```
 
 The problem here is that odoc will not generate a page for the module `F(M)`.

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -402,7 +402,7 @@ module L = struct
           | _ -> find tl)
       | [] -> Error (`Find_by_name (`Page, name))
     in
-    find p.Odoc_model.Lang.Page.content
+    find p.Odoc_model.Lang.Page.content.elements
 
   let of_component _env ~parent_ref label =
     Ok

--- a/src/xref2/test.md
+++ b/src/xref2/test.md
@@ -206,7 +206,9 @@ and so we simply look up the type in the environment, giving a `Component.Type.t
             ihash = 818126955; ikey = "r_Root.p_None"},
            x);
        ihash = 622581103; ikey = "t_x.r_Root.p_None"};
-     source_loc = None; doc = []; canonical = None;
+     source_loc = None;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+     canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest = None; constraints = []};
@@ -224,7 +226,9 @@ and so we simply look up the type in the environment, giving a `Component.Type.t
             ihash = 818126955; ikey = "r_Root.p_None"},
            u);
        ihash = 15973539; ikey = "t_u.r_Root.p_None"};
-     source_loc = None; doc = []; canonical = None;
+     source_loc = None;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+     canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest =
@@ -246,7 +250,8 @@ and so we simply look up the type in the environment, giving a `Component.Type.t
            []));
        constraints = []};
      representation = None})];
- compiled = true; removed = []; doc = []}
+ compiled = true; removed = [];
+ doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false}}
 ```
 
 ### One module
@@ -332,7 +337,10 @@ val path : Cpath.Resolved.module_ =
 val module_ : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
-     {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+     {Odoc_xref2.Component.Module.source_loc = None;
+      doc =
+       {Odoc_xref2.Component.CComment.elements = [];
+        suppress_warnings = false};
       type_ =
        Odoc_xref2.Component.Module.ModuleType
         (Odoc_xref2.Component.ModuleType.Signature
@@ -341,14 +349,20 @@ val module_ : Component.Module.t Component.Delayed.t =
               Odoc_model.Lang.Signature.Ordinary,
               {Odoc_xref2.Component.Delayed.v =
                 Some
-                 {Odoc_xref2.Component.TypeDecl.source_loc = None; doc = [];
+                 {Odoc_xref2.Component.TypeDecl.source_loc = None;
+                  doc =
+                   {Odoc_xref2.Component.CComment.elements = [];
+                    suppress_warnings = false};
                   canonical = None;
                   equation =
                    {Odoc_xref2.Component.TypeDecl.Equation.params = [];
                     private_ = false; manifest = None; constraints = []};
                   representation = None};
                get = None})];
-           compiled = false; removed = []; doc = []});
+           compiled = false; removed = [];
+           doc =
+            {Odoc_xref2.Component.CComment.elements = [];
+             suppress_warnings = false}});
       canonical = None; hidden = false};
    get = None}
 ```
@@ -364,14 +378,19 @@ Odoc_xref2.Tools.Signature
      Odoc_model.Lang.Signature.Ordinary,
      {Odoc_xref2.Component.Delayed.v =
        Some
-        {Odoc_xref2.Component.TypeDecl.source_loc = None; doc = [];
+        {Odoc_xref2.Component.TypeDecl.source_loc = None;
+         doc =
+          {Odoc_xref2.Component.CComment.elements = [];
+           suppress_warnings = false};
          canonical = None;
          equation =
           {Odoc_xref2.Component.TypeDecl.Equation.params = [];
            private_ = false; manifest = None; constraints = []};
          representation = None};
       get = None})];
-  compiled = false; removed = []; doc = []}
+  compiled = false; removed = [];
+  doc =
+   {Odoc_xref2.Component.CComment.elements = []; suppress_warnings = false}}
 ```
 
 We're now in a position to verify the existence of the type `t` we're
@@ -419,7 +438,10 @@ val path : Cpath.Resolved.module_ =
 val module_ : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
-     {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+     {Odoc_xref2.Component.Module.source_loc = None;
+      doc =
+       {Odoc_xref2.Component.CComment.elements = [];
+        suppress_warnings = false};
       type_ =
        Odoc_xref2.Component.Module.ModuleType
         (Odoc_xref2.Component.ModuleType.Path
@@ -485,7 +507,10 @@ val m : Component.Element.module_type option =
              ihash = 818126955; ikey = "r_Root.p_None"},
             M);
         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
-       {Odoc_xref2.Component.ModuleType.source_loc = None; doc = [];
+       {Odoc_xref2.Component.ModuleType.source_loc = None;
+        doc =
+         {Odoc_xref2.Component.CComment.elements = [];
+          suppress_warnings = false};
         canonical = None;
         expr =
          Some
@@ -496,7 +521,10 @@ val m : Component.Element.module_type option =
                 {Odoc_xref2.Component.Delayed.v =
                   Some
                    {Odoc_xref2.Component.ModuleType.source_loc = None;
-                    doc = []; canonical = None;
+                    doc =
+                     {Odoc_xref2.Component.CComment.elements = [];
+                      suppress_warnings = false};
+                    canonical = None;
                     expr =
                      Some
                       (Odoc_xref2.Component.ModuleType.Signature
@@ -508,7 +536,10 @@ val m : Component.Element.module_type option =
                               Some
                                {Odoc_xref2.Component.TypeDecl.source_loc =
                                  None;
-                                doc = []; canonical = None;
+                                doc =
+                                 {Odoc_xref2.Component.CComment.elements = [];
+                                  suppress_warnings = false};
+                                canonical = None;
                                 equation =
                                  {Odoc_xref2.Component.TypeDecl.Equation.params
                                    = [];
@@ -516,13 +547,19 @@ val m : Component.Element.module_type option =
                                   constraints = []};
                                 representation = None};
                              get = None})];
-                         compiled = false; removed = []; doc = []})};
+                         compiled = false; removed = [];
+                         doc =
+                          {Odoc_xref2.Component.CComment.elements = [];
+                           suppress_warnings = false}})};
                  get = None});
                Odoc_xref2.Component.Signature.Module (`LModule (B, 0),
                 Odoc_model.Lang.Signature.Ordinary,
                 {Odoc_xref2.Component.Delayed.v =
                   Some
-                   {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+                   {Odoc_xref2.Component.Module.source_loc = None;
+                    doc =
+                     {Odoc_xref2.Component.CComment.elements = [];
+                      suppress_warnings = false};
                     type_ =
                      Odoc_xref2.Component.Module.ModuleType
                       (Odoc_xref2.Component.ModuleType.Path
@@ -530,7 +567,10 @@ val m : Component.Element.module_type option =
                          p_path = `Local (`LModuleType (N, 1), false)});
                     canonical = None; hidden = false};
                  get = None})];
-             compiled = false; removed = []; doc = []})}))
+             compiled = false; removed = [];
+             doc =
+              {Odoc_xref2.Component.CComment.elements = [];
+               suppress_warnings = false}})}))
 ```
 
 We can see here that module `B` has type `` Path (`Resolved (`Local (`LModuleType (N, 1)))) `` which refers to the module type defined just above it.
@@ -840,7 +880,8 @@ val module_C_lens :
         ihash = 818126955; ikey = "r_Root.p_None"},
        C);
    ihash = 43786577; ikey = "m_C.r_Root.p_None"};
- source_loc = None; doc = [];
+ source_loc = None;
+ doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
  type_ =
   Odoc_model.Lang.Module.ModuleType
    (Odoc_model.Lang.ModuleType.With
@@ -888,7 +929,10 @@ of module `C` we see the following:
 val m : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
-     {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+     {Odoc_xref2.Component.Module.source_loc = None;
+      doc =
+       {Odoc_xref2.Component.CComment.elements = [];
+        suppress_warnings = false};
       type_ =
        Odoc_xref2.Component.Module.ModuleType
         (Odoc_xref2.Component.ModuleType.With
@@ -941,7 +985,10 @@ val sg : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None;
+           doc =
+            {Odoc_xref2.Component.CComment.elements = [];
+             suppress_warnings = false};
            type_ =
             Odoc_xref2.Component.Module.Alias
              (`Identifier
@@ -964,7 +1011,10 @@ val sg : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None;
+           doc =
+            {Odoc_xref2.Component.CComment.elements = [];
+             suppress_warnings = false};
            type_ =
             Odoc_xref2.Component.Module.ModuleType
              (Odoc_xref2.Component.ModuleType.Path
@@ -973,7 +1023,9 @@ val sg : Tools.expansion =
                  `DotMT (`Substituted (`Local (`LModule (M, 32), false)), S)});
            canonical = None; hidden = false};
         get = None})];
-    compiled = false; removed = []; doc = []}
+    compiled = false; removed = [];
+    doc =
+     {Odoc_xref2.Component.CComment.elements = []; suppress_warnings = false}}
 ```
 
 and we can see the module `M` is now an alias of the root module `B`. We can now
@@ -985,7 +1037,10 @@ look up module `N` from within this and find its signature:
 val m : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
-     {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+     {Odoc_xref2.Component.Module.source_loc = None;
+      doc =
+       {Odoc_xref2.Component.CComment.elements = [];
+        suppress_warnings = false};
       type_ =
        Odoc_xref2.Component.Module.ModuleType
         (Odoc_xref2.Component.ModuleType.Path
@@ -1021,14 +1076,19 @@ Odoc_xref2.Tools.Signature
      Odoc_model.Lang.Signature.Ordinary,
      {Odoc_xref2.Component.Delayed.v =
        Some
-        {Odoc_xref2.Component.TypeDecl.source_loc = None; doc = [];
+        {Odoc_xref2.Component.TypeDecl.source_loc = None;
+         doc =
+          {Odoc_xref2.Component.CComment.elements = [];
+           suppress_warnings = false};
          canonical = None;
          equation =
           {Odoc_xref2.Component.TypeDecl.Equation.params = [];
            private_ = false; manifest = None; constraints = []};
          representation = None};
       get = None})];
-  compiled = false; removed = []; doc = []}
+  compiled = false; removed = [];
+  doc =
+   {Odoc_xref2.Component.CComment.elements = []; suppress_warnings = false}}
 ```
 
 where we've correctly identified that a type `t` exists in the signature. The path in
@@ -1589,7 +1649,10 @@ val p : Cpath.Resolved.module_ =
 val m : Component.Module.t Component.Delayed.t =
   {Odoc_xref2.Component.Delayed.v =
     Some
-     {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+     {Odoc_xref2.Component.Module.source_loc = None;
+      doc =
+       {Odoc_xref2.Component.CComment.elements = [];
+        suppress_warnings = false};
       type_ =
        Odoc_xref2.Component.Module.ModuleType
         (Odoc_xref2.Component.ModuleType.Path
@@ -1641,7 +1704,10 @@ val sg' : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None;
+           doc =
+            {Odoc_xref2.Component.CComment.elements = [];
+             suppress_warnings = false};
            type_ =
             Odoc_xref2.Component.Module.ModuleType
              (Odoc_xref2.Component.ModuleType.Path
@@ -1671,7 +1737,9 @@ val sg' : Tools.expansion =
                     T)});
            canonical = None; hidden = false};
         get = None})];
-    compiled = false; removed = []; doc = []}
+    compiled = false; removed = [];
+    doc =
+     {Odoc_xref2.Component.CComment.elements = []; suppress_warnings = false}}
 # let sg' = get_ok @@ Tools.expansion_of_module env (Component.Delayed.get m);;
 val sg' : Tools.expansion =
   Odoc_xref2.Tools.Signature
@@ -1680,7 +1748,10 @@ val sg' : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None;
+           doc =
+            {Odoc_xref2.Component.CComment.elements = [];
+             suppress_warnings = false};
            type_ =
             Odoc_xref2.Component.Module.ModuleType
              (Odoc_xref2.Component.ModuleType.Path
@@ -1710,7 +1781,9 @@ val sg' : Tools.expansion =
                     T)});
            canonical = None; hidden = false};
         get = None})];
-    compiled = false; removed = []; doc = []}
+    compiled = false; removed = [];
+    doc =
+     {Odoc_xref2.Component.CComment.elements = []; suppress_warnings = false}}
 # let sg' = get_ok @@ Tools.expansion_of_module env (Component.Delayed.get m);;
 val sg' : Tools.expansion =
   Odoc_xref2.Tools.Signature
@@ -1719,7 +1792,10 @@ val sg' : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None;
+           doc =
+            {Odoc_xref2.Component.CComment.elements = [];
+             suppress_warnings = false};
            type_ =
             Odoc_xref2.Component.Module.ModuleType
              (Odoc_xref2.Component.ModuleType.Path
@@ -1749,7 +1825,9 @@ val sg' : Tools.expansion =
                     T)});
            canonical = None; hidden = false};
         get = None})];
-    compiled = false; removed = []; doc = []}
+    compiled = false; removed = [];
+    doc =
+     {Odoc_xref2.Component.CComment.elements = []; suppress_warnings = false}}
 # let sg' = get_ok @@ Tools.expansion_of_module env (Component.Delayed.get m);;
 val sg' : Tools.expansion =
   Odoc_xref2.Tools.Signature
@@ -1758,7 +1836,10 @@ val sg' : Tools.expansion =
        Odoc_model.Lang.Signature.Ordinary,
        {Odoc_xref2.Component.Delayed.v =
          Some
-          {Odoc_xref2.Component.Module.source_loc = None; doc = [];
+          {Odoc_xref2.Component.Module.source_loc = None;
+           doc =
+            {Odoc_xref2.Component.CComment.elements = [];
+             suppress_warnings = false};
            type_ =
             Odoc_xref2.Component.Module.ModuleType
              (Odoc_xref2.Component.ModuleType.Path
@@ -1788,7 +1869,9 @@ val sg' : Tools.expansion =
                     T)});
            canonical = None; hidden = false};
         get = None})];
-    compiled = false; removed = []; doc = []}
+    compiled = false; removed = [];
+    doc =
+     {Odoc_xref2.Component.CComment.elements = []; suppress_warnings = false}}
 ```
 
 ```ocaml env=e1
@@ -2537,27 +2620,29 @@ let resolved = Common.compile_signature sg;;
    ihash = 1016576344; ikey = "t_t.r_Root.p_None"};
  source_loc = None;
  doc =
-  [{Odoc_model__.Location_.location =
-     {Odoc_model__.Location_.file = "";
-      start = {Odoc_model__.Location_.line = 3; column = 6};
-      end_ = {Odoc_model__.Location_.line = 3; column = 14}};
-    value =
-     `Paragraph
-       [{Odoc_model__.Location_.location =
-          {Odoc_model__.Location_.file = "";
-           start = {Odoc_model__.Location_.line = 3; column = 6};
-           end_ = {Odoc_model__.Location_.line = 3; column = 9}};
-         value = `Code_span "t"};
-        {Odoc_model__.Location_.location =
-          {Odoc_model__.Location_.file = "";
-           start = {Odoc_model__.Location_.line = 3; column = 9};
-           end_ = {Odoc_model__.Location_.line = 3; column = 10}};
-         value = `Space};
-        {Odoc_model__.Location_.location =
-          {Odoc_model__.Location_.file = "";
-           start = {Odoc_model__.Location_.line = 3; column = 10};
-           end_ = {Odoc_model__.Location_.line = 3; column = 14}};
-         value = `Reference (`Root ("t", `TUnknown), [])}]}];
+  {Odoc_model__.Comment.elements =
+    [{Odoc_model__.Location_.location =
+       {Odoc_model__.Location_.file = "";
+        start = {Odoc_model__.Location_.line = 3; column = 6};
+        end_ = {Odoc_model__.Location_.line = 3; column = 14}};
+      value =
+       `Paragraph
+         [{Odoc_model__.Location_.location =
+            {Odoc_model__.Location_.file = "";
+             start = {Odoc_model__.Location_.line = 3; column = 6};
+             end_ = {Odoc_model__.Location_.line = 3; column = 9}};
+           value = `Code_span "t"};
+          {Odoc_model__.Location_.location =
+            {Odoc_model__.Location_.file = "";
+             start = {Odoc_model__.Location_.line = 3; column = 9};
+             end_ = {Odoc_model__.Location_.line = 3; column = 10}};
+           value = `Space};
+          {Odoc_model__.Location_.location =
+            {Odoc_model__.Location_.file = "";
+             start = {Odoc_model__.Location_.line = 3; column = 10};
+             end_ = {Odoc_model__.Location_.line = 3; column = 14}};
+           value = `Reference (`Root ("t", `TUnknown), [])}]}];
+   suppress_warnings = false};
  canonical = None;
  equation =
   {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
@@ -2599,7 +2684,9 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 818126955; ikey = "r_Root.p_None"},
            M);
        ihash = 459143770; ikey = "mt_M.r_Root.p_None"};
-     source_loc = None; doc = []; canonical = None;
+     source_loc = None;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+     canonical = None;
      expr =
       Some
        (Odoc_model.Lang.ModuleType.Signature
@@ -2623,12 +2710,18 @@ let sg = Common.signature_of_mli_string test_data;;
                      ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                     t);
                 ihash = 825731485; ikey = "t_t.mt_M.r_Root.p_None"};
-              source_loc = None; doc = []; canonical = None;
+              source_loc = None;
+              doc =
+               {Odoc_model__.Comment.elements = [];
+                suppress_warnings = false};
+              canonical = None;
               equation =
                {Odoc_model.Lang.TypeDecl.Equation.params = [];
                 private_ = false; manifest = None; constraints = []};
               representation = None})];
-          compiled = false; removed = []; doc = []})};
+          compiled = false; removed = [];
+          doc =
+           {Odoc_model__.Comment.elements = []; suppress_warnings = false}})};
    Odoc_model.Lang.Signature.Type (Odoc_model.Lang.Signature.Ordinary,
     {Odoc_model.Lang.TypeDecl.id =
       {Odoc_model__Paths_types.iv =
@@ -2642,7 +2735,9 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 818126955; ikey = "r_Root.p_None"},
            u);
        ihash = 15973539; ikey = "t_u.r_Root.p_None"};
-     source_loc = None; doc = []; canonical = None;
+     source_loc = None;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+     canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest = None; constraints = []};
@@ -2660,7 +2755,9 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 818126955; ikey = "r_Root.p_None"},
            M1);
        ihash = 756272831; ikey = "mt_M1.r_Root.p_None"};
-     source_loc = None; doc = []; canonical = None;
+     source_loc = None;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+     canonical = None;
      expr =
       Some
        (Odoc_model.Lang.ModuleType.With
@@ -2703,7 +2800,8 @@ let sg = Common.signature_of_mli_string test_data;;
                         ihash = 818126955; ikey = "r_Root.p_None"},
                        M);
                    ihash = 459143770; ikey = "mt_M.r_Root.p_None"}))})}];
- compiled = false; removed = []; doc = []}
+ compiled = false; removed = [];
+ doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false}}
 ```
 
 # Expansion continued
@@ -2750,7 +2848,10 @@ Odoc_model.Lang.ModuleType.Path
                   ihash = 716453475; ikey = "m_M.r_Root.p_None"},
                  s);
              ihash = 395135148; ikey = "t_s.m_M.r_Root.p_None"};
-           source_loc = None; doc = []; canonical = None;
+           source_loc = None;
+           doc =
+            {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+           canonical = None;
            equation =
             {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
              manifest = None; constraints = []};
@@ -2778,7 +2879,9 @@ Odoc_model.Lang.ModuleType.Path
                         ihash = 395135148; ikey = "t_s.m_M.r_Root.p_None"},
                        <abstr>);
                    ihash = 2570800; ikey = "ctor_C.t_s.m_M.r_Root.p_None"};
-                 doc = [];
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
                  args =
                   Odoc_model.Lang.TypeDecl.Constructor.Tuple
                    [Odoc_model.Lang.TypeExpr.Constr
@@ -2820,7 +2923,8 @@ Odoc_model.Lang.ModuleType.Path
                             t)),
                      [])];
                  res = None}])})];
-       compiled = true; removed = []; doc = []});
+       compiled = true; removed = [];
+       doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false}});
   p_path =
    `Resolved
      (`ModuleType
@@ -2905,7 +3009,8 @@ let m_e_i_s_value mod_name n val_name =
         ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
        id);
    ihash = 424389437; ikey = "v_id.m_Foo3.r_Root.p_None"};
- source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+ source_loc = None; value = Odoc_model.Lang.Value.Abstract;
+ doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
  type_ =
   Odoc_model.Lang.TypeExpr.Constr
    (`DotT
@@ -2942,7 +3047,8 @@ let m_e_i_s_value mod_name n val_name =
         ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
        id2);
    ihash = 412619918; ikey = "v_id2.m_Foo3.r_Root.p_None"};
- source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+ source_loc = None; value = Odoc_model.Lang.Value.Abstract;
+ doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
  type_ =
   Odoc_model.Lang.TypeExpr.Constr
    (`Identifier
@@ -3015,7 +3121,9 @@ let sg = Common.signature_of_mli_string test_data;;
            {t}3/shadowed/(XXXX));
        ihash = 584226322;
        ikey = "t_{t}3/shadowed/(XXXX).m_Foo3.r_Root.p_None"};
-     source_loc = None; doc = []; canonical = None;
+     source_loc = None;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+     canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest =
@@ -3056,7 +3164,8 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            id);
        ihash = 424389437; ikey = "v_id.m_Foo3.r_Root.p_None"};
-     source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+     source_loc = None; value = Odoc_model.Lang.Value.Abstract;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
      type_ =
       Odoc_model.Lang.TypeExpr.Constr
        (`Identifier
@@ -3078,7 +3187,8 @@ let sg = Common.signature_of_mli_string test_data;;
             ikey = "t_{t}3/shadowed/(XXXX).m_Foo3.r_Root.p_None"},
            false),
        [])}];
- compiled = false; removed = []; doc = []}
+ compiled = false; removed = [];
+ doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false}}
 # Common.LangUtils.Lens.get (module_expansion_include_sig "Foo3" 1) sg;;
 - : Odoc_model.Lang.Signature.t =
 {Odoc_model.Lang.Signature.items =
@@ -3100,7 +3210,9 @@ let sg = Common.signature_of_mli_string test_data;;
            {t}4/shadowed/(XXXX));
        ihash = 466750041;
        ikey = "t_{t}4/shadowed/(XXXX).m_Foo3.r_Root.p_None"};
-     source_loc = None; doc = []; canonical = None;
+     source_loc = None;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+     canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest =
@@ -3141,7 +3253,8 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            id2);
        ihash = 412619918; ikey = "v_id2.m_Foo3.r_Root.p_None"};
-     source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+     source_loc = None; value = Odoc_model.Lang.Value.Abstract;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
      type_ =
       Odoc_model.Lang.TypeExpr.Constr
        (`Identifier
@@ -3163,7 +3276,8 @@ let sg = Common.signature_of_mli_string test_data;;
             ikey = "t_{t}4/shadowed/(XXXX).m_Foo3.r_Root.p_None"},
            false),
        [])}];
- compiled = false; removed = []; doc = []}
+ compiled = false; removed = [];
+ doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false}}
 ```
 
 
@@ -3217,7 +3331,9 @@ let sg = Common.signature_of_mli_string test_data;;
            {t}5/shadowed/(XXXX));
        ihash = 995358055;
        ikey = "t_{t}5/shadowed/(XXXX).m_Foo3.r_Root.p_None"};
-     source_loc = None; doc = []; canonical = None;
+     source_loc = None;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+     canonical = None;
      equation =
       {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
        manifest =
@@ -3259,7 +3375,8 @@ let sg = Common.signature_of_mli_string test_data;;
            {x}6/shadowed/(XXXX));
        ihash = 1011043008;
        ikey = "v_{x}6/shadowed/(XXXX).m_Foo3.r_Root.p_None"};
-     source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+     source_loc = None; value = Odoc_model.Lang.Value.Abstract;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
      type_ = Odoc_model.Lang.TypeExpr.Constr (`Resolved (`CoreType int), [])};
    Odoc_model.Lang.Signature.Value
     {Odoc_model.Lang.Value.id =
@@ -3278,7 +3395,8 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            id);
        ihash = 424389437; ikey = "v_id.m_Foo3.r_Root.p_None"};
-     source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+     source_loc = None; value = Odoc_model.Lang.Value.Abstract;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
      type_ =
       Odoc_model.Lang.TypeExpr.Constr
        (`Identifier
@@ -3300,7 +3418,8 @@ let sg = Common.signature_of_mli_string test_data;;
             ikey = "t_{t}5/shadowed/(XXXX).m_Foo3.r_Root.p_None"},
            false),
        [])}];
- compiled = false; removed = []; doc = []}
+ compiled = false; removed = [];
+ doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false}}
 ```
 
 
@@ -3353,7 +3472,8 @@ let sg = Common.signature_of_mli_string test_data;;
            {Bar}8/shadowed/(XXXX));
        ihash = 38422300;
        ikey = "m_{Bar}8/shadowed/(XXXX).m_Foo3.r_Root.p_None"};
-     source_loc = None; doc = [];
+     source_loc = None;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
      type_ =
       Odoc_model.Lang.Module.Alias
        (`Dot
@@ -3390,7 +3510,8 @@ let sg = Common.signature_of_mli_string test_data;;
             ihash = 670280318; ikey = "m_Foo3.r_Root.p_None"},
            id);
        ihash = 424389437; ikey = "v_id.m_Foo3.r_Root.p_None"};
-     source_loc = None; value = Odoc_model.Lang.Value.Abstract; doc = [];
+     source_loc = None; value = Odoc_model.Lang.Value.Abstract;
+     doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
      type_ =
       Odoc_model.Lang.TypeExpr.Constr
        (`DotT
@@ -3415,5 +3536,6 @@ let sg = Common.signature_of_mli_string test_data;;
               true),
            t),
        [])}];
- compiled = false; removed = []; doc = []}
+ compiled = false; removed = [];
+ doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false}}
 ```

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -1711,7 +1711,7 @@ and expansion_of_module :
       let sg =
         (* Override the signature's documentation when the module also has
            a comment attached. *)
-        match m.doc with [] -> sg | doc -> { sg with doc }
+        match m.doc.elements with [] -> sg | _ -> { sg with doc = m.doc }
       in
       Ok (Signature sg)
   | Functor _ as f -> Ok f

--- a/test/frontmatter/frontmatter.t/run.t
+++ b/test/frontmatter/frontmatter.t/run.t
@@ -36,7 +36,7 @@ When there is one frontmatter, it is extracted from the content:
     "toc_status": "None",
     "order_category": "None"
   }
-  $ odoc_print page-one_frontmatter.odoc | jq '.content'
+  $ odoc_print page-one_frontmatter.odoc | jq '.content.elements'
   [
     {
       "`Heading": [
@@ -91,7 +91,7 @@ When there is more than one children order, we raise a warning and keep only the
     "toc_status": "None",
     "order_category": "None"
   }
-  $ odoc_print page-two_frontmatters.odoc | jq '.content'
+  $ odoc_print page-two_frontmatters.odoc | jq '.content.elements'
   [
     {
       "`Heading": [

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -71,7 +71,6 @@
      </li><li><a href="#aliases">Aliases again</a></li>
      <li><a href="#section-title-splicing">Section title splicing</a></li>
      <li><a href="#new-reference-syntax">New reference syntax</a></li>
-     <li><a href="#unresolved-references">Unresolved references</a></li>
     </ul>
    </nav>
   </div>
@@ -2961,13 +2960,6 @@
      </code>
     </div>
    </div>
-   <h2 id="unresolved-references">
-    <a href="#unresolved-references" class="anchor"></a>Unresolved references
-   </h2>
-   <ul><li><code>Stdlib.Invalid_argument</code></li>
-    <li><code>Hashtbl.t</code></li><li><code>Set.S.empty</code></li>
-    <li><code>CollectionModule.InnerModuleA.foo</code></li>
-   </ul>
   </div>
  </body>
 </html>

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -895,11 +895,6 @@ Here goes:
 \label{Ocamlary-module-type-TypeExtPruned-val-f}\ocamlcodefragment{\ocamltag{keyword}{val} f : \hyperref[Ocamlary-type-new_t]{\ocamlinlinecode{new\_\allowbreak{}t}} \ocamltag{arrow}{$\rightarrow$} unit}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Unresolved references\label{unresolved-references}}%
-\begin{itemize}\item{\ocamlinlinecode{Stdlib.\allowbreak{}Invalid\_\allowbreak{}argument}}%
-\item{\ocamlinlinecode{Hashtbl.\allowbreak{}t}}%
-\item{\ocamlinlinecode{Set.\allowbreak{}S.\allowbreak{}empty}}%
-\item{\ocamlinlinecode{CollectionModule.\allowbreak{}InnerModuleA.\allowbreak{}foo}}\end{itemize}%
 
 \input{Ocamlary.ModuleWithSignature.tex}
 \input{Ocamlary.ModuleWithSignatureAlias.tex}

--- a/test/generators/man/Ocamlary.3o
+++ b/test/generators/man/Ocamlary.3o
@@ -1902,18 +1902,3 @@ Here goes:
 \f[CB]val\fR f : new_t \f[CB]\->\fR unit
 .br 
 \f[CB]end\fR
-.sp 
-.in 3
-\fB8 Unresolved references\fR
-.in 
-.sp 
-.fi 
-\(bu Stdlib\.Invalid_argument
-.br 
-\(bu Hashtbl\.t
-.br 
-\(bu Set\.S\.empty
-.br 
-\(bu CollectionModule\.InnerModuleA\.foo
-.nf 
-

--- a/test/integration/dune
+++ b/test/integration/dune
@@ -1,6 +1,12 @@
+(env
+ (_
+  (binaries
+   (../odoc_print/odoc_print.exe as odoc_print))))
+
 (cram
  (deps
-  (package odoc)))
+  (package odoc)
+  %{bin:odoc_print}))
 
 (cram
  (applies_to json_expansion_with_sources)

--- a/test/integration/suppress_warnings.t/main.mli
+++ b/test/integration/suppress_warnings.t/main.mli
@@ -1,0 +1,3 @@
+include Module_with_errors.S
+
+

--- a/test/integration/suppress_warnings.t/module_with_errors.mli
+++ b/test/integration/suppress_warnings.t/module_with_errors.mli
@@ -1,0 +1,9 @@
+module type S = sig
+  (** {1:t section} *)
+
+  type t
+
+  val here_is_the_problem : t
+  (** {!t} *)
+end
+

--- a/test/integration/suppress_warnings.t/run.t
+++ b/test/integration/suppress_warnings.t/run.t
@@ -1,0 +1,20 @@
+  $ ocamlc -c -bin-annot module_with_errors.mli
+  $ ocamlc -c -bin-annot main.mli
+
+  $ odoc compile module_with_errors.cmti
+  $ odoc compile main.cmti -I .
+  $ odoc link main.odoc
+  File "module_with_errors.mli", line 7, characters 6-10:
+  Warning: While resolving the expansion of include at File "main.mli", line 1, character 0
+  Reference to 't' is ambiguous. Please specify its kind: section-t, type-t.
+  $ odoc html-generate -o html main.odocl
+  $ odoc support-files -o html
+
+  $ odoc compile --suppress-warnings module_with_errors.cmti
+  $ odoc compile main.cmti -I .
+  $ odoc link main.odoc
+  $ odoc html-generate -o html2 main.odocl
+  $ odoc support-files -o html2
+
+
+

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -11,7 +11,7 @@ let parser_output_desc =
     ( Error.unpack_warnings,
       Record
         [
-          F ("value", fst, Indirect (fst, Comment_desc.docs));
+          F ("value", fst, Indirect (fst, Comment_desc.elements));
           F ("warnings", snd, List warning_desc);
         ] )
 

--- a/test/pages/resolution.t/run.t
+++ b/test/pages/resolution.t/run.t
@@ -27,7 +27,7 @@ If everything has worked to plan, we'll have resolved references for all of the 
 references should be to the correct identifiers - so top1 should be a RootPage, sub1 is a Page, sub2 is a LeafPage, and m1 is a Root.
 
 This is the '{!childpage-sub1}' reference
-  $ odoc_print page-top1.odocl | jq '.content[1]["`Paragraph"][0]["`Reference"][0]'
+  $ odoc_print page-top1.odocl | jq '.content.elements[1]["`Paragraph"][0]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {
@@ -47,7 +47,7 @@ This is the '{!childpage-sub1}' reference
   }
 
 This is the '{!childpage:sub2}' reference
-  $ odoc_print page-top1.odocl | jq '.content[1]["`Paragraph"][2]["`Reference"][0]'
+  $ odoc_print page-top1.odocl | jq '.content.elements[1]["`Paragraph"][2]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {
@@ -67,7 +67,7 @@ This is the '{!childpage:sub2}' reference
   }
 
 This is the '{!childmodule:M1}' reference
-  $ odoc_print page-sub1.odocl | jq '.content[1]["`Paragraph"][0]["`Reference"][0]'
+  $ odoc_print page-sub1.odocl | jq '.content.elements[1]["`Paragraph"][0]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {

--- a/test/xref2/canonical_nested.t/run.t
+++ b/test/xref2/canonical_nested.t/run.t
@@ -55,7 +55,10 @@ unresolved in the paths though:
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "type_": {
       "Alias": [
         {
@@ -121,7 +124,10 @@ unresolved in the paths though:
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "type_": {
       "Alias": [
         {
@@ -186,7 +192,10 @@ unresolved in the paths though:
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "type_": {
       "Alias": [
         {
@@ -278,7 +287,10 @@ unresolved in the paths though:
                         ]
                       },
                       "source_loc": "None",
-                      "doc": [],
+                      "doc": {
+                        "elements": [],
+                        "suppress_warnings": "false"
+                      },
                       "equation": {
                         "params": [],
                         "private_": "false",
@@ -291,7 +303,10 @@ unresolved in the paths though:
                 }
               ],
               "compiled": "true",
-              "doc": []
+              "doc": {
+                "elements": [],
+                "suppress_warnings": "false"
+              }
             }
           }
         }

--- a/test/xref2/classes.t/run.t
+++ b/test/xref2/classes.t/run.t
@@ -27,7 +27,10 @@ resolve correctly. All of the 'Class' json objects should contain
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "type_": {
       "Class": [
         {
@@ -64,7 +67,10 @@ resolve correctly. All of the 'Class' json objects should contain
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "type_": {
       "Class": [
         {

--- a/test/xref2/cross_references.t/run.t
+++ b/test/xref2/cross_references.t/run.t
@@ -11,7 +11,7 @@ Two modules that reference each other:
 
 Check that references are resolved:
 
-  $ odoc_print a.odocl | jq '.content.Module.items[0].Type[1].doc[0]'
+  $ odoc_print a.odocl | jq '.content.Module.items[0].Type[1].doc.elements[0]'
   {
     "`Paragraph": [
       {
@@ -38,7 +38,7 @@ Check that references are resolved:
       }
     ]
   }
-  $ odoc_print b.odocl | jq '.content.Module.items[0].Type[1].doc[0]'
+  $ odoc_print b.odocl | jq '.content.Module.items[0].Type[1].doc.elements[0]'
   {
     "`Paragraph": [
       {

--- a/test/xref2/deep_substitution.t/run.t
+++ b/test/xref2/deep_substitution.t/run.t
@@ -38,7 +38,10 @@ its RHS correctly replaced with an `int`
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "equation": {
       "params": [],
       "private_": "false",

--- a/test/xref2/hidden_modules.t/run.t
+++ b/test/xref2/hidden_modules.t/run.t
@@ -101,7 +101,10 @@ There should be an expansion on `NotHidden`
                   ]
                 },
                 "source_loc": "None",
-                "doc": [],
+                "doc": {
+                  "elements": [],
+                  "suppress_warnings": "false"
+                },
                 "equation": {
                   "params": [],
                   "private_": "false",
@@ -114,7 +117,10 @@ There should be an expansion on `NotHidden`
           }
         ],
         "compiled": "true",
-        "doc": []
+        "doc": {
+          "elements": [],
+          "suppress_warnings": "false"
+        }
       }
     }
   }
@@ -128,7 +134,7 @@ There should be an expansion on `NotHidden`
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": { "elements": [], "suppress_warnings": "false" },
     "type_": {
       "Constr": [
         {

--- a/test/xref2/labels/page_labels.t/run.t
+++ b/test/xref2/labels/page_labels.t/run.t
@@ -1,6 +1,6 @@
   $ odoc compile page.mld
   $ odoc link page-page.odoc
-  $ odoc_print page-page.odocl | jq '.content[1]["`Paragraph"][0]["`Reference"][0]'
+  $ odoc_print page-page.odocl | jq '.content.elements[1]["`Paragraph"][0]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -70,7 +70,7 @@ let root_pp fmt (_ : Odoc_model.Root.t) = Format.fprintf fmt "Common.root"
 
 let model_of_string str = 
     let cmti = cmti_of_string str in
-    Odoc_loader__Cmti.read_interface (Some parent) "Root" cmti
+    Odoc_loader__Cmti.read_interface (Some parent) "Root" false cmti
 
 let model_of_string_impl str =
 #if OCAML_VERSION < (4,13,0)
@@ -78,7 +78,7 @@ let model_of_string_impl str =
 #else
     let cmt = (cmt_of_string str).structure in
 #endif
-    Odoc_loader__Cmt.read_implementation (Some parent) "Root" cmt
+    Odoc_loader__Cmt.read_implementation (Some parent) "Root" false cmt
 
 let signature_of_mli_string str =
     Odoc_xref2.Ident.reset ();
@@ -650,7 +650,7 @@ let mkresolver () =
     ) ~open_modules:[]
 
 let warnings_options =
-  { Odoc_model.Error.warn_error = false; print_warnings = true }
+  { Odoc_model.Error.warn_error = false; print_warnings = true; suppress_warnings = false }
 
 let handle_warnings ww =
   match Odoc_model.Error.handle_warnings ~warnings_options ww with

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -70,7 +70,7 @@ let root_pp fmt (_ : Odoc_model.Root.t) = Format.fprintf fmt "Common.root"
 
 let model_of_string str = 
     let cmti = cmti_of_string str in
-    Odoc_loader__Cmti.read_interface (Some parent) "Root" false cmti
+    Odoc_loader__Cmti.read_interface (Some parent) "Root" ~suppress_warnings:false cmti
 
 let model_of_string_impl str =
 #if OCAML_VERSION < (4,13,0)
@@ -78,7 +78,7 @@ let model_of_string_impl str =
 #else
     let cmt = (cmt_of_string str).structure in
 #endif
-    Odoc_loader__Cmt.read_implementation (Some parent) "Root" false cmt
+    Odoc_loader__Cmt.read_implementation (Some parent) "Root" ~suppress_warnings:false cmt
 
 let signature_of_mli_string str =
     Odoc_xref2.Ident.reset ();

--- a/test/xref2/module_type_alias.t/run.t
+++ b/test/xref2/module_type_alias.t/run.t
@@ -23,92 +23,95 @@ as they are both referencing items that won't be expanded.
   $ odoc_print test.odocl | jq ".content.Module.items[2]"
   {
     "Comment": {
-      "`Docs": [
-        {
-          "`Paragraph": [
-            {
-              "`Reference": [
-                {
-                  "`Resolved": {
-                    "`AliasModuleType": [
-                      {
-                        "`Identifier": {
-                          "`ModuleType": [
-                            {
-                              "`Root": [
-                                "None",
-                                "Test"
-                              ]
-                            },
-                            "A"
-                          ]
-                        }
-                      },
-                      {
-                        "`Identifier": {
-                          "`ModuleType": [
-                            {
-                              "`Root": [
-                                "None",
-                                "Test"
-                              ]
-                            },
-                            "B"
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                },
-                []
-              ]
-            },
-            "`Space",
-            {
-              "`Reference": [
-                {
-                  "`Resolved": {
-                    "`Type": [
-                      {
-                        "`AliasModuleType": [
-                          {
-                            "`Identifier": {
-                              "`ModuleType": [
-                                {
-                                  "`Root": [
-                                    "None",
-                                    "Test"
-                                  ]
-                                },
-                                "A"
-                              ]
-                            }
-                          },
-                          {
-                            "`Identifier": {
-                              "`ModuleType": [
-                                {
-                                  "`Root": [
-                                    "None",
-                                    "Test"
-                                  ]
-                                },
-                                "B"
-                              ]
-                            }
+      "`Docs": {
+        "elements": [
+          {
+            "`Paragraph": [
+              {
+                "`Reference": [
+                  {
+                    "`Resolved": {
+                      "`AliasModuleType": [
+                        {
+                          "`Identifier": {
+                            "`ModuleType": [
+                              {
+                                "`Root": [
+                                  "None",
+                                  "Test"
+                                ]
+                              },
+                              "A"
+                            ]
                           }
-                        ]
-                      },
-                      "t"
-                    ]
-                  }
-                },
-                []
-              ]
-            }
-          ]
-        }
-      ]
+                        },
+                        {
+                          "`Identifier": {
+                            "`ModuleType": [
+                              {
+                                "`Root": [
+                                  "None",
+                                  "Test"
+                                ]
+                              },
+                              "B"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  []
+                ]
+              },
+              "`Space",
+              {
+                "`Reference": [
+                  {
+                    "`Resolved": {
+                      "`Type": [
+                        {
+                          "`AliasModuleType": [
+                            {
+                              "`Identifier": {
+                                "`ModuleType": [
+                                  {
+                                    "`Root": [
+                                      "None",
+                                      "Test"
+                                    ]
+                                  },
+                                  "A"
+                                ]
+                              }
+                            },
+                            {
+                              "`Identifier": {
+                                "`ModuleType": [
+                                  {
+                                    "`Root": [
+                                      "None",
+                                      "Test"
+                                    ]
+                                  },
+                                  "B"
+                                ]
+                              }
+                            }
+                          ]
+                        },
+                        "t"
+                      ]
+                    }
+                  },
+                  []
+                ]
+              }
+            ]
+          }
+        ],
+        "suppress_warnings": "false"
+      }
     }
   }
 

--- a/test/xref2/resolve/test.md
+++ b/test/xref2/resolve/test.md
@@ -101,7 +101,9 @@ Simplest possible resolution:
                ihash = 818126955; ikey = "r_Root.p_None"},
               t);
           ihash = 1016576344; ikey = "t_t.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         equation =
          {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
           manifest = None; constraints = []};
@@ -119,7 +121,9 @@ Simplest possible resolution:
                ihash = 818126955; ikey = "r_Root.p_None"},
               u);
           ihash = 15973539; ikey = "t_u.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         equation =
          {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
           manifest =
@@ -142,7 +146,8 @@ Simplest possible resolution:
               []));
           constraints = []};
         representation = None})];
-    compiled = true; removed = []; doc = []};
+    compiled = true; removed = [];
+    doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false}};
  expansion = None; linked = false; source_loc = None; canonical = None}
 ```
 
@@ -246,7 +251,8 @@ Basic resolution 2, environment lookup:
                ihash = 818126955; ikey = "r_Root.p_None"},
               M);
           ihash = 716453475; ikey = "m_M.r_Root.p_None"};
-        source_loc = None; doc = [];
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Signature
@@ -270,12 +276,18 @@ Basic resolution 2, environment lookup:
                         ihash = 716453475; ikey = "m_M.r_Root.p_None"},
                        t);
                    ihash = 746522241; ikey = "t_t.m_M.r_Root.p_None"};
-                 source_loc = None; doc = []; canonical = None;
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
+                 canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
                  representation = None})];
-             compiled = true; removed = []; doc = []});
+             compiled = true; removed = [];
+             doc =
+              {Odoc_model__.Comment.elements = []; suppress_warnings = false}});
         canonical = None; hidden = false});
       Odoc_model.Lang.Signature.Type (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.TypeDecl.id =
@@ -290,7 +302,9 @@ Basic resolution 2, environment lookup:
                ihash = 818126955; ikey = "r_Root.p_None"},
               u);
           ihash = 15973539; ikey = "t_u.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         equation =
          {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
           manifest =
@@ -315,7 +329,8 @@ Basic resolution 2, environment lookup:
               []));
           constraints = []};
         representation = None})];
-    compiled = true; removed = []; doc = []};
+    compiled = true; removed = [];
+    doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false}};
  expansion = None; linked = false; source_loc = None; canonical = None}
 ```
 
@@ -392,7 +407,9 @@ Basic resolution 3, module type:
                ihash = 818126955; ikey = "r_Root.p_None"},
               M);
           ihash = 459143770; ikey = "mt_M.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -416,12 +433,18 @@ Basic resolution 3, module type:
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        t);
                    ihash = 825731485; ikey = "t_t.mt_M.r_Root.p_None"};
-                 source_loc = None; doc = []; canonical = None;
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
+                 canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
                  representation = None})];
-             compiled = true; removed = []; doc = []})};
+             compiled = true; removed = [];
+             doc =
+              {Odoc_model__.Comment.elements = []; suppress_warnings = false}})};
       Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.Module.id =
          {Odoc_model__Paths_types.iv =
@@ -435,7 +458,8 @@ Basic resolution 3, module type:
                ihash = 818126955; ikey = "r_Root.p_None"},
               N);
           ihash = 502470005; ikey = "m_N.r_Root.p_None"};
-        source_loc = None; doc = [];
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Path
@@ -462,12 +486,19 @@ Basic resolution 3, module type:
                              ihash = 502470005; ikey = "m_N.r_Root.p_None"},
                             t);
                         ihash = 598040815; ikey = "t_t.m_N.r_Root.p_None"};
-                      source_loc = None; doc = []; canonical = None;
+                      source_loc = None;
+                      doc =
+                       {Odoc_model__.Comment.elements = [];
+                        suppress_warnings = false};
+                      canonical = None;
                       equation =
                        {Odoc_model.Lang.TypeDecl.Equation.params = [];
                         private_ = false; manifest = None; constraints = []};
                       representation = None})];
-                  compiled = true; removed = []; doc = []});
+                  compiled = true; removed = [];
+                  doc =
+                   {Odoc_model__.Comment.elements = [];
+                    suppress_warnings = false}});
              p_path =
               `Resolved
                 (`Identifier
@@ -496,24 +527,14 @@ Basic resolution 3, module type:
                    Root);
                ihash = 818126955; ikey = "r_Root.p_None"},
               u);
-          ihash = 15973539; ikey = "t_u.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+          ihash = 15973539;
+          ikey = "t_u.r_Root.p_"... (* string length 17; truncated *)};
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         equation =
          {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
-          manifest =
-           Some
-            (Odoc_model.Lang.TypeExpr.Constr
-              (`Resolved
-                 (`Type
-                    (`Identifier
-                       {Odoc_model__Paths_types.iv =
-                         `Module
-                           ({Odoc_model__Paths_types.iv = ...; ihash = ...;
-                             ikey = ...},
-                            ...);
-                        ihash = ...; ikey = ...},
-                     ...)),
-              ...));
+          manifest = Some (Odoc_model.Lang.TypeExpr.Constr (...));
           constraints = ...};
         representation = ...});
       ...];
@@ -572,7 +593,9 @@ Basic resolution 4, module type:
                ihash = 818126955; ikey = "r_Root.p_None"},
               M);
           ihash = 459143770; ikey = "mt_M.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -596,7 +619,10 @@ Basic resolution 4, module type:
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        N);
                    ihash = 998243332; ikey = "m_N.mt_M.r_Root.p_None"};
-                 source_loc = None; doc = [];
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Signature
@@ -629,15 +655,24 @@ Basic resolution 4, module type:
                                 t);
                             ihash = 687003328;
                             ikey = "t_t.m_N.mt_M.r_Root.p_None"};
-                          source_loc = None; doc = []; canonical = None;
+                          source_loc = None;
+                          doc =
+                           {Odoc_model__.Comment.elements = [];
+                            suppress_warnings = false};
+                          canonical = None;
                           equation =
                            {Odoc_model.Lang.TypeDecl.Equation.params = [];
                             private_ = false; manifest = None;
                             constraints = []};
                           representation = None})];
-                      compiled = true; removed = []; doc = []});
+                      compiled = true; removed = [];
+                      doc =
+                       {Odoc_model__.Comment.elements = [];
+                        suppress_warnings = false}});
                  canonical = None; hidden = false})];
-             compiled = true; removed = []; doc = []})};
+             compiled = true; removed = [];
+             doc =
+              {Odoc_model__.Comment.elements = []; suppress_warnings = false}})};
       Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.Module.id =
          {Odoc_model__Paths_types.iv =
@@ -651,7 +686,8 @@ Basic resolution 4, module type:
                ihash = 818126955; ikey = "r_Root.p_None"},
               A);
           ihash = 353272258; ikey = "m_A.r_Root.p_None"};
-        source_loc = None; doc = [];
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Path
@@ -678,7 +714,10 @@ Basic resolution 4, module type:
                              ihash = 353272258; ikey = "m_A.r_Root.p_None"},
                             N);
                         ihash = 456955352; ikey = "m_N.m_A.r_Root.p_None"};
-                      source_loc = None; doc = [];
+                      source_loc = None;
+                      doc =
+                       {Odoc_model__.Comment.elements = [];
+                        suppress_warnings = false};
                       type_ =
                        Odoc_model.Lang.Module.ModuleType
                         (Odoc_model.Lang.ModuleType.Signature
@@ -693,34 +732,26 @@ Basic resolution 4, module type:
                                          ({Odoc_model__Paths_types.iv =
                                             `Module
                                               ({Odoc_model__Paths_types.iv =
-                                                 `Root
-                                                   (Some
-                                                     {Odoc_model__Paths_types.iv
-                                                       = `Page (None, None);
-                                                      ihash = 236059787;
-                                                      ikey = "p_None"},
-                                                    Root);
-                                                ihash = 818126955;
-                                                ikey =
-                                                 "r_Root.p"... (* string length 13; truncated *)},
-                                               ...);
-                                           ihash = ...; ikey = ...},
-                                          ...);
-                                      ihash = ...; ikey = ...},
-                                     ...);
-                                 ihash = ...; ikey = ...};
-                               source_loc = ...; doc = ...; canonical = ...;
-                               equation = ...; representation = ...});
-                             ...];
-                           compiled = ...; removed = ...; doc = ...});
-                      canonical = ...; hidden = ...});
-                    ...];
-                  compiled = ...; removed = ...; doc = ...});
-             p_path = ...});
-        canonical = ...; hidden = ...});
-      ...];
-    compiled = ...; removed = ...; doc = ...};
- expansion = ...; linked = ...; source_loc = ...; canonical = ...}
+                                                 `Root ...; ihash = ...;
+                                                 ikey = ...},
+                                                ...);
+                                            ihash = ...; ikey = ...},
+                                           ...);
+                                       ihash = ...; ikey = ...},
+                                      ...);
+                                  ihash = ...; ikey = ...};
+                                source_loc = ...; doc = ...; canonical = ...;
+                                equation = ...; representation = ...});
+                              ...];
+                            compiled = ...; removed = ...; doc = ...});
+                       canonical = ...; hidden = ...});
+                     ...];
+                   compiled = ...; removed = ...; doc = ...});
+              p_path = ...});
+         canonical = ...; hidden = ...});
+       ...];
+     compiled = ...; removed = ...; doc = ...};
+  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 This example is rather more interesting:
@@ -810,7 +841,9 @@ and then we can look up the type `t`.
                ihash = 818126955; ikey = "r_Root.p_None"},
               M);
           ihash = 459143770; ikey = "mt_M.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -833,7 +866,11 @@ and then we can look up the type `t`.
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        N);
                    ihash = 887387323; ikey = "mt_N.mt_M.r_Root.p_None"};
-                 source_loc = None; doc = []; canonical = None;
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
+                 canonical = None;
                  expr =
                   Some
                    (Odoc_model.Lang.ModuleType.Signature
@@ -866,13 +903,20 @@ and then we can look up the type `t`.
                                 t);
                             ihash = 652783314;
                             ikey = "t_t.mt_N.mt_M.r_Root.p_None"};
-                          source_loc = None; doc = []; canonical = None;
+                          source_loc = None;
+                          doc =
+                           {Odoc_model__.Comment.elements = [];
+                            suppress_warnings = false};
+                          canonical = None;
                           equation =
                            {Odoc_model.Lang.TypeDecl.Equation.params = [];
                             private_ = false; manifest = None;
                             constraints = []};
                           representation = None})];
-                      compiled = true; removed = []; doc = []})};
+                      compiled = true; removed = [];
+                      doc =
+                       {Odoc_model__.Comment.elements = [];
+                        suppress_warnings = false}})};
                Odoc_model.Lang.Signature.Module
                 (Odoc_model.Lang.Signature.Ordinary,
                 {Odoc_model.Lang.Module.id =
@@ -892,7 +936,10 @@ and then we can look up the type `t`.
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        B);
                    ihash = 301928208; ikey = "m_B.mt_M.r_Root.p_None"};
-                 source_loc = None; doc = [];
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Path
@@ -927,28 +974,24 @@ and then we can look up the type `t`.
                                       ikey = "m_B.mt_M.r_Root.p_None"},
                                      t);
                                  ihash = 484865120;
-                                 ikey = "t_t.m_B.mt_M.r_Root.p_None"};
-                               source_loc = None; doc = []; canonical = None;
+                                 ikey =
+                                  "t_t.m_B.mt_M.r_Root.p_No"... (* string length 26; truncated *)};
+                               source_loc = None;
+                               doc =
+                                {Odoc_model__.Comment.elements = [];
+                                 suppress_warnings = false};
+                               canonical = None;
                                equation =
                                 {Odoc_model.Lang.TypeDecl.Equation.params =
                                   [];
                                  private_ = false; manifest = None;
                                  constraints = []};
                                representation = None})];
-                           compiled = true; removed = []; doc = []});
-                      p_path =
-                       `Resolved
-                         (`Identifier
-                            {Odoc_model__Paths_types.iv =
-                              `ModuleType
-                                ({Odoc_model__Paths_types.iv =
-                                   `ModuleType
-                                     ({Odoc_model__Paths_types.iv =
-                                        `Root ...; ihash = ...; ikey = ...},
-                                       ...);
-                                   ihash = ...; ikey = ...},
-                                  ...);
-                              ihash = ...; ikey = ...})});
+                           compiled = true; removed = [];
+                           doc =
+                            {Odoc_model__.Comment.elements = [];
+                             suppress_warnings = false}});
+                      p_path = `Resolved (`Identifier ...)});
                   canonical = ...; hidden = ...});
                 ...];
               compiled = ...; removed = ...; doc = ...})};
@@ -997,7 +1040,9 @@ and then we can look up the type `t`.
                ihash = 818126955; ikey = "r_Root.p_None"},
               M);
           ihash = 459143770; ikey = "mt_M.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -1020,7 +1065,11 @@ and then we can look up the type `t`.
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        N);
                    ihash = 887387323; ikey = "mt_N.mt_M.r_Root.p_None"};
-                 source_loc = None; doc = []; canonical = None;
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
+                 canonical = None;
                  expr =
                   Some
                    (Odoc_model.Lang.ModuleType.Signature
@@ -1053,13 +1102,20 @@ and then we can look up the type `t`.
                                 t);
                             ihash = 652783314;
                             ikey = "t_t.mt_N.mt_M.r_Root.p_None"};
-                          source_loc = None; doc = []; canonical = None;
+                          source_loc = None;
+                          doc =
+                           {Odoc_model__.Comment.elements = [];
+                            suppress_warnings = false};
+                          canonical = None;
                           equation =
                            {Odoc_model.Lang.TypeDecl.Equation.params = [];
                             private_ = false; manifest = None;
                             constraints = []};
                           representation = None})];
-                      compiled = true; removed = []; doc = []})};
+                      compiled = true; removed = [];
+                      doc =
+                       {Odoc_model__.Comment.elements = [];
+                        suppress_warnings = false}})};
                Odoc_model.Lang.Signature.Module
                 (Odoc_model.Lang.Signature.Ordinary,
                 {Odoc_model.Lang.Module.id =
@@ -1079,7 +1135,10 @@ and then we can look up the type `t`.
                         ihash = 459143770; ikey = "mt_M.r_Root.p_None"},
                        X);
                    ihash = 573009176; ikey = "m_X.mt_M.r_Root.p_None"};
-                 source_loc = None; doc = [];
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Signature
@@ -1112,7 +1171,10 @@ and then we can look up the type `t`.
                                 B);
                             ihash = 413241446;
                             ikey = "m_B.m_X.mt_M.r_Root.p_None"};
-                          source_loc = None; doc = [];
+                          source_loc = None;
+                          doc =
+                           {Odoc_model__.Comment.elements = [];
+                            suppress_warnings = false};
                           type_ =
                            Odoc_model.Lang.Module.ModuleType
                             (Odoc_model.Lang.ModuleType.Path
@@ -1126,23 +1188,7 @@ and then we can look up the type `t`.
                                          {Odoc_model__Paths_types.iv =
                                            `Type
                                              ({Odoc_model__Paths_types.iv =
-                                                `Module
-                                                  ({Odoc_model__Paths_types.iv
-                                                     =
-                                                     `Module
-                                                       ({Odoc_model__Paths_types.iv
-                                                          =
-                                                          `ModuleType
-                                                            ({Odoc_model__Paths_types.iv
-                                                               = ...;
-                                                              ihash = ...;
-                                                              ikey = ...},
-                                                             ...);
-                                                         ihash = ...;
-                                                         ikey = ...},
-                                                        ...);
-                                                    ihash = ...; ikey = ...},
-                                                   ...);
+                                                `Module (...);
                                                ihash = ...; ikey = ...},
                                               ...);
                                           ihash = ...; ikey = ...};
@@ -1205,7 +1251,9 @@ Ensure a substitution is taken into account during resolution:
                ihash = 818126955; ikey = "r_Root.p_None"},
               A);
           ihash = 231492881; ikey = "mt_A.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -1229,7 +1277,10 @@ Ensure a substitution is taken into account during resolution:
                         ihash = 231492881; ikey = "mt_A.r_Root.p_None"},
                        M);
                    ihash = 564635453; ikey = "m_M.mt_A.r_Root.p_None"};
-                 source_loc = None; doc = [];
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Signature
@@ -1261,9 +1312,15 @@ Ensure a substitution is taken into account during resolution:
                                 S);
                             ihash = 3092406;
                             ikey = "mt_S.m_M.mt_A.r_Root.p_None"};
-                          source_loc = None; doc = []; canonical = None;
-                          expr = None}];
-                      compiled = true; removed = []; doc = []});
+                          source_loc = None;
+                          doc =
+                           {Odoc_model__.Comment.elements = [];
+                            suppress_warnings = false};
+                          canonical = None; expr = None}];
+                      compiled = true; removed = [];
+                      doc =
+                       {Odoc_model__.Comment.elements = [];
+                        suppress_warnings = false}});
                  canonical = None; hidden = false});
                Odoc_model.Lang.Signature.Module
                 (Odoc_model.Lang.Signature.Ordinary,
@@ -1284,7 +1341,10 @@ Ensure a substitution is taken into account during resolution:
                         ihash = 231492881; ikey = "mt_A.r_Root.p_None"},
                        N);
                    ihash = 50158313; ikey = "m_N.mt_A.r_Root.p_None"};
-                 source_loc = None; doc = [];
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Path
@@ -1316,7 +1376,9 @@ Ensure a substitution is taken into account during resolution:
                                    ikey = "m_M.mt_A.r_Root.p_None"},
                                 S)))});
                  canonical = None; hidden = false})];
-             compiled = true; removed = []; doc = []})};
+             compiled = true; removed = [];
+             doc =
+              {Odoc_model__.Comment.elements = []; suppress_warnings = false}})};
       Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.Module.id =
          {Odoc_model__Paths_types.iv =
@@ -1326,19 +1388,12 @@ Ensure a substitution is taken into account during resolution:
                   (Some
                     {Odoc_model__Paths_types.iv = `Page (None, None);
                      ihash = 236059787; ikey = "p_None"},
-                   Root);
-               ihash = 818126955;
-               ikey = "r_Root.p_"... (* string length 13; truncated *)},
-              B);
-          ihash = 814134997;
-          ikey = "m_B.r_Ro"... (* string length 17; truncated *)};
-        source_loc = None; doc = [];
-        type_ =
-         Odoc_model.Lang.Module.ModuleType
-          (Odoc_model.Lang.ModuleType.Signature
-            {Odoc_model.Lang.Signature.items = ...; compiled = ...;
-             removed = ...; doc = ...});
-        canonical = ...; hidden = ...});
+                   ...);
+               ihash = ...; ikey = ...},
+              ...);
+          ihash = ...; ikey = ...};
+        source_loc = ...; doc = ...; type_ = ...; canonical = ...;
+        hidden = ...});
       ...];
     compiled = ...; removed = ...; doc = ...};
  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
@@ -1386,7 +1441,9 @@ Ensure a destructive substitution is taken into account during resolution:
                ihash = 818126955; ikey = "r_Root.p_None"},
               A);
           ihash = 231492881; ikey = "mt_A.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -1410,7 +1467,10 @@ Ensure a destructive substitution is taken into account during resolution:
                         ihash = 231492881; ikey = "mt_A.r_Root.p_None"},
                        M);
                    ihash = 564635453; ikey = "m_M.mt_A.r_Root.p_None"};
-                 source_loc = None; doc = [];
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Signature
@@ -1442,9 +1502,15 @@ Ensure a destructive substitution is taken into account during resolution:
                                 S);
                             ihash = 3092406;
                             ikey = "mt_S.m_M.mt_A.r_Root.p_None"};
-                          source_loc = None; doc = []; canonical = None;
-                          expr = None}];
-                      compiled = true; removed = []; doc = []});
+                          source_loc = None;
+                          doc =
+                           {Odoc_model__.Comment.elements = [];
+                            suppress_warnings = false};
+                          canonical = None; expr = None}];
+                      compiled = true; removed = [];
+                      doc =
+                       {Odoc_model__.Comment.elements = [];
+                        suppress_warnings = false}});
                  canonical = None; hidden = false});
                Odoc_model.Lang.Signature.Module
                 (Odoc_model.Lang.Signature.Ordinary,
@@ -1465,7 +1531,10 @@ Ensure a destructive substitution is taken into account during resolution:
                         ihash = 231492881; ikey = "mt_A.r_Root.p_None"},
                        N);
                    ihash = 50158313; ikey = "m_N.mt_A.r_Root.p_None"};
-                 source_loc = None; doc = [];
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
                  type_ =
                   Odoc_model.Lang.Module.ModuleType
                    (Odoc_model.Lang.ModuleType.Path
@@ -1497,7 +1566,9 @@ Ensure a destructive substitution is taken into account during resolution:
                                    ikey = "m_M.mt_A.r_Root.p_None"},
                                 S)))});
                  canonical = None; hidden = false})];
-             compiled = true; removed = []; doc = []})};
+             compiled = true; removed = [];
+             doc =
+              {Odoc_model__.Comment.elements = []; suppress_warnings = false}})};
       Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.Module.id =
          {Odoc_model__Paths_types.iv =
@@ -1507,19 +1578,12 @@ Ensure a destructive substitution is taken into account during resolution:
                   (Some
                     {Odoc_model__Paths_types.iv = `Page (None, None);
                      ihash = 236059787; ikey = "p_None"},
-                   Root);
-               ihash = 818126955;
-               ikey = "r_Root.p_"... (* string length 13; truncated *)},
-              B);
-          ihash = 814134997;
-          ikey = "m_B.r_Ro"... (* string length 17; truncated *)};
-        source_loc = None; doc = [];
-        type_ =
-         Odoc_model.Lang.Module.ModuleType
-          (Odoc_model.Lang.ModuleType.Signature
-            {Odoc_model.Lang.Signature.items = ...; compiled = ...;
-             removed = ...; doc = ...});
-        canonical = ...; hidden = ...});
+                   ...);
+               ihash = ...; ikey = ...},
+              ...);
+          ihash = ...; ikey = ...};
+        source_loc = ...; doc = ...; type_ = ...; canonical = ...;
+        hidden = ...});
       ...];
     compiled = ...; removed = ...; doc = ...};
  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
@@ -1562,7 +1626,8 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               A);
           ihash = 353272258; ikey = "m_A.r_Root.p_None"};
-        source_loc = None; doc = [];
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Signature
@@ -1586,12 +1651,18 @@ Resolve a module alias:
                         ihash = 353272258; ikey = "m_A.r_Root.p_None"},
                        t);
                    ihash = 394964294; ikey = "t_t.m_A.r_Root.p_None"};
-                 source_loc = None; doc = []; canonical = None;
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
+                 canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
                  representation = None})];
-             compiled = true; removed = []; doc = []});
+             compiled = true; removed = [];
+             doc =
+              {Odoc_model__.Comment.elements = []; suppress_warnings = false}});
         canonical = None; hidden = false});
       Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.Module.id =
@@ -1606,7 +1677,8 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               B);
           ihash = 814134997; ikey = "m_B.r_Root.p_None"};
-        source_loc = None; doc = [];
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
         type_ =
          Odoc_model.Lang.Module.Alias
           (`Resolved
@@ -1637,7 +1709,9 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               t);
           ihash = 1016576344; ikey = "t_t.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         equation =
          {Odoc_model.Lang.TypeDecl.Equation.params = []; private_ = false;
           manifest =
@@ -1669,18 +1743,15 @@ Resolve a module alias:
                                         `Page (None, None);
                                        ihash = 236059787; ikey = "p_None"},
                                      Root);
-                                 ihash = 818126955;
-                                 ikey =
-                                  "r_Root.p"... (* string length 13; truncated *)},
-                                B);
-                            ihash = 814134997;
-                            ikey =
-                             "m_B.r_Ro"... (* string length 17; truncated *)},
-                           false)),
-                     t)),
-              []));
-          constraints = []};
-        representation = None})];
+                                 ihash = ...; ikey = ...},
+                                ...);
+                            ihash = ...; ikey = ...},
+                           ...)),
+                     ...)),
+              ...));
+          constraints = ...};
+        representation = ...});
+      ...];
     compiled = ...; removed = ...; doc = ...};
  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
@@ -1723,7 +1794,8 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               A);
           ihash = 353272258; ikey = "m_A.r_Root.p_None"};
-        source_loc = None; doc = [];
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Signature
@@ -1747,12 +1819,18 @@ Resolve a module alias:
                         ihash = 353272258; ikey = "m_A.r_Root.p_None"},
                        t);
                    ihash = 394964294; ikey = "t_t.m_A.r_Root.p_None"};
-                 source_loc = None; doc = []; canonical = None;
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
+                 canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
                  representation = None})];
-             compiled = true; removed = []; doc = []});
+             compiled = true; removed = [];
+             doc =
+              {Odoc_model__.Comment.elements = []; suppress_warnings = false}});
         canonical = None; hidden = false});
       Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.Module.id =
@@ -1767,7 +1845,8 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               B);
           ihash = 814134997; ikey = "m_B.r_Root.p_None"};
-        source_loc = None; doc = [];
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
         type_ =
          Odoc_model.Lang.Module.Alias
           (`Resolved
@@ -1798,7 +1877,8 @@ Resolve a module alias:
                ihash = 818126955; ikey = "r_Root.p_None"},
               C);
           ihash = 43786577; ikey = "m_C.r_Root.p_None"};
-        source_loc = None; doc = [];
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
         type_ =
          Odoc_model.Lang.Module.Alias
           (`Resolved
@@ -1826,22 +1906,18 @@ Resolve a module alias:
                                  `Page (None, None);
                                 ihash = 236059787; ikey = "p_None"},
                               Root);
-                          ihash = 818126955; ikey = "r_Root.p_None"},
+                          ihash = 818126955;
+                          ikey =
+                           "r_Root.p"... (* string length 13; truncated *)},
                          B);
                      ihash = 814134997;
-                     ikey =
-                      "m_B.r_Root.p"... (* string length 17; truncated *)},
+                     ikey = "m_B.r_Ro"... (* string length 17; truncated *)},
                     false))),
            None);
-        canonical = None; hidden = false});
-      Odoc_model.Lang.Signature.Type (Odoc_model.Lang.Signature.Ordinary,
-       {Odoc_model.Lang.TypeDecl.id =
-         {Odoc_model__Paths_types.iv = `Type ...; ihash = ...; ikey = ...};
-         source_loc = ...; doc = ...; canonical = ...; equation = ...;
-         representation = ...});
-       ...];
-     compiled = ...; removed = ...; doc = ...};
-  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
+        canonical = ...; hidden = ...});
+      ...];
+    compiled = ...; removed = ...; doc = ...};
+ expansion = ...; linked = ...; source_loc = ...; canonical = ...}
 ```
 
 Resolve a functor:
@@ -1885,7 +1961,9 @@ Resolve a functor:
                ihash = 818126955; ikey = "r_Root.p_None"},
               S);
           ihash = 527535255; ikey = "mt_S.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -1909,12 +1987,18 @@ Resolve a functor:
                         ihash = 527535255; ikey = "mt_S.r_Root.p_None"},
                        t);
                    ihash = 130637260; ikey = "t_t.mt_S.r_Root.p_None"};
-                 source_loc = None; doc = []; canonical = None;
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
+                 canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
                  representation = None})];
-             compiled = true; removed = []; doc = []})};
+             compiled = true; removed = [];
+             doc =
+              {Odoc_model__.Comment.elements = []; suppress_warnings = false}})};
       Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.Module.id =
          {Odoc_model__Paths_types.iv =
@@ -1928,7 +2012,8 @@ Resolve a functor:
                ihash = 818126955; ikey = "r_Root.p_None"},
               F);
           ihash = 748202139; ikey = "m_F.r_Root.p_None"};
-        source_loc = None; doc = [];
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Functor
@@ -1984,13 +2069,20 @@ Resolve a functor:
                                  t);
                              ihash = 1065278958;
                              ikey = "t_t.p_X.m_F.r_Root.p_None"};
-                           source_loc = None; doc = []; canonical = None;
+                           source_loc = None;
+                           doc =
+                            {Odoc_model__.Comment.elements = [];
+                             suppress_warnings = false};
+                           canonical = None;
                            equation =
                             {Odoc_model.Lang.TypeDecl.Equation.params = [];
                              private_ = false; manifest = None;
                              constraints = []};
                            representation = None})];
-                       compiled = true; removed = []; doc = []});
+                       compiled = true; removed = [];
+                       doc =
+                        {Odoc_model__.Comment.elements = [];
+                         suppress_warnings = false}});
                   p_path =
                    `Resolved
                      (`Identifier
@@ -2003,22 +2095,12 @@ Resolve a functor:
                                      `Page (None, None);
                                     ihash = 236059787; ikey = "p_None"},
                                   Root);
-                              ihash = 818126955; ikey = "r_Root.p_None"},
+                              ihash = 818126955;
+                              ikey =
+                               "r_Root.p"... (* string length 13; truncated *)},
                              S);
-                         ihash = 527535255;
-                         ikey =
-                          "mt_S.r_Root"... (* string length 18; truncated *)})}},
-            Odoc_model.Lang.ModuleType.Functor
-             (Odoc_model.Lang.FunctorParameter.Named
-               {Odoc_model.Lang.FunctorParameter.id =
-                 {Odoc_model__Paths_types.iv =
-                   `Parameter
-                     ({Odoc_model__Paths_types.iv = ...; ihash = ...;
-                       ikey = ...},
-                      ...);
-                  ihash = ...; ikey = ...};
-                expr = ...},
-             ...)));
+                         ihash = 527535255; ikey = ...})}},
+            ...));
         canonical = ...; hidden = ...});
       ...];
     compiled = ...; removed = ...; doc = ...};
@@ -2088,7 +2170,9 @@ Resolve a functor:
                ihash = 818126955; ikey = "r_Root.p_None"},
               S);
           ihash = 527535255; ikey = "mt_S.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -2112,12 +2196,18 @@ Resolve a functor:
                         ihash = 527535255; ikey = "mt_S.r_Root.p_None"},
                        t);
                    ihash = 130637260; ikey = "t_t.mt_S.r_Root.p_None"};
-                 source_loc = None; doc = []; canonical = None;
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
+                 canonical = None;
                  equation =
                   {Odoc_model.Lang.TypeDecl.Equation.params = [];
                    private_ = false; manifest = None; constraints = []};
                  representation = None})];
-             compiled = true; removed = []; doc = []})};
+             compiled = true; removed = [];
+             doc =
+              {Odoc_model__.Comment.elements = []; suppress_warnings = false}})};
       Odoc_model.Lang.Signature.ModuleType
        {Odoc_model.Lang.ModuleType.id =
          {Odoc_model__Paths_types.iv =
@@ -2131,7 +2221,9 @@ Resolve a functor:
                ihash = 818126955; ikey = "r_Root.p_None"},
               S1);
           ihash = 289200525; ikey = "mt_S1.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Functor
@@ -2187,13 +2279,20 @@ Resolve a functor:
                                  t);
                              ihash = 993900890;
                              ikey = "t_t.p__.mt_S1.r_Root.p_None"};
-                           source_loc = None; doc = []; canonical = None;
+                           source_loc = None;
+                           doc =
+                            {Odoc_model__.Comment.elements = [];
+                             suppress_warnings = false};
+                           canonical = None;
                            equation =
                             {Odoc_model.Lang.TypeDecl.Equation.params = [];
                              private_ = false; manifest = None;
                              constraints = []};
                            representation = None})];
-                       compiled = true; removed = []; doc = []});
+                       compiled = true; removed = [];
+                       doc =
+                        {Odoc_model__.Comment.elements = [];
+                         suppress_warnings = false}});
                   p_path =
                    `Resolved
                      (`Identifier
@@ -2206,24 +2305,12 @@ Resolve a functor:
                                      `Page (None, None);
                                     ihash = 236059787; ikey = "p_None"},
                                   Root);
-                              ihash = 818126955; ikey = "r_Root.p_None"},
+                              ihash = 818126955;
+                              ikey =
+                               "r_Root.p"... (* string length 13; truncated *)},
                              S);
-                         ihash = 527535255;
-                         ikey =
-                          "mt_S.r_Root"... (* string length 18; truncated *)})}},
-            Odoc_model.Lang.ModuleType.Path
-             {Odoc_model.Lang.ModuleType.p_expansion =
-               Some
-                (Odoc_model.Lang.ModuleType.Signature
-                  {Odoc_model.Lang.Signature.items =
-                    [Odoc_model.Lang.Signature.Type
-                      (Odoc_model.Lang.Signature.Ordinary,
-                      {Odoc_model.Lang.TypeDecl.id = ...; source_loc = ...;
-                       doc = ...; canonical = ...; equation = ...;
-                       representation = ...});
-                     ...];
-                   compiled = ...; removed = ...; doc = ...});
-              p_path = ...}))};
+                         ihash = 527535255; ikey = ...})}},
+            ...))};
       ...];
     compiled = ...; removed = ...; doc = ...};
  expansion = ...; linked = ...; source_loc = ...; canonical = ...}
@@ -2310,7 +2397,9 @@ Functor app nightmare:
                ihash = 818126955; ikey = "r_Root.p_None"},
               Type);
           ihash = 359972898; ikey = "mt_Type.r_Root.p_None"};
-        source_loc = None; doc = []; canonical = None;
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
+        canonical = None;
         expr =
          Some
           (Odoc_model.Lang.ModuleType.Signature
@@ -2333,8 +2422,14 @@ Functor app nightmare:
                         ihash = 359972898; ikey = "mt_Type.r_Root.p_None"},
                        T);
                    ihash = 1011869183; ikey = "mt_T.mt_Type.r_Root.p_None"};
-                 source_loc = None; doc = []; canonical = None; expr = None}];
-             compiled = true; removed = []; doc = []})};
+                 source_loc = None;
+                 doc =
+                  {Odoc_model__.Comment.elements = [];
+                   suppress_warnings = false};
+                 canonical = None; expr = None}];
+             compiled = true; removed = [];
+             doc =
+              {Odoc_model__.Comment.elements = []; suppress_warnings = false}})};
       Odoc_model.Lang.Signature.Module (Odoc_model.Lang.Signature.Ordinary,
        {Odoc_model.Lang.Module.id =
          {Odoc_model__Paths_types.iv =
@@ -2348,7 +2443,8 @@ Functor app nightmare:
                ihash = 818126955; ikey = "r_Root.p_None"},
               App);
           ihash = 855073208; ikey = "m_App.r_Root.p_None"};
-        source_loc = None; doc = [];
+        source_loc = None;
+        doc = {Odoc_model__.Comment.elements = []; suppress_warnings = false};
         type_ =
          Odoc_model.Lang.Module.ModuleType
           (Odoc_model.Lang.ModuleType.Functor
@@ -2403,9 +2499,15 @@ Functor app nightmare:
                                  T);
                              ihash = 167832761;
                              ikey = "mt_T.p_T.m_App.r_Root.p_None"};
-                           source_loc = None; doc = []; canonical = None;
-                           expr = None}];
-                       compiled = true; removed = []; doc = []});
+                           source_loc = None;
+                           doc =
+                            {Odoc_model__.Comment.elements = [];
+                             suppress_warnings = false};
+                           canonical = None; expr = None}];
+                       compiled = true; removed = [];
+                       doc =
+                        {Odoc_model__.Comment.elements = [];
+                         suppress_warnings = false}});
                   p_path =
                    `Resolved
                      (`Identifier
@@ -2420,21 +2522,16 @@ Functor app nightmare:
                                   Root);
                               ihash = 818126955; ikey = "r_Root.p_None"},
                              Type);
-                         ihash = 359972898; ikey = "mt_Type.r_Root.p_None"})}},
+                         ihash = 359972898;
+                         ikey =
+                          "mt_Type.r_R"... (* string length 21; truncated *)})}},
             Odoc_model.Lang.ModuleType.Functor
              (Odoc_model.Lang.FunctorParameter.Named
                {Odoc_model.Lang.FunctorParameter.id =
                  {Odoc_model__Paths_types.iv =
                    `Parameter
-                     ({Odoc_model__Paths_types.iv =
-                        `Result
-                          {Odoc_model__Paths_types.iv =
-                            `Module
-                              ({Odoc_model__Paths_types.iv = `Root (...);
-                                ihash = ...; ikey = ...},
-                               ...);
-                           ihash = ...; ikey = ...};
-                       ihash = ...; ikey = ...},
+                     ({Odoc_model__Paths_types.iv = ...; ihash = ...;
+                       ikey = ...},
                       ...);
                   ihash = ...; ikey = ...};
                 expr = ...},


### PR DESCRIPTION
Authors of documentation sometimes have warnings from other documentation "leak" in their API, due to eg `include`s from dependencies, or functor expansions, ... This mixes warnings you should act on, with warnings you can't do anything about.

This PR (taken from one of @jonludlam's branch) add a `--suppress-warnings` flag to tag the docs as not raising warnings. This tag is taken with the `includes` and expansions, so solve the issue.

No that they are easily available, the PR fixes the warnings reported on odoc's documentation.

The main difference with the taken commits are:
- Other names (I used `elements` instead of `docs` otherwise that's a lot of `docs.docs`)
- Formatting of unocamlformatted code

Otherwise, I not only cherry-picked the commits but also reviewed them, and it looks good.