### PR TITLE
Try to resolve references in stage 0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- Addded `--suppress-warnings` to the CLI to remove warnings from a unit, even
+  if they end up being raised in another unit through expansion (@jonludlam,
+  #1260)
 - Improve jump to implementation in rendered source code, and add a
   `count-occurrences` flag and command to count occurrences of every identifiers
   (@panglesd, #976)

--- a/doc/examples/resolution.mli
+++ b/doc/examples/resolution.mli
@@ -86,7 +86,6 @@ module Hidden : sig
 
   type v = T of t
 
-  type w = U of u
 end
 
 module References : sig

--- a/doc/odoc.mld
+++ b/doc/odoc.mld
@@ -59,5 +59,3 @@ The main other pages of this site:
 - {!page-dune} shows how to create docs using Dune.
 - {!page-parent_child_spec} delineates parent/child specifications.
 - {!page-interface} describes [odoc]'s public-facing interface and their support guarantees.
-- {!page-ocamlary} demonstrates the rendering of most of the OCaml constructs.
-- {!page-api_reference} lists [odoc]'s API reference library.

--- a/dune
+++ b/dune
@@ -23,3 +23,8 @@
   (progn
    (bash "diff doc/driver.mld doc/driver.mld.corrected >&2 || true")
    (cat doc/driver-benchmarks.json))))
+
+(install
+ (files odoc-config.sexp)
+ (section doc)
+ (package odoc))

--- a/odoc-config.sexp
+++ b/odoc-config.sexp
@@ -1,0 +1,2 @@
+(libraries fmt)
+

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -415,6 +415,6 @@ let standalone docs =
 
 let to_ir (docs : Comment.docs) =
   Utils.flatmap ~f:block_element
-  @@ List.map (fun x -> x.Odoc_model.Location_.value) docs
+  @@ List.map (fun x -> x.Odoc_model.Location_.value) docs.elements
 
 let has_doc docs = docs <> []

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -94,7 +94,7 @@ end = struct
             | Page { short_title = None; _ } ->
                 let title =
                   let open Odoc_model in
-                  match Comment.find_zero_heading entry.doc with
+                  match Comment.find_zero_heading entry.doc.elements with
                   | Some t -> t
                   | None ->
                       let name =

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -143,6 +143,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.t list) =
                  in
                  Odoc.compile ~output_dir:unit.output_dir
                    ~input_file:unit.input_file ~includes
+                   ~suppress_warnings:(not unit.enable_warnings)
                    ~parent_id:unit.parent_id;
                  Atomic.incr Stats.stats.compiled_units;
 
@@ -191,7 +192,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.t list) =
     | `Mld ->
         let includes = Fpath.Set.empty in
         Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
-          ~includes ~parent_id:unit.parent_id;
+          ~includes ~suppress_warnings:false ~parent_id:unit.parent_id;
         Atomic.incr Stats.stats.compiled_mlds;
         Ok [ unit ]
     | `Md ->

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -18,13 +18,14 @@ let make_index ~dirs ?pkg ~rel_dir ?index ~content () =
   let odoc_file = Fpath.(odoc_dir // rel_dir / "page-index.odoc") in
   let odocl_file = Fpath.(odocl_dir // rel_dir / "page-index.odocl") in
   let parent_id = rel_dir |> Odoc.Id.of_fpath in
+  let pkg_args = Pkg_args.v ~pages ~libs ~odoc_dir ~odocl_dir in
   Util.with_out_to input_file (fun oc ->
       fpf (Format.formatter_of_out_channel oc) "%t@?" content)
   |> Result.get_ok;
   {
     output_dir = dirs.odoc_dir;
     pkgname = None;
-    pkg_args = { Pkg_args.pages; libs; odoc_dir; odocl_dir };
+    pkg_args;
     parent_id;
     input_file;
     odoc_file;

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -36,7 +36,7 @@ let compile_deps f =
   | [ (_, digest) ], deps -> Ok { digest; deps }
   | _ -> Error (`Msg "odd")
 
-let compile ~output_dir ~input_file:file ~includes ~parent_id =
+let compile ~output_dir ~input_file:file ~includes ~suppress_warnings ~parent_id =
   let open Cmd in
   let includes =
     Fpath.Set.fold
@@ -52,6 +52,7 @@ let compile ~output_dir ~input_file:file ~includes ~parent_id =
     %% includes % "--enable-missing-root-warning"
   in
   let cmd = cmd % "--parent-id" % Id.to_string parent_id in
+  let cmd = if suppress_warnings then cmd % "--suppress-warnings" else cmd in
   let desc = Printf.sprintf "Compiling %s" (Fpath.to_string file) in
   ignore
   @@ Cmd_outputs.submit

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -24,6 +24,7 @@ val compile :
   output_dir:Fpath.t ->
   input_file:Fpath.t ->
   includes:Fpath.set ->
+  suppress_warnings:bool ->
   parent_id:Id.t ->
   unit
 val compile_md :

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -1,15 +1,16 @@
 module Pkg_args : sig
-  type t = {
-    odoc_dir : Fpath.t;
-    odocl_dir : Fpath.t;
-    pages : (string * Fpath.t) list;
-    libs : (string * Fpath.t) list;
-  }
+  type t
 
   val compiled_pages : t -> (string * Fpath.t) list
   val compiled_libs : t -> (string * Fpath.t) list
   val linked_pages : t -> (string * Fpath.t) list
   val linked_libs : t -> (string * Fpath.t) list
+
+  val v : odoc_dir:Fpath.t ->
+    odocl_dir:Fpath.t ->
+    pages:(string * Fpath.t) list ->
+    libs:(string * Fpath.t) list ->
+    t
 
   val combine : t -> t -> t
 

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -46,7 +46,7 @@ let packages ~dirs ~extra_paths ~remap (pkgs : Packages.t list) : t list =
   let base_args pkg lib_deps : Pkg_args.t =
     let own_page = dash_p pkg.Packages.name (doc_dir pkg) in
     let own_libs = List.concat_map dash_l (Util.StringSet.to_list lib_deps) in
-    { pages = [ own_page ]; libs = own_libs; odoc_dir; odocl_dir }
+    Pkg_args.v ~pages:[ own_page ] ~libs:own_libs ~odoc_dir ~odocl_dir
   in
   let args_of_config config : Pkg_args.t =
     let { Global_config.deps = { packages; libraries } } = config in
@@ -61,7 +61,7 @@ let packages ~dirs ~extra_paths ~remap (pkgs : Packages.t list) : t list =
         packages
     in
     let libs_rel = List.concat_map dash_l libraries in
-    { pages = pages_rel; libs = libs_rel; odoc_dir; odocl_dir }
+    Pkg_args.v ~pages:pages_rel ~libs:libs_rel ~odoc_dir ~odocl_dir
   in
   let args_of =
     let cache = Hashtbl.create 10 in

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -193,10 +193,9 @@ let packages ~dirs ~extra_paths ~remap (pkgs : Packages.t list) : t list =
   in
   let of_lib pkg (lib : Packages.libty) =
     let lib_deps = Util.StringSet.add lib.lib_name lib.lib_deps in
-    let landing_page :> t =
-      let index = index_of pkg in
-      Landing_pages.library ~dirs ~pkg ~index lib
-    in
+    let lib_deps = List.fold_left (fun acc lib -> Util.StringSet.add lib.Packages.lib_name acc) lib_deps pkg.Packages.libraries in
+    let index = index_of pkg in
+    let landing_page :> t = Landing_pages.library ~dirs ~pkg ~index lib in
     landing_page :: List.concat_map (of_module pkg lib lib_deps) lib.modules
   in
   let of_mld pkg (mld : Packages.mld) : mld unit list =

--- a/src/index/skeleton.ml
+++ b/src/index/skeleton.ml
@@ -8,7 +8,12 @@ type t = Entry.t Tree.t
 module Entry = struct
   let of_comp_unit (u : Compilation_unit.t) =
     let has_expansion = true in
-    let doc = match u.content with Pack _ -> [] | Module m -> m.doc in
+    let doc =
+      match u.content with
+      | Pack _ ->
+          { Odoc_model.Comment.elements = []; suppress_warnings = false }
+      | Module m -> m.doc
+    in
     Entry.entry ~id:u.id ~doc ~kind:(Module { has_expansion })
 
   let of_module (m : Module.t) =

--- a/src/index/skeleton_of.ml
+++ b/src/index/skeleton_of.ml
@@ -39,6 +39,8 @@ let compare_entry (t1 : t) (t2 : t) =
   try_ Astring.String.compare by_name @@ fun () -> 0
 
 let rec t_of_in_progress (dir : In_progress.in_progress) : t =
+  let empty_doc = { Comment.elements = []; suppress_warnings = false } in
+
   let entry_of_page page =
     let kind = Entry.Page page.Lang.Page.frontmatter in
     let doc = page.content in
@@ -47,7 +49,7 @@ let rec t_of_in_progress (dir : In_progress.in_progress) : t =
   in
   let entry_of_impl id =
     let kind = Entry.Impl in
-    let doc = [] in
+    let doc = empty_doc in
     Entry.entry ~kind ~doc ~id
   in
   let children_order, index =
@@ -61,7 +63,7 @@ let rec t_of_in_progress (dir : In_progress.in_progress) : t =
           match In_progress.root_dir dir with
           | Some id ->
               let kind = Entry.Dir in
-              let doc = [] in
+              let doc = empty_doc in
               Entry.entry ~kind ~doc ~id
           | None ->
               let id =
@@ -69,7 +71,7 @@ let rec t_of_in_progress (dir : In_progress.in_progress) : t =
                 Id.Mk.leaf_page (None, Names.PageName.make_std "index")
               in
               let kind = Entry.Dir in
-              let doc = [] in
+              let doc = empty_doc in
               Entry.entry ~kind ~doc ~id
         in
         (None, entry)

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -25,6 +25,14 @@ open Odoc_model.Names
 module Env = Ident_env
 module Paths = Odoc_model.Paths
 
+
+type env = {
+  ident_env : Env.t;
+  suppress_warnings : bool;  (** suppress warnings *)
+}
+
+let empty_doc = { Odoc_model.Comment.elements = []; suppress_warnings = false }
+
 module Compat = struct
 #if OCAML_VERSION >= (4, 14, 0)
 #if OCAML_VERSION >= (5, 3, 0)
@@ -458,7 +466,7 @@ let rec read_type_expr env typ =
           let typs = List.map (read_type_expr env) typs in
             Tuple typs
       | Tconstr(p, params, _) ->
-          let p = Env.Path.read_type env p in
+          let p = Env.Path.read_type env.ident_env p in
           let params = List.map (read_type_expr env) params in
             Constr(p, params)
       | Tvariant row -> read_row env px row
@@ -479,7 +487,7 @@ let rec read_type_expr env typ =
         let eqs = List.combine frags tyl in
 #endif
           let open TypeExpr.Package in
-          let path = Env.Path.read_module_type env p in
+          let path = Env.Path.read_module_type env.ident_env p in
           let substitutions =
             List.map
               (fun (frag,typ) ->
@@ -522,7 +530,7 @@ and read_row env _px row =
   let all_present = List.length present = List.length sorted_fields in
   match Compat.get_row_name row with
   | Some(p, params) when namable_row row ->
-      let p = Env.Path.read_type env p in
+      let p = Env.Path.read_type env.ident_env p in
       let params = List.map (read_type_expr env) params in
       if Compat.row_closed row && all_present then
         Constr (p, params)
@@ -535,15 +543,16 @@ and read_row env _px row =
       let elements =
         List.map
           (fun (name, f) ->
+            let doc = empty_doc in
             match Compat.row_field_repr f with
               | Rpresent None ->
-                Constructor {name; constant = true; arguments = []; doc = []}
+                Constructor {name; constant = true; arguments = []; doc}
               | Rpresent (Some typ) ->
                 Constructor {
                   name;
                   constant = false;
                   arguments = [read_type_expr env typ];
-                  doc = [];
+                  doc;
                 }
 #if OCAML_VERSION >= (4, 14, 0)
               | Reither(constant, typs, _) ->
@@ -553,7 +562,7 @@ and read_row env _px row =
                 let arguments =
                   List.map (read_type_expr env) typs
                 in
-                Constructor {name; constant; arguments; doc = []}
+                Constructor {name; constant; arguments; doc}
               | Rabsent -> assert false)
           sorted_fields
       in
@@ -600,20 +609,20 @@ and read_object env fi nm =
         in
         Object {fields = methods; open_}
     | Some (p, _ :: params) ->
-        let p = Env.Path.read_class_type env p in
+        let p = Env.Path.read_class_type env.ident_env p in
         let params = List.map (read_type_expr env) params in
         Class (p, params)
     | _ -> assert false
   end
 
-let read_value_description env parent id vd =
+let read_value_description ({ident_env ; suppress_warnings} as env) parent id vd =
   let open Signature in
-  let id = Env.find_value_identifier env id in
+  let id = Env.find_value_identifier ident_env id in
   let source_loc = None in
   let container =
     (parent : Identifier.Signature.t :> Identifier.LabelParent.t)
   in
-  let doc = Doc_attr.attached_no_tag container vd.val_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings container vd.val_attributes in
   mark_value_description vd;
   let type_ = read_type_expr env vd.val_type in
   let value =
@@ -635,7 +644,7 @@ let read_label_declaration env parent ld =
   let name = Ident.name ld.ld_id in
   let id = Identifier.Mk.field (parent, Odoc_model.Names.FieldName.make_std name) in
   let doc =
-    Doc_attr.attached_no_tag
+    Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings
       (parent :> Identifier.LabelParent.t) ld.ld_attributes
   in
   let mutable_ = (ld.ld_mutable = Mutable) in
@@ -658,9 +667,9 @@ let read_constructor_declaration_arguments env parent arg =
 
 let read_constructor_declaration env parent cd =
   let open TypeDecl.Constructor in
-  let id = Ident_env.find_constructor_identifier env cd.cd_id in
+  let id = Ident_env.find_constructor_identifier env.ident_env cd.cd_id in
   let container = (parent :> Identifier.LabelParent.t) in
-  let doc = Doc_attr.attached_no_tag container cd.cd_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings container cd.cd_attributes in
   let args =
     read_constructor_declaration_arguments env
       (parent :> Identifier.FieldParent.t) cd.cd_args
@@ -735,15 +744,15 @@ let read_class_constraints env params =
   let open ClassSignature in
   read_type_constraints env params
   |> List.map (fun (left, right) ->
-         Constraint { Constraint.left; right; doc = [] })
+         Constraint { Constraint.left; right; doc = empty_doc })
 
 let read_type_declaration env parent id decl =
   let open TypeDecl in
-  let id = Env.find_type_identifier env id in
+  let id = Env.find_type_identifier env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc, canonical =
-    Doc_attr.attached Odoc_model.Semantics.Expect_canonical container decl.type_attributes
+    Doc_attr.attached ~suppress_warnings:env.suppress_warnings Odoc_model.Semantics.Expect_canonical container decl.type_attributes
   in
   let canonical = match canonical with | None -> None | Some s -> Doc_attr.conv_canonical_type s in
   let params = mark_type_declaration decl in
@@ -779,10 +788,10 @@ let read_type_declaration env parent id decl =
 
 let read_extension_constructor env parent id ext =
   let open Extension.Constructor in
-  let id = Env.find_extension_identifier env id in
+  let id = Env.find_extension_identifier env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc = Doc_attr.attached_no_tag container ext.ext_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings container ext.ext_attributes in
   let args =
     read_constructor_declaration_arguments env
       (parent : Identifier.Signature.t :> Identifier.FieldParent.t) ext.ext_args
@@ -792,7 +801,7 @@ let read_extension_constructor env parent id ext =
 
 let read_type_extension env parent id ext rest =
   let open Extension in
-  let type_path = Env.Path.read_type env ext.ext_type_path in
+  let type_path = Env.Path.read_type env.ident_env ext.ext_type_path in
   let doc = Doc_attr.empty in
   let type_params = mark_type_extension' ext rest in
   let first = read_extension_constructor env parent id ext in
@@ -812,10 +821,10 @@ let read_type_extension env parent id ext rest =
 
 let read_exception env parent id ext =
   let open Exception in
-  let id = Env.find_exception_identifier env id in
+  let id = Env.find_exception_identifier env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc = Doc_attr.attached_no_tag container ext.ext_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings container ext.ext_attributes in
     mark_exception ext;
     let args =
       read_constructor_declaration_arguments env
@@ -854,7 +863,7 @@ let rec read_class_signature env parent params =
       || List.exists aliasable params
       then read_class_signature env parent params cty
       else begin
-        let p = Env.Path.read_class_type env p in
+        let p = Env.Path.read_class_type env.ident_env p in
         let params = List.map (read_type_expr env) params in
           Constr(p, params)
       end
@@ -881,7 +890,7 @@ let rec read_class_signature env parent params =
         List.map (read_method env parent (Compat.csig_concr csig)) methods
       in
       let items = constraints @ instance_variables @ methods in
-      Signature {self; items; doc = []}
+      Signature {self; items; doc = empty_doc}
   | Cty_arrow _ -> assert false
 
 let rec read_virtual = function
@@ -906,10 +915,10 @@ let rec read_virtual = function
 
 let read_class_type_declaration env parent id cltd =
   let open ClassType in
-  let id = Env.find_class_type_identifier env id in
+  let id = Env.find_class_type_identifier env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc = Doc_attr.attached_no_tag container cltd.clty_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings container cltd.clty_attributes in
     mark_class_type_declaration cltd;
     let params =
       List.map2
@@ -942,10 +951,10 @@ let rec read_class_type env parent params =
 
 let read_class_declaration env parent id cld =
   let open Class in
-  let id = Env.find_class_identifier env id in
+  let id = Env.find_class_identifier env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc = Doc_attr.attached_no_tag container cld.cty_attributes in
+  let doc = Doc_attr.attached_no_tag ~suppress_warnings:env.suppress_warnings container cld.cty_attributes in
     mark_class_declaration cld;
     let params =
       List.map2
@@ -961,7 +970,7 @@ let read_class_declaration env parent id cld =
 let rec read_module_type env parent (mty : Odoc_model.Compat.module_type) =
   let open ModuleType in
     match mty with
-    | Mty_ident p -> Path {p_path = Env.Path.read_module_type env p; p_expansion=None }
+    | Mty_ident p -> Path {p_path = Env.Path.read_module_type env.ident_env p; p_expansion=None }
     | Mty_signature sg -> Signature (read_signature env parent sg)
     | Mty_functor(parameter, res) ->
         let f_parameter, env =
@@ -970,8 +979,8 @@ let rec read_module_type env parent (mty : Odoc_model.Compat.module_type) =
           | Named (id_opt, arg) ->
               let id, env = match id_opt with
                 | None -> Identifier.Mk.parameter(parent, Odoc_model.Names.ModuleName.make_std "_"), env
-                | Some id -> let env = Env.add_parameter parent id (ModuleName.of_ident id) env in
-                  Ident_env.find_parameter_identifier env id, env
+                | Some id -> let e' = Env.add_parameter parent id (ModuleName.of_ident id) env.ident_env in
+                  Ident_env.find_parameter_identifier e' id, {env with ident_env = e'}
               in
               let arg = read_module_type env (id :> Identifier.Signature.t) arg in
               Odoc_model.Lang.FunctorParameter.Named ({ FunctorParameter. id; expr = arg }), env
@@ -979,30 +988,30 @@ let rec read_module_type env parent (mty : Odoc_model.Compat.module_type) =
         let res = read_module_type env (Identifier.Mk.result parent) res in
         Functor( f_parameter, res)
     | Mty_alias p ->
-        let t_original_path = Env.Path.read_module env p in
+        let t_original_path = Env.Path.read_module env.ident_env p in
         let t_desc = ModPath t_original_path in
         TypeOf { t_desc; t_expansion = None; t_original_path }
 
 and read_module_type_declaration env parent id (mtd : Odoc_model.Compat.modtype_declaration) =
   let open ModuleType in
-  let id = Env.find_module_type env id in
+  let id = Env.find_module_type env.ident_env id in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container mtd.mtd_attributes in
+  let doc, canonical = Doc_attr.attached ~suppress_warnings:env.suppress_warnings Odoc_model.Semantics.Expect_canonical container mtd.mtd_attributes in
   let canonical = match canonical with | None -> None | Some s -> Doc_attr.conv_canonical_module_type s in
   let expr = opt_map (read_module_type env (id :> Identifier.Signature.t)) mtd.mtd_type in
   {id; source_loc; doc; canonical; expr }
 
 and read_module_declaration env parent ident (md : Odoc_model.Compat.module_declaration) =
   let open Module in
-  let id = (Env.find_module_identifier env ident :> Identifier.Module.t) in
+  let id = (Env.find_module_identifier env.ident_env ident :> Identifier.Module.t) in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc, canonical = Doc_attr.attached Odoc_model.Semantics.Expect_canonical container md.md_attributes in
+  let doc, canonical = Doc_attr.attached ~suppress_warnings:env.suppress_warnings Odoc_model.Semantics.Expect_canonical container md.md_attributes in
   let canonical = match canonical with | None -> None | Some s -> Some (Doc_attr.conv_canonical_module s) in
   let type_ =
     match md.md_type with
-    | Mty_alias p -> Alias (Env.Path.read_module env p, None)
+    | Mty_alias p -> Alias (Env.Path.read_module env.ident_env p, None)
     | _ -> ModuleType (read_module_type env (id :> Identifier.Signature.t) md.md_type)
   in
   let hidden =
@@ -1035,9 +1044,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_value(id, v, _) :: rest ->
         let vd = read_value_description env parent id v in
         let shadowed =
-          if Env.is_shadowed env id
+          if Env.is_shadowed env.ident_env id
           then
-            let identifier = Env.find_value_identifier env id in
+            let identifier = Env.find_value_identifier env.ident_env id in
           match identifier.iv with
           | `Value (_, n) -> { shadowed with s_values = (Odoc_model.Names.parenthesise (Ident.name id), n) :: shadowed.s_values }
           else shadowed
@@ -1049,9 +1058,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_type(id, decl, rec_status, _)::rest ->
         let decl = read_type_declaration env parent id decl in
         let shadowed =
-          if Env.is_shadowed env id
+          if Env.is_shadowed env.ident_env id
           then
-            let identifier = Env.find_type_identifier env id in
+            let identifier = Env.find_type_identifier env.ident_env id in
             let `Type (_, name) = identifier.iv in
             { shadowed with s_types = (Ident.name id, name) :: shadowed.s_types }
           else shadowed
@@ -1077,9 +1086,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_module (id, _, md, rec_status, _)::rest ->
           let md = read_module_declaration env parent id md in
           let shadowed =
-            if Env.is_shadowed env id
+            if Env.is_shadowed env.ident_env id
             then
-              let identifier = Env.find_module_identifier env id in
+              let identifier = Env.find_module_identifier env.ident_env id in
             let name =
               match identifier.iv with
               | `Module (_, n) -> n 
@@ -1093,9 +1102,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_modtype(id, mtd, _) :: rest ->
           let mtd = read_module_type_declaration env parent id mtd in
           let shadowed =
-            if Env.is_shadowed env id
+            if Env.is_shadowed env.ident_env id
             then
-              let identifier = Env.find_module_type env id in
+              let identifier = Env.find_module_type env.ident_env id in
             let name =
               match identifier.iv with
               | `ModuleType (_, n) -> n
@@ -1114,9 +1123,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
 #endif
           let cl = read_class_declaration env parent id cl in
           let shadowed =
-            if Env.is_shadowed env id
+            if Env.is_shadowed env.ident_env id
             then
-              let identifier = Env.find_class_identifier env id in
+              let identifier = Env.find_class_identifier env.ident_env id in
             let name =
               match identifier.iv with
               | `Class (_, n) -> n
@@ -1133,9 +1142,9 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
 #endif
         let cltyp = read_class_type_declaration env parent id cltyp in
         let shadowed =
-          if Env.is_shadowed env id
+          if Env.is_shadowed env.ident_env id
           then
-            let identifier = Env.find_class_type_identifier env id in
+            let identifier = Env.find_class_type_identifier env.ident_env id in
           let name =
             match identifier.iv with
             | `ClassType (_, n) -> n
@@ -1152,16 +1161,23 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
     | Sig_class_type _ :: _
     | Sig_class _ :: _ -> assert false
 
-    | [] -> ({items = List.rev acc; compiled=false; removed = []; doc = [] }, shadowed)
+    | [] -> ({items = List.rev acc; compiled=false; removed = []; doc = empty_doc }, shadowed)
   in
     loop ([],{s_modules=[]; s_module_types=[]; s_values=[];s_types=[]; s_classes=[]; s_class_types=[]}) items
 
 and read_signature env parent (items : Odoc_model.Compat.signature) =
-  let env = Env.handle_signature_type_items parent items env in
+  let e' = Env.handle_signature_type_items parent items env.ident_env in
+  let env = { env with ident_env = e' } in
   fst @@ read_signature_noenv env parent items
 
 
-let read_interface root name intf =
-  let id = Identifier.Mk.root (root, Odoc_model.Names.ModuleName.make_std name) in
-  let items = read_signature (Env.empty ()) id intf in
+let read_interface root name suppress_warnings intf =
+  let id =
+    Identifier.Mk.root (root, Odoc_model.Names.ModuleName.make_std name)
+  in
+  let items =
+    read_signature
+      { ident_env = Env.empty (); suppress_warnings }
+      id intf
+  in
   (id, items)

--- a/src/loader/cmi.mli
+++ b/src/loader/cmi.mli
@@ -18,9 +18,16 @@
 
 module Paths = Odoc_model.Paths
 
+
+type env = {
+  ident_env : Ident_env.t; (** Environment *)
+  suppress_warnings : bool (** Suppress warnings *)
+}
+
 val read_interface :
   Odoc_model.Paths.Identifier.ContainerPage.t option ->
   string ->
+  bool ->
   Odoc_model.Compat.signature ->
   Paths.Identifier.RootModule.t * Odoc_model.Lang.Signature.t
 
@@ -32,7 +39,7 @@ val read_label : Asttypes.arg_label -> Odoc_model.Lang.TypeExpr.label option
 
 val mark_type_expr : Types.type_expr -> unit
 
-val read_type_expr : Ident_env.t ->
+val read_type_expr : env ->
                      Types.type_expr -> Odoc_model.Lang.TypeExpr.t
 
 val mark_type_extension : Types.type_expr list ->
@@ -46,44 +53,45 @@ val mark_class_declaration : Types.class_declaration -> unit
 
 val read_self_type : Types.type_expr -> Odoc_model.Lang.TypeExpr.t option
 
-val read_type_constraints : Ident_env.t -> Types.type_expr list ->
+val read_type_constraints : env -> Types.type_expr list ->
                             (Odoc_model.Lang.TypeExpr.t
                              * Odoc_model.Lang.TypeExpr.t) list
 
 val read_class_constraints :
-  Ident_env.t ->
+  env ->
   Types.type_expr list ->
   Odoc_model.Lang.ClassSignature.item list
 
-val read_class_signature : Ident_env.t ->
+val read_class_signature : env ->
                            Paths.Identifier.ClassSignature.t ->
                            Types.type_expr list -> Types.class_type ->
                            Odoc_model.Lang.ClassType.expr
 
-val read_class_type : Ident_env.t ->
+val read_class_type : env ->
                       Paths.Identifier.ClassSignature.t ->
                       Types.type_expr list -> Types.class_type ->
                       Odoc_model.Lang.Class.decl
 
-val read_module_type : Ident_env.t ->
+val read_module_type : env ->
                        Paths.Identifier.Signature.t ->
                        Odoc_model.Compat.module_type -> Odoc_model.Lang.ModuleType.expr
 
-val read_signature_noenv : Ident_env.t ->
+val read_signature_noenv : env ->
                        Paths.Identifier.Signature.t ->
                        Odoc_model.Compat.signature ->
                        (Odoc_model.Lang.Signature.t * Odoc_model.Lang.Include.shadowed)
 
-val read_signature : Ident_env.t ->
+val read_signature : env ->
                      Paths.Identifier.Signature.t ->
                      Odoc_model.Compat.signature -> Odoc_model.Lang.Signature.t
 
 
-val read_extension_constructor : Ident_env.t ->
+val read_extension_constructor : env ->
                        Paths.Identifier.Signature.t ->
                        Ident.t -> Types.extension_constructor ->
                        Odoc_model.Lang.Extension.Constructor.t
 
-val read_exception : Ident_env.t ->
+val read_exception : env ->
   Paths.Identifier.Signature.t -> Ident.t ->
   Types.extension_constructor -> Odoc_model.Lang.Exception.t
+ 

--- a/src/loader/cmt.mli
+++ b/src/loader/cmt.mli
@@ -17,6 +17,7 @@
 val read_implementation :
   Odoc_model.Paths.Identifier.ContainerPage.t option ->
   string ->
+  bool ->
   Typedtree.structure ->
   Odoc_model.Paths.Identifier.RootModule.t
   * Odoc_model.Lang.Signature.t

--- a/src/loader/cmti.mli
+++ b/src/loader/cmti.mli
@@ -17,7 +17,7 @@
 module Paths = Odoc_model.Paths
 
 val read_module_expr :
-  (Ident_env.t ->
+  (Cmi.env ->
   Paths.Identifier.Signature.t ->
   Paths.Identifier.LabelParent.t ->
   Typedtree.module_expr ->
@@ -27,6 +27,7 @@ val read_module_expr :
 val read_interface :
   Odoc_model.Paths.Identifier.ContainerPage.t option ->
   string ->
+  bool ->
   Typedtree.signature ->
   Paths.Identifier.RootModule.t
   * Odoc_model.Lang.Signature.t
@@ -35,33 +36,33 @@ val read_interface :
     [@canonical] tag. *)
 
 val read_module_type :
-  Ident_env.t ->
+  Cmi.env ->
   Paths.Identifier.Signature.t ->
   Paths.Identifier.LabelParent.t ->
   Typedtree.module_type ->
   Odoc_model.Lang.ModuleType.expr
 
 val read_value_description :
-  Ident_env.t ->
+  Cmi.env ->
   Paths.Identifier.Signature.t ->
   Typedtree.value_description ->
   Odoc_model.Lang.Signature.item
 
 val read_type_declarations :
-  Ident_env.t ->
+  Cmi.env ->
   Paths.Identifier.Signature.t ->
   Odoc_model.Lang.Signature.recursive ->
   Typedtree.type_declaration list ->
   Odoc_model.Lang.Signature.item list
 
 val read_module_type_declaration :
-  Ident_env.t ->
+  Cmi.env ->
   Paths.Identifier.Signature.t ->
   Typedtree.module_type_declaration ->
   Odoc_model.Lang.ModuleType.t
 
 val read_class_type_declarations :
-  Ident_env.t ->
+  Cmi.env ->
   Paths.Identifier.Signature.t ->
   Typedtree.class_type Typedtree.class_infos list ->
   Odoc_model.Lang.Signature.item list

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -22,12 +22,14 @@ val empty : Odoc_model.Comment.docs
 val is_stop_comment : Parsetree.attribute -> bool
 
 val attached :
+  suppress_warnings:bool ->
   'tags Semantics.handle_internal_tags ->
   Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
   Odoc_model.Comment.docs * 'tags
 
 val attached_no_tag :
+  suppress_warnings:bool ->
   Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
   Odoc_model.Comment.docs
@@ -47,11 +49,13 @@ val page :
 
 val standalone :
   Paths.Identifier.LabelParent.t ->
+  suppress_warnings:bool ->
   Parsetree.attribute ->
   Odoc_model.Comment.docs_or_stop option
 
 val standalone_multiple :
   Paths.Identifier.LabelParent.t ->
+  suppress_warnings:bool ->
   Parsetree.attributes ->
   Odoc_model.Comment.docs_or_stop list
 

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -23,6 +23,7 @@ val is_stop_comment : Parsetree.attribute -> bool
 
 val attached :
   suppress_warnings:bool ->
+  env:Ident_env.t ->
   'tags Semantics.handle_internal_tags ->
   Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
@@ -30,6 +31,7 @@ val attached :
 
 val attached_no_tag :
   suppress_warnings:bool ->
+  env:Ident_env.t ->
   Paths.Identifier.LabelParent.t ->
   Parsetree.attributes ->
   Odoc_model.Comment.docs
@@ -60,6 +62,7 @@ val standalone_multiple :
   Odoc_model.Comment.docs_or_stop list
 
 val extract_top_comment :
+  env:Ident_env.t ->
   'tags Semantics.handle_internal_tags ->
   classify:('item -> [ `Attribute of Parsetree.attribute | `Open ] option) ->
   Paths.Identifier.Signature.t ->

--- a/src/loader/ident_env.cppo.mli
+++ b/src/loader/ident_env.cppo.mli
@@ -87,3 +87,31 @@ val identifier_of_loc : t -> Location.t -> Paths.Identifier.t option
 val iter_located_identifier :
   t -> (Location.t -> Paths.Identifier.t -> unit) -> unit
 (** Iter on all stored pair [location]-[identifier]. *)
+
+val lookup_module_by_name : t -> string -> Paths.Identifier.Module.t list
+(** Lookup a module by its name. *)
+
+val lookup_module_type_by_name :
+  t -> string -> Paths.Identifier.ModuleType.t list
+(** Lookup a module type by its name. *)
+
+val lookup_type_by_name : t -> string -> Paths.Identifier.Type.t list
+(** Lookup a type by its name. *)
+
+val lookup_value_by_name : t -> string -> Paths.Identifier.Value.t list
+(** Lookup a value by its name. *)
+
+val lookup_exception_by_name :
+  t -> string -> Paths.Identifier.Exception.t list
+(** Lookup an exception by its name. *)
+
+val lookup_constructor_by_name :
+  t -> string -> Paths.Identifier.Constructor.t list
+(** Lookup a constructor by its name. *)
+
+val lookup_class_by_name : t -> string -> Paths.Identifier.Class.t list
+(** Lookup a class by its name *)
+
+val lookup_class_type_by_name :
+  t -> string -> Paths.Identifier.ClassType.t list
+(** Lookup a class type by its name *)

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -101,7 +101,7 @@ let compilation_unit_of_sig ~make_root ~imports ~interface ?sourcefile ~name ~id
   make_compilation_unit ~make_root ~imports ~interface ?sourcefile ~name ~id
     ?canonical content
 
-let read_cmti ~make_root ~parent ~filename () =
+let read_cmti ~make_root ~parent ~filename ~suppress_warnings () =
   let cmt_info = Cmt_format.read_cmt filename in
   match cmt_info.cmt_annots with
   | Interface intf -> (
@@ -118,12 +118,14 @@ let read_cmti ~make_root ~parent ~filename () =
               cmt_info.cmt_source_digest,
               cmt_info.cmt_builddir )
           in
-          let id, sg, canonical = Cmti.read_interface parent name intf in
+          let id, sg, canonical =
+            Cmti.read_interface parent name suppress_warnings intf
+          in
           compilation_unit_of_sig ~make_root ~imports:cmt_info.cmt_imports
             ~interface ~sourcefile ~name ~id ?canonical sg)
   | _ -> raise Not_an_interface
 
-let read_cmt ~make_root ~parent ~filename () =
+let read_cmt ~make_root ~parent ~filename ~suppress_warnings () =
   match Cmt_format.read_cmt filename with
   | exception Cmi_format.Error (Not_an_interface _) ->
       raise Not_an_implementation
@@ -175,17 +177,19 @@ let read_cmt ~make_root ~parent ~filename () =
           make_compilation_unit ~make_root ~imports ~interface ~sourcefile ~name
             ~id content
       | Implementation impl ->
-          let id, sg, canonical = Cmt.read_implementation parent name impl in
+          let id, sg, canonical =
+            Cmt.read_implementation parent name suppress_warnings impl
+          in
           compilation_unit_of_sig ~make_root ~imports ~interface ~sourcefile
             ~name ~id ?canonical sg
       | _ -> raise Not_an_implementation)
 
-let read_cmi ~make_root ~parent ~filename () =
+let read_cmi ~make_root ~parent ~filename ~suppress_warnings () =
   let cmi_info = Cmi_format.read_cmi filename in
   match cmi_info.cmi_crcs with
   | (name, (Some _ as interface)) :: imports when name = cmi_info.cmi_name ->
       let id, sg =
-        Cmi.read_interface parent name
+        Cmi.read_interface parent name suppress_warnings
           (Odoc_model.Compat.signature cmi_info.cmi_sign)
       in
       compilation_unit_of_sig ~make_root ~imports ~interface ~name ~id sg
@@ -251,16 +255,19 @@ let wrap_errors ~filename f =
       | Not_an_interface -> not_an_interface filename
       | Make_root_error m -> error_msg filename m)
 
-let read_cmti ~make_root ~parent ~filename =
-  wrap_errors ~filename (read_cmti ~make_root ~parent ~filename)
+let read_cmti ~make_root ~parent ~filename ~suppress_warnings =
+  wrap_errors ~filename
+    (read_cmti ~make_root ~parent ~filename ~suppress_warnings)
 
-let read_cmt ~make_root ~parent ~filename =
-  wrap_errors ~filename (read_cmt ~make_root ~parent ~filename)
+let read_cmt ~make_root ~parent ~filename ~suppress_warnings =
+  wrap_errors ~filename
+    (read_cmt ~make_root ~parent ~filename ~suppress_warnings)
 
 let read_impl ~make_root ~filename ~source_id =
   wrap_errors ~filename (read_impl ~make_root ~source_id ~filename)
 
-let read_cmi ~make_root ~parent ~filename =
-  wrap_errors ~filename (read_cmi ~make_root ~parent ~filename)
+let read_cmi ~make_root ~parent ~filename ~suppress_warnings =
+  wrap_errors ~filename
+    (read_cmi ~make_root ~parent ~filename ~suppress_warnings)
 
 let read_location = Doc_attr.read_location

--- a/src/loader/odoc_loader.mli
+++ b/src/loader/odoc_loader.mli
@@ -17,12 +17,14 @@ val read_cmti :
   make_root:make_root ->
   parent:Identifier.ContainerPage.t option ->
   filename:string ->
+  suppress_warnings:bool ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_cmt :
   make_root:make_root ->
   parent:Identifier.ContainerPage.t option ->
   filename:string ->
+  suppress_warnings:bool ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_impl :
@@ -35,6 +37,7 @@ val read_cmi :
   make_root:make_root ->
   parent:Identifier.ContainerPage.t option ->
   filename:string ->
+  suppress_warnings:bool ->
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_location : Location.t -> Location_.span

--- a/src/loader/resolve_init.ml
+++ b/src/loader/resolve_init.ml
@@ -1,0 +1,137 @@
+(* Partially resolve references in docs *)
+open Odoc_model
+
+module Resolve = struct
+  let lookup_signature env name : Paths.Reference.Signature.t option =
+    let all =
+      (Ident_env.lookup_module_by_name env name
+        :> Paths.Identifier.Signature.t list)
+      @ (Ident_env.lookup_module_type_by_name env name
+          :> Paths.Identifier.Signature.t list)
+    in
+    match all with x :: _ -> Some (`Resolved (`Identifier x)) | _ -> None
+
+  let lookup_any env name : Paths.Reference.t option =
+    let all =
+      (Ident_env.lookup_module_by_name env name :> Paths.Identifier.t list)
+      @ (Ident_env.lookup_module_type_by_name env name
+          :> Paths.Identifier.t list)
+      @ (Ident_env.lookup_type_by_name env name :> Paths.Identifier.t list)
+      @ (Ident_env.lookup_value_by_name env name :> Paths.Identifier.t list)
+    in
+    match all with x :: _ -> Some (`Resolved (`Identifier x)) | _ -> None
+
+  let rec signature env (x : Odoc_model.Paths.Reference.Signature.t) :
+      Odoc_model.Paths.Reference.Signature.t =
+    match x with
+    | `Resolved _ -> x
+    | `Root (r, t) -> (
+        match t with
+        | `TUnknown -> (
+            match lookup_signature env r with Some x -> x | None -> x)
+        | `TModule | `TModuleType -> x)
+    | `Dot (p, n) -> `Dot (label_parent env p, n)
+    | `Module_path _ -> x
+    | `Module (x, n) -> `Module (signature env x, n)
+    | `ModuleType (x, n) -> `ModuleType (signature env x, n)
+
+  and label_parent env (x : Odoc_model.Paths.Reference.LabelParent.t) :
+      Odoc_model.Paths.Reference.LabelParent.t =
+    match x with
+    | `Resolved _ -> x
+    | `Dot (p, n) -> `Dot (label_parent env p, n)
+    | `Root (r, t) -> (
+        match t with
+        | `TUnknown -> (
+            match lookup_signature env r with
+            | Some x -> (x :> Odoc_model.Paths.Reference.LabelParent.t)
+            | None -> x)
+        | `TModule | `TModuleType | `TClass | `TClassType | `TType | `TPage
+        | `TChildPage | `TChildModule ->
+            x)
+    | `Module_path _ | `Any_path _ | `Page_path _ -> x
+    | `Module (x, n) -> `Module (signature env x, n)
+    | `ModuleType (x, n) -> `ModuleType (signature env x, n)
+    | `Type (x, n) -> `Type (signature env x, n)
+    | `Class (x, n) -> `Class (signature env x, n)
+    | `ClassType (x, n) -> `ClassType (signature env x, n)
+
+  let do_resolve env (x : Odoc_model.Paths.Reference.t) :
+      Odoc_model.Paths.Reference.t =
+    match x with
+    | `Resolved _ -> x
+    | `Root
+        ( _r,
+          ( `TModule | `TModuleType | `TType | `TConstructor | `TField
+          | `TExtension | `TExtensionDecl | `TException | `TValue | `TClass
+          | `TClassType | `TMethod | `TInstanceVariable | `TLabel | `TPage
+          | `TAsset | `TChildPage | `TChildModule | `TUnknown ) ) ->
+        x
+    | `Dot (p, n) -> `Dot (label_parent env p, n)
+    | `Page_path _ | `Module_path _ | `Asset_path _ | `Any_path _ -> x
+    | `Module (r, n) -> `Module (signature env r, n)
+    | `ModuleType (r, n) -> `ModuleType (signature env r, n)
+    | `Type (r, n) -> `Type (signature env r, n)
+    | `Constructor _ -> x (* TODO *)
+    | `Field _ -> x (* TODO *)
+    | `Extension _ -> x (* TODO *)
+    | `ExtensionDecl _ -> x (* TODO *)
+    | `Exception _ -> x (* TODO *)
+    | `Value _ -> x (* TODO *)
+    | `Class (r, n) -> `Class (signature env r, n)
+    | `ClassType (r, n) -> `ClassType (signature env r, n)
+    | `Method _ -> x (* TODO *)
+    | `InstanceVariable _ -> x (* TODO *)
+    | `Label _ -> x (* TODO *)
+end
+
+let with_location :
+    ('a -> 'b) -> 'a Comment.with_location -> 'b Comment.with_location =
+ fun handler v -> { v with value = handler v.value }
+
+let rec inline_element env (x : Comment.inline_element) : Comment.inline_element
+    =
+  match x with
+  | `Space -> x
+  | `Word _ -> x
+  | `Code_span _ -> x
+  | `Math_span _ -> x
+  | `Raw_markup _ -> x
+  | `Reference (r, x) -> `Reference (Resolve.do_resolve env r, x)
+  | `Styled (s, i) ->
+      `Styled (s, List.map (with_location (inline_element env)) i)
+  | `Link _ -> x
+
+let paragraph env = List.map (with_location (inline_element env))
+
+let rec nestable_block_element :
+    Ident_env.t ->
+    Comment.nestable_block_element ->
+    Comment.nestable_block_element =
+ fun env -> function
+  | `Paragraph p -> `Paragraph (paragraph env p)
+  | `Code_block _ as x -> x
+  | `Math_block _ as x -> x
+  | `Verbatim _ as x -> x
+  | `Modules _ as x -> x
+  | `Table _ as x -> x
+  | `List (kind, items) ->
+      `List
+        ( kind,
+          List.map (List.map (with_location (nestable_block_element env))) items
+        )
+  | `Media _ as x -> x
+
+let tag : Comment.tag -> Comment.tag = function x -> x
+
+let block_element env : Comment.block_element -> Comment.block_element =
+  function
+  | #Comment.nestable_block_element as e ->
+      (nestable_block_element env e :> Comment.block_element)
+  | `Heading (attrs, label, content) ->
+      `Heading
+        (attrs, label, List.map (with_location (inline_element env)) content)
+  | `Tag t -> `Tag t
+
+let resolve env (v : Comment.elements) =
+  List.map (with_location (block_element env)) v

--- a/src/markdown/odoc_md.ml
+++ b/src/markdown/odoc_md.ml
@@ -20,9 +20,9 @@ let parse id input_s =
   in
   (content, List.map Error.t_of_parser_t parser_warnings @ semantics_warnings)
 
-let mk_page input_s id content =
+let mk_page input_s id elements =
   (* Construct the output file representation *)
-  let zero_heading = Comment.find_zero_heading content in
+  let zero_heading = Comment.find_zero_heading elements in
   let frontmatter = Frontmatter.empty in
   let digest = Digest.file input_s in
   let root =
@@ -34,7 +34,7 @@ let mk_page input_s id content =
     Lang.Page.name = id;
     root;
     children;
-    content;
+    content = { elements; suppress_warnings = false };
     digest;
     linked = false;
     frontmatter;

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -113,7 +113,9 @@ type block_element =
     heading_attrs * Identifier.Label.t * inline_element with_location list
   | `Tag of tag ]
 
-type docs = block_element with_location list
+type elements = block_element with_location list
+
+type docs = { elements : elements; suppress_warnings : bool }
 
 type docs_or_stop = [ `Docs of docs | `Stop ]
 

--- a/src/model/error.ml
+++ b/src/model/error.ml
@@ -101,7 +101,11 @@ let print_error ?prefix t = prerr_endline (_to_string ?prefix t)
 
 let print_errors = List.iter print_error
 
-type warnings_options = { warn_error : bool; print_warnings : bool }
+type warnings_options = {
+  warn_error : bool;
+  print_warnings : bool;
+  suppress_warnings : bool;
+}
 
 let print_warnings ~warnings_options warnings =
   if warnings_options.print_warnings then

--- a/src/model/error.mli
+++ b/src/model/error.mli
@@ -41,6 +41,7 @@ val catch_errors_and_warnings : (unit -> 'a) -> 'a with_errors_and_warnings
 type warnings_options = {
   warn_error : bool;  (** If [true], warnings will result in an error. *)
   print_warnings : bool;  (** Whether to print warnings. *)
+  suppress_warnings : bool;  (** Whether to suppress warnings. *)
 }
 
 val handle_warnings :

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -571,5 +571,6 @@ let extract_signature_doc (s : Signature.t) =
     | { decl = ModuleType expr; _ } -> uexpr_considered_hidden expr
   in
   match (s.doc, s.items) with
-  | [], Include inc :: _ when should_take_top inc -> inc.expansion.content.doc
+  | { elements = []; _ }, Include inc :: _ when should_take_top inc ->
+      inc.expansion.content.doc
   | doc, _ -> doc

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -551,9 +551,9 @@ module rec Reference : sig
   type tag_only_child_module = [ `TChildModule ]
 
   type tag_hierarchy =
-    [ `TRelativePath  (** {!identifier/} *)
-    | `TAbsolutePath  (** {!/identifier} *)
-    | `TCurrentPackage  (** {!//identifier} *) ]
+    [ `TRelativePath  (** [{!identifier/}] *)
+    | `TAbsolutePath  (** [{!/identifier}] *)
+    | `TCurrentPackage  (** [{!//identifier}] *) ]
   (** @canonical Odoc_model.Paths.Reference.tag_hierarchy *)
 
   type tag_any =

--- a/src/model/semantics.ml
+++ b/src/model/semantics.ml
@@ -531,7 +531,7 @@ let append_alerts_to_comment alerts
           comment)
       alerts
   in
-  comment @ (alerts : alerts :> Comment.docs)
+  comment @ (alerts :> Comment.elements)
 
 let handle_internal_tags (type a) tags : a handle_internal_tags -> a = function
   | Expect_status -> (

--- a/src/model/semantics.mli
+++ b/src/model/semantics.mli
@@ -17,7 +17,7 @@ val ast_to_comment :
   parent_of_sections:Paths.Identifier.LabelParent.t ->
   Odoc_parser.Ast.t ->
   alerts ->
-  (Comment.docs * 'tags) Error.with_warnings
+  (Comment.elements * 'tags) Error.with_warnings
 
 val non_link_inline_element :
   context:string ->
@@ -30,6 +30,6 @@ val parse_comment :
   containing_definition:Paths.Identifier.LabelParent.t ->
   location:Lexing.position ->
   text:string ->
-  (Comment.docs * 'tags) Error.with_warnings
+  (Comment.elements * 'tags) Error.with_warnings
 
 val parse_reference : string -> Paths.Reference.t Error.with_errors_and_warnings

--- a/src/model_desc/comment_desc.mli
+++ b/src/model_desc/comment_desc.mli
@@ -1,8 +1,10 @@
 open Odoc_model
 open Odoc_model.Comment
 
-val docs : docs Type_desc.t
-
 val inline_element : inline_element Location_.with_location list Type_desc.t
+
+val elements : elements Type_desc.t
+
+val docs : docs Type_desc.t
 
 val docs_or_stop : docs_or_stop Type_desc.t

--- a/src/ocamlary/ocamlary.mli
+++ b/src/ocamlary/ocamlary.mli
@@ -1068,10 +1068,3 @@ type new_t = ..
 type new_t += C
 
 module type TypeExtPruned = TypeExt with type t := new_t
-
-(** {1 Unresolved references} *)
-
-(** - {!Stdlib.Invalid_argument}
-    - {!Hashtbl.t}
-    - {!Set.S.empty}
-    - {!CollectionModule.InnerModuleA.foo} *)

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -141,12 +141,29 @@ let warnings_options =
     let env = Arg.env_var "ODOC_ENABLE_MISSING_ROOT_WARNING" ~doc in
     Arg.(value & flag & info ~docs ~doc ~env [ "enable-missing-root-warning" ])
   in
+  let suppress_warnings =
+    let doc =
+      "Suppress warnings. This is useful when you want to declare that \
+       warnings that would be generated resolving the references defined in \
+       this unit should be ignored if they end up in expansions in other \
+       units."
+    in
+    let env = Arg.env_var "ODOC_SUPPRESS_WARNINGS" ~doc in
+    Arg.(value & flag & info ~docs ~doc ~env [ "suppress-warnings" ])
+  in
   Term.(
-    const (fun warn_error print_warnings enable_missing_root_warning ->
+    const
+      (fun
+        warn_error
+        print_warnings
+        enable_missing_root_warning
+        suppress_warnings
+      ->
         Odoc_model.Error.enable_missing_root_warning :=
           enable_missing_root_warning;
-        { Odoc_model.Error.warn_error; print_warnings })
-    $ warn_error $ print_warnings $ enable_missing_root_warning)
+        { Odoc_model.Error.warn_error; print_warnings; suppress_warnings })
+    $ warn_error $ print_warnings $ enable_missing_root_warning
+    $ suppress_warnings)
 
 let dst ?create () =
   let doc = "Output directory where the HTML tree is expected to be saved." in
@@ -965,7 +982,11 @@ end = struct
           ~roots:None
       in
       let warnings_options =
-        { Odoc_model.Error.warn_error = false; print_warnings = false }
+        {
+          Odoc_model.Error.warn_error = false;
+          print_warnings = false;
+          suppress_warnings = false;
+        }
       in
       Rendering.targets_odoc ~resolver ~warnings_options ~syntax:OCaml
         ~renderer:R.renderer ~output:output_dir ~extra odoc_file
@@ -1000,7 +1021,11 @@ end = struct
   module Targets_source = struct
     let list_targets output_dir source_file extra odoc_file =
       let warnings_options =
-        { Odoc_model.Error.warn_error = false; print_warnings = false }
+        {
+          Odoc_model.Error.warn_error = false;
+          print_warnings = false;
+          suppress_warnings = false;
+        }
       in
       Rendering.targets_source_odoc ~warnings_options ~syntax:OCaml
         ~renderer:R.renderer ~output:output_dir ~extra ~source_file odoc_file

--- a/src/odoc/odoc_link.ml
+++ b/src/odoc/odoc_link.ml
@@ -34,7 +34,14 @@ let content_for_hidden_modules =
       `Word "hidden.";
     ]
   in
-  [ Comment (`Docs [ with_loc @@ `Paragraph (List.map with_loc sentence) ]) ]
+  [
+    Comment
+      (`Docs
+        {
+          elements = [ with_loc @@ `Paragraph (List.map with_loc sentence) ];
+          suppress_warnings = true;
+        });
+  ]
 
 let link_unit ~resolver ~filename m =
   let open Odoc_model in
@@ -49,7 +56,7 @@ let link_unit ~resolver ~filename m =
               items = content_for_hidden_modules;
               compiled = false;
               removed = [];
-              doc = [];
+              doc = { elements = []; suppress_warnings = false };
             };
         expansion = None;
       }

--- a/src/odoc/url.ml
+++ b/src/odoc/url.ml
@@ -7,7 +7,13 @@ let resolve url_to_string directories reference =
   in
   let reference =
     let open Odoc_model in
-    let warnings_options = { Error.warn_error = true; print_warnings = true } in
+    let warnings_options =
+      {
+        Error.warn_error = true;
+        print_warnings = true;
+        suppress_warnings = false;
+      }
+    in
     Semantics.parse_reference reference
     |> Error.handle_errors_and_warnings ~warnings_options
   in

--- a/src/search/html.mli
+++ b/src/search/html.mli
@@ -9,7 +9,7 @@ val url : Entry.t -> string
 
 (** The below is intended for search engine that do not use the Json output but
     Odoc as a library. Most search engine will use their own representation
-    instead of {!Entry.t}, and may not want to store the whole HTML in their
+    instead of {!Odoc_index.Entry.t}, and may not want to store the whole HTML in their
     database. The following functions help give correct values to store in a
     search database. *)
 

--- a/src/search/odoc_html_frontend.mli
+++ b/src/search/odoc_html_frontend.mli
@@ -1,6 +1,6 @@
 (**  This library is intended for search engine that do not use the Json output
     but Odoc as a library. Most search engine will use their own representation
-    instead of {!Entry.t}, and may not want to store the whole HTML in their
+    instead of {!Odoc_index.Entry.t}, and may not want to store the whole HTML in their
     database.
     This library contains functions that are useful for the frontend of such
     search engines.

--- a/src/search/text.ml
+++ b/src/search/text.ml
@@ -42,7 +42,7 @@ module Of_comments = struct
   let get_value x = x.Odoc_model.Location_.value
 
   let rec string_of_doc (doc : Odoc_model.Comment.docs) =
-    doc |> List.map get_value
+    doc.elements |> List.map get_value
     |> List.map s_of_block_element
     |> String.concat "\n"
 

--- a/src/utils/odoc_list.ml
+++ b/src/utils/odoc_list.ml
@@ -16,7 +16,7 @@ let rec filter_map acc f = function
 
 let filter_map f x = filter_map [] f x
 
-(** @raise [Failure] if the list is empty. *)
+(** @raise Failure if the list is empty. *)
 let rec last = function
   | [] -> failwith "Odoc_utils.List.last"
   | [ x ] -> x

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -253,7 +253,11 @@ and signature_items : Env.t -> Id.Signature.t -> Signature.item list -> _ =
                 Component.Delayed.(
                   put (fun () -> Component.Of_Lang.(module_ (empty ()) m)))
               in
-              Env.add_module (m.id :> Paths.Identifier.Path.Module.t) ty [] env
+              Env.add_module
+                (m.id :> Paths.Identifier.Path.Module.t)
+                ty
+                { elements = []; suppress_warnings = false }
+                env
             in
             let env =
               match r with

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -433,7 +433,10 @@ and CComment : sig
     | `Media of
       Odoc_model.Comment.media_href * Odoc_model.Comment.media * string ]
 
-  type docs = block_element Odoc_model.Comment.with_location list
+  type docs = {
+    elements : block_element Odoc_model.Comment.with_location list;
+    suppress_warnings : bool;
+  }
 
   type docs_or_stop = [ `Docs of docs | `Stop ]
 end

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -273,7 +273,7 @@ let add_docs (docs : Comment.docs) env =
           let label = Ident.Of_Identifier.label id in
           add_label id { Component.Label.attrs; label; text; location } env
       | _ -> env)
-    env docs
+    env docs.elements
 
 let add_comment (com : Comment.docs_or_stop) env =
   match com with `Docs doc -> add_docs doc env | `Stop -> env
@@ -289,7 +289,7 @@ let add_cdocs p (docs : Component.CComment.docs) env =
           in
           add_label label h env
       | _ -> env)
-    env docs
+    env docs.elements
 
 let add_module identifier m docs env =
   let env' = add_to_elts Kind_Module identifier (`Module (identifier, m)) env in
@@ -373,7 +373,7 @@ let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
           {
             id;
             source_loc = None;
-            doc = [];
+            doc = { elements = []; suppress_warnings = false };
             type_ = ModuleType (Signature s);
             canonical = unit.canonical;
             hidden = unit.hidden;
@@ -387,11 +387,16 @@ let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
           {
             id;
             source_loc = None;
-            doc = [];
+            doc = { elements = []; suppress_warnings = false };
             type_ =
               ModuleType
                 (Signature
-                   { items = []; compiled = true; removed = []; doc = [] });
+                   {
+                     items = [];
+                     compiled = true;
+                     removed = [];
+                     doc = { elements = []; suppress_warnings = false };
+                   });
             canonical = unit.canonical;
             hidden = unit.hidden;
           }
@@ -644,7 +649,13 @@ let lookup_fragment_root env =
 let mk_functor_parameter module_type =
   let type_ = Component.Module.ModuleType module_type in
   Component.Module.
-    { source_loc = None; doc = []; type_; canonical = None; hidden = false }
+    {
+      source_loc = None;
+      doc = { elements = []; suppress_warnings = false };
+      type_;
+      canonical = None;
+      hidden = false;
+    }
 
 let add_functor_parameter : Lang.FunctorParameter.t -> t -> t =
  fun p t ->
@@ -656,7 +667,10 @@ let add_functor_parameter : Lang.FunctorParameter.t -> t -> t =
         let open Component.Of_Lang in
         mk_functor_parameter (module_type_expr (empty ()) n.expr)
       in
-      add_module id (Component.Delayed.put_val m) [] t
+      add_module id
+        (Component.Delayed.put_val m)
+        { elements = []; suppress_warnings = false }
+        t
 
 let add_functor_args' :
     Paths.Identifier.Signature.t -> Component.ModuleType.expr -> t -> t =

--- a/src/xref2/errors.ml
+++ b/src/xref2/errors.ml
@@ -121,7 +121,8 @@ module Tools_error = struct
       [ `Not_found | `Is_directory | `Wrong_kind of path_kind list * path_kind ]
       * Reference.tag_hierarchy
       * string list
-    | `Parent of parent_lookup_error ]
+    | `Parent of parent_lookup_error
+    | `Lookup_by_id of Identifier.t ]
 
   type any =
     [ simple_type_lookup_error
@@ -252,6 +253,8 @@ module Tools_error = struct
         )
     | `Path_error (err, tag, path) -> pp_path_error fmt err tag path
     | `Parent e -> pp fmt (e :> any)
+    | `Lookup_by_id id -> Format.fprintf fmt "Couldn't find identifier %s"
+        (String.concat "." (Identifier.fullname id))
 end
 
 type kind = [ `OpaqueModule | `Root of string ]

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -271,7 +271,7 @@ let any_in_sig sg name =
         | Some r -> Some (`In_type (N.typed_type id, typ, r))
         | None -> None)
     | TypExt typext -> any_in_typext typext name
-    | Comment (`Docs d) -> any_in_comment d (LabelName.make_std name)
+    | Comment (`Docs d) -> any_in_comment d.elements (LabelName.make_std name)
     | _ -> None)
 
 let signature_in_sig sg name =
@@ -303,7 +303,7 @@ let value_in_sig sg name =
 
 let label_in_sig sg name =
   filter_in_sig sg (function
-    | Signature.Comment (`Docs d) -> any_in_comment d name
+    | Signature.Comment (`Docs d) -> any_in_comment d.elements name
     | _ -> None)
 
 let exception_in_sig sg name =

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -1092,7 +1092,12 @@ and docs :
     Identifier.LabelParent.t ->
     Component.CComment.docs ->
     Odoc_model.Comment.docs =
- fun parent ds -> List.rev_map (fun d -> block_element parent d) ds |> List.rev
+ fun parent ds ->
+  {
+    elements =
+      List.rev_map (fun d -> block_element parent d) ds.elements |> List.rev;
+    suppress_warnings = ds.suppress_warnings;
+  }
 
 and docs_or_stop parent (d : Component.CComment.docs_or_stop) =
   match d with `Docs d -> `Docs (docs parent d) | `Stop -> `Stop

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -402,7 +402,7 @@ module L = struct
           | _ -> find tl)
       | [] -> Error (`Find_by_name (`Page, name))
     in
-    find p.Odoc_model.Lang.Page.content
+    find p.Odoc_model.Lang.Page.content.elements
 
   let of_component _env ~parent_ref label =
     Ok

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -181,8 +181,26 @@ let type_lookup_to_class_signature_lookup =
         |> of_option ~error:(`Parent (`Parent_type `OpaqueClass))
         >>= resolved p'
 
-module M = struct
-  (** Module *)
+module rec M 
+: sig
+            type t = module_lookup_result
+          
+            val of_component : Env.t -> Component.Module.t -> Cpath.Resolved.module_ -> Resolved.Module.t -> t
+          
+          val in_signature : Env.t -> signature_lookup_result ->
+             ModuleName.t ->
+              (t, Errors.Tools_error.reference_lookup_error) result
+          
+            val of_element : Env.t -> Component.Element.module_ -> t
+          
+            val in_env : Env.t -> string -> (t, Errors.Tools_error.reference_lookup_error) result
+
+            val in_env_by_id : Env.t -> Identifier.Module.t -> (t, Errors.Tools_error.reference_lookup_error) result
+          end 
+          
+          =
+          
+          struct  (** Module *)
 
   type t = module_lookup_result
 
@@ -225,17 +243,81 @@ module M = struct
           (`Parent
             (`Parent_module (`Lookup_failure_root (ModuleName.make_std name))))
 
-  let rec in_env_by_id env id =
+  let rec in_env_by_id env (id : Identifier.Module.t) =
     match Env.lookup_by_id Env.s_module id env with
     | Some e -> Ok (of_element env e)
     | None -> match id.iv with
-      | `Module (p, name) ->
+      | `Module ({ Identifier.iv = #Identifier.Module.t_pv; _} as p, name) ->
           in_env_by_id env p >>=
           module_lookup_to_signature_lookup env >>=
           fun x -> in_signature env x name
-     | _ -> Error
-       (`Parent
-         (`Parent_module (`Lookup_failure_root (ModuleName.make_std (Identifier.name id)))))
+      |  `Module ({ Identifier.iv = #Identifier.ModuleType.t_pv; _} as p, name) ->
+        MT.in_env_by_id env p >>=
+        module_type_lookup_to_signature_lookup env >>=
+        fun x -> in_signature env x name
+      | `Module ({ Identifier.iv = `Result _; _}, _) 
+      | `Parameter (_, _)
+      | `Root _ -> Error (`Lookup_by_id (id :> Identifier.t))
+end and 
+
+MT : sig
+  type t = module_type_lookup_result
+
+  val of_element : Env.t -> Component.Element.module_type -> t
+
+  val of_component : Env.t -> Component.ModuleType.t -> Cpath.Resolved.module_type -> Resolved.ModuleType.t -> t
+
+  val in_signature : Env.t -> signature_lookup_result -> ModuleTypeName.t -> (t, Errors.Tools_error.reference_lookup_error) result
+  
+  val in_env : Env.t -> string -> (t, Errors.Tools_error.reference_lookup_error) result
+
+  val in_env_by_id : Env.t -> Identifier.ModuleType.t -> (t, Errors.Tools_error.reference_lookup_error) result
+
+end = struct
+  (** Module type *)
+
+  type t = module_type_lookup_result
+
+  let of_component env mt base_path base_ref : t =
+    match Tools.get_module_type_path_modifiers env mt with
+    | None -> (base_ref, base_path, mt)
+    | Some (`AliasModuleType cp) ->
+        let cp = Tools.reresolve_module_type env cp in
+        let p = Lang_of.(Path.resolved_module_type (empty ()) cp) in
+        (`AliasModuleType (p, base_ref), `AliasModuleType (cp, base_path), mt)
+
+  let in_signature env ((parent', parent_cp, sg) : signature_lookup_result) name
+      =
+    let sg = Tools.prefix_signature (parent_cp, sg) in
+    find Find.module_type_in_sig sg ModuleTypeName.to_string name
+    >>= fun (`FModuleType (name, mt)) ->
+    Ok
+      (of_component env mt
+         (`ModuleType (parent_cp, name))
+         (`ModuleType (parent', name)))
+
+  let of_element env (`ModuleType (id, mt)) : t =
+    of_component env mt (`Gpath (`Identifier id)) (`Identifier id)
+
+  let in_env env name =
+    env_lookup_by_name Env.s_module_type name env >>= fun e ->
+    Ok (of_element env e)
+
+  let rec in_env_by_id env id =
+    match Env.lookup_by_id Env.s_module_type id env with
+    | Some e -> Ok (of_element env e)
+    | None -> match id.iv with
+      | `ModuleType ({ Identifier.iv = #Identifier.Module.t_pv; _} as p, name) ->
+          M.in_env_by_id env p >>=
+          module_lookup_to_signature_lookup env >>=
+          fun x -> in_signature env x name
+      | `ModuleType ({ Identifier.iv = #Identifier.ModuleType.t_pv; _} as p, name) ->
+        in_env_by_id env p >>=
+        module_type_lookup_to_signature_lookup env >>=
+        fun x -> in_signature env x name
+      | `ModuleType ({ Identifier.iv = `Result _; _}, _) ->
+        Error (`Lookup_by_id (id :> Identifier.t))
+  
 end
 
 module Path = struct
@@ -274,49 +356,6 @@ module Path = struct
     | Error _, Error _ -> mk_lookup_error p
 end
 
-module MT = struct
-  (** Module type *)
-
-  type t = module_type_lookup_result
-
-  let of_component env mt base_path base_ref : t =
-    match Tools.get_module_type_path_modifiers env mt with
-    | None -> (base_ref, base_path, mt)
-    | Some (`AliasModuleType cp) ->
-        let cp = Tools.reresolve_module_type env cp in
-        let p = Lang_of.(Path.resolved_module_type (empty ()) cp) in
-        (`AliasModuleType (p, base_ref), `AliasModuleType (cp, base_path), mt)
-
-  let in_signature env ((parent', parent_cp, sg) : signature_lookup_result) name
-      =
-    let sg = Tools.prefix_signature (parent_cp, sg) in
-    find Find.module_type_in_sig sg ModuleTypeName.to_string name
-    >>= fun (`FModuleType (name, mt)) ->
-    Ok
-      (of_component env mt
-         (`ModuleType (parent_cp, name))
-         (`ModuleType (parent', name)))
-
-  let of_element env (`ModuleType (id, mt)) : t =
-    of_component env mt (`Gpath (`Identifier id)) (`Identifier id)
-
-  let in_env env name =
-    env_lookup_by_name Env.s_module_type name env >>= fun e ->
-    Ok (of_element env e)
-
-  let in_env_by_id env id =
-    match Env.lookup_by_id Env.s_module_type id env with
-    | Some e -> Ok (of_element env e)
-    | None -> match id.iv with
-      | `ModuleType (p, name) ->
-          M.in_env_by_id env p >>=
-          module_lookup_to_signature_lookup env >>=
-          fun x -> in_signature env x name
-      | _ -> Error
-        (`Parent
-          (`Parent_module (`Lookup_failure_root (ModuleName.make_std (Identifier.name id)))))
-  
-end
 
 module CL = struct
   (** Class *)

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -1711,7 +1711,7 @@ and expansion_of_module :
       let sg =
         (* Override the signature's documentation when the module also has
            a comment attached. *)
-        match m.doc with [] -> sg | doc -> { sg with doc }
+        match m.doc.elements with [] -> sg | _ -> { sg with doc = m.doc }
       in
       Ok (Signature sg)
   | Functor _ as f -> Ok f

--- a/test/frontmatter/frontmatter.t/run.t
+++ b/test/frontmatter/frontmatter.t/run.t
@@ -36,7 +36,7 @@ When there is one frontmatter, it is extracted from the content:
     "toc_status": "None",
     "order_category": "None"
   }
-  $ odoc_print page-one_frontmatter.odoc | jq '.content'
+  $ odoc_print page-one_frontmatter.odoc | jq '.content.elements'
   [
     {
       "`Heading": [
@@ -91,7 +91,7 @@ When there is more than one children order, we raise a warning and keep only the
     "toc_status": "None",
     "order_category": "None"
   }
-  $ odoc_print page-two_frontmatters.odoc | jq '.content'
+  $ odoc_print page-two_frontmatters.odoc | jq '.content.elements'
   [
     {
       "`Heading": [

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -71,7 +71,6 @@
      </li><li><a href="#aliases">Aliases again</a></li>
      <li><a href="#section-title-splicing">Section title splicing</a></li>
      <li><a href="#new-reference-syntax">New reference syntax</a></li>
-     <li><a href="#unresolved-references">Unresolved references</a></li>
     </ul>
    </nav>
   </div>
@@ -2961,13 +2960,6 @@
      </code>
     </div>
    </div>
-   <h2 id="unresolved-references">
-    <a href="#unresolved-references" class="anchor"></a>Unresolved references
-   </h2>
-   <ul><li><code>Stdlib.Invalid_argument</code></li>
-    <li><code>Hashtbl.t</code></li><li><code>Set.S.empty</code></li>
-    <li><code>CollectionModule.InnerModuleA.foo</code></li>
-   </ul>
   </div>
  </body>
 </html>

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -895,11 +895,6 @@ Here goes:
 \label{Ocamlary-module-type-TypeExtPruned-val-f}\ocamlcodefragment{\ocamltag{keyword}{val} f : \hyperref[Ocamlary-type-new_t]{\ocamlinlinecode{new\_\allowbreak{}t}} \ocamltag{arrow}{$\rightarrow$} unit}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Unresolved references\label{unresolved-references}}%
-\begin{itemize}\item{\ocamlinlinecode{Stdlib.\allowbreak{}Invalid\_\allowbreak{}argument}}%
-\item{\ocamlinlinecode{Hashtbl.\allowbreak{}t}}%
-\item{\ocamlinlinecode{Set.\allowbreak{}S.\allowbreak{}empty}}%
-\item{\ocamlinlinecode{CollectionModule.\allowbreak{}InnerModuleA.\allowbreak{}foo}}\end{itemize}%
 
 \input{Ocamlary.ModuleWithSignature.tex}
 \input{Ocamlary.ModuleWithSignatureAlias.tex}

--- a/test/generators/man/Ocamlary.3o
+++ b/test/generators/man/Ocamlary.3o
@@ -1902,18 +1902,3 @@ Here goes:
 \f[CB]val\fR f : new_t \f[CB]\->\fR unit
 .br 
 \f[CB]end\fR
-.sp 
-.in 3
-\fB8 Unresolved references\fR
-.in 
-.sp 
-.fi 
-\(bu Stdlib\.Invalid_argument
-.br 
-\(bu Hashtbl\.t
-.br 
-\(bu Set\.S\.empty
-.br 
-\(bu CollectionModule\.InnerModuleA\.foo
-.nf 
-

--- a/test/integration/dune
+++ b/test/integration/dune
@@ -1,6 +1,12 @@
+(env
+ (_
+  (binaries
+   (../odoc_print/odoc_print.exe as odoc_print))))
+
 (cram
  (deps
-  (package odoc)))
+  (package odoc)
+  %{bin:odoc_print}))
 
 (cram
  (applies_to json_expansion_with_sources)

--- a/test/integration/suppress_warnings.t/main.mli
+++ b/test/integration/suppress_warnings.t/main.mli
@@ -1,0 +1,3 @@
+include Module_with_errors.S
+
+

--- a/test/integration/suppress_warnings.t/module_with_errors.mli
+++ b/test/integration/suppress_warnings.t/module_with_errors.mli
@@ -1,0 +1,9 @@
+module type S = sig
+  (** {1:t section} *)
+
+  type t
+
+  val here_is_the_problem : t
+  (** {!t} *)
+end
+

--- a/test/integration/suppress_warnings.t/run.t
+++ b/test/integration/suppress_warnings.t/run.t
@@ -1,0 +1,20 @@
+  $ ocamlc -c -bin-annot module_with_errors.mli
+  $ ocamlc -c -bin-annot main.mli
+
+  $ odoc compile module_with_errors.cmti
+  $ odoc compile main.cmti -I .
+  $ odoc link main.odoc
+  File "module_with_errors.mli", line 7, characters 6-10:
+  Warning: While resolving the expansion of include at File "main.mli", line 1, character 0
+  Reference to 't' is ambiguous. Please specify its kind: section-t, type-t.
+  $ odoc html-generate -o html main.odocl
+  $ odoc support-files -o html
+
+  $ odoc compile --suppress-warnings module_with_errors.cmti
+  $ odoc compile main.cmti -I .
+  $ odoc link main.odoc
+  $ odoc html-generate -o html2 main.odocl
+  $ odoc support-files -o html2
+
+
+

--- a/test/model/semantics/test.ml
+++ b/test/model/semantics/test.ml
@@ -11,7 +11,7 @@ let parser_output_desc =
     ( Error.unpack_warnings,
       Record
         [
-          F ("value", fst, Indirect (fst, Comment_desc.docs));
+          F ("value", fst, Indirect (fst, Comment_desc.elements));
           F ("warnings", snd, List warning_desc);
         ] )
 

--- a/test/pages/resolution.t/run.t
+++ b/test/pages/resolution.t/run.t
@@ -27,7 +27,7 @@ If everything has worked to plan, we'll have resolved references for all of the 
 references should be to the correct identifiers - so top1 should be a RootPage, sub1 is a Page, sub2 is a LeafPage, and m1 is a Root.
 
 This is the '{!childpage-sub1}' reference
-  $ odoc_print page-top1.odocl | jq '.content[1]["`Paragraph"][0]["`Reference"][0]'
+  $ odoc_print page-top1.odocl | jq '.content.elements[1]["`Paragraph"][0]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {
@@ -47,7 +47,7 @@ This is the '{!childpage-sub1}' reference
   }
 
 This is the '{!childpage:sub2}' reference
-  $ odoc_print page-top1.odocl | jq '.content[1]["`Paragraph"][2]["`Reference"][0]'
+  $ odoc_print page-top1.odocl | jq '.content.elements[1]["`Paragraph"][2]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {
@@ -67,7 +67,7 @@ This is the '{!childpage:sub2}' reference
   }
 
 This is the '{!childmodule:M1}' reference
-  $ odoc_print page-sub1.odocl | jq '.content[1]["`Paragraph"][0]["`Reference"][0]'
+  $ odoc_print page-sub1.odocl | jq '.content.elements[1]["`Paragraph"][0]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {

--- a/test/xref2/canonical_nested.t/run.t
+++ b/test/xref2/canonical_nested.t/run.t
@@ -55,7 +55,10 @@ unresolved in the paths though:
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "type_": {
       "Alias": [
         {
@@ -121,7 +124,10 @@ unresolved in the paths though:
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "type_": {
       "Alias": [
         {
@@ -186,7 +192,10 @@ unresolved in the paths though:
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "type_": {
       "Alias": [
         {
@@ -278,7 +287,10 @@ unresolved in the paths though:
                         ]
                       },
                       "source_loc": "None",
-                      "doc": [],
+                      "doc": {
+                        "elements": [],
+                        "suppress_warnings": "false"
+                      },
                       "equation": {
                         "params": [],
                         "private_": "false",
@@ -291,7 +303,10 @@ unresolved in the paths though:
                 }
               ],
               "compiled": "true",
-              "doc": []
+              "doc": {
+                "elements": [],
+                "suppress_warnings": "false"
+              }
             }
           }
         }

--- a/test/xref2/classes.t/run.t
+++ b/test/xref2/classes.t/run.t
@@ -27,7 +27,10 @@ resolve correctly. All of the 'Class' json objects should contain
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "type_": {
       "Class": [
         {
@@ -64,7 +67,10 @@ resolve correctly. All of the 'Class' json objects should contain
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "type_": {
       "Class": [
         {

--- a/test/xref2/cross_references.t/run.t
+++ b/test/xref2/cross_references.t/run.t
@@ -11,7 +11,7 @@ Two modules that reference each other:
 
 Check that references are resolved:
 
-  $ odoc_print a.odocl | jq '.content.Module.items[0].Type[1].doc[0]'
+  $ odoc_print a.odocl | jq '.content.Module.items[0].Type[1].doc.elements[0]'
   {
     "`Paragraph": [
       {
@@ -38,7 +38,7 @@ Check that references are resolved:
       }
     ]
   }
-  $ odoc_print b.odocl | jq '.content.Module.items[0].Type[1].doc[0]'
+  $ odoc_print b.odocl | jq '.content.Module.items[0].Type[1].doc.elements[0]'
   {
     "`Paragraph": [
       {

--- a/test/xref2/deep_substitution.t/run.t
+++ b/test/xref2/deep_substitution.t/run.t
@@ -38,7 +38,10 @@ its RHS correctly replaced with an `int`
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": {
+      "elements": [],
+      "suppress_warnings": "false"
+    },
     "equation": {
       "params": [],
       "private_": "false",

--- a/test/xref2/hidden_modules.t/run.t
+++ b/test/xref2/hidden_modules.t/run.t
@@ -101,7 +101,10 @@ There should be an expansion on `NotHidden`
                   ]
                 },
                 "source_loc": "None",
-                "doc": [],
+                "doc": {
+                  "elements": [],
+                  "suppress_warnings": "false"
+                },
                 "equation": {
                   "params": [],
                   "private_": "false",
@@ -114,7 +117,10 @@ There should be an expansion on `NotHidden`
           }
         ],
         "compiled": "true",
-        "doc": []
+        "doc": {
+          "elements": [],
+          "suppress_warnings": "false"
+        }
       }
     }
   }
@@ -128,7 +134,7 @@ There should be an expansion on `NotHidden`
       ]
     },
     "source_loc": "None",
-    "doc": [],
+    "doc": { "elements": [], "suppress_warnings": "false" },
     "type_": {
       "Constr": [
         {

--- a/test/xref2/labels/page_labels.t/run.t
+++ b/test/xref2/labels/page_labels.t/run.t
@@ -1,6 +1,6 @@
   $ odoc compile page.mld
   $ odoc link page-page.odoc
-  $ odoc_print page-page.odocl | jq '.content[1]["`Paragraph"][0]["`Reference"][0]'
+  $ odoc_print page-page.odocl | jq '.content.elements[1]["`Paragraph"][0]["`Reference"][0]'
   {
     "`Resolved": {
       "`Identifier": {

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -70,7 +70,7 @@ let root_pp fmt (_ : Odoc_model.Root.t) = Format.fprintf fmt "Common.root"
 
 let model_of_string str = 
     let cmti = cmti_of_string str in
-    Odoc_loader__Cmti.read_interface (Some parent) "Root" cmti
+    Odoc_loader__Cmti.read_interface (Some parent) "Root" false cmti
 
 let model_of_string_impl str =
 #if OCAML_VERSION < (4,13,0)
@@ -78,7 +78,7 @@ let model_of_string_impl str =
 #else
     let cmt = (cmt_of_string str).structure in
 #endif
-    Odoc_loader__Cmt.read_implementation (Some parent) "Root" cmt
+    Odoc_loader__Cmt.read_implementation (Some parent) "Root" false cmt
 
 let signature_of_mli_string str =
     Odoc_xref2.Ident.reset ();
@@ -650,7 +650,7 @@ let mkresolver () =
     ) ~open_modules:[]
 
 let warnings_options =
-  { Odoc_model.Error.warn_error = false; print_warnings = true }
+  { Odoc_model.Error.warn_error = false; print_warnings = true; suppress_warnings = false }
 
 let handle_warnings ww =
   match Odoc_model.Error.handle_warnings ~warnings_options ww with

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -1,14 +1,10 @@
 # Testing {!modules:...} lists
 
   $ compile external.mli starts_with_open.mli main.mli
-  File "main.mli", line 63, characters 22-43:
-  Warning: Failed to resolve reference unresolvedroot(Resolve_synopsis).t Couldn't find "Resolve_synopsis"
   File "main.mli", line 63, characters 17-21:
   Warning: Failed to resolve reference unresolvedroot(t) Couldn't find "t"
   File "external.mli", line 9, characters 6-10:
   Warning: Failed to resolve reference unresolvedroot(t) Couldn't find "t"
-  File "main.mli", line 63, characters 22-43:
-  Warning: Failed to resolve reference unresolvedroot(Resolve_synopsis).t Couldn't find "Resolve_synopsis"
   File "main.mli", line 63, characters 17-21:
   Warning: Failed to resolve reference unresolvedroot(t) Couldn't find "t"
 
@@ -46,7 +42,7 @@ Everything should resolve:
   {"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Starts_with_open"]}}}
   {"Some":[{"`Word":"Synopsis"},"`Space",{"`Word":"of"},"`Space",{"`Code_span":"Starts_with_open"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Resolve_synopsis"]}}}
-  {"Some":[{"`Word":"This"},"`Space",{"`Word":"should"},"`Space",{"`Word":"be"},"`Space",{"`Word":"resolved"},"`Space",{"`Word":"when"},"`Space",{"`Word":"included:"},"`Space",{"`Reference":[{"`Resolved":{"`Type":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]},"t"]}},[]]},{"`Word":"."},"`Space",{"`Word":"These"},"`Space",{"`Word":"shouldn't:"},"`Space",{"`Reference":[{"`Root":["t","`TUnknown"]},[]]},"`Space",{"`Reference":[{"`Dot":[{"`Root":["Resolve_synopsis","`TUnknown"]},"t"]},[]]}]}
+  {"Some":[{"`Word":"This"},"`Space",{"`Word":"should"},"`Space",{"`Word":"be"},"`Space",{"`Word":"resolved"},"`Space",{"`Word":"when"},"`Space",{"`Word":"included:"},"`Space",{"`Reference":[{"`Resolved":{"`Type":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]},"t"]}},[]]},{"`Word":"."},"`Space",{"`Word":"These"},"`Space",{"`Word":"shouldn't:"},"`Space",{"`Reference":[{"`Root":["t","`TUnknown"]},[]]},"`Space",{"`Reference":[{"`Resolved":{"`Type":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]},"t"]}},[]]}]}
   {"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"External"]}},"Resolve_synopsis"]}}
   {"Some":[{"`Reference":[{"`Root":["t","`TUnknown"]},[]]}]}
 
@@ -55,6 +51,6 @@ References in the synopses above should be resolved.
 
   $ odoc_print external.odocl | jq -c '.. | .["`Modules"]? | select(.) | .[] | .[]'
   {"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]}}
-  {"Some":[{"`Word":"This"},"`Space",{"`Word":"should"},"`Space",{"`Word":"be"},"`Space",{"`Word":"resolved"},"`Space",{"`Word":"when"},"`Space",{"`Word":"included:"},"`Space",{"`Reference":[{"`Resolved":{"`Type":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]},"t"]}},[]]},{"`Word":"."},"`Space",{"`Word":"These"},"`Space",{"`Word":"shouldn't:"},"`Space",{"`Reference":[{"`Root":["t","`TUnknown"]},[]]},"`Space",{"`Reference":[{"`Dot":[{"`Root":["Resolve_synopsis","`TUnknown"]},"t"]},[]]}]}
+  {"Some":[{"`Word":"This"},"`Space",{"`Word":"should"},"`Space",{"`Word":"be"},"`Space",{"`Word":"resolved"},"`Space",{"`Word":"when"},"`Space",{"`Word":"included:"},"`Space",{"`Reference":[{"`Resolved":{"`Type":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]},"t"]}},[]]},{"`Word":"."},"`Space",{"`Word":"These"},"`Space",{"`Word":"shouldn't:"},"`Space",{"`Reference":[{"`Root":["t","`TUnknown"]},[]]},"`Space",{"`Reference":[{"`Resolved":{"`Type":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]},"t"]}},[]]}]}
 
 'Type_of' and 'Alias' don't have a summary. `C1` and `C2` neither, we expect at least `C2` to have one.

--- a/test/xref2/module_type_alias.t/run.t
+++ b/test/xref2/module_type_alias.t/run.t
@@ -23,92 +23,95 @@ as they are both referencing items that won't be expanded.
   $ odoc_print test.odocl | jq ".content.Module.items[2]"
   {
     "Comment": {
-      "`Docs": [
-        {
-          "`Paragraph": [
-            {
-              "`Reference": [
-                {
-                  "`Resolved": {
-                    "`AliasModuleType": [
-                      {
-                        "`Identifier": {
-                          "`ModuleType": [
-                            {
-                              "`Root": [
-                                "None",
-                                "Test"
-                              ]
-                            },
-                            "A"
-                          ]
-                        }
-                      },
-                      {
-                        "`Identifier": {
-                          "`ModuleType": [
-                            {
-                              "`Root": [
-                                "None",
-                                "Test"
-                              ]
-                            },
-                            "B"
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                },
-                []
-              ]
-            },
-            "`Space",
-            {
-              "`Reference": [
-                {
-                  "`Resolved": {
-                    "`Type": [
-                      {
-                        "`AliasModuleType": [
-                          {
-                            "`Identifier": {
-                              "`ModuleType": [
-                                {
-                                  "`Root": [
-                                    "None",
-                                    "Test"
-                                  ]
-                                },
-                                "A"
-                              ]
-                            }
-                          },
-                          {
-                            "`Identifier": {
-                              "`ModuleType": [
-                                {
-                                  "`Root": [
-                                    "None",
-                                    "Test"
-                                  ]
-                                },
-                                "B"
-                              ]
-                            }
+      "`Docs": {
+        "elements": [
+          {
+            "`Paragraph": [
+              {
+                "`Reference": [
+                  {
+                    "`Resolved": {
+                      "`AliasModuleType": [
+                        {
+                          "`Identifier": {
+                            "`ModuleType": [
+                              {
+                                "`Root": [
+                                  "None",
+                                  "Test"
+                                ]
+                              },
+                              "A"
+                            ]
                           }
-                        ]
-                      },
-                      "t"
-                    ]
-                  }
-                },
-                []
-              ]
-            }
-          ]
-        }
-      ]
+                        },
+                        {
+                          "`Identifier": {
+                            "`ModuleType": [
+                              {
+                                "`Root": [
+                                  "None",
+                                  "Test"
+                                ]
+                              },
+                              "B"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  []
+                ]
+              },
+              "`Space",
+              {
+                "`Reference": [
+                  {
+                    "`Resolved": {
+                      "`Type": [
+                        {
+                          "`AliasModuleType": [
+                            {
+                              "`Identifier": {
+                                "`ModuleType": [
+                                  {
+                                    "`Root": [
+                                      "None",
+                                      "Test"
+                                    ]
+                                  },
+                                  "A"
+                                ]
+                              }
+                            },
+                            {
+                              "`Identifier": {
+                                "`ModuleType": [
+                                  {
+                                    "`Root": [
+                                      "None",
+                                      "Test"
+                                    ]
+                                  },
+                                  "B"
+                                ]
+                              }
+                            }
+                          ]
+                        },
+                        "t"
+                      ]
+                    }
+                  },
+                  []
+                ]
+              }
+            ]
+          }
+        ],
+        "suppress_warnings": "false"
+      }
     }
   }
 


### PR DESCRIPTION
Some references get "moved" to some other context when expansions are computed, which make them resolve to something else/not resolve anymore.

This PR tries to resolve reference at the earliest, before any expansions are computed: at load time. So resolved references go to the original referenced item.

This is extracted from some branch of @jonludlam, as a draft. I have not reviewed the commits. It put it as a draft, just so that the idea does not get forgotten, but it is planned as post 3.0

(currently based on #1260)