### PR TITLE
Improve driver experience

### DIFF
--- a/src/driver/common_args.ml
+++ b/src/driver/common_args.ml
@@ -60,6 +60,10 @@ let index_grep =
   let doc = "Show compile-index commands containing the string" in
   Arg.(value & opt (some string) None & info [ "index-grep" ] ~doc)
 
+let generate_json =
+  let doc = "Also generate json output" in
+  Arg.(value & flag & info [ "json-output" ] ~doc)
+
 type t = {
   verbose : bool;
   odoc_dir : Fpath.t;
@@ -75,6 +79,7 @@ type t = {
   generate_grep : string option;
   remap : bool;
   index_grep : string option;
+  generate_json : bool;
 }
 
 let term =
@@ -91,6 +96,7 @@ let term =
   and+ nb_workers = nb_workers
   and+ odoc_bin = odoc_bin
   and+ compile_grep = compile_grep
+  and+ generate_json = generate_json
   and+ link_grep = link_grep
   and+ generate_grep = generate_grep
   and+ index_grep = index_grep
@@ -110,4 +116,5 @@ let term =
     generate_grep;
     remap;
     index_grep;
+    generate_json;
   }

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -263,7 +263,7 @@ let sherlodoc_index_one ~output_dir (index : Odoc_unit.index) =
   Sherlodoc.index ~format:`js ~inputs ~dst ();
   rel_path
 
-let html_generate ~occurrence_file ~remaps output_dir linked =
+let html_generate ~occurrence_file ~remaps ~generate_json output_dir linked =
   let tbl = Hashtbl.create 10 in
   let _ = OS.Dir.create output_dir |> Result.get_ok in
   Sherlodoc.js Fpath.(output_dir // Sherlodoc.js_file);
@@ -312,9 +312,11 @@ let html_generate ~occurrence_file ~remaps output_dir linked =
           in
           Odoc.html_generate_source ?search_uris ?sidebar ~output_dir
             ~input_file ~source:src_path ();
-          Odoc.html_generate_source ?search_uris ?sidebar ~output_dir
-            ~input_file ~source:src_path ~as_json:true ();
-          Atomic.incr Stats.stats.generated_units
+          Atomic.incr Stats.stats.generated_units;
+          if generate_json then (
+            Odoc.html_generate_source ?search_uris ?sidebar ~output_dir
+              ~input_file ~source:src_path ~as_json:true ();
+            Atomic.incr Stats.stats.generated_units)
       | `Asset ->
           Odoc.html_generate_asset ~output_dir ~input_file:l.odoc_file
             ~asset_path:l.input_file ()
@@ -329,9 +331,11 @@ let html_generate ~occurrence_file ~remaps output_dir linked =
           in
           Odoc.html_generate ?search_uris ?sidebar ?remap:remap_file ~output_dir
             ~input_file ();
-          Odoc.html_generate ?search_uris ?sidebar ~output_dir ~input_file
-            ~as_json:true ();
-          Atomic.incr Stats.stats.generated_units
+          Atomic.incr Stats.stats.generated_units;
+          if generate_json then (
+            Odoc.html_generate ?search_uris ?sidebar ~output_dir ~input_file
+              ~as_json:true ();
+            Atomic.incr Stats.stats.generated_units)
   in
   if List.length remaps = 0 then Fiber.List.iter (html_generate None) linked
   else

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -296,42 +296,42 @@ let html_generate ~occurrence_file ~remaps output_dir linked =
   in
   let html_generate : Fpath.t option -> linked -> unit =
    fun remap_file l ->
-    (if l.to_output then
-       let output_dir = Fpath.to_string output_dir in
-       let input_file = l.odocl_file in
-       match l.kind with
-       | `Intf { hidden = true; _ } -> ()
-       | `Impl { src_path; _ } ->
-           let search_uris, sidebar =
-             match l.index with
-             | None -> (None, None)
-             | Some index ->
-                 let db_path, sidebar = compile_index index in
-                 let search_uris = [ db_path; Sherlodoc.js_file ] in
-                 (Some search_uris, sidebar)
-           in
-           Odoc.html_generate_source ?search_uris ?sidebar ~output_dir
-             ~input_file ~source:src_path ();
-           Odoc.html_generate_source ?search_uris ?sidebar ~output_dir
-             ~input_file ~source:src_path ~as_json:true ();
-           Atomic.incr Stats.stats.generated_units
-       | `Asset ->
-           Odoc.html_generate_asset ~output_dir ~input_file:l.odoc_file
-             ~asset_path:l.input_file ()
-       | _ ->
-           let search_uris, sidebar =
-             match l.index with
-             | None -> (None, None)
-             | Some index ->
-                 let db_path, sidebar = compile_index index in
-                 let search_uris = [ db_path; Sherlodoc.js_file ] in
-                 (Some search_uris, sidebar)
-           in
-           Odoc.html_generate ?search_uris ?sidebar ?remap:remap_file
-             ~output_dir ~input_file ();
-           Odoc.html_generate ?search_uris ?sidebar ~output_dir ~input_file
-             ~as_json:true ());
-    Atomic.incr Stats.stats.generated_units
+    if l.to_output then
+      let output_dir = Fpath.to_string output_dir in
+      let input_file = l.odocl_file in
+      match l.kind with
+      | `Intf { hidden = true; _ } -> ()
+      | `Impl { src_path; _ } ->
+          let search_uris, sidebar =
+            match l.index with
+            | None -> (None, None)
+            | Some index ->
+                let db_path, sidebar = compile_index index in
+                let search_uris = [ db_path; Sherlodoc.js_file ] in
+                (Some search_uris, sidebar)
+          in
+          Odoc.html_generate_source ?search_uris ?sidebar ~output_dir
+            ~input_file ~source:src_path ();
+          Odoc.html_generate_source ?search_uris ?sidebar ~output_dir
+            ~input_file ~source:src_path ~as_json:true ();
+          Atomic.incr Stats.stats.generated_units
+      | `Asset ->
+          Odoc.html_generate_asset ~output_dir ~input_file:l.odoc_file
+            ~asset_path:l.input_file ()
+      | _ ->
+          let search_uris, sidebar =
+            match l.index with
+            | None -> (None, None)
+            | Some index ->
+                let db_path, sidebar = compile_index index in
+                let search_uris = [ db_path; Sherlodoc.js_file ] in
+                (Some search_uris, sidebar)
+          in
+          Odoc.html_generate ?search_uris ?sidebar ?remap:remap_file ~output_dir
+            ~input_file ();
+          Odoc.html_generate ?search_uris ?sidebar ~output_dir ~input_file
+            ~as_json:true ();
+          Atomic.incr Stats.stats.generated_units
   in
   if List.length remaps = 0 then Fiber.List.iter (html_generate None) linked
   else

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -17,6 +17,7 @@ val link : compiled list -> linked list
 val html_generate :
   occurrence_file:Fpath.t ->
   remaps:(string * string) list ->
+  generate_json:bool ->
   Fpath.t ->
   linked list ->
   unit

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -30,7 +30,7 @@ let render_stats env nprocs =
   let non_hidden = Atomic.get Stats.stats.non_hidden_units in
 
   let dline x y = Multi.line (bar x y) in
-  let config = Progress.Config.v ~persistent:false () in
+  let config = Progress.Config.v ~persistent:true () in
   with_reporters ~config
     Multi.(
       dline "Compiling" total
@@ -249,6 +249,7 @@ let run mode
       (fun () -> render_stats env nb_workers)
   in
 
+  Format.eprintf "Collected logs... \n%!";
   let grep_log ty s =
     let open Astring in
     let do_ affix =
@@ -286,6 +287,7 @@ let run mode
       | _ -> ())
     !Cmd_outputs.outputs;
 
+  Format.eprintf "Benchmarking... \n%!";
   if stats then Stats.bench_results html_dir
 
 open Cmdliner

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -15,11 +15,11 @@ let render_stats env nprocs =
   let total_indexes = Atomic.get Stats.stats.total_indexes in
   let bar message total =
     let open Progress.Line in
-    list [ lpad 16 (const message); bar total; count_to total ]
+    list [ lpad 16 (const message); bar total; rpad 10 (count_to total) ]
   in
   let procs total =
     let open Progress.Line in
-    list [ lpad 16 (const "Processes"); bar total; count_to total ]
+    list [ lpad 16 (const "Processes"); bar total; rpad 10 (count_to total) ]
   in
   let description =
     let open Progress.Line in
@@ -30,7 +30,8 @@ let render_stats env nprocs =
   let non_hidden = Atomic.get Stats.stats.non_hidden_units in
 
   let dline x y = Multi.line (bar x y) in
-  with_reporters
+  let config = Progress.Config.v ~persistent:false () in
+  with_reporters ~config
     Multi.(
       dline "Compiling" total
       ++ dline "Compiling impls" total_impls
@@ -205,6 +206,7 @@ let run mode
     else []
   in
   Logs.debug (fun m -> m "XXXX Remaps length: %d" (List.length remaps));
+  Format.eprintf "Starting the compilation process... \n%!";
   let () =
     Eio.Fiber.both
       (fun () ->
@@ -284,8 +286,6 @@ let run mode
       | _ -> ())
     !Cmd_outputs.outputs;
 
-  Format.eprintf "Final stats: %a@.%!" Stats.pp_stats Stats.stats;
-  Format.eprintf "Total time: %f@.%!" (Stats.total_time ());
   if stats then Stats.bench_results html_dir
 
 open Cmdliner

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -30,7 +30,7 @@ let render_stats env ~generate_json nprocs =
   let non_hidden = Atomic.get Stats.stats.non_hidden_units in
 
   let dline x y = Multi.line (bar x y) in
-  let config = Progress.Config.v ~persistent:true () in
+  let config = Progress.Config.v ~persistent:false () in
   let total_generate =
     let units = total_impls + non_hidden + total_mlds in
     if generate_json then 2 * units else units

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -211,7 +211,7 @@ let run mode
     else []
   in
   Logs.debug (fun m -> m "XXXX Remaps length: %d" (List.length remaps));
-  Logs.app (fun m -> m "Starting the compilation process... \n%!");
+  Logs.app (fun m -> m "Starting the compilation process...");
   let () =
     Eio.Fiber.both
       (fun () ->
@@ -255,7 +255,7 @@ let run mode
       (fun () -> render_stats env ~generate_json nb_workers)
   in
 
-  Logs.app (fun m -> m "Collected logs... \n%!");
+  Logs.app (fun m -> m "Collected logs...");
   let grep_log ty s =
     let open Astring in
     let do_ affix =
@@ -293,7 +293,7 @@ let run mode
       | _ -> ())
     !Cmd_outputs.outputs;
 
-  Logs.app (fun m -> m "Benchmarking... \n%!");
+  Logs.app (fun m -> m "Benchmarking...");
 
   if stats then Stats.bench_results html_dir
 

--- a/src/driver/odoc_driver.ml
+++ b/src/driver/odoc_driver.ml
@@ -211,7 +211,7 @@ let run mode
     else []
   in
   Logs.debug (fun m -> m "XXXX Remaps length: %d" (List.length remaps));
-  Format.eprintf "Starting the compilation process... \n%!";
+  Logs.app (fun m -> m "Starting the compilation process... \n%!");
   let () =
     Eio.Fiber.both
       (fun () ->
@@ -255,7 +255,7 @@ let run mode
       (fun () -> render_stats env ~generate_json nb_workers)
   in
 
-  Format.eprintf "Collected logs... \n%!";
+  Logs.app (fun m -> m "Collected logs... \n%!");
   let grep_log ty s =
     let open Astring in
     let do_ affix =
@@ -293,7 +293,8 @@ let run mode
       | _ -> ())
     !Cmd_outputs.outputs;
 
-  Format.eprintf "Benchmarking... \n%!";
+  Logs.app (fun m -> m "Benchmarking... \n%!");
+
   if stats then Stats.bench_results html_dir
 
 open Cmdliner

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -416,6 +416,7 @@ let of_libs ~packages_dir libs =
   fix_missing_deps packages
 
 let of_packages ~packages_dir packages =
+  Format.eprintf "Computing deps... \n%!";
   let deps =
     if packages = [] then Opam.all_opam_packages () else Opam.deps packages
   in
@@ -441,6 +442,7 @@ let of_packages ~packages_dir packages =
 
   let all = orig @ ps in
 
+  Format.eprintf "Analyzing packages needed to be built... \n%!";
   let packages =
     List.fold_left
       (fun acc (pkg, files) ->

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -416,7 +416,7 @@ let of_libs ~packages_dir libs =
   fix_missing_deps packages
 
 let of_packages ~packages_dir packages =
-  Format.eprintf "Computing deps... \n%!";
+  Logs.app (fun m -> m "Computing deps... \n%!");
   let deps =
     if packages = [] then Opam.all_opam_packages () else Opam.deps packages
   in
@@ -442,7 +442,7 @@ let of_packages ~packages_dir packages =
 
   let all = orig @ ps in
 
-  Format.eprintf "Analyzing packages needed to be built... \n%!";
+  Logs.app (fun m -> m "Analyzing packages needed to be built... \n%!");
   let packages =
     List.fold_left
       (fun acc (pkg, files) ->

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -416,7 +416,7 @@ let of_libs ~packages_dir libs =
   fix_missing_deps packages
 
 let of_packages ~packages_dir packages =
-  Logs.app (fun m -> m "Computing deps... \n%!");
+  Logs.app (fun m -> m "Computing deps...");
   let deps =
     if packages = [] then Opam.all_opam_packages () else Opam.deps packages
   in
@@ -442,7 +442,7 @@ let of_packages ~packages_dir packages =
 
   let all = orig @ ps in
 
-  Logs.app (fun m -> m "Analyzing packages needed to be built... \n%!");
+  Logs.app (fun m -> m "Analyzing packages needed to be built...");
   let packages =
     List.fold_left
       (fun acc (pkg, files) ->


### PR DESCRIPTION
- Avoid "hanging state" where computation happen but the user does not know what is going on,
- Fix wrong computation of the number of executed generation,
- Only generate JSON output if requested with `--generate-json` (@jonludlam let me know if you want me to revert this one, but it takes a bit of time when, for users, JSON output is not needed).