### PR TITLE
Fix stack overflow when highlighting large source files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,7 @@
 - Fix bug where source rendering would cause odoc to fail completely if it
   encounters invalid syntax (@jonludlam #1208)
 - Add missing parentheses in 'val (let*) : ...' (@Julow, #1268)
+- Fix syntax highlighting not working for very large files (@jonludlam, @Julow, #1277)
 
 # 2.4.4
 

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -290,7 +290,7 @@ module Make (Syntax : SYNTAX) = struct
       in
       let infos = Odoc_utils.List.filter_map mapper infos in
       let syntax_info =
-        List.map (fun (ty, loc) -> (Source_page.Syntax ty, loc)) syntax_info
+        List.rev_map (fun (ty, loc) -> (Source_page.Syntax ty, loc)) syntax_info |> List.rev
       in
       let contents = Impl.impl ~infos:(infos @ syntax_info) source_code in
       { Source_page.url; contents }

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -290,7 +290,8 @@ module Make (Syntax : SYNTAX) = struct
       in
       let infos = Odoc_utils.List.filter_map mapper infos in
       let syntax_info =
-        List.rev_map (fun (ty, loc) -> (Source_page.Syntax ty, loc)) syntax_info |> List.rev
+        List.rev_map (fun (ty, loc) -> (Source_page.Syntax ty, loc)) syntax_info
+        |> List.rev
       in
       let contents = Impl.impl ~infos:(infos @ syntax_info) source_code in
       { Source_page.url; contents }

--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -86,7 +86,7 @@ and source k ?a (t : Source.t) =
         let content = tokens l in
         if content = [] then [] else [ Html.span content ]
     | Tag (Some s, l) -> [ Html.span ~a:[ Html.a_class [ s ] ] (tokens l) ]
-  and tokens t = Odoc_utils.List.concat_map t ~f:token in
+  and tokens t = List.concat_map token t in
   match tokens t with [] -> [] | l -> [ Html.code ?a l ]
 
 and styled style ~emph_level =
@@ -155,7 +155,7 @@ and inline ~config ?(emph_level = 0) ~resolve (l : Inline.t) :
     | Math s -> [ inline_math s ]
     | Raw_markup r -> raw_markup r
   in
-  Odoc_utils.List.concat_map ~f:one l
+  List.concat_map one l
 
 and inline_nolink ?(emph_level = 0) (l : Inline.t) :
     non_link_phrasing Html.elt list =
@@ -176,7 +176,7 @@ and inline_nolink ?(emph_level = 0) (l : Inline.t) :
     | Math s -> [ inline_math s ]
     | Raw_markup r -> raw_markup r
   in
-  Odoc_utils.List.concat_map ~f:one l
+  List.concat_map one l
 
 let heading ~config ~resolve (h : Heading.t) =
   let a, anchor =
@@ -290,7 +290,7 @@ let rec block ~config ~resolve (l : Block.t) : flow Html.elt list =
         mk_media_block image target alt
   in
 
-  Odoc_utils.List.concat_map l ~f:one
+  List.concat_map one l
 
 and mk_rows ~config ~resolve { align; data } =
   let mk_row row =
@@ -577,7 +577,7 @@ module Breadcrumbs = struct
     let find_parent =
       List.find_opt (function
         | ({ node = { url = { page; anchor = ""; _ }; _ }; _ } :
-            Odoc_document.Sidebar.entry Odoc_utils.Tree.t)
+            Odoc_document.Sidebar.entry Tree.t)
           when Url.Path.is_prefix page current_url ->
             true
         | _ -> false)

--- a/src/html/html_page.ml
+++ b/src/html/html_page.ml
@@ -78,7 +78,7 @@ let html_of_breadcrumbs (breadcrumbs : Types.breadcrumbs) =
   let sep = [ space; Html.entity "#x00BB"; space ] in
   let html =
     (* Create breadcrumbs *)
-    Odoc_utils.List.concat_map ~sep
+    List.concat_map_sep ~sep
       ~f:(fun (breadcrumb : Types.breadcrumb) ->
         match breadcrumb.href with
         | Some href ->

--- a/src/html/html_source.ml
+++ b/src/html/html_source.ml
@@ -1,3 +1,4 @@
+open Odoc_utils
 module HLink = Link
 open Odoc_document.Types
 open Tyxml
@@ -23,7 +24,7 @@ let html_of_doc ~config ~resolve docs =
     | Source_page.Plain_code s -> [ txt s ]
     | Tagged_code (info, docs) -> (
         let is_in_a = match info with Link _ -> true | _ -> is_in_a in
-        let children = List.concat @@ (List.rev_map (doc_to_html ~is_in_a) docs |> List.rev) in
+        let children = List.concat_map (doc_to_html ~is_in_a) docs in
         match info with
         | Syntax tok -> [ span ~a:[ a_class [ tok ] ] children ]
         (* Currently, we do not render links to documentation *)
@@ -33,9 +34,7 @@ let html_of_doc ~config ~resolve docs =
             [ a ~a:[ a_href href ] children ]
         | Anchor lbl -> [ span ~a:[ a_id lbl ] children ])
   in
-  let span_content_l = List.rev_map (doc_to_html ~is_in_a:false) docs |> List.rev in
-  (* This is List.concat, tail recursive version *)
-  let span_content = List.fold_left (fun acc x -> List.rev_append x acc) [] span_content_l |> List.rev in
+  let span_content = List.concat_map (doc_to_html ~is_in_a:false) docs in
   span ~a:[] span_content
 
 let count_lines_in_string s =

--- a/src/html/html_source.ml
+++ b/src/html/html_source.ml
@@ -53,7 +53,8 @@ and count_lines l =
     match l with
     | [] -> acc
     | hd :: tl -> inner tl (count_lines_in_span hd + acc)
-  in inner l 0
+  in
+  inner l 0
 
 let rec line_numbers acc n =
   let open Html in

--- a/src/index/skeleton.ml
+++ b/src/index/skeleton.ml
@@ -162,7 +162,7 @@ let rec unit (u : Compilation_unit.t) =
 
 and signature id (s : Signature.t) =
   let items = filter_signature s.items in
-  List.concat_map ~f:(signature_item (id :> Identifier.LabelParent.t)) items
+  List.concat_map (signature_item (id :> Identifier.LabelParent.t)) items
 
 and signature_item id s_item =
   match s_item with
@@ -215,8 +215,8 @@ and type_decl td =
     match td.representation with
     | None -> []
     | Some (Variant cl) ->
-        List.concat_map ~f:(constructor td.id td.equation.params) cl
-    | Some (Record fl) -> List.concat_map ~f:(field td.id td.equation.params) fl
+        List.concat_map (constructor td.id td.equation.params) cl
+    | Some (Record fl) -> List.concat_map (field td.id td.equation.params) fl
     | Some Extensible -> []
   in
   [ { Tree.node = entry; children } ]
@@ -288,7 +288,7 @@ and module_type_expr id mte =
 
 and class_signature id ct_expr =
   let items = filter_class_signature ct_expr.items in
-  List.concat_map ~f:(class_signature_item id) items
+  List.concat_map (class_signature_item id) items
 
 and class_signature_item id item =
   match item with

--- a/src/latex/generator.ml
+++ b/src/latex/generator.ml
@@ -218,7 +218,7 @@ let source k (t : Source.t) =
     | Elt i -> k i
     | Tag (None, l) -> tokens l
     | Tag (Some s, l) -> [ Tag (s, tokens l) ]
-  and tokens t = Odoc_utils.List.concat_map t ~f:token in
+  and tokens t = Odoc_utils.List.concat_map token t in
   tokens t
 
 let rec internalref ~verbatim ~in_source (t : Target.internal) (c : Inline.t) =
@@ -310,7 +310,7 @@ let rec block ~in_source (l : Block.t) =
           Break Paragraph;
         ]
   in
-  Odoc_utils.List.concat_map l ~f:one
+  Odoc_utils.List.concat_map one l
 
 and table_block { Table.data; align } =
   let data =

--- a/src/loader/ident_env.cppo.ml
+++ b/src/loader/ident_env.cppo.ml
@@ -201,7 +201,7 @@ let rec extract_signature_tree_items : bool -> Typedtree.signature_item list -> 
 #else
   | { sig_desc = Tsig_type (_, decls); _} :: rest ->
 #endif
-    Odoc_utils.List.concat_map ~f:(fun decl ->
+    Odoc_utils.List.concat_map (fun decl ->
       if Btype.is_row_name (Ident.name decl.typ_id)
       then []
       else
@@ -337,7 +337,7 @@ let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> 
 #else
     | { str_desc = Tstr_type (_, decls); _ } :: rest -> (* TODO: handle rec_flag *)
 #endif
-  Odoc_utils.List.concat_map ~f:(fun decl ->
+  Odoc_utils.List.concat_map (fun decl ->
       `Type (decl.typ_id, hide_item, Some decl.typ_loc) ::
         (match decl.typ_kind with
           Ttype_abstract -> []

--- a/src/utils/odoc_list.ml
+++ b/src/utils/odoc_list.ml
@@ -1,12 +1,21 @@
 include List
 
-let rec concat_map ?sep ~f = function
+let rec concat_map_sep ~sep ~f = function
   | [] -> []
   | [ x ] -> f x
-  | x :: xs -> (
+  | x :: xs ->
       let hd = f x in
-      let tl = concat_map ?sep ~f xs in
-      match sep with None -> hd @ tl | Some sep -> hd @ (sep :: tl))
+      let tl = concat_map_sep ~sep ~f xs in
+      hd @ (sep :: tl)
+
+let concat_map f l =
+  let rec aux f acc = function
+    | [] -> rev acc
+    | x :: l ->
+        let xs = f x in
+        aux f (rev_append xs acc) l
+  in
+  aux f [] l
 
 let rec filter_map acc f = function
   | hd :: tl ->


### PR DESCRIPTION
This is enough to highlight `reason_parser.ml` in `reason.3.8.0`, which is one very large file that Odoc has to process.