### PR TITLE
Driver: by default, use a reasonable number of domains

### DIFF
--- a/src/driver/common_args.ml
+++ b/src/driver/common_args.ml
@@ -22,7 +22,10 @@ let stats =
 
 let nb_workers =
   let doc = "Number of workers." in
-  Arg.(value & opt int 15 & info [ "j" ] ~doc ~docs:Manpage.s_common_options)
+  Arg.(
+    value
+    & opt int (Domain.recommended_domain_count () - 1)
+    & info [ "j" ] ~doc ~docs:Manpage.s_common_options)
 
 let odoc_bin =
   let doc = "Odoc binary to use" in


### PR DESCRIPTION
Makes the `-j` option of the driver to use `Domain.recommended_domain_count () - 1` number of domains.

I could not see a difference in performance (my machine has 8 recommended domains and previous value was hardcoded 15), but I think that it is still better like that.