### PR TITLE
css: update selectors for odig package title

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@
   Allows to specify the title of a page, the order of sub-pages and other
   behaviors in the sidebar.
 - Added `odoc-md` to process standalone Markdown pages (@jonludlam, #1234)
+- Added CSS selectors to style version and and nav links when they appear within page titles, as produced by odig (@katrinafyi, #1290)
 
 ### Changed
 

--- a/src/html_support_files/odoc.css
+++ b/src/html_support_files/odoc.css
@@ -815,13 +815,13 @@ td.def-doc *:first-child {
 
 /* Odig package page */
 
-.package nav {
+.package nav, h1 nav {
   display: inline;
   font-size: 14px;
   font-weight: normal;
 }
 
-.package .version {
+.package .version, h1 .version {
   font-size: 14px;
 }
 


### PR DESCRIPTION
this is for the package index pages with the titles that look like: **Package angstrom 0.16.1 [issues](https://github.com/inhabitedtype/angstrom/issues) [more…](#)**.


it appears that the new heading structure is something like this:
```html
<header class="odoc-preamble">
  <h1 id="package-angstrom">
    <a href="#package-angstrom" class="anchor"></a>
    Package angstrom
    <span class="version">0.16.1</span>
    <nav>
      <a href="https://github.com/inhabitedtype/angstrom/issues">issues</a>
      <a href="#package_info">more…</a>
    </nav>
  </h1>
```
notably, the h1 element doesn't have a .package classname anymore which breaks the styling, reverting the version and links to the large title text size.

the new selectors are borrowed from the odig css.
https://github.com/b0-system/odig/blob/b0e7b144d921d345d49cf4958caab06059739754/themes/odoc.css#L293-L297

