### PR TITLE
test: Remove 'type_desc_to_yojson' library

### DIFF
--- a/test/model/semantics/dune
+++ b/test/model/semantics/dune
@@ -1,3 +1,6 @@
+(rule
+ (copy ../../odoc_print/type_desc_to_yojson.ml type_desc_to_yojson.ml))
+
 (library
  (name odoc_model_semantics_test)
  (package odoc)
@@ -7,4 +10,4 @@
   (>= %{ocaml_version} 4.04.1))
  (preprocess
   (pps ppx_expect))
- (libraries sexplib0 odoc_model type_desc_to_yojson))
+ (libraries sexplib0 odoc_model odoc_model_desc yojson))

--- a/test/odoc_print/dune
+++ b/test/odoc_print/dune
@@ -1,25 +1,12 @@
-(library
- (name type_desc_to_yojson)
- (package odoc)
- (optional)
- (modules type_desc_to_yojson)
- (libraries odoc_model_desc yojson))
-
 (executable
  (name odoc_print)
- (modules odoc_print)
- (libraries odoc_odoc type_desc_to_yojson odoc_model_desc compatcmdliner))
+ (modules odoc_print type_desc_to_yojson)
+ (libraries odoc_odoc odoc_model_desc yojson compatcmdliner))
 
 (executable
  (name print_index)
  (modules print_index)
- (libraries
-  odoc_odoc
-  type_desc_to_yojson
-  odoc_model_desc
-  compatcmdliner
-  yojson
-  odoc_json_index))
+ (libraries odoc_odoc odoc_model_desc compatcmdliner yojson odoc_json_index))
 
 (executable
  (name occurrences_print)


### PR DESCRIPTION
The library is installable and is built when the tests are not going to be run.
This fails in the lower-bounds CI because of the requirement on yojson is not respected when the dependencies are installed with 'with-test'.

    "yojson" {>= "2.1.0" & with-test}