### PR TITLE
Add png, pdf and jpeg image support to the latex backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+### Added
+
+- Added support for (local) images in the latex backend (@Octachron, #1297)
+
 ### Changed
 
 - Drop support for OCaml < 4.08 (@jonludlam, #1300)
@@ -26,7 +30,7 @@
 - Added support for images, videos, audio and other assets
   The syntax is `{image!/reference/to/asset}` or `{image:URL}` for images.
   The syntax for `{video...}` and `{audio...}` is the same.
-  (@panglesd, @EmileTrotignon, #1170, #1171, #1184, #1185, #1297)
+  (@panglesd, @EmileTrotignon, #1170, #1171, #1184, #1185)
 
 - Search using Sherlodoc (@panglesd, @EmileTrotignon, @Julow)
   A new search bar that supports full-text and type-based search.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@
 - Added support for images, videos, audio and other assets
   The syntax is `{image!/reference/to/asset}` or `{image:URL}` for images.
   The syntax for `{video...}` and `{audio...}` is the same.
-  (@panglesd, @EmileTrotignon, #1170, #1171, #1184, #1185)
+  (@panglesd, @EmileTrotignon, #1170, #1171, #1184, #1185, #1297)
 
 - Search using Sherlodoc (@panglesd, @EmileTrotignon, @Julow)
   A new search bar that supports full-text and type-based search.

--- a/src/latex/raw.ml
+++ b/src/latex/raw.ml
@@ -126,6 +126,8 @@ let code_block pp ppf x =
   Fmt.cut ppf ();
   mend ppf name
 
+let includegraphics pp = create "includegraphics" pp
+
 let section pp = create "section" pp
 
 let subsection pp = create "subsection" pp

--- a/src/latex/raw.mli
+++ b/src/latex/raw.mli
@@ -66,7 +66,7 @@ val small_table : ('a, Types.alignment list option * 'a list list) tr
 
 val input : Fpath.t Fmt.t
 
-val includegraphics: 'a t
+val includegraphics : 'a t
 
 (** {1 Required OCaml-specific primitives}
     All the macro should be implemented as "ocaml"-suffixed macro in the latex

--- a/src/latex/raw.mli
+++ b/src/latex/raw.mli
@@ -66,6 +66,8 @@ val small_table : ('a, Types.alignment list option * 'a list list) tr
 
 val input : Fpath.t Fmt.t
 
+val includegraphics: 'a t
+
 (** {1 Required OCaml-specific primitives}
     All the macro should be implemented as "ocaml"-suffixed macro in the latex
     preamble *)

--- a/src/latex/types.ml
+++ b/src/latex/types.ml
@@ -26,6 +26,7 @@ type elt =
   | Layout_table of layout_table
   | Table of table
   | Ligaturable of string
+  | Image of Fpath.t
 
 and section = { level : int; label : string option; content : t }
 

--- a/test/pages/medias.t/index.mld
+++ b/test/pages/medias.t/index.mld
@@ -7,7 +7,7 @@
 Some image:
 
 - Without alt text:{image!caml.gif}
-- With an alt text: {{image!caml.gif}With alt text and {b emphasis}}
+- With an alt text: {{image!caml.png}With alt text and {b emphasis}}
 - Unresolved without alt text: {image!caqzdqzdml.gif}
 - Unresolved with alt text: {{image!camezfzeffl.gif}With alt text and {b emphasis}}
 

--- a/test/pages/medias.t/run.t
+++ b/test/pages/medias.t/run.t
@@ -3,6 +3,7 @@ We need to odoc-compile the package mld file, listing its children
   $ odoc compile index.mld --parent-id pkg1/ --output-dir _odoc
 
   $ odoc compile-asset --parent-id pkg1/ --output-dir _odoc --name caml.gif
+  $ odoc compile-asset --parent-id pkg1/ --output-dir _odoc --name caml.png
   $ odoc compile-asset --parent-id pkg1/ --output-dir _odoc --name Cri_du_chameau.ogg
   $ odoc compile-asset --parent-id pkg1/ --output-dir _odoc --name flower.webm
 
@@ -28,8 +29,8 @@ Testing the working references:
   $ cat html/pkg1/index.html | grep img
         <a href="caml.gif" class="img-link">
          <img src="caml.gif" alt="caml.gif"/>
-        <a href="caml.gif" class="img-link">
-         <img src="caml.gif" alt="With alt text and {b emphasis}"/>
+        <a href="caml.png" class="img-link">
+         <img src="caml.png" alt="With alt text and {b emphasis}"/>
         <a href="https://picsum.photos/200/300" class="img-link">
          <img src="https://picsum.photos/200/300" alt="reference"/>
         <a href="https://picsum.photos/200/300" class="img-link">
@@ -71,6 +72,9 @@ Testing latex and manpages
   $ cat latex/pkg1/index.tex | grep gif
   caml.gif
   ./caqzdqzdml.gif
+
+  $ cat latex/pkg1/index.tex | grep png
+  \includegraphics{pkg1/caml.png}}%
 
   $ odoc man-generate -o man _odoc/pkg1/page-index.odocl
   $ cat man/pkg1/index.3o | grep gif


### PR DESCRIPTION
This  small PR adds support for images to the latex backed for png, pdf, and jpeg internal assets.

As a side-note, I am slightly surprised that there is no support for width information on the media tags since both image and video are hard to place properly without fixing their size.