### PR TITLE
Fix issue #610 - `odoc html-fragment` not producing headings correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
 - Fix incomplete handling of `--suppress-warnings` (now `--warnings-tag`)
   (@jonludlam, #1304)
 - Fix bug in odoc_driver_voodoo related to virtual libraries (@jonludlam, #1309)
+- Fix issue #610 where `odoc html-fragment` wasn't rendering headings correctly
+  (@jonludlam, #1306)
 
 # 3.0.0~beta1
 

--- a/src/html/generator.mli
+++ b/src/html/generator.mli
@@ -6,6 +6,12 @@ val render :
 
 val filepath : config:Config.t -> Odoc_document.Url.Path.t -> Fpath.t
 
+val items :
+  config:Config.t ->
+  resolve:Link.resolve ->
+  Odoc_document.Types.Item.t list ->
+  Html_types.flow5_without_header_footer Tyxml.Html.elt list
+
 val doc :
   config:Config.t ->
   xref_base_uri:string ->


### PR DESCRIPTION
@dbuenzli could you please check this works for you? As a quick check, with this I get:

```
$ echo "{0:sample OCaml 4.11.1 sample package documentation}" > frag.mld 
$ dune exec -- odoc html-fragment frag.mld  
<h1 id="sample"><a href="#sample" class="anchor"></a>OCaml 4.11.1 sample package documentation</h1>
```