### PR TITLE
Further fixes for virtual libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
   (@jonludlam, #1311)
 - Fix incomplete handling of `--suppress-warnings` (now `--warnings-tag`)
   (@jonludlam, #1304)
+- Fix bug in odoc_driver_voodoo related to virtual libraries (@jonludlam, #1309)
 
 # 3.0.0~beta1
 

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -138,8 +138,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
           (Odoc_unit.Pkg_args.compiled_libs unit.pkg_args)
       in
       Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
-        ~includes ~warnings_tag:unit.pkgname
-        ~parent_id:unit.parent_id;
+        ~includes ~warnings_tag:unit.pkgname ~parent_id:unit.parent_id;
       (match unit.input_copy with
       | None -> ()
       | Some p -> Util.cp (Fpath.to_string unit.input_file) (Fpath.to_string p));

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -28,6 +28,7 @@ let make_index ~dirs ~rel_dir ~libs ~pkgs ~index ~enable_warnings ~content :
     pkg_args;
     parent_id;
     input_file;
+    input_copy = None;
     odoc_file;
     odocl_file;
     enable_warnings;

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -76,7 +76,8 @@ type 'a t = {
   parent_id : Odoc.Id.t;
   input_file : Fpath.t;
   input_copy : Fpath.t option;
-      (* Used to stash cmtis from virtual libraries into the odoc dir for voodoo mode *)
+      (* Used to stash cmtis from virtual libraries into the odoc dir for voodoo mode.
+         See https://github.com/ocaml/odoc/pull/1309 *)
   output_dir : Fpath.t;
   odoc_file : Fpath.t;
   odocl_file : Fpath.t;

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -208,7 +208,7 @@ let fix_virtual ~(precompiled_units : intf t list Util.StringMap.t)
                            cmti found for %a"
                           (List.length xs) Fpath.pp unit.input_file);
                     let possibles =
-                      List.filter_map
+                      List.find_map
                         (fun x ->
                           match x.input_copy with
                           | Some x ->
@@ -221,10 +221,10 @@ let fix_virtual ~(precompiled_units : intf t list Util.StringMap.t)
                         xs
                     in
                     match possibles with
-                    | [] ->
+                    | None ->
                         Logs.debug (fun m -> m "Not replacing input file");
                         unit
-                    | x :: _ ->
+                    | Some x ->
                         Logs.debug (fun m ->
                             m "Replacing input_file of unit with %a" Fpath.pp x);
                         { unit with input_file = x })))

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -32,6 +32,8 @@ type index = {
 type 'a t = {
   parent_id : Odoc.Id.t;
   input_file : Fpath.t;
+  input_copy : Fpath.t option;
+      (* Used to stash cmtis from virtual libraries into the odoc dir for voodoo mode *)
   output_dir : Fpath.t;
   odoc_file : Fpath.t;
   odocl_file : Fpath.t;


### PR DESCRIPTION
So in the docs-ci, we don't have the 'prep' dir (with all the cmts/cmtis) for any package apart from the one being built. This is a problem for implementations of virtual libraries that aren't in the same package as the virtual library itself, as we try to copy the cmti from the virtual library to the implementation. 

The solution here it to copy _all_ cmtis for libraries without archives to the odoc dir. These will then be available to be used.