### PR TITLE
Fix classify when there are archives sharing modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
 - Fix bug in odoc_driver_voodoo related to virtual libraries (@jonludlam, #1309)
 - Fix issue #610 where `odoc html-fragment` wasn't rendering headings correctly
   (@jonludlam, #1306)
+- Fix bug in `odoc classify` when there are archives that can't be co-linked
+  (@jonludlam, #1310)
 
 # 3.0.0~beta1
 

--- a/src/odoc/classify.cppo.ml
+++ b/src/odoc/classify.cppo.ml
@@ -141,6 +141,7 @@ module Deps = struct
         let deps =
           List.filter
             (fun l2 ->
+              ((StringSet.inter l1.Archive.modules l2.Archive.modules |> StringSet.cardinal) = 0) && (* Can't be co-linked if there are common module names *)
               not
               @@ StringSet.is_empty
                    (StringSet.inter l1.Archive.impl_deps l2.Archive.modules))


### PR DESCRIPTION
This breaks docs for at least rdbg.1.184.1 