### PR TITLE
Fix "box model" for code blocks

### DIFF
--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -124,7 +124,7 @@ let trim_leading_whitespace : first_line_offset:int -> string -> string =
       (* Since blank lines were ignored when calculating
          [least_amount_of_whitespace], their length might be less than the
          amount. *)
-      if String.length line < n then line
+      if String.length line < n then ""
       else String.sub line n (String.length line - n)
     in
     let lines =

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -104,15 +104,15 @@ let trim_leading_whitespace : first_line_offset:int -> string -> string =
       | _ -> least_so_far)
   in
 
-  let first_line_max_drop, least_amount_of_whitespace =
+  let least_amount_of_whitespace =
     match lines with
-    | [] -> 0, None
+    | [] -> None
     | first_line :: tl ->
       begin match count_leading_whitespace first_line with
         | Some n ->
-          n, least_amount_of_whitespace (Some (first_line_offset + n)) tl
+          least_amount_of_whitespace (Some (first_line_offset + n)) tl
         | None ->
-          0, least_amount_of_whitespace None tl
+          least_amount_of_whitespace None tl
       end
   in
 
@@ -131,8 +131,9 @@ let trim_leading_whitespace : first_line_offset:int -> string -> string =
       match lines with
       | [] -> []
       | first_line :: tl ->
-        drop (min first_line_max_drop least_amount_of_whitespace) first_line
-        :: List.map (drop least_amount_of_whitespace) tl
+         let first_line_drop = max 0 (least_amount_of_whitespace - first_line_offset) in
+         drop first_line_drop first_line
+         :: List.map (drop least_amount_of_whitespace) tl
     in
     String.concat "\n" lines
 

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -131,9 +131,14 @@ let trim_leading_whitespace : first_line_offset:int -> string -> string =
       match lines with
       | [] -> []
       | first_line :: tl ->
-         let first_line_drop = max 0 (least_amount_of_whitespace - first_line_offset) in
-         drop first_line_drop first_line
-         :: List.map (drop least_amount_of_whitespace) tl
+         let first_line =
+           let spaces_to_remove = least_amount_of_whitespace - first_line_offset in
+           if spaces_to_remove >= 0 then
+             drop spaces_to_remove first_line
+           else
+             (String.make (-spaces_to_remove) ' ') ^ first_line
+         in
+         first_line :: List.map (drop least_amount_of_whitespace) tl
     in
     String.concat "\n" lines
 

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -2566,7 +2566,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "foo\
+          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  " foo\
                                                                \nbar")))))
          (warnings ()))
         |}]
@@ -2576,7 +2576,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "foo\r\
+          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  " foo\r\
                                                                \nbar")))))
          (warnings ()))
         |}]
@@ -2595,7 +2595,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "  foo\
+          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "   foo\
                                                                \nbar")))))
          (warnings ()))
         |}]
@@ -2614,7 +2614,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (3 6)) (code_block ((f.ml (1 2) (3 4))  "foo\
+          (((f.ml (1 0) (3 6)) (code_block ((f.ml (1 2) (3 4))  " foo\
                                                                \n\
                                                                \nbar")))))
          (warnings ()))
@@ -2625,7 +2625,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (3 7)) (code_block ((f.ml (1 2) (3 5))  "foo\
+          (((f.ml (1 0) (3 7)) (code_block ((f.ml (1 2) (3 5))  "  foo\
                                                                \n\
                                                                \nbar")))))
          (warnings ()))
@@ -2639,7 +2639,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (2 7) (4 4)) (code_block ((f.ml (2 9) (4 2))  "a\
+          (((f.ml (2 7) (4 4)) (code_block ((f.ml (2 9) (4 2))  " a\
                                                                \nb\
                                                                \nc")))))
          (warnings ()))
@@ -2650,7 +2650,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (3 6)) (code_block ((f.ml (1 2) (3 4))  "foo\
+          (((f.ml (1 0) (3 6)) (code_block ((f.ml (1 2) (3 4))  " foo\
                                                                \n  \
                                                                \nbar")))))
          (warnings ()))
@@ -2677,7 +2677,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "foo\
+          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "\tfoo\
                                                                \nbar")))))
          (warnings ()))
         |}]
@@ -2687,7 +2687,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 7)) (code_block ((f.ml (1 2) (2 5))  "foo\
+          (((f.ml (1 0) (2 7)) (code_block ((f.ml (1 2) (2 5))  "\tfoo\
                                                                \nbar")))))
          (warnings ()))
         |}]
@@ -2701,7 +2701,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (2 1) (4 3)) (code_block ((f.ml (2 3) (4 1))  " foo\
+          (((f.ml (2 1) (4 3)) (code_block ((f.ml (2 3) (4 1))  "  foo\
                                                                \nbar")))))
          (warnings ()))
         |}]

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -2568,7 +2568,8 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "foo\
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let leading_whitespace_two_cr_lf =
       test "{[ foo\r\n bar]}";
@@ -2577,7 +2578,8 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "foo\r\
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let leading_whitespace_two_different_indent =
       test "{[ foo\n   bar]}";
@@ -2595,7 +2597,8 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "  foo\
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let leading_whitespace_two_different_indent_reloc =
       test "{[ foo\n      bar]}";
@@ -2614,7 +2617,8 @@ let%expect_test _ =
           (((f.ml (1 0) (3 6)) (code_block ((f.ml (1 2) (3 4))  "foo\
                                                                \n\
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let leading_whitespace_with_whitespace_line_short =
       test "{[  foo\n \n  bar]}";
@@ -2627,6 +2631,20 @@ let%expect_test _ =
          (warnings ()))
         |}]
 
+    let bli =
+      test {|
+       {[ a
+ b
+ c]}|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (2 7) (4 4)) (code_block ((f.ml (2 9) (4 2))  "a\
+                                                               \nb\
+                                                               \nc")))))
+         (warnings ()))
+        |}]
+
     let leading_whitespace_with_whitespace_line_long =
       test "{[ foo\n   \n bar]}";
       [%expect
@@ -2635,7 +2653,8 @@ let%expect_test _ =
           (((f.ml (1 0) (3 6)) (code_block ((f.ml (1 2) (3 4))  "foo\
                                                                \n  \
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let leading_whitespace_leading_newline =
       test "{[\n  foo\n  bar\n]}";
@@ -2660,7 +2679,8 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "foo\
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let leading_tab_two_different_indent =
       test "{[\tfoo\n\t\tbar]}";
@@ -2669,7 +2689,22 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (2 7)) (code_block ((f.ml (1 2) (2 5))  "foo\
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
+
+    let leading_whitespace_when_box_model_not_applicable =
+      test {|
+ {[  foo
+ bar
+ ]}
+|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (2 1) (4 3)) (code_block ((f.ml (2 3) (4 1))  " foo\
+                                                               \nbar")))))
+         (warnings ()))
+        |}]
 
     let leading_newline =
       test "{[\nfoo]}";

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -2531,28 +2531,31 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 5)) (code_block ((f.ml (1 2) (2 3))  "foo\
+          (((f.ml (1 0) (2 5)) (code_block ((f.ml (1 2) (2 3))  "  foo\
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let cr_lf =
       test "{[foo\r\nbar]}";
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 5)) (code_block ((f.ml (1 2) (2 3))  "foo\r\
+          (((f.ml (1 0) (2 5)) (code_block ((f.ml (1 2) (2 3))  "  foo\r\
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let blank_line =
       test "{[foo\n\nbar]}";
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (3 5)) (code_block ((f.ml (1 2) (3 3))  "foo\
+          (((f.ml (1 0) (3 5)) (code_block ((f.ml (1 2) (3 3))  "  foo\
                                                                \n\
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let leading_whitespace =
       test "{[ foo]}";
@@ -2566,7 +2569,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  " foo\
+          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "  foo\
                                                                \nbar")))))
          (warnings ()))
         |}]
@@ -2576,7 +2579,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  " foo\r\
+          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "  foo\r\
                                                                \nbar")))))
          (warnings ()))
         |}]
@@ -2595,7 +2598,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "   foo\
+          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "    foo\
                                                                \nbar")))))
          (warnings ()))
         |}]
@@ -2614,7 +2617,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (3 6)) (code_block ((f.ml (1 2) (3 4))  " foo\
+          (((f.ml (1 0) (3 6)) (code_block ((f.ml (1 2) (3 4))  "  foo\
                                                                \n\
                                                                \nbar")))))
          (warnings ()))
@@ -2639,9 +2642,10 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (2 7) (4 4)) (code_block ((f.ml (2 9) (4 2))  " a\
-                                                               \nb\
-                                                               \nc")))))
+          (((f.ml (2 7) (4 4))
+            (code_block ((f.ml (2 9) (4 2))  "         a\
+                                            \nb\
+                                            \nc")))))
          (warnings ()))
         |}]
 
@@ -2650,7 +2654,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (3 6)) (code_block ((f.ml (1 2) (3 4))  " foo\
+          (((f.ml (1 0) (3 6)) (code_block ((f.ml (1 2) (3 4))  "  foo\
                                                                \n  \
                                                                \nbar")))))
          (warnings ()))
@@ -2677,7 +2681,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  "\tfoo\
+          (((f.ml (1 0) (2 6)) (code_block ((f.ml (1 2) (2 4))  " \tfoo\
                                                                \nbar")))))
          (warnings ()))
         |}]
@@ -2701,7 +2705,7 @@ let%expect_test _ =
       [%expect
         {|
         ((output
-          (((f.ml (2 1) (4 3)) (code_block ((f.ml (2 3) (4 1))  "  foo\
+          (((f.ml (2 1) (4 3)) (code_block ((f.ml (2 3) (4 1))  "    foo\
                                                                \nbar")))))
          (warnings ()))
         |}]
@@ -2928,9 +2932,10 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (2 14))
-            (code_block ((f.ml (1 2) (2 12))  "(* foo *)\
+            (code_block ((f.ml (1 2) (2 12))  "  (* foo *)\
                                              \nlet bar = ()")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let docstring =
       test "{[(** foo *)\nlet bar = ()]}";
@@ -2938,9 +2943,10 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (2 14))
-            (code_block ((f.ml (1 2) (2 12))  "(** foo *)\
+            (code_block ((f.ml (1 2) (2 12))  "  (** foo *)\
                                              \nlet bar = ()")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let docstring_with_code_block =
       test "{[(** {[foo]} *)\nlet bar = ()]}";

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -2622,9 +2622,10 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (3 7)) (code_block ((f.ml (1 2) (3 5))  "foo\
-                                                               \n \
+                                                               \n\
                                                                \nbar")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let leading_whitespace_with_whitespace_line_long =
       test "{[ foo\n   \n bar]}";


### PR DESCRIPTION
In my mental model, code blocks are supposed to follow a "box model", where the actual content of a code block is the smallest box that contains it all:

![image](https://github.com/user-attachments/assets/7897c470-3c72-4c3d-9a95-a80c05b0224d)

In the example above, the actual content of the code blocks is in lighter blue. As you can see, some whitespace has been stripped before, after, but also at the beginning of each line.

However, (supposing my mental model is the right one), there are two bugs in the implementation.

---

The first one is about lines with only whitespace, but less than the box:

![image](https://github.com/user-attachments/assets/1d73061c-19f4-4f47-8b77-f59c20bca98a)

Suppose that `_` are spaces (I used `_` to make it visible). I think those spaces are not part of the box and should be stripped, but currently they _are_ part of the content, which would be:

```
    Here is some content
___
With some other content

  Hey!
```

---

The second one is about a corner case of the "box model": when the code block does not start with a new line.

In this case, it is clear what the content of the code block should be:

![image](https://github.com/user-attachments/assets/09cdad99-c677-4619-8ab3-f95b34d3d25d)

However, in this case it is not! 

![image](https://github.com/user-attachments/assets/c2c244cf-c224-4aa4-a8b0-9999facdc3b3)

Of course, `  {[` should not be part of "the box". So, what do we put instead?

One possibility would be to fill it with spaces:

```
     Here is some content

With some other content
```

Another solution would be to keep the first line as it is, in this degenerated case:

```
 Here is some content

With some other content
```

The currently implemented solution is very confusing in my opinion. For the first line, it removes a number of spaces corresponding to the min between the de-indentation level and the number of opening spaces in the first line. In effect it ignores the offset in which the first line start.

The first solution seems the most consistent with the box model, but also probably the most "breaking change". The second solution seems good as:
```
{[a
b
c]}
```
is turned as:
```
a
b
c
```
and not 
```
  a
b
c
```
as it would in the first solution.

Which solution do you think is best?
