### PR TITLE
Disable warnings coming from linking implementations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
   (@jonludlam, #1304)
 - Remove `--suppress-warnings` argument in favour of `--warnings-tag`
   which is more friendly for caching and voodoo (@jonludlam, #1304)
+- Filter out warnings coming from linking implementations (@jonludlam, #1319)
 
 ### Fixed
 

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -168,7 +168,7 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
         in
         let unit =
           make_unit ~name ~kind ~rel_dir ~input_file:impl.mip_path ~pkg
-            ~lib_deps ~enable_warnings:pkg.selected ~to_output:pkg.selected
+            ~lib_deps ~enable_warnings:false ~to_output:pkg.selected
             ~stash_input:false
         in
         Some unit


### PR DESCRIPTION
These warnings cannot be fixed by the user, therefore they serve no purpose.