### PR TITLE
Driver compile warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Remove `--suppress-warnings` argument in favour of `--warnings-tag`
   which is more friendly for caching and voodoo (@jonludlam, #1304)
 - Filter out warnings coming from linking implementations (@jonludlam, #1319)
+- Output warnings coming from the `compile` phase in the driver (@jonludlam, #1323)
 
 ### Fixed
 

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -45,7 +45,7 @@ can use the name of the tree in the reference.
 
 Different situations will give different meanings to the trees. In the case of
 [opam] packages, though, there is a natural meaning to give to those trees
-(you'll find more details in the {{!label-conv}convention for opam-installed packages}). Any
+(you'll find more details in the {{!section-conv}convention for opam-installed packages}). Any
 opam package will have an associated "documentation tree", named with the name
 of the package. Any of its libraries will have an associated "module tree",
 named with the name of the library. Another package can thus refer to the doc

--- a/doc/odoc_for_authors.mld
+++ b/doc/odoc_for_authors.mld
@@ -88,7 +88,7 @@ doc, you can add the following to your [doc/dune] file:
   (files (asset.jpg as odoc-pages/asset.jpg)))
 v}
 
-Odoc 3.0 introduces a per-package configuration file, {{!section-config-file}odoc-config.sexp}, which is important if you'd like your
+Odoc 3.0 introduces a per-package configuration file, {{!section-"config-file"}odoc-config.sexp}, which is important if you'd like your
 documentation to link to the docs of other packages or libraries. If your documentation needs
 this configuration file, this will also need to be installed as follows:
 
@@ -954,7 +954,7 @@ Finally, documentation pages should start with a level-0 heading:
 
 {v
 {0 Title of the page}
-v}.
+v}
 
 Level-0 headings should not be used elsewhere.
 

--- a/src/driver/bin/odoc_driver.ml
+++ b/src/driver/bin/odoc_driver.ml
@@ -130,7 +130,7 @@ let run_inner ~odoc_dir ~odocl_dir ~index_dir ~mld_dir ~compile_grep ~link_grep
   List.iter
     (fun { Cmd_outputs.log_dest; prefix; run } ->
       match log_dest with
-      | `Link ->
+      | `Link | `Compile ->
           [ run.Run.output; run.Run.errors ]
           |> List.iter @@ fun content ->
              if String.length content = 0 then ()

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -138,7 +138,8 @@ let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
           (Odoc_unit.Pkg_args.compiled_libs unit.pkg_args)
       in
       Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
-        ~includes ~warnings_tag:unit.pkgname ~parent_id:unit.parent_id;
+        ~includes ~warnings_tag:unit.pkgname ~parent_id:unit.parent_id
+        ~ignore_output:(not unit.enable_warnings);
       (match unit.input_copy with
       | None -> ()
       | Some p -> Util.cp (Fpath.to_string unit.input_file) (Fpath.to_string p));
@@ -196,7 +197,8 @@ let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
     | `Mld ->
         let includes = Fpath.Set.empty in
         Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
-          ~includes ~warnings_tag:None ~parent_id:unit.parent_id;
+          ~includes ~warnings_tag:None ~parent_id:unit.parent_id
+          ~ignore_output:(not unit.enable_warnings);
         Atomic.incr Stats.stats.compiled_mlds;
         Ok [ unit ]
     | `Md ->

--- a/src/driver/odoc.ml
+++ b/src/driver/odoc.ml
@@ -36,7 +36,8 @@ let compile_deps f =
   | [ (_, digest) ], deps -> Ok { digest; deps }
   | _ -> Error (`Msg "odd")
 
-let compile ~output_dir ~input_file:file ~includes ~warnings_tag ~parent_id =
+let compile ~output_dir ~input_file:file ~includes ~warnings_tag ~parent_id
+    ~ignore_output =
   let open Cmd in
   let includes =
     Fpath.Set.fold
@@ -59,10 +60,10 @@ let compile ~output_dir ~input_file:file ~includes ~warnings_tag ~parent_id =
     | Some tag -> cmd % "--warnings-tag" % tag
   in
   let desc = Printf.sprintf "Compiling %s" (Fpath.to_string file) in
-  ignore
-  @@ Cmd_outputs.submit
-       (Some (`Compile, Fpath.to_string file))
-       desc cmd output_file
+  let log =
+    if ignore_output then None else Some (`Compile, Fpath.to_string file)
+  in
+  ignore @@ Cmd_outputs.submit log desc cmd output_file
 
 let compile_md ~output_dir ~input_file:file ~parent_id =
   let open Cmd in

--- a/src/driver/odoc.mli
+++ b/src/driver/odoc.mli
@@ -27,6 +27,7 @@ val compile :
   includes:Fpath.set ->
   warnings_tag:string option ->
   parent_id:Id.t ->
+  ignore_output:bool ->
   unit
 val compile_md :
   output_dir:Fpath.t -> input_file:Fpath.t -> parent_id:Id.t -> unit


### PR DESCRIPTION
We currently only output warnings from the Link phase. This PR also outputs warnings from the compile phase, including those that come from the parser. 

This PR also fixes some warnings that this change made apparent.
