### PR TITLE
Extract code blocks by name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Added support for (local) images in the latex backend (@Octachron, #1297)
 - Added a `header` field to the json output (@panglesd, #1314)
+- Added an `extract-code` subcommand to extract code blocks from mld files
+  (@panglesd, #1326)
 
 ### Changed
 

--- a/src/.ocamlformat-ignore
+++ b/src/.ocamlformat-ignore
@@ -11,6 +11,7 @@ loader/lookup_def.ml
 loader/lookup_def.mli
 syntax_highlighter/syntax_highlighter.ml
 model/*.cppo.ml
+odoc/*.cppo.ml
 html_support_files/*.ml
 xref2/shape_tools.*
 odoc/classify.cppo.ml

--- a/src/loader/doc_attr.mli
+++ b/src/loader/doc_attr.mli
@@ -81,3 +81,15 @@ val conv_canonical_module : Odoc_model.Reference.path -> Paths.Path.Module.t
 val conv_canonical_type : Odoc_model.Reference.path -> Paths.Path.Type.t option
 val conv_canonical_module_type :
   Odoc_model.Reference.path -> Paths.Path.ModuleType.t option
+
+type payload = string * Location.t
+
+type parsed_attribute =
+  [ `Text of payload (* Standalone comment. *)
+  | `Doc of payload (* Attached comment. *)
+  | `Stop of Location.t (* [(**/**)]. *)
+  | `Alert of string * payload option * Location.t
+    (* [`Alert (name, payload, loc)] is for [\[@@alert name "payload"\]] attributes. *)
+  ]
+
+val parse_attribute : Parsetree.attribute -> parsed_attribute option

--- a/src/loader/odoc_loader.ml
+++ b/src/loader/odoc_loader.ml
@@ -268,3 +268,5 @@ let read_cmi ~make_root ~parent ~filename ~warnings_tag =
   wrap_errors ~filename (read_cmi ~make_root ~parent ~filename ~warnings_tag)
 
 let read_location = Doc_attr.read_location
+
+let parse_attribute = Doc_attr.parse_attribute

--- a/src/loader/odoc_loader.mli
+++ b/src/loader/odoc_loader.mli
@@ -41,3 +41,5 @@ val read_cmi :
   (Lang.Compilation_unit.t, Error.t) result Error.with_warnings
 
 val read_location : Location.t -> Location_.span
+
+val parse_attribute : Parsetree.attribute -> Doc_attr.parsed_attribute option

--- a/src/loader/odoc_loader.mli
+++ b/src/loader/odoc_loader.mli
@@ -42,4 +42,9 @@ val read_cmi :
 
 val read_location : Location.t -> Location_.span
 
+val wrap_errors :
+  filename:string ->
+  (unit -> 'a) ->
+  'a Odoc_model.Error.with_errors_and_warnings
+
 val parse_attribute : Parsetree.attribute -> Doc_attr.parsed_attribute option

--- a/src/markdown/doc_of_md.ml
+++ b/src/markdown/doc_of_md.ml
@@ -454,12 +454,8 @@ let code_block_to_nestable_block_element ~locator cb m (bs, warns) =
             split_info_string_locs ~left_count ~right_count im
           in
           let env =
-            if env = "" then None
-            else
-              Some
-                (Loc.at
-                   (textloc_to_loc ~locator env_loc)
-                   [ Loc.at (textloc_to_loc ~locator env_loc) (`Tag env) ])
+            if env = "" then []
+            else [ `Tag (Loc.at (textloc_to_loc ~locator env_loc) env) ]
           in
           let lang = Loc.at (textloc_to_loc ~locator lang_loc) lang in
           let metadata = Some { Ast.language = lang; tags = env } in

--- a/src/markdown/doc_of_md.ml
+++ b/src/markdown/doc_of_md.ml
@@ -455,7 +455,11 @@ let code_block_to_nestable_block_element ~locator cb m (bs, warns) =
           in
           let env =
             if env = "" then None
-            else Some (Loc.at (textloc_to_loc ~locator env_loc) env)
+            else
+              Some
+                (Loc.at
+                   (textloc_to_loc ~locator env_loc)
+                   [ Loc.at (textloc_to_loc ~locator env_loc) (`Tag env) ])
           in
           let lang = Loc.at (textloc_to_loc ~locator lang_loc) lang in
           let metadata = Some { Ast.language = lang; tags = env } in

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -1692,21 +1692,18 @@ module Extract_code = struct
     Arg.(value & flag & info ~doc [ "line-directives" ])
 
   let names =
-    let doc = "From which name of code blocks to extract content" in
+    let doc =
+      "From which name(s) of code blocks to extract content. When no names are \
+       provided, extract all OCaml code blocks."
+    in
     Arg.(value & opt_all string [] & info ~doc [ "name" ])
 
   let input =
-    let doc = "Input $(i,.cmti), $(i,.cmt), $(i,.cmi) or $(i,.mld) file." in
+    let doc = "Input $(i,.mld) file." in
     Arg.(required & pos 0 (some file) None & info ~doc ~docv:"FILE" [])
 
   let dst =
-    let doc =
-      "Output file path. Non-existing intermediate directories are created. If \
-       absent outputs a $(i,BASE.odoc) file in the same directory as the input \
-       file where $(i,BASE) is the basename of the input file. For mld files \
-       the \"page-\" prefix will be added if not already present in the input \
-       basename."
-    in
+    let doc = "Output file path." in
     Arg.(
       value
       & opt (some string) None
@@ -1720,8 +1717,7 @@ module Extract_code = struct
   let info ~docs =
     Term.info "extract-code" ~docs
       ~doc:
-        "Classify the modules into libraries based on heuristics. Libraries \
-         are specified by the --library option."
+        "Extract code blocks from mld files in order to be able to execute them"
 end
 
 let section_pipeline = "COMMANDS: Compilation pipeline"

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -1715,7 +1715,7 @@ module Extract_code = struct
       $ (const extract $ dst $ input $ line_directives $ names))
 
   let info ~docs =
-    Term.info "extract-code" ~docs
+    Cmd.info "extract-code" ~docs
       ~doc:
         "Extract code blocks from mld files in order to be able to execute them"
 end

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -1684,8 +1684,8 @@ module Classify = struct
 end
 
 module Extract_code = struct
-  let extract dst input line_directives names =
-    Ok (Extract_code.extract ~dst ~input ~line_directives ~names)
+  let extract dst input line_directives names warnings_options =
+    Extract_code.extract ~dst ~input ~line_directives ~names ~warnings_options
 
   let line_directives =
     let doc = "Whether to include line directives in the output file" in
@@ -1712,7 +1712,8 @@ module Extract_code = struct
   let cmd =
     Term.(
       const handle_error
-      $ (const extract $ dst $ input $ line_directives $ names))
+      $ (const extract $ dst $ input $ line_directives $ names
+       $ warnings_options))
 
   let info ~docs =
     Cmd.info "extract-code" ~docs

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -1683,6 +1683,47 @@ module Classify = struct
          are specified by the --library option."
 end
 
+module Extract_code = struct
+  let extract dst input line_directives names =
+    Ok (Extract_code.extract ~dst ~input ~line_directives ~names)
+
+  let line_directives =
+    let doc = "Whether to include line directives in the output file" in
+    Arg.(value & flag & info ~doc [ "line-directives" ])
+
+  let names =
+    let doc = "From which name of code blocks to extract content" in
+    Arg.(value & opt_all string [] & info ~doc [ "name" ])
+
+  let input =
+    let doc = "Input $(i,.cmti), $(i,.cmt), $(i,.cmi) or $(i,.mld) file." in
+    Arg.(required & pos 0 (some file) None & info ~doc ~docv:"FILE" [])
+
+  let dst =
+    let doc =
+      "Output file path. Non-existing intermediate directories are created. If \
+       absent outputs a $(i,BASE.odoc) file in the same directory as the input \
+       file where $(i,BASE) is the basename of the input file. For mld files \
+       the \"page-\" prefix will be added if not already present in the input \
+       basename."
+    in
+    Arg.(
+      value
+      & opt (some string) None
+      & info ~docs ~docv:"PATH" ~doc [ "o"; "output" ])
+
+  let cmd =
+    Term.(
+      const handle_error
+      $ (const extract $ dst $ input $ line_directives $ names))
+
+  let info ~docs =
+    Term.info "extract-code" ~docs
+      ~doc:
+        "Classify the modules into libraries based on heuristics. Libraries \
+         are specified by the --library option."
+end
+
 let section_pipeline = "COMMANDS: Compilation pipeline"
 let section_generators = "COMMANDS: Alternative generators"
 let section_support = "COMMANDS: Scripting"
@@ -1737,6 +1778,7 @@ let () =
          Css.(cmd, info ~docs:section_deprecated);
          Depends.Odoc_html.(cmd, info ~docs:section_deprecated);
          Classify.(cmd, info ~docs:section_pipeline);
+         Extract_code.(cmd, info ~docs:section_pipeline);
        ]
   in
   let main =

--- a/src/odoc/dune
+++ b/src/odoc/dune
@@ -29,5 +29,14 @@
    %{workspace_root}
    (run %{bin:cppo} -V OCAML:%{ocaml_version} %{x} -o %{targets}))))
 
+(rule
+ (targets extract_code.ml)
+ (deps
+  (:x extract_code.cppo.ml))
+ (action
+  (chdir
+   %{workspace_root}
+   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{x} -o %{targets}))))
+
 (documentation
  (package odoc))

--- a/src/odoc/extract_code.cppo.ml
+++ b/src/odoc/extract_code.cppo.ml
@@ -1,3 +1,4 @@
+#if OCAML_VERSION >= (4,10,0)
 open Odoc_utils
 open Odoc_parser
 
@@ -236,3 +237,10 @@ let extract ~dst ~input ~names ~line_directives ~warnings_options =
   | Some dst ->
       Io_utils.with_open_out dst @@ fun oc ->
       loader line_directives oc names input
+
+#else
+
+let extract ~dst:_ ~input:_ ~names:_ ~line_directives:_ ~warnings_options:_ =
+  Error (`Msg "Extract-code is not available for OCaml < 4.10")
+
+#endif

--- a/src/odoc/extract_code.cppo.ml
+++ b/src/odoc/extract_code.cppo.ml
@@ -5,9 +5,7 @@ open Odoc_parser
 let tags_included_in_names names tags =
   List.exists
     (function
-      | {
-          Loc.value = `Binding ({ Loc.value = "name"; _ }, { Loc.value = n; _ }); _
-        }
+      | `Binding ({ Loc.value = "name"; _ }, { Loc.value = n; _ })
         when List.exists (String.equal n) names ->
           true
       | _ -> false)
@@ -21,8 +19,8 @@ let needs_extraction names meta =
   in
   let check_name () =
     match meta with
-    | Some { Ast.tags = Some tags; _ } ->
-        tags_included_in_names names tags.Loc.value
+    | Some { Ast.tags; _ } ->
+        tags_included_in_names names tags
     | _ -> false
   in
   match names with [] -> check_language () | _ :: _ -> check_name ()

--- a/src/odoc/extract_code.cppo.ml
+++ b/src/odoc/extract_code.cppo.ml
@@ -6,7 +6,7 @@ let tags_included_in_names names tags =
   List.exists
     (function
       | {
-          Loc.value = `Binding ({ Loc.value = "name"; _ }, { Loc.value = n; _ });
+          Loc.value = `Binding ({ Loc.value = "name"; _ }, { Loc.value = n; _ }); _
         }
         when List.exists (String.equal n) names ->
           true

--- a/src/odoc/extract_code.ml
+++ b/src/odoc/extract_code.ml
@@ -1,0 +1,58 @@
+open Odoc_utils
+open Odoc_parser
+
+let rec nestable_block_element = function
+  | {
+      Loc.location = _;
+      value = `Verbatim _ | `Modules _ | `Math_block _ | `Media _ | `Paragraph _;
+    } ->
+      ()
+  | {
+      location = _;
+      value = `Code_block { Ast.content = { value; location }; _ };
+    } ->
+      Format.printf "#%d \"%s\"\n" (location.start.line + 1) location.file;
+      Format.printf "%s"
+        (String.v ~len:(location.start.column + 1) (fun _ -> ' '));
+      Format.printf "%s" value
+  | { location = _; value = `List (_, _, l) } ->
+      List.iter (List.iter nestable_block_element) l
+  | { location = _; value = `Table ((table, _), _) } ->
+      List.iter
+        (List.iter (fun (x, _) -> List.iter nestable_block_element x))
+        table
+
+and block_element = function
+  | {
+      Loc.value =
+        `Tag
+          ( `Deprecated l
+          | `Param (_, l)
+          | `Raise (_, l)
+          | `Return l
+          | `See (_, _, l)
+          | `Before (_, l) );
+      _;
+    } ->
+      List.iter nestable_block_element l
+  | {
+      Loc.value =
+        `Tag
+          ( `Author _ | `Since _ | `Version _ | `Canonical _ | `Inline | `Open
+          | `Children_order _ | `Toc_status _ | `Order_category _
+          | `Short_title _ | `Closed | `Hidden );
+      _;
+    }
+  | { Loc.value = `Heading _; _ } ->
+      ()
+  | { Loc.value = #Ast.nestable_block_element; _ } as x ->
+      nestable_block_element x
+
+let extract ~dst:_ ~input ~names:_ ~line_directives:_ =
+  let location =
+    { Lexing.pos_fname = input; pos_lnum = 0; pos_bol = 0; pos_cnum = 0 }
+  in
+  let c = Io_utils.read_lines input |> String.concat ~sep:"\n" in
+  let parsed = parse_comment ~location ~text:c in
+  let ast = ast parsed in
+  List.iter block_element ast

--- a/src/odoc/extract_code.ml
+++ b/src/odoc/extract_code.ml
@@ -4,7 +4,9 @@ open Odoc_parser
 let tags_included_in_names names tags =
   List.exists
     (function
-      | { Loc.value = `Binding ("name", n) }
+      | {
+          Loc.value = `Binding ({ Loc.value = "name"; _ }, { Loc.value = n; _ });
+        }
         when List.exists (String.equal n) names ->
           true
       | _ -> false)

--- a/src/odoc/extract_code.ml
+++ b/src/odoc/extract_code.ml
@@ -4,7 +4,9 @@ open Odoc_parser
 let tags_included_in_names names tags =
   List.exists
     (function
-      | `Binding ("name", n) when List.exists (String.equal n) names -> true
+      | { Loc.value = `Binding ("name", n) }
+        when List.exists (String.equal n) names ->
+          true
       | _ -> false)
     tags
 

--- a/src/odoc/extract_code.ml
+++ b/src/odoc/extract_code.ml
@@ -1,58 +1,76 @@
 open Odoc_utils
 open Odoc_parser
 
-let rec nestable_block_element = function
-  | {
-      Loc.location = _;
-      value = `Verbatim _ | `Modules _ | `Math_block _ | `Media _ | `Paragraph _;
-    } ->
-      ()
-  | {
-      location = _;
-      value = `Code_block { Ast.content = { value; location }; _ };
-    } ->
-      Format.printf "#%d \"%s\"\n" (location.start.line + 1) location.file;
-      Format.printf "%s"
-        (String.v ~len:(location.start.column + 1) (fun _ -> ' '));
-      Format.printf "%s" value
-  | { location = _; value = `List (_, _, l) } ->
-      List.iter (List.iter nestable_block_element) l
-  | { location = _; value = `Table ((table, _), _) } ->
+let tags_included_in_names names tags =
+  let fields = String.fields ~empty:false tags in
+  List.exists
+    (fun tag ->
+      match String.cut ~sep:"=" tag with
+      | Some ("name", n) -> List.exists (String.equal n) names
+      | _ -> false)
+    fields
+
+let needs_extraction names meta =
+  let check_language l = String.equal "ocaml" l.Loc.value in
+  let check_name tags =
+    if List.is_empty names then true
+    else
+      match tags with
+      | None -> false
+      | Some tags -> tags_included_in_names names tags.Loc.value
+  in
+  match meta with
+  | None -> false
+  | Some meta -> check_language meta.Ast.language && check_name meta.tags
+
+let print oc line_directives location value =
+  if line_directives then (
+    Printf.fprintf oc "#%d \"%s\"\n" (location.Loc.start.line + 1) location.file;
+    Printf.fprintf oc "%s%s\n"
+      (String.v ~len:(location.start.column + 1) (fun _ -> ' '))
+      value)
+  else Printf.fprintf oc "%s" value
+
+let rec nestable_block_element line_directives oc names v =
+  match v.Loc.value with
+  | `Verbatim _ | `Modules _ | `Math_block _ | `Media _ | `Paragraph _ -> ()
+  | `Code_block { Ast.content = { value; location }; meta; _ }
+    when needs_extraction names meta ->
+      print oc line_directives location value
+  | `Code_block _ -> ()
+  | `List (_, _, l) ->
+      List.iter (List.iter (nestable_block_element line_directives oc names)) l
+  | `Table ((table, _), _) ->
       List.iter
-        (List.iter (fun (x, _) -> List.iter nestable_block_element x))
+        (List.iter (fun (x, _) ->
+             List.iter (nestable_block_element line_directives oc names) x))
         table
 
-and block_element = function
-  | {
-      Loc.value =
-        `Tag
-          ( `Deprecated l
-          | `Param (_, l)
-          | `Raise (_, l)
-          | `Return l
-          | `See (_, _, l)
-          | `Before (_, l) );
-      _;
-    } ->
-      List.iter nestable_block_element l
-  | {
-      Loc.value =
-        `Tag
-          ( `Author _ | `Since _ | `Version _ | `Canonical _ | `Inline | `Open
-          | `Children_order _ | `Toc_status _ | `Order_category _
-          | `Short_title _ | `Closed | `Hidden );
-      _;
-    }
-  | { Loc.value = `Heading _; _ } ->
+and block_element line_directives oc names v =
+  match v.Loc.value with
+  | `Tag
+      ( `Deprecated l
+      | `Param (_, l)
+      | `Raise (_, l)
+      | `Return l
+      | `See (_, _, l)
+      | `Before (_, l) ) ->
+      List.iter (nestable_block_element line_directives oc names) l
+  | `Tag
+      ( `Author _ | `Since _ | `Version _ | `Canonical _ | `Inline | `Open
+      | `Children_order _ | `Toc_status _ | `Order_category _ | `Short_title _
+      | `Closed | `Hidden )
+  | `Heading _ ->
       ()
-  | { Loc.value = #Ast.nestable_block_element; _ } as x ->
-      nestable_block_element x
+  | #Ast.nestable_block_element as value ->
+      nestable_block_element line_directives oc names { v with value }
 
-let extract ~dst:_ ~input ~names:_ ~line_directives:_ =
+let extract ~dst ~input ~names ~line_directives =
   let location =
     { Lexing.pos_fname = input; pos_lnum = 0; pos_bol = 0; pos_cnum = 0 }
   in
   let c = Io_utils.read_lines input |> String.concat ~sep:"\n" in
   let parsed = parse_comment ~location ~text:c in
   let ast = ast parsed in
-  List.iter block_element ast
+  let go oc = List.iter (block_element line_directives oc names) ast in
+  match dst with None -> go stdout | Some dst -> Io_utils.with_open_out dst go

--- a/src/odoc/extract_code.ml
+++ b/src/odoc/extract_code.ml
@@ -11,17 +11,18 @@ let tags_included_in_names names tags =
     fields
 
 let needs_extraction names meta =
-  let check_language l = String.equal "ocaml" l.Loc.value in
-  let check_name tags =
-    if List.is_empty names then true
-    else
-      match tags with
-      | None -> false
-      | Some tags -> tags_included_in_names names tags.Loc.value
+  let check_language () =
+    match meta with
+    | None -> true
+    | Some { Ast.language; _ } -> String.equal "ocaml" language.Loc.value
   in
-  match meta with
-  | None -> false
-  | Some meta -> check_language meta.Ast.language && check_name meta.tags
+  let check_name () =
+    match meta with
+    | Some { Ast.tags = Some tags; _ } ->
+        tags_included_in_names names tags.Loc.value
+    | _ -> false
+  in
+  match names with [] -> check_language () | _ :: _ -> check_name ()
 
 let print oc line_directives location value =
   if line_directives then (

--- a/src/odoc/extract_code.ml
+++ b/src/odoc/extract_code.ml
@@ -2,13 +2,11 @@ open Odoc_utils
 open Odoc_parser
 
 let tags_included_in_names names tags =
-  let fields = String.fields ~empty:false tags in
   List.exists
-    (fun tag ->
-      match String.cut ~sep:"=" tag with
-      | Some ("name", n) -> List.exists (String.equal n) names
+    (function
+      | `Binding ("name", n) when List.exists (String.equal n) names -> true
       | _ -> false)
-    fields
+    tags
 
 let needs_extraction names meta =
   let check_language () =
@@ -18,8 +16,7 @@ let needs_extraction names meta =
   in
   let check_name () =
     match meta with
-    | Some { Ast.tags = Some tags; _ } ->
-        tags_included_in_names names tags.Loc.value
+    | Some { Ast.tags = Some tags; _ } -> tags_included_in_names names tags
     | _ -> false
   in
   match names with [] -> check_language () | _ :: _ -> check_name ()

--- a/src/odoc/extract_code.ml
+++ b/src/odoc/extract_code.ml
@@ -20,7 +20,8 @@ let needs_extraction names meta =
   in
   let check_name () =
     match meta with
-    | Some { Ast.tags = Some tags; _ } -> tags_included_in_names names tags
+    | Some { Ast.tags = Some tags; _ } ->
+        tags_included_in_names names tags.Loc.value
     | _ -> false
   in
   match names with [] -> check_language () | _ :: _ -> check_name ()

--- a/src/odoc/extract_code.mli
+++ b/src/odoc/extract_code.mli
@@ -1,0 +1,7 @@
+val extract :
+  dst:string option ->
+  input:string ->
+  names:string list ->
+  line_directives:bool ->
+  warnings_options:Odoc_model.Error.warnings_options ->
+  (unit, [> `Msg of string ]) result

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -40,7 +40,7 @@ type code_block_tag =
   [ `Tag of string
   | `Binding of string (* with_location *) * string (* with_location *) ]
 
-type code_block_tags = code_block_tag (* with_location *) list
+type code_block_tags = code_block_tag with_location list
 
 type code_block_meta = {
   language : string with_location;

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -37,13 +37,14 @@ type 'a grid = 'a row list
 type 'a abstract_table = 'a grid * alignment option list option
 
 type code_block_tag =
-  [ `Tag of string | `Binding of string with_location * string with_location ]
+  [ `Tag of string with_location
+  | `Binding of string with_location * string with_location ]
 
-type code_block_tags = code_block_tag with_location list
+type code_block_tags = code_block_tag list
 
 type code_block_meta = {
   language : string with_location;
-  tags : code_block_tags with_location option;
+  tags : code_block_tags;
 }
 
 type media = Token.media

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -36,9 +36,15 @@ type 'a row = 'a cell list
 type 'a grid = 'a row list
 type 'a abstract_table = 'a grid * alignment option list option
 
+type code_block_tag =
+  [ `Tag of string
+  | `Binding of string (* with_location *) * string (* with_location *) ]
+
+type code_block_tags = code_block_tag (* with_location *) list
+
 type code_block_meta = {
   language : string with_location;
-  tags : string with_location option;
+  tags : code_block_tags (* with_location *) option;
 }
 
 type media = Token.media

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -43,7 +43,7 @@ type code_block_tags = code_block_tag with_location list
 
 type code_block_meta = {
   language : string with_location;
-  tags : code_block_tags (* with_location *) option;
+  tags : code_block_tags with_location option;
 }
 
 type media = Token.media

--- a/src/parser/ast.ml
+++ b/src/parser/ast.ml
@@ -37,8 +37,7 @@ type 'a grid = 'a row list
 type 'a abstract_table = 'a grid * alignment option list option
 
 type code_block_tag =
-  [ `Tag of string
-  | `Binding of string (* with_location *) * string (* with_location *) ]
+  [ `Tag of string | `Binding of string with_location * string with_location ]
 
 type code_block_tags = code_block_tag with_location list
 

--- a/src/parser/lexer.mli
+++ b/src/parser/lexer.mli
@@ -5,6 +5,7 @@ type input = {
   offset_to_location : int -> Loc.point;
   warnings : Warning.t list ref;
   lexbuf : Lexing.lexbuf;
+  string_buffer : Buffer.t;
 }
 
 val token : input -> Lexing.lexbuf -> Token.t Loc.with_location

--- a/src/parser/lexer.mll
+++ b/src/parser/lexer.mll
@@ -16,7 +16,7 @@ let unescape_word : string -> string = fun s ->
           | '\\' ->
             if index + 1 < String.length s then
               match s.[index + 1] with
-              | '{' | '}' | '[' | ']' | '@' as c -> c, 2
+              | '{' | '}' | '[' | ']' | '@' | '"' as c -> c, 2
               | _ -> c, 1
             else c, 1
           | _ -> c, 1
@@ -707,7 +707,7 @@ and code_block_metadata_tail acc = parse
  | (space_char+) (('"' (tag_quoted_atom as value) '"')
                   | (tag_unquoted_atom as value))
     {
-      let acc = `Tag (value) :: acc in
+      let acc = `Tag (unescape_word value) :: acc in
       code_block_metadata_tail acc lexbuf
     }
  | (space_char+)
@@ -716,7 +716,7 @@ and code_block_metadata_tail acc = parse
                                         (tag_unquoted_atom as value)
   ))
     {
-      let acc = `Binding (key, value) :: acc in
+      let acc = `Binding (unescape_word key, unescape_word value) :: acc in
       code_block_metadata_tail acc lexbuf
     }
   | _ as c

--- a/src/parser/odoc_parser.ml
+++ b/src/parser/odoc_parser.ml
@@ -103,13 +103,20 @@ let position_of_point : t -> Loc.point -> Lexing.position =
 let parse_comment ~location ~text =
   let warnings = ref [] in
   let reversed_newlines = reversed_newlines ~input:text in
+  let string_buffer = Buffer.create 256 in
   let token_stream =
     let lexbuf = Lexing.from_string text in
     let offset_to_location =
       offset_to_location ~reversed_newlines ~comment_location:location
     in
     let input : Lexer.input =
-      { file = location.Lexing.pos_fname; offset_to_location; warnings; lexbuf }
+      {
+        file = location.Lexing.pos_fname;
+        offset_to_location;
+        warnings;
+        lexbuf;
+        string_buffer;
+      }
     in
     Stream.from (fun _token_index -> Some (Lexer.token input lexbuf))
   in

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -65,6 +65,9 @@ let truncated_see : Loc.span -> Warning.t =
   Warning.make
     "'@see' should be followed by <url>, 'file', or \"document title\"."
 
+let truncated_string : Loc.span -> Warning.t =
+  Warning.make "Truncated string literal"
+
 let unknown_tag : string -> Loc.span -> Warning.t =
   Warning.make "Unknown tag '%s'."
 
@@ -81,6 +84,9 @@ let no_language_tag_in_meta : Loc.span -> Warning.t =
 let language_tag_invalid_char lang_tag : char -> Loc.span -> Warning.t =
   let suggestion = "try '{@" ^ lang_tag ^ "[ ... ]}'." in
   Warning.make ~suggestion "Invalid character '%c' in language tag."
+
+let code_block_tag_invalid_char : char -> Loc.span -> Warning.t =
+  Warning.make "Invalid character in code block metadata tag '%c'."
 
 let truncated_code_block_meta : Loc.span -> Warning.t =
   Warning.make ~suggestion:"try '{@ocaml[ ... ]}'." "Missing end of code block."

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -92,3 +92,8 @@ let end_not_allowed : in_what:string -> Loc.span -> Warning.t =
  fun ~in_what ->
   Warning.make ~suggestion:"add '}'." "End of text is not allowed in %s."
     in_what
+
+let should_not_be_escaped : char -> Loc.span -> Warning.t =
+ fun c ->
+  Warning.make ~suggestion:"Remove \\."
+    "The '%c' character should not be escaped." c

--- a/src/parser/parse_error.ml
+++ b/src/parser/parse_error.ml
@@ -88,6 +88,9 @@ let language_tag_invalid_char lang_tag : char -> Loc.span -> Warning.t =
 let code_block_tag_invalid_char : char -> Loc.span -> Warning.t =
   Warning.make "Invalid character in code block metadata tag '%c'."
 
+let invalid_char_code : int -> Loc.span -> Warning.t =
+  Warning.make "Invalid escape sequence '\\%d"
+
 let truncated_code_block_meta : Loc.span -> Warning.t =
   Warning.make ~suggestion:"try '{@ocaml[ ... ]}'." "Missing end of code block."
 

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -70,8 +70,16 @@ module Ast_to_sexp = struct
     | `Link (u, es) ->
         List [ str u; List (List.map (at.at (inline_element at)) es) ]
 
+  let code_block_tags at tags =
+    List
+      (List.map
+         (function
+           | `Tag s -> Atom s
+           | `Binding (key, value) -> List [ Atom key; Atom value ])
+         tags)
+
   let code_block_lang at { Ast.language; tags } =
-    List [ at.at str_at language; opt (at.at str_at) tags ]
+    List [ at.at str_at language; opt (code_block_tags str_at) tags ]
 
   let media_href =
    fun v ->
@@ -3011,9 +3019,7 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (1 46))
-            (code_block
-             (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 8) (1 28)) "env=f1 version>=4.06")))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) (((env f1) (version> 4.06))))
              ((f.ml (1 30) (1 44)) "code goes here")))))
          (warnings ())) |}]
 
@@ -3035,9 +3041,7 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (1 61))
-            (code_block
-             (((f.ml (1 7) (1 12)) ocaml)
-              (((f.ml (1 13) (1 33)) "env=f1 version>=4.06")))
+            (code_block (((f.ml (1 7) (1 12)) ocaml) (((env f1) (version> 4.06))))
              ((f.ml (1 35) (1 38)) foo)
              ((paragraph
                (((f.ml (1 45) (1 51)) (word output)) ((f.ml (1 51) (1 52)) space)
@@ -3148,8 +3152,7 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (2 9))
-            (code_block
-             (((f.ml (1 2) (1 7)) ocaml) (((f.ml (1 8) (1 21)) kind=toplevel)))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) (((kind toplevel))))
              ((f.ml (2 1) (2 7)) " code ")))))
          (warnings ()))
         |}]
@@ -3160,8 +3163,7 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (1 31))
-            (code_block
-             (((f.ml (1 2) (1 7)) ocaml) (((f.ml (1 8) (1 21)) kind=toplevel)))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) (((kind toplevel))))
              ((f.ml (1 23) (1 29)) " code ")))))
          (warnings ()))
         |}]
@@ -3172,8 +3174,7 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (2 11))
-            (code_block
-             (((f.ml (1 2) (1 7)) ocaml) (((f.ml (1 8) (1 21)) kind=toplevel)))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) (((kind toplevel))))
              ((f.ml (2 3) (2 9)) " code ")))))
          (warnings ()))
         |}]
@@ -3184,10 +3185,7 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (2 15))
-            (code_block
-             (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 8) (2 6))  "kind=toplevel\
-                                   \nenv=e1")))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) (((kind toplevel) (env e1))))
              ((f.ml (2 7) (2 13)) " code ")))))
          (warnings ()))
         |}]
@@ -3198,8 +3196,7 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (2 22))
-            (code_block
-             (((f.ml (1 2) (1 7)) ocaml) (((f.ml (2 0) (2 13)) kind=toplevel)))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) (((kind toplevel))))
              ((f.ml (2 14) (2 20)) " code ")))))
          (warnings ()))
         |}]

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -3398,6 +3398,70 @@ let%expect_test _ =
               \nCode blocks should be indented at the opening `{`.")))))
          (warnings ()))
         |}]
+
+    (** {3 Metadata tags}
+
+        Code blocks have a metadata field, with bindings and simple tags. *)
+
+    let lots_of_tags =
+      test
+        {|{@ocaml env=f1 version=4.06 "tag with several words" "binding with"=singleword also="other case" "everything has"="multiple words" [foo]}|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (1 0) (1 137))
+            (code_block
+             (((f.ml (1 2) (1 7)) ocaml)
+              (((env f1) (version 4.06) "tag with several words"
+                ("binding with" singleword) (also "other case")
+                ("everything has" "multiple words"))))
+             ((f.ml (1 132) (1 135)) foo)))))
+         (warnings ())) |}]
+
+    let lots_of_tags_with_newlines =
+      test
+        {|{@ocaml
+         env=f1
+         version=4.06
+         "tag with several words"
+         "binding with"=singleword
+         also="other case"
+         "everything has"="multiple words"
+         [foo]}|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (1 0) (8 15))
+            (code_block
+             (((f.ml (1 2) (1 7)) ocaml)
+              (((env f1) (version 4.06) "tag with several words"
+                ("binding with" singleword) (also "other case")
+                ("everything has" "multiple words"))))
+             ((f.ml (8 10) (8 13)) foo)))))
+         (warnings ())) |}]
+
+    let escaping1 =
+      test {|{@ocaml "\""="\"" [foo]}|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (1 0) (1 24))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) ((("\"" "\""))))
+             ((f.ml (1 19) (1 22)) foo)))))
+         (warnings ())) |}]
+
+    let escaping2 =
+      test {|{@ocaml \"=\" [foo]}|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (1 0) (1 20))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) ())
+             ((f.ml (1 10) (1 18)) "=\\\" [foo")))))
+         (warnings
+          ( "File \"f.ml\", line 1, characters 0-10:\
+           \nInvalid character '\"' in language tag.\
+           \nSuggestion: try '{@ocaml[ ... ]}'."))) |}]
   end in
   ()
 

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -74,7 +74,7 @@ module Ast_to_sexp = struct
     let code_block_tag t =
       match t.Loc.value with
       | `Tag s -> Atom s
-      | `Binding (key, value) -> List [ Atom key; Atom value ]
+      | `Binding (key, value) -> List [ at.at str_at key; at.at str_at value ]
     in
     List (List.map (at.at code_block_tag) tags)
 
@@ -3021,8 +3021,10 @@ let%expect_test _ =
           (((f.ml (1 0) (1 46))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (1 8) (1 14)) (env f1))
-                ((f.ml (1 15) (1 28)) (version> 4.06)))))
+              ((((f.ml (1 8) (1 14))
+                 (((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1)))
+                ((f.ml (1 15) (1 28))
+                 (((f.ml (1 15) (1 23)) version>) ((f.ml (1 24) (1 28)) 4.06))))))
              ((f.ml (1 30) (1 44)) "code goes here")))))
          (warnings ())) |}]
 
@@ -3046,8 +3048,10 @@ let%expect_test _ =
           (((f.ml (1 0) (1 61))
             (code_block
              (((f.ml (1 7) (1 12)) ocaml)
-              ((((f.ml (1 13) (1 19)) (env f1))
-                ((f.ml (1 20) (1 33)) (version> 4.06)))))
+              ((((f.ml (1 13) (1 19))
+                 (((f.ml (1 13) (1 16)) env) ((f.ml (1 17) (1 19)) f1)))
+                ((f.ml (1 20) (1 33))
+                 (((f.ml (1 20) (1 28)) version>) ((f.ml (1 29) (1 33)) 4.06))))))
              ((f.ml (1 35) (1 38)) foo)
              ((paragraph
                (((f.ml (1 45) (1 51)) (word output)) ((f.ml (1 51) (1 52)) space)
@@ -3159,7 +3163,9 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (2 9))
             (code_block
-             (((f.ml (1 2) (1 7)) ocaml) ((((f.ml (1 8) (1 21)) (kind toplevel)))))
+             (((f.ml (1 2) (1 7)) ocaml)
+              ((((f.ml (1 8) (1 21))
+                 (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel))))))
              ((f.ml (2 1) (2 7)) " code ")))))
          (warnings ()))
         |}]
@@ -3171,7 +3177,9 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (1 31))
             (code_block
-             (((f.ml (1 2) (1 7)) ocaml) ((((f.ml (1 8) (1 21)) (kind toplevel)))))
+             (((f.ml (1 2) (1 7)) ocaml)
+              ((((f.ml (1 8) (1 21))
+                 (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel))))))
              ((f.ml (1 23) (1 29)) " code ")))))
          (warnings ()))
         |}]
@@ -3183,7 +3191,9 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (2 11))
             (code_block
-             (((f.ml (1 2) (1 7)) ocaml) ((((f.ml (1 8) (1 21)) (kind toplevel)))))
+             (((f.ml (1 2) (1 7)) ocaml)
+              ((((f.ml (1 8) (1 21))
+                 (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel))))))
              ((f.ml (2 3) (2 9)) " code ")))))
          (warnings ()))
         |}]
@@ -3196,7 +3206,10 @@ let%expect_test _ =
           (((f.ml (1 0) (2 15))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (1 8) (1 21)) (kind toplevel)) ((f.ml (2 0) (2 6)) (env e1)))))
+              ((((f.ml (1 8) (1 21))
+                 (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel)))
+                ((f.ml (2 0) (2 6))
+                 (((f.ml (2 0) (2 3)) env) ((f.ml (2 4) (2 6)) e1))))))
              ((f.ml (2 7) (2 13)) " code ")))))
          (warnings ()))
         |}]
@@ -3208,7 +3221,9 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (2 22))
             (code_block
-             (((f.ml (1 2) (1 7)) ocaml) ((((f.ml (2 0) (2 13)) (kind toplevel)))))
+             (((f.ml (1 2) (1 7)) ocaml)
+              ((((f.ml (2 0) (2 13))
+                 (((f.ml (2 0) (2 4)) kind) ((f.ml (2 5) (2 13)) toplevel))))))
              ((f.ml (2 14) (2 20)) " code ")))))
          (warnings ()))
         |}]
@@ -3424,11 +3439,19 @@ let%expect_test _ =
           (((f.ml (1 0) (1 137))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (1 8) (1 14)) (env f1)) ((f.ml (1 15) (1 27)) (version 4.06))
+              ((((f.ml (1 8) (1 14))
+                 (((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1)))
+                ((f.ml (1 15) (1 27))
+                 (((f.ml (1 15) (1 22)) version) ((f.ml (1 23) (1 27)) 4.06)))
                 ((f.ml (1 28) (1 52)) "tag with several words")
-                ((f.ml (1 53) (1 78)) ("binding with" singleword))
-                ((f.ml (1 79) (1 96)) (also "other case"))
-                ((f.ml (1 97) (1 130)) ("everything has" "multiple words")))))
+                ((f.ml (1 53) (1 78))
+                 (((f.ml (1 53) (1 67)) "binding with")
+                  ((f.ml (1 68) (1 78)) singleword)))
+                ((f.ml (1 79) (1 96))
+                 (((f.ml (1 79) (1 83)) also) ((f.ml (1 84) (1 96)) "other case")))
+                ((f.ml (1 97) (1 130))
+                 (((f.ml (1 97) (1 113)) "everything has")
+                  ((f.ml (1 114) (1 130)) "multiple words"))))))
              ((f.ml (1 132) (1 135)) foo)))))
          (warnings ())) |}]
 
@@ -3449,12 +3472,20 @@ let%expect_test _ =
           (((f.ml (1 0) (9 15))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (2 9) (2 15)) (env f1)) ((f.ml (3 9) (3 21)) (version 4.06))
+              ((((f.ml (2 9) (2 15))
+                 (((f.ml (2 9) (2 12)) env) ((f.ml (2 13) (2 15)) f1)))
+                ((f.ml (3 9) (3 21))
+                 (((f.ml (3 9) (3 16)) version) ((f.ml (3 17) (3 21)) 4.06)))
                 ((f.ml (4 9) (4 19)) single_tag)
                 ((f.ml (5 9) (5 33)) "tag with several words")
-                ((f.ml (6 9) (6 34)) ("binding with" singleword))
-                ((f.ml (7 9) (7 26)) (also "other case"))
-                ((f.ml (8 9) (8 42)) ("everything has" "multiple words")))))
+                ((f.ml (6 9) (6 34))
+                 (((f.ml (6 9) (6 23)) "binding with")
+                  ((f.ml (6 24) (6 34)) singleword)))
+                ((f.ml (7 9) (7 26))
+                 (((f.ml (7 9) (7 13)) also) ((f.ml (7 14) (7 26)) "other case")))
+                ((f.ml (8 9) (8 42))
+                 (((f.ml (8 9) (8 25)) "everything has")
+                  ((f.ml (8 26) (8 42)) "multiple words"))))))
              ((f.ml (9 10) (9 13)) foo)))))
          (warnings ())) |}]
 
@@ -3465,7 +3496,9 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (1 24))
             (code_block
-             (((f.ml (1 2) (1 7)) ocaml) ((((f.ml (1 8) (1 17)) ("\"" "\"")))))
+             (((f.ml (1 2) (1 7)) ocaml)
+              ((((f.ml (1 8) (1 17))
+                 (((f.ml (1 8) (1 12)) "\"") ((f.ml (1 13) (1 17)) "\""))))))
              ((f.ml (1 19) (1 22)) foo)))))
          (warnings ())) |}]
 

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -3241,7 +3241,7 @@ let%expect_test _ =
          (warnings
           ( "File \"f.ml\", line 1, characters 8-9:\
            \nInvalid character in code block metadata tag '='."
-            "File \"f.ml\", line 1, characters 9-14:\
+            "File \"f.ml\", line 1, characters 9-10:\
            \nInvalid character in code block metadata tag 'f'.")))
         |}]
 
@@ -3267,7 +3267,7 @@ let%expect_test _ =
           (((f.ml (1 0) (1 30))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((binding ((f.ml (1 9) (1 13)) A) ((f.ml (1 15) (1 20)) hello))))
+              ((binding ((f.ml (1 8) (1 14)) A) ((f.ml (1 15) (1 20)) hello))))
              ((f.ml (1 22) (1 28)) " code ")))))
          (warnings ()))
         |}]
@@ -3281,7 +3281,7 @@ let%expect_test _ =
             (code_block (((f.ml (1 2) (1 7)) ocaml) ())
              ((f.ml (1 12) (1 18)) " code ")))))
          (warnings
-          ( "File \"f.ml\", line 1, characters 7-12:\
+          ( "File \"f.ml\", line 1, characters 7-8:\
            \nInvalid character in code block metadata tag ','.")))
         |}]
 
@@ -3484,13 +3484,13 @@ let%expect_test _ =
              (((f.ml (1 2) (1 7)) ocaml)
               ((binding ((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1))
                (binding ((f.ml (1 15) (1 22)) version) ((f.ml (1 23) (1 27)) 4.06))
-               (tag ((f.ml (1 29) (1 51)) "tag with several words"))
-               (binding ((f.ml (1 54) (1 66)) "binding with")
+               (tag ((f.ml (1 28) (1 52)) "tag with several words"))
+               (binding ((f.ml (1 53) (1 67)) "binding with")
                 ((f.ml (1 68) (1 78)) singleword))
                (binding ((f.ml (1 79) (1 83)) also)
-                ((f.ml (1 85) (1 95)) "other case"))
-               (binding ((f.ml (1 98) (1 112)) "everything has")
-                ((f.ml (1 115) (1 129)) "multiple words"))))
+                ((f.ml (1 84) (1 96)) "other case"))
+               (binding ((f.ml (1 97) (1 113)) "everything has")
+                ((f.ml (1 114) (1 130)) "multiple words"))))
              ((f.ml (1 132) (1 135)) foo)))))
          (warnings ()))
         |}]
@@ -3515,13 +3515,13 @@ let%expect_test _ =
               ((binding ((f.ml (2 9) (2 12)) env) ((f.ml (2 13) (2 15)) f1))
                (binding ((f.ml (3 9) (3 16)) version) ((f.ml (3 17) (3 21)) 4.06))
                (tag ((f.ml (4 9) (4 19)) single_tag))
-               (tag ((f.ml (5 10) (5 32)) "tag with several words"))
-               (binding ((f.ml (6 10) (6 22)) "binding with")
+               (tag ((f.ml (5 9) (5 33)) "tag with several words"))
+               (binding ((f.ml (6 9) (6 23)) "binding with")
                 ((f.ml (6 24) (6 34)) singleword))
                (binding ((f.ml (7 9) (7 13)) also)
-                ((f.ml (7 15) (7 25)) "other case"))
-               (binding ((f.ml (8 10) (8 24)) "everything has")
-                ((f.ml (8 27) (8 41)) "multiple words"))))
+                ((f.ml (7 14) (7 26)) "other case"))
+               (binding ((f.ml (8 9) (8 25)) "everything has")
+                ((f.ml (8 26) (8 42)) "multiple words"))))
              ((f.ml (9 10) (9 13)) foo)))))
          (warnings ()))
         |}]
@@ -3534,7 +3534,7 @@ let%expect_test _ =
           (((f.ml (1 0) (1 24))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((binding ((f.ml (1 9) (1 11)) "\"") ((f.ml (1 14) (1 16)) "\""))))
+              ((binding ((f.ml (1 8) (1 12)) "\"") ((f.ml (1 13) (1 17)) "\""))))
              ((f.ml (1 19) (1 22)) foo)))))
          (warnings ()))
         |}]
@@ -3547,7 +3547,7 @@ let%expect_test _ =
           (((f.ml (1 0) (1 20))
             (code_block (((f.ml (1 2) (1 7)) ocaml) ()) ((f.ml (1 15) (1 18)) foo)))))
          (warnings
-          ( "File \"f.ml\", line 1, characters 9-15:\
+          ( "File \"f.ml\", line 1, characters 9-10:\
            \nInvalid character in code block metadata tag '\"'.")))
         |}]
 
@@ -3558,7 +3558,7 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (1 19))
             (code_block
-             (((f.ml (1 2) (1 7)) ocaml) ((tag ((f.ml (1 9) (1 11)) "\\"))))
+             (((f.ml (1 2) (1 7)) ocaml) ((tag ((f.ml (1 8) (1 12)) "\\"))))
              ((f.ml (1 14) (1 17)) foo)))))
          (warnings ()))
         |}]
@@ -3571,7 +3571,7 @@ let%expect_test _ =
         ((output
           (((f.ml (2 5) (2 28))
             (code_block
-             (((f.ml (2 7) (2 12)) ocaml) ((tag ((f.ml (2 14) (2 20)) "a\bc"))))
+             (((f.ml (2 7) (2 12)) ocaml) ((tag ((f.ml (2 13) (2 21)) "a\bc"))))
              ((f.ml (2 23) (2 26)) foo)))))
          (warnings
           ( "File \"f.ml\", line 2, characters 14-16:\
@@ -3591,7 +3591,7 @@ let%expect_test _ =
           (((f.ml (2 5) (2 37))
             (code_block
              (((f.ml (2 7) (2 12)) ocaml)
-              ((binding ((f.ml (2 14) (2 20)) "a\bc") ((f.ml (2 23) (2 29)) xyz))))
+              ((binding ((f.ml (2 13) (2 21)) "a\bc") ((f.ml (2 22) (2 30)) xyz))))
              ((f.ml (2 32) (2 35)) foo)))))
          (warnings
           ( "File \"f.ml\", line 2, characters 14-16:\

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -71,6 +71,7 @@ module Ast_to_sexp = struct
         List [ str u; List (List.map (at.at (inline_element at)) es) ]
 
   let code_block_tags at tags =
+    let tags = Loc.value tags in
     let code_block_tag t =
       match t.Loc.value with
       | `Tag s -> Atom s
@@ -79,7 +80,7 @@ module Ast_to_sexp = struct
     List (List.map (at.at code_block_tag) tags)
 
   let code_block_lang at { Ast.language; tags } =
-    List [ at.at str_at language; opt (code_block_tags at) tags ]
+    List [ at.at str_at language; opt (at.at (code_block_tags at)) tags ]
 
   let media_href =
    fun v ->
@@ -3021,10 +3022,11 @@ let%expect_test _ =
           (((f.ml (1 0) (1 46))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (1 8) (1 14))
-                 (((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1)))
-                ((f.ml (1 15) (1 28))
-                 (((f.ml (1 15) (1 23)) version>) ((f.ml (1 24) (1 28)) 4.06))))))
+              (((f.ml (1 7) (1 29))
+                (((f.ml (1 8) (1 14))
+                  (((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1)))
+                 ((f.ml (1 15) (1 28))
+                  (((f.ml (1 15) (1 23)) version>) ((f.ml (1 24) (1 28)) 4.06)))))))
              ((f.ml (1 30) (1 44)) "code goes here")))))
          (warnings ())) |}]
 
@@ -3048,10 +3050,11 @@ let%expect_test _ =
           (((f.ml (1 0) (1 61))
             (code_block
              (((f.ml (1 7) (1 12)) ocaml)
-              ((((f.ml (1 13) (1 19))
-                 (((f.ml (1 13) (1 16)) env) ((f.ml (1 17) (1 19)) f1)))
-                ((f.ml (1 20) (1 33))
-                 (((f.ml (1 20) (1 28)) version>) ((f.ml (1 29) (1 33)) 4.06))))))
+              (((f.ml (1 12) (1 34))
+                (((f.ml (1 13) (1 19))
+                  (((f.ml (1 13) (1 16)) env) ((f.ml (1 17) (1 19)) f1)))
+                 ((f.ml (1 20) (1 33))
+                  (((f.ml (1 20) (1 28)) version>) ((f.ml (1 29) (1 33)) 4.06)))))))
              ((f.ml (1 35) (1 38)) foo)
              ((paragraph
                (((f.ml (1 45) (1 51)) (word output)) ((f.ml (1 51) (1 52)) space)
@@ -3164,8 +3167,9 @@ let%expect_test _ =
           (((f.ml (1 0) (2 9))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (1 8) (1 21))
-                 (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel))))))
+              (((f.ml (1 7) (2 0))
+                (((f.ml (1 8) (1 21))
+                  (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel)))))))
              ((f.ml (2 1) (2 7)) " code ")))))
          (warnings ()))
         |}]
@@ -3178,8 +3182,9 @@ let%expect_test _ =
           (((f.ml (1 0) (1 31))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (1 8) (1 21))
-                 (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel))))))
+              (((f.ml (1 7) (1 22))
+                (((f.ml (1 8) (1 21))
+                  (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel)))))))
              ((f.ml (1 23) (1 29)) " code ")))))
          (warnings ()))
         |}]
@@ -3192,8 +3197,9 @@ let%expect_test _ =
           (((f.ml (1 0) (2 11))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (1 8) (1 21))
-                 (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel))))))
+              (((f.ml (1 7) (2 2))
+                (((f.ml (1 8) (1 21))
+                  (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel)))))))
              ((f.ml (2 3) (2 9)) " code ")))))
          (warnings ()))
         |}]
@@ -3206,10 +3212,11 @@ let%expect_test _ =
           (((f.ml (1 0) (2 15))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (1 8) (1 21))
-                 (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel)))
-                ((f.ml (2 0) (2 6))
-                 (((f.ml (2 0) (2 3)) env) ((f.ml (2 4) (2 6)) e1))))))
+              (((f.ml (1 7) (2 6))
+                (((f.ml (1 8) (1 21))
+                  (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel)))
+                 ((f.ml (2 0) (2 6))
+                  (((f.ml (2 0) (2 3)) env) ((f.ml (2 4) (2 6)) e1)))))))
              ((f.ml (2 7) (2 13)) " code ")))))
          (warnings ()))
         |}]
@@ -3222,8 +3229,9 @@ let%expect_test _ =
           (((f.ml (1 0) (2 22))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (2 0) (2 13))
-                 (((f.ml (2 0) (2 4)) kind) ((f.ml (2 5) (2 13)) toplevel))))))
+              (((f.ml (1 7) (2 13))
+                (((f.ml (2 0) (2 13))
+                  (((f.ml (2 0) (2 4)) kind) ((f.ml (2 5) (2 13)) toplevel)))))))
              ((f.ml (2 14) (2 20)) " code ")))))
          (warnings ()))
         |}]
@@ -3439,19 +3447,20 @@ let%expect_test _ =
           (((f.ml (1 0) (1 137))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (1 8) (1 14))
-                 (((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1)))
-                ((f.ml (1 15) (1 27))
-                 (((f.ml (1 15) (1 22)) version) ((f.ml (1 23) (1 27)) 4.06)))
-                ((f.ml (1 28) (1 52)) "tag with several words")
-                ((f.ml (1 53) (1 78))
-                 (((f.ml (1 53) (1 67)) "binding with")
-                  ((f.ml (1 68) (1 78)) singleword)))
-                ((f.ml (1 79) (1 96))
-                 (((f.ml (1 79) (1 83)) also) ((f.ml (1 84) (1 96)) "other case")))
-                ((f.ml (1 97) (1 130))
-                 (((f.ml (1 97) (1 113)) "everything has")
-                  ((f.ml (1 114) (1 130)) "multiple words"))))))
+              (((f.ml (1 7) (1 131))
+                (((f.ml (1 8) (1 14))
+                  (((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1)))
+                 ((f.ml (1 15) (1 27))
+                  (((f.ml (1 15) (1 22)) version) ((f.ml (1 23) (1 27)) 4.06)))
+                 ((f.ml (1 28) (1 52)) "tag with several words")
+                 ((f.ml (1 53) (1 78))
+                  (((f.ml (1 53) (1 67)) "binding with")
+                   ((f.ml (1 68) (1 78)) singleword)))
+                 ((f.ml (1 79) (1 96))
+                  (((f.ml (1 79) (1 83)) also) ((f.ml (1 84) (1 96)) "other case")))
+                 ((f.ml (1 97) (1 130))
+                  (((f.ml (1 97) (1 113)) "everything has")
+                   ((f.ml (1 114) (1 130)) "multiple words")))))))
              ((f.ml (1 132) (1 135)) foo)))))
          (warnings ())) |}]
 
@@ -3472,20 +3481,21 @@ let%expect_test _ =
           (((f.ml (1 0) (9 15))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (2 9) (2 15))
-                 (((f.ml (2 9) (2 12)) env) ((f.ml (2 13) (2 15)) f1)))
-                ((f.ml (3 9) (3 21))
-                 (((f.ml (3 9) (3 16)) version) ((f.ml (3 17) (3 21)) 4.06)))
-                ((f.ml (4 9) (4 19)) single_tag)
-                ((f.ml (5 9) (5 33)) "tag with several words")
-                ((f.ml (6 9) (6 34))
-                 (((f.ml (6 9) (6 23)) "binding with")
-                  ((f.ml (6 24) (6 34)) singleword)))
-                ((f.ml (7 9) (7 26))
-                 (((f.ml (7 9) (7 13)) also) ((f.ml (7 14) (7 26)) "other case")))
-                ((f.ml (8 9) (8 42))
-                 (((f.ml (8 9) (8 25)) "everything has")
-                  ((f.ml (8 26) (8 42)) "multiple words"))))))
+              (((f.ml (1 7) (9 9))
+                (((f.ml (2 9) (2 15))
+                  (((f.ml (2 9) (2 12)) env) ((f.ml (2 13) (2 15)) f1)))
+                 ((f.ml (3 9) (3 21))
+                  (((f.ml (3 9) (3 16)) version) ((f.ml (3 17) (3 21)) 4.06)))
+                 ((f.ml (4 9) (4 19)) single_tag)
+                 ((f.ml (5 9) (5 33)) "tag with several words")
+                 ((f.ml (6 9) (6 34))
+                  (((f.ml (6 9) (6 23)) "binding with")
+                   ((f.ml (6 24) (6 34)) singleword)))
+                 ((f.ml (7 9) (7 26))
+                  (((f.ml (7 9) (7 13)) also) ((f.ml (7 14) (7 26)) "other case")))
+                 ((f.ml (8 9) (8 42))
+                  (((f.ml (8 9) (8 25)) "everything has")
+                   ((f.ml (8 26) (8 42)) "multiple words")))))))
              ((f.ml (9 10) (9 13)) foo)))))
          (warnings ())) |}]
 
@@ -3497,8 +3507,9 @@ let%expect_test _ =
           (((f.ml (1 0) (1 24))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((((f.ml (1 8) (1 17))
-                 (((f.ml (1 8) (1 12)) "\"") ((f.ml (1 13) (1 17)) "\""))))))
+              (((f.ml (1 7) (1 18))
+                (((f.ml (1 8) (1 17))
+                  (((f.ml (1 8) (1 12)) "\"") ((f.ml (1 13) (1 17)) "\"")))))))
              ((f.ml (1 19) (1 22)) foo)))))
          (warnings ())) |}]
 

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -3230,6 +3230,48 @@ let%expect_test _ =
          (warnings ()))
         |}]
 
+    let empty_key =
+      test "{@ocaml =foo [ code ]}";
+      [%expect
+        {|
+        ((output
+          (((f.ml (1 0) (1 22))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) ())
+             ((f.ml (1 14) (1 20)) " code ")))))
+         (warnings
+          ( "File \"f.ml\", line 1, characters 8-9:\
+           \nInvalid character in code block metadata tag '='."
+            "File \"f.ml\", line 1, characters 9-14:\
+           \nInvalid character in code block metadata tag 'f'.")))
+        |}]
+
+    let no_escape_without_quotes =
+      test {|{@ocaml \n\t\b=hello [ code ]}|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (1 0) (1 30))
+            (code_block
+             (((f.ml (1 2) (1 7)) ocaml)
+              ((binding ((f.ml (1 8) (1 14)) "\\n\\t\\b")
+                ((f.ml (1 15) (1 20)) hello))))
+             ((f.ml (1 22) (1 28)) " code ")))))
+         (warnings ()))
+        |}]
+
+    let escape_within_quotes =
+      test {|{@ocaml "\065"=hello [ code ]}|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (1 0) (1 30))
+            (code_block
+             (((f.ml (1 2) (1 7)) ocaml)
+              ((binding ((f.ml (1 9) (1 13)) A) ((f.ml (1 15) (1 20)) hello))))
+             ((f.ml (1 22) (1 28)) " code ")))))
+         (warnings ()))
+        |}]
+
     let langtag_non_word =
       test "{@ocaml,top[ code ]}";
       [%expect

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -3539,17 +3539,61 @@ let%expect_test _ =
          (warnings ()))
         |}]
 
-    let escaped_char_are_allowed =
-      test {|{@ocaml "\a\b\c" [foo]}|};
+    let escaped_char_are_allowed_but_warn =
+      test {|
+     {@ocaml "\a\b\c" [foo]}|};
       [%expect
         {|
         ((output
-          (((f.ml (1 0) (1 23))
+          (((f.ml (2 5) (2 28))
             (code_block
-             (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (1 17)) (((f.ml (1 8) (1 16)) abc)))))
-             ((f.ml (1 18) (1 21)) foo)))))
-         (warnings ()))
+             (((f.ml (2 7) (2 12)) ocaml)
+              (((f.ml (2 12) (2 22)) (((f.ml (2 13) (2 21)) abc)))))
+             ((f.ml (2 23) (2 26)) foo)))))
+         (warnings
+          ( "File \"f.ml\", line 2, characters 14-16:\
+           \nThe 'a' character should not be escaped.\
+           \nSuggestion: Remove \\."
+            "File \"f.ml\", line 2, characters 16-18:\
+           \nThe 'b' character should not be escaped.\
+           \nSuggestion: Remove \\."
+            "File \"f.ml\", line 2, characters 18-20:\
+           \nThe 'c' character should not be escaped.\
+           \nSuggestion: Remove \\.")))
+        |}]
+
+    let escaped_char_are_allowed_but_warn2 =
+      test {|
+     {@ocaml "\a\b\c"="\x\y\z" [foo]}|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (2 5) (2 37))
+            (code_block
+             (((f.ml (2 7) (2 12)) ocaml)
+              (((f.ml (2 12) (2 31))
+                (((f.ml (2 13) (2 30))
+                  (((f.ml (2 13) (2 21)) abc) ((f.ml (2 22) (2 30)) xyz)))))))
+             ((f.ml (2 32) (2 35)) foo)))))
+         (warnings
+          ( "File \"f.ml\", line 2, characters 14-16:\
+           \nThe 'a' character should not be escaped.\
+           \nSuggestion: Remove \\."
+            "File \"f.ml\", line 2, characters 16-18:\
+           \nThe 'b' character should not be escaped.\
+           \nSuggestion: Remove \\."
+            "File \"f.ml\", line 2, characters 18-20:\
+           \nThe 'c' character should not be escaped.\
+           \nSuggestion: Remove \\."
+            "File \"f.ml\", line 2, characters 25-27:\
+           \nThe 'x' character should not be escaped.\
+           \nSuggestion: Remove \\."
+            "File \"f.ml\", line 2, characters 27-29:\
+           \nThe 'y' character should not be escaped.\
+           \nSuggestion: Remove \\."
+            "File \"f.ml\", line 2, characters 29-31:\
+           \nThe 'z' character should not be escaped.\
+           \nSuggestion: Remove \\.")))
         |}]
   end in
   ()

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -3022,8 +3022,8 @@ let%expect_test _ =
           (((f.ml (1 0) (1 46))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((binding ((f.ml (1 7) (1 12)) env) ((f.ml (1 12) (1 14)) f1))
-               (binding ((f.ml (1 14) (1 24)) version>) ((f.ml (1 24) (1 28)) 4.06))))
+              ((binding ((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1))
+               (binding ((f.ml (1 15) (1 23)) version>) ((f.ml (1 24) (1 28)) 4.06))))
              ((f.ml (1 30) (1 44)) "code goes here")))))
          (warnings ()))
         |}]
@@ -3038,7 +3038,8 @@ let%expect_test _ =
              ((paragraph
                (((f.ml (1 23) (1 29)) (word output)) ((f.ml (1 29) (1 30)) space)
                 ((f.ml (1 30) (1 37)) (bold (((f.ml (1 33) (1 36)) (word foo))))))))))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let delimited_code_block_with_meta_and_output =
       test "{delim@ocaml env=f1 version>=4.06 [foo]delim[output {b foo}]}";
@@ -3048,8 +3049,8 @@ let%expect_test _ =
           (((f.ml (1 0) (1 61))
             (code_block
              (((f.ml (1 7) (1 12)) ocaml)
-              ((binding ((f.ml (1 12) (1 17)) env) ((f.ml (1 17) (1 19)) f1))
-               (binding ((f.ml (1 19) (1 29)) version>) ((f.ml (1 29) (1 33)) 4.06))))
+              ((binding ((f.ml (1 13) (1 16)) env) ((f.ml (1 17) (1 19)) f1))
+               (binding ((f.ml (1 20) (1 28)) version>) ((f.ml (1 29) (1 33)) 4.06))))
              ((f.ml (1 35) (1 38)) foo)
              ((paragraph
                (((f.ml (1 45) (1 51)) (word output)) ((f.ml (1 51) (1 52)) space)
@@ -3065,7 +3066,8 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (1 23))
             (code_block ((f.ml (1 2) (1 21)) "foo][output {b foo}")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     (* Code block contains ']['. *)
     let code_block_with_output_and_lang_without_delim =
@@ -3076,7 +3078,8 @@ let%expect_test _ =
           (((f.ml (1 0) (1 29))
             (code_block (((f.ml (1 2) (1 7)) ocaml) ())
              ((f.ml (1 8) (1 27)) "foo][output {b foo}")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let code_block_with_output_unexpected_delim =
       test "{[foo]unexpected[output {b foo}]}";
@@ -3085,7 +3088,8 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (1 33))
             (code_block ((f.ml (1 2) (1 31)) "foo]unexpected[output {b foo}")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let code_block_with_output_lang_unexpected_delim =
       test "{@ocaml[foo]unexpected[output {b foo}]}";
@@ -3095,7 +3099,8 @@ let%expect_test _ =
           (((f.ml (1 0) (1 39))
             (code_block (((f.ml (1 2) (1 7)) ocaml) ())
              ((f.ml (1 8) (1 37)) "foo]unexpected[output {b foo}")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let code_block_with_output_wrong_delim =
       test "{delim@ocaml[foo]wrong[output {b foo}]delim}";
@@ -3105,7 +3110,8 @@ let%expect_test _ =
           (((f.ml (1 0) (1 44))
             (code_block (((f.ml (1 7) (1 12)) ocaml) ())
              ((f.ml (1 13) (1 37)) "foo]wrong[output {b foo}")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let code_block_empty_meta =
       test "{@[code goes here]}";
@@ -3116,7 +3122,8 @@ let%expect_test _ =
          (warnings
           ( "File \"f.ml\", line 1, characters 0-3:\
            \n'{@' should be followed by a language tag.\
-           \nSuggestion: try '{[ ... ]}' or '{@ocaml[ ... ]}'."))) |}]
+           \nSuggestion: try '{[ ... ]}' or '{@ocaml[ ... ]}'.")))
+        |}]
 
     let unterminated_code_block_with_meta =
       test "{@meta[foo";
@@ -3128,7 +3135,8 @@ let%expect_test _ =
          (warnings
           ( "File \"f.ml\", line 1, characters 0-10:\
            \nMissing end of code block.\
-           \nSuggestion: add ']}'."))) |}]
+           \nSuggestion: add ']}'.")))
+        |}]
 
     let unterminated_code_block_with_meta =
       test "{@met";
@@ -3142,7 +3150,8 @@ let%expect_test _ =
            \nMissing end of code block.\
            \nSuggestion: try '{@ocaml[ ... ]}'."
             "File \"f.ml\", line 1, characters 0-5:\
-           \n'{[...]}' (code block) should not be empty."))) |}]
+           \n'{[...]}' (code block) should not be empty.")))
+        |}]
 
     let newlines_after_langtag =
       test "{@ocaml\n[ code ]}";
@@ -3163,7 +3172,7 @@ let%expect_test _ =
           (((f.ml (1 0) (2 9))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((binding ((f.ml (1 7) (1 13)) kind) ((f.ml (1 13) (1 21)) toplevel))))
+              ((binding ((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel))))
              ((f.ml (2 1) (2 7)) " code ")))))
          (warnings ()))
         |}]
@@ -3176,7 +3185,7 @@ let%expect_test _ =
           (((f.ml (1 0) (1 31))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((binding ((f.ml (1 7) (1 13)) kind) ((f.ml (1 13) (1 21)) toplevel))))
+              ((binding ((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel))))
              ((f.ml (1 23) (1 29)) " code ")))))
          (warnings ()))
         |}]
@@ -3189,7 +3198,7 @@ let%expect_test _ =
           (((f.ml (1 0) (2 11))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((binding ((f.ml (1 7) (1 13)) kind) ((f.ml (1 13) (1 21)) toplevel))))
+              ((binding ((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel))))
              ((f.ml (2 3) (2 9)) " code ")))))
          (warnings ()))
         |}]
@@ -3202,8 +3211,8 @@ let%expect_test _ =
           (((f.ml (1 0) (2 15))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((binding ((f.ml (1 7) (1 13)) kind) ((f.ml (1 13) (1 21)) toplevel))
-               (binding ((f.ml (1 21) (2 4)) env) ((f.ml (2 4) (2 6)) e1))))
+              ((binding ((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel))
+               (binding ((f.ml (2 0) (2 3)) env) ((f.ml (2 4) (2 6)) e1))))
              ((f.ml (2 7) (2 13)) " code ")))))
          (warnings ()))
         |}]
@@ -3216,7 +3225,7 @@ let%expect_test _ =
           (((f.ml (1 0) (2 22))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((binding ((f.ml (1 7) (2 5)) kind) ((f.ml (2 5) (2 13)) toplevel))))
+              ((binding ((f.ml (2 0) (2 4)) kind) ((f.ml (2 5) (2 13)) toplevel))))
              ((f.ml (2 14) (2 20)) " code ")))))
          (warnings ()))
         |}]
@@ -3228,11 +3237,10 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (1 20))
             (code_block (((f.ml (1 2) (1 7)) ocaml) ())
-             ((f.ml (1 8) (1 18)) "top[ code ")))))
+             ((f.ml (1 12) (1 18)) " code ")))))
          (warnings
-          ( "File \"f.ml\", line 1, characters 0-8:\
-           \nInvalid character ',' in language tag.\
-           \nSuggestion: try '{@ocaml[ ... ]}'.")))
+          ( "File \"f.ml\", line 1, characters 7-12:\
+           \nInvalid character in code block metadata tag ','.")))
         |}]
 
     let delimited_code_block =
@@ -3432,12 +3440,12 @@ let%expect_test _ =
           (((f.ml (1 0) (1 137))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((binding ((f.ml (1 7) (1 12)) env) ((f.ml (1 12) (1 14)) f1))
-               (binding ((f.ml (1 14) (1 23)) version) ((f.ml (1 23) (1 27)) 4.06))
+              ((binding ((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1))
+               (binding ((f.ml (1 15) (1 22)) version) ((f.ml (1 23) (1 27)) 4.06))
                (tag ((f.ml (1 29) (1 51)) "tag with several words"))
                (binding ((f.ml (1 54) (1 66)) "binding with")
                 ((f.ml (1 68) (1 78)) singleword))
-               (binding ((f.ml (1 78) (1 84)) also)
+               (binding ((f.ml (1 79) (1 83)) also)
                 ((f.ml (1 85) (1 95)) "other case"))
                (binding ((f.ml (1 98) (1 112)) "everything has")
                 ((f.ml (1 115) (1 129)) "multiple words"))))
@@ -3462,13 +3470,13 @@ let%expect_test _ =
           (((f.ml (1 0) (9 15))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              ((binding ((f.ml (1 7) (2 13)) env) ((f.ml (2 13) (2 15)) f1))
-               (binding ((f.ml (2 15) (3 17)) version) ((f.ml (3 17) (3 21)) 4.06))
-               (tag ((f.ml (3 21) (4 19)) single_tag))
+              ((binding ((f.ml (2 9) (2 12)) env) ((f.ml (2 13) (2 15)) f1))
+               (binding ((f.ml (3 9) (3 16)) version) ((f.ml (3 17) (3 21)) 4.06))
+               (tag ((f.ml (4 9) (4 19)) single_tag))
                (tag ((f.ml (5 10) (5 32)) "tag with several words"))
                (binding ((f.ml (6 10) (6 22)) "binding with")
                 ((f.ml (6 24) (6 34)) singleword))
-               (binding ((f.ml (6 34) (7 14)) also)
+               (binding ((f.ml (7 9) (7 13)) also)
                 ((f.ml (7 15) (7 25)) "other case"))
                (binding ((f.ml (8 10) (8 24)) "everything has")
                 ((f.ml (8 27) (8 41)) "multiple words"))))
@@ -3495,12 +3503,11 @@ let%expect_test _ =
         {|
         ((output
           (((f.ml (1 0) (1 20))
-            (code_block (((f.ml (1 2) (1 7)) ocaml) ())
-             ((f.ml (1 10) (1 18)) "=\\\" [foo")))))
+            (code_block (((f.ml (1 2) (1 7)) ocaml) ()) ((f.ml (1 15) (1 18)) foo)))))
          (warnings
-          ( "File \"f.ml\", line 1, characters 0-10:\
-           \nInvalid character '\"' in language tag.\
-           \nSuggestion: try '{@ocaml[ ... ]}'."))) |}]
+          ( "File \"f.ml\", line 1, characters 9-15:\
+           \nInvalid character in code block metadata tag '\"'.")))
+        |}]
 
     let two_slashes_are_required =
       test {|{@ocaml "\\" [foo]}|};
@@ -3522,14 +3529,11 @@ let%expect_test _ =
         ((output
           (((f.ml (2 5) (2 28))
             (code_block
-             (((f.ml (2 7) (2 12)) ocaml) ((tag ((f.ml (2 14) (2 20)) abc))))
+             (((f.ml (2 7) (2 12)) ocaml) ((tag ((f.ml (2 14) (2 20)) "a\bc"))))
              ((f.ml (2 23) (2 26)) foo)))))
          (warnings
           ( "File \"f.ml\", line 2, characters 14-16:\
            \nThe 'a' character should not be escaped.\
-           \nSuggestion: Remove \\."
-            "File \"f.ml\", line 2, characters 16-18:\
-           \nThe 'b' character should not be escaped.\
            \nSuggestion: Remove \\."
             "File \"f.ml\", line 2, characters 18-20:\
            \nThe 'c' character should not be escaped.\
@@ -3545,14 +3549,11 @@ let%expect_test _ =
           (((f.ml (2 5) (2 37))
             (code_block
              (((f.ml (2 7) (2 12)) ocaml)
-              ((binding ((f.ml (2 14) (2 20)) abc) ((f.ml (2 23) (2 29)) xyz))))
+              ((binding ((f.ml (2 14) (2 20)) "a\bc") ((f.ml (2 23) (2 29)) xyz))))
              ((f.ml (2 32) (2 35)) foo)))))
          (warnings
           ( "File \"f.ml\", line 2, characters 14-16:\
            \nThe 'a' character should not be escaped.\
-           \nSuggestion: Remove \\."
-            "File \"f.ml\", line 2, characters 16-18:\
-           \nThe 'b' character should not be escaped.\
            \nSuggestion: Remove \\."
             "File \"f.ml\", line 2, characters 18-20:\
            \nThe 'c' character should not be escaped.\

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -3525,6 +3525,32 @@ let%expect_test _ =
           ( "File \"f.ml\", line 1, characters 0-10:\
            \nInvalid character '\"' in language tag.\
            \nSuggestion: try '{@ocaml[ ... ]}'."))) |}]
+
+    let two_slashes_are_required =
+      test {|{@ocaml "\\" [foo]}|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (1 0) (1 19))
+            (code_block
+             (((f.ml (1 2) (1 7)) ocaml)
+              (((f.ml (1 7) (1 13)) (((f.ml (1 8) (1 12)) "\\")))))
+             ((f.ml (1 14) (1 17)) foo)))))
+         (warnings ()))
+        |}]
+
+    let escaped_char_are_allowed =
+      test {|{@ocaml "\a\b\c" [foo]}|};
+      [%expect
+        {|
+        ((output
+          (((f.ml (1 0) (1 23))
+            (code_block
+             (((f.ml (1 2) (1 7)) ocaml)
+              (((f.ml (1 7) (1 17)) (((f.ml (1 8) (1 16)) abc)))))
+             ((f.ml (1 18) (1 21)) foo)))))
+         (warnings ()))
+        |}]
   end in
   ()
 

--- a/src/parser/test/test.ml
+++ b/src/parser/test/test.ml
@@ -71,16 +71,16 @@ module Ast_to_sexp = struct
         List [ str u; List (List.map (at.at (inline_element at)) es) ]
 
   let code_block_tags at tags =
-    let tags = Loc.value tags in
     let code_block_tag t =
-      match t.Loc.value with
-      | `Tag s -> Atom s
-      | `Binding (key, value) -> List [ at.at str_at key; at.at str_at value ]
+      match t with
+      | `Tag s -> List [ Atom "tag"; at.at str_at s ]
+      | `Binding (key, value) ->
+          List [ Atom "binding"; at.at str_at key; at.at str_at value ]
     in
-    List (List.map (at.at code_block_tag) tags)
+    List (List.map code_block_tag tags)
 
   let code_block_lang at { Ast.language; tags } =
-    List [ at.at str_at language; opt (at.at (code_block_tags at)) tags ]
+    List [ at.at str_at language; code_block_tags at tags ]
 
   let media_href =
    fun v ->
@@ -3022,13 +3022,11 @@ let%expect_test _ =
           (((f.ml (1 0) (1 46))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (1 29))
-                (((f.ml (1 8) (1 14))
-                  (((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1)))
-                 ((f.ml (1 15) (1 28))
-                  (((f.ml (1 15) (1 23)) version>) ((f.ml (1 24) (1 28)) 4.06)))))))
+              ((binding ((f.ml (1 7) (1 12)) env) ((f.ml (1 12) (1 14)) f1))
+               (binding ((f.ml (1 14) (1 24)) version>) ((f.ml (1 24) (1 28)) 4.06))))
              ((f.ml (1 30) (1 44)) "code goes here")))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let code_block_with_output =
       test "{delim@ocaml[foo]delim[output {b foo}]}";
@@ -3050,16 +3048,14 @@ let%expect_test _ =
           (((f.ml (1 0) (1 61))
             (code_block
              (((f.ml (1 7) (1 12)) ocaml)
-              (((f.ml (1 12) (1 34))
-                (((f.ml (1 13) (1 19))
-                  (((f.ml (1 13) (1 16)) env) ((f.ml (1 17) (1 19)) f1)))
-                 ((f.ml (1 20) (1 33))
-                  (((f.ml (1 20) (1 28)) version>) ((f.ml (1 29) (1 33)) 4.06)))))))
+              ((binding ((f.ml (1 12) (1 17)) env) ((f.ml (1 17) (1 19)) f1))
+               (binding ((f.ml (1 19) (1 29)) version>) ((f.ml (1 29) (1 33)) 4.06))))
              ((f.ml (1 35) (1 38)) foo)
              ((paragraph
                (((f.ml (1 45) (1 51)) (word output)) ((f.ml (1 51) (1 52)) space)
                 ((f.ml (1 52) (1 59)) (bold (((f.ml (1 55) (1 58)) (word foo))))))))))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     (* Code block contains ']['. *)
     let code_block_with_output_without_delim =
@@ -3167,9 +3163,7 @@ let%expect_test _ =
           (((f.ml (1 0) (2 9))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (2 0))
-                (((f.ml (1 8) (1 21))
-                  (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel)))))))
+              ((binding ((f.ml (1 7) (1 13)) kind) ((f.ml (1 13) (1 21)) toplevel))))
              ((f.ml (2 1) (2 7)) " code ")))))
          (warnings ()))
         |}]
@@ -3182,9 +3176,7 @@ let%expect_test _ =
           (((f.ml (1 0) (1 31))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (1 22))
-                (((f.ml (1 8) (1 21))
-                  (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel)))))))
+              ((binding ((f.ml (1 7) (1 13)) kind) ((f.ml (1 13) (1 21)) toplevel))))
              ((f.ml (1 23) (1 29)) " code ")))))
          (warnings ()))
         |}]
@@ -3197,9 +3189,7 @@ let%expect_test _ =
           (((f.ml (1 0) (2 11))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (2 2))
-                (((f.ml (1 8) (1 21))
-                  (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel)))))))
+              ((binding ((f.ml (1 7) (1 13)) kind) ((f.ml (1 13) (1 21)) toplevel))))
              ((f.ml (2 3) (2 9)) " code ")))))
          (warnings ()))
         |}]
@@ -3212,11 +3202,8 @@ let%expect_test _ =
           (((f.ml (1 0) (2 15))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (2 6))
-                (((f.ml (1 8) (1 21))
-                  (((f.ml (1 8) (1 12)) kind) ((f.ml (1 13) (1 21)) toplevel)))
-                 ((f.ml (2 0) (2 6))
-                  (((f.ml (2 0) (2 3)) env) ((f.ml (2 4) (2 6)) e1)))))))
+              ((binding ((f.ml (1 7) (1 13)) kind) ((f.ml (1 13) (1 21)) toplevel))
+               (binding ((f.ml (1 21) (2 4)) env) ((f.ml (2 4) (2 6)) e1))))
              ((f.ml (2 7) (2 13)) " code ")))))
          (warnings ()))
         |}]
@@ -3229,9 +3216,7 @@ let%expect_test _ =
           (((f.ml (1 0) (2 22))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (2 13))
-                (((f.ml (2 0) (2 13))
-                  (((f.ml (2 0) (2 4)) kind) ((f.ml (2 5) (2 13)) toplevel)))))))
+              ((binding ((f.ml (1 7) (2 5)) kind) ((f.ml (2 5) (2 13)) toplevel))))
              ((f.ml (2 14) (2 20)) " code ")))))
          (warnings ()))
         |}]
@@ -3447,22 +3432,18 @@ let%expect_test _ =
           (((f.ml (1 0) (1 137))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (1 131))
-                (((f.ml (1 8) (1 14))
-                  (((f.ml (1 8) (1 11)) env) ((f.ml (1 12) (1 14)) f1)))
-                 ((f.ml (1 15) (1 27))
-                  (((f.ml (1 15) (1 22)) version) ((f.ml (1 23) (1 27)) 4.06)))
-                 ((f.ml (1 28) (1 52)) "tag with several words")
-                 ((f.ml (1 53) (1 78))
-                  (((f.ml (1 53) (1 67)) "binding with")
-                   ((f.ml (1 68) (1 78)) singleword)))
-                 ((f.ml (1 79) (1 96))
-                  (((f.ml (1 79) (1 83)) also) ((f.ml (1 84) (1 96)) "other case")))
-                 ((f.ml (1 97) (1 130))
-                  (((f.ml (1 97) (1 113)) "everything has")
-                   ((f.ml (1 114) (1 130)) "multiple words")))))))
+              ((binding ((f.ml (1 7) (1 12)) env) ((f.ml (1 12) (1 14)) f1))
+               (binding ((f.ml (1 14) (1 23)) version) ((f.ml (1 23) (1 27)) 4.06))
+               (tag ((f.ml (1 29) (1 51)) "tag with several words"))
+               (binding ((f.ml (1 54) (1 66)) "binding with")
+                ((f.ml (1 68) (1 78)) singleword))
+               (binding ((f.ml (1 78) (1 84)) also)
+                ((f.ml (1 85) (1 95)) "other case"))
+               (binding ((f.ml (1 98) (1 112)) "everything has")
+                ((f.ml (1 115) (1 129)) "multiple words"))))
              ((f.ml (1 132) (1 135)) foo)))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let lots_of_tags_with_newlines =
       test
@@ -3481,23 +3462,19 @@ let%expect_test _ =
           (((f.ml (1 0) (9 15))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (9 9))
-                (((f.ml (2 9) (2 15))
-                  (((f.ml (2 9) (2 12)) env) ((f.ml (2 13) (2 15)) f1)))
-                 ((f.ml (3 9) (3 21))
-                  (((f.ml (3 9) (3 16)) version) ((f.ml (3 17) (3 21)) 4.06)))
-                 ((f.ml (4 9) (4 19)) single_tag)
-                 ((f.ml (5 9) (5 33)) "tag with several words")
-                 ((f.ml (6 9) (6 34))
-                  (((f.ml (6 9) (6 23)) "binding with")
-                   ((f.ml (6 24) (6 34)) singleword)))
-                 ((f.ml (7 9) (7 26))
-                  (((f.ml (7 9) (7 13)) also) ((f.ml (7 14) (7 26)) "other case")))
-                 ((f.ml (8 9) (8 42))
-                  (((f.ml (8 9) (8 25)) "everything has")
-                   ((f.ml (8 26) (8 42)) "multiple words")))))))
+              ((binding ((f.ml (1 7) (2 13)) env) ((f.ml (2 13) (2 15)) f1))
+               (binding ((f.ml (2 15) (3 17)) version) ((f.ml (3 17) (3 21)) 4.06))
+               (tag ((f.ml (3 21) (4 19)) single_tag))
+               (tag ((f.ml (5 10) (5 32)) "tag with several words"))
+               (binding ((f.ml (6 10) (6 22)) "binding with")
+                ((f.ml (6 24) (6 34)) singleword))
+               (binding ((f.ml (6 34) (7 14)) also)
+                ((f.ml (7 15) (7 25)) "other case"))
+               (binding ((f.ml (8 10) (8 24)) "everything has")
+                ((f.ml (8 27) (8 41)) "multiple words"))))
              ((f.ml (9 10) (9 13)) foo)))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let escaping1 =
       test {|{@ocaml "\""="\"" [foo]}|};
@@ -3507,11 +3484,10 @@ let%expect_test _ =
           (((f.ml (1 0) (1 24))
             (code_block
              (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (1 18))
-                (((f.ml (1 8) (1 17))
-                  (((f.ml (1 8) (1 12)) "\"") ((f.ml (1 13) (1 17)) "\"")))))))
+              ((binding ((f.ml (1 9) (1 11)) "\"") ((f.ml (1 14) (1 16)) "\""))))
              ((f.ml (1 19) (1 22)) foo)))))
-         (warnings ())) |}]
+         (warnings ()))
+        |}]
 
     let escaping2 =
       test {|{@ocaml \"=\" [foo]}|};
@@ -3533,8 +3509,7 @@ let%expect_test _ =
         ((output
           (((f.ml (1 0) (1 19))
             (code_block
-             (((f.ml (1 2) (1 7)) ocaml)
-              (((f.ml (1 7) (1 13)) (((f.ml (1 8) (1 12)) "\\")))))
+             (((f.ml (1 2) (1 7)) ocaml) ((tag ((f.ml (1 9) (1 11)) "\\"))))
              ((f.ml (1 14) (1 17)) foo)))))
          (warnings ()))
         |}]
@@ -3547,8 +3522,7 @@ let%expect_test _ =
         ((output
           (((f.ml (2 5) (2 28))
             (code_block
-             (((f.ml (2 7) (2 12)) ocaml)
-              (((f.ml (2 12) (2 22)) (((f.ml (2 13) (2 21)) abc)))))
+             (((f.ml (2 7) (2 12)) ocaml) ((tag ((f.ml (2 14) (2 20)) abc))))
              ((f.ml (2 23) (2 26)) foo)))))
          (warnings
           ( "File \"f.ml\", line 2, characters 14-16:\
@@ -3571,9 +3545,7 @@ let%expect_test _ =
           (((f.ml (2 5) (2 37))
             (code_block
              (((f.ml (2 7) (2 12)) ocaml)
-              (((f.ml (2 12) (2 31))
-                (((f.ml (2 13) (2 30))
-                  (((f.ml (2 13) (2 21)) abc) ((f.ml (2 22) (2 30)) xyz)))))))
+              ((binding ((f.ml (2 14) (2 20)) abc) ((f.ml (2 23) (2 29)) xyz))))
              ((f.ml (2 32) (2 35)) foo)))))
          (warnings
           ( "File \"f.ml\", line 2, characters 14-16:\
@@ -3585,13 +3557,13 @@ let%expect_test _ =
             "File \"f.ml\", line 2, characters 18-20:\
            \nThe 'c' character should not be escaped.\
            \nSuggestion: Remove \\."
-            "File \"f.ml\", line 2, characters 25-27:\
+            "File \"f.ml\", line 2, characters 23-25:\
            \nThe 'x' character should not be escaped.\
            \nSuggestion: Remove \\."
-            "File \"f.ml\", line 2, characters 27-29:\
+            "File \"f.ml\", line 2, characters 25-27:\
            \nThe 'y' character should not be escaped.\
            \nSuggestion: Remove \\."
-            "File \"f.ml\", line 2, characters 29-31:\
+            "File \"f.ml\", line 2, characters 27-29:\
            \nThe 'z' character should not be escaped.\
            \nSuggestion: Remove \\.")))
         |}]

--- a/src/parser/token.ml
+++ b/src/parser/token.ml
@@ -48,7 +48,7 @@ type code_block_tag =
   | `Binding of string (* Loc.with_location *) * string (* Loc.with_location *)
   ]
 
-type code_block_tags = code_block_tag (* Loc.with_location *) list
+type code_block_tags = code_block_tag Loc.with_location list
 
 type t =
   [ (* End of input. *)

--- a/src/parser/token.ml
+++ b/src/parser/token.ml
@@ -44,10 +44,10 @@ let s_of_media kind media =
   | `Replaced, `Image -> "{{image!"
 
 type code_block_tag =
-  [ `Tag of string
+  [ `Tag of string Loc.with_location
   | `Binding of string Loc.with_location * string Loc.with_location ]
 
-type code_block_tags = code_block_tag Loc.with_location list
+type code_block_tags = code_block_tag list
 
 type t =
   [ (* End of input. *)
@@ -89,7 +89,7 @@ type t =
   | media_markup
   | (* Leaf block element markup. *)
     `Code_block of
-    (string Loc.with_location * code_block_tags Loc.with_location option) option
+    (string Loc.with_location * code_block_tags) option
     * string
     * string Loc.with_location
     * bool

--- a/src/parser/token.ml
+++ b/src/parser/token.ml
@@ -89,8 +89,7 @@ type t =
   | media_markup
   | (* Leaf block element markup. *)
     `Code_block of
-    (string Loc.with_location * code_block_tags (* Loc.with_location *) option)
-    option
+    (string Loc.with_location * code_block_tags Loc.with_location option) option
     * string
     * string Loc.with_location
     * bool

--- a/src/parser/token.ml
+++ b/src/parser/token.ml
@@ -45,8 +45,7 @@ let s_of_media kind media =
 
 type code_block_tag =
   [ `Tag of string
-  | `Binding of string (* Loc.with_location *) * string (* Loc.with_location *)
-  ]
+  | `Binding of string Loc.with_location * string Loc.with_location ]
 
 type code_block_tags = code_block_tag Loc.with_location list
 

--- a/src/parser/token.ml
+++ b/src/parser/token.ml
@@ -43,6 +43,13 @@ let s_of_media kind media =
   | `Replaced, `Video -> "{{video!"
   | `Replaced, `Image -> "{{image!"
 
+type code_block_tag =
+  [ `Tag of string
+  | `Binding of string (* Loc.with_location *) * string (* Loc.with_location *)
+  ]
+
+type code_block_tags = code_block_tag (* Loc.with_location *) list
+
 type t =
   [ (* End of input. *)
     `End
@@ -83,7 +90,8 @@ type t =
   | media_markup
   | (* Leaf block element markup. *)
     `Code_block of
-    (string Loc.with_location * string Loc.with_location option) option
+    (string Loc.with_location * code_block_tags (* Loc.with_location *) option)
+    option
     * string
     * string Loc.with_location
     * bool

--- a/test/extract_code/cmti_extraction.t/main.mli
+++ b/test/extract_code/cmti_extraction.t/main.mli
@@ -1,0 +1,25 @@
+(** {[
+      let x = 1
+    ]} *)
+
+val x : int
+[@@deriving none]
+(** {[
+      let () =
+        print_int x;
+        print_newline ()
+    ]} *)
+
+module A : sig
+  val x : int
+  (** {[
+        let hello = 2
+      ]} *)
+end
+
+type t =
+  | A of int
+      (** {[
+            let _ = hello +. hello
+          ]} *)
+  | B of int

--- a/test/extract_code/cmti_extraction.t/run.t
+++ b/test/extract_code/cmti_extraction.t/run.t
@@ -1,0 +1,29 @@
+  $ ocamlc -bin-annot main.mli
+  $ odoc extract-code -o output.ml --line-directives main.cmti
+
+  $ cat output.ml
+  #1 "main.mli"
+        
+        let x = 1
+      
+  #7 "main.mli"
+        
+        let () =
+          print_int x;
+          print_newline ()
+      
+  #15 "main.mli"
+          
+          let hello = 2
+        
+  #22 "main.mli"
+              
+              let _ = hello +. hello
+            
+
+  $ ocaml output.ml
+  1
+  File "main.mli", line 23, characters 20-25:
+  Error: This expression has type "int" but an expression was expected of type
+           "float"
+  [2]

--- a/test/extract_code/cmti_extraction.t/run.t
+++ b/test/extract_code/cmti_extraction.t/run.t
@@ -21,9 +21,8 @@
               let _ = hello +. hello
             
 
-  $ ocaml output.ml
+  $ ocaml output.ml 2> error.txt
   1
-  File "main.mli", line 23, characters 20-25:
-  Error: This expression has type "int" but an expression was expected of type
-           "float"
   [2]
+  $ grep File error.txt
+  File "main.mli", line 23, characters 20-25:

--- a/test/extract_code/dune
+++ b/test/extract_code/dune
@@ -1,3 +1,5 @@
 (cram
  (package odoc)
+ (enabled_if
+  (>= %{ocaml_version} 4.10.0))
  (deps %{bin:odoc}))

--- a/test/extract_code/dune
+++ b/test/extract_code/dune
@@ -1,0 +1,3 @@
+(cram
+ (package odoc)
+ (deps %{bin:odoc}))

--- a/test/extract_code/error.t/run.t
+++ b/test/extract_code/error.t/run.t
@@ -1,0 +1,10 @@
+  $ echo "hello" > file.cmti
+  $ odoc extract-code -o output.ml --line-directives file.cmti
+  ERROR: Error while unmarshalling input file file.cmti:
+  End_of_file
+  Check that the input file is a valid cmti file
+  [1]
+  $ touch hello.ext
+  $ odoc extract-code -o output.ml --line-directives hello.ext
+  ERROR: Input must have either mld or cmti as extension
+  [1]

--- a/test/extract_code/mld_extraction.t/main.mld
+++ b/test/extract_code/mld_extraction.t/main.mld
@@ -15,13 +15,13 @@ printf(a,10,34,a,34);
 }
 ]}
 
-{@ocaml name=error.ml name=printing[let x = 5]}
+{@ocaml name=error.ml name=printing[let five = 5]}
 
    {@ocaml name=printing[
-   let () = print_int x
+   let () = print_int five
   ]}
 
 
    {@ocaml name=error.ml[
-   let y = x + 6. (* This is a typing error *)
+   let y = five +. five (* This is a typing error *)
    ]}

--- a/test/extract_code/mld_extraction.t/main.mld
+++ b/test/extract_code/mld_extraction.t/main.mld
@@ -1,0 +1,27 @@
+{0 Test}
+
+By default, language is assumed to be OCaml
+
+{[
+(** By default, an odoc code block is assumed to contain OCaml code *)
+let () = ()
+]}
+
+{@c name=c-quine[
+#include <stdio.h>
+int main(){
+char*a="#include <stdio.h>%cint main(){char*a=%c%s%c;printf(a,10,34,a,34);}";
+printf(a,10,34,a,34);
+}
+]}
+
+{@ocaml name=error.ml name=printing[let x = 5]}
+
+   {@ocaml name=printing[
+   let () = print_int x
+  ]}
+
+
+   {@ocaml name=error.ml[
+   let y = x + 6. (* This is a typing error *)
+   ]}

--- a/test/extract_code/mld_extraction.t/run.t
+++ b/test/extract_code/mld_extraction.t/run.t
@@ -78,12 +78,13 @@ We can output to a file
      let y = x + 6. (* This is a typing error *)
      
 
-Let's check line directive work:
+Let's check line directive work ("-color always" to make sure the error message
+is the same in all context):
 
-  $ ocaml error.ml
+  $ ocaml -color always error.ml
   File "main.mld", line 26, characters 15-17:
-  Error: This expression has type "float" but an expression was expected of type
-           "int"
+  Error: This expression has type float but an expression was expected of type
+           int
   [2]
 
 Here is the line 26, and the characters 15-17:

--- a/test/extract_code/mld_extraction.t/run.t
+++ b/test/extract_code/mld_extraction.t/run.t
@@ -1,0 +1,79 @@
+Without --name argument, all OCaml code blocks are extracted
+
+  $ odoc extract-code main.mld
+  let x = 5
+     let () = print_int x
+    
+     let y = x + 6. (* This is a typing error *)
+     
+
+We can add (OCaml) line directives
+
+  $ odoc extract-code --line-directives main.mld
+  #18 "main.mld"
+                                       let x = 5
+  #20 "main.mld"
+                            
+     let () = print_int x
+    
+  #25 "main.mld"
+                            
+     let y = x + 6. (* This is a typing error *)
+     
+
+We can restrict to a named code blocks
+
+  $ odoc extract-code --line-directives --name error.ml main.mld
+  #18 "main.mld"
+                                       let x = 5
+  #25 "main.mld"
+                            
+     let y = x + 6. (* This is a typing error *)
+     
+
+We can output to a file
+
+  $ odoc extract-code --line-directives --name error.ml -o error.ml main.mld
+  $ cat error.ml
+  #18 "main.mld"
+                                       let x = 5
+  #25 "main.mld"
+                            
+     let y = x + 6. (* This is a typing error *)
+     
+
+Let's check line directive work:
+
+  $ ocaml error.ml
+  File "main.mld", line 26, characters 15-17:
+  Error: This expression has type "float" but an expression was expected of type
+           "int"
+  [2]
+
+Here is the line 26, and the characters 15-17:
+
+  $ sed -n '26p' main.mld
+     let y = x + 6. (* This is a typing error *)
+  $ sed -n '26p' main.mld | cut -c15-17
+   6.
+
+We can get content from multiple names
+
+  $ odoc extract-code --line-directives --name error.ml --name printing main.mld
+  #18 "main.mld"
+                                       let x = 5
+  #20 "main.mld"
+                            
+     let () = print_int x
+    
+  #25 "main.mld"
+                            
+     let y = x + 6. (* This is a typing error *)
+     
+  $ odoc extract-code --line-directives --name error.ml --name printing -o names.ml main.mld
+  $ ocaml names.ml
+  File "main.mld", line 26, characters 15-17:
+  Error: This expression has type "float" but an expression was expected of type
+           "int"
+  5
+  [2]

--- a/test/extract_code/mld_extraction.t/run.t
+++ b/test/extract_code/mld_extraction.t/run.t
@@ -1,15 +1,30 @@
-Without --name argument, all OCaml code blocks are extracted
+----------- Names ---------------------------------------------
+
+Without --name argument, all **OCaml** code blocks are extracted
 
   $ odoc extract-code main.mld
+  
+  (** By default, an odoc code block is assumed to contain OCaml code *)
+  let () = ()
   let x = 5
      let () = print_int x
     
      let y = x + 6. (* This is a typing error *)
      
 
-We can add (OCaml) line directives
+With --name argument, language does not matter
 
-  $ odoc extract-code --line-directives main.mld
+  $ odoc extract-code --name c-quine main.mld
+  
+  #include <stdio.h>
+  int main(){
+  char*a="#include <stdio.h>%cint main(){char*a=%c%s%c;printf(a,10,34,a,34);}";
+  printf(a,10,34,a,34);
+  }
+
+Multiple name can be given
+
+  $ odoc extract-code --line-directives --name error.ml --name printing main.mld
   #18 "main.mld"
                                        let x = 5
   #20 "main.mld"
@@ -21,7 +36,28 @@ We can add (OCaml) line directives
      let y = x + 6. (* This is a typing error *)
      
 
-We can restrict to a named code blocks
+------- Line directives ---------------------------------------
+
+We can add (OCaml) line directives
+
+  $ odoc extract-code --line-directives main.mld
+  #5 "main.mld"
+     
+  (** By default, an odoc code block is assumed to contain OCaml code *)
+  let () = ()
+  
+  #18 "main.mld"
+                                       let x = 5
+  #20 "main.mld"
+                            
+     let () = print_int x
+    
+  #25 "main.mld"
+                            
+     let y = x + 6. (* This is a typing error *)
+     
+
+Let's restrict to a named code blocks
 
   $ odoc extract-code --line-directives --name error.ml main.mld
   #18 "main.mld"
@@ -56,24 +92,3 @@ Here is the line 26, and the characters 15-17:
      let y = x + 6. (* This is a typing error *)
   $ sed -n '26p' main.mld | cut -c15-17
    6.
-
-We can get content from multiple names
-
-  $ odoc extract-code --line-directives --name error.ml --name printing main.mld
-  #18 "main.mld"
-                                       let x = 5
-  #20 "main.mld"
-                            
-     let () = print_int x
-    
-  #25 "main.mld"
-                            
-     let y = x + 6. (* This is a typing error *)
-     
-  $ odoc extract-code --line-directives --name error.ml --name printing -o names.ml main.mld
-  $ ocaml names.ml
-  File "main.mld", line 26, characters 15-17:
-  Error: This expression has type "float" but an expression was expected of type
-           "int"
-  5
-  [2]

--- a/test/extract_code/mld_extraction.t/run.t
+++ b/test/extract_code/mld_extraction.t/run.t
@@ -26,13 +26,13 @@ Multiple name can be given
 
   $ odoc extract-code --line-directives --name error.ml --name printing main.mld
   #18 "main.mld"
-                                       let five = 5
+                                      let five = 5
   #20 "main.mld"
-                            
+                           
      let () = print_int five
     
   #25 "main.mld"
-                            
+                           
      let y = five +. five (* This is a typing error *)
      
 
@@ -42,18 +42,18 @@ We can add (OCaml) line directives
 
   $ odoc extract-code --line-directives main.mld
   #5 "main.mld"
-     
+    
   (** By default, an odoc code block is assumed to contain OCaml code *)
   let () = ()
   
   #18 "main.mld"
-                                       let five = 5
+                                      let five = 5
   #20 "main.mld"
-                            
+                           
      let () = print_int five
     
   #25 "main.mld"
-                            
+                           
      let y = five +. five (* This is a typing error *)
      
 
@@ -61,9 +61,9 @@ Let's restrict to a named code blocks
 
   $ odoc extract-code --line-directives --name error.ml main.mld
   #18 "main.mld"
-                                       let five = 5
+                                      let five = 5
   #25 "main.mld"
-                            
+                           
      let y = five +. five (* This is a typing error *)
      
 
@@ -72,9 +72,9 @@ We can output to a file
   $ odoc extract-code --line-directives --name error.ml -o error.ml main.mld
   $ cat error.ml
   #18 "main.mld"
-                                       let five = 5
+                                      let five = 5
   #25 "main.mld"
-                            
+                           
      let y = five +. five (* This is a typing error *)
      
 

--- a/test/extract_code/mld_extraction.t/run.t
+++ b/test/extract_code/mld_extraction.t/run.t
@@ -6,10 +6,10 @@ Without --name argument, all **OCaml** code blocks are extracted
   
   (** By default, an odoc code block is assumed to contain OCaml code *)
   let () = ()
-  let x = 5
-     let () = print_int x
+  let five = 5
+     let () = print_int five
     
-     let y = x + 6. (* This is a typing error *)
+     let y = five +. five (* This is a typing error *)
      
 
 With --name argument, language does not matter
@@ -26,14 +26,14 @@ Multiple name can be given
 
   $ odoc extract-code --line-directives --name error.ml --name printing main.mld
   #18 "main.mld"
-                                       let x = 5
+                                       let five = 5
   #20 "main.mld"
                             
-     let () = print_int x
+     let () = print_int five
     
   #25 "main.mld"
                             
-     let y = x + 6. (* This is a typing error *)
+     let y = five +. five (* This is a typing error *)
      
 
 ------- Line directives ---------------------------------------
@@ -47,24 +47,24 @@ We can add (OCaml) line directives
   let () = ()
   
   #18 "main.mld"
-                                       let x = 5
+                                       let five = 5
   #20 "main.mld"
                             
-     let () = print_int x
+     let () = print_int five
     
   #25 "main.mld"
                             
-     let y = x + 6. (* This is a typing error *)
+     let y = five +. five (* This is a typing error *)
      
 
 Let's restrict to a named code blocks
 
   $ odoc extract-code --line-directives --name error.ml main.mld
   #18 "main.mld"
-                                       let x = 5
+                                       let five = 5
   #25 "main.mld"
                             
-     let y = x + 6. (* This is a typing error *)
+     let y = five +. five (* This is a typing error *)
      
 
 We can output to a file
@@ -72,24 +72,25 @@ We can output to a file
   $ odoc extract-code --line-directives --name error.ml -o error.ml main.mld
   $ cat error.ml
   #18 "main.mld"
-                                       let x = 5
+                                       let five = 5
   #25 "main.mld"
                             
-     let y = x + 6. (* This is a typing error *)
+     let y = five +. five (* This is a typing error *)
      
 
-Let's check line directive work ("-color always" to make sure the error message
-is the same in all context):
+Let's check line directive work (we only look at the location to avoid ocaml
+version-dependent output):
 
-  $ ocaml -color always error.ml
-  File "main.mld", line 26, characters 15-17:
-  Error: This expression has type float but an expression was expected of type
-           int
+  $ ocaml error.ml 2> error.txt
   [2]
+  $ grep File error.txt
+  File "main.mld", line 26, characters 11-15:
 
-Here is the line 26, and the characters 15-17:
+Here is the line 26, and the characters 11-15:
 
   $ sed -n '26p' main.mld
-     let y = x + 6. (* This is a typing error *)
-  $ sed -n '26p' main.mld | cut -c15-17
-   6.
+     let y = five +. five (* This is a typing error *)
+  $ sed -n '26p' main.mld | cut -c11-15
+   five
+
+"five" has type int and should have type float.


### PR DESCRIPTION
This is an early prototype (on top of #1325) of an `extract-code` command, which extracts named code blocks into a file. Supersedes the venerable #303.

This demonstrates that the location is right:

`test.mld`:
```
{0 hello}

  {[

  let f x = x +. 2.

]}


  {[ let x = f 2

]}
```

```
$ dune exec -- odoc extract-code test.mld > ocaml.ml
$ ocaml ocaml.ml
File "test.mld", line 10, characters 16-17:
Error: This expression has type int but an expression was expected of type
         float
  Hint: Did you mean 2.?
```