### PR TITLE
latex backend: full path in heading labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Drop support for OCaml < 4.08 (@jonludlam, #1300)
 - Allow referencing libraries from package added in `odoc-config.sexp`
   (@panglesd, #1343)
+- Use full path in heading labels in LaTeX backend (@octachron, #1332)
 
 ### Fixed
 - Fix bug in parsing META files when there are no dependencies (@jonludlam, #1352)

--- a/test/generators/latex/Functor.F1.tex
+++ b/test/generators/latex/Functor.F1.tex
@@ -1,9 +1,9 @@
 \section{Module \ocamlinlinecode{Functor.\allowbreak{}F1}}\label{Functor-F1}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Functor-F1-parameters}}%
 \label{Functor-F1-argument-1-Arg}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor-F1-argument-1-Arg]{\ocamlinlinecode{Arg}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor-F1-argument-1-Arg-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Functor-F1-signature}}%
 \label{Functor-F1-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 
 

--- a/test/generators/latex/Functor.F2.tex
+++ b/test/generators/latex/Functor.F2.tex
@@ -1,9 +1,9 @@
 \section{Module \ocamlinlinecode{Functor.\allowbreak{}F2}}\label{Functor-F2}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Functor-F2-parameters}}%
 \label{Functor-F2-argument-1-Arg}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor-F2-argument-1-Arg]{\ocamlinlinecode{Arg}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor-F2-argument-1-Arg-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Functor-F2-signature}}%
 \label{Functor-F2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[Functor-F2-argument-1-Arg-type-t]{\ocamlinlinecode{Arg.\allowbreak{}t}}}\\
 
 

--- a/test/generators/latex/Functor.F3.tex
+++ b/test/generators/latex/Functor.F3.tex
@@ -1,9 +1,9 @@
 \section{Module \ocamlinlinecode{Functor.\allowbreak{}F3}}\label{Functor-F3}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Functor-F3-parameters}}%
 \label{Functor-F3-argument-1-Arg}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor-F3-argument-1-Arg]{\ocamlinlinecode{Arg}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor-F3-argument-1-Arg-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Functor-F3-signature}}%
 \label{Functor-F3-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[Functor-F3-argument-1-Arg-type-t]{\ocamlinlinecode{Arg.\allowbreak{}t}}}\\
 
 

--- a/test/generators/latex/Functor.F4.tex
+++ b/test/generators/latex/Functor.F4.tex
@@ -1,9 +1,9 @@
 \section{Module \ocamlinlinecode{Functor.\allowbreak{}F4}}\label{Functor-F4}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Functor-F4-parameters}}%
 \label{Functor-F4-argument-1-Arg}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor-F4-argument-1-Arg]{\ocamlinlinecode{Arg}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor-F4-argument-1-Arg-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Functor-F4-signature}}%
 \label{Functor-F4-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 
 

--- a/test/generators/latex/Functor.F5.tex
+++ b/test/generators/latex/Functor.F5.tex
@@ -1,6 +1,6 @@
 \section{Module \ocamlinlinecode{Functor.\allowbreak{}F5}}\label{Functor-F5}%
-\subsection{Parameters\label{parameters}}%
-\subsection{Signature\label{signature}}%
+\subsection{Parameters\label{Functor-F5-parameters}}%
+\subsection{Signature\label{Functor-F5-signature}}%
 \label{Functor-F5-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 
 

--- a/test/generators/latex/Functor.tex
+++ b/test/generators/latex/Functor.tex
@@ -2,11 +2,11 @@
 \label{Functor-module-type-S}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Functor-module-type-S]{\ocamlinlinecode{S}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor-module-type-S-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{Functor-module-type-S1}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Functor-module-type-S1]{\ocamlinlinecode{S1}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{parameters}}%
+\label{Functor-module-type-S1}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Functor-module-type-S1]{\ocamlinlinecode{S1}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{Functor-module-type-S1-parameters}}%
 \label{Functor-module-type-S1-argument-1-_}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor-module-type-S1-argument-1-_]{\ocamlinlinecode{\_\allowbreak{}}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor-module-type-S1-argument-1-_-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsubsection{Signature\label{signature}}%
+\subsubsection{Signature\label{Functor-module-type-S1-signature}}%
 \label{Functor-module-type-S1-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\

--- a/test/generators/latex/Functor2.X.tex
+++ b/test/generators/latex/Functor2.X.tex
@@ -1,12 +1,12 @@
 \section{Module \ocamlinlinecode{Functor2.\allowbreak{}X}}\label{Functor2-X}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Functor2-X-parameters}}%
 \label{Functor2-X-argument-1-Y}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor2-X-argument-1-Y]{\ocamlinlinecode{Y}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor2-X-argument-1-Y-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Functor2-X-argument-2-Z}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor2-X-argument-2-Z]{\ocamlinlinecode{Z}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor2-X-argument-2-Z-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Functor2-X-signature}}%
 \label{Functor2-X-type-y_t}\ocamlcodefragment{\ocamltag{keyword}{type} y\_\allowbreak{}t = \hyperref[Functor2-X-argument-1-Y-type-t]{\ocamlinlinecode{Y.\allowbreak{}t}}}\\
 \label{Functor2-X-type-z_t}\ocamlcodefragment{\ocamltag{keyword}{type} z\_\allowbreak{}t = \hyperref[Functor2-X-argument-2-Z-type-t]{\ocamlinlinecode{Z.\allowbreak{}t}}}\\
 \label{Functor2-X-type-x_t}\ocamlcodefragment{\ocamltag{keyword}{type} x\_\allowbreak{}t = \hyperref[Functor2-X-type-y_t]{\ocamlinlinecode{y\_\allowbreak{}t}}}\\

--- a/test/generators/latex/Functor2.tex
+++ b/test/generators/latex/Functor2.tex
@@ -3,14 +3,14 @@
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Functor2-module-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor2-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ (\hyperref[Functor2-X-argument-1-Y]{\ocamlinlinecode{Y}} : \hyperref[Functor2-module-type-S]{\ocamlinlinecode{S}}) (\hyperref[Functor2-X-argument-2-Z]{\ocamlinlinecode{Z}} : \hyperref[Functor2-module-type-S]{\ocamlinlinecode{S}}) : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\\
-\label{Functor2-module-type-XF}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Functor2-module-type-XF]{\ocamlinlinecode{XF}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{parameters_2}}%
+\label{Functor2-module-type-XF}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Functor2-module-type-XF]{\ocamlinlinecode{XF}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{Functor2-module-type-XF-parameters_2}}%
 \label{Functor2-module-type-XF-argument-1-Y}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor2-module-type-XF-argument-1-Y]{\ocamlinlinecode{Y}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor2-module-type-XF-argument-1-Y-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Functor2-module-type-XF-argument-2-Z}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor2-module-type-XF-argument-2-Z]{\ocamlinlinecode{Z}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor2-module-type-XF-argument-2-Z-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsubsection{Signature\label{signature_2}}%
+\subsubsection{Signature\label{Functor2-module-type-XF-signature_2}}%
 \label{Functor2-module-type-XF-type-y_t}\ocamlcodefragment{\ocamltag{keyword}{type} y\_\allowbreak{}t = \hyperref[Functor2-module-type-XF-argument-1-Y-type-t]{\ocamlinlinecode{Y.\allowbreak{}t}}}\\
 \label{Functor2-module-type-XF-type-z_t}\ocamlcodefragment{\ocamltag{keyword}{type} z\_\allowbreak{}t = \hyperref[Functor2-module-type-XF-argument-2-Z-type-t]{\ocamlinlinecode{Z.\allowbreak{}t}}}\\
 \label{Functor2-module-type-XF-type-x_t}\ocamlcodefragment{\ocamltag{keyword}{type} x\_\allowbreak{}t = \hyperref[Functor2-module-type-XF-type-y_t]{\ocamlinlinecode{y\_\allowbreak{}t}}}\\

--- a/test/generators/latex/Functor_ml.Foo'.tex
+++ b/test/generators/latex/Functor_ml.Foo'.tex
@@ -1,9 +1,9 @@
 \section{Module \ocamlinlinecode{Functor\_\allowbreak{}ml.\allowbreak{}Foo'}}\label{Functor_ml-Foo'}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Functor_ml-Foo'-parameters}}%
 \label{Functor_ml-Foo'-argument-1-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Functor_ml-Foo'-argument-1-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Functor_ml-Foo'-argument-1-X-val-foo}\ocamlcodefragment{\ocamltag{keyword}{val} foo : int}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Functor_ml-Foo'-signature}}%
 \label{Functor_ml-Foo'-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[Functor_ml-Bar-type-t]{\ocamlinlinecode{Bar.\allowbreak{}t}}}\\
 
 

--- a/test/generators/latex/Include_sections.tex
+++ b/test/generators/latex/Include_sections.tex
@@ -1,13 +1,13 @@
 \section{Module \ocamlinlinecode{Include\_\allowbreak{}sections}}\label{Include_sections}%
 \label{Include_sections-module-type-Something}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Include_sections-module-type-Something]{\ocamlinlinecode{Something}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Include_sections-module-type-Something-val-something}\ocamlcodefragment{\ocamltag{keyword}{val} something : unit}\\
-\subsubsection{Something 1\label{something-1}}%
+\subsubsection{Something 1\label{Include_sections-module-type-Something-something-1}}%
 foo
 
 \label{Include_sections-module-type-Something-val-foo}\ocamlcodefragment{\ocamltag{keyword}{val} foo : unit}\\
-\subsubsection{Something 2\label{something-2}}%
+\subsubsection{Something 2\label{Include_sections-module-type-Something-something-2}}%
 \label{Include_sections-module-type-Something-val-bar}\ocamlcodefragment{\ocamltag{keyword}{val} bar : unit}\begin{ocamlindent}foo bar\end{ocamlindent}%
 \medbreak
-\subsubsection{Something 1-bis\label{something-1-bis}}%
+\subsubsection{Something 1-bis\label{Include_sections-module-type-Something-something-1-bis}}%
 Some text.
 
 \end{ocamlindent}%
@@ -15,44 +15,44 @@ Some text.
 \medbreak
 Let's include \hyperref[Include_sections-module-type-Something]{\ocamlinlinecode{\ocamlinlinecode{Something}}[p\pageref*{Include_sections-module-type-Something}]} once
 
-\ocamltag{keyword}{include} \hyperref[Include_sections-module-type-Something]{\ocamlinlinecode{Something}}\subsection{Something 1\label{something-1_2}}%
+\ocamltag{keyword}{include} \hyperref[Include_sections-module-type-Something]{\ocamlinlinecode{Something}}\subsection{Something 1\label{Include_sections-something-1_2}}%
 foo
 
-\subsubsection{Something 2\label{something-2_2}}%
-\subsection{Something 1-bis\label{something-1-bis_2}}%
+\subsubsection{Something 2\label{Include_sections-something-2_2}}%
+\subsection{Something 1-bis\label{Include_sections-something-1-bis_2}}%
 Some text.
 
-\subsection{Second include\label{second-include}}%
+\subsection{Second include\label{Include_sections-second-include}}%
 Let's include \hyperref[Include_sections-module-type-Something]{\ocamlinlinecode{\ocamlinlinecode{Something}}[p\pageref*{Include_sections-module-type-Something}]} a second time: the heading level should be shift here.
 
-\ocamltag{keyword}{include} \hyperref[Include_sections-module-type-Something]{\ocamlinlinecode{Something}}\subsection{Something 1\label{something-1_3}}%
+\ocamltag{keyword}{include} \hyperref[Include_sections-module-type-Something]{\ocamlinlinecode{Something}}\subsection{Something 1\label{Include_sections-something-1_3}}%
 foo
 
-\subsubsection{Something 2\label{something-2_3}}%
-\subsection{Something 1-bis\label{something-1-bis_3}}%
+\subsubsection{Something 2\label{Include_sections-something-2_3}}%
+\subsection{Something 1-bis\label{Include_sections-something-1-bis_3}}%
 Some text.
 
-\subsubsection{Third include\label{third-include}}%
+\subsubsection{Third include\label{Include_sections-third-include}}%
 Shifted some more.
 
-\ocamltag{keyword}{include} \hyperref[Include_sections-module-type-Something]{\ocamlinlinecode{Something}}\subsection{Something 1\label{something-1_4}}%
+\ocamltag{keyword}{include} \hyperref[Include_sections-module-type-Something]{\ocamlinlinecode{Something}}\subsection{Something 1\label{Include_sections-something-1_4}}%
 foo
 
-\subsubsection{Something 2\label{something-2_4}}%
-\subsection{Something 1-bis\label{something-1-bis_4}}%
+\subsubsection{Something 2\label{Include_sections-something-2_4}}%
+\subsection{Something 1-bis\label{Include_sections-something-1-bis_4}}%
 Some text.
 
 And let's include it again, but without inlining it this time: the ToC shouldn't grow.
 
 \ocamltag{keyword}{include} \hyperref[Include_sections-module-type-Something]{\ocamlinlinecode{Something}}\label{Include_sections-val-something}\ocamlcodefragment{\ocamltag{keyword}{val} something : unit}\\
-\subsection{Something 1\label{something-1_5}}%
+\subsection{Something 1\label{Include_sections-something-1_5}}%
 foo
 
 \label{Include_sections-val-foo}\ocamlcodefragment{\ocamltag{keyword}{val} foo : unit}\\
-\subsubsection{Something 2\label{something-2_5}}%
+\subsubsection{Something 2\label{Include_sections-something-2_5}}%
 \label{Include_sections-val-bar}\ocamlcodefragment{\ocamltag{keyword}{val} bar : unit}\begin{ocamlindent}foo bar\end{ocamlindent}%
 \medbreak
-\subsection{Something 1-bis\label{something-1-bis_5}}%
+\subsection{Something 1-bis\label{Include_sections-something-1-bis_5}}%
 Some text.
 
 

--- a/test/generators/latex/Labels.c.tex
+++ b/test/generators/latex/Labels.c.tex
@@ -1,4 +1,4 @@
 \section{Class \ocamlinlinecode{Labels.\allowbreak{}c}}\label{Labels-class-c}%
-\subsection{Attached to class\label{L7}}%
+\subsection{Attached to class\label{Labels-class-c-L7}}%
 
 

--- a/test/generators/latex/Labels.tex
+++ b/test/generators/latex/Labels.tex
@@ -1,7 +1,7 @@
 \section{Module \ocamlinlinecode{Labels}}\label{Labels}%
-\subsection{Attached to unit\label{L1}}%
-\subsection{Attached to nothing\label{L2}}%
-\label{Labels-module-A}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Labels-A]{\ocamlinlinecode{A}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Attached to module\label{L3}}%
+\subsection{Attached to unit\label{Labels-L1}}%
+\subsection{Attached to nothing\label{Labels-L2}}%
+\label{Labels-module-A}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Labels-A]{\ocamlinlinecode{A}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Attached to module\label{Labels-A-L3}}%
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Labels-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Attached to type\end{ocamlindent}%
@@ -10,11 +10,11 @@
 \medbreak
 \label{Labels-val-e}\ocamlcodefragment{\ocamltag{keyword}{val} e : unit \ocamltag{arrow}{$\rightarrow$} \hyperref[Labels-type-t]{\ocamlinlinecode{t}}}\begin{ocamlindent}Attached to external\end{ocamlindent}%
 \medbreak
-\label{Labels-module-type-S}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Labels-module-type-S]{\ocamlinlinecode{S}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Attached to module type\label{L6}}%
+\label{Labels-module-type-S}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Labels-module-type-S]{\ocamlinlinecode{S}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Attached to module type\label{Labels-module-type-S-L6}}%
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Labels-class-c}\ocamlcodefragment{\ocamltag{keyword}{class} \hyperref[Labels-class-c]{\ocamlinlinecode{c}}}\ocamlcodefragment{ : \ocamltag{keyword}{object} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\\
-\label{Labels-class-type-cs}\ocamlcodefragment{\ocamltag{keyword}{class} \ocamltag{keyword}{type}  \hyperref[Labels-class-type-cs]{\ocamlinlinecode{cs}}}\ocamlcodefragment{ = \ocamltag{keyword}{object}}\begin{ocamlindent}\subsubsection{Attached to class type\label{L8}}%
+\label{Labels-class-type-cs}\ocamlcodefragment{\ocamltag{keyword}{class} \ocamltag{keyword}{type}  \hyperref[Labels-class-type-cs]{\ocamlinlinecode{cs}}}\ocamlcodefragment{ = \ocamltag{keyword}{object}}\begin{ocamlindent}\subsubsection{Attached to class type\label{Labels-class-type-cs-L8}}%
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Labels-exception-E}\ocamlcodefragment{\ocamltag{keyword}{exception} \ocamltag{exception}{E}}\begin{ocamlindent}Attached to exception\end{ocamlindent}%

--- a/test/generators/latex/Markup.tex
+++ b/test/generators/latex/Markup.tex
@@ -1,27 +1,27 @@
 \section{Module \ocamlinlinecode{Markup}}\label{Markup}%
 Here, we test the rendering of comment markup.
 
-\subsection{Sections\label{sections}}%
+\subsection{Sections\label{Markup-sections}}%
 Let's get these done first, because sections will be used to break up the rest of this test.
 
 Besides the section heading above, there are also
 
-\subsubsection{Subsection headings\label{subsection-headings}}%
+\subsubsection{Subsection headings\label{Markup-subsection-headings}}%
 and
 
-\subsubsection{Sub-subsection headings\label{sub-subsection-headings}}%
+\subsubsection{Sub-subsection headings\label{Markup-sub-subsection-headings}}%
 but odoc has banned deeper headings. There are also title headings, but they are only allowed in mld files.
 
-\subsubsection{Anchors\label{anchors}}%
+\subsubsection{Anchors\label{Markup-anchors}}%
 Sections can have attached \hyperref[Markup-anchors]{\ocamlinlinecode{Anchors}[p\pageref*{Markup-anchors}]}, and it is possible to \hyperref[Markup-anchors]{\ocamlinlinecode{link}[p\pageref*{Markup-anchors}]} to them. Links to section headers should not be set in source code style.
 
-\subsubsection{Paragraph\label{paragraph}}%
+\subsubsection{Paragraph\label{Markup-paragraph}}%
 Individual paragraphs can have a heading.
 
-\subsubsection{Subparagraph\label{subparagraph}}%
+\subsubsection{Subparagraph\label{Markup-subparagraph}}%
 Parts of a longer paragraph that can be considered alone can also have headings.
 
-\subsection{Styling\label{styling}}%
+\subsection{Styling\label{Markup-styling}}%
 This paragraph has some styled elements: \bold{bold} and \emph{italic}, \bold{\emph{bold italic}}, \emph{emphasis}, \emph{\emph{emphasis} within emphasis}, \bold{\emph{bold italic}}, super\textsuperscript{script}, sub\textsubscript{script}. The line spacing should be enough for superscripts and subscripts not to look odd.
 
 Note: \emph{In italics \emph{emphasis} is rendered as normal text while \emph{emphasis \emph{in} emphasis} is rendered in italics.} \emph{It also work the same in \href{\#}{links in italics with \emph{emphasis \emph{in} emphasis}.}\footnote{\url{\#}}}
@@ -38,12 +38,12 @@ There is no differences between \ocamlinlinecode{a b} and \ocamlinlinecode{a b}.
 
 Consecutive whitespaces not after a newline are conserved as they are: \ocamlinlinecode{a   b}.
 
-\subsection{Links and references\label{links-and-references}}%
+\subsection{Links and references\label{Markup-links-and-references}}%
 This is a \href{\#}{link}\footnote{\url{\#}}. It sends you to the top of this page. Links can have markup inside them: \href{\#}{\bold{bold}}\footnote{\url{\#}}, \href{\#}{\emph{italics}}\footnote{\url{\#}}, \href{\#}{\emph{emphasis}}\footnote{\url{\#}}, \href{\#}{super\textsuperscript{script}}\footnote{\url{\#}}, \href{\#}{sub\textsubscript{script}}\footnote{\url{\#}}, and \href{\#}{\ocamlinlinecode{code}}\footnote{\url{\#}}. Links can also be nested \emph{\href{\#}{inside}\footnote{\url{\#}}} markup. Links cannot be nested inside each other. This link has no replacement text: \href{\#}{\#}\footnote{\url{\#}}. The text is filled in by odoc. This is a shorthand link: \href{\#}{\#}\footnote{\url{\#}}. The text is also filled in by odoc in this case.
 
 This is a reference to \hyperref[Markup-val-foo]{\ocamlinlinecode{\ocamlinlinecode{foo}}[p\pageref*{Markup-val-foo}]}. References can have replacement text: \hyperref[Markup-val-foo]{\ocamlinlinecode{the value foo}[p\pageref*{Markup-val-foo}]}. Except for the special lookup support, references are pretty much just like links. The replacement text can have nested styles: \hyperref[Markup-val-foo]{\ocamlinlinecode{\bold{bold}}[p\pageref*{Markup-val-foo}]}, \hyperref[Markup-val-foo]{\ocamlinlinecode{\emph{italic}}[p\pageref*{Markup-val-foo}]}, \hyperref[Markup-val-foo]{\ocamlinlinecode{\emph{emphasis}}[p\pageref*{Markup-val-foo}]}, \hyperref[Markup-val-foo]{\ocamlinlinecode{super\textsuperscript{script}}[p\pageref*{Markup-val-foo}]}, \hyperref[Markup-val-foo]{\ocamlinlinecode{sub\textsubscript{script}}[p\pageref*{Markup-val-foo}]}, and \hyperref[Markup-val-foo]{\ocamlinlinecode{\ocamlinlinecode{code}}[p\pageref*{Markup-val-foo}]}. It's also possible to surround a reference in a style: \bold{\hyperref[Markup-val-foo]{\ocamlinlinecode{\ocamlinlinecode{foo}}[p\pageref*{Markup-val-foo}]}}. References can't be nested inside references, and links and references can't be nested inside each other.
 
-\subsection{Preformatted text\label{preformatted-text}}%
+\subsection{Preformatted text\label{Markup-preformatted-text}}%
 This is a code block:\medbreak
 \begin{ocamlcodeblock}
     let foo = ()
@@ -57,7 +57,7 @@ This is a code block:\medbreak
 There are also verbatim blocks:
 
 \begin{verbatim}The main difference is these don't get syntax highlighting.\end{verbatim}%
-\subsection{Lists\label{lists}}%
+\subsection{Lists\label{Markup-lists}}%
 \begin{itemize}\item{This is a}%
 \item{shorthand bulleted list,}%
 \item{and the paragraphs in each list item support \emph{styling}.}\end{itemize}%
@@ -80,15 +80,15 @@ can use explicitly-delimited lists.
 \item{and can include references}%
 \item{\hyperref[Markup-val-foo]{\ocamlinlinecode{\ocamlinlinecode{foo}}[p\pageref*{Markup-val-foo}]}}\end{itemize}%
 }\end{itemize}%
-\subsection{Unicode\label{unicode}}%
+\subsection{Unicode\label{Markup-unicode}}%
 The parser supports any ASCII-compatible encoding.
 
 In particuλar UTF-8.
 
-\subsection{Raw HTML\label{raw-html}}%
+\subsection{Raw HTML\label{Markup-raw-html}}%
 Raw HTML can be  as inline elements into sentences.
 
-\subsection{Math\label{math}}%
+\subsection{Math\label{Markup-math}}%
 Math elements can be inline: $\int_{-\infty}^\infty$, or blocks:
 
 \begin{equation*}
@@ -99,7 +99,7 @@ Math elements can be inline: $\int_{-\infty}^\infty$, or blocks:
     \,d\xi
 \end{equation*}
 
-\subsection{Modules\label{modules}}%
+\subsection{Modules\label{Markup-modules}}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
 \item[{\hyperref[Markup-X]{\ocamlinlinecode{\ocamlinlinecode{X}}[p\pageref*{Markup-X}]}}]{}\end{description}%
@@ -107,7 +107,7 @@ Math elements can be inline: $\int_{-\infty}^\infty$, or blocks:
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
 \item[{\hyperref[Markup-X]{\ocamlinlinecode{\ocamlinlinecode{X}}[p\pageref*{Markup-X}]}}]{}%
 \item[{\hyperref[Markup-Y]{\ocamlinlinecode{\ocamlinlinecode{Y}}[p\pageref*{Markup-Y}]}}]{}\end{description}%
-\subsection{Tables\label{tables}}\\
+\subsection{Tables\label{Markup-tables}}\\
 \begin{ocamltabular}{w{l}{0.250\textwidth}w{c}{0.250\textwidth}w{r}{0.250\textwidth}p{0.250\textwidth}}\bold{Left
 
 }& \bold{Center
@@ -197,7 +197,7 @@ Data 1
 \\
 \end{ocamltabular}%
 \\
-\subsection{Tags\label{tags}}%
+\subsection{Tags\label{Markup-tags}}%
 Each comment can end with zero or more tags. Here are some examples:
 
 \begin{description}\kern-\topsep

--- a/test/generators/latex/Module_type_alias.tex
+++ b/test/generators/latex/Module_type_alias.tex
@@ -4,31 +4,31 @@ Module Type Aliases
 \label{Module_type_alias-module-type-A}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Module_type_alias-module-type-A]{\ocamlinlinecode{A}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Module_type_alias-module-type-A-type-a}\ocamlcodefragment{\ocamltag{keyword}{type} a}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{Module_type_alias-module-type-B}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Module_type_alias-module-type-B]{\ocamlinlinecode{B}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{parameters}}%
+\label{Module_type_alias-module-type-B}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Module_type_alias-module-type-B]{\ocamlinlinecode{B}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{Module_type_alias-module-type-B-parameters}}%
 \label{Module_type_alias-module-type-B-argument-1-C}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Module_type_alias-module-type-B-argument-1-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Module_type_alias-module-type-B-argument-1-C-type-c}\ocamlcodefragment{\ocamltag{keyword}{type} c}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsubsection{Signature\label{signature}}%
+\subsubsection{Signature\label{Module_type_alias-module-type-B-signature}}%
 \label{Module_type_alias-module-type-B-type-b}\ocamlcodefragment{\ocamltag{keyword}{type} b}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Module_type_alias-module-type-D}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} D = \hyperref[Module_type_alias-module-type-A]{\ocamlinlinecode{A}}}\\
-\label{Module_type_alias-module-type-E}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Module_type_alias-module-type-E]{\ocamlinlinecode{E}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{parameters_2}}%
+\label{Module_type_alias-module-type-E}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Module_type_alias-module-type-E]{\ocamlinlinecode{E}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{Module_type_alias-module-type-E-parameters_2}}%
 \label{Module_type_alias-module-type-E-argument-1-F}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Module_type_alias-module-type-E-argument-1-F]{\ocamlinlinecode{F}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Module_type_alias-module-type-E-argument-1-F-type-f}\ocamlcodefragment{\ocamltag{keyword}{type} f}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Module_type_alias-module-type-E-argument-2-C}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Module_type_alias-module-type-E-argument-2-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Module_type_alias-module-type-E-argument-2-C-type-c}\ocamlcodefragment{\ocamltag{keyword}{type} c}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsubsection{Signature\label{signature_2}}%
+\subsubsection{Signature\label{Module_type_alias-module-type-E-signature_2}}%
 \label{Module_type_alias-module-type-E-type-b}\ocamlcodefragment{\ocamltag{keyword}{type} b}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{Module_type_alias-module-type-G}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Module_type_alias-module-type-G]{\ocamlinlinecode{G}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{parameters_3}}%
+\label{Module_type_alias-module-type-G}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Module_type_alias-module-type-G]{\ocamlinlinecode{G}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{Module_type_alias-module-type-G-parameters_3}}%
 \label{Module_type_alias-module-type-G-argument-1-H}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Module_type_alias-module-type-G-argument-1-H]{\ocamlinlinecode{H}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Module_type_alias-module-type-G-argument-1-H-type-h}\ocamlcodefragment{\ocamltag{keyword}{type} h}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsubsection{Signature\label{signature_3}}%
+\subsubsection{Signature\label{Module_type_alias-module-type-G-signature_3}}%
 \label{Module_type_alias-module-type-G-type-a}\ocamlcodefragment{\ocamltag{keyword}{type} a}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\

--- a/test/generators/latex/Nested.F.tex
+++ b/test/generators/latex/Nested.F.tex
@@ -3,22 +3,22 @@ This is a functor F.
 
 Some additional comments.
 
-\subsection{Parameters\label{parameters}}%
-\label{Nested-F-argument-1-Arg1}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Nested-F-argument-1-Arg1]{\ocamlinlinecode{Arg1}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
+\subsection{Parameters\label{Nested-F-parameters}}%
+\label{Nested-F-argument-1-Arg1}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Nested-F-argument-1-Arg1]{\ocamlinlinecode{Arg1}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{Nested-F-argument-1-Arg1-type}}%
 \label{Nested-F-argument-1-Arg1-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
-\subsubsection{Values\label{values}}%
+\subsubsection{Values\label{Nested-F-argument-1-Arg1-values}}%
 \label{Nested-F-argument-1-Arg1-val-y}\ocamlcodefragment{\ocamltag{keyword}{val} y : \hyperref[Nested-F-argument-1-Arg1-type-t]{\ocamlinlinecode{t}}}\begin{ocamlindent}The value of y.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{Nested-F-argument-2-Arg2}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Nested-F-argument-2-Arg2]{\ocamlinlinecode{Arg2}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type_2}}%
+\label{Nested-F-argument-2-Arg2}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Nested-F-argument-2-Arg2]{\ocamlinlinecode{Arg2}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{Nested-F-argument-2-Arg2-type_2}}%
 \label{Nested-F-argument-2-Arg2-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
-\subsection{Type\label{type_3}}%
+\subsection{Signature\label{Nested-F-signature}}%
+\subsection{Type\label{Nested-F-type_3}}%
 \label{Nested-F-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[Nested-F-argument-1-Arg1-type-t]{\ocamlinlinecode{Arg1.\allowbreak{}t}} * \hyperref[Nested-F-argument-2-Arg2-type-t]{\ocamlinlinecode{Arg2.\allowbreak{}t}}}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
 

--- a/test/generators/latex/Nested.tex
+++ b/test/generators/latex/Nested.tex
@@ -1,30 +1,30 @@
 \section{Module \ocamlinlinecode{Nested}}\label{Nested}%
 This comment needs to be here before \#235 is fixed.
 
-\subsection{Module\label{module}}%
-\label{Nested-module-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Nested-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type}}%
+\subsection{Module\label{Nested-module}}%
+\label{Nested-module-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Nested-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{Nested-X-type}}%
 \label{Nested-X-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
-\subsubsection{Values\label{values}}%
+\subsubsection{Values\label{Nested-X-values}}%
 \label{Nested-X-val-x}\ocamlcodefragment{\ocamltag{keyword}{val} x : \hyperref[Nested-X-type-t]{\ocamlinlinecode{t}}}\begin{ocamlindent}The value of x.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}This is module X.\end{ocamlindent}%
 \medbreak
-\subsection{Module type\label{module-type}}%
-\label{Nested-module-type-Y}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Nested-module-type-Y]{\ocamlinlinecode{Y}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{type_2}}%
+\subsection{Module type\label{Nested-module-type}}%
+\label{Nested-module-type-Y}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Nested-module-type-Y]{\ocamlinlinecode{Y}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Type\label{Nested-module-type-Y-type_2}}%
 \label{Nested-module-type-Y-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\begin{ocamlindent}Some type.\end{ocamlindent}%
 \medbreak
-\subsubsection{Values\label{values_2}}%
+\subsubsection{Values\label{Nested-module-type-Y-values_2}}%
 \label{Nested-module-type-Y-val-y}\ocamlcodefragment{\ocamltag{keyword}{val} y : \hyperref[Nested-module-type-Y-type-t]{\ocamlinlinecode{t}}}\begin{ocamlindent}The value of y.\end{ocamlindent}%
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}This is module type Y.\end{ocamlindent}%
 \medbreak
-\subsection{Functor\label{functor}}%
+\subsection{Functor\label{Nested-functor}}%
 \label{Nested-module-F}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Nested-F]{\ocamlinlinecode{F}}}\ocamlcodefragment{ (\hyperref[Nested-F-argument-1-Arg1]{\ocamlinlinecode{Arg1}} : \hyperref[Nested-module-type-Y]{\ocamlinlinecode{Y}}) (\hyperref[Nested-F-argument-2-Arg2]{\ocamlinlinecode{Arg2}} : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}) : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\begin{ocamlindent}This is a functor F.\end{ocamlindent}%
 \medbreak
-\subsection{Class\label{class}}%
+\subsection{Class\label{Nested-class}}%
 \label{Nested-class-z}\ocamlcodefragment{\ocamltag{keyword}{class} \ocamltag{keyword}{virtual} \hyperref[Nested-class-z]{\ocamlinlinecode{z}}}\ocamlcodefragment{ : \ocamltag{keyword}{object} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\begin{ocamlindent}This is class z.\end{ocamlindent}%
 \medbreak
 \label{Nested-class-inherits}\ocamlcodefragment{\ocamltag{keyword}{class} \ocamltag{keyword}{virtual} \hyperref[Nested-class-inherits]{\ocamlinlinecode{inherits}}}\ocamlcodefragment{ : \ocamltag{keyword}{object} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\\

--- a/test/generators/latex/Nested.z.tex
+++ b/test/generators/latex/Nested.z.tex
@@ -6,7 +6,7 @@ Some additional comments.
 \label{Nested-class-z-val-y}\ocamlcodefragment{\ocamltag{keyword}{val} y : int}\begin{ocamlindent}Some value.\end{ocamlindent}%
 \medbreak
 \label{Nested-class-z-val-y'}\ocamlcodefragment{\ocamltag{keyword}{val} \ocamltag{keyword}{mutable} \ocamltag{keyword}{virtual} y' : int}\\
-\subsection{Methods\label{methods}}%
+\subsection{Methods\label{Nested-class-z-methods}}%
 \label{Nested-class-z-method-z}\ocamlcodefragment{\ocamltag{keyword}{method} z : int}\begin{ocamlindent}Some method.\end{ocamlindent}%
 \medbreak
 \label{Nested-class-z-method-z'}\ocamlcodefragment{\ocamltag{keyword}{method} \ocamltag{keyword}{private} \ocamltag{keyword}{virtual} z' : int}\\

--- a/test/generators/latex/Ocamlary.Dep12.tex
+++ b/test/generators/latex/Ocamlary.Dep12.tex
@@ -1,9 +1,9 @@
 \section{Module \ocamlinlinecode{Ocamlary.\allowbreak{}Dep12}}\label{Ocamlary-Dep12}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Ocamlary-Dep12-parameters}}%
 \label{Ocamlary-Dep12-argument-1-Arg}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Dep12-argument-1-Arg]{\ocamlinlinecode{Arg}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Dep12-argument-1-Arg-module-type-S}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} S}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Ocamlary-Dep12-signature}}%
 \label{Ocamlary-Dep12-module-type-T}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} T = \hyperref[Ocamlary-Dep12-argument-1-Arg-module-type-S]{\ocamlinlinecode{Arg.\allowbreak{}S}}}\\
 
 

--- a/test/generators/latex/Ocamlary.Dep2.tex
+++ b/test/generators/latex/Ocamlary.Dep2.tex
@@ -1,12 +1,12 @@
 \section{Module \ocamlinlinecode{Ocamlary.\allowbreak{}Dep2}}\label{Ocamlary-Dep2}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Ocamlary-Dep2-parameters}}%
 \label{Ocamlary-Dep2-argument-1-Arg}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Dep2-argument-1-Arg]{\ocamlinlinecode{Arg}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Dep2-argument-1-Arg-module-type-S}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} S}\\
 \label{Ocamlary-Dep2-argument-1-Arg-module-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Dep2-argument-1-Arg-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Dep2-argument-1-Arg-X-module-Y}\ocamlcodefragment{\ocamltag{keyword}{module} Y : \hyperref[Ocamlary-Dep2-argument-1-Arg-module-type-S]{\ocamlinlinecode{S}}}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Ocamlary-Dep2-signature}}%
 \label{Ocamlary-Dep2-module-A}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Dep2-A]{\ocamlinlinecode{A}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Dep2-A-module-Y}\ocamlcodefragment{\ocamltag{keyword}{module} Y : \hyperref[Ocamlary-Dep2-argument-1-Arg-module-type-S]{\ocamlinlinecode{Arg.\allowbreak{}S}}}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\

--- a/test/generators/latex/Ocamlary.Dep5.tex
+++ b/test/generators/latex/Ocamlary.Dep5.tex
@@ -1,5 +1,5 @@
 \section{Module \ocamlinlinecode{Ocamlary.\allowbreak{}Dep5}}\label{Ocamlary-Dep5}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Ocamlary-Dep5-parameters}}%
 \label{Ocamlary-Dep5-argument-1-Arg}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Dep5-argument-1-Arg]{\ocamlinlinecode{Arg}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Dep5-argument-1-Arg-module-type-T}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} T}\\
 \label{Ocamlary-Dep5-argument-1-Arg-module-type-S}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-Dep5-argument-1-Arg-module-type-S]{\ocamlinlinecode{S}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Dep5-argument-1-Arg-module-type-S-module-X}\ocamlcodefragment{\ocamltag{keyword}{module} X : \hyperref[Ocamlary-Dep5-argument-1-Arg-module-type-T]{\ocamlinlinecode{T}}}\\
 \label{Ocamlary-Dep5-argument-1-Arg-module-type-S-module-Y}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Dep5-argument-1-Arg-module-type-S-Y]{\ocamlinlinecode{Y}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
@@ -9,7 +9,7 @@
 \label{Ocamlary-Dep5-argument-1-Arg-module-X}\ocamlcodefragment{\ocamltag{keyword}{module} X : \hyperref[Ocamlary-Dep5-argument-1-Arg-module-type-T]{\ocamlinlinecode{T}}}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Ocamlary-Dep5-signature}}%
 \label{Ocamlary-Dep5-module-Z}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Dep5-Z]{\ocamlinlinecode{Z}}}\ocamlcodefragment{ : \hyperref[Ocamlary-Dep5-argument-1-Arg-module-type-S]{\ocamlinlinecode{Arg.\allowbreak{}S}} \ocamltag{keyword}{with} \ocamltag{keyword}{module} \hyperref[Ocamlary-Dep5-argument-1-Arg-module-type-S-Y]{\ocamlinlinecode{Y}} = \hyperref[Ocamlary-Dep3]{\ocamlinlinecode{Dep3}}}\\
 
 \input{Ocamlary.Dep5.Z.tex}

--- a/test/generators/latex/Ocamlary.Dep7.tex
+++ b/test/generators/latex/Ocamlary.Dep7.tex
@@ -1,5 +1,5 @@
 \section{Module \ocamlinlinecode{Ocamlary.\allowbreak{}Dep7}}\label{Ocamlary-Dep7}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Ocamlary-Dep7-parameters}}%
 \label{Ocamlary-Dep7-argument-1-Arg}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Dep7-argument-1-Arg]{\ocamlinlinecode{Arg}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Dep7-argument-1-Arg-module-type-S}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} S}\\
 \label{Ocamlary-Dep7-argument-1-Arg-module-type-T}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-Dep7-argument-1-Arg-module-type-T]{\ocamlinlinecode{T}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Dep7-argument-1-Arg-module-type-T-module-type-R}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} R = \hyperref[Ocamlary-Dep7-argument-1-Arg-module-type-S]{\ocamlinlinecode{S}}}\\
 \label{Ocamlary-Dep7-argument-1-Arg-module-type-T-module-Y}\ocamlcodefragment{\ocamltag{keyword}{module} Y : \hyperref[Ocamlary-Dep7-argument-1-Arg-module-type-S]{\ocamlinlinecode{R}}}\\
@@ -11,7 +11,7 @@
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Ocamlary-Dep7-signature}}%
 \label{Ocamlary-Dep7-module-M}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Dep7-M]{\ocamlinlinecode{M}}}\ocamlcodefragment{ : \hyperref[Ocamlary-Dep7-argument-1-Arg-module-type-T]{\ocamlinlinecode{Arg.\allowbreak{}T}}}\\
 
 \input{Ocamlary.Dep7.M.tex}

--- a/test/generators/latex/Ocamlary.Dep9.tex
+++ b/test/generators/latex/Ocamlary.Dep9.tex
@@ -1,9 +1,9 @@
 \section{Module \ocamlinlinecode{Ocamlary.\allowbreak{}Dep9}}\label{Ocamlary-Dep9}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Ocamlary-Dep9-parameters}}%
 \label{Ocamlary-Dep9-argument-1-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Dep9-argument-1-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Dep9-argument-1-X-module-type-T}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} T}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Ocamlary-Dep9-signature}}%
 \label{Ocamlary-Dep9-module-type-T}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} T = \hyperref[Ocamlary-Dep9-argument-1-X-module-type-T]{\ocamlinlinecode{X.\allowbreak{}T}}}\\
 
 

--- a/test/generators/latex/Ocamlary.FunctorTypeOf.tex
+++ b/test/generators/latex/Ocamlary.FunctorTypeOf.tex
@@ -1,7 +1,7 @@
 \section{Module \ocamlinlinecode{Ocamlary.\allowbreak{}FunctorTypeOf}}\label{Ocamlary-FunctorTypeOf}%
 This comment is for \ocamlinlinecode{FunctorTypeOf}.
 
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Ocamlary-FunctorTypeOf-parameters}}%
 \label{Ocamlary-FunctorTypeOf-argument-1-Collection}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-FunctorTypeOf-argument-1-Collection]{\ocamlinlinecode{Collection}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-FunctorTypeOf-argument-1-Collection-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{Ocamlary-FunctorTypeOf-argument-1-Collection-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element}\\
@@ -24,7 +24,7 @@ This comment is for \ocamlinlinecode{FunctorTypeOf}.
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Ocamlary-FunctorTypeOf-signature}}%
 \label{Ocamlary-FunctorTypeOf-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t = \hyperref[Ocamlary-FunctorTypeOf-argument-1-Collection-type-collection]{\ocamlinlinecode{Collection.\allowbreak{}collection}}}\begin{ocamlindent}This comment is for \ocamlinlinecode{t}.\end{ocamlindent}%
 \medbreak
 

--- a/test/generators/latex/Ocamlary.Recollection.tex
+++ b/test/generators/latex/Ocamlary.Recollection.tex
@@ -1,7 +1,7 @@
 \section{Module \ocamlinlinecode{Ocamlary.\allowbreak{}Recollection}}\label{Ocamlary-Recollection}%
 This comment is for \ocamlinlinecode{CollectionModule}.
 
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Ocamlary-Recollection-parameters}}%
 \label{Ocamlary-Recollection-argument-1-C}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Recollection-argument-1-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Recollection-argument-1-C-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{Ocamlary-Recollection-argument-1-C-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element}\\
@@ -24,7 +24,7 @@ This comment is for \ocamlinlinecode{CollectionModule}.
 \medbreak
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Ocamlary-Recollection-signature}}%
 \label{Ocamlary-Recollection-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection = \hyperref[Ocamlary-Recollection-argument-1-C-type-element]{\ocamlinlinecode{C.\allowbreak{}element}} list}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{Ocamlary-Recollection-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element = \hyperref[Ocamlary-Recollection-argument-1-C-type-collection]{\ocamlinlinecode{C.\allowbreak{}collection}}}\\

--- a/test/generators/latex/Ocamlary.With7.tex
+++ b/test/generators/latex/Ocamlary.With7.tex
@@ -1,9 +1,9 @@
 \section{Module \ocamlinlinecode{Ocamlary.\allowbreak{}With7}}\label{Ocamlary-With7}%
-\subsection{Parameters\label{parameters}}%
+\subsection{Parameters\label{Ocamlary-With7-parameters}}%
 \label{Ocamlary-With7-argument-1-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-With7-argument-1-X]{\ocamlinlinecode{X}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-With7-argument-1-X-module-type-T}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} T}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsection{Signature\label{signature}}%
+\subsection{Signature\label{Ocamlary-With7-signature}}%
 \label{Ocamlary-With7-module-type-T}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} T = \hyperref[Ocamlary-With7-argument-1-X-module-type-T]{\ocamlinlinecode{X.\allowbreak{}T}}}\\
 
 

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -51,11 +51,11 @@ Here is some \emph{emphasis} \ocamlinlinecode{followed by code}.
 
 An unassociated comment
 
-\subsection{Level 1\label{level-1}}%
-\subsubsection{Level 2\label{level-2}}%
-\subsubsection{Level 3\label{level-3}}%
-\subsubsection{Level 4\label{level-4}}%
-\subsubsection{Basic module stuff\label{basic-module-stuff}}%
+\subsection{Level 1\label{Ocamlary-level-1}}%
+\subsubsection{Level 2\label{Ocamlary-level-2}}%
+\subsubsection{Level 3\label{Ocamlary-level-3}}%
+\subsubsection{Level 4\label{Ocamlary-level-4}}%
+\subsubsection{Basic module stuff\label{Ocamlary-basic-module-stuff}}%
 \label{Ocamlary-module-Empty}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Empty]{\ocamlinlinecode{Empty}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}A plain, empty module\end{ocamlindent}%
 \medbreak
@@ -67,10 +67,10 @@ An unassociated comment
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}An ambiguous, misnamed module type\end{ocamlindent}%
 \medbreak
-\subsection{Section 9000\label{s9000}}%
+\subsection{Section 9000\label{Ocamlary-s9000}}%
 \label{Ocamlary-module-EmptyAlias}\ocamlcodefragment{\ocamltag{keyword}{module} EmptyAlias = \hyperref[Ocamlary-Empty]{\ocamlinlinecode{Empty}}}\begin{ocamlindent}A plain module alias of \ocamlinlinecode{Empty}\end{ocamlindent}%
 \medbreak
-\subsubsection{EmptySig\label{emptySig}}%
+\subsubsection{EmptySig\label{Ocamlary-emptySig}}%
 \label{Ocamlary-module-type-EmptySig}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-module-type-EmptySig]{\ocamlinlinecode{EmptySig}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}A plain, empty module signature\end{ocamlindent}%
 \medbreak
@@ -90,14 +90,14 @@ An unassociated comment
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}There's a signature in a module in this signature.\end{ocamlindent}%
 \medbreak
-\label{Ocamlary-module-type-SuperSig}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-module-type-SuperSig]{\ocamlinlinecode{SuperSig}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-module-type-SuperSig-module-type-SubSigA}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-module-type-SuperSig-module-type-SubSigA]{\ocamlinlinecode{SubSigA}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{A Labeled Section Header Inside of a Signature\label{subSig}}%
+\label{Ocamlary-module-type-SuperSig}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-module-type-SuperSig]{\ocamlinlinecode{SuperSig}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-module-type-SuperSig-module-type-SubSigA}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-module-type-SuperSig-module-type-SubSigA]{\ocamlinlinecode{SubSigA}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{A Labeled Section Header Inside of a Signature\label{Ocamlary-module-type-SuperSig-module-type-SubSigA-subSig}}%
 \label{Ocamlary-module-type-SuperSig-module-type-SubSigA-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \label{Ocamlary-module-type-SuperSig-module-type-SubSigA-module-SubSigAMod}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod]{\ocamlinlinecode{SubSigAMod}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-module-type-SuperSig-module-type-SubSigA-SubSigAMod-type-sub_sig_a_mod}\ocamlcodefragment{\ocamltag{keyword}{type} sub\_\allowbreak{}sig\_\allowbreak{}a\_\allowbreak{}mod}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{Ocamlary-module-type-SuperSig-module-type-SubSigB}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-module-type-SuperSig-module-type-SubSigB]{\ocamlinlinecode{SubSigB}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Another Labeled Section Header Inside of a Signature\label{subSig_2}}%
+\label{Ocamlary-module-type-SuperSig-module-type-SubSigB}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-module-type-SuperSig-module-type-SubSigB]{\ocamlinlinecode{SubSigB}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Another Labeled Section Header Inside of a Signature\label{Ocamlary-module-type-SuperSig-module-type-SubSigB-subSig_2}}%
 \label{Ocamlary-module-type-SuperSig-module-type-SubSigB-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
@@ -119,7 +119,7 @@ For a good time, see \hyperref[Ocamlary-module-type-SuperSig-module-type-SubSigA
 \medbreak
 Some text before exception title.
 
-\subsubsection{Basic exception stuff\label{basic-exception-stuff}}%
+\subsubsection{Basic exception stuff\label{Ocamlary-basic-exception-stuff}}%
 After exception title.
 
 \label{Ocamlary-exception-Kaboom}\ocamlcodefragment{\ocamltag{keyword}{exception} \ocamltag{exception}{Kaboom} \ocamltag{keyword}{of} unit}\begin{ocamlindent}Unary exception constructor\end{ocamlindent}%
@@ -132,7 +132,7 @@ After exception title.
 \medbreak
 \label{Ocamlary-exception-EmptySigAlias}\ocamlcodefragment{\ocamltag{keyword}{exception} \ocamltag{exception}{EmptySigAlias}}\begin{ocamlindent}\hyperref[Ocamlary-exception-EmptySigAlias]{\ocamlinlinecode{\ocamlinlinecode{EmptySigAlias}}[p\pageref*{Ocamlary-exception-EmptySigAlias}]} is this exception.\end{ocamlindent}%
 \medbreak
-\subsubsection{Basic type and value stuff with advanced doc comments\label{basic-type-and-value-stuff-with-advanced-doc-comments}}%
+\subsubsection{Basic type and value stuff with advanced doc comments\label{Ocamlary-basic-type-and-value-stuff-with-advanced-doc-comments}}%
 \label{Ocamlary-type-a_function}\ocamlcodefragment{\ocamltag{keyword}{type} ('a,\allowbreak{} 'b) a\_\allowbreak{}function = \ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'b}}\begin{ocamlindent}\hyperref[Ocamlary-type-a_function]{\ocamlinlinecode{\ocamlinlinecode{a\_\allowbreak{}function}}[p\pageref*{Ocamlary-type-a_function}]} is this type and \hyperref[Ocamlary-val-a_function]{\ocamlinlinecode{\ocamlinlinecode{a\_\allowbreak{}function}}[p\pageref*{Ocamlary-val-a_function}]} is the value below.\end{ocamlindent}%
 \medbreak
 \label{Ocamlary-val-a_function}\ocamlcodefragment{\ocamltag{keyword}{val} a\_\allowbreak{}function : \ocamltag{label}{x}:int \ocamltag{arrow}{$\rightarrow$} int}\begin{ocamlindent}This is \ocamlinlinecode{a\_\allowbreak{}function} with param and return type.\begin{description}\kern-\topsep
@@ -186,7 +186,7 @@ After exception title.
 \item[{version}]{1.2.0}\end{description}%
 \end{ocamlindent}%
 \medbreak
-\subsubsection{Some Operators\label{some-operators}}%
+\subsubsection{Some Operators\label{Ocamlary-some-operators}}%
 \label{Ocamlary-val-(+t+-)}\ocamlcodefragment{\ocamltag{keyword}{val} (\textasciitilde{}-) : unit}\\
 \label{Ocamlary-val-(!)}\ocamlcodefragment{\ocamltag{keyword}{val} (!) : unit}\\
 \label{Ocamlary-val-(@)}\ocamlcodefragment{\ocamltag{keyword}{val} (@) : unit}\\
@@ -201,7 +201,7 @@ After exception title.
 \label{Ocamlary-val-(:=)}\ocamlcodefragment{\ocamltag{keyword}{val} (:=) : unit}\\
 \label{Ocamlary-val-(=)}\ocamlcodefragment{\ocamltag{keyword}{val} (=) : unit}\\
 \label{Ocamlary-val-(land)}\ocamlcodefragment{\ocamltag{keyword}{val} (land) : unit}\\
-\subsubsection{Advanced Module Stuff\label{advanced-module-stuff}}%
+\subsubsection{Advanced Module Stuff\label{Ocamlary-advanced-module-stuff}}%
 \label{Ocamlary-module-CollectionModule}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-CollectionModule]{\ocamlinlinecode{CollectionModule}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-CollectionModule-type-collection}\ocamlcodefragment{\ocamltag{keyword}{type} collection}\begin{ocamlindent}This comment is for \ocamlinlinecode{collection}.\end{ocamlindent}%
 \medbreak
 \label{Ocamlary-CollectionModule-type-element}\ocamlcodefragment{\ocamltag{keyword}{type} element}\\
@@ -403,7 +403,7 @@ After exception title.
 \label{Ocamlary-module-type-IncludedB}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-module-type-IncludedB]{\ocamlinlinecode{IncludedB}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-module-type-IncludedB-type-s}\ocamlcodefragment{\ocamltag{keyword}{type} s}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsubsection{Advanced Type Stuff\label{advanced-type-stuff}}%
+\subsubsection{Advanced Type Stuff\label{Ocamlary-advanced-type-stuff}}%
 \label{Ocamlary-type-record}\ocamlcodefragment{\ocamltag{keyword}{type} record = \{}\\
 \begin{ocamltabular}{p{0.500\textwidth}p{0.500\textwidth}}\ocamlinlinecode{field1 : int;\allowbreak{}}\label{Ocamlary-type-record.field1}& This comment is for \ocamlinlinecode{field1}.\\
 \ocamlinlinecode{field2 : int;\allowbreak{}}\label{Ocamlary-type-record.field2}& This comment is for \ocamlinlinecode{field2}.\\
@@ -762,7 +762,7 @@ After exception title.
 \label{Ocamlary-module-IncludeInclude2_M}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-IncludeInclude2_M]{\ocamlinlinecode{IncludeInclude2\_\allowbreak{}M}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \ocamltag{keyword}{include} \hyperref[Ocamlary-module-type-IncludeInclude2]{\ocamlinlinecode{IncludeInclude2}}\label{Ocamlary-type-include_include}\ocamlcodefragment{\ocamltag{keyword}{type} include\_\allowbreak{}include}\\
-\subsection{Trying the \{!modules: ...\} command.\label{indexmodules}}%
+\subsection{Trying the \{!modules: ...\} command.\label{Ocamlary-indexmodules}}%
 With ocamldoc, toplevel units will be linked and documented, while submodules will behave as simple references.
 
 With odoc, everything should be resolved (and linked) but only toplevel units will be documented.
@@ -772,12 +772,12 @@ With odoc, everything should be resolved (and linked) but only toplevel units wi
 \item[{\hyperref[Ocamlary-Dep1-X]{\ocamlinlinecode{\ocamlinlinecode{Dep1.\allowbreak{}X}}[p\pageref*{Ocamlary-Dep1-X}]}}]{}%
 \item[{\hyperref[Ocamlary-IncludeInclude1]{\ocamlinlinecode{\ocamlinlinecode{Ocamlary.\allowbreak{}IncludeInclude1}}[p\pageref*{Ocamlary-IncludeInclude1}]}}]{}%
 \item[{\hyperref[Ocamlary]{\ocamlinlinecode{\ocamlinlinecode{Ocamlary}}[p\pageref*{Ocamlary}]}}]{This is an \emph{interface} with \bold{all} of the \emph{module system} features. This documentation demonstrates:}\end{description}%
-\subsubsection{Weirder usages involving module types\label{weirder-usages-involving-module-types}}%
+\subsubsection{Weirder usages involving module types\label{Ocamlary-weirder-usages-involving-module-types}}%
 \begin{description}\kern-\topsep
 \makeatletter\advance\@topsepadd-\topsep\makeatother% topsep is hardcoded
 \item[{\hyperref[Ocamlary-IncludeInclude1-IncludeInclude2_M]{\ocamlinlinecode{\ocamlinlinecode{IncludeInclude1.\allowbreak{}IncludeInclude2\_\allowbreak{}M}}[p\pageref*{Ocamlary-IncludeInclude1-IncludeInclude2_M}]}}]{}%
 \item[{\hyperref[Ocamlary-Dep4-X]{\ocamlinlinecode{\ocamlinlinecode{Dep4.\allowbreak{}X}}[p\pageref*{Ocamlary-Dep4-X}]}}]{}\end{description}%
-\subsection{Playing with @canonical paths\label{playing-with-@canonical-paths}}%
+\subsection{Playing with @canonical paths\label{Ocamlary-playing-with-@canonical-paths}}%
 \label{Ocamlary-module-CanonicalTest}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-CanonicalTest]{\ocamlinlinecode{CanonicalTest}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-CanonicalTest-module-Base}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-CanonicalTest-Base]{\ocamlinlinecode{Base}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-CanonicalTest-Base-module-List}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-CanonicalTest-Base-List]{\ocamlinlinecode{List}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
@@ -793,7 +793,7 @@ With odoc, everything should be resolved (and linked) but only toplevel units wi
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 Some ref to \hyperref[Ocamlary-CanonicalTest-Base_Tests-C-type-t]{\ocamlinlinecode{\ocamlinlinecode{CanonicalTest.\allowbreak{}Base\_\allowbreak{}Tests.\allowbreak{}C.\allowbreak{}t}}[p\pageref*{Ocamlary-CanonicalTest-Base_Tests-C-type-t}]} and \hyperref[Ocamlary-CanonicalTest-Base-List-val-id]{\ocamlinlinecode{\ocamlinlinecode{CanonicalTest.\allowbreak{}Base\_\allowbreak{}Tests.\allowbreak{}L.\allowbreak{}id}}[p\pageref*{Ocamlary-CanonicalTest-Base-List-val-id}]}. But also to \hyperref[Ocamlary-CanonicalTest-Base-List]{\ocamlinlinecode{\ocamlinlinecode{CanonicalTest.\allowbreak{}Base.\allowbreak{}List}}[p\pageref*{Ocamlary-CanonicalTest-Base-List}]} and \hyperref[Ocamlary-CanonicalTest-Base-List-type-t]{\ocamlinlinecode{\ocamlinlinecode{CanonicalTest.\allowbreak{}Base.\allowbreak{}List.\allowbreak{}t}}[p\pageref*{Ocamlary-CanonicalTest-Base-List-type-t}]}
 
-\subsection{Aliases again\label{aliases}}%
+\subsection{Aliases again\label{Ocamlary-aliases}}%
 \label{Ocamlary-module-Aliases}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Aliases]{\ocamlinlinecode{Aliases}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Aliases-module-Foo}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Aliases-Foo]{\ocamlinlinecode{Foo}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-Aliases-Foo-module-A}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Aliases-Foo-A]{\ocamlinlinecode{A}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\\
 \label{Ocamlary-Aliases-Foo-module-B}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Aliases-Foo-B]{\ocamlinlinecode{B}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\\
 \label{Ocamlary-Aliases-Foo-module-C}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Ocamlary-Aliases-Foo-C]{\ocamlinlinecode{C}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\\
@@ -815,7 +815,7 @@ Some ref to \hyperref[Ocamlary-CanonicalTest-Base_Tests-C-type-t]{\ocamlinlineco
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Ocamlary-Aliases-type-stde}\ocamlcodefragment{\ocamltag{keyword}{type} stde = \hyperref[Ocamlary-Aliases-Foo-E-type-t]{\ocamlinlinecode{Std.\allowbreak{}E.\allowbreak{}t}}}\\
-\subsubsection{include of Foo\label{incl}}%
+\subsubsection{include of Foo\label{Ocamlary-Aliases-incl}}%
 Just for giggle, let's see what happens when we include \hyperref[Ocamlary-Aliases-Foo]{\ocamlinlinecode{\ocamlinlinecode{Foo}}[p\pageref*{Ocamlary-Aliases-Foo}]}.
 
 \ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \hyperref[Ocamlary-Aliases-Foo]{\ocamlinlinecode{Foo}}\label{Ocamlary-Aliases-module-A}\ocamlcodefragment{\ocamltag{keyword}{module} A = \hyperref[Ocamlary-Aliases-Foo-A]{\ocamlinlinecode{Foo.\allowbreak{}A}}}\\
@@ -842,7 +842,7 @@ And also, let's refer to \hyperref[Ocamlary-Aliases-Foo-A-type-t]{\ocamlinlineco
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Let's imitate jst's layout.\end{ocamlindent}%
 \medbreak
-\subsection{Section title splicing\label{section-title-splicing}}%
+\subsection{Section title splicing\label{Ocamlary-section-title-splicing}}%
 I can refer to
 
 \begin{itemize}\item{\ocamlinlinecode{\{!section:indexmodules\}} : \hyperref[Ocamlary-indexmodules]{\ocamlinlinecode{Trying the \{!modules: ...\} command.}[p\pageref*{Ocamlary-indexmodules}]}}%
@@ -857,7 +857,7 @@ And just to make sure we do not mess up:
 \item{\ocamlinlinecode{\{\{!aliases\}B\}} : \hyperref[Ocamlary-aliases]{\ocamlinlinecode{B}[p\pageref*{Ocamlary-aliases}]}}%
 \item{\ocamlinlinecode{\{\{!section:SuperSig.\allowbreak{}SubSigA.\allowbreak{}subSig\}C\}} : \hyperref[Ocamlary-module-type-SuperSig-module-type-SubSigA-subSig]{\ocamlinlinecode{C}[p\pageref*{Ocamlary-module-type-SuperSig-module-type-SubSigA-subSig}]}}%
 \item{\ocamlinlinecode{\{\{!Aliases.\allowbreak{}incl\}D\}} : \hyperref[Ocamlary-Aliases-incl]{\ocamlinlinecode{D}[p\pageref*{Ocamlary-Aliases-incl}]}}\end{itemize}%
-\subsection{New reference syntax\label{new-reference-syntax}}%
+\subsection{New reference syntax\label{Ocamlary-new-reference-syntax}}%
 \label{Ocamlary-module-type-M}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Ocamlary-module-type-M]{\ocamlinlinecode{M}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Ocamlary-module-type-M-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\

--- a/test/generators/latex/Recent.tex
+++ b/test/generators/latex/Recent.tex
@@ -1,10 +1,10 @@
 \section{Module \ocamlinlinecode{Recent}}\label{Recent}%
 \label{Recent-module-type-S}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Recent-module-type-S]{\ocamlinlinecode{S}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{Recent-module-type-S1}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Recent-module-type-S1]{\ocamlinlinecode{S1}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{parameters}}%
+\label{Recent-module-type-S1}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Recent-module-type-S1]{\ocamlinlinecode{S1}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{Recent-module-type-S1-parameters}}%
 \label{Recent-module-type-S1-argument-1-_}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Recent-module-type-S1-argument-1-_]{\ocamlinlinecode{\_\allowbreak{}}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsubsection{Signature\label{signature}}%
+\subsubsection{Signature\label{Recent-module-type-S1-signature}}%
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Recent-type-variant}\ocamlcodefragment{\ocamltag{keyword}{type} variant = }\begin{ocamlindent}\ocamlcodefragment{| \ocamltag{constructor}{A}}\label{Recent-type-variant.A}%

--- a/test/generators/latex/Recent_impl.tex
+++ b/test/generators/latex/Recent_impl.tex
@@ -15,10 +15,10 @@
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
 \label{Recent_impl-module-B}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Recent_impl-B]{\ocamlinlinecode{B}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\\
 \label{Recent_impl-type-u}\ocamlcodefragment{\ocamltag{keyword}{type} u}\\
-\label{Recent_impl-module-type-S}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Recent_impl-module-type-S]{\ocamlinlinecode{S}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Recent_impl-module-type-S-module-F}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Recent_impl-module-type-S-F]{\ocamlinlinecode{F}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{parameters}}%
+\label{Recent_impl-module-type-S}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Recent_impl-module-type-S]{\ocamlinlinecode{S}}}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Recent_impl-module-type-S-module-F}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Recent_impl-module-type-S-F]{\ocamlinlinecode{F}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\subsubsection{Parameters\label{Recent_impl-module-type-S-F-parameters}}%
 \label{Recent_impl-module-type-S-F-argument-1-_}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Recent_impl-module-type-S-F-argument-1-_]{\ocamlinlinecode{\_\allowbreak{}}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsubsection{Signature\label{signature}}%
+\subsubsection{Signature\label{Recent_impl-module-type-S-F-signature}}%
 \label{Recent_impl-module-type-S-F-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\

--- a/test/generators/latex/Section.tex
+++ b/test/generators/latex/Section.tex
@@ -1,19 +1,19 @@
 \section{Module \ocamlinlinecode{Section}}\label{Section}%
 This is the module comment. Eventually, sections won't be allowed in it.
 
-\subsection{Empty section\label{empty-section}}%
-\subsection{Text only\label{text-only}}%
+\subsection{Empty section\label{Section-empty-section}}%
+\subsection{Text only\label{Section-text-only}}%
 Foo bar.
 
-\subsection{Aside only\label{aside-only}}%
+\subsection{Aside only\label{Section-aside-only}}%
 Foo bar.
 
-\subsection{Value only\label{value-only}}%
+\subsection{Value only\label{Section-value-only}}%
 \label{Section-val-foo}\ocamlcodefragment{\ocamltag{keyword}{val} foo : unit}\\
-\subsection{Empty section\label{empty-section_2}}%
-\subsection{within a comment\label{within-a-comment}}%
-\subsubsection{and one with a nested section\label{and-one-with-a-nested-section}}%
-\subsection{\emph{This} \ocamlinlinecode{section} \bold{title} \textsubscript{has} \textsuperscript{markup}\label{this-section-title-has-markup}}%
+\subsection{Empty section\label{Section-empty-section_2}}%
+\subsection{within a comment\label{Section-within-a-comment}}%
+\subsubsection{and one with a nested section\label{Section-and-one-with-a-nested-section}}%
+\subsection{\emph{This} \ocamlinlinecode{section} \bold{title} \textsubscript{has} \textsuperscript{markup}\label{Section-this-section-title-has-markup}}%
 But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents - no link will be nested inside another link.
 
 

--- a/test/generators/latex/Toplevel_comments.tex
+++ b/test/generators/latex/Toplevel_comments.tex
@@ -46,7 +46,7 @@ A doc comment at the beginning of a module is considered to be that module's doc
 \label{Toplevel_comments-module-Comments_on_open}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Toplevel_comments-Comments_on_open]{\ocamlinlinecode{Comments\_\allowbreak{}on\_\allowbreak{}open}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Toplevel_comments-Comments_on_open-module-M}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Toplevel_comments-Comments_on_open-M]{\ocamlinlinecode{M}}}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Toplevel_comments-Comments_on_open-M-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\subsubsection{Section\label{sec}}%
+\subsubsection{Section\label{Toplevel_comments-Comments_on_open-sec}}%
 Comments attached to open are treated as floating comments. Referencing \hyperref[Toplevel_comments-Comments_on_open-sec]{\ocamlinlinecode{Section}[p\pageref*{Toplevel_comments-Comments_on_open-sec}]} \hyperref[Toplevel_comments-Comments_on_open-M-type-t]{\ocamlinlinecode{\ocamlinlinecode{M.\allowbreak{}t}}[p\pageref*{Toplevel_comments-Comments_on_open-M-type-t}]} works
 
 \end{ocamlindent}%

--- a/test/generators/latex/mld.tex
+++ b/test/generators/latex/mld.tex
@@ -1,26 +1,26 @@
-\section{Mld Page\label{mld-page}}\label{mld}%
+\section{Mld Page\label{mld-mld-page}}\label{mld}%
 This is an \ocamlinlinecode{.\allowbreak{}mld} file. It doesn't have an auto-generated title, like modules and other pages generated fully by odoc do.
 
 It will have a TOC generated from section headings.
 
-\subsection{Section\label{section}}%
+\subsection{Section\label{mld-section}}%
 This is a section.
 
 Another paragraph in section.
 
-\subsection{Another section\label{another-section}}%
+\subsection{Another section\label{mld-another-section}}%
 This is another section.
 
 Another paragraph in section 2.
 
-\subsubsection{Subsection\label{subsection}}%
+\subsubsection{Subsection\label{mld-subsection}}%
 This is a subsection.
 
 Another paragraph in subsection.
 
 Yet another paragraph in subsection.
 
-\subsubsection{Another Subsection\label{another-subsection}}%
+\subsubsection{Another Subsection\label{mld-another-subsection}}%
 This is another subsection.
 
 Another paragraph in subsection 2.

--- a/test/xref2/github_issue_857.t/run.t
+++ b/test/xref2/github_issue_857.t/run.t
@@ -12,8 +12,8 @@ In latex, labels in subpages should be disambiguated since the subpage is inline
   $ cat latex/A.tex | sed 's/\\/\n\\/g' | grep label
   \label{A}%
   \label{A-module-type-A}
-  \label{first}}%
-  \label{first_2}}%
+  \label{A-module-type-A-first}}%
+  \label{A-first_2}}%
 
 In html, labels in subpages should not be disambiguated since they won't have the same URL.
 


### PR DESCRIPTION
This PR fixes the label used for headings in the latex backend.

Previously, the latex backend used only the heading label, for instance,

```ocaml

(** {1:s_name Title } *)
```
generated
```latex
\subsection{Title\label{s_name}}
```
whereas the references used the full path
```latex
\hyperref[Module_name-s_name]{Title[p\pageref*{Module_name-s-name}]}
```

This PR fixes this discrepancy (observed on the odoc version of the OCaml manual) by using the full path in the heading translation.