### PR TITLE
Use `(format-dune-file)` instead of `dune format-dune-file`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.18)
 
 (name odoc)
 

--- a/odoc-bench.opam
+++ b/odoc-bench.opam
@@ -31,7 +31,7 @@ depends: [
   "astring"
   "cmdliner" {>= "1.3.0"}
   "cppo" {build & >= "1.1.0"}
-  "dune" {>= "3.7.0"}
+  "dune" {>= "3.18.0"}
   "fpath"
   "ocaml" {>= "4.02.0"}
   "result"

--- a/odoc-driver.opam
+++ b/odoc-driver.opam
@@ -36,7 +36,7 @@ documentation for installed packages.
 depends: [
   "ocaml" {>= "5.1.0"}
   "odoc" {= version}
-  "dune" {>= "3.7.0"}
+  "dune" {>= "3.18.0"}
   "odoc-md"
   "bos"
   "fpath"

--- a/odoc-md.opam
+++ b/odoc-md.opam
@@ -29,7 +29,7 @@ This package provides support for generating documentation from Markdown files.
 depends: [
   "ocaml" {>= "4.14.0"}
   "odoc" {= version}
-  "dune" {>= "3.7.0"}
+  "dune" {>= "3.18.0"}
   "cmarkit"
 ]
 

--- a/odoc-parser.opam
+++ b/odoc-parser.opam
@@ -14,7 +14,7 @@ dev-repo: "git+https://github.com/ocaml/odoc.git"
 doc: "https://ocaml.github.io/odoc/odoc_parser"
 flags: [ avoid-version ]
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08.0" & < "5.5"}
   "astring"
   "camlp-streams"

--- a/odoc.opam
+++ b/odoc.opam
@@ -44,7 +44,7 @@ depends: [
   "astring"
   "cmdliner" {>= "1.3.0"}
   "cppo" {build & >= "1.1.0"}
-  "dune" {>= "3.7.0"}
+  "dune" {>= "3.18.0"}
   "fpath"
   "ocaml" {>= "4.08.0" & < "5.5"}
   "tyxml" {>= "4.4.0"}

--- a/test/generators/dune
+++ b/test/generators/dune
@@ -11,10 +11,11 @@
   (>= %{ocaml_version} 4.04))
  (action
   (with-stdout-to
-   link.dune.inc.gen
-   (pipe-stdout
-    (run gen_rules/gen_rules.exe)
-    (run dune format-dune-file)))))
+   link.dune.inc.gen.raw
+   (run gen_rules/gen_rules.exe))))
+
+(rule
+ (format-dune-file link.dune.inc.gen.raw link.dune.inc.gen))
 
 (rule
  (alias runtest)


### PR DESCRIPTION
Hello,

You are currently calling `dune format-dune-file` from one of your tests. This command does not honour the Dune lang version used in the project which means that your test will break whenever we change the formatting style in Dune.

In Dune 3.18 we introduced a built-in action `(format-dune-file <src> <dst>)` precisely for this purpose. This action honours the current Dune lang version and does not require shelling out to an external process.

Note that `dune format-dune-file` may evolve in ways that may not be backwards compatible in the near future (as the CLI interface does not have any backwards compatibility or versioning guarantees), so we are encouraging users of this command to switch to the action instead.

See https://github.com/ocaml/dune/pull/10892#issuecomment-2503530595 for some of the context.