### PR TITLE
Driver and convention: includes libs from packages in `odoc-config.sexp`

### DIFF
--- a/doc/odoc_for_authors.mld
+++ b/doc/odoc_for_authors.mld
@@ -493,7 +493,7 @@ Here is some Python code:
 Code blocks may have arbitrary metadata associated with them. This metadata is
 used, for example, for selecting code blocks when extracting them from a source file via the
 [odoc extract-code] command. The metadata may also be used by other tools that
-operate on code blocks, for example, {{!https://github.com/realworldocaml/mdx}mdx}.
+operate on code blocks, for example, {{:https://github.com/realworldocaml/mdx}mdx}.
 
 The metadata follows immediately after the language header, and is a list of tags and bindings, separated by whitespace. Tags are simple
 keywords, and bindings are key-value pairs separated by an equals sign. If whitespace

--- a/doc/odoc_for_authors.mld
+++ b/doc/odoc_for_authors.mld
@@ -1123,7 +1123,7 @@ As an example, here is [odoc]'s configuration file:
 v}
 
 This file applies to all pages and all modules of all libraries in a package. With this config file, the
-modules of the [fmt] library, and the pages of the [odoc-driver], [cmdliner] and [odig] packages can be
+modules of the [fmt] library, and the {e modules and pages} of the [odoc-driver], [cmdliner] and [odig] packages can be
 linked to via the following syntax:
 
 {v

--- a/src/driver/voodoo.mli
+++ b/src/driver/voodoo.mli
@@ -6,6 +6,7 @@ val of_voodoo : string -> blessed:bool -> Packages.t list
 type extra_paths = {
   pkgs : Fpath.t Util.StringMap.t;
   libs : Fpath.t Util.StringMap.t;
+  libs_of_pkg : string list Util.StringMap.t;
 }
 
 val empty_extra_paths : extra_paths


### PR DESCRIPTION
Currently, the `packages` and `libraries` fields of `odoc-config.sexp` are used to determine what can be referenced. More precisely:
```
(libraries lib1)
(packages pkg1)
```
in `odoc-config.sexp` means that we can reference the _pages_ from `pkg1` and the _modules_ from `lib1`.

This forces the doc author to specify both if they want to references pages and modules. For instance, to be able to both reference the `brr` [ffi manual](https://erratique.ch/software/brr/doc/ffi_manual.html) and the [`Brr` module](https://erratique.ch/software/brr/doc/Brr/index.html), one would need the following `odoc-config.sexp`:
```
(libraries brr)
(packages brr)
```

This feels redundant. Moreover, the driver anyway needs to group libraries in packages. With this PR, I propose to update the convention so that the `(packages ...)` field allows to link _both_ pages and the modules of a library belonging to the package. In the example, the following would suffice:
```
(package brr)
```

I updated both the docs, and the odoc reference driver.