### PR TITLE
Expose sherlodoc libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Added a `header` field to the json output (@panglesd, #1314)
 - Added an `extract-code` subcommand to extract code blocks from mld files
   (@panglesd, #1326)
+- Exposed sherlodoc libraries for use in other projects (@jonludlam, #1349)
 
 ### Changed
 

--- a/sherlodoc/db/dune
+++ b/sherlodoc/db/dune
@@ -1,3 +1,4 @@
 (library
  (name db)
+ (public_name sherlodoc.db)
  (libraries fmt))

--- a/sherlodoc/query/dune
+++ b/sherlodoc/query/dune
@@ -1,5 +1,6 @@
 (library
  (name query)
+ (public_name sherlodoc.query)
  (libraries db))
 
 (menhir

--- a/sherlodoc/store/dune
+++ b/sherlodoc/store/dune
@@ -1,5 +1,6 @@
 (library
  (name db_store)
+ (public_name sherlodoc.db_store)
  (modules db_store)
  (libraries
   storage_marshal
@@ -12,6 +13,7 @@
 
 (library
  (name storage_ancient)
+ (public_name sherlodoc.storage_ancient)
  (modules storage_ancient)
  (optional)
  (libraries db ancient unix))
@@ -19,9 +21,11 @@
 (library
  (name storage_js)
  (modules storage_js)
+ (public_name sherlodoc.storage_js)
  (libraries db base64 bigstringaf decompress.zl))
 
 (library
  (name storage_marshal)
+ (public_name sherlodoc.storage_marshal)
  (modules storage_marshal)
  (libraries db))


### PR DESCRIPTION
This is so we can compile the web server of sherlodoc outside of odoc.