### PR TITLE
odoc_driver_voodoo: fix library name issue

### DIFF
--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -30,8 +30,15 @@ let read_libraries_from_pkg_defs ~library_name pkg_defs =
         with _ -> None)
     in
 
-    let deps_str = Fl_metascanner.lookup "requires" [] pkg_defs in
-    let deps = Astring.String.fields ~empty:false deps_str in
+    let deps =
+      try
+        let deps_str = Fl_metascanner.lookup "requires" [] pkg_defs in
+        (* The deps_str is a string of space-separated package names, e.g. "a b c" *)
+        (* We use Astring to split the string into a list of package names *)
+        Astring.String.fields ~empty:false deps_str
+      with _ -> []
+    in
+
     let dir =
       List.find_opt (fun d -> d.Fl_metascanner.def_var = "directory") pkg_defs
     in


### PR DESCRIPTION
When packages have no dependencies, we were failing to parse the META file correctly. This led to a problem where the library name was incorrectly equated with the archive name.

Fixes #1351