### PR TITLE
OCaml 5.4 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 - Fix bug in parsing META files when there are no dependencies (@jonludlam, #1352)
+- OCaml 5.4.0 support
+  (@Octachron, #???)
 
 # 3.0.0
 

--- a/sherlodoc/index/load_doc.ml
+++ b/sherlodoc/index/load_doc.ml
@@ -81,7 +81,8 @@ let searchable_type_of_constructor args res =
   match args with
   | TypeDecl.Constructor.Tuple args -> begin
       match args with
-      | _ :: _ :: _ -> TypeExpr.(Arrow (None, Tuple args, res))
+      | _ :: _ :: _ ->
+          TypeExpr.(Arrow (None, Tuple (List.map (fun x -> None, x) args), res))
       | [ arg ] -> TypeExpr.(Arrow (None, arg, res))
       | _ -> res
     end

--- a/sherlodoc/index/type_cache.ml
+++ b/sherlodoc/index/type_cache.ml
@@ -19,5 +19,5 @@ let rec of_odoc ~cache otyp =
   | Arrow (_lbl, left, right) -> cache (Arrow (of_odoc ~cache left, of_odoc ~cache right))
   | Constr (name, args) ->
       cache (Constr (Typename.to_string name, List.map (of_odoc ~cache) args))
-  | Tuple li -> cache (Tuple (List.map (of_odoc ~cache) li))
+  | Tuple li -> cache (Tuple (List.map (fun (_, ty) -> of_odoc ~cache ty) li))
   | _ -> Unhandled

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -448,7 +448,13 @@ module Make (Syntax : SYNTAX) = struct
           let res =
             O.box_hv_no_indent
               (O.list lst ~sep:Syntax.Type.Tuple.element_separator
-                 ~f:(type_expr ~needs_parentheses:true))
+                 ~f:(fun (lbl, ty) ->
+                   match lbl with
+                   | None -> type_expr ~needs_parentheses:true ty
+                   | Some lbl ->
+                       tag "label" (O.txt lbl)
+                       ++ O.txt ":" ++ O.cut
+                       ++ type_expr ~needs_parentheses:true ty))
           in
           if Syntax.Type.Tuple.always_parenthesize || needs_parentheses then
             enclose ~l:"(" res ~r:")"
@@ -772,6 +778,7 @@ module Make (Syntax : SYNTAX) = struct
           | None -> desc
           | Some Odoc_model.Lang.TypeDecl.Pos -> "+" :: desc
           | Some Odoc_model.Lang.TypeDecl.Neg -> "-" :: desc
+          | Some Odoc_model.Lang.TypeDecl.Bivariant -> "+" :: "-" :: desc
         in
         let final = if injectivity then "!" :: var_desc else var_desc in
         String.concat ~sep:"" final

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -467,7 +467,7 @@ let rec read_type_expr env typ =
           let res = read_type_expr env res in
             Arrow(lbl, arg, res)
       | Ttuple typs ->
-          let typs = List.map (read_type_expr env) typs in
+          let typs = List.map (fun x -> None, read_type_expr env x) typs in
             Tuple typs
       | Tconstr(p, params, _) ->
           let p = Env.Path.read_type env.ident_env p in

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -64,7 +64,7 @@ let rec read_core_type env container ctyp =
         let res = read_core_type env container res in
           Arrow(lbl, arg, res)
     | Ttyp_tuple typs ->
-        let typs = List.map (read_core_type env container) typs in
+        let typs = List.map (fun x -> None, read_core_type env container x) typs in
           Tuple typs
     | Ttyp_constr(p, _, params) ->
         let p = Env.Path.read_type env.ident_env p in

--- a/src/loader/typedtree_traverse.ml
+++ b/src/loader/typedtree_traverse.ml
@@ -33,7 +33,9 @@ module Analysis = struct
               match maybe_localvalue id loc.loc with
               | Some x -> poses := x :: !poses
               | None -> ())
-#if OCAML_VERSION >= (5, 2, 0)
+#if OCAML_VERSION >= (5, 4, 0)
+          | Tpat_alias (_, id, loc, _uid, _ty) -> (
+#elif OCAML_VERSION >= (5, 2, 0)
           | Tpat_alias (_, id, loc, _uid) -> (
 #else
           | Tpat_alias (_, id, loc) -> (

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -231,7 +231,7 @@ and TypeDecl : sig
       | Extensible
   end
 
-  type variance = Pos | Neg
+  type variance = Pos | Neg | Bivariant
 
   type param_desc = Any | Var of string
 
@@ -439,7 +439,7 @@ and TypeExpr : sig
     | Any
     | Alias of t * string
     | Arrow of label option * t * t
-    | Tuple of t list
+    | Tuple of (string option * t) list
     | Constr of Path.Type.t * t list
     | Polymorphic_variant of TypeExpr.Polymorphic_variant.t
     | Object of TypeExpr.Object.t

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -336,7 +336,8 @@ and typedecl_representation =
 
 and typedecl_variance =
   let open Lang.TypeDecl in
-  Variant (function Pos -> C0 "Pos" | Neg -> C0 "Neg")
+  Variant
+    (function Pos -> C0 "Pos" | Neg -> C0 "Neg" | Bivariant -> C0 "Bivariant")
 
 and typedecl_param_desc =
   let open Lang.TypeDecl in
@@ -628,7 +629,7 @@ and typeexpr_t =
           ( "Arrow",
             (x1, x2, x3),
             Triple (Option typeexpr_label, typeexpr_t, typeexpr_t) )
-    | Tuple x -> C ("Tuple", x, List typeexpr_t)
+    | Tuple x -> C ("Tuple", x, List (Pair (Option string, typeexpr_t)))
     | Constr (x1, x2) ->
         C ("Constr", ((x1 :> Paths.Path.t), x2), Pair (path, List typeexpr_t))
     | Polymorphic_variant x ->

--- a/src/search/html.ml
+++ b/src/search/html.ml
@@ -35,7 +35,8 @@ let display_constructor_args args =
   match args with
   | TypeDecl.Constructor.Tuple args ->
       (match args with
-      | _ :: _ :: _ -> Some TypeExpr.(Tuple args)
+      | _ :: _ :: _ ->
+          Some TypeExpr.(Tuple (List.map (fun x -> (None, x)) args))
       | [ arg ] -> Some arg
       | _ -> None)
       |> map_option Text.of_type
@@ -63,6 +64,7 @@ let typedecl_params ?(delim = `parens) params =
       | None -> desc
       | Some TypeDecl.Pos -> "+" :: desc
       | Some TypeDecl.Neg -> "-" :: desc
+      | Some TypeDecl.Bivariant -> "+" :: "-" :: desc
     in
     let final = if injectivity then "!" :: var_desc else var_desc in
     String.concat "" final

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -903,7 +903,9 @@ and type_expression : Env.t -> Id.LabelParent.t -> _ -> _ =
   | Var _ | Any -> texpr
   | Alias (t, str) -> Alias (type_expression env parent t, str)
   | Arrow (lbl, t1, t2) -> handle_arrow env parent lbl t1 t2
-  | Tuple ts -> Tuple (List.map (type_expression env parent) ts)
+  | Tuple ts ->
+      Tuple
+        (List.map (fun (lbl, ty) -> (lbl, type_expression env parent ty)) ts)
   | Constr (path, ts') -> (
       let cp = Component.Of_Lang.(type_path (empty ()) path) in
       let ts = List.map (type_expression env parent) ts' in

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -117,7 +117,7 @@ and TypeExpr : sig
     | Any
     | Alias of t * string
     | Arrow of label option * t * t
-    | Tuple of t list
+    | Tuple of (string option * t) list
     | Constr of Cpath.type_ * t list
     | Polymorphic_variant of TypeExpr.Polymorphic_variant.t
     | Object of TypeExpr.Object.t

--- a/src/xref2/expand_tools.ml
+++ b/src/xref2/expand_tools.ml
@@ -57,7 +57,7 @@ let rec type_expr map t =
   | Alias (t, s) ->
       if List.mem_assoc s map then raise Clash else Alias (type_expr map t, s)
   | Arrow (l, t1, t2) -> Arrow (l, type_expr map t1, type_expr map t2)
-  | Tuple ts -> Tuple (List.map (type_expr map) ts)
+  | Tuple ts -> Tuple (List.map (fun (l, ty) -> (l, type_expr map ty)) ts)
   | Constr (p, ts) -> Constr (p, List.map (type_expr map) ts)
   | Polymorphic_variant pv -> Polymorphic_variant (polymorphic_variant map pv)
   | Object o -> Object (object_ map o)

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -990,7 +990,8 @@ and type_expr map (parent : Identifier.LabelParent.t) (t : Component.TypeExpr.t)
     | Alias (t, str) -> Alias (type_expr map parent t, str)
     | Arrow (lbl, t1, t2) ->
         Arrow (lbl, type_expr map parent t1, type_expr map parent t2)
-    | Tuple ts -> Tuple (List.map (type_expr map parent) ts)
+    | Tuple ts ->
+        Tuple (List.map (fun (lbl, ty) -> (lbl, type_expr map parent ty)) ts)
     | Constr (path, ts) ->
         Constr
           ( (Path.type_ map path :> Paths.Path.Type.t),

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -442,7 +442,8 @@ let warn_on_hidden_representation (id : Id.Type.t)
         || List.exists (fun t -> internal_typ_exp t) ts
     | Poly (_, t) | Alias (t, _) -> internal_typ_exp t
     | Arrow (_, t, t2) -> internal_typ_exp t || internal_typ_exp t2
-    | Tuple ts | Class (_, ts) -> List.exists (fun t -> internal_typ_exp t) ts
+    | Tuple ts -> List.exists (fun (_, t) -> internal_typ_exp t) ts
+    | Class (_, ts) -> List.exists (fun t -> internal_typ_exp t) ts
     | _ -> false
   in
 
@@ -1103,7 +1104,11 @@ and type_expression : Env.t -> Id.Signature.t -> _ -> _ =
         ( lbl,
           type_expression env parent visited t1,
           type_expression env parent visited t2 )
-  | Tuple ts -> Tuple (List.map (type_expression env parent visited) ts)
+  | Tuple ts ->
+      Tuple
+        (List.map
+           (fun (lbl, ty) -> (lbl, type_expression env parent visited ty))
+           ts)
   | Constr (path', ts') -> (
       let path = type_path env path' in
       let ts = List.map (type_expression env parent visited) ts' in

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -123,7 +123,8 @@ let rec substitute_vars vars t =
   | Alias (t, str) -> Alias (substitute_vars vars t, str)
   | Arrow (lbl, t1, t2) ->
       Arrow (lbl, substitute_vars vars t1, substitute_vars vars t2)
-  | Tuple ts -> Tuple (List.map (substitute_vars vars) ts)
+  | Tuple ts ->
+      Tuple (List.map (fun (lbl, ty) -> (lbl, substitute_vars vars ty)) ts)
   | Constr (p, ts) -> Constr (p, List.map (substitute_vars vars) ts)
   | Polymorphic_variant v ->
       Polymorphic_variant (substitute_vars_poly_variant vars v)
@@ -546,7 +547,7 @@ and type_expr s t =
   | Any -> Any
   | Alias (t, str) -> Alias (type_expr s t, str)
   | Arrow (lbl, t1, t2) -> Arrow (lbl, type_expr s t1, type_expr s t2)
-  | Tuple ts -> Tuple (List.map (type_expr s) ts)
+  | Tuple ts -> Tuple (List.map (fun (lbl, ty) -> (lbl, type_expr s ty)) ts)
   | Constr (p, ts) -> (
       match type_path s p with
       | Replaced (t, eq) ->

--- a/test/generators/cases/markup.mli
+++ b/test/generators/cases/markup.mli
@@ -140,7 +140,9 @@ v}
 
     {1 Unicode}
 
-    The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
+    The parser supports any ASCII-compatible encoding.
+
+    In particuλar UTF-8.
 
 
     {1 Raw HTML}

--- a/test/generators/cases/recent.mli
+++ b/test/generators/cases/recent.mli
@@ -58,3 +58,6 @@ module type PolyS = sig
   type t = [ a | `B ]
 end
 with type a := [ `A ]
+
+type +-'a phantom
+val f: (x:int * y:int) phantom -> unit

--- a/test/generators/cases/section.mli
+++ b/test/generators/cases/section.mli
@@ -26,5 +26,5 @@ val foo : unit
 (** {1 {e This} [section] {b title} {_has} {^markup}}
 
     But links are impossible thanks to the parser, so we never have trouble
-    rendering a section title in a table of contents – no link will be nested
+    rendering a section title in a table of contents - no link will be nested
     inside another link. *)

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -204,9 +204,9 @@
      </ul>
     </li>
    </ul><h2 id="unicode"><a href="#unicode" class="anchor"></a>Unicode</h2>
-   <p>The parser supports any ASCII-compatible encoding, in particuλar
-     UTF-8.
-   </p><h2 id="raw-html"><a href="#raw-html" class="anchor"></a>Raw HTML</h2>
+   <p>The parser supports any ASCII-compatible encoding.</p>
+   <p>In particuλar UTF-8.</p>
+   <h2 id="raw-html"><a href="#raw-html" class="anchor"></a>Raw HTML</h2>
    <p>Raw HTML can be <input type="text" placeholder="inserted"> as inline
      elements into sentences.
    </p>

--- a/test/generators/html/Recent.html
+++ b/test/generators/html/Recent.html
@@ -309,6 +309,31 @@
      </code>
     </div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-phantom">
+     <a href="#type-phantom" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> <span>+-'a phantom</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-f">
+     <a href="#val-f" class="anchor"></a>
+     <code>
+      <span><span class="keyword">val</span> f : 
+       <span>
+        <span>
+         <span>(<span class="label">x</span>:int * 
+          <span class="label">y</span>:int)
+         </span> <a href="#type-phantom">phantom</a>
+        </span> <span class="arrow">&#45;&gt;</span>
+       </span> unit
+      </span>
+     </code>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Section.html
+++ b/test/generators/html/Section.html
@@ -72,8 +72,8 @@
      <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
    </h2>
    <p>But links are impossible thanks to the parser, so we never have
-     trouble rendering a section title in a table of contents – no 
-    link will be nested inside another link.
+     trouble rendering a section title in a table of contents - no link
+     will be nested inside another link.
    </p>
   </div>
  </body>

--- a/test/generators/latex/Markup.tex
+++ b/test/generators/latex/Markup.tex
@@ -81,7 +81,9 @@ can use explicitly-delimited lists.
 \item{\hyperref[Markup-val-foo]{\ocamlinlinecode{\ocamlinlinecode{foo}}[p\pageref*{Markup-val-foo}]}}\end{itemize}%
 }\end{itemize}%
 \subsection{Unicode\label{unicode}}%
-The parser supports any ASCII-compatible encoding, in particuλar UTF-8.
+The parser supports any ASCII-compatible encoding.
+
+In particuλar UTF-8.
 
 \subsection{Raw HTML\label{raw-html}}%
 Raw HTML can be  as inline elements into sentences.

--- a/test/generators/latex/Recent.tex
+++ b/test/generators/latex/Recent.tex
@@ -74,5 +74,7 @@
 \ocamlcodefragment{ ]}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\label{Recent-type-phantom}\ocamlcodefragment{\ocamltag{keyword}{type} +-'a phantom}\\
+\label{Recent-val-f}\ocamlcodefragment{\ocamltag{keyword}{val} f : (\ocamltag{label}{x}:int * \ocamltag{label}{y}:int) \hyperref[Recent-type-phantom]{\ocamlinlinecode{phantom}} \ocamltag{arrow}{$\rightarrow$} unit}\\
 
 

--- a/test/generators/latex/Section.tex
+++ b/test/generators/latex/Section.tex
@@ -14,7 +14,7 @@ Foo bar.
 \subsection{within a comment\label{within-a-comment}}%
 \subsubsection{and one with a nested section\label{and-one-with-a-nested-section}}%
 \subsection{\emph{This} \ocamlinlinecode{section} \bold{title} \textsubscript{has} \textsuperscript{markup}\label{this-section-title-has-markup}}%
-But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link.
+But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents - no link will be nested inside another link.
 
 
 

--- a/test/generators/man/Markup.3o
+++ b/test/generators/man/Markup.3o
@@ -214,7 +214,9 @@ can use explicitly-delimited lists\.
 .in 
 .sp 
 .fi 
-The parser supports any ASCII-compatible encoding, in particuλar UTF-8\.
+The parser supports any ASCII-compatible encoding\.
+.sp 
+In particuλar UTF-8\.
 .nf 
 .sp 
 .in 3

--- a/test/generators/man/Recent.3o
+++ b/test/generators/man/Recent.3o
@@ -143,3 +143,7 @@ a : int;
  ]
 .br 
 \f[CB]end\fR
+.sp 
+\f[CB]type\fR +-'a phantom
+.sp 
+\f[CB]val\fR f : (\f[CB]x\fR:int * \f[CB]y\fR:int) phantom \f[CB]\->\fR unit

--- a/test/generators/man/Section.3o
+++ b/test/generators/man/Section.3o
@@ -58,6 +58,6 @@ Foo bar\.
 .in 
 .sp 
 .fi 
-But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents – no link will be nested inside another link\.
+But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents - no link will be nested inside another link\.
 .nf 
 

--- a/test/xref2/shadow2.t/a.mli
+++ b/test/xref2/shadow2.t/a.mli
@@ -6,7 +6,7 @@ end
 
 include B1
 
-module type B2 = sig
+module type B2 := sig
   module A : sig
     include module type of struct include A end
     type u
@@ -15,7 +15,7 @@ end
 
 include B2
 
-module type B3 = sig
+module type B3 := sig
   module A : sig
     include module type of struct include A end
     type v

--- a/test/xref2/shadow2.t/run.t
+++ b/test/xref2/shadow2.t/run.t
@@ -7,7 +7,7 @@
   
   include B1
   
-  module type B2 = sig
+  module type B2 := sig
     module A : sig
       include module type of struct include A end
       type u
@@ -16,7 +16,7 @@
   
   include B2
   
-  module type B3 = sig
+  module type B3 := sig
     module A : sig
       include module type of struct include A end
       type v

--- a/test/xref2/shadow3.t/a.mli
+++ b/test/xref2/shadow3.t/a.mli
@@ -6,7 +6,7 @@ end
 
 include B
 
-module type B1 = sig
+module type B1 := sig
   module A : sig
     include module type of struct include A end
     type a

--- a/test/xref2/shadow3.t/b.mli
+++ b/test/xref2/shadow3.t/b.mli
@@ -6,7 +6,7 @@ end
 
 include B
 
-module type B1 = sig
+module type B1 := sig
   module A : sig
     include module type of struct include A end
     type b

--- a/test/xref2/shadow3.t/run.t
+++ b/test/xref2/shadow3.t/run.t
@@ -6,7 +6,6 @@ Module `C` then includes them both, causing further shadowing.
   $ ocamlc -c -bin-annot c.mli
   $ ocamlc -i c.mli
   module type B = B.B
-  module type B1 = B.B1
   module A : sig type t = B.A.t type b = B.A.b end
 
   $ odoc compile a.cmti --unique-id AAAA
@@ -19,23 +18,46 @@ Module `C` then includes them both, causing further shadowing.
       module type {B}1/shadowed/(CCCC) = A.B
       include {B}1/shadowed/(CCCC)
         (sig : module {A}1/shadowed/(AAAA) = A.A end)
-      module type {B1}2/shadowed/(CCCC) = A.B1
-      include {B1}2/shadowed/(CCCC)
-        (sig : module {A}3/shadowed/(CCCC) = A.A end)
+      module type B1 := 
+        sig
+          module A : 
+            sig
+              include module type of struct include {A}1/shadowed/(AAAA) end
+                (sig :
+                  include module type of struct include A.{A}1/shadowed/(AAAA) end
+                    (sig : type t = {A}1/shadowed/(AAAA).t end)
+                  type a = A.A.a
+                 end)
+              type a
+            end
+        end
+      include B1 (sig : module {A}2/shadowed/(CCCC) = A.A end)
      end)
   include module type of struct include B end
     (sig :
       module type B = B.B
       include B (sig : module {A}1/shadowed/(BBBB) = B.A end)
-      module type B1 = B.B1
-      include B1 (sig : module {A}4/shadowed/(CCCC) = B.A end)
+      module type B1 := 
+        sig
+          module A : 
+            sig
+              include module type of struct include {A}1/shadowed/(BBBB) end
+                (sig :
+                  include module type of struct include B.{A}1/shadowed/(BBBB) end
+                    (sig : type t = {A}1/shadowed/(BBBB).t end)
+                  type b = B.A.b
+                 end)
+              type b
+            end
+        end
+      include B1 (sig : module {A}3/shadowed/(CCCC) = B.A end)
      end)
   module A : 
     sig
-      include module type of struct include {A}4/shadowed/(CCCC) end
+      include module type of struct include {A}3/shadowed/(CCCC) end
         (sig :
           include module type of struct include B.{A}1/shadowed/(BBBB) end
-            (sig : type t = {A}4/shadowed/(CCCC).t end)
+            (sig : type t = {A}3/shadowed/(CCCC).t end)
           type b = B.A.b
          end)
     end


### PR DESCRIPTION
This PR updates the odoc model to support labelled type and bivariant type parameters (in commit 6928546a5952474e3ac2361b2770d076958379ba) and update the loader to be compatible with the OCaml 5.4 AST in dcd8b8bfb725b6a0e977ec6fca0d7b4cd0e9da3a .

There is also one test modified in eb5c6e5877ab77d262e5a33ad866df98fa2d06a7 to avoid a problematic case that is now rejected in OCaml 5.4 (a module type being abstracted due to a module shadowing).

Similarly, 4fe1af921b06fd17cccbdfa9017ca3e8fe7a86e5 updates two tests using unicode character to be more stable due to the improved handling of non-ascii character in Format in OCaml 5.4 .