### PR TITLE
Fix extra quote added after images

### DIFF
--- a/src/markdown/doc_of_md.ml
+++ b/src/markdown/doc_of_md.ml
@@ -243,7 +243,7 @@ let image_to_inline_element ~locator defs i m (is, warns) =
             alt;
             {|" title="|};
             title;
-            {|" >"|};
+            {|" >|};
           ]
       in
       (Loc.at loc (`Raw_markup (Some "html", img)) :: is, warns)


### PR DESCRIPTION
Fix #1356. 

I have confirmed that this now renders the [problematic example](https://github.com/codex-semantics-library/patricia-tree/blob/main/README.md) correctly. However, running `dune test` failed with lots of diffs which seem unrelated to this PR's changes.