### PR TITLE
Add missing parentheses in type expr `(_ as 'a) t`

### DIFF
--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -409,12 +409,16 @@ module Make (Syntax : SYNTAX) = struct
 
     and type_expr ?(needs_parentheses = false) (t : Odoc_model.Lang.TypeExpr.t)
         =
+      let enclose_parens_if_needed res =
+        if needs_parentheses then enclose ~l:"(" res ~r:")" else res
+      in
       match t with
       | Var s -> type_var (Syntax.Type.var_prefix ^ s)
       | Any -> type_var Syntax.Type.any
       | Alias (te, alias) ->
-          type_expr ~needs_parentheses:true te
-          ++ O.txt " " ++ O.keyword "as" ++ O.txt " '" ++ O.txt alias
+          enclose_parens_if_needed
+            (type_expr ~needs_parentheses:true te
+            ++ O.txt " " ++ O.keyword "as" ++ O.txt " '" ++ O.txt alias)
       | Arrow (None, src, dst) ->
           let res =
             O.span

--- a/test/generators/cases/type.mli
+++ b/test/generators/cases/type.mli
@@ -136,3 +136,5 @@ and recursive = B of mutually
 
 (* Not a type, but analogous to extensions. *)
 exception Foo of int * int
+
+type 'a t = ([ `A ] as 'a) option

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -1412,9 +1412,10 @@
      <code>
       <span><span class="keyword">type</span> <span>'a poly_fun</span></span>
       <span> = 
-       <span><span>[&gt; <span>`ConstrB of int</span> ]</span> 
-        <span class="keyword">as</span> 'a 
-        <span class="arrow">&#45;&gt;</span>
+       <span>
+        <span>(<span>[&gt; <span>`ConstrB of int</span> ]</span> 
+         <span class="keyword">as</span> 'a)
+        </span> <span class="arrow">&#45;&gt;</span>
        </span> <span class="type-var">'a</span>
       </span>
      </code>
@@ -1746,9 +1747,10 @@
      <a href="#type-oof" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a oof</span></span>
       <span> = 
-       <span><span>&lt; a : unit.. &gt;</span> 
-        <span class="keyword">as</span> 'a 
-        <span class="arrow">&#45;&gt;</span>
+       <span>
+        <span>(<span>&lt; a : unit.. &gt;</span> 
+         <span class="keyword">as</span> 'a)
+        </span> <span class="arrow">&#45;&gt;</span>
        </span> <span class="type-var">'a</span>
       </span>
      </code>

--- a/test/generators/html/Type.html
+++ b/test/generators/html/Type.html
@@ -832,6 +832,17 @@
      </code>
     </div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t">
+     <a href="#type-t" class="anchor"></a>
+     <code><span><span class="keyword">type</span> <span>'a t</span></span>
+      <span> = 
+       <span><span>[ `A ]</span> <span class="keyword">as</span> 'a option
+       </span>
+      </span>
+     </code>
+    </div>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Type.html
+++ b/test/generators/html/Type.html
@@ -734,8 +734,8 @@
     <div class="spec type anchored" id="type-as_">
      <a href="#type-as_" class="anchor"></a>
      <code><span><span class="keyword">type</span> as_</span>
-      <span> = int <span class="keyword">as</span> 'a * 
-       <span class="type-var">'a</span>
+      <span> = <span>(int <span class="keyword">as</span> 'a)</span> 
+       * <span class="type-var">'a</span>
       </span>
      </code>
     </div>
@@ -837,7 +837,9 @@
      <a href="#type-t" class="anchor"></a>
      <code><span><span class="keyword">type</span> <span>'a t</span></span>
       <span> = 
-       <span><span>[ `A ]</span> <span class="keyword">as</span> 'a option
+       <span>
+        <span>(<span>[ `A ]</span> <span class="keyword">as</span> 'a)</span>
+         option
        </span>
       </span>
      </code>

--- a/test/generators/latex/Ocamlary.tex
+++ b/test/generators/latex/Ocamlary.tex
@@ -497,7 +497,7 @@ After exception title.
 \label{Ocamlary-type-open_poly_variant}\ocamlcodefragment{\ocamltag{keyword}{type} 'a open\_\allowbreak{}poly\_\allowbreak{}variant = [> `TagA ] \ocamltag{keyword}{as} 'a}\\
 \label{Ocamlary-type-open_poly_variant2}\ocamlcodefragment{\ocamltag{keyword}{type} 'a open\_\allowbreak{}poly\_\allowbreak{}variant2 = [> `ConstrB of int ] \ocamltag{keyword}{as} 'a}\\
 \label{Ocamlary-type-open_poly_variant_alias}\ocamlcodefragment{\ocamltag{keyword}{type} 'a open\_\allowbreak{}poly\_\allowbreak{}variant\_\allowbreak{}alias = \ocamltag{type-var}{'a} \hyperref[Ocamlary-type-open_poly_variant]{\ocamlinlinecode{open\_\allowbreak{}poly\_\allowbreak{}variant}} \hyperref[Ocamlary-type-open_poly_variant2]{\ocamlinlinecode{open\_\allowbreak{}poly\_\allowbreak{}variant2}}}\\
-\label{Ocamlary-type-poly_fun}\ocamlcodefragment{\ocamltag{keyword}{type} 'a poly\_\allowbreak{}fun = [> `ConstrB of int ] \ocamltag{keyword}{as} 'a \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a}}\\
+\label{Ocamlary-type-poly_fun}\ocamlcodefragment{\ocamltag{keyword}{type} 'a poly\_\allowbreak{}fun = ([> `ConstrB of int ] \ocamltag{keyword}{as} 'a) \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a}}\\
 \label{Ocamlary-type-poly_fun_constraint}\ocamlcodefragment{\ocamltag{keyword}{type} 'a poly\_\allowbreak{}fun\_\allowbreak{}constraint = \ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a} \ocamltag{keyword}{constraint} \ocamltag{type-var}{'a} = [> `TagA ]}\\
 \label{Ocamlary-type-closed_poly_variant}\ocamlcodefragment{\ocamltag{keyword}{type} 'a closed\_\allowbreak{}poly\_\allowbreak{}variant = [< `One | `Two ] \ocamltag{keyword}{as} 'a}\\
 \label{Ocamlary-type-clopen_poly_variant}\ocamlcodefragment{\ocamltag{keyword}{type} 'a clopen\_\allowbreak{}poly\_\allowbreak{}variant = [< `One | `Two of int | `Three Two Three ] \ocamltag{keyword}{as} 'a}\\
@@ -544,7 +544,7 @@ After exception title.
 \medbreak
 \label{Ocamlary-type-rec_obj}\ocamlcodefragment{\ocamltag{keyword}{type} rec\_\allowbreak{}obj = < f : int ;\allowbreak{} g : unit \ocamltag{arrow}{$\rightarrow$} unit ;\allowbreak{} h : \hyperref[Ocamlary-type-rec_obj]{\ocamlinlinecode{rec\_\allowbreak{}obj}} >}\\
 \label{Ocamlary-type-open_obj}\ocamlcodefragment{\ocamltag{keyword}{type} 'a open\_\allowbreak{}obj = < f : int ;\allowbreak{} g : unit \ocamltag{arrow}{$\rightarrow$} unit.\allowbreak{}.\allowbreak{} > \ocamltag{keyword}{as} 'a}\\
-\label{Ocamlary-type-oof}\ocamlcodefragment{\ocamltag{keyword}{type} 'a oof = < a : unit.\allowbreak{}.\allowbreak{} > \ocamltag{keyword}{as} 'a \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a}}\\
+\label{Ocamlary-type-oof}\ocamlcodefragment{\ocamltag{keyword}{type} 'a oof = (< a : unit.\allowbreak{}.\allowbreak{} > \ocamltag{keyword}{as} 'a) \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a}}\\
 \label{Ocamlary-type-any_obj}\ocamlcodefragment{\ocamltag{keyword}{type} 'a any\_\allowbreak{}obj = < .\allowbreak{}.\allowbreak{} > \ocamltag{keyword}{as} 'a}\\
 \label{Ocamlary-type-empty_obj}\ocamlcodefragment{\ocamltag{keyword}{type} empty\_\allowbreak{}obj = <  >}\\
 \label{Ocamlary-type-one_meth}\ocamlcodefragment{\ocamltag{keyword}{type} one\_\allowbreak{}meth = < meth : unit >}\\

--- a/test/generators/latex/Type.tex
+++ b/test/generators/latex/Type.tex
@@ -114,7 +114,7 @@
 \label{Type-type-lower_object}\ocamlcodefragment{\ocamltag{keyword}{type} 'a lower\_\allowbreak{}object = \ocamltag{type-var}{'a} \ocamltag{keyword}{constraint} \ocamltag{type-var}{'a} = < a : int ;\allowbreak{} b : int.\allowbreak{}.\allowbreak{} >}\\
 \label{Type-type-poly_object}\ocamlcodefragment{\ocamltag{keyword}{type} 'a poly\_\allowbreak{}object = \ocamltag{type-var}{'a} \ocamltag{keyword}{constraint} \ocamltag{type-var}{'a} = < a : 'a.\allowbreak{} \ocamltag{type-var}{'a} >}\\
 \label{Type-type-double_constrained}\ocamlcodefragment{\ocamltag{keyword}{type} ('a,\allowbreak{} 'b) double\_\allowbreak{}constrained = \ocamltag{type-var}{'a} * \ocamltag{type-var}{'b} \ocamltag{keyword}{constraint} \ocamltag{type-var}{'a} = int \ocamltag{keyword}{constraint} \ocamltag{type-var}{'b} = unit}\\
-\label{Type-type-as_}\ocamlcodefragment{\ocamltag{keyword}{type} as\_\allowbreak{} = int \ocamltag{keyword}{as} 'a * \ocamltag{type-var}{'a}}\\
+\label{Type-type-as_}\ocamlcodefragment{\ocamltag{keyword}{type} as\_\allowbreak{} = (int \ocamltag{keyword}{as} 'a) * \ocamltag{type-var}{'a}}\\
 \label{Type-type-extensible}\ocamlcodefragment{\ocamltag{keyword}{type} extensible = .\allowbreak{}.\allowbreak{}}\\
 \label{Type-extension-decl-Extension}\ocamlcodefragment{\ocamltag{keyword}{type} \hyperref[Type-type-extensible]{\ocamlinlinecode{extensible}} += }\\
 \begin{ocamltabular}{p{0.500\textwidth}p{0.500\textwidth}}\ocamlcodefragment{| \ocamltag{extension}{Extension}}\label{Type-extension-Extension}& Documentation for \hyperref[Type-extension-Extension]{\ocamlinlinecode{\ocamlinlinecode{Extension}}[p\pageref*{Type-extension-Extension}]}.\\
@@ -130,6 +130,6 @@
 \end{ocamltabular}%
 \\
 \label{Type-exception-Foo}\ocamlcodefragment{\ocamltag{keyword}{exception} \ocamltag{exception}{Foo} \ocamltag{keyword}{of} int * int}\\
-\label{Type-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} 'a t = [ `A ] \ocamltag{keyword}{as} 'a option}\\
+\label{Type-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} 'a t = ([ `A ] \ocamltag{keyword}{as} 'a) option}\\
 
 

--- a/test/generators/latex/Type.tex
+++ b/test/generators/latex/Type.tex
@@ -130,5 +130,6 @@
 \end{ocamltabular}%
 \\
 \label{Type-exception-Foo}\ocamlcodefragment{\ocamltag{keyword}{exception} \ocamltag{exception}{Foo} \ocamltag{keyword}{of} int * int}\\
+\label{Type-type-t}\ocamlcodefragment{\ocamltag{keyword}{type} 'a t = [ `A ] \ocamltag{keyword}{as} 'a option}\\
 
 

--- a/test/generators/man/Ocamlary.3o
+++ b/test/generators/man/Ocamlary.3o
@@ -1370,7 +1370,7 @@ This comment is for poly_variant_union\.
 .sp 
 \f[CB]type\fR 'a open_poly_variant_alias = \f[CB]'a\fR open_poly_variant open_poly_variant2
 .sp 
-\f[CB]type\fR 'a poly_fun = [> `ConstrB of int ] \f[CB]as\fR 'a \f[CB]\->\fR \f[CB]'a\fR
+\f[CB]type\fR 'a poly_fun = ([> `ConstrB of int ] \f[CB]as\fR 'a) \f[CB]\->\fR \f[CB]'a\fR
 .sp 
 \f[CB]type\fR 'a poly_fun_constraint = \f[CB]'a\fR \f[CB]\->\fR \f[CB]'a\fR \f[CB]constraint\fR \f[CB]'a\fR = [> `TagA ]
 .sp 
@@ -1476,7 +1476,7 @@ This comment is for \f[CI]mutual_constr_b\fR then \f[CI]mutual_constr_a\fR\.
 .sp 
 \f[CB]type\fR 'a open_obj = < f : int ; g : unit \f[CB]\->\fR unit\.\. > \f[CB]as\fR 'a
 .sp 
-\f[CB]type\fR 'a oof = < a : unit\.\. > \f[CB]as\fR 'a \f[CB]\->\fR \f[CB]'a\fR
+\f[CB]type\fR 'a oof = (< a : unit\.\. > \f[CB]as\fR 'a) \f[CB]\->\fR \f[CB]'a\fR
 .sp 
 \f[CB]type\fR 'a any_obj = < \.\. > \f[CB]as\fR 'a
 .sp 

--- a/test/generators/man/Type.3o
+++ b/test/generators/man/Type.3o
@@ -264,3 +264,5 @@ e : 'a\. \f[CB]'a\fR;
 .br 
 .sp 
 \f[CB]exception\fR \f[CB]Foo\fR \f[CB]of\fR int * int
+.sp 
+\f[CB]type\fR 'a t = [ `A ] \f[CB]as\fR 'a option

--- a/test/generators/man/Type.3o
+++ b/test/generators/man/Type.3o
@@ -232,7 +232,7 @@ e : 'a\. \f[CB]'a\fR;
 .sp 
 \f[CB]type\fR ('a, 'b) double_constrained = \f[CB]'a\fR * \f[CB]'b\fR \f[CB]constraint\fR \f[CB]'a\fR = int \f[CB]constraint\fR \f[CB]'b\fR = unit
 .sp 
-\f[CB]type\fR as_ = int \f[CB]as\fR 'a * \f[CB]'a\fR
+\f[CB]type\fR as_ = (int \f[CB]as\fR 'a) * \f[CB]'a\fR
 .sp 
 \f[CB]type\fR extensible = \.\.
 .sp 
@@ -265,4 +265,4 @@ e : 'a\. \f[CB]'a\fR;
 .sp 
 \f[CB]exception\fR \f[CB]Foo\fR \f[CB]of\fR int * int
 .sp 
-\f[CB]type\fR 'a t = [ `A ] \f[CB]as\fR 'a option
+\f[CB]type\fR 'a t = ([ `A ] \f[CB]as\fR 'a) option


### PR DESCRIPTION
This bug is found for example in Eio: https://ocaml.org/p/eio/latest/doc/Eio/Domain_manager/index.html#type-t
Type `t` renders as invalid syntax:
```
type 'a t = [> ty ] as 'a Resource.t
```
In the source code, it's:
```
type 'a t = ([> ty] as 'a) Resource.t
```