### PR TITLE
Add lower-bound constraint on fpath

### DIFF
--- a/odoc-driver.opam
+++ b/odoc-driver.opam
@@ -38,7 +38,7 @@ depends: [
   "dune" {>= "3.18.0"}
   "odoc-md"
   "bos"
-  "fpath"
+  "fpath" {>= "0.7.3"}
   "yojson" {>= "2.0.0"}
   "ocamlfind"
   "opam-format" {>= "2.1.0"}

--- a/odoc.opam
+++ b/odoc.opam
@@ -44,7 +44,7 @@ depends: [
   "cmdliner" {>= "1.3.0"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.18.0"}
-  "fpath"
+  "fpath" {>= "0.7.3"}
   "ocaml" {>= "4.08.0" & < "5.5"}
   "tyxml" {>= "4.4.0"}
   "fmt"


### PR DESCRIPTION
Fpath 0.7.1 seems to have an odd interaction with the result library and dune, where sometimes the result library is omitted from the include path passed to ocaml. 0.7.3 is supported on all versions of OCaml that Odoc supports.