### PR TITLE
Don't allow links to hidden pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
 - Fix #1335 - incorrect rendering when on medium screen size with no global
   sidebar (@lukemaurer, #1361)
 - Fixed generation of occurrences for docs CI (@jonludlam, #1362)
+- Partial fix for #1369 - ensure that we never create a link to a hidden page
+  (@jonludlam, #1370)
 
 # 3.0.0
 

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -122,8 +122,13 @@ module Reference = struct
           | None -> None
           | Some _ -> Some rendered
         in
-        let url = Url.from_identifier ~stop_before:false id in
-        let target = Target.Internal (Resolved url) in
+        let target =
+          match id with
+          | Some id ->
+              let url = Url.from_identifier ~stop_before:false id in
+              Target.Internal (Resolved url)
+          | None -> Internal Unresolved
+        in
         let link = { Link.target; content; tooltip } in
         [ inline @@ Inline.Link link ]
     | _ -> (

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -188,8 +188,11 @@ module Make (Syntax : SYNTAX) = struct
       let open Fragment in
       let id = Resolved.identifier (fragment :> Resolved.t) in
       let txt = render_resolved_fragment (fragment :> Resolved.t) in
-      let href = Url.from_identifier ~stop_before:false id in
-      resolved href [ inline @@ Text txt ]
+      match id with
+      | Some id ->
+          let href = Url.from_identifier ~stop_before:false id in
+          resolved href [ inline @@ Text txt ]
+      | None -> unresolved [ inline @@ Text txt ]
 
     let from_fragment : Fragment.leaf -> text = function
       | `Resolved r

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -450,7 +450,7 @@ module Fragment : sig
 
     type t = Paths_types.Resolved_fragment.any
 
-    val identifier : t -> Identifier.t
+    val identifier : t -> Identifier.t option
 
     val is_hidden : t -> bool
   end
@@ -567,7 +567,7 @@ module rec Reference : sig
 
     type t = Paths_types.Resolved_reference.any
 
-    val identifier : t -> Identifier.t
+    val identifier : t -> Identifier.t option
   end
 
   module Signature : sig

--- a/src/odoc/url.ml
+++ b/src/odoc/url.ml
@@ -28,16 +28,19 @@ let resolve url_to_string directories reference =
               Odoc_xref2.Errors.Tools_error.pp_reference_lookup_error e
           in
           Error (`Msg error)
-      | Ok (resolved_reference, _) ->
-          let identifier =
+      | Ok (resolved_reference, _) -> (
+          match
             Odoc_model.Paths.Reference.Resolved.identifier resolved_reference
-          in
-          let url =
-            Odoc_document.Url.from_identifier ~stop_before:false identifier
-          in
-          let href = url_to_string url in
-          print_endline href;
-          Ok ())
+          with
+          | Some identifier ->
+              (* We have a valid identifier, we can create the URL *)
+              let url =
+                Odoc_document.Url.from_identifier ~stop_before:false identifier
+              in
+              let href = url_to_string url in
+              print_endline href;
+              Ok ()
+          | None -> Error (`Msg "Hidden reference")))
 
 let reference_to_url_html { Html_page.html_config = config; _ } root_url =
   let url_to_string url =

--- a/test/occurrences/double_wrapped.t/run.t
+++ b/test/occurrences/double_wrapped.t/run.t
@@ -125,9 +125,6 @@ We can also include hidden ids:
   Main.A.M was used directly 2 times and indirectly 0 times
   Main.A.t was used directly 1 times and indirectly 0 times
   Main.A.x was used directly 1 times and indirectly 0 times
-  Main__ was used directly 0 times and indirectly 2 times
-  Main__.C was used directly 1 times and indirectly 1 times
-  Main__.C.y was used directly 1 times and indirectly 0 times
 
   $ odoc count-occurrences . -o all.odoc-occurrences --include-hidden
   $ occurrences_print all.odoc-occurrences | sort
@@ -138,12 +135,6 @@ We can also include hidden ids:
   Main.A.t was used directly 1 times and indirectly 0 times
   Main.A.x was used directly 2 times and indirectly 0 times
   Main.B was used directly 1 times and indirectly 0 times
-  Main__ was used directly 0 times and indirectly 2 times
-  Main__.C was used directly 1 times and indirectly 1 times
-  Main__.C.y was used directly 1 times and indirectly 0 times
-  Main__A was used directly 1 times and indirectly 0 times
-  Main__B was used directly 1 times and indirectly 0 times
-  Main__C was used directly 1 times and indirectly 0 times
 
 We can use the generated table when generating the json output:
 


### PR DESCRIPTION
A while back we changed the type of `Path.Resolved.identifier` so we could return `None` for the case where there is genuinely no identifier that can be used. This was initially for to allow paths to core types to be resolved, even though there's no destination for them.

This commit extends this idea so that attempting to generate an identifier for a hidden path will result in `None`. Whilst we would prefer not to generate these paths at all, it can happen as a consequence of incorrect canonical paths.

Partial fix for #1369