### PR TITLE
Add support for opam 2.5

### DIFF
--- a/src/driver/opam.ml
+++ b/src/driver/opam.ml
@@ -58,7 +58,7 @@ let pkg_contents { name; _ } =
           OpamFile.Changes.read_from_string ~filename
           @@
           (* Field [opam-version] is invalid in [*.changes] files, displaying a warning. *)
-          if OpamStd.String.starts_with ~prefix:"opam-version" str then
+          if String.starts_with ~prefix:"opam-version" str then
             match OpamStd.String.cut_at str '\n' with
             | Some (_, str) -> str
             | None -> assert false


### PR DESCRIPTION
See https://github.com/ocaml/opam/pull/6442

String.starts_with has been available since OCaml 4.13, so this change is fully backward compatible given that odoc-driver requires at least 5.1