### PR TITLE
Change markdown-* from pipeline to generators

### DIFF
--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -1779,8 +1779,8 @@ let () =
          Compile_impl.(cmd, info ~docs:section_pipeline);
          Indexing.(cmd, info ~docs:section_pipeline);
          Sidebar.(cmd, info ~docs:section_pipeline);
-         Odoc_markdown_cmd.generate ~docs:section_pipeline;
-         Odoc_markdown_cmd.generate_source ~docs:section_pipeline;
+         Odoc_markdown_cmd.generate ~docs:section_generators;
+         Odoc_markdown_cmd.generate_source ~docs:section_generators;
          Odoc_markdown_cmd.targets ~docs:section_support;
          Odoc_manpage.generate ~docs:section_generators;
          Odoc_latex.generate ~docs:section_generators;


### PR DESCRIPTION
```diff
ODOC(1)     Odoc Manual         ODOC(1)

NAME
       odoc

SYNOPSIS
       odoc [COMMAND] …

COMMANDS: Compilation pipeline
      aggregate-occurrences [--file-list=FILE] [--strip-path] [OPTION]…
      [FILE]…
      Aggregate hashtables created with odoc count-occurrences.

      classify [OPTION]… [DIR]…
      Classify the modules into libraries based on heuristics. Libraries
      are specified by the --library option.

-     markdown-generate [--extra-suffix=SUFFIX] [--sidebar=FILE.odoc-sidebar]
-     [--syntax=SYNTAX] [OPTION]… FILE.odocl
-     Generate markdown files from a .odocl.

-     markdown-generate-source [OPTION]… FILE.ml
-     Generate markdown files from a impl-*.odocl.

      sidebar-generate [--json] [OPTION]… FILE
      Generate a sidebar from an index file.

      support-files [--without-theme] [OPTION]…
      Copy the support files (e.g. default theme, JavaScript files) to the output directory.

COMMANDS: Alternative generators
      latex-generate [OPTION]… FILE.odocl
      Generate latex files from a .odocl.

      man-generate [--extra-suffix=SUFFIX] [--sidebar=FILE.odoc-sidebar]
      [--syntax=SYNTAX] [OPTION]… FILE.odocl
      Generate man files from a .odocl.

+     markdown-generate [--extra-suffix=SUFFIX] [--sidebar=FILE.odoc-sidebar]
+     [--syntax=SYNTAX] [OPTION]… FILE.odocl
+     Generate markdown files from a .odocl.

+     markdown-generate-source [OPTION]… FILE.ml
+     Generate markdown files from a impl-*.odocl.