### PR TITLE
OxCaml: Fix missing parens for polymorphic parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Fix URL remapping for page references (@jonludlam, #1395)
 - Fix #1396, which broke incrememntal builds (@jonludlam, #1402)
 - Ensure all warnings turn into errors with --warn-error (@jonludlam, #1402)
+- Fix missing parentheses for polymorphic arguments (@art-w, #1404)
 
 # 3.1.0
 

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -446,7 +446,7 @@ module Make (Syntax : SYNTAX) = struct
             ++ O.sp ++ type_expr dst
             (* ++ O.end_hv *)
           in
-          if not needs_parentheses then res else enclose ~l:"(" res ~r:")"
+          enclose_parens_if_needed res
       | Arrow (Some (RawOptional _ as lbl), _src, dst) ->
           let res =
             O.span
@@ -456,7 +456,7 @@ module Make (Syntax : SYNTAX) = struct
                  ++ O.txt " " ++ Syntax.Type.arrow)
             ++ O.sp ++ type_expr dst
           in
-          if not needs_parentheses then res else enclose ~l:"(" res ~r:")"
+          enclose_parens_if_needed res
       | Arrow (Some lbl, src, dst) ->
           let res =
             O.span
@@ -466,7 +466,7 @@ module Make (Syntax : SYNTAX) = struct
               ++ O.txt " " ++ Syntax.Type.arrow)
             ++ O.sp ++ type_expr dst
           in
-          if not needs_parentheses then res else enclose ~l:"(" res ~r:")"
+          enclose_parens_if_needed res
       | Tuple lst -> tuple ~needs_parentheses ~boxed:true lst
       | Unboxed_tuple lst -> tuple ~needs_parentheses ~boxed:false lst
       | Constr (path, args) ->
@@ -478,7 +478,9 @@ module Make (Syntax : SYNTAX) = struct
           format_type_path ~delim:`brackets args
             (Link.from_path (path :> Paths.Path.t))
       | Poly (polyvars, t) ->
-          O.txt ("'" ^ String.concat ~sep:" '" polyvars ^ ". ") ++ type_expr t
+          enclose_parens_if_needed
+          @@ O.txt ("'" ^ String.concat ~sep:" '" polyvars ^ ". ")
+             ++ type_expr t
       | Quote t -> O.span (O.txt "<[ " ++ O.box_hv (type_expr t) ++ O.txt " ]>")
       | Splice t -> O.span (O.txt "$" ++ type_expr ~needs_parentheses:true t)
       | Package pkg ->

--- a/test/generators/cases/oxcaml.mli
+++ b/test/generators/cases/oxcaml.mli
@@ -1,0 +1,2 @@
+val f : int -> ('a . 'a -> 'a) -> unit
+(** Polymorphic arguments require parentheses *)

--- a/test/generators/gen_rules/gen_rules.ml
+++ b/test/generators/gen_rules/gen_rules.ml
@@ -67,6 +67,7 @@ let constraints =
     ("module_type_subst.mli", Min "4.13");
     ("class_comments.mli", Min "4.08");
     ("functor_ml.ml", Min "4.14");
+    ("oxcaml.mli", OxCaml);
   ]
 
 let test_cases_dir = Fpath.v "cases"

--- a/test/generators/gen_rules_lib.ml
+++ b/test/generators/gen_rules_lib.ml
@@ -2,7 +2,11 @@ open Odoc_utils
 
 type sexp = Sexplib0.Sexp.t = Atom of string | List of sexp list
 
-type enabledif = Min of string | Max of string | MinMax of string * string
+type enabledif =
+  | Min of string
+  | Max of string
+  | MinMax of string * string
+  | OxCaml
 
 type test_case = {
   input : Fpath.t;
@@ -49,6 +53,7 @@ module Dune = struct
                 ];
             ];
         ]
+    | Some OxCaml -> [ List [ Atom "enabled_if"; Atom "%{ocaml-config:ox}" ] ]
     | None -> []
 
   let run cmd = List (Atom "run" :: arg_list cmd)

--- a/test/generators/html/Oxcaml.html
+++ b/test/generators/html/Oxcaml.html
@@ -21,11 +21,12 @@
      <code>
       <span><span class="keyword">val</span> f : 
        <span>int <span class="arrow">&#45;&gt;</span></span> 
-       <span>'a. 
-        <span><span class="type-var">'a</span> 
-         <span class="arrow">&#45;&gt;</span>
-        </span> <span class="type-var">'a</span> 
-        <span class="arrow">&#45;&gt;</span>
+       <span>
+        <span>('a. 
+         <span><span class="type-var">'a</span> 
+          <span class="arrow">&#45;&gt;</span>
+         </span> <span class="type-var">'a</span>)
+        </span> <span class="arrow">&#45;&gt;</span>
        </span> unit
       </span>
      </code>

--- a/test/generators/html/Oxcaml.html
+++ b/test/generators/html/Oxcaml.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Oxcaml (Oxcaml)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="index.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; Oxcaml
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Oxcaml</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-f">
+     <a href="#val-f" class="anchor"></a>
+     <code>
+      <span><span class="keyword">val</span> f : 
+       <span>int <span class="arrow">&#45;&gt;</span></span> 
+       <span>'a. 
+        <span><span class="type-var">'a</span> 
+         <span class="arrow">&#45;&gt;</span>
+        </span> <span class="type-var">'a</span> 
+        <span class="arrow">&#45;&gt;</span>
+       </span> unit
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc"><p>Polymorphic arguments require parentheses</p>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/oxcaml.targets
+++ b/test/generators/html/oxcaml.targets
@@ -1,0 +1,1 @@
+Oxcaml.html

--- a/test/generators/latex/Oxcaml.tex
+++ b/test/generators/latex/Oxcaml.tex
@@ -1,5 +1,5 @@
 \section{Module \ocamlinlinecode{Oxcaml}}\label{Oxcaml}%
-\label{Oxcaml--val-f}\ocamlcodefragment{\ocamltag{keyword}{val} f : int \ocamltag{arrow}{$\rightarrow$} 'a.\allowbreak{} \ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} unit}\begin{ocamlindent}Polymorphic arguments require parentheses\end{ocamlindent}%
+\label{Oxcaml--val-f}\ocamlcodefragment{\ocamltag{keyword}{val} f : int \ocamltag{arrow}{$\rightarrow$} ('a.\allowbreak{} \ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a}) \ocamltag{arrow}{$\rightarrow$} unit}\begin{ocamlindent}Polymorphic arguments require parentheses\end{ocamlindent}%
 \medbreak
 
 

--- a/test/generators/latex/Oxcaml.tex
+++ b/test/generators/latex/Oxcaml.tex
@@ -1,0 +1,5 @@
+\section{Module \ocamlinlinecode{Oxcaml}}\label{Oxcaml}%
+\label{Oxcaml--val-f}\ocamlcodefragment{\ocamltag{keyword}{val} f : int \ocamltag{arrow}{$\rightarrow$} 'a.\allowbreak{} \ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} unit}\begin{ocamlindent}Polymorphic arguments require parentheses\end{ocamlindent}%
+\medbreak
+
+

--- a/test/generators/latex/oxcaml.targets
+++ b/test/generators/latex/oxcaml.targets
@@ -1,0 +1,1 @@
+Oxcaml.tex

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -567,6 +567,27 @@
   (>= %{ocaml_version} 4.14)))
 
 (rule
+ (target oxcaml.cmti)
+ (package odoc)
+ (action
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/oxcaml.mli}))
+ (enabled_if %{ocaml-config:ox}))
+
+(rule
+ (target oxcaml.odoc)
+ (package odoc)
+ (action
+  (run odoc compile -o %{target} %{dep:oxcaml.cmti}))
+ (enabled_if %{ocaml-config:ox}))
+
+(rule
+ (target oxcaml.odocl)
+ (package odoc)
+ (action
+  (run odoc link -o %{target} %{dep:oxcaml.odoc}))
+ (enabled_if %{ocaml-config:ox}))
+
+(rule
  (target recent.cmti)
  (package odoc)
  (action
@@ -11676,6 +11697,150 @@
    (diff ocamlary.targets ocamlary.targets.gen))
   (enabled_if
    (>= %{ocaml_version} 4.14))))
+
+(subdir
+ html
+ (rule
+  (targets Oxcaml.html.gen)
+  (package odoc)
+  (action
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../oxcaml.odocl}))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.html Oxcaml.html.gen))
+  (enabled_if %{ocaml-config:ox})))
+
+(subdir
+ html
+ (rule
+  (target oxcaml.targets.gen)
+  (package odoc)
+  (action
+   (with-outputs-to
+    oxcaml.targets.gen
+    (run odoc html-targets -o . %{dep:../oxcaml.odocl} --flat)))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff oxcaml.targets oxcaml.targets.gen))
+  (enabled_if %{ocaml-config:ox})))
+
+(subdir
+ latex
+ (rule
+  (targets Oxcaml.tex.gen)
+  (package odoc)
+  (action
+   (run odoc latex-generate -o . --extra-suffix gen %{dep:../oxcaml.odocl}))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.tex Oxcaml.tex.gen))
+  (enabled_if %{ocaml-config:ox})))
+
+(subdir
+ latex
+ (rule
+  (target oxcaml.targets.gen)
+  (package odoc)
+  (action
+   (with-outputs-to
+    oxcaml.targets.gen
+    (run odoc latex-targets -o . %{dep:../oxcaml.odocl})))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff oxcaml.targets oxcaml.targets.gen))
+  (enabled_if %{ocaml-config:ox})))
+
+(subdir
+ man
+ (rule
+  (targets Oxcaml.3o.gen)
+  (package odoc)
+  (action
+   (run odoc man-generate -o . --extra-suffix gen %{dep:../oxcaml.odocl}))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.3o Oxcaml.3o.gen))
+  (enabled_if %{ocaml-config:ox})))
+
+(subdir
+ man
+ (rule
+  (target oxcaml.targets.gen)
+  (package odoc)
+  (action
+   (with-outputs-to
+    oxcaml.targets.gen
+    (run odoc man-targets -o . %{dep:../oxcaml.odocl})))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff oxcaml.targets oxcaml.targets.gen))
+  (enabled_if %{ocaml-config:ox})))
+
+(subdir
+ markdown
+ (rule
+  (targets Oxcaml.md.gen)
+  (package odoc)
+  (action
+   (run
+    odoc
+    markdown-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../oxcaml.odocl}))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.md Oxcaml.md.gen))
+  (enabled_if %{ocaml-config:ox})))
+
+(subdir
+ markdown
+ (rule
+  (target oxcaml.targets.gen)
+  (package odoc)
+  (action
+   (with-outputs-to
+    oxcaml.targets.gen
+    (run odoc markdown-targets -o . %{dep:../oxcaml.odocl})))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff oxcaml.targets oxcaml.targets.gen))
+  (enabled_if %{ocaml-config:ox})))
 
 (subdir
  html

--- a/test/generators/man/Oxcaml.3o
+++ b/test/generators/man/Oxcaml.3o
@@ -11,7 +11,7 @@ Oxcaml
 .SH Documentation
 .sp 
 .nf 
-\f[CB]val\fR f : int \f[CB]\->\fR 'a\. \f[CB]'a\fR \f[CB]\->\fR \f[CB]'a\fR \f[CB]\->\fR unit
+\f[CB]val\fR f : int \f[CB]\->\fR ('a\. \f[CB]'a\fR \f[CB]\->\fR \f[CB]'a\fR) \f[CB]\->\fR unit
 .fi 
 .br 
 .ti +2

--- a/test/generators/man/Oxcaml.3o
+++ b/test/generators/man/Oxcaml.3o
@@ -1,0 +1,20 @@
+
+.TH Oxcaml 3 "" "Odoc" "OCaml Library"
+.SH Name
+Oxcaml
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Oxcaml\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]val\fR f : int \f[CB]\->\fR 'a\. \f[CB]'a\fR \f[CB]\->\fR \f[CB]'a\fR \f[CB]\->\fR unit
+.fi 
+.br 
+.ti +2
+Polymorphic arguments require parentheses
+.nf 
+

--- a/test/generators/man/oxcaml.targets
+++ b/test/generators/man/oxcaml.targets
@@ -1,0 +1,1 @@
+Oxcaml.3o

--- a/test/generators/markdown/Oxcaml.md
+++ b/test/generators/markdown/Oxcaml.md
@@ -1,0 +1,7 @@
+
+# Module `Oxcaml`
+
+```ocaml
+val f : int -> 'a. 'a -> 'a -> unit
+```
+Polymorphic arguments require parentheses

--- a/test/generators/markdown/Oxcaml.md
+++ b/test/generators/markdown/Oxcaml.md
@@ -2,6 +2,6 @@
 # Module `Oxcaml`
 
 ```ocaml
-val f : int -> 'a. 'a -> 'a -> unit
+val f : int -> ('a. 'a -> 'a) -> unit
 ```
 Polymorphic arguments require parentheses

--- a/test/generators/markdown/oxcaml.targets
+++ b/test/generators/markdown/oxcaml.targets
@@ -1,0 +1,1 @@
+Oxcaml.md


### PR DESCRIPTION
Follow up on #1399: OxCaml polymorphic parameters were missing parentheses in Odoc rendering (note that polymorphic parameters were upstreamed https://github.com/ocaml/ocaml/pull/13806 and are expected in OCaml 5.5).

(Only the last two commits are new: the first adds a test for OxCaml to check the support, the second patch fixes the missing parens.)

edit: marked as draft because we need to merge #1399 first, but otherwise the PR is ready to review!