### PR TITLE
Add @inline tag support for module declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 ### Added
+- Support `[@inline]` tag on module declarations. When a module declaration's
+  doc comment includes `@inline`, its contents are rendered directly on the
+  parent page rather than on a separate sub-page — matching the behaviour of
+  `include … (** @inline *)`. (#564)
 - Allow persistent latex macros in HTML/KaTeX backend (@dlesbre, #1391)
 - `markdown-generate` command now accepts multiple `.odocl` files in a single
   invocation, eliminating the need for shell scripting (@davesnx, #1387)

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -1443,40 +1443,59 @@ module Make (Syntax : SYNTAX) = struct
         | ModuleType e -> expansion_of_module_type_expr e
       in
       let source_anchor = source_anchor t.source_loc in
-      let modname, status, expansion, expansion_doc =
-        match expansion with
-        | None -> (O.txt modname, `Default, None, None)
-        | Some (expansion_doc, items) ->
-            let status =
-              match t.type_ with
-              | ModuleType (Signature _) -> `Inline
-              | _ -> `Default
-            in
-            let url = Url.Path.from_identifier t.id in
-            let link = path url [ inline @@ Text modname ] in
-            let page =
-              make_expansion_page ~source_anchor url
-                [ t.doc.elements; expansion_doc ]
-                items
-            in
-            (link, status, Some page, Some expansion_doc)
-      in
-      let intro = O.keyword "module" ++ O.txt " " ++ modname in
-      let summary = O.ignore intro ++ mdexpr_in_decl t.id t.type_ in
-      let modexpr =
-        attach_expansion ~status
-          (Syntax.Type.annotation_separator, "sig", "end")
-          expansion summary
-      in
-      let content =
-        O.documentedSrc intro @ modexpr
-        @ O.documentedSrc
-            (if Syntax.Mod.close_tag_semicolon then O.txt ";" else O.noop)
-      in
-      let attr = [ "module" ] in
-      let anchor = path_to_id t.id in
-      let doc = Comment.synopsis ~decl_doc:t.doc.elements ~expansion_doc in
-      Item.Declaration { attr; anchor; doc; content; source_anchor }
+      (* When [@inline] is requested and an expansion is available, render the
+         module's items directly on the parent page instead of on a sub-page.
+         This mirrors how [include … (**@inline*)] works: no separate page is
+         generated, and the full documentation is shown here (not just the
+         synopsis, since there is no sub-page to fall back to). *)
+      match t.inline, expansion with
+      | true, Some (_expansion_doc, items) ->
+          let summary =
+            O.render
+              (O.keyword "module" ++ O.txt " " ++ O.txt modname
+              ++ O.txt Syntax.Type.annotation_separator
+              ++ O.keyword "sig" ++ O.txt " ... " ++ O.keyword "end")
+          in
+          let content = { Include.status = `Inline; content = items; summary } in
+          let attr = [ "module" ] in
+          let anchor = path_to_id t.id in
+          let doc = Comment.to_ir t.doc.elements in
+          Item.Include { attr; anchor; content; doc; source_anchor }
+      | _ ->
+          let modname, status, expansion, expansion_doc =
+            match expansion with
+            | None -> (O.txt modname, `Default, None, None)
+            | Some (expansion_doc, items) ->
+                let status =
+                  match t.type_ with
+                  | ModuleType (Signature _) -> `Inline
+                  | _ -> `Default
+                in
+                let url = Url.Path.from_identifier t.id in
+                let link = path url [ inline @@ Text modname ] in
+                let page =
+                  make_expansion_page ~source_anchor url
+                    [ t.doc.elements; expansion_doc ]
+                    items
+                in
+                (link, status, Some page, Some expansion_doc)
+          in
+          let intro = O.keyword "module" ++ O.txt " " ++ modname in
+          let summary = O.ignore intro ++ mdexpr_in_decl t.id t.type_ in
+          let modexpr =
+            attach_expansion ~status
+              (Syntax.Type.annotation_separator, "sig", "end")
+              expansion summary
+          in
+          let content =
+            O.documentedSrc intro @ modexpr
+            @ O.documentedSrc
+                (if Syntax.Mod.close_tag_semicolon then O.txt ";" else O.noop)
+          in
+          let attr = [ "module" ] in
+          let anchor = path_to_id t.id in
+          let doc = Comment.synopsis ~decl_doc:t.doc.elements ~expansion_doc in
+          Item.Declaration { attr; anchor; doc; content; source_anchor }
 
     and simple_expansion_in_decl (base : Paths.Identifier.Module.t) se =
       let rec ty_of_se :

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -1031,8 +1031,9 @@ and read_module_declaration env parent ident (md : Odoc_model.Compat.module_decl
   let id = (Env.find_module_identifier env.ident_env ident :> Identifier.Module.t) in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc, canonical = Doc_attr.attached ~warnings_tag:env.warnings_tag Odoc_model.Semantics.Expect_canonical container md.md_attributes in
-  let canonical = match canonical with | None -> None | Some s -> Some (Doc_attr.conv_canonical_module s) in
+  let doc, (inline_status, canonical_raw) = Doc_attr.attached ~warnings_tag:env.warnings_tag Odoc_model.Semantics.Expect_module_tags container md.md_attributes in
+  let inline = (inline_status = `Inline) in
+  let canonical = match canonical_raw with | None -> None | Some s -> Some (Doc_attr.conv_canonical_module s) in
   let type_ =
     match md.md_type with
     | Mty_alias p -> Alias (Env.Path.read_module env.ident_env p, None)
@@ -1043,7 +1044,7 @@ and read_module_declaration env parent ident (md : Odoc_model.Compat.module_decl
     | Some _ -> false
     | None -> Odoc_model.Names.contains_double_underscore (Ident.name ident)
   in
-  {id; source_loc; doc; type_; canonical; hidden }
+  {id; source_loc; doc; type_; canonical; hidden; inline}
 
 and read_type_rec_status rec_status =
   let open Signature in

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -458,7 +458,9 @@ and read_module_binding env parent mb =
   let id = (mid :> Identifier.Module.t) in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc, canonical = Doc_attr.attached ~warnings_tag:env.warnings_tag Odoc_model.Semantics.Expect_canonical container mb.mb_attributes in
+  let doc, (inline_status, canonical_raw) = Doc_attr.attached ~warnings_tag:env.warnings_tag Odoc_model.Semantics.Expect_module_tags container mb.mb_attributes in
+  let inline = (inline_status = `Inline) in
+  let canonical = canonical_raw in
   let type_, canonical =
     match unwrap_module_expr_desc mb.mb_expr.mod_desc with
     | Tmod_ident (p, _) -> (Alias (Env.Path.read_module env.ident_env p, None), canonical)
@@ -481,7 +483,7 @@ and read_module_binding env parent mb =
     | Some _, _ -> false
 #endif
   in
-  Some {id; source_loc; doc; type_; canonical; hidden; }
+  Some {id; source_loc; doc; type_; canonical; hidden; inline}
 
 and read_module_bindings env parent mbs =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t)

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -642,7 +642,9 @@ and read_module_declaration env parent md =
   let id = (mid :> Identifier.Module.t) in
   let source_loc = None in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
-  let doc, canonical = Doc_attr.attached ~warnings_tag:env.warnings_tag Odoc_model.Semantics.Expect_canonical container md.md_attributes in
+  let doc, (inline_status, canonical_raw) = Doc_attr.attached ~warnings_tag:env.warnings_tag Odoc_model.Semantics.Expect_module_tags container md.md_attributes in
+  let inline = (inline_status = `Inline) in
+  let canonical = canonical_raw in
   let type_, canonical =
     match md.md_type.mty_desc with
     | Tmty_alias (p, _) -> (Alias (Env.Path.read_module env.ident_env p, None), canonical)
@@ -666,7 +668,7 @@ and read_module_declaration env parent md =
     | _ -> false
 #endif
   in
-  Some {id; source_loc; doc; type_; canonical; hidden}
+  Some {id; source_loc; doc; type_; canonical; hidden; inline}
 
 and read_module_declarations env parent mds =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -32,6 +32,10 @@ module rec Module : sig
     type_ : decl;
     canonical : Path.Module.t option;
     hidden : bool;
+    inline : bool;
+        (** [true] when the module's doc comment carries [\@inline], requesting
+            that its contents be rendered on the parent page rather than on a
+            separate sub-page. *)
   }
 
   module Equation : sig

--- a/src/model/semantics.ml
+++ b/src/model/semantics.ml
@@ -17,6 +17,12 @@ type _ handle_internal_tags =
   | Expect_canonical : Reference.path option handle_internal_tags
   | Expect_none : unit handle_internal_tags
   | Expect_page_tags : Frontmatter.t handle_internal_tags
+  | Expect_module_tags :
+      ([ `Default | `Inline | `Open | `Closed ] * Reference.path option)
+      handle_internal_tags
+      (** Combined handler for module declarations: accepts both the display
+          status tags ([\@inline], [\@open], [\@closed]) and [\@canonical]. *)
+
 
 let describe_internal_tag = function
   | `Canonical _ -> "@canonical"
@@ -598,6 +604,40 @@ let handle_internal_tags (type a) tags : a handle_internal_tags -> a = function
       (* Will raise warnings. *)
       ignore (find_tag ~filter:(fun _ -> None) tags);
       ()
+  | Expect_module_tags ->
+      (* Process module declaration tags in a single pass so that neither
+         @inline/@open/@closed nor @canonical triggers spurious "unexpected tag"
+         warnings for the other. *)
+      let matched =
+        find_tags []
+          ~filter:(function
+            | (`Inline | `Open | `Closed) as s -> Some (`Status s)
+            | `Canonical p -> Some (`Canonical p)
+            | _ -> None)
+          tags
+      in
+      let status =
+        match
+          List.find_opt
+            (fun (t, _) -> match t with `Status _ -> true | _ -> false)
+            matched
+        with
+        | Some (`Status s, _) -> s
+        | _ -> `Default
+      in
+      let canonical =
+        match
+          List.find_opt
+            (fun (t, _) -> match t with `Canonical _ -> true | _ -> false)
+            matched
+        with
+        | Some (`Canonical (`Root _), loc) ->
+            warn_root_canonical loc;
+            None
+        | Some (`Canonical (`Dot _ as p), _) -> Some p
+        | _ -> None
+      in
+      (status, canonical)
 
 let ast_to_comment ~internal_tags ~tags_allowed ~parent_of_sections
     (ast : Ast.t) alerts =

--- a/src/model/semantics.mli
+++ b/src/model/semantics.mli
@@ -5,6 +5,12 @@ type _ handle_internal_tags =
   | Expect_canonical : Reference.path option handle_internal_tags
   | Expect_none : unit handle_internal_tags
   | Expect_page_tags : Frontmatter.t handle_internal_tags
+  | Expect_module_tags :
+      ([ `Default | `Inline | `Open | `Closed ] * Reference.path option)
+      handle_internal_tags
+      (** Combined handler for module declarations: accepts both display-status
+          tags ([\@inline], [\@open], [\@closed]) and [\@canonical] in a single
+          pass so neither triggers a spurious "unexpected tag" warning. *)
 
 type sections_allowed = [ `All | `No_titles | `None ]
 

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -43,6 +43,7 @@ and module_t =
           (fun t -> (t.canonical :> Paths.Path.t option)),
           Option path );
       F ("hidden", (fun t -> t.hidden), bool);
+      F ("inline", (fun t -> t.inline), bool);
     ]
 
 (** {3 FunctorParameter} *)

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -69,6 +69,8 @@ module rec Module : sig
     type_ : decl;
     canonical : Odoc_model.Paths.Path.Module.t option;
     hidden : bool;
+    inline : bool;
+        (** Mirrors [Lang.Module.t.inline]: true when [\@inline] was present. *)
   }
 end =
   Module
@@ -2330,6 +2332,7 @@ module Of_Lang = struct
       type_;
       canonical;
       hidden = m.hidden;
+      inline = m.inline;
     }
 
   and with_module_type_substitution ident_map m =
@@ -2628,6 +2631,7 @@ module Of_Lang = struct
       type_ = Alias (manifest, None);
       canonical = None;
       hidden = false;
+      inline = false;
     }
 
   and signature : _ -> Odoc_model.Lang.Signature.t -> Signature.t =
@@ -2749,6 +2753,7 @@ let module_of_functor_argument (arg : FunctorParameter.parameter) =
     type_ = ModuleType arg.expr;
     canonical = None;
     hidden = false;
+    inline = false;
   }
 
 (** This is equivalent to {!Lang.extract_signature_doc}. *)

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -67,6 +67,7 @@ module rec Module : sig
     type_ : decl;
     canonical : Odoc_model.Paths.Path.Module.t option;
     hidden : bool;
+    inline : bool;
   }
 end
 

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -385,6 +385,7 @@ let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
             type_ = ModuleType (Signature s);
             canonical = unit.canonical;
             hidden = unit.hidden;
+            inline = false;
           }
       in
       let ty = Component.Of_Lang.(module_ (empty ()) m) in
@@ -407,6 +408,7 @@ let module_of_unit : Lang.Compilation_unit.t -> Component.Module.t =
                    });
             canonical = unit.canonical;
             hidden = unit.hidden;
+            inline = false;
           }
       in
       let ty = Component.Of_Lang.(module_ (empty ()) m) in
@@ -660,6 +662,7 @@ let mk_functor_parameter module_type =
       type_;
       canonical = None;
       hidden = false;
+      inline = false;
     }
 
 let add_functor_parameter : Lang.FunctorParameter.t -> t -> t =

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -736,6 +736,7 @@ and module_ map parent id m =
       type_ = module_decl map identifier m.type_;
       canonical = m.canonical;
       hidden = m.hidden;
+      inline = m.inline;
     }
   with e ->
     let bt = Printexc.get_backtrace () in

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -2376,6 +2376,7 @@ let apply_inner_substs env (sg : Component.Signature.t) : Component.Signature.t
                     type_ = Alias (modsubst.manifest, None);
                     canonical = None;
                     hidden = false;
+                    inline = false;
                   }) )
           :: inner rest
         in

--- a/test/generators/cases/module_inline.mli
+++ b/test/generators/cases/module_inline.mli
@@ -1,0 +1,34 @@
+(** Tests for the [\@inline] attribute on module declarations.
+
+    When a module declaration carries [\@inline] in its doc comment, its
+    contents are rendered directly on the parent page rather than on a separate
+    sub-page. This mirrors how [include … (**\@inline*)] works. *)
+
+(** A normal module — contents appear on a separate page (default behaviour). *)
+module Normal : sig
+  type t
+  val create : unit -> t
+end
+
+(** An inlined module — contents appear directly on this page.
+    @inline *)
+module Inlined : sig
+  type t
+  val create : unit -> t
+end
+
+(** A module without an inline signature is unaffected by [\@inline].
+    @inline *)
+module Alias = Normal
+
+(** Nested: the outer module is inlined; inner sub-modules still get their own
+    pages unless they are also marked [\@inline].
+    @inline *)
+module Outer : sig
+  (** Nested module without [\@inline] — separate page. *)
+  module Inner : sig
+    type u
+  end
+
+  val x : int
+end

--- a/test/generators/html/Module_inline-Normal.html
+++ b/test/generators/html/Module_inline-Normal.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Normal (Module_inline.Normal)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Module_inline.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; 
+   <a href="Module_inline.html">Module_inline</a> &#x00BB; Normal
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Module_inline.Normal</span></code></h1>
+   <p>A normal module — contents appear on a separate page (default
+     behaviour).
+   </p>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t">
+     <a href="#type-t" class="anchor"></a>
+     <code><span><span class="keyword">type</span> t</span></code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-create">
+     <a href="#val-create" class="anchor"></a>
+     <code>
+      <span><span class="keyword">val</span> create : 
+       <span>unit <span class="arrow">&#45;&gt;</span></span> 
+       <a href="#type-t">t</a>
+      </span>
+     </code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Module_inline-Outer-Inner.html
+++ b/test/generators/html/Module_inline-Outer-Inner.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Inner (Module_inline.Outer.Inner)</title>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Module_inline-Outer.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; 
+   <a href="Module_inline.html">Module_inline</a> &#x00BB; 
+   <a href="Module_inline-Outer.html">Outer</a> &#x00BB; Inner
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Outer.Inner</span></code></h1>
+   <p>Nested module without <code>\@inline</code> — separate page.</p>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-u">
+     <a href="#type-u" class="anchor"></a>
+     <code><span><span class="keyword">type</span> u</span></code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Module_inline.html
+++ b/test/generators/html/Module_inline.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Module_inline (Module_inline)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="index.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; Module_inline
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Module_inline</span></code></h1>
+   <p>Tests for the <code>\@inline</code> attribute on module declarations.
+   </p>
+   <p>When a module declaration carries <code>\@inline</code> in its 
+    doc comment, its contents are rendered directly on the parent page
+     rather than on a separate sub-page. This mirrors how 
+    <code>include … (**\@inline*)</code> works.
+   </p>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-Normal">
+     <a href="#module-Normal" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Module_inline-Normal.html">Normal</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A normal module — contents appear on a separate page (default
+       behaviour).
+     </p>
+    </div>
+   </div>
+   <div class="spec-doc">
+    <p>An inlined module — contents appear directly on this page.</p>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t">
+     <a href="#type-t" class="anchor"></a>
+     <code><span><span class="keyword">type</span> t</span></code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-create">
+     <a href="#val-create" class="anchor"></a>
+     <code>
+      <span><span class="keyword">val</span> create : 
+       <span>unit <span class="arrow">&#45;&gt;</span></span> 
+       <a href="Module_inline-Inlined.html#type-t">t</a>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-Alias">
+     <a href="#module-Alias" class="anchor"></a>
+     <code><span><span class="keyword">module</span> Alias</span>
+      <span> = <a href="Module_inline-Normal.html">Normal</a></span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A module without an inline signature is unaffected by 
+      <code>\@inline</code>.
+     </p>
+    </div>
+   </div>
+   <div class="spec-doc">
+    <p>Nested: the outer module is inlined; inner sub-modules still get
+      their own pages unless they are also marked <code>\@inline</code>
+     .
+    </p>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-Inner">
+     <a href="#module-Inner" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Module_inline-Outer-Inner.html">Inner</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>Nested module without <code>\@inline</code> — separate page.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-x">
+     <a href="#val-x" class="anchor"></a>
+     <code><span><span class="keyword">val</span> x : int</span></code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/module_inline.targets
+++ b/test/generators/html/module_inline.targets
@@ -1,0 +1,3 @@
+Module_inline.html
+Module_inline-Normal.html
+Module_inline-Outer-Inner.html

--- a/test/generators/latex/Module_inline.tex
+++ b/test/generators/latex/Module_inline.tex
@@ -1,0 +1,21 @@
+\section{Module \ocamlinlinecode{Module\_\allowbreak{}inline}}\label{Module_inline}%
+Tests for the \ocamlinlinecode{\textbackslash{}@inline} attribute on module declarations.
+
+When a module declaration carries \ocamlinlinecode{\textbackslash{}@inline} in its doc comment, its contents are rendered directly on the parent page rather than on a separate sub-page. This mirrors how \ocamlinlinecode{include … (**\textbackslash{}@inline*)} works.
+
+\label{Module_inline--module-Normal}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Module_inline-Normal]{\ocamlinlinecode{Normal}}}\label{Module_inline-Normal}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Module_inline-Normal--type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
+\label{Module_inline-Normal--val-create}\ocamlcodefragment{\ocamltag{keyword}{val} create : unit \ocamltag{arrow}{$\rightarrow$} \hyperref[Module_inline-Normal--type-t]{\ocamlinlinecode{t}}}\\
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}A normal module — contents appear on a separate page (default behaviour).\end{ocamlindent}%
+\medbreak
+\label{Module_inline--module-Inlined}An inlined module — contents appear directly on this page.\ocamltag{keyword}{module} Inlined : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}\label{Module_inline-Inlined--type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t}\\
+\label{Module_inline-Inlined--val-create}\ocamlcodefragment{\ocamltag{keyword}{val} create : unit \ocamltag{arrow}{$\rightarrow$} \hyperref[Module_inline-Inlined--type-t]{\ocamlinlinecode{t}}}\\
+\label{Module_inline--module-Alias}\ocamlcodefragment{\ocamltag{keyword}{module} Alias = \hyperref[Module_inline-Normal]{\ocamlinlinecode{Normal}}}\begin{ocamlindent}A module without an inline signature is unaffected by \ocamlinlinecode{\textbackslash{}@inline}.\end{ocamlindent}%
+\medbreak
+\label{Module_inline--module-Outer}Nested: the outer module is inlined; inner sub-modules still get their own pages unless they are also marked \ocamlinlinecode{\textbackslash{}@inline}.\ocamltag{keyword}{module} Outer : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}\label{Module_inline-Outer--module-Inner}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Module_inline-Outer-Inner]{\ocamlinlinecode{Inner}}}\label{Module_inline-Outer-Inner}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Module_inline-Outer-Inner--type-u}\ocamlcodefragment{\ocamltag{keyword}{type} u}\\
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}Nested module without \ocamlinlinecode{\textbackslash{}@inline} — separate page.\end{ocamlindent}%
+\medbreak
+\label{Module_inline-Outer--val-x}\ocamlcodefragment{\ocamltag{keyword}{val} x : int}\\
+
+

--- a/test/generators/latex/module_inline.targets
+++ b/test/generators/latex/module_inline.targets
@@ -1,0 +1,1 @@
+Module_inline.tex

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -447,6 +447,30 @@
   (>= %{ocaml_version} 4.04)))
 
 (rule
+ (target module_inline.cmti)
+ (package odoc)
+ (action
+  (run ocamlc -c -bin-annot -o %{target} %{dep:cases/module_inline.mli}))
+ (enabled_if
+  (>= %{ocaml_version} 4.04)))
+
+(rule
+ (target module_inline.odoc)
+ (package odoc)
+ (action
+  (run odoc compile -o %{target} %{dep:module_inline.cmti}))
+ (enabled_if
+  (>= %{ocaml_version} 4.04)))
+
+(rule
+ (target module_inline.odocl)
+ (package odoc)
+ (action
+  (run odoc link -o %{target} %{dep:module_inline.odoc}))
+ (enabled_if
+  (>= %{ocaml_version} 4.04)))
+
+(rule
  (target module_type_alias.cmti)
  (package odoc)
  (action
@@ -5429,6 +5453,231 @@
   (package odoc)
   (action
    (diff module.targets module.targets.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04))))
+
+(subdir
+ html
+ (rule
+  (targets
+   Module_inline.html.gen
+   Module_inline-Normal.html.gen
+   Module_inline-Outer-Inner.html.gen)
+  (package odoc)
+  (action
+   (run
+    odoc
+    html-generate
+    --indent
+    --flat
+    --extra-suffix
+    gen
+    -o
+    .
+    %{dep:../module_inline.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Module_inline.html Module_inline.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Module_inline-Normal.html Module_inline-Normal.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Module_inline-Outer-Inner.html Module_inline-Outer-Inner.html.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04))))
+
+(subdir
+ html
+ (rule
+  (target module_inline.targets.gen)
+  (package odoc)
+  (action
+   (with-outputs-to
+    module_inline.targets.gen
+    (run odoc html-targets -o . %{dep:../module_inline.odocl} --flat)))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff module_inline.targets module_inline.targets.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04))))
+
+(subdir
+ latex
+ (rule
+  (targets Module_inline.tex.gen)
+  (package odoc)
+  (action
+   (run
+    odoc
+    latex-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../module_inline.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Module_inline.tex Module_inline.tex.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04))))
+
+(subdir
+ latex
+ (rule
+  (target module_inline.targets.gen)
+  (package odoc)
+  (action
+   (with-outputs-to
+    module_inline.targets.gen
+    (run odoc latex-targets -o . %{dep:../module_inline.odocl})))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff module_inline.targets module_inline.targets.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04))))
+
+(subdir
+ man
+ (rule
+  (targets
+   Module_inline.3o.gen
+   Module_inline.Normal.3o.gen
+   Module_inline.Outer.Inner.3o.gen)
+  (package odoc)
+  (action
+   (run
+    odoc
+    man-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../module_inline.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Module_inline.3o Module_inline.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Module_inline.Normal.3o Module_inline.Normal.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Module_inline.Outer.Inner.3o Module_inline.Outer.Inner.3o.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04))))
+
+(subdir
+ man
+ (rule
+  (target module_inline.targets.gen)
+  (package odoc)
+  (action
+   (with-outputs-to
+    module_inline.targets.gen
+    (run odoc man-targets -o . %{dep:../module_inline.odocl})))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff module_inline.targets module_inline.targets.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04))))
+
+(subdir
+ markdown
+ (rule
+  (targets
+   Module_inline.md.gen
+   Module_inline-Normal.md.gen
+   Module_inline-Outer-Inner.md.gen)
+  (package odoc)
+  (action
+   (run
+    odoc
+    markdown-generate
+    -o
+    .
+    --extra-suffix
+    gen
+    %{dep:../module_inline.odocl}))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Module_inline.md Module_inline.md.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Module_inline-Normal.md Module_inline-Normal.md.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Module_inline-Outer-Inner.md Module_inline-Outer-Inner.md.gen))
+  (enabled_if
+   (>= %{ocaml_version} 4.04))))
+
+(subdir
+ markdown
+ (rule
+  (target module_inline.targets.gen)
+  (package odoc)
+  (action
+   (with-outputs-to
+    module_inline.targets.gen
+    (run odoc markdown-targets -o . %{dep:../module_inline.odocl})))
+  (enabled_if
+   (>= %{ocaml_version} 4.04)))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff module_inline.targets module_inline.targets.gen))
   (enabled_if
    (>= %{ocaml_version} 4.04))))
 

--- a/test/generators/man/Module_inline.3o
+++ b/test/generators/man/Module_inline.3o
@@ -1,0 +1,46 @@
+
+.TH Module_inline 3 "" "Odoc" "OCaml Library"
+.SH Name
+Module_inline
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Module_inline\fR
+.in 
+.sp 
+.fi 
+Tests for the \\@inline attribute on module declarations\.
+.nf 
+.sp 
+.fi 
+When a module declaration carries \\@inline in its doc comment, its contents are rendered directly on the parent page rather than on a separate sub-page\. This mirrors how include … (**\\@inline*) works\.
+.nf 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]module\fR Normal : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.fi 
+.br 
+.ti +2
+A normal module — contents appear on a separate page (default behaviour)\.
+.nf 
+.sp 
+\f[CB]type\fR t
+.sp 
+\f[CB]val\fR create : unit \f[CB]\->\fR t
+.sp 
+\f[CB]module\fR Alias = Normal
+.fi 
+.br 
+.ti +2
+A module without an inline signature is unaffected by \\@inline\.
+.nf 
+.sp 
+\f[CB]module\fR Inner : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.fi 
+.br 
+.ti +2
+Nested module without \\@inline — separate page\.
+.nf 
+.sp 
+\f[CB]val\fR x : int

--- a/test/generators/man/Module_inline.Normal.3o
+++ b/test/generators/man/Module_inline.Normal.3o
@@ -1,0 +1,19 @@
+
+.TH Normal 3 "" "Odoc" "OCaml Library"
+.SH Name
+Module_inline\.Normal
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Module_inline\.Normal\fR
+.in 
+.sp 
+.fi 
+A normal module — contents appear on a separate page (default behaviour)\.
+.nf 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]type\fR t
+.sp 
+\f[CB]val\fR create : unit \f[CB]\->\fR t

--- a/test/generators/man/Module_inline.Outer.Inner.3o
+++ b/test/generators/man/Module_inline.Outer.Inner.3o
@@ -1,0 +1,17 @@
+
+.TH Inner 3 "" "Odoc" "OCaml Library"
+.SH Name
+Module_inline\.Outer\.Inner
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Outer\.Inner\fR
+.in 
+.sp 
+.fi 
+Nested module without \\@inline — separate page\.
+.nf 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]type\fR u

--- a/test/generators/man/module_inline.targets
+++ b/test/generators/man/module_inline.targets
@@ -1,0 +1,3 @@
+Module_inline.3o
+Module_inline.Normal.3o
+Module_inline.Outer.Inner.3o

--- a/test/generators/markdown/Module_inline-Normal.md
+++ b/test/generators/markdown/Module_inline-Normal.md
@@ -1,0 +1,11 @@
+
+# Module `Module_inline.Normal`
+
+A normal module — contents appear on a separate page (default behaviour).
+
+```ocaml
+type t
+```
+```ocaml
+val create : unit -> t
+```

--- a/test/generators/markdown/Module_inline-Outer-Inner.md
+++ b/test/generators/markdown/Module_inline-Outer-Inner.md
@@ -1,0 +1,8 @@
+
+# Module `Outer.Inner`
+
+Nested module without `\@inline` — separate page.
+
+```ocaml
+type u
+```

--- a/test/generators/markdown/Module_inline.md
+++ b/test/generators/markdown/Module_inline.md
@@ -1,0 +1,35 @@
+
+# Module `Module_inline`
+
+Tests for the `\@inline` attribute on module declarations.
+
+When a module declaration carries `\@inline` in its doc comment, its contents are rendered directly on the parent page rather than on a separate sub-page. This mirrors how `include … (**\@inline*)` works.
+
+```ocaml
+module Normal : sig ... end
+```
+A normal module — contents appear on a separate page (default behaviour).
+
+An inlined module — contents appear directly on this page.
+
+```ocaml
+type t
+```
+```ocaml
+val create : unit -> t
+```
+```ocaml
+module Alias = Normal
+```
+A module without an inline signature is unaffected by `\@inline`.
+
+Nested: the outer module is inlined; inner sub-modules still get their own pages unless they are also marked `\@inline`.
+
+```ocaml
+module Inner : sig ... end
+```
+Nested module without `\@inline` — separate page.
+
+```ocaml
+val x : int
+```

--- a/test/generators/markdown/module_inline.targets
+++ b/test/generators/markdown/module_inline.targets
@@ -1,0 +1,3 @@
+Module_inline.md
+Module_inline-Normal.md
+Module_inline-Outer-Inner.md


### PR DESCRIPTION
This PR was generated by Claude Code to give a sense of how much work is needed to implement #564. It may or may not be great.

## Summary

Support `@inline` on module declarations, as requested in #564.

When a module declaration's doc comment includes `@inline`, its contents
are rendered directly on the parent page rather than on a separate sub-page:

```ocaml
(** An inlined module — contents appear directly on this page.
    @inline *)
module Inlined : sig
  type t
  val create : unit -> t
end
```

This mirrors the existing behaviour of `include … (** @inline *)`.

Modules without an inline signature (aliases) are unaffected, and nested
sub-modules within an inlined module still get their own pages unless they
are also marked `@inline`.

## Implementation notes

- `Lang.Module.t` gains an `inline : bool` field.
- A new `Expect_module_tags` variant in `Semantics` processes both `@canonical`
  and `@inline` in a single pass over a module's doc-comment tags, avoiding
  spurious warnings that would arise from two separate `find_tag` calls.
- The `inline` field is threaded through `Component.Module.t` and the xref2
  round-trip so it survives link resolution.
- The document generator emits `Item.Include { status = \`Inline }` for
  inline modules, reusing the rendering path already used by inlined includes.

**Known limitation:** cross-references inside an inline module's items (e.g.
`val create : unit -> t`) currently point to the ungenerated subpage
(`Module-Inlined.html#type-t`). This is the same situation as with inlined
`include` statements and can be addressed in a follow-up.

## Test plan

- [ ] New test case `test/generators/cases/module_inline.mli` covering:
  normal module, `@inline` module, `@inline` on an alias (no-op), and
  nested inlined module with a non-inlined inner module.
- [ ] Expected outputs checked in for HTML, LaTeX, man, and markdown generators.
- [ ] `dune runtest test/generators` passes.
