### PR TITLE
Compatibility with OxCaml-minus31

### DIFF
--- a/sherlodoc/jsoo/tyxml.ml
+++ b/sherlodoc/jsoo/tyxml.ml
@@ -47,7 +47,8 @@ end = struct
       let next = i + 1 in
       loop next next
     in
-    loop 0 0
+    let result = loop 0 0 in
+    result
 
   let to_string t =
     let buf = Buffer.create 16 in

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -326,6 +326,7 @@ let mark_type ty =
       | Tquote typ -> loop visited typ
       | Tsplice typ -> loop visited typ
       | Tof_kind _ -> ()
+      | Trepr _ -> ()
 #endif
   in
   loop [] ty
@@ -605,6 +606,7 @@ let rec read_type_expr env typ =
       | Tquote typ -> Quote (read_type_expr env typ)
       | Tsplice typ -> Splice (read_type_expr env typ)
       | Tof_kind _ -> assert false
+      | Trepr _ -> Any  (* oxcaml: representation annotations are ignored *)
 #endif
     in
       match alias with

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -114,6 +114,10 @@ let rec read_pattern env parent doc pat =
     | Tpat_exception pat ->
         read_pattern env parent doc pat
 #endif
+#if defined OXCAML
+    | Tpat_unboxed_unit -> []
+    | Tpat_unboxed_bool _ -> []
+#endif
 
 let read_value_binding env parent vb =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
@@ -583,6 +587,9 @@ and read_structure_item env parent item =
     | Tstr_class_type cltyps ->
         let cltyps = List.map (fun (_, _, clty) -> clty) cltyps in
           Cmti.read_class_type_declarations env parent cltyps
+#if defined OXCAML
+    | Tstr_jkind _ -> []
+#endif
     | Tstr_attribute attr ->
       let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
           match Doc_attr.standalone container ~warnings_tag:env.warnings_tag attr with

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -406,7 +406,11 @@ let rec read_module_expr env parent label_parent mexpr =
         let f_parameter, env =
           match parameter with
           | Unit -> FunctorParameter.Unit, env
+#if defined OXCAML
+          | Named (id_opt, _, arg, _) ->
+#else
           | Named (id_opt, _, arg) ->
+#endif
               let id, env =
                 match id_opt with
                 | None -> Identifier.Mk.parameter (parent, Odoc_model.Names.ModuleName.make_std "_"), env
@@ -440,8 +444,13 @@ let rec read_module_expr env parent label_parent mexpr =
     | Tmod_apply_unit _ ->
         Cmi.read_module_type env parent (Odoc_model.Compat.module_type mexpr.mod_type)
 #endif
+#if defined OXCAML
+    | Tmod_constraint(_, _, Tmodtype_explicit (mty, _), _) ->
+        Cmti.read_module_type env parent label_parent mty
+#else
     | Tmod_constraint(_, _, Tmodtype_explicit mty, _) ->
         Cmti.read_module_type env parent label_parent mty
+#endif
     | Tmod_constraint(mexpr, _, Tmodtype_implicit, _) ->
         read_module_expr env parent label_parent mexpr
     | Tmod_unpack(_, mty) ->

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -52,7 +52,11 @@ let rec read_core_type env container ctyp =
     | Ttyp_any -> Any
     | Ttyp_var s -> Var s
 #endif
+#if defined OXCAML
+    | Ttyp_arrow(lbl, arg, _, res, _) ->
+#else
     | Ttyp_arrow(lbl, arg, res) ->
+#endif
         let lbl = read_label lbl in
 #if OCAML_VERSION < (4,3,0)
         (* NOTE(@ostera): Unbox the optional value for this optional labelled
@@ -638,11 +642,19 @@ and read_module_type env parent label_parent mty =
         let sg, () = read_signature Odoc_model.Semantics.Expect_none env parent sg in
         Signature sg
 #if OCAML_VERSION >= (4,10,0)
+#if defined OXCAML
+    | Tmty_functor(parameter, res, _) ->
+#else
     | Tmty_functor(parameter, res) ->
+#endif
         let f_parameter, env =
           match parameter with
           | Unit -> FunctorParameter.Unit, env
+#if defined OXCAML
+          | Named (id_opt, _, arg, _) ->
+#else
           | Named (id_opt, _, arg) ->
+#endif
             let id, env =
               match id_opt with
               | None -> Identifier.Mk.parameter (parent, ModuleName.make_std "_"), env

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -196,6 +196,7 @@ let rec read_core_type env container ctyp =
     | Ttyp_splice typ -> Splice (read_core_type env container typ)
     | Ttyp_call_pos -> Constr(Env.Path.read_type env.ident_env Predef.path_lexing_position, [])
     | Ttyp_of_kind _ -> assert false
+    | Ttyp_repr _ -> Any  (* oxcaml: representation annotations are ignored *)
 #elif OCAML_VERSION >= (5,5,0)
   | Ttyp_functor (lbl, id, pkg, ret_type) ->
     let lbl = read_label lbl in
@@ -875,6 +876,9 @@ and read_signature_item env parent item =
 #if OCAML_VERSION >= (4,13,0)
     | Tsig_modtypesubst mtst ->
         [ModuleTypeSubstitution (read_module_type_substitution env parent mtst)]
+#endif
+#if defined OXCAML
+    | Tsig_jkind _ -> []
 #endif
 
 

--- a/src/loader/ident_env.ml
+++ b/src/loader/ident_env.ml
@@ -316,6 +316,9 @@ let rec extract_signature_tree_items : bool -> Typedtree.signature_item list -> 
       [`ModuleType (mtd.mtd_id, hide_item, Some sig_loc)] @ extract_signature_tree_items hide_item rest
 #endif
     | { sig_desc = Tsig_open _;_} :: rest -> extract_signature_tree_items hide_item rest
+#if defined OXCAML
+    | { sig_desc = Tsig_jkind _;_} :: rest -> extract_signature_tree_items hide_item rest
+#endif
     | [] -> []
 
 let rec read_pattern hide_item pat =
@@ -376,6 +379,10 @@ let rec read_pattern hide_item pat =
   | Tpat_any | Tpat_constant _ | Tpat_variant(_, None, _) -> []
 #if OCAML_VERSION >= (4,8,0) && OCAML_VERSION < (4,11,0)
   | Tpat_exception pat -> read_pattern hide_item pat
+#endif
+#if defined OXCAML
+  | Tpat_unboxed_unit -> []
+  | Tpat_unboxed_bool _ -> []
 #endif
 
 let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> items list = fun hide_item items ->
@@ -486,6 +493,9 @@ let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> 
     | { str_desc = Tstr_primitive {val_id; _}; str_loc; _ } :: rest ->
       [`Value (val_id, false, Some str_loc)] @ extract_structure_tree_items hide_item rest
     | { str_desc = Tstr_eval _; _} :: rest -> extract_structure_tree_items hide_item rest
+#if defined OXCAML
+    | { str_desc = Tstr_jkind _; _ } :: rest -> extract_structure_tree_items hide_item rest
+#endif
     | [] -> []
 
 

--- a/src/loader/implementation.ml
+++ b/src/loader/implementation.ml
@@ -69,9 +69,11 @@ module Env = struct
     match mty.mty_desc with
     | Tmty_signature sg -> signature env (parent : Identifier.Signature.t) sg
     | Tmty_with (mty, _) -> module_type env parent mty
-    | Tmty_functor (_, t) -> module_type env parent t
 #if defined OXCAML
+    | Tmty_functor (_, t, _) -> module_type env parent t
     | Tmty_strengthen (t, _, _) -> module_type env parent t
+#else
+    | Tmty_functor (_, t) -> module_type env parent t
 #endif
     | Tmty_ident _ | Tmty_alias _ | Tmty_typeof _ -> ()
 
@@ -101,7 +103,11 @@ module Env = struct
         let env =
           match parameter with
           | Unit -> env
+#if defined OXCAML
+          | Named (id_opt, _, arg, _) -> (
+#else
           | Named (id_opt, _, arg) -> (
+#endif
               match id_opt with
               | Some id ->
                   let env =
@@ -118,7 +124,11 @@ module Env = struct
         let () =
           match constr with
           | Tmodtype_implicit -> ()
+#if defined OXCAML
+          | Tmodtype_explicit (mt, _) -> module_type env parent mt
+#else
           | Tmodtype_explicit mt -> module_type env parent mt
+#endif
         in
         module_expr env parent me
     | _ -> ()

--- a/src/loader/implementation.ml
+++ b/src/loader/implementation.ml
@@ -38,6 +38,9 @@ module Env = struct
     | Tsig_exception _ | Tsig_modsubst _ | Tsig_open _ | Tsig_include _
     | Tsig_class _ | Tsig_class_type _ | Tsig_attribute _ ->
         ()
+#if defined OXCAML
+    | Tsig_jkind _ -> ()
+#endif
 
   and module_declaration env _parent md =
     match md.md_id with
@@ -64,6 +67,9 @@ module Env = struct
     | Tstr_class_type _ | Tstr_include _ | Tstr_attribute _ | Tstr_primitive _
     | Tstr_type _ | Tstr_typext _ | Tstr_exception _ ->
         ()
+#if defined OXCAML
+    | Tstr_jkind _ -> ()
+#endif
 
   and module_type env (parent : Identifier.Signature.t) mty =
     match mty.mty_desc with

--- a/src/loader/typedtree_traverse.ml
+++ b/src/loader/typedtree_traverse.ml
@@ -14,7 +14,7 @@ module Analysis = struct
     else
       match expr.exp_desc with
 #if defined OXCAML
-      | Texp_ident (p, _, _, _, _) ->
+      | Texp_ident (p, _, _, _, _, _) ->
 #else
       | Texp_ident (p, _, _) ->
 #endif

--- a/src/model/compat.cppo.ml
+++ b/src/model/compat.cppo.ml
@@ -78,7 +78,14 @@ let opt conv = function | None -> None | Some x -> Some (conv x)
 
 #if OCAML_VERSION >= (4,10,0)
 
-let rec signature : Types.signature -> signature = fun x -> List.map signature_item x
+let rec signature : Types.signature -> signature = fun x ->
+#if defined OXCAML
+  List.filter_map (function
+    | Types.Sig_jkind _ -> None
+    | si -> Some (signature_item si)) x
+#else
+  List.map signature_item x
+#endif
 
 and signature_item : Types.signature_item -> signature_item = function
   | Types.Sig_value (a,b,c) -> Sig_value (a,b,visibility c)
@@ -88,6 +95,9 @@ and signature_item : Types.signature_item -> signature_item = function
   | Types.Sig_modtype (a,b,c) -> Sig_modtype (a, modtype_declaration b, visibility c)
   | Types.Sig_class (a,b,c,d) -> Sig_class (a,b,c, visibility d)
   | Types.Sig_class_type (a,b,c,d) -> Sig_class_type (a,b,c, visibility d)
+#if defined OXCAML
+  | Types.Sig_jkind _ -> assert false  (* filtered in [signature] *)
+#endif
 
 and visibility : Types.visibility -> visibility = function
   | Types.Hidden -> Hidden
@@ -280,6 +290,9 @@ let shape_info_of_cmt_infos : Cmt_format.cmt_infos -> (shape * uid_to_loc) optio
     | Module_type mt -> mt.mtd_loc
     | Class cd -> cd.ci_id_name.loc
     | Class_type ctd -> ctd.ci_id_name.loc
+#if defined OXCAML
+    | Jkind _ -> Location.none  (* oxcaml: odoc ignores jkind declarations *)
+#endif
   in
   fun x -> Option.map (fun s -> (s, Shape.Uid.Tbl.map x.cmt_uid_to_decl loc_of_declaration)) x.cmt_impl_shape
 #endif

--- a/src/model/compat.cppo.ml
+++ b/src/model/compat.cppo.ml
@@ -96,7 +96,13 @@ and visibility : Types.visibility -> visibility = function
 and module_type : Types.module_type -> module_type = function
   | Types.Mty_ident p -> Mty_ident p
   | Types.Mty_signature s -> Mty_signature (signature s)
+#if defined OXCAML
+  (* oxcaml: [Mty_functor] gained a third [Mode.Alloc.lr] argument;
+     odoc has no use for the mode so we drop it. *)
+  | Types.Mty_functor (a, b, _mode) -> Mty_functor(functor_parameter a, module_type b)
+#else
   | Types.Mty_functor (a, b) -> Mty_functor(functor_parameter a, module_type b)
+#endif
   | Types.Mty_alias p -> Mty_alias p
 #if defined OXCAML
   | Types.Mty_strengthen (mty,p,a) ->
@@ -109,7 +115,12 @@ and aliasability : Types.Aliasability.t -> Aliasability.t = function
 
 and functor_parameter : Types.functor_parameter -> functor_parameter = function
   | Types.Unit -> Unit
-  | Types.Named (a,b) -> Named (a, module_type b)
+#if defined OXCAML
+  (* oxcaml adds a [Mode.Alloc.lr] third argument that odoc ignores. *)
+  | Types.Named (a, b, _mode) -> Named (a, module_type b)
+#else
+  | Types.Named (a, b) -> Named (a, module_type b)
+#endif
 
 and module_presence : Types.module_presence -> module_presence = function
   | Types.Mp_present -> Mp_present

--- a/src/search/odoc_html_frontend.ml
+++ b/src/search/odoc_html_frontend.ml
@@ -19,7 +19,7 @@ end = struct
 
   let add_escape_string buf s =
     (* https://discuss.ocaml.org/t/html-encoding-of-string/4289/4 *)
-    let add = Buffer.add_string buf in
+    let add s = Buffer.add_string buf s in
     let len = String.length s in
     let max_idx = len - 1 in
     let flush start i =

--- a/src/syntax_highlighter/syntax_highlighter.ml
+++ b/src/syntax_highlighter/syntax_highlighter.ml
@@ -159,7 +159,7 @@ let tag_of_token (tok : Parser.token) =
   | HASH_FLOAT _ -> "HASH_FLOAT"
   | HASH_INT _ -> "HASH_INT"
   | HASH_SUFFIX -> "HASH_SUFFIX"
-  | KIND_ABBREV -> "KIND_ABBREV"
+  | KIND -> "KIND"
   | KIND_OF -> "KIND_OF"
   | LBRACKETCOLON -> "LBRACKETCOLON"
   | LESSLBRACKET -> "LESSLBRACKET"

--- a/src/syntax_highlighter/syntax_highlighter.ml
+++ b/src/syntax_highlighter/syntax_highlighter.ml
@@ -177,6 +177,13 @@ let tag_of_token (tok : Parser.token) =
   | METAOCAML_BRACKET_CLOSE -> "METAOCAML_BRACKET_CLOSE"
   | EFFECT -> "EFFECT"
 #endif
+#if defined OXCAML
+  | BORROW -> "BORROW"
+  | HASHTRUE -> "HASHTRUE"
+  | HASHFALSE -> "HASHFALSE"
+  | POLY -> "POLY"
+  | REPR -> "REPR"
+#endif
 
 
 let syntax_highlighting_locs src =


### PR DESCRIPTION
The latest release of OxCaml introduced some breaking changes to the ASTs, which @jonludlam fixed in the following commits :) Note that this PR only intend to fix the compilation of Odoc with OxCaml, as the real support for the new features is being done in separate PRs (so in the mean time we just ignore the new AST nodes).

Requires https://github.com/oxcaml/opam-repository/pull/39 and https://github.com/oxcaml/opam-repository/pull/42 to fix Odoc's dependencies on dune and opam-format