### PR TITLE
Remove bisect_ppx from odoc's opam file

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -55,7 +55,6 @@ depends: [
   "conf-jq" {with-test}
   "ppx_expect" {with-test}
   "bos" {with-test}
-  "bisect_ppx" {with-test & > "2.5.0"}
 ]
 
 conflicts: [ "ocaml-option-bytecode-only" ]

--- a/sherlodoc/test/cram/link_in_docstring.t/run.t
+++ b/sherlodoc/test/cram/link_in_docstring.t/run.t
@@ -4,9 +4,9 @@
   $ export SHERLODOC_DB=db.bin
   $ export SHERLODOC_FORMAT=marshal
   $ sherlodoc index $(find . -name '*.odocl')
-  $ sherlodoc search --print-docstring "foo"
+  $ sherlodoc search --print-docstring-html "foo"
   val A.foo : int
   <div><p>This is a docstring with a <span>link</span></p></div>
-  $ sherlodoc search --print-docstring "bar"
+  $ sherlodoc search --print-docstring-html "bar"
   val A.bar : int
   <div><p>This is a docstring with a ref to <span><code>foo</code></span></p></div>


### PR DESCRIPTION
bisect_ppx is not needed for any actual tests, and is a slightly painful dependency to have. The GHA that calculates coverage already had an `opam install bisect_ppx`, so shouldn't be affected.