### PR TITLE
voodoo: transitive-close lib_deps before per-compile -I emission

### DIFF
--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -104,6 +104,29 @@ let of_voodoo pkg =
       (Util.StringMap.empty, []) metas
   in
 
+  (* Transitively close [all_lib_deps] over itself so each lib's deps
+     reflect every lib reachable through META requires. *)
+  let all_lib_deps =
+    let cache : (string, Util.StringSet.t) Hashtbl.t =
+      Hashtbl.create (Util.StringMap.cardinal all_lib_deps) in
+    let rec close lib =
+      match Hashtbl.find_opt cache lib with
+      | Some r -> r
+      | None ->
+        Hashtbl.add cache lib Util.StringSet.empty;
+        let direct = match Util.StringMap.find_opt lib all_lib_deps with
+          | Some s -> s
+          | None -> Util.StringSet.empty
+        in
+        let closed = Util.StringSet.fold (fun dep acc ->
+          Util.StringSet.union (Util.StringSet.add dep (close dep)) acc
+        ) direct Util.StringSet.empty in
+        Hashtbl.replace cache lib closed;
+        closed
+    in
+    Util.StringMap.mapi (fun lib _ -> close lib) all_lib_deps
+  in
+
   let ss_pp fmt ss = Format.fprintf fmt "[%d]" (Util.StringSet.cardinal ss) in
   Logs.debug (fun m ->
       m "all_lib_deps: %a\n%!"


### PR DESCRIPTION
We've been missing some include paths when building docs for some packages. This doesn't affect other modes of odoc_driver as they go through `Packages.fix_missing_deps`.