### PR TITLE
Inline raise tag content in HTML rendering.

### DIFF
--- a/src/html/generator.ml
+++ b/src/html/generator.ml
@@ -209,7 +209,7 @@ let text_align = function
 
 let cell_kind = function `Header -> Html.th | `Data -> Html.td
 
-let rec block ~config ~resolve (l : Block.t) : flow Html.elt list =
+let rec block ?(inline_paragraph=false) ~config ~resolve (l : Block.t) : flow Html.elt list =
   let as_flow x = (x : phrasing Html.elt list :> flow Html.elt list) in
   let one (t : Block.one) =
     let mk_block ?(extra_class = []) mk content =
@@ -234,7 +234,7 @@ let rec block ~config ~resolve (l : Block.t) : flow Html.elt list =
     | Inline i ->
         if t.attr = [] then as_flow @@ inline ~config ~resolve i
         else mk_block Html.span (inline ~config ~resolve i)
-    | Paragraph i -> mk_block Html.p (inline ~config ~resolve i)
+    | Paragraph i -> if inline_paragraph then mk_block Html.span (inline ~config ~resolve i)  else mk_block Html.p (inline ~config ~resolve i)
     | List (typ, l) ->
         let mk = match typ with Ordered -> Html.ol | Unordered -> Html.ul in
         mk_block mk (List.map (fun x -> Html.li (block ~config ~resolve x)) l)
@@ -250,7 +250,9 @@ let rec block ~config ~resolve (l : Block.t) : flow Html.elt list =
               : phrasing Html.elt list
               :> flow Html.elt list)
           in
-          let def = block ~config ~resolve i.Description.definition in
+          let def =
+            block ~inline_paragraph:(i.attr = ["raises"])  ~config ~resolve i.Description.definition
+          in
           Html.li ~a (term @ (Html.txt " " :: def))
         in
         mk_block Html.ul (List.map item l)

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -311,7 +311,7 @@
    </ul>
    <ul class="at-tags">
     <li class="raises"><span class="at-tag">raises</span> 
-     <code>Failure</code> <p>always</p>
+     <code>Failure</code> <span>always</span>
     </li>
    </ul>
    <ul class="at-tags">

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -456,7 +456,7 @@
     <div class="spec-doc">
      <ul class="at-tags">
       <li class="raises"><span class="at-tag">raises</span> 
-       <code>Not_found</code> <p>That's all it does</p>
+       <code>Not_found</code> <span>That's all it does</span>
       </li>
      </ul>
     </div>
@@ -474,7 +474,7 @@
      <ul class="at-tags">
       <li class="raises"><span class="at-tag">raises</span> 
        <a href="#exception-Kaboom"><code>Kaboom</code></a> 
-       <p>That's all it does</p>
+       <span>That's all it does</span>
       </li>
      </ul>
     </div>

--- a/test/generators/html/Tag_link.html
+++ b/test/generators/html/Tag_link.html
@@ -34,7 +34,7 @@
    </ul>
    <ul class="at-tags">
     <li class="raises"><span class="at-tag">raises</span> <code>Foo</code>
-      <p><a href="#val-foo"><code>foo</code></a></p>
+      <span><a href="#val-foo"><code>foo</code></a></span>
     </li>
    </ul>
    <ul class="at-tags">


### PR DESCRIPTION
The fix is a bit ugly (`l.attr = [ "raises"]`) but I can easily remove this part by adding a field `should_inline` in the record definition of the type of `Odoc_document.Types.Description.t` to avoid relying on a fragile string comparison.

Should fix theses two issues:
- https://github.com/ocaml/odoc/issues/1136
- https://github.com/ocaml/odoc/issues/1198

cc @panglesd
