### PR TITLE
Make cram tests portable to OpenBSD

### DIFF
--- a/test/integration/depends.t/run.t
+++ b/test/integration/depends.t/run.t
@@ -4,7 +4,7 @@ Testing the depends command.
   $ ocamlc -c -bin-annot -I . -o lib_a.cmti a.mli
   $ ocamlc -c -bin-annot -I . -o lib_b.cmti b.mli
 
-  $ odoc compile-deps lib_b.cmti | grep -v "CamlinternalFormatBasics\|Stdlib\|Pervasives" | cut -d ' ' -f 1 | sort -u
+  $ odoc compile-deps lib_b.cmti | grep -v CamlinternalFormatBasics | grep -v Stdlib | grep -v Pervasives | cut -d ' ' -f 1 | sort -u
   Lib
   Lib_a
   Lib_b

--- a/test/sources/functor.t/run.t
+++ b/test/sources/functor.t/run.t
@@ -47,7 +47,7 @@ Verify the behavior on functors.
 
 In this test, the functor expansion contains the right link.
 
-  $ cat html/A/F/index.html | grep source_link -C 1
+  $ cat html/A/F/index.html | grep source_link --context=1
      <h1>Module <code><span>A.F</span></code>
       <a href="../../src/a.ml.html#module-F" class="source_link">Source</a>
      </h1>
@@ -65,7 +65,7 @@ In this test, the functor expansion contains the right link.
 
 However, on functor results, there is a link to source in the file:
 
-  $ cat html/B/R/index.html | grep source_link -C 2
+  $ cat html/B/R/index.html | grep source_link --context=2
     <header class="odoc-preamble">
      <h1>Module <code><span>B.R</span></code>
       <a href="../../src/b.ml.html#module-R" class="source_link">Source</a>
@@ -86,5 +86,5 @@ However, on functor results, there is a link to source in the file:
 
 Source links in functor parameters might not make sense. Currently we generate none:
 
-  $ cat html/A/F/argument-1-S/index.html | grep source_link -C 1
+  $ cat html/A/F/argument-1-S/index.html | grep source_link --context=1
   [1]

--- a/test/sources/functor.t/run.t
+++ b/test/sources/functor.t/run.t
@@ -47,7 +47,7 @@ Verify the behavior on functors.
 
 In this test, the functor expansion contains the right link.
 
-  $ cat html/A/F/index.html | grep source_link --context=1
+  $ cat html/A/F/index.html | grep source_link -C1
      <h1>Module <code><span>A.F</span></code>
       <a href="../../src/a.ml.html#module-F" class="source_link">Source</a>
      </h1>
@@ -65,7 +65,7 @@ In this test, the functor expansion contains the right link.
 
 However, on functor results, there is a link to source in the file:
 
-  $ cat html/B/R/index.html | grep source_link --context=2
+  $ cat html/B/R/index.html | grep source_link -C2
     <header class="odoc-preamble">
      <h1>Module <code><span>B.R</span></code>
       <a href="../../src/b.ml.html#module-R" class="source_link">Source</a>
@@ -86,5 +86,5 @@ However, on functor results, there is a link to source in the file:
 
 Source links in functor parameters might not make sense. Currently we generate none:
 
-  $ cat html/A/F/argument-1-S/index.html | grep source_link --context=1
+  $ cat html/A/F/argument-1-S/index.html | grep source_link -C1
   [1]

--- a/test/sources/include_in_expansion.t/run.t
+++ b/test/sources/include_in_expansion.t/run.t
@@ -26,7 +26,7 @@ Checking that source parents are kept, using include.
 In Main.A, the source parent of value x should be to Main__A, while the
 source parent of value y should be left to B.
 
-  $ grep source_link html/Main/A/index.html --contex=1
+  $ grep source_link html/Main/A/index.html -C1
      <h1>Module <code><span>Main.A</span></code>
       <a href="../../src/a.ml.html" class="source_link">Source</a>
      </h1>

--- a/test/sources/include_in_expansion.t/run.t
+++ b/test/sources/include_in_expansion.t/run.t
@@ -26,7 +26,7 @@ Checking that source parents are kept, using include.
 In Main.A, the source parent of value x should be to Main__A, while the
 source parent of value y should be left to B.
 
-  $ grep source_link html/Main/A/index.html -C 1
+  $ grep source_link html/Main/A/index.html --contex=1
      <h1>Module <code><span>Main.A</span></code>
       <a href="../../src/a.ml.html" class="source_link">Source</a>
      </h1>

--- a/test/sources/recursive_module.t/run.t
+++ b/test/sources/recursive_module.t/run.t
@@ -10,14 +10,14 @@ Checking that source links exists inside recursive modules.
 
 Both modules should contain source links
 
-  $ grep source_link html/Main/A/index.html --context=2
+  $ grep source_link html/Main/A/index.html -C2
     <header class="odoc-preamble">
      <h1>Module <code><span>Main.A</span></code>
       <a href="../../src/main.ml.html#module-A" class="source_link">Source</a>
      </h1>
     </header>
 
-  $ grep source_link html/Main/B/index.html --context=2
+  $ grep source_link html/Main/B/index.html -C2
     <header class="odoc-preamble">
      <h1>Module <code><span>Main.B</span></code>
       <a href="../../src/main.ml.html#module-B" class="source_link">Source</a>

--- a/test/sources/recursive_module.t/run.t
+++ b/test/sources/recursive_module.t/run.t
@@ -10,14 +10,14 @@ Checking that source links exists inside recursive modules.
 
 Both modules should contain source links
 
-  $ grep source_link html/Main/A/index.html -C 2
+  $ grep source_link html/Main/A/index.html --context=2
     <header class="odoc-preamble">
      <h1>Module <code><span>Main.A</span></code>
       <a href="../../src/main.ml.html#module-A" class="source_link">Source</a>
      </h1>
     </header>
 
-  $ grep source_link html/Main/B/index.html -C 2
+  $ grep source_link html/Main/B/index.html --context=2
     <header class="odoc-preamble">
      <h1>Module <code><span>Main.B</span></code>
       <a href="../../src/main.ml.html#module-B" class="source_link">Source</a>

--- a/test/xref2/github_issue_857.t/run.t
+++ b/test/xref2/github_issue_857.t/run.t
@@ -9,7 +9,11 @@ A quick test to repro the issue found in #857
   $ odoc latex-generate -o latex/ a.odocl
 
 In latex, labels in subpages should be disambiguated since the subpage is inlined inside the generated latex source.
-  $ cat latex/A.tex | sed 's/\\/\n\\/g' | grep label
+
+(Replace \\ with \n\ for readability)
+
+  $ awk '{ gsub("\\\\","\n\\",$0); print $0 }' < latex/A.tex > newlines.tex
+  $ grep label < newlines.tex
   \label{A}%
   \label{A--module-type-A}
   \label{A-module-type-A}

--- a/test/xref2/label_reference_text.t/run.t
+++ b/test/xref2/label_reference_text.t/run.t
@@ -13,7 +13,7 @@ A quick test to repro the issue found in #941
 
 The rendered html
 
-  $ cat html/Foo/index.html | grep "splice_me" -A 3
+  $ grep "splice_me" -A 3 < html/Foo/index.html | grep -v -- "--"
       <ul><li><a href="#splice_me">Splice me</a></li></ul>
      </nav>
     </div>


### PR DESCRIPTION
Since we got the OCaml-CI testing on OpenBSD and fixed the `jq` depext we are now running the tests mostly successfully on OpenBSD. The failures are mostly due to small discrepancies between the tools, e.g. they fail because the `-C <NUM>` syntax of GNU `grep` is unsupported. What is supported is `-C<NUM>` and `--context=<NUM>` so for clarity I've opted for the latter.

Also apparently OpenBSD `sed` does not interpret `\n` in sed patterns so I've swapped in `awk` instead.