### PR TITLE
Fix lower bound issue in CI

### DIFF
--- a/odoc.opam
+++ b/odoc.opam
@@ -49,7 +49,7 @@ depends: [
   "tyxml" {>= "4.4.0"}
   "fmt"
   "crunch" {>= "1.4.1"}
-  "ocamlfind" {with-test}
+  "ocamlfind" {>= "1.9.8" & with-test}
   "yojson" {>= "2.1.0" & with-test}
   "sexplib0" {with-test}
   "conf-jq" {with-test}
@@ -60,7 +60,6 @@ depends: [
 conflicts: [
   "ocaml-option-bytecode-only"
   "oxcaml-compiler" {< "5.2.0minus31"}
-  "ocamlfind" {< "1.9.8"}
 ]
 
 x-extra-doc-deps: [

--- a/odoc.opam
+++ b/odoc.opam
@@ -60,6 +60,7 @@ depends: [
 conflicts: [
   "ocaml-option-bytecode-only"
   "oxcaml-compiler" {< "5.2.0minus31"}
+  "ocamlfind" {< "1.9.8"}
 ]
 
 x-extra-doc-deps: [


### PR DESCRIPTION
Currently OCaml CI is succeeding to build with regular constraints (prefering newest versions) and failing to build on the lower-bound check ([example](https://ocaml.ci.dev/github/ocaml/odoc/commit/793f8385e755e9078ea8e6ce0d9cb456ad3f1c6e/variant/%28lower-bound%29)):

```
File "_none_", line 1:
Error (warning 58 [no-cmx-file]): no cmx file was found in path for module Fl_metascanner, and its interface was not compiled with -opaque
(cd _build/default && /home/opam/.opam/5.2/bin/ocamlopt.opt -short-paths -keep-locs -warn-error +a -g -w -18-53 -g -I src/driver/.odoc_driver_lib.objs/byte -I src/driver/.odoc_driver_lib.objs/native -I /home/opam/.opam/5.2/lib/astring -I /home/opam/.opam/5.2/lib/bigarray-compat -I /home/opam/.opam/5.2/lib/bigstringaf -I /home/opam/.opam/5.2/lib/bos -I /home/opam/.opam/5.2/lib/cmdliner -I /home/opam/.opam/5.2/lib/cstruct -I /home/opam/.opam/5.2/lib/domain-local-await -I /home/opam/.opam/5.2/lib/eio -I /home/opam/.opam/5.2/lib/eio/core -I /home/opam/.opam/5.2/lib/eio/runtime_events -I /home/opam/.opam/5.2/lib/eio/unix -I /home/opam/.opam/5.2/lib/eio/utils -I /home/opam/.opam/5.2/lib/eio_linux -I /home/opam/.opam/5.2/lib/eio_main -I /home/opam/.opam/5.2/lib/eio_posix -I /home/opam/.opam/5.2/lib/findlib -I /home/opam/.opam/5.2/lib/fmt -I /home/opam/.opam/5.2/lib/fpath -I /home/opam/.opam/5.2/lib/hmap -I /home/opam/.opam/5.2/lib/iomux -I /home/opam/.opam/5.2/lib/logs -I /home/opam/.opam/5.2/lib/lwt -I /home/opam/.opam/5.2/lib/lwt-dllist -I /home/opam/.opam/5.2/lib/mtime -I /home/opam/.opam/5.2/lib/mtime/clock -I /home/opam/.opam/5.2/lib/ocaml/runtime_events -I /home/opam/.opam/5.2/lib/ocaml/threads -I /home/opam/.opam/5.2/lib/ocaml/unix -I /home/opam/.opam/5.2/lib/ocamlgraph -I /home/opam/.opam/5.2/lib/opam-core -I /home/opam/.opam/5.2/lib/opam-file-format -I /home/opam/.opam/5.2/lib/opam-format -I /home/opam/.opam/5.2/lib/optint -I /home/opam/.opam/5.2/lib/parsexp -I /home/opam/.opam/5.2/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.2/lib/progress -I /home/opam/.opam/5.2/lib/progress/engine -I /home/opam/.opam/5.2/lib/psq -I /home/opam/.opam/5.2/lib/re -I /home/opam/.opam/5.2/lib/rresult -I /home/opam/.opam/5.2/lib/seq -I /home/opam/.opam/5.2/lib/sexplib -I /home/opam/.opam/5.2/lib/sexplib0 -I /home/opam/.opam/5.2/lib/stdlib-shims -I /home/opam/.opam/5.2/lib/terminal -I /home/opam/.opam/5.2/lib/uring -I /home/opam/.opam/5.2/lib/uucp -I /home/opam/.opam/5.2/lib/uutf -I /home/opam/.opam/5.2/lib/vector -I /home/opam/.opam/5.2/lib/yojson -cmi-file src/driver/.odoc_driver_lib.objs/byte/odoc_driver_lib__Ocamlfind.cmi -no-alias-deps -opaque -open Odoc_driver_lib -o src/driver/.odoc_driver_lib.objs/native/odoc_driver_lib__Ocamlfind.cmx -c -impl src/driver/ocamlfind.pp.ml)
File "_none_", line 1:
Error (warning 58 [no-cmx-file]): no cmx file was found in path for module Findlib, and its interface was not compiled with -opaque


File "_none_", line 1:
Error (warning 58 [no-cmx-file]): no cmx file was found in path for module Fl_metascanner, and its interface was not compiled with -opaque


File "_none_", line 1:
Error (warning 58 [no-cmx-file]): no cmx file was found in path for module Fl_package_base, and its interface was not compiled with -opaque
```

To be it looks like a packaging issue with `ocamlfind`. The lower bounds check uses 1.9.6 (failing) and the regular check uses 1.9.8 (succeeding); there is no 1.9.7 packaged in opam-repository.

Thus this PR aims to bump the version of `ocamlfind` to be used to at least `>= 1.9.8`.