### PR TITLE
driver: link units only against their actual lib deps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+- Support for OxCaml unboxed named types (@art-w, #1407)
+- Support for OxCaml zero alloc definitions (@Leonidas-from-XIV, #1422, #1444)
+- Remove requirement for ppx_expect in tests (@jonludlam, #1445)
+- Support for OxCaml modalities (@art-w, #1420)
+- Driver: link each unit only against its actual library dependencies, so
+  sibling libraries sharing module names (e.g. `eliom.server` / `eliom.client`)
+  no longer resolve references to the wrong sibling (@balat, #1449)
+
 # 3.2.1
 
 ### Fixed

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -56,12 +56,14 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
     let includes =
       List.concat_map dash_l (Util.StringSet.to_list lib_deps) |> List.map snd
     in
-    let libs =
-      List.fold_left
-        (fun acc lib -> Util.StringSet.add lib.Packages.lib_name acc)
-        lib_deps pkg.Packages.libraries
-    in
-    let libs = List.concat_map dash_l (Util.StringSet.to_list libs) in
+    (* Link only against this unit's actual library dependencies ([lib_deps]
+       already holds the unit's own library plus its declared deps). Adding
+       every library of the package put sibling libraries that neither depend on
+       each other nor share a dependency (e.g. eliom.server / eliom.client, two
+       libs with the SAME module names) on the link path, so a module defined in
+       both, typically a functor result like [Content.Html], resolved to the
+       wrong sibling. *)
+    let libs = List.concat_map dash_l (Util.StringSet.to_list lib_deps) in
     Pkg_args.v ~pages:[ own_page ] ~libs ~includes ~odoc_dir ~odocl_dir
   in
   let args_of_config config : Pkg_args.t =


### PR DESCRIPTION
The driver added every library of a package to each unit's link path (`-L`), not just the unit's own dependencies.

For a package with sibling libraries that share module names but do not depend on each other (for example `eliom.server` and `eliom.client`), both end up on the link path. A module defined in both, typically a functor result like `Content.Html`, then resolves to the wrong sibling: the client API ended up showing the server's `Content.Html`.

This builds the link path from `lib_deps` (the unit's own library plus its declared deps), like the `-I` includes already do.

Verified by hand on the Eliom packages, where the client and server libraries share module names.