### PR TITLE
Use `grep` CLI in a portable way

### DIFF
--- a/test/frontmatter/toc_order.t/run.t
+++ b/test/frontmatter/toc_order.t/run.t
@@ -70,7 +70,7 @@ Omitted has been added in the children of index, after the ones that were ordere
 Typo is in the children field of index, but does not exist. It is omitted to,
 but this should be a warning!
 
-  $ cat _html/pkg/index.html | grep odoc-global-toc -A 11
+  $ cat _html/pkg/index.html | grep -A11 odoc-global-toc
      <nav class="odoc-toc odoc-global-toc">
       <ul>
        <li><a href="#" class="current_unit">This is the main index</a>

--- a/test/roots_and_hierarchy/sidebar.t/run.t
+++ b/test/roots_and_hierarchy/sidebar.t/run.t
@@ -142,7 +142,7 @@ A json version of a sidebar can be obtained using the sidebar-generate command:
     }
   ]
 
-  $ cat html/pkg/index.html | grep odoc-global-toc -A 15
+  $ cat html/pkg/index.html | grep -A15 odoc-global-toc
      <nav class="odoc-toc odoc-global-toc">
       <ul>
        <li><a href="#" class="current_unit">Package <code>pkg</code></a>
@@ -160,7 +160,7 @@ A json version of a sidebar can be obtained using the sidebar-generate command:
          </li>
         </ul>
 
-  $ cat html/pkg/libname/Unit/X/index.html | grep odoc-global-toc -A 15
+  $ cat html/pkg/libname/Unit/X/index.html | grep -A15 odoc-global-toc
      <nav class="odoc-toc odoc-global-toc">
       <ul>
        <li><a href="../../../index.html">Package <code>pkg</code></a>

--- a/test/roots_and_hierarchy/sidebar_with_indexes.t/run.t
+++ b/test/roots_and_hierarchy/sidebar_with_indexes.t/run.t
@@ -28,7 +28,7 @@ Since -L subfolders are omitted from -P roots, the index page should not be adde
   $ odoc html-generate --indent --sidebar sidebar.odoc-sidebar -o html _odoc/pkg/libname/unit.odocl
   $ odoc html-generate --indent --sidebar sidebar.odoc-sidebar -o html _odoc/pkg/libname/page-index.odocl
 
-  $ cat html/pkg/index.html | grep odoc-global-toc -A 15
+  $ cat html/pkg/index.html | grep -A15 odoc-global-toc
      <nav class="odoc-toc odoc-global-toc">
       <ul>
        <li><a href="#" class="current_unit">Package <code>pkg</code></a>

--- a/test/sources/functor.t/run.t
+++ b/test/sources/functor.t/run.t
@@ -47,7 +47,7 @@ Verify the behavior on functors.
 
 In this test, the functor expansion contains the right link.
 
-  $ cat html/A/F/index.html | grep source_link -C1
+  $ cat html/A/F/index.html | grep -C1 source_link
      <h1>Module <code><span>A.F</span></code>
       <a href="../../src/a.ml.html#module-F" class="source_link">Source</a>
      </h1>
@@ -65,7 +65,7 @@ In this test, the functor expansion contains the right link.
 
 However, on functor results, there is a link to source in the file:
 
-  $ cat html/B/R/index.html | grep source_link -C2
+  $ cat html/B/R/index.html | grep -C2 source_link
     <header class="odoc-preamble">
      <h1>Module <code><span>B.R</span></code>
       <a href="../../src/b.ml.html#module-R" class="source_link">Source</a>
@@ -86,5 +86,5 @@ However, on functor results, there is a link to source in the file:
 
 Source links in functor parameters might not make sense. Currently we generate none:
 
-  $ cat html/A/F/argument-1-S/index.html | grep source_link -C1
+  $ cat html/A/F/argument-1-S/index.html | grep -C1 source_link
   [1]

--- a/test/sources/include_in_expansion.t/run.t
+++ b/test/sources/include_in_expansion.t/run.t
@@ -26,7 +26,7 @@ Checking that source parents are kept, using include.
 In Main.A, the source parent of value x should be to Main__A, while the
 source parent of value y should be left to B.
 
-  $ grep source_link html/Main/A/index.html -C1
+  $ grep -C1 source_link html/Main/A/index.html
      <h1>Module <code><span>Main.A</span></code>
       <a href="../../src/a.ml.html" class="source_link">Source</a>
      </h1>

--- a/test/sources/recursive_module.t/run.t
+++ b/test/sources/recursive_module.t/run.t
@@ -10,14 +10,14 @@ Checking that source links exists inside recursive modules.
 
 Both modules should contain source links
 
-  $ grep source_link html/Main/A/index.html -C2
+  $ grep -C2 source_link html/Main/A/index.html
     <header class="odoc-preamble">
      <h1>Module <code><span>Main.A</span></code>
       <a href="../../src/main.ml.html#module-A" class="source_link">Source</a>
      </h1>
     </header>
 
-  $ grep source_link html/Main/B/index.html -C2
+  $ grep -C2 source_link html/Main/B/index.html
     <header class="odoc-preamble">
      <h1>Module <code><span>Main.B</span></code>
       <a href="../../src/main.ml.html#module-B" class="source_link">Source</a>

--- a/test/sources/source.t/run.t
+++ b/test/sources/source.t/run.t
@@ -104,7 +104,7 @@ Compile the pages with the --source option:
 
 Source links generated in the documentation:
 
-  $ grep source_link html/A/index.html -B 2
+  $ grep -B2 source_link html/A/index.html
     <header class="odoc-preamble">
      <h1>Module <code><span>A</span></code>
       <a href="../src/a.ml.html" class="source_link">Source</a>

--- a/test/xref2/github_issue_342.t/run.t
+++ b/test/xref2/github_issue_342.t/run.t
@@ -9,7 +9,7 @@ A quick test to repro the issue found in #342
 
 The table of content:
 
-  $ cat html/Foo/index.html | grep "odoc-toc" -A 9
+  $ cat html/Foo/index.html | grep -A9 "odoc-toc"
     <div class="odoc-tocs">
      <nav class="odoc-toc odoc-local-toc">
       <ul>
@@ -24,7 +24,7 @@ The table of content:
 
 The rendered headings
 
-  $ cat html/Foo/index.html | grep "<h2" -A 3
+  $ cat html/Foo/index.html | grep -A3 "<h2"
      <h2 id="references--and-with-text-in-title">
       <a href="#references--and-with-text-in-title" class="anchor"></a>
       References <a href="A/index.html"><code>A</code></a> and 

--- a/test/xref2/github_issue_932.t/run.t
+++ b/test/xref2/github_issue_932.t/run.t
@@ -9,7 +9,7 @@ A quick test to repro the issue found in #941
 
 The rendered html
 
-  $ cat html/Foo/index.html | grep "extension" -A 3
+  $ cat html/Foo/index.html | grep -A3 "extension"
       <div class="spec type extension anchored" id="extension-decl-A">
        <a href="#extension-decl-A" class="anchor"></a>
        <code>

--- a/test/xref2/label_reference_text.t/run.t
+++ b/test/xref2/label_reference_text.t/run.t
@@ -13,7 +13,7 @@ A quick test to repro the issue found in #941
 
 The rendered html
 
-  $ grep "splice_me" -A 3 < html/Foo/index.html | grep -v -- "--"
+  $ grep -A3 "splice_me" < html/Foo/index.html | grep -v -- "--"
       <ul><li><a href="#splice_me">Splice me</a></li></ul>
      </nav>
     </div>

--- a/test/xref2/reference_to_polymorphic.t/run.t
+++ b/test/xref2/reference_to_polymorphic.t/run.t
@@ -11,7 +11,7 @@
   Warning: Failed to resolve reference unresolvedroot(On) Couldn't find "On"
 
   $ odoc html-generate -o html --indent main.odocl
-  $ cat html/Main/index.html | grep "<li>" -A 3
+  $ cat html/Main/index.html | grep -A3 "<li>"
      <ul><li><a href="#type-switch.On"><code>switch.`On</code></a></li>
       <li><a href="#type-switch.Off"><code>switch.`Off</code></a></li>
       <li><a href="#type-switch.On"><code>switch.`On</code></a></li>


### PR DESCRIPTION
OpenBSD keeps failing, because BSD grep can't take `grep <term> <options>` but needs `grep <options> term`. This PR fixes the failures. Also the `-A` `-B`, `-C` options don't accept spaces.

Followup to #1442.