### PR TITLE
Driver: Transitive deps in voodoo mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,14 @@
 # Unreleased
 
+### Added
 - Support for OxCaml unboxed named types (@art-w, #1407)
 - Support for OxCaml zero alloc definitions (@Leonidas-from-XIV, #1422, #1444)
 - Remove requirement for ppx_expect in tests (@jonludlam, #1445)
 - Support for OxCaml modalities (@art-w, #1420)
+
+### Fixed
+- Fixed missing transitive deps when driver is run in voodoo mode (@jonludlam,
+  #1457)
 
 # 3.2.1
 

--- a/src/driver/bin/odoc_driver_voodoo.ml
+++ b/src/driver/bin/odoc_driver_voodoo.ml
@@ -76,6 +76,24 @@ let run package_name blessed actions odoc_dir odocl_dir
 
   let all = Packages.remap_virtual [ all ] in
 
+  (* The META files only tell us a library's directly-declared requires, and
+     only for this package's own libraries. Dependencies reached solely through
+     a transitive META edge (e.g. [tyxml.functor], required by [tyxml] but not
+     by [eliom]) are therefore missing from the include paths, leaving their
+     modules unresolved. Recover them the same way the non-voodoo driver does,
+     with {!Packages.fix_missing_deps}, resolving module hashes against this
+     package's own modules merged with the module hashes recorded in the lib
+     markers of its already-compiled dependencies. *)
+  let all =
+    let lib_name_by_hash =
+      Util.StringMap.union
+        (fun _ a b -> Some (a @ b))
+        (Packages.lib_name_by_hash all)
+        extra_paths.Voodoo.lib_name_by_hash
+    in
+    Packages.fix_missing_deps_with lib_name_by_hash all
+  in
+
   let partial =
     match all with
     | [ p ] ->

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -303,23 +303,31 @@ let mk_mlds docs =
             { md_path = doc.file; md_rel_path = doc.rel_path } :: others ))
     ([], [], []) docs
 
-let fix_missing_deps pkgs =
-  let lib_name_by_hash =
-    List.fold_right
-      (fun pkg acc ->
-        List.fold_left
-          (fun acc lib ->
-            List.fold_left
-              (fun acc m ->
-                Util.StringMap.update m.m_intf.mif_hash
-                  (function
-                    | None -> Some [ lib.lib_name ]
-                    | Some l -> Some (lib.lib_name :: l))
-                  acc)
-              acc lib.modules)
-          acc pkg.libraries)
-      pkgs Util.StringMap.empty
-  in
+(* Map from a module's interface hash to the name(s) of the library(ies) that
+   provide it. This is the raw material [fix_missing_deps] uses to recover
+   library dependencies that a package's META files fail to declare. *)
+let lib_name_by_hash pkgs =
+  List.fold_right
+    (fun pkg acc ->
+      List.fold_left
+        (fun acc lib ->
+          List.fold_left
+            (fun acc m ->
+              Util.StringMap.update m.m_intf.mif_hash
+                (function
+                  | None -> Some [ lib.lib_name ]
+                  | Some l -> Some (lib.lib_name :: l))
+                acc)
+            acc lib.modules)
+        acc pkg.libraries)
+    pkgs Util.StringMap.empty
+
+(* Like [fix_missing_deps] but with a caller-supplied [lib_name_by_hash]. In
+   voodoo mode the dependencies' modules aren't loaded in memory, so the map is
+   assembled from the lib markers written alongside their odoc files (see
+   {!Voodoo.write_lib_markers}) and merged with the current package's own
+   modules. *)
+let fix_missing_deps_with lib_name_by_hash pkgs =
   List.map
     (fun pkg ->
       let libraries =
@@ -363,6 +371,8 @@ let fix_missing_deps pkgs =
       in
       { pkg with libraries })
     pkgs
+
+let fix_missing_deps pkgs = fix_missing_deps_with (lib_name_by_hash pkgs) pkgs
 
 let of_libs ~packages_dir libs =
   let Ocamlfind.Db.

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -91,6 +91,17 @@ val pp : Format.formatter -> t -> unit
 
 val fix_missing_deps : t list -> t list
 
+val lib_name_by_hash : t list -> string list Util.StringMap.t
+(** [lib_name_by_hash pkgs] maps each module interface hash to the name(s) of
+    the library(ies) in [pkgs] providing a module with that hash. *)
+
+val fix_missing_deps_with : string list Util.StringMap.t -> t list -> t list
+(** [fix_missing_deps_with lib_name_by_hash pkgs] is like {!fix_missing_deps}
+    but resolves module hashes against the supplied map rather than only the
+    modules present in [pkgs]. Used in voodoo mode, where the dependencies'
+    modules aren't loaded but their hashes are available from the lib markers
+    written by {!Voodoo.write_lib_markers}. *)
+
 val mk_mlds : Opam.doc_file list -> mld list * asset list * md list
 
 val of_libs : packages_dir:Fpath.t option -> Util.StringSet.t -> t list

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -333,8 +333,7 @@ let read_lib_hashes libname marker_path acc =
           | Some (hash, _module_name) when is_hex_digest hash ->
               Util.StringMap.update hash
                 (function
-                  | None -> Some [ libname ]
-                  | Some l -> Some (libname :: l))
+                  | None -> Some [ libname ] | Some l -> Some (libname :: l))
                 acc
           | _ -> acc)
         acc lines

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -302,6 +302,7 @@ type extra_paths = {
   pkgs : Fpath.t Util.StringMap.t;
   libs : Fpath.t Util.StringMap.t;
   libs_of_pkg : string list Util.StringMap.t;
+  lib_name_by_hash : string list Util.StringMap.t;
 }
 
 let empty_extra_paths =
@@ -309,7 +310,34 @@ let empty_extra_paths =
     pkgs = Util.StringMap.empty;
     libs = Util.StringMap.empty;
     libs_of_pkg = Util.StringMap.empty;
+    lib_name_by_hash = Util.StringMap.empty;
   }
+
+(* Parse a lib marker written by {!write_lib_markers} and fold its
+   "<digest> <module>" lines into [acc], mapping each digest to [libname]. Only
+   lines whose first token is a 32-char hex MD5 digest are accepted, so markers
+   written by older drivers (a prose sentence) are ignored. *)
+let read_lib_hashes libname marker_path acc =
+  let is_hex_digest s =
+    String.length s = 32
+    && String.for_all
+         (fun c -> (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))
+         s
+  in
+  match Bos.OS.File.read_lines marker_path with
+  | Error _ -> acc
+  | Ok lines ->
+      List.fold_left
+        (fun acc line ->
+          match Astring.String.cut ~sep:" " line with
+          | Some (hash, _module_name) when is_hex_digest hash ->
+              Util.StringMap.update hash
+                (function
+                  | None -> Some [ libname ]
+                  | Some l -> Some (libname :: l))
+                acc
+          | _ -> acc)
+        acc lines
 
 let extra_paths compile_dir =
   let contents =
@@ -322,41 +350,51 @@ let extra_paths compile_dir =
       (function None -> Some [ libname ] | Some l -> Some (libname :: l))
       libs_of_pkg
   in
-  let pkgs, libs, libs_of_pkg =
+  let pkgs, libs, libs_of_pkg, lib_name_by_hash =
     match contents with
     | Error _ ->
-        (Util.StringMap.empty, Util.StringMap.empty, Util.StringMap.empty)
+        ( Util.StringMap.empty,
+          Util.StringMap.empty,
+          Util.StringMap.empty,
+          Util.StringMap.empty )
     | Ok c ->
         List.fold_left
-          (fun (pkgs, libs, libs_of_pkg) abs_path ->
+          (fun (pkgs, libs, libs_of_pkg, lnbh) abs_path ->
             let path = Fpath.rem_prefix compile_dir abs_path |> Option.get in
             match Fpath.segs path with
             | [ "p"; pkg; _version; "doc"; libname; l ] when l = lib_marker ->
                 Logs.debug (fun m -> m "Found lib marker: %a" Fpath.pp path);
                 ( pkgs,
                   Util.StringMap.add libname (Fpath.parent path) libs,
-                  add_libs pkg libname libs_of_pkg )
+                  add_libs pkg libname libs_of_pkg,
+                  read_lib_hashes libname abs_path lnbh )
             | [ "p"; pkg; _version; "doc"; l ] when l = pkg_marker ->
                 Logs.debug (fun m -> m "Found pkg marker: %a" Fpath.pp path);
                 ( Util.StringMap.add pkg (Fpath.parent path) pkgs,
                   libs,
-                  libs_of_pkg )
+                  libs_of_pkg,
+                  lnbh )
             | [ "u"; _universe; pkg; _version; "doc"; libname; l ]
               when l = lib_marker ->
                 Logs.debug (fun m -> m "Found lib marker: %a" Fpath.pp path);
                 ( pkgs,
                   Util.StringMap.add libname (Fpath.parent path) libs,
-                  add_libs pkg libname libs_of_pkg )
+                  add_libs pkg libname libs_of_pkg,
+                  read_lib_hashes libname abs_path lnbh )
             | [ "u"; _universe; pkg; _version; "doc"; l ] when l = pkg_marker ->
                 Logs.debug (fun m -> m "Found pkg marker: %a" Fpath.pp path);
                 ( Util.StringMap.add pkg (Fpath.parent path) pkgs,
                   libs,
-                  libs_of_pkg )
-            | _ -> (pkgs, libs, libs_of_pkg))
-          (Util.StringMap.empty, Util.StringMap.empty, Util.StringMap.empty)
+                  libs_of_pkg,
+                  lnbh )
+            | _ -> (pkgs, libs, libs_of_pkg, lnbh))
+          ( Util.StringMap.empty,
+            Util.StringMap.empty,
+            Util.StringMap.empty,
+            Util.StringMap.empty )
           c
   in
-  { pkgs; libs; libs_of_pkg }
+  { pkgs; libs; libs_of_pkg; lib_name_by_hash }
 
 let write_lib_markers odoc_dir pkgs =
   let write file str =
@@ -380,10 +418,21 @@ let write_lib_markers odoc_dir pkgs =
         (fun (lib : Packages.libty) ->
           let lib_dir = Odoc_unit.lib_dir pkg lib in
           let marker = Fpath.(odoc_dir // lib_dir / lib_marker) in
-          write marker
-            (Fmt.str
-               "This marks this directory as the location of odoc files for \
-                library %s in package %s"
-               lib.lib_name pkg.name))
+          (* The marker also records module hashes: one "<digest> <module>"
+             line per module in the library. A dependent package reads these in
+             {!extra_paths} to recover which library provides a given module
+             hash, so that {!Packages.fix_missing_deps_with} can add include
+             paths for dependencies that the META files fail to declare (e.g.
+             [tyxml.functor], reached only through [tyxml]'s own META). *)
+          let contents =
+            List.filter_map
+              (fun (m : Packages.modulety) ->
+                let hash = m.m_intf.Packages.mif_hash in
+                if String.length hash = 0 then None
+                else Some (Fmt.str "%s %s" hash m.m_name))
+              lib.modules
+            |> String.concat "\n"
+          in
+          write marker contents)
         libs)
     pkgs

--- a/src/driver/voodoo.mli
+++ b/src/driver/voodoo.mli
@@ -17,6 +17,10 @@ type extra_paths = {
   pkgs : Fpath.t Util.StringMap.t;
   libs : Fpath.t Util.StringMap.t;
   libs_of_pkg : string list Util.StringMap.t;
+  lib_name_by_hash : string list Util.StringMap.t;
+      (** Maps a module interface hash to the name(s) of the previously-compiled
+          library(ies) providing it, read from the lib markers written by
+          {!write_lib_markers}. Consumed by {!Packages.fix_missing_deps_with}. *)
 }
 
 val empty_extra_paths : extra_paths

--- a/src/driver/voodoo.mli
+++ b/src/driver/voodoo.mli
@@ -20,7 +20,8 @@ type extra_paths = {
   lib_name_by_hash : string list Util.StringMap.t;
       (** Maps a module interface hash to the name(s) of the previously-compiled
           library(ies) providing it, read from the lib markers written by
-          {!write_lib_markers}. Consumed by {!Packages.fix_missing_deps_with}. *)
+          {!write_lib_markers}. Consumed by {!Packages.fix_missing_deps_with}.
+      *)
 }
 
 val empty_extra_paths : extra_paths


### PR DESCRIPTION
When in voodoo mode, we only have access to one packages META files. Finding dependencies from this meant that we only had direct deps, not transitive deps. This fixes that problem by recording the module hashes in the stamp files we drop per library, then using the pre-existing function that adds missing dependencies via the hash.