### PR TITLE
Remove code for OCaml < 4.08

### DIFF
--- a/sherlodoc.opam
+++ b/sherlodoc.opam
@@ -9,7 +9,7 @@ doc: "https://ocaml.github.io/odoc/"
 bug-reports: "https://github.com/ocaml/odoc/issues"
 depends: [
   "dune" {>= "3.21"}
-  "ocaml" {>= "4.0.8"}
+  "ocaml" {>= "4.08.0"}
   "odoc" {= version}
   "base64" {>= "3.5.1"}
   "bigstringaf" {>= "0.9.1"}

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -100,16 +100,7 @@ let opt_iter f = function
 
 let read_label lbl =
   let open TypeExpr in
-#if OCAML_VERSION < (4,3,0)
-  (* NOTE(@ostera): 4.02 does not have an Asttypes variant for whether the
-   * label exists, and is an optional label or not, so I went back to string
-   * manipulation *)
-  if String.length lbl == 0
-  then None
-  else match String.get lbl 0 with
-      | '?' -> Some (Optional (String.sub lbl 1 (String.length lbl - 1)))
-      | _ -> Some (Label lbl)
-#elif defined OXCAML
+#if defined OXCAML
   match lbl with
   | Types.Nolabel -> None
   | Types.Labelled s -> Some (Label s)
@@ -396,9 +387,6 @@ let prepare_type_parameters params manifest =
 
 (* NOTE(@ostera): constructor with inlined records were introduced post 4.02 *)
 let mark_constructor_args =
-#if OCAML_VERSION < (4,3,0)
-  List.iter mark_type
-#else
   function
 #if defined OXCAML
    | Cstr_tuple args -> List.iter (fun carg -> mark_type carg.ca_type) args
@@ -406,7 +394,6 @@ let mark_constructor_args =
    | Cstr_tuple args -> List.iter mark_type args
 #endif
    | Cstr_record lds -> List.iter (fun ld -> mark_type ld.ld_type) lds
-#endif
 
 let mark_type_kind = function
 #if OCAML_VERSION >= (5,2,0)
@@ -857,12 +844,6 @@ let read_label_declaration env parent ld =
   {id; doc; mutable_; type_; modalities}
 
 let read_constructor_declaration_arguments env parent arg =
-#if OCAML_VERSION < (4,3,0)
-  (* NOTE(@ostera): constructor with inlined records were introduced post 4.02
-     so it's safe to use Tuple here *)
-  ignore parent;
-  TypeDecl.Constructor.Tuple(List.map (fun x -> read_type_expr env x, []) arg)
-#else
   let open TypeDecl.Constructor in
     match arg with
     | Cstr_tuple args ->
@@ -876,7 +857,6 @@ let read_constructor_declaration_arguments env parent arg =
         Tuple args_with_modalities
     | Cstr_record lds ->
         Record (List.map (read_label_declaration env parent) lds)
-#endif
 
 let read_constructor_declaration env parent cd =
   let open TypeDecl.Constructor in

--- a/src/loader/cmi.mli
+++ b/src/loader/cmi.mli
@@ -31,9 +31,7 @@ val read_interface :
   Odoc_model.Compat.signature ->
   Paths.Identifier.RootModule.t * Odoc_model.Lang.Signature.t
 
-#if OCAML_VERSION < (4,3,0)
-val read_label : Asttypes.label -> Odoc_model.Lang.TypeExpr.label option
-#elif defined OXCAML
+#if defined OXCAML
 val read_label : Types.arg_label -> Odoc_model.Lang.TypeExpr.label option
 #else
 val read_label : Asttypes.arg_label -> Odoc_model.Lang.TypeExpr.label option

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -113,7 +113,7 @@ let rec read_pattern env parent doc id_attrs pat =
         read_pattern env parent doc id_attrs pat
     | Tpat_lazy pat ->
         read_pattern env parent doc id_attrs pat
-#if OCAML_VERSION >= (4,8,0) && OCAML_VERSION < (4,11,0)
+#if OCAML_VERSION < (4,11,0)
     | Tpat_exception pat ->
         read_pattern env parent doc pat
 #endif
@@ -244,9 +244,7 @@ and read_class_signature env parent params cltyp =
         Signature {self; items; doc}
 
     | Tcty_arrow _ -> assert false
-#if OCAML_VERSION >= (4,6,0)
     | Tcty_open _ -> assert false
-#endif
 
 let rec read_class_type env parent params cty =
   let open Class in
@@ -258,11 +256,7 @@ let rec read_class_type env parent params cty =
       let arg = read_core_type env arg in
       let res = read_class_type env parent params res in
         Arrow(lbl, arg, res)
-#if OCAML_VERSION >= (4,8,0)
   | Tcty_open (_, cty) -> read_class_type env parent params cty
-#elif OCAML_VERSION >= (4,6,0)
-  | Tcty_open (_, _, _, _, cty) -> read_class_type env parent params cty
-#endif
 
 
 let rec read_class_field env parent cf =
@@ -343,11 +337,7 @@ and read_class_structure env parent params cl =
     | Tcl_constraint(cl, None, _, _, _) -> read_class_structure env parent params cl
     | Tcl_constraint(_, Some cltyp, _, _, _) ->
         read_class_signature env parent params cltyp
-#if OCAML_VERSION >= (4,8,0)
     | Tcl_open (_, cl) -> read_class_structure env parent params cl
-#elif OCAML_VERSION >= (4,6,0)
-    | Tcl_open (_, _, _, _, cl) -> read_class_structure env parent params cl
-#endif
 
 
 let rec read_class_expr env parent params cl =
@@ -368,11 +358,7 @@ let rec read_class_expr env parent params cl =
       read_class_expr env parent params cl
   | Tcl_constraint(_, Some cltyp, _, _, _) ->
       read_class_type env parent params cltyp
-#if OCAML_VERSION >= (4,8,0)
     | Tcl_open (_, cl) -> read_class_expr env parent params cl
-#elif OCAML_VERSION >= (4,6,0)
-    | Tcl_open (_, _, _, _, cl) -> read_class_expr env parent params cl
-#endif
 
 let read_class_declaration env parent cld =
   let open Class in
@@ -546,27 +532,18 @@ and read_structure_item env parent item =
         read_value_bindings env parent vbs
     | Tstr_primitive vd ->
         [Cmti.read_value_description env parent vd]
-#if OCAML_VERSION < (4,3,0)
-    | Tstr_type (decls) ->
-      let rec_flag = Ordinary in
-#else
     | Tstr_type (rec_flag, decls) ->
       let rec_flag =
         match rec_flag with
         | Recursive -> Ordinary
         | Nonrecursive -> Nonrec
       in
-#endif
       Cmti.read_type_declarations env parent rec_flag decls
     | Tstr_typext tyext ->
         [TypExt (read_type_extension env parent tyext)]
     | Tstr_exception ext ->
         let ext =
-#if OCAML_VERSION >= (4,8,0)
           Cmi.read_exception env parent ext.tyexn_constructor.ext_id ext.tyexn_constructor.ext_type
-#else
-          Cmi.read_exception env parent ext.ext_id ext.ext_type
-#endif
         in
           [Exception ext]
     | Tstr_module mb -> begin
@@ -584,14 +561,7 @@ and read_structure_item env parent item =
     | Tstr_include incl ->
         read_include env parent incl
     | Tstr_class cls ->
-        let cls = List.map
-#if OCAML_VERSION < (4,3,0)
-          (* NOTE(@ostera): remember the virtual flag was removed post 4.02 *)
-          (fun (cl, _, _) -> cl)
-#else
-          (fun (cl, _) -> cl)
-#endif
-          cls in
+        let cls = List.map (fun (cl, _) -> cl) cls in
           read_class_declarations env parent cls
     | Tstr_class_type cltyps ->
         let cltyps = List.map (fun (_, _, clty) -> clty) cltyps in
@@ -639,11 +609,7 @@ and read_include env parent incl =
 and read_open env parent o =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag ~warnings_tag:env.warnings_tag container o.open_attributes in
-  #if OCAML_VERSION >= (4,8,0)
   let signature = o.open_bound_items in
-  #else
-  let signature = [] in
-  #endif
   let expansion, _ = Cmi.read_signature_noenv env parent (Odoc_model.Compat.signature signature) in
   Open.{expansion; doc}
 

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -58,21 +58,7 @@ let rec read_core_type env container ctyp =
     | Ttyp_arrow(lbl, arg, res) ->
 #endif
         let lbl = read_label lbl in
-#if OCAML_VERSION < (4,3,0)
-        (* NOTE(@ostera): Unbox the optional value for this optional labelled
-           argument since the 4.02.x representation includes it explicitly. *)
-        let arg = match lbl with
-          | None | Some(Label(_)) -> read_core_type env container arg
-          | Some(Optional(_)) | Some(RawOptional(_)) ->
-              let arg' = match arg.ctyp_desc with
-                | Ttyp_constr(_, _, param :: _) -> param
-                | _ -> arg
-              in
-              read_core_type env container arg'
-#else
-        let arg = read_core_type env container arg
-#endif
-        in
+        let arg = read_core_type env container arg in
         let res = read_core_type env container res in
           Arrow(lbl, arg, res)
     | Ttyp_tuple typs ->
@@ -95,18 +81,6 @@ let rec read_core_type env container ctyp =
         let open TypeExpr.Object in
         let fields =
           List.map
-#if OCAML_VERSION < (4,6,0)
-            (fun (name, _, typ) ->
-              Method {name; type_ = read_core_type env container typ})
-#elif OCAML_VERSION < (4,8,0)
-            (function
-              | OTtag (name, _, typ) ->
-                Method {
-                  name = name.txt;
-                  type_ = read_core_type env container typ;
-                }
-              | OTinherit typ -> Inherit (read_core_type env container typ))
-#else
             (function
               | {of_desc=OTtag (name, typ); _} ->
                 Method {
@@ -114,7 +88,6 @@ let rec read_core_type env container ctyp =
                   type_ = read_core_type env container typ;
                 }
               | {of_desc=OTinherit typ; _} -> Inherit (read_core_type env container typ))
-#endif
             methods
         in
           Object {fields; open_ = (closed = Asttypes.Open)}
@@ -144,19 +117,11 @@ let rec read_core_type env container ctyp =
         let open TypeExpr.Polymorphic_variant in
         let elements =
           fields |> List.map begin fun field ->
-#if OCAML_VERSION >= (4,8,0)
             match field.rf_desc with
               | Ttag(name, constant, arguments) ->
                 let attributes = field.rf_attributes in
-#else
-            match field with
-              | Ttag(name, attributes, constant, arguments) ->
-#endif
-                let arguments =
-                  List.map (read_core_type env container) arguments in
-#if OCAML_VERSION >= (4,6,0)
-                  let name = name.txt in
-#endif
+                let arguments = List.map (read_core_type env container) arguments in
+                let name = name.txt in
                 let doc = Doc_attr.attached_no_tag ~warnings_tag:env.warnings_tag container attributes in
                 Constructor {name; constant; arguments; doc}
               | Tinherit typ -> Type (read_core_type env container typ)
@@ -322,10 +287,6 @@ let read_unboxed_label_declaration env parent label_parent ld =
 
 let read_constructor_declaration_arguments env parent label_parent arg =
   let open TypeDecl.Constructor in
-#if OCAML_VERSION < (4,3,0)
-  ignore parent;
-  Tuple (List.map (fun x -> read_core_type env label_parent x, []) arg)
-#else
   match arg with
   | Cstr_tuple args ->
       let args =
@@ -338,7 +299,6 @@ let read_constructor_declaration_arguments env parent label_parent arg =
       Tuple args
   | Cstr_record lds ->
       Record (List.map (read_label_declaration env parent label_parent) lds)
-#endif
 
 let read_constructor_declaration env parent cd =
   let open TypeDecl.Constructor in
@@ -434,10 +394,8 @@ let read_type_declarations env parent rec_flag decls =
   in
     List.rev items
 
-#if OCAML_VERSION >= (4,8,0)
 let read_type_substitutions env parent decls =
   List.map (fun decl -> Odoc_model.Lang.Signature.TypeSubstitution (read_type_declaration env parent decl)) decls
-#endif
 
 let read_extension_constructor env parent ext =
   let open Extension.Constructor in
@@ -561,11 +519,7 @@ and read_class_signature env parent label_parent cltyp =
         in
         Signature {self; items; doc}
     | Tcty_arrow _ -> assert false
-#if OCAML_VERSION >= (4,8,0)
   | Tcty_open (_, cty) -> read_class_signature env parent label_parent cty
-#elif OCAML_VERSION >= (4,6,0)
-  | Tcty_open (_, _, _, _, cty) -> read_class_signature env parent label_parent cty
-#endif
 
 let read_class_type_declaration env parent cltd =
   let open ClassType in
@@ -600,11 +554,7 @@ let rec read_class_type env parent label_parent cty =
     let arg = read_core_type env label_parent arg in
     let res = read_class_type env parent label_parent res in
         Arrow(lbl, arg, res)
-#if OCAML_VERSION >= (4,8,0)
   | Tcty_open (_, cty) -> read_class_type env parent label_parent cty
-#elif OCAML_VERSION >= (4,6,0)
-  | Tcty_open (_, _, _, _, cty) -> read_class_type env parent label_parent cty
-#endif
 
 let read_class_description env parent cld =
   let open Class in
@@ -854,26 +804,17 @@ and read_signature_item env parent item =
     match item.sig_desc with
     | Tsig_value vd ->
         [read_value_description env parent vd]
-#if OCAML_VERSION < (4,3,0)
-    | Tsig_type decls ->
-      let rec_flag = Ordinary in
-#else
     | Tsig_type (rec_flag, decls) ->
       let rec_flag =
         match rec_flag with
         | Recursive -> Ordinary
         | Nonrecursive -> Nonrec
       in
-#endif
       read_type_declarations env parent rec_flag decls
     | Tsig_typext tyext ->
         [TypExt (read_type_extension env parent tyext)]
     | Tsig_exception ext ->
-#if OCAML_VERSION >= (4,8,0)
         [Exception (read_exception env parent ext.tyexn_constructor)]
-#else
-        [Exception (read_exception env parent ext)]
-#endif
     | Tsig_module md -> begin
         match read_module_declaration env parent md with
         | Some m -> [Module (Ordinary, m)]
@@ -903,7 +844,6 @@ and read_signature_item env parent item =
           | None -> []
           | Some doc -> [Comment doc]
       end
-#if OCAML_VERSION >= (4,8,0)
     | Tsig_typesubst tst ->
         read_type_substitutions env parent tst
     | Tsig_modsubst mst ->
@@ -939,7 +879,6 @@ and read_module_type_substitution env parent mtd =
 #endif
 
 
-#endif
 
 and read_include env parent incl =
   let open Include in
@@ -972,11 +911,7 @@ and read_include env parent incl =
 and read_open env parent o =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container ~warnings_tag:env.warnings_tag o.open_attributes in
-  #if OCAML_VERSION >= (4,8,0)
   let signature = o.open_bound_items in
-  #else
-  let signature = [] in
-  #endif
   let expansion, _ = Cmi.read_signature_noenv env parent (Odoc_model.Compat.signature signature) in
   { expansion; doc }
 

--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -35,9 +35,7 @@ let empty warnings_tag : Odoc_model.Comment.docs = empty_body warnings_tag
 
 let load_constant_string = function
   | {Parsetree.pexp_desc =
-#if OCAML_VERSION < (4,3,0)
-     Pexp_constant (Const_string (text, _))
-#elif OCAML_VERSION < (4,11,0)
+#if OCAML_VERSION < (4,11,0)
      Pexp_constant (Pconst_string (text, _))
 #elif OCAML_VERSION < (5,3,0)
      Pexp_constant (Pconst_string (text, _, _))
@@ -65,14 +63,9 @@ let load_alert_name_and_payload = function
       | _ -> None)
   | _ -> None
 
-#if OCAML_VERSION >= (4,8,0)
 let attribute_unpack = function
   | { Parsetree.attr_name = { Location.txt = name; _ }; attr_payload; attr_loc } ->
       (name, attr_payload, attr_loc)
-#else
-let attribute_unpack = function
-  | { Location.txt = name; loc }, attr_payload -> (name, attr_payload, loc)
-#endif
 
 #if defined OXCAML
 (* the input is a [Zero_alloc.t] which is not present in OCaml, so it can't be

--- a/src/loader/ident_env.ml
+++ b/src/loader/ident_env.ml
@@ -196,22 +196,16 @@ and extract_signature_type_items_skip vis item rest =
   | Sig_class _, _
   | Sig_class_type _, _ -> assert false
 
-#if OCAML_VERSION >= (4,8,0)
 
 let extract_extended_open o =
   let open Typedtree in
   extract_signature_type_items Hidden (Compat.signature o.open_bound_items)
-#endif
 
 
 let rec extract_signature_tree_items : bool -> Typedtree.signature_item list -> items list = fun hide_item items ->
   let open Typedtree in
   match items with
-#if OCAML_VERSION < (4,3,0)
-  | { sig_desc = Tsig_type decls; _} :: rest ->
-#else
   | { sig_desc = Tsig_type (_, decls); _} :: rest ->
-#endif
     Odoc_utils.List.concat_map (fun decl ->
       if Btype.is_row_name (Ident.name decl.typ_id)
       then []
@@ -231,11 +225,7 @@ let rec extract_signature_tree_items : bool -> Typedtree.signature_item list -> 
           )
       decls @ extract_signature_tree_items hide_item rest
 
-#if OCAML_VERSION < (4,8,0)
-    | { sig_desc = Tsig_exception tyexn_constructor; _ } :: rest ->
-#else
     | { sig_desc = Tsig_exception { tyexn_constructor; _ }; _ } :: rest ->
-#endif
        `Exception (tyexn_constructor.ext_id, Some tyexn_constructor.ext_loc) :: extract_signature_tree_items hide_item rest
 
   | { sig_desc = Tsig_typext { tyext_constructors; _ }; _} :: rest ->
@@ -279,9 +269,7 @@ let rec extract_signature_tree_items : bool -> Typedtree.signature_item list -> 
       List.map
         (fun cld ->
             let typehash =
-#if OCAML_VERSION < (4,4,0)
-            Some cld.ci_id_typesharp
-#elif OCAML_VERSION < (5,1,0)
+#if OCAML_VERSION < (5,1,0)
             Some cld.ci_id_typehash
 #else
             None
@@ -293,9 +281,7 @@ let rec extract_signature_tree_items : bool -> Typedtree.signature_item list -> 
     List.map
       (fun clty ->
           let typehash =
-#if OCAML_VERSION < (4,4,0)
-            Some clty.ci_id_typesharp
-#elif OCAML_VERSION < (5,1,0)
+#if OCAML_VERSION < (5,1,0)
             Some clty.ci_id_typehash
 #else
             None
@@ -304,13 +290,11 @@ let rec extract_signature_tree_items : bool -> Typedtree.signature_item list -> 
             
             `ClassType (clty.ci_id_class_type, clty.ci_id_object, typehash, hide_item, Some clty.ci_id_name.loc))
               cltyps @ extract_signature_tree_items hide_item rest
-#if OCAML_VERSION >= (4,8,0)
     | { sig_desc = Tsig_modsubst ms; sig_loc; _ } :: rest ->
       [`Module (ms.ms_id, hide_item, Some sig_loc )] @ extract_signature_tree_items hide_item rest
     | { sig_desc = Tsig_typesubst ts; sig_loc; _} :: rest ->
       List.map (fun decl -> `Type (decl.typ_id, hide_item, Some sig_loc)) 
         ts @ extract_signature_tree_items hide_item rest
-#endif
 #if OCAML_VERSION >= (4,13,0)
     | { sig_desc = Tsig_modtypesubst mtd; sig_loc; _ } :: rest ->
       [`ModuleType (mtd.mtd_id, hide_item, Some sig_loc)] @ extract_signature_tree_items hide_item rest
@@ -377,7 +361,7 @@ let rec read_pattern hide_item pat =
   | Tpat_variant(_, Some pat, _)
   | Tpat_lazy pat -> read_pattern hide_item pat
   | Tpat_any | Tpat_constant _ | Tpat_variant(_, None, _) -> []
-#if OCAML_VERSION >= (4,8,0) && OCAML_VERSION < (4,11,0)
+#if OCAML_VERSION < (4,11,0)
   | Tpat_exception pat -> read_pattern hide_item pat
 #endif
 #if defined OXCAML
@@ -388,11 +372,7 @@ let rec read_pattern hide_item pat =
 let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> items list = fun hide_item items ->
   let open Typedtree in
     match items with
-#if OCAML_VERSION < (4,3,0)
-    | { str_desc = Tstr_type decls; _ } :: rest ->
-#else
     | { str_desc = Tstr_type (_, decls); _ } :: rest -> (* TODO: handle rec_flag *)
-#endif
   Odoc_utils.List.concat_map (fun decl ->
       `Type (decl.typ_id, hide_item, Some decl.typ_loc) ::
         (match decl.typ_kind with
@@ -409,22 +389,14 @@ let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> 
           ))
            decls @ extract_structure_tree_items hide_item rest
 
-#if OCAML_VERSION < (4,8,0)
-    | { str_desc = Tstr_exception tyexn_constructor; _ } :: rest ->
-#else
     | { str_desc = Tstr_exception { tyexn_constructor; _ }; _ } :: rest ->
-#endif
        `Exception (tyexn_constructor.ext_id, Some tyexn_constructor.ext_loc) :: extract_structure_tree_items hide_item rest
 
   | { str_desc = Tstr_typext { tyext_constructors; _ }; _} :: rest ->
     let x = List.map (fun { ext_id; ext_loc; _ } -> `Extension (ext_id, Some ext_loc)) tyext_constructors in
     x @ extract_structure_tree_items hide_item rest
 
-#if OCAML_VERSION < (4,3,0)
-    | { str_desc = Tstr_value (_, vbs ); _} :: rest ->
-#else
     | { str_desc = Tstr_value (_, vbs); _ } :: rest -> (*TODO: handle rec_flag *)
-#endif
    ( List.map (fun vb -> read_pattern hide_item vb.vb_pat) vbs
       |> List.flatten) @ extract_structure_tree_items hide_item rest
 
@@ -454,16 +426,10 @@ let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> 
         extract_structure_tree_items hide_item rest
     | { str_desc = Tstr_class cls; _ } :: rest ->
         List.map
-#if OCAML_VERSION < (4,3,0)
-          (fun (cld, _, _) ->
-#else
           (fun (cld, _) ->
-#endif
              `Class (cld.ci_id_class,
                cld.ci_id_class_type, cld.ci_id_object,
-#if OCAML_VERSION < (4,4,0)
-               Some cld.ci_id_typesharp,
-#elif OCAML_VERSION < (5,1,0)
+#if OCAML_VERSION < (5,1,0)
                Some cld.ci_id_typehash,
 #else
                None,
@@ -475,21 +441,15 @@ let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> 
           (fun (_, _, clty) ->
              `ClassType (clty.ci_id_class_type,
                clty.ci_id_object,
-#if OCAML_VERSION < (4,4,0)
-               Some clty.ci_id_typesharp,
-#elif OCAML_VERSION < (5,1,0)
+#if OCAML_VERSION < (5,1,0)
                Some clty.ci_id_typehash,
 #else
                None,
 #endif
               hide_item, Some clty.ci_id_name.loc
              )) cltyps @ extract_structure_tree_items hide_item rest
-#if OCAML_VERSION < (4,8,0)
-    | { str_desc = Tstr_open _; _} :: rest -> extract_structure_tree_items hide_item rest
-#else
     | { str_desc = Tstr_open o; _ } :: rest ->
         ((extract_extended_open o) :> items list)  @ extract_structure_tree_items hide_item rest
-#endif
     | { str_desc = Tstr_primitive {val_id; _}; str_loc; _ } :: rest ->
       [`Value (val_id, false, Some str_loc)] @ extract_structure_tree_items hide_item rest
     | { str_desc = Tstr_eval _; _} :: rest -> extract_structure_tree_items hide_item rest
@@ -795,11 +755,7 @@ module Path = struct
 
   let rec read_module : t -> Path.t -> Paths.Path.Module.t = fun env -> function
     | Path.Pident id -> read_module_ident env id
-#if OCAML_VERSION >= (4,8,0)
     | Path.Pdot(p, s) -> `Dot(read_module env p, ModuleName.make_std s)
-#else
-    | Path.Pdot(p, s, _) -> `Dot(read_module env p, ModuleName.make_std s)
-#endif
     | Path.Papply(p, arg) -> `Apply(read_module env p, read_module env arg)
 #if OCAML_VERSION >= (5,1,0)
     | Path.Pextra_ty _ -> assert false
@@ -807,11 +763,7 @@ module Path = struct
 
   let read_module_type env = function
     | Path.Pident id -> read_module_type_ident env id
-#if OCAML_VERSION >= (4,8,0)
     | Path.Pdot(p, s) -> `DotMT(read_module env p, ModuleTypeName.make_std s)
-#else
-    | Path.Pdot(p, s, _) -> `DotMT(read_module env p, ModuleTypeName.make_std s)
-#endif
     | Path.Papply(_, _)-> assert false
 #if OCAML_VERSION >= (5,1,0)
     | Path.Pextra_ty _ -> assert false
@@ -819,11 +771,7 @@ module Path = struct
 
   let read_class_type env = function
     | Path.Pident id -> read_class_type_ident env id
-#if OCAML_VERSION >= (4,8,0)
     | Path.Pdot(p, s) -> `DotT(read_module env p, TypeName.make_std (strip_hash s))
-#else
-    | Path.Pdot(p, s, _) -> `DotT(read_module env p, TypeName.make_std (strip_hash s))
-#endif
     | Path.Papply(_, _)-> assert false
 #if OCAML_VERSION >= (5,1,0)
     | Path.Pextra_ty _ -> assert false
@@ -835,11 +783,7 @@ module Path = struct
     let rec read_type env = function
 #endif
     | Path.Pident id -> read_type_ident env id
-#if OCAML_VERSION >= (4,8,0)
     | Path.Pdot(p, s) ->
-#else
-    | Path.Pdot(p, s, _) ->
-#endif
         `DotT(read_module env p, TypeName.make_std (strip_hash s))
     | Path.Papply(_, _)-> assert false
 #if defined OXCAML
@@ -852,11 +796,7 @@ module Path = struct
 
   let read_value env = function
     | Path.Pident id -> read_value_ident env id
-#if OCAML_VERSION >= (4,8,0)
     | Path.Pdot(p, s) -> `DotV(read_module env p, ValueName.make_std s)
-#else
-    | Path.Pdot(p, s, _) -> `DotV(read_module env p, ValueName.make_std s)
-#endif
     | Path.Papply(_, _) -> assert false
 #if OCAML_VERSION >= (5,1,0)
     | Path.Pextra_ty _ -> assert false

--- a/src/model/compat.cppo.ml
+++ b/src/model/compat.cppo.ml
@@ -146,7 +146,7 @@ and modtype_declaration : Types.modtype_declaration -> modtype_declaration = fun
     mtd_attributes = x.Types.mtd_attributes;
     mtd_loc = x.Types.mtd_loc }
 
-#elif OCAML_VERSION >= (4,8,0)
+#else
 
 let rec signature : Types.signature -> signature = fun x -> List.map signature_item x
 
@@ -186,75 +186,6 @@ and modtype_declaration : Types.modtype_declaration -> modtype_declaration = fun
   { mtd_type = opt module_type x.Types.mtd_type;
     mtd_attributes = x.Types.mtd_attributes;
     mtd_loc = x.Types.mtd_loc }
-
-#elif OCAML_VERSION >= (4,4,0) && OCAML_VERSION < (4,8,0)
-
-  let rec module_type : Types.module_type -> module_type = function
-  | Types.Mty_ident p -> Mty_ident p
-  | Types.Mty_signature s -> Mty_signature (signature s)
-  | Types.Mty_functor (a, b, c) -> begin
-    match b with
-    | Some m -> Mty_functor(Named(Some a,module_type m),module_type c)
-    | None -> Mty_functor(Unit,module_type c)
-    end
-  | Types.Mty_alias (_,q) -> Mty_alias q
-
-  and signature_item : Types.signature_item -> signature_item = function
-  | Types.Sig_value (id, d) -> Sig_value (id, d, Exported)
-  | Types.Sig_type (id, td, rec_status) -> Sig_type (id, td, rec_status, Exported)
-  | Types.Sig_typext (id, ec, es) -> Sig_typext (id, ec, es, Exported)
-  | Types.Sig_module (id, ({md_type = Types.Mty_alias (Types.Mta_present, _); _} as md), rs) -> Sig_module (id, Mp_present, module_declaration md, rs, Exported)
-  | Types.Sig_module (id, ({md_type = Types.Mty_alias (Types.Mta_absent, _); _} as md), rs) -> Sig_module (id, Mp_absent, module_declaration md, rs, Exported)
-  | Types.Sig_module (id, md, rs) -> Sig_module (id, Mp_present, module_declaration md, rs, Exported)
-  | Types.Sig_modtype (id, mtd) -> Sig_modtype (id, modtype_declaration mtd, Exported)
-  | Types.Sig_class (id, cd, rs) -> Sig_class (id, cd, rs, Exported)
-  | Types.Sig_class_type (id, ctd, rs) -> Sig_class_type (id, ctd, rs, Exported)
-
-  and signature : Types.signature -> signature = fun x -> List.map signature_item x
-
-  and module_declaration : Types.module_declaration -> module_declaration = fun x ->
-    { md_type = module_type x.Types.md_type;
-      md_attributes = x.Types.md_attributes;
-      md_loc = x.Types.md_loc }
-
-  and modtype_declaration : Types.modtype_declaration -> modtype_declaration = fun x ->
-    { mtd_type = opt module_type x.Types.mtd_type;
-      mtd_attributes = x.Types.mtd_attributes;
-      mtd_loc = x.Types.mtd_loc }
-
-#elif OCAML_VERSION >= (4,2,0) && OCAML_VERSION < (4,4,0)
-
-  let rec module_type : Types.module_type -> module_type = function
-  | Types.Mty_ident p -> Mty_ident p
-  | Types.Mty_signature s -> Mty_signature (signature s)
-  | Types.Mty_functor (a, b, c) -> begin
-    match b with
-    | Some m -> Mty_functor(Named(Some a,module_type m),module_type c)
-    | None -> Mty_functor(Unit,module_type c)
-    end
-  | Types.Mty_alias q -> Mty_alias q
-
-  and signature_item : Types.signature_item -> signature_item = function
-  | Types.Sig_value (id, d) -> Sig_value (id, d, Exported)
-  | Types.Sig_type (id, td, rec_status) -> Sig_type (id, td, rec_status, Exported)
-  | Types.Sig_typext (id, ec, es) -> Sig_typext (id, ec, es, Exported)
-  | Types.Sig_module (id, md, rs) -> Sig_module (id, Mp_present, module_declaration md, rs, Exported)
-  | Types.Sig_modtype (id, mtd) -> Sig_modtype (id, modtype_declaration mtd, Exported)
-  | Types.Sig_class (id, cd, rs) -> Sig_class (id, cd, rs, Exported)
-  | Types.Sig_class_type (id, ctd, rs) -> Sig_class_type (id, ctd, rs, Exported)
-
-  and signature : Types.signature -> signature = fun x -> List.map signature_item x
-
-  and module_declaration : Types.module_declaration -> module_declaration = fun x ->
-    { md_type = module_type x.Types.md_type;
-      md_attributes = x.Types.md_attributes;
-      md_loc = x.Types.md_loc }
-
-  and modtype_declaration : Types.modtype_declaration -> modtype_declaration = fun x ->
-    { mtd_type = opt module_type x.Types.mtd_type;
-      mtd_attributes = x.Types.mtd_attributes;
-      mtd_loc = x.Types.mtd_loc }
-
 
 #endif
 
@@ -322,14 +253,9 @@ let compunit_name : Cmo_format.compunit -> string = function | Compunit x -> x
 
 let required_compunit_names x = List.map compunit_name x.Cmo_format.cu_required_compunits
 
-#elif OCAML_VERSION >= (4,04,0)
+#else
 
 let compunit_name x = x
 let required_compunit_names x = List.map Ident.name x.Cmo_format.cu_required_globals
-
-#else
-
-  let compunit_name x = x
-  let required_compunit_names x = List.map fst x.Cmo_format.cu_imports
 
 #endif

--- a/src/syntax_highlighter/syntax_highlighter.ml
+++ b/src/syntax_highlighter/syntax_highlighter.ml
@@ -119,32 +119,16 @@ let tag_of_token (tok : Parser.token) =
   | WHEN -> "WHEN"
   | WHILE -> "WHILE"
   | WITH -> "WITH"
-(* Removed *)
-#if OCAML_VERSION <= (4,2,3)
-  | INT32 _ -> "INT32"
-  | INT64 _ -> "INT64"
-  | NATIVEINT _ -> "NATIVEINT"
-#endif
-#if OCAML_VERSION <= (4,3,0)
-  | SHARP -> "SHARP"
-  | SHARPOP _ -> "SHARPOP"
-#endif
-(* Added *)
-#if OCAML_VERSION >= (4,4,0)
   | HASH -> "HASH"
   | HASHOP _ -> "HASHOP"
-#endif
-#if OCAML_VERSION >= (4,6,0)
   | DOTOP _ -> "DOTOP"
-#endif
+  (* Added *)
 #if OCAML_VERSION >= (4,11,0)
   | QUOTED_STRING_EXPR _ -> "QUOTED_STRING_EXPR"
   | QUOTED_STRING_ITEM _ -> "QUOTED_STRING_ITEM"
 #endif
-#if OCAML_VERSION >= (4,8,0)
   | ANDOP _ -> "ANDOP"
   | LETOP _ -> "LETOP"
-#endif
 #if defined OXCAML
   | AT -> "AT"
   | ATAT -> "ATAT"
@@ -189,11 +173,7 @@ let tag_of_token (tok : Parser.token) =
 let syntax_highlighting_locs src =
   try
     Lexer.init ();
-    let lexbuf = Lexing.from_string
-  #if OCAML_VERSION >= (4,8,0)
-        ~with_positions:true
-  #endif
-        src in
+    let lexbuf = Lexing.from_string ~with_positions:true src in
     let rec collect lexbuf tokens =
       let tok = Lexer.token_with_comments lexbuf in
       let loc_start, loc_end = (lexbuf.lex_start_p, lexbuf.lex_curr_p) in

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -29,7 +29,7 @@ let cmti_of_string s =
     let l = Lexing.from_string s in
     let p = Parse.interface l in
     Typemod.type_interface
-#if OCAML_VERSION >= (4,4,0) && OCAML_VERSION < (4,9,0)
+#if OCAML_VERSION < (4,9,0)
     ""
 #elif defined OXCAML
     ~sourcefile:""
@@ -623,10 +623,8 @@ let mkresolver () =
 #if OCAML_VERSION >= (5,2,0)
   (let paths = Load_path.get_paths () in
    List.filter (fun s -> s <> "") (paths.visible @ paths.hidden))
-#elif OCAML_VERSION >= (4,8,0)
-    (Load_path.get_paths () |> List.filter (fun s -> s <> ""))
 #else
-    !Config.load_path
+    (Load_path.get_paths () |> List.filter (fun s -> s <> ""))
 #endif
     ) ~open_modules:[]
 


### PR DESCRIPTION
The minimal supported version according to .opam files is OCaml 4.08. There is no need to conserve and maintain support for prior versions.