### PR TITLE
Eliminate duplicate branch

### DIFF
--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -510,15 +510,9 @@ and read_module_binding env parent mb =
   in
   let canonical = match canonical with | None -> None | Some s -> Some (Doc_attr.conv_canonical_module s) in
   let hidden =
-#if OCAML_VERSION >= (4,10,0)
     match canonical, mid.iv with
     | None, (`Module (_, n) | `Parameter (_, n) | `Root (_, n)) -> Odoc_model.Names.ModuleName.is_hidden n
     | Some _, _ -> false
-#else
-    match canonical, mid.iv with
-    | None, (`Module (_, n) | `Parameter (_, n) | `Root (_, n)) -> Odoc_model.Names.ModuleName.is_hidden n
-    | Some _, _ -> false
-#endif
   in
   Some {id; source_loc; doc; type_; canonical; hidden; }
 


### PR DESCRIPTION
While thinking on how to best implement `include functor` I was looking at the code that loads modules to see how to best create dummy modules. Which led me to this piece of code.

Both sides of the branch seemed have the same code (in the end I verified with `diff` to make sure I am not missing something subtle), thus might as well get rid of the branch itself.

I assume this might have been part of a bigger branching code for different versions but it seems all supported versions can use the same code these days.