### PR TITLE
Allow overriding the output path for compile and compile-impl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 - Support for OxCaml zero alloc definitions (@Leonidas-from-XIV, #1422, #1444)
 - Remove requirement for ppx_expect in tests (@jonludlam, #1445)
 - Support for OxCaml modalities (@art-w, #1420)
+- Improve documentation of link scope in odoc-driver (@jonludlam, #1461)
+
+### Fixed
+- Fix #1450 - incorrect linking of same-named but different digest modules
+  (@jonludlam, #1461)
 
 # 3.2.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 - Remove requirement for ppx_expect in tests (@jonludlam, #1445)
 - Support for OxCaml modalities (@art-w, #1420)
 - Improve documentation of link scope in odoc-driver (@jonludlam, #1461)
+- `odoc compile`: `-o` now overrides the output path computed from
+  `--parent-id` and `--output-dir`, which is no longer required in that case
+  (@jonludlam)
 
 ### Fixed
 - Fix #1450 - incorrect linking of same-named but different digest modules

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - `odoc compile`: `-o` now overrides the output path computed from
   `--parent-id` and `--output-dir`, which is no longer required in that case
   (@jonludlam)
+- `odoc compile-impl`: `-o` now overrides the output path computed from
+  `--parent-id` and `--output-dir`, matching `odoc compile` (@jonludlam)
 
 ### Fixed
 - Fix #1450 - incorrect linking of same-named but different digest modules

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,9 @@
 - Improve documentation of link scope in odoc-driver (@jonludlam, #1461)
 - `odoc compile`: `-o` now overrides the output path computed from
   `--parent-id` and `--output-dir`, which is no longer required in that case
-  (@jonludlam)
+  (@jonludlam, #1462)
 - `odoc compile-impl`: `-o` now overrides the output path computed from
-  `--parent-id` and `--output-dir`, matching `odoc compile` (@jonludlam)
+  `--parent-id` and `--output-dir`, matching `odoc compile` (@jonludlam, #1462)
 
 ### Fixed
 - Fix #1450 - incorrect linking of same-named but different digest modules

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -100,23 +100,33 @@ Let's have a look at a generic invocation of [odoc] during the compile phase:
   file. Prefer [.cmti] files over the other formats!
 
 - [--output-dir <od>] allows to specify the directory that will contain all the
-  [.odoc] files. This directory has to be fully managed by [odoc] and should not
-  be modified by another tool! The output file depends on the [--parent-id]
-  option.
+  [.odoc] files. The location of the output file below it depends on the
+  [--parent-id] option.
 
 - [--parent-id <pid>] allows to place the output [.odoc] file in the
   documentation hierarchy. This consists in a [/] separated sequence of non
   empty strings (used as directory name). This "path" determines where the
   [.odoc] file will be located below the [<od>] output dir. The name of the
   output file is [<input-file>.odoc] for modules, and [page-<input-file>.odoc]
-  for pages. Documentation artifacts that will be in the same {{!units}unit of
-  documentation} need to hare a common root in their parent id.
+  for pages. Documentation artifacts that will be in the same {{!units}unit of documentation} need to hare a common root in their parent id.
 
 - [-I <dir>] corresponds to the search path for other [.odoc] files. Multiple
   directory can be added to the search path, so every required [.odoc] file is
   in the search path. The required [.odoc] files are the one generated from a
   [.cm{i;t;ti}] file listed when calling [odoc compile-deps] on the input
-  file.
+  file. There should be roughly a one-to-one correspondence between the
+  set of paths provided to the OCaml compiler when building the unit, and
+  the set of directories passed to odoc via the [-I] argument, where each
+  directory passed to the compiler containing cmi files should have an
+  equivalent directory passed to odoc containing the corresponding odoc files.
+
+Note that a unit's identifier — which determines how references to it resolve
+and the URLs of its generated pages — is computed from [--parent-id] at
+compile time and stored inside the [.odoc] file itself. The file's location
+on disk carries no meaning of its own: later phases find files only through
+the paths they are given ([-I], [-P]/[-L], the index inputs), so a driver is
+free to arrange (or relocate) [.odoc] and [.odocl] files as it likes,
+provided it points later invocations at the right places.
 
 A concrete example for such command would be:
 
@@ -210,9 +220,8 @@ A generic link command is:
 ]}
 
 - [<path/to/file.odoc] is the input [.odoc] file. The result of this command is
-  [path/to/file.odocl]. This path was determined by [--output-dir] and
-  [--parent-id] from the link phase, and it is important for the indexing phase
-  that it stays in the same location.
+  [path/to/file.odocl], which can be placed elsewhere with [-o]; the indexing
+  phase must be pointed at wherever the [.odocl] files end up.
 
 - [-P <name>:<dir>] are used to list the "page trees", used to resolve
   references such as [{!/ocamlfind/index}].
@@ -224,6 +233,23 @@ A generic link command is:
 - [-I <dir>] adds [<dir>] to the search path. The search path is used to resolve
   references that do not use the "named tree" mechanism, such as [{!Module}] and
   [{!page-pagename}].
+
+The trees given to [-P] and [-L] must be mutually disjoint: odoc rejects
+nested or overlapping roots. Layouts where this cannot hold — for instance
+several libraries installed in a single directory — can pass
+[--custom-layout], which disables the check.
+
+Two different resolution mechanisms are served by these paths, and it is
+worth distinguishing them. The modules a unit was compiled against (those
+listed by [odoc compile-deps], with their interface digests) are looked up by
+name across every search-path directory provided via [-I] and disambiguated by digest, both at
+compile and at link time: several same-named files on the search path are
+handled correctly. References written in documentation comments are resolved
+by name in the search-path directories provided via [-L] and [-P]; when a
+name is provided by several roots, authors can disambiguate
+with a path reference naming the root — [{!/foo/module-A}] when [A] is
+present in library [foo] and in others. Drivers can therefore afford to be
+liberal in the roots they pass.
 
 {2 The indexing phase}
 
@@ -443,6 +469,51 @@ during the link phase, so that the proper [-P] and [-L] arguments are
 added. (Note that these dependencies can be circular, as they
 happen during the link phase and only require the artifact from the compile
 phase.)
+
+The reference driver decides this scope {e per package}: every library and
+every page of a package is linked with the same [-P] and [-L] arguments, so
+they resolve references against the same units. The scope has two halves — the
+{e module trees} that can be referenced (one [-L] per library) and the {e page
+trees} that can be referenced (one [-P] per package).
+
+For a package [<p>], the module trees ([-L]) are:
+
+{ul
+{- every library of [<p>] itself;}
+{- the {e direct} dependencies of those libraries — the libraries named in each
+   [META] [requires] field — but {e not} the full transitive closure;}
+{- the OCaml standard library;}
+{- any library named in [<p>]'s [odoc-config.sexp] (see below).}}
+
+The page trees ([-P]) are the packages that own those libraries — [<p>] itself
+and the packages providing its direct dependencies — plus any package named in
+[<p>]'s [odoc-config.sexp]. This is the driver side of the
+{{!odoc_for_authors.reference_scope}reference scope} seen by authors; other
+drivers should aim for equivalent behaviour. If you need to reference something
+in a transitive dependency, name it explicitly in the [META] [requires] field
+or in [odoc-config.sexp].
+
+The [-I] search path has a different job from [-P]/[-L]: it resolves each unit's
+imports, their expansions, and source links, which can reach {e deeper} than the
+declared scope — rendering a source link into a functor's body needs the functor
+library's own dependencies (e.g. [uutf] for [tyxml.functor]). The units of a
+library share a single [-I]: the union of their dependency cones, i.e. the
+directories the compiler used to build the library (see the compile phase). This
+is sufficient for the same reason, and providing it does not widen the reference
+scope defined by [-P] and [-L].
+
+Virtual libraries affect what a driver should compile. An implementation
+ships its modules as [.cmt] files only; the [.mli] and the documentation
+written in it belong to the virtual library, which ships the [.cmti].
+Implementing a virtual library adds it to the implementation's [requires], so
+the virtual [.cmti] is findable on the implementation's dependency cone (by
+file name and matching interface digest). The reference driver documents each
+implementation by {e re-compiling the virtual library's [.cmti]} under the
+implementation's own [--parent-id]: the interface documentation is compiled
+once per implementation — plus once for the virtual library itself — each copy
+living in its own tree. For instance [checkseum]'s single [checkseum.cmti] is
+compiled three times, under [checkseum/checkseum], [checkseum/checkseum.c] and
+[checkseum/checkseum.ocaml]. 
 
 An installed package [<p>] specifies its tree dependencies in a file at
 [<opam root>/doc/<p>/odoc-config.sexp]. This file contains s-expressions.

--- a/doc/odoc_for_authors.mld
+++ b/doc/odoc_for_authors.mld
@@ -658,9 +658,38 @@ inline [open] statements do {e not} bring other elements into scope.
 In order for [odoc] to resolve links to other compilation units or [.mld] pages,
 the referenced
 unit or page must be {e compiled} and available to [odoc]. That is, when performing the
-[odoc link] command, one of the include paths passed via the command-line argument
-[-I] must contain the relevant [.odoc] file. This is normally the responsibility of
-the {{!page-driver}driver}.
+[odoc link] command, the referenced [.odoc] file must be reachable through one of
+the library ([-L]), package ([-P]) or include ([-I]) arguments. Deciding which
+units to make available is the responsibility of the {{!page-driver}driver}, and
+this is what determines the set of things you can actually reference.
+
+{4:reference_scope What is in scope}
+
+The reference driver computes this scope {e per package}: every library and
+every page in a package shares the same set of visible units. Other drivers
+should aim for equivalent behaviour. For a package [P], the following are in scope.
+
+You may reference the modules of (and the types, values, etc. within):
+
+{ul
+{- every library in [P] itself;}
+{- the {e direct} dependencies of those libraries — the libraries listed in each
+   library's [META] [requires] field;}
+{- the OCaml standard library;}
+{- any library named in the package's {{!section-"config-file"}[odoc-config.sexp]},
+   whether listed there directly or belonging to a package listed there.}}
+
+You may reference the {e pages} of:
+
+{ul
+{- [P] itself;}
+{- every package that provides one of the in-scope libraries above;}
+{- any package named in [odoc-config.sexp].}}
+
+We make no effort to ensure {e transitive} dependencies are in scope for
+references. Should you need to refer to elements in a transitive dependency,
+add it to the explicit dependencies in the META file, or to
+{{!section-"config-file"}[odoc-config.sexp]}.
 
 {2:tags Tags}
 

--- a/src/driver/bin/odoc_driver.ml
+++ b/src/driver/bin/odoc_driver.ml
@@ -72,7 +72,8 @@ let run_inner ~odoc_dir ~odocl_dir ~index_dir ~mld_dir ~compile_grep ~link_grep
         Compile.init_stats units;
         let compiled = Compile.compile ~partial_dir:odoc_dir units in
         let linked =
-          Compile.link ~warnings_tags:packages ~custom_layout:false compiled
+          Compile.link ~partial_dir:odoc_dir ~warnings_tags:packages
+            ~custom_layout:false compiled
         in
         let odoc_dirs =
           List.fold_left

--- a/src/driver/bin/odoc_driver_monorepo.ml
+++ b/src/driver/bin/odoc_driver_monorepo.ml
@@ -50,7 +50,8 @@ let real_run ~odoc_dir ~odocl_dir ~index_dir ~mld_dir path extra_pkgs extra_libs
         Compile.init_stats units;
         let compiled = Compile.compile ~partial_dir:odoc_dir units in
         let linked =
-          Compile.link ~warnings_tags:[] ~custom_layout:true compiled
+          Compile.link ~partial_dir:odoc_dir ~warnings_tags:[]
+            ~custom_layout:true compiled
         in
         let occurrence_file =
           let output =

--- a/src/driver/bin/odoc_driver_voodoo.ml
+++ b/src/driver/bin/odoc_driver_voodoo.ml
@@ -76,6 +76,23 @@ let run package_name blessed actions odoc_dir odocl_dir
 
   let all = Packages.remap_virtual [ all ] in
 
+  (* The META files only declare a library's direct dependencies, and don't
+     always name a transitively-needed library (e.g. [tyxml.functor], reached
+     only through [tyxml]'s own META). Recover the missing ones by digest, the
+     same way the non-voodoo driver does: resolve this package's module
+     dependencies against its own modules merged with those of its
+     already-compiled dependencies, whose [digest -> library] mapping is read
+     back from their partials. *)
+  let all =
+    let lib_name_by_hash =
+      Util.StringMap.union
+        (fun _ a b -> Some (a @ b))
+        (Packages.lib_name_by_hash all)
+        (Compile.lib_name_by_hash_of_partials odoc_dir)
+    in
+    Packages.fix_missing_deps_with lib_name_by_hash all
+  in
+
   let partial =
     match all with
     | [ p ] ->
@@ -100,8 +117,8 @@ let run package_name blessed actions odoc_dir odocl_dir
     | CompileOnly -> ()
     | LinkAndGen | All ->
         let linked =
-          Compile.link ~warnings_tags:[ package_name ] ~custom_layout:false
-            compiled
+          Compile.link ?partial ~partial_dir:odoc_dir
+            ~warnings_tags:[ package_name ] ~custom_layout:false compiled
         in
         let () =
           Odoc.count_occurrences ~input:odocl_dirs ~output:occurrence_file

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -99,23 +99,42 @@ let find_partials odoc_dir :
 
 let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
   let hashes = mk_byhash all in
+  let other_hashes, tbl =
+    match partial with
+    | Some _ -> find_partials partial_dir
+    | None -> (Util.StringMap.empty, Hashtbl.create 10)
+  in
+  let hashes =
+    Odoc_unit.fix_virtual ~precompiled_units:other_hashes ~units:hashes
+  in
+  let all_hashes =
+    Util.StringMap.union (fun _x o1 o2 -> Some (o1 @ o2)) hashes other_hashes
+  in
+  (* Include set for compiling a unit: the directories that provide the modules
+     it actually depends on. Each dependency carries the interface hash of the
+     module it refers to, so we look that hash up in [all_hashes] (this run's
+     units plus the partials of already-compiled dependencies) and add the
+     directory of every providing unit. This is more precise than including
+     whole libraries and doesn't depend on the META files declaring every
+     transitively-needed library. *)
+  let includes_of_deps deps =
+    List.fold_left
+      (fun acc (_name, dep_hash) ->
+        match Util.StringMap.find_opt dep_hash all_hashes with
+        | Some units ->
+            List.fold_left
+              (fun acc (u : Odoc_unit.intf Odoc_unit.t) ->
+                Fpath.Set.add (Fpath.parent u.Odoc_unit.odoc_file) acc)
+              acc units
+        | None -> acc)
+      Fpath.Set.empty deps
+  in
   let compile_mod =
     (* Modules have a more complicated compilation because:
        - They have dependencies and must be compiled in the right order
        - In Voodoo mode, there might exists already compiled parts *)
-    let other_hashes, tbl =
-      match partial with
-      | Some _ -> find_partials partial_dir
-      | None -> (Util.StringMap.empty, Hashtbl.create 10)
-    in
-    let hashes =
-      Odoc_unit.fix_virtual ~precompiled_units:other_hashes ~units:hashes
-    in
-    let all_hashes =
-      Util.StringMap.union (fun _x o1 o2 -> Some (o1 @ o2)) hashes other_hashes
-    in
     let compile_one compile_other (unit : Odoc_unit.intf Odoc_unit.t) =
-      let (`Intf { Odoc_unit.deps; _ }) = unit.kind in
+      let deps = unit.Odoc_unit.deps in
       let _fibers =
         Fiber.List.map
           (fun (other_unit_name, other_unit_hash) ->
@@ -131,12 +150,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
                 None)
           deps
       in
-      let includes =
-        List.fold_left
-          (fun acc (_lib, path) -> Fpath.Set.add path acc)
-          Fpath.Set.empty
-          (Odoc_unit.Pkg_args.compiled_libs unit.pkg_args)
-      in
+      let includes = includes_of_deps deps in
       Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
         ~includes ~warnings_tag:unit.pkgname ~parent_id:unit.parent_id
         ~ignore_output:(not unit.enable_warnings);
@@ -177,12 +191,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
     match unit.kind with
     | `Intf intf -> (compile_mod intf.hash :> (Odoc_unit.any list, _) Result.t)
     | `Impl src ->
-        let includes =
-          List.fold_left
-            (fun acc (_lib, path) -> Fpath.Set.add path acc)
-            Fpath.Set.empty
-            (Odoc_unit.Pkg_args.compiled_libs unit.pkg_args)
-        in
+        let includes = includes_of_deps unit.Odoc_unit.deps in
         let source_id = src.src_id in
         Odoc.compile_impl ~output_dir:unit.output_dir
           ~input_file:unit.input_file ~includes ~parent_id:unit.parent_id

--- a/src/driver/compile.ml
+++ b/src/driver/compile.ml
@@ -97,7 +97,99 @@ let find_partials odoc_dir :
   | Ok h -> (h, tbl)
   | Error _ -> (* odoc_dir doesn't exist...? *) (Util.StringMap.empty, tbl)
 
-let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
+(* Build a [digest -> library name(s)] map from the partials written by earlier
+   [compile] runs under [odoc_dir]. Each partial is keyed by interface hash and
+   its units carry their [lib_name], so this reconstructs the same information
+   [Packages.lib_name_by_hash] gives for in-memory packages — but for
+   already-compiled dependencies, as needed in voodoo mode. *)
+let lib_name_by_hash_of_partials odoc_dir : string list Util.StringMap.t =
+  let result =
+    OS.Dir.fold_contents ~dotfiles:false ~elements:`Dirs
+      (fun p acc ->
+        let index_m = Fpath.( / ) p odoc_partial_filename in
+        match OS.File.exists index_m with
+        | Ok true ->
+            Util.StringMap.fold
+              (fun h units acc ->
+                List.fold_left
+                  (fun acc u ->
+                    let lib_name = u.Odoc_unit.lib_name in
+                    Util.StringMap.update h
+                      (function
+                        | None -> Some [ lib_name ]
+                        | Some l -> Some (lib_name :: l))
+                      acc)
+                  acc units)
+              (unmarshal index_m) acc
+        | _ -> acc)
+      Util.StringMap.empty odoc_dir
+  in
+  match result with Ok m -> m | Error _ -> Util.StringMap.empty
+
+(* Include set for compiling a unit: the directories that provide the modules
+   it actually depends on. Each dependency carries the interface hash of the
+   module it refers to, so we look that hash up in [all_hashes] (this run's
+   units plus the partials of already-compiled dependencies) and add the
+   directory of a providing unit. This is more precise than including whole
+   libraries and doesn't depend on the META files declaring every
+   transitively-needed library.
+
+   A single hash can be offered by more than one unit — the interface of a
+   virtual library and each of its implementations all share it, for instance.
+   When that happens we prefer a provider whose library is in [prefer] (the
+   unit's own library plus that library's dependencies), so a unit resolves
+   its actual dependency rather than an unrelated sibling implementation. If
+   none of the providers is a dependency we pick an arbitrary one; sharing the
+   interface hash, they are interchangeable for compilation anyway. *)
+let includes_of_deps ~all_hashes ~prefer deps =
+  List.fold_left
+    (fun acc (_name, dep_hash) ->
+      match Util.StringMap.find_opt dep_hash all_hashes with
+      | None | Some [] -> acc
+      | Some units ->
+          let chosen =
+            match
+              List.find_opt
+                (fun u -> Util.StringSet.mem u.Odoc_unit.lib_name prefer)
+                units
+            with
+            | Some u -> u
+            | None -> List.hd units
+          in
+          Fpath.Set.add (Fpath.parent chosen.Odoc_unit.odoc_file) acc)
+    Fpath.Set.empty deps
+
+(* PROTOTYPE: per-library -I. Every unit of a library shares one include set --
+   the union of its units' dependency cones (see [includes_of_deps]) -- rather
+   than each unit getting its own. Keyed by library name; pages/assets/md
+   contribute nothing and get an empty set. *)
+let library_includes ~all_hashes all : (string, Fpath.Set.t) Hashtbl.t =
+  let tbl = Hashtbl.create 16 in
+  List.iter
+    (fun (u : Odoc_unit.any) ->
+      match u.Odoc_unit.kind with
+      | `Intf _ | `Impl _ ->
+          let prev =
+            Option.value ~default:Fpath.Set.empty
+              (Hashtbl.find_opt tbl u.Odoc_unit.lib_name)
+          in
+          let inc =
+            includes_of_deps ~all_hashes ~prefer:u.Odoc_unit.lib_deps
+              u.Odoc_unit.deps
+          in
+          Hashtbl.replace tbl u.Odoc_unit.lib_name (Fpath.Set.union prev inc)
+      | `Mld | `Asset | `Md -> ())
+    all;
+  tbl
+
+let unit_includes ~lib_includes (unit : Odoc_unit.any) : Fpath.Set.t =
+  match unit.Odoc_unit.kind with
+  | `Intf _ | `Impl _ ->
+      Option.value ~default:Fpath.Set.empty
+        (Hashtbl.find_opt lib_includes unit.Odoc_unit.lib_name)
+  | `Mld | `Asset | `Md -> Fpath.Set.empty
+
+let build_all_hashes ?partial ~partial_dir all =
   let hashes = mk_byhash all in
   let other_hashes, tbl =
     match partial with
@@ -110,25 +202,11 @@ let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
   let all_hashes =
     Util.StringMap.union (fun _x o1 o2 -> Some (o1 @ o2)) hashes other_hashes
   in
-  (* Include set for compiling a unit: the directories that provide the modules
-     it actually depends on. Each dependency carries the interface hash of the
-     module it refers to, so we look that hash up in [all_hashes] (this run's
-     units plus the partials of already-compiled dependencies) and add the
-     directory of every providing unit. This is more precise than including
-     whole libraries and doesn't depend on the META files declaring every
-     transitively-needed library. *)
-  let includes_of_deps deps =
-    List.fold_left
-      (fun acc (_name, dep_hash) ->
-        match Util.StringMap.find_opt dep_hash all_hashes with
-        | Some units ->
-            List.fold_left
-              (fun acc (u : Odoc_unit.intf Odoc_unit.t) ->
-                Fpath.Set.add (Fpath.parent u.Odoc_unit.odoc_file) acc)
-              acc units
-        | None -> acc)
-      Fpath.Set.empty deps
-  in
+  (all_hashes, hashes, tbl)
+
+let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
+  let all_hashes, hashes, tbl = build_all_hashes ?partial ~partial_dir all in
+  let lib_includes = library_includes ~all_hashes all in
   let compile_mod =
     (* Modules have a more complicated compilation because:
        - They have dependencies and must be compiled in the right order
@@ -150,7 +228,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
                 None)
           deps
       in
-      let includes = includes_of_deps deps in
+      let includes = unit_includes ~lib_includes (unit :> Odoc_unit.any) in
       Odoc.compile ~output_dir:unit.output_dir ~input_file:unit.input_file
         ~includes ~warnings_tag:unit.pkgname ~parent_id:unit.parent_id
         ~ignore_output:(not unit.enable_warnings);
@@ -191,7 +269,7 @@ let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
     match unit.kind with
     | `Intf intf -> (compile_mod intf.hash :> (Odoc_unit.any list, _) Result.t)
     | `Impl src ->
-        let includes = includes_of_deps unit.Odoc_unit.deps in
+        let includes = unit_includes ~lib_includes unit in
         let source_id = src.src_id in
         Odoc.compile_impl ~output_dir:unit.output_dir
           ~input_file:unit.input_file ~includes ~parent_id:unit.parent_id
@@ -225,15 +303,22 @@ let compile ?partial ~partial_dir (all : Odoc_unit.any list) =
 
 type linked = Odoc_unit.any
 
-let link : warnings_tags:string list -> custom_layout:bool -> compiled list -> _
-    =
- fun ~warnings_tags ~custom_layout compiled ->
+let link :
+    warnings_tags:string list ->
+    custom_layout:bool ->
+    ?partial:Fpath.t ->
+    partial_dir:Fpath.t ->
+    compiled list ->
+    _ =
+ fun ~warnings_tags ~custom_layout ?partial ~partial_dir compiled ->
+  let all_hashes, _, _ = build_all_hashes ?partial ~partial_dir compiled in
+  let lib_includes = library_includes ~all_hashes compiled in
   let link : compiled -> linked =
    fun c ->
     let link input_file output_file enable_warnings =
       let libs = Odoc_unit.Pkg_args.compiled_libs c.pkg_args in
       let pages = Odoc_unit.Pkg_args.compiled_pages c.pkg_args in
-      let includes = Odoc_unit.Pkg_args.includes c.pkg_args in
+      let includes = Fpath.Set.elements (unit_includes ~lib_includes c) in
       Odoc.link ~custom_layout ~input_file ~output_file ~libs ~docs:pages
         ~includes ~ignore_output:(not enable_warnings) ~warnings_tags
         ?current_package:c.pkgname ()

--- a/src/driver/compile.mli
+++ b/src/driver/compile.mli
@@ -2,6 +2,13 @@ type compiled = Odoc_unit.any
 
 val init_stats : Odoc_unit.any list -> unit
 
+val lib_name_by_hash_of_partials : Fpath.t -> string list Util.StringMap.t
+(** [lib_name_by_hash_of_partials odoc_dir] reconstructs a
+    [digest -> library name(s)] map from the partials ([__odoc_partial.m])
+    written by earlier compilations under [odoc_dir]. Used in voodoo mode to
+    feed {!Packages.fix_missing_deps_with} with the dependencies' modules, which
+    aren't loaded in memory. *)
+
 val compile :
   ?partial:Fpath.t -> partial_dir:Fpath.t -> Odoc_unit.any list -> compiled list
 (** Use [partial] to reuse the output of a previous call to [compile]. Useful in
@@ -15,6 +22,8 @@ type linked
 val link :
   warnings_tags:string list ->
   custom_layout:bool ->
+  ?partial:Fpath.t ->
+  partial_dir:Fpath.t ->
   compiled list ->
   linked list
 

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -26,6 +26,7 @@ let make_index ~dirs ~rel_dir ~libs ~pkgs ~index ~enable_warnings ~content :
     output_dir = dirs.odoc_dir;
     pkgname = None;
     pkg_args;
+    deps = [];
     parent_id;
     input_file;
     input_copy = None;

--- a/src/driver/landing_pages.ml
+++ b/src/driver/landing_pages.ml
@@ -26,7 +26,9 @@ let make_index ~dirs ~rel_dir ~libs ~pkgs ~index ~enable_warnings ~content :
     output_dir = dirs.odoc_dir;
     pkgname = None;
     pkg_args;
+    lib_name = "";
     deps = [];
+    lib_deps = Util.StringSet.empty;
     parent_id;
     input_file;
     input_copy = None;

--- a/src/driver/library_names.ml
+++ b/src/driver/library_names.ml
@@ -24,10 +24,24 @@ type t = { meta_dir : Fpath.t; libraries : library list }
 let read_libraries_from_pkg_defs ~library_name pkg_defs =
   try
     let archive_filename =
-      try Some (Fl_metascanner.lookup "archive" [ "byte" ] pkg_defs)
-      with _ -> (
-        try Some (Fl_metascanner.lookup "archive" [ "native" ] pkg_defs)
-        with _ -> None)
+      (* Try the plain [byte]/[native] archives first, then the [ppx_driver]
+         variants. ppx derivers such as [ppxlib.traverse] and [ppxlib.metaquot]
+         declare their archive only under the [ppx_driver] predicate; without
+         this they'd be dropped here and later re-discovered by the no-META
+         fallback, which names a library after its [.cma] file (e.g.
+         [ppxlib_traverse] instead of [ppxlib.traverse]). Mirrors
+         [Ocamlfind.archives]. *)
+      let lookup preds =
+        try Some (Fl_metascanner.lookup "archive" preds pkg_defs)
+        with _ -> None
+      in
+      List.find_map lookup
+        [
+          [ "byte" ];
+          [ "native" ];
+          [ "byte"; "ppx_driver" ];
+          [ "native"; "ppx_driver" ];
+        ]
     in
 
     let deps =

--- a/src/driver/ocamlfind.ml
+++ b/src/driver/ocamlfind.ml
@@ -81,6 +81,17 @@ let deps pkgs =
        (Util.StringSet.singleton "stdlib")
        (List.map (Result.value ~default:Util.StringSet.empty) results))
 
+(* The directly-declared dependencies of a package, from its META [requires] —
+   not transitively closed. *)
+let direct_deps pkg =
+  init ();
+  try
+    Ok
+      (Util.StringSet.add "stdlib"
+         (Util.StringSet.of_list
+            (Fl_package_base.requires ~preds:[ "ppx_driver" ] pkg)))
+  with e -> Error (`Msg (Printexc.to_string e))
+
 module Db = struct
   type t = {
     all_libs : Util.StringSet.t;
@@ -110,11 +121,13 @@ module Db = struct
     in
     let all_libs = Util.StringSet.elements all_libs_set in
 
-    (* Now we need the dependency tree of those libraries *)
+    (* The directly-declared dependencies of each library. We deliberately keep
+       these un-closed: transitive gaps are recovered by digest later
+       ([Packages.fix_missing_deps]). *)
     let all_lib_deps =
       List.fold_right
         (fun lib_name acc ->
-          match deps [ lib_name ] with
+          match direct_deps lib_name with
           | Ok deps -> Util.StringMap.add lib_name deps acc
           | Error (`Msg msg) ->
               Logs.err (fun m ->

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -83,18 +83,17 @@ type 'a t = {
   odocl_file : Fpath.t;
   pkg_args : Pkg_args.t;
   pkgname : string option;
+  deps : (string * Digest.t) list;
+      (* The unit's per-module dependencies (interface deps for [`Intf], the
+         implementation's for [`Impl]; empty otherwise). Used by
+         [Compile.includes_of_deps] to derive the compile include set. *)
   index : index option;
   enable_warnings : bool;
   to_output : bool;
   kind : 'a;
 }
 
-type intf_extra = {
-  hidden : bool;
-  hash : string;
-  deps : (string * Digest.t) list;
-}
-
+type intf_extra = { hidden : bool; hash : string }
 and intf = [ `Intf of intf_extra ]
 
 type impl_extra = { src_id : Odoc.Id.t; src_path : Fpath.t }
@@ -117,9 +116,7 @@ let rec pp_kind : all_kinds Fmt.t =
   | `Asset -> Format.fprintf fmt "`Asset"
 
 and pp_intf_extra fmt x =
-  Format.fprintf fmt "@[<hov>hidden: %b@;hash: %s@;deps: [%a]@]" x.hidden x.hash
-    Fmt.Dump.(list (pair string string))
-    x.deps
+  Format.fprintf fmt "@[<hov>hidden: %b@;hash: %s@]" x.hidden x.hash
 
 and pp_impl_extra fmt x =
   Format.fprintf fmt "@[<hov>src_id: %s@;src_path: %a@]"
@@ -136,13 +133,15 @@ and pp : all_kinds t Fmt.t =
      odocl_file: %a@;\
      pkg_args: %a@;\
      pkgname: %a@;\
+     deps: [%a]@;\
      index: %a@;\
      kind:%a@;\
      @]"
     (Odoc.Id.to_string x.parent_id)
     Fpath.pp x.input_file Fpath.pp x.output_dir Fpath.pp x.odoc_file Fpath.pp
     x.odocl_file Pkg_args.pp x.pkg_args (Fmt.option Fmt.string) x.pkgname
-    (Fmt.option pp_index) x.index pp_kind
+    Fmt.Dump.(list (pair string string))
+    x.deps (Fmt.option pp_index) x.index pp_kind
     (x.kind :> all_kinds)
 
 let pkg_dir : Packages.t -> Fpath.t = fun pkg -> pkg.pkg_dir

--- a/src/driver/odoc_unit.ml
+++ b/src/driver/odoc_unit.ml
@@ -1,3 +1,5 @@
+(* Arguments for the link step ([-L] / [-P] / [-I]); not used by compile, which
+   derives its includes per module (see [Compile.includes_of_deps]). *)
 module Pkg_args = struct
   type t = {
     odoc_dir : Fpath.t;
@@ -83,10 +85,18 @@ type 'a t = {
   odocl_file : Fpath.t;
   pkg_args : Pkg_args.t;
   pkgname : string option;
+  lib_name : string;
+      (* The library this unit belongs to (empty for pages and assets, which
+         aren't part of a library). *)
   deps : (string * Digest.t) list;
       (* The unit's per-module dependencies (interface deps for [`Intf], the
-         implementation's for [`Impl]; empty otherwise). Used by
-         [Compile.includes_of_deps] to derive the compile include set. *)
+         implementation's for [`Impl]; empty otherwise). *)
+  lib_deps : Util.StringSet.t;
+      (* The unit's own library plus that library's dependencies. Used by
+         [Compile.includes_of_deps] to pick the right provider when a dependency
+         hash is offered by more than one unit (e.g. virtual-library
+         implementations). Not the link-step arguments — those live in
+         [pkg_args]. *)
   index : index option;
   enable_warnings : bool;
   to_output : bool;
@@ -133,15 +143,21 @@ and pp : all_kinds t Fmt.t =
      odocl_file: %a@;\
      pkg_args: %a@;\
      pkgname: %a@;\
+     lib_name: %s@;\
      deps: [%a]@;\
+     lib_deps: [%a]@;\
      index: %a@;\
      kind:%a@;\
      @]"
     (Odoc.Id.to_string x.parent_id)
     Fpath.pp x.input_file Fpath.pp x.output_dir Fpath.pp x.odoc_file Fpath.pp
     x.odocl_file Pkg_args.pp x.pkg_args (Fmt.option Fmt.string) x.pkgname
+    x.lib_name
     Fmt.Dump.(list (pair string string))
-    x.deps (Fmt.option pp_index) x.index pp_kind
+    x.deps
+    Fmt.Dump.(list string)
+    (Util.StringSet.elements x.lib_deps)
+    (Fmt.option pp_index) x.index pp_kind
     (x.kind :> all_kinds)
 
 let pkg_dir : Packages.t -> Fpath.t = fun pkg -> pkg.pkg_dir

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -39,17 +39,17 @@ type 'a t = {
   odocl_file : Fpath.t;
   pkg_args : Pkg_args.t;
   pkgname : string option;
+  deps : (string * Digest.t) list;
+      (** The unit's per-module dependencies (interface deps for [`Intf], the
+          implementation's for [`Impl]; empty otherwise). Used by
+          [Compile.includes_of_deps] to derive the compile [-I] set. *)
   index : index option;
   enable_warnings : bool;
   to_output : bool;
   kind : 'a;
 }
 
-type intf_extra = {
-  hidden : bool;
-  hash : string;
-  deps : (string * Digest.t) list;
-}
+type intf_extra = { hidden : bool; hash : string }
 and intf = [ `Intf of intf_extra ]
 
 type impl_extra = { src_id : Odoc.Id.t; src_path : Fpath.t }

--- a/src/driver/odoc_unit.mli
+++ b/src/driver/odoc_unit.mli
@@ -1,3 +1,6 @@
+(** Arguments for the {e link} step ([-L] / [-P] / [-I]). The compile step does
+    not use these — it derives its includes per module from the unit's own
+    dependencies (see [Compile.includes_of_deps]). *)
 module Pkg_args : sig
   type t
 
@@ -37,12 +40,17 @@ type 'a t = {
   output_dir : Fpath.t;
   odoc_file : Fpath.t;
   odocl_file : Fpath.t;
-  pkg_args : Pkg_args.t;
+  pkg_args : Pkg_args.t;  (** Consumed only at link time (see {!Pkg_args}). *)
   pkgname : string option;
+  lib_name : string;
+      (** The library this unit belongs to (empty for pages and assets). *)
   deps : (string * Digest.t) list;
       (** The unit's per-module dependencies (interface deps for [`Intf], the
-          implementation's for [`Impl]; empty otherwise). Used by
-          [Compile.includes_of_deps] to derive the compile [-I] set. *)
+          implementation's for [`Impl]; empty otherwise). *)
+  lib_deps : Util.StringSet.t;
+      (** The unit's own library plus that library's dependencies. Used by
+          [Compile.includes_of_deps] to disambiguate which provider of a
+          dependency hash to add to the compile [-I] set. *)
   index : index option;
   enable_warnings : bool;
   to_output : bool;

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -117,8 +117,8 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
     }
   in
 
-  let make_unit ~name ~kind ~rel_dir ~input_file ~pkg ~lib_deps ~enable_warnings
-      ~to_output ~stash_input : _ t =
+  let make_unit ~name ~kind ~rel_dir ~input_file ~pkg ~lib_deps ~deps
+      ~enable_warnings ~to_output ~stash_input : _ t =
     let to_output = to_output || not remap in
     (* If we haven't got active remapping, we output everything *)
     let ( // ) = Fpath.( // ) in
@@ -141,6 +141,7 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
       output_dir = odoc_dir;
       pkgname = Some pkg.Packages.name;
       pkg_args;
+      deps;
       parent_id;
       input_file;
       input_copy;
@@ -156,15 +157,12 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
   let of_intf hidden pkg (lib : Packages.libty) lib_deps (intf : Packages.intf)
       : intf t =
     let rel_dir = lib_dir pkg lib in
-    let kind =
-      let deps = intf.mif_deps in
-      let kind = `Intf { hidden; hash = intf.mif_hash; deps } in
-      kind
-    in
+    let kind = `Intf { hidden; hash = intf.mif_hash } in
     let name = intf.mif_path |> Fpath.rem_ext |> Fpath.basename in
     let stash_input = lib.archive_name = None in
     make_unit ~name ~kind ~rel_dir ~input_file:intf.mif_path ~pkg ~lib_deps
-      ~enable_warnings:pkg.selected ~to_output:pkg.selected ~stash_input
+      ~deps:intf.mif_deps ~enable_warnings:pkg.selected ~to_output:pkg.selected
+      ~stash_input
   in
   let of_impl pkg lib lib_deps (impl : Packages.impl) : impl t option =
     match impl.mip_src_info with
@@ -184,8 +182,8 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
         in
         let unit =
           make_unit ~name ~kind ~rel_dir ~input_file:impl.mip_path ~pkg
-            ~lib_deps ~enable_warnings:false ~to_output:pkg.selected
-            ~stash_input:false
+            ~lib_deps ~deps:impl.mip_deps ~enable_warnings:false
+            ~to_output:pkg.selected ~stash_input:false
         in
         Some unit
   in
@@ -220,7 +218,8 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
     in
     let unit =
       make_unit ~name ~kind ~rel_dir ~input_file:mld_path ~pkg ~lib_deps
-        ~enable_warnings:pkg.selected ~to_output:pkg.selected ~stash_input:false
+        ~deps:[] ~enable_warnings:pkg.selected ~to_output:pkg.selected
+        ~stash_input:false
     in
     [ unit ]
   in
@@ -240,7 +239,7 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
         let lib_deps = Util.StringSet.empty in
         let unit =
           make_unit ~name ~kind ~rel_dir ~input_file:md_path ~pkg ~lib_deps
-            ~enable_warnings:pkg.selected ~to_output:pkg.selected
+            ~deps:[] ~enable_warnings:pkg.selected ~to_output:pkg.selected
             ~stash_input:false
         in
         [ unit ]
@@ -259,8 +258,8 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
     let unit =
       let name = asset_path |> Fpath.basename |> ( ^ ) "asset-" in
       make_unit ~name ~kind ~rel_dir ~input_file:asset_path ~pkg
-        ~lib_deps:Util.StringSet.empty ~enable_warnings:false ~to_output:true
-        ~stash_input:false
+        ~lib_deps:Util.StringSet.empty ~deps:[] ~enable_warnings:false
+        ~to_output:true ~stash_input:false
     in
     [ unit ]
   in

--- a/src/driver/odoc_units_of.ml
+++ b/src/driver/odoc_units_of.ml
@@ -51,52 +51,83 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
         Logs.debug (fun m -> m "Library %s not found" lib_name);
         []
   in
-  let base_args pkg lib_deps : Pkg_args.t =
-    let own_page = dash_p pkg.Packages.name (doc_dir pkg) in
-    let includes =
-      List.concat_map dash_l (Util.StringSet.to_list lib_deps) |> List.map snd
-    in
-    let libs =
-      List.fold_left
-        (fun acc lib -> Util.StringSet.add lib.Packages.lib_name acc)
-        lib_deps pkg.Packages.libraries
-    in
-    let libs = List.concat_map dash_l (Util.StringSet.to_list libs) in
-    Pkg_args.v ~pages:[ own_page ] ~libs ~includes ~odoc_dir ~odocl_dir
+  (* Inverse of [libs_of_pkg]: which package provides a given library. *)
+  let pkg_of_lib =
+    Util.StringMap.fold
+      (fun pkgname libs acc ->
+        List.fold_left
+          (fun acc lib -> Util.StringMap.add lib pkgname acc)
+          acc libs)
+      libs_of_pkg Util.StringMap.empty
   in
-  let args_of_config config : Pkg_args.t =
-    let { Global_config.deps = { packages; libraries } } = config in
-    let pages_rel =
-      List.filter_map
-        (fun pkgname ->
-          match Util.StringMap.find_opt pkgname pkg_paths with
-          | None ->
-              Logs.debug (fun m -> m "Package '%s' not found" pkgname);
-              None
-          | Some path -> Some (dash_p pkgname path))
-        packages
-    in
-    (* Add all liraries from added packages *)
-    let libraries_from_pkgs =
-      List.filter_map
-        (fun pkgname -> Util.StringMap.find_opt pkgname libs_of_pkg)
-        packages
-    in
-    let libraries = List.concat @@ (libraries :: libraries_from_pkgs) in
-    let libs_rel = List.concat_map dash_l libraries in
-    Pkg_args.v ~pages:pages_rel ~libs:libs_rel ~includes:[] ~odoc_dir ~odocl_dir
-  in
-  let args_of =
+
+  (* Link arguments ([-L]/[-P]) are computed per package, so every unit in
+     a package gets the same set. [-L] is the directly-declared library
+     dependencies of all the package's libraries (which therefore includes the
+     package's own libraries), plus any libraries named in [odoc-config.sexp]
+     (directly, or via a named package). We do not take the transitive closure:
+     dependencies the META files omit are recovered earlier by digest
+     ([Packages.fix_missing_deps]). [-P] is every package that provides one of
+     those libraries, plus the package itself and any package named in
+     [odoc-config.sexp]. [-I] is computed per unit instead (see
+     [Compile.includes_of_deps] / [Compile.unit_includes]). *)
+  let link_args_of =
     let cache = Hashtbl.create 10 in
-    fun pkg lib_deps : Pkg_args.t ->
-      match Hashtbl.find_opt cache (pkg, lib_deps) with
+    fun pkg _lib_deps : Pkg_args.t ->
+      match Hashtbl.find_opt cache pkg.Packages.name with
       | Some res -> res
       | None ->
-          let result =
-            Pkg_args.combine (base_args pkg lib_deps)
-              (args_of_config pkg.Packages.config)
+          let {
+            Global_config.deps = { packages = cfg_pkgs; libraries = cfg_libs };
+          } =
+            pkg.Packages.config
           in
-          Hashtbl.add cache (pkg, lib_deps) result;
+          let libs_from_pkg =
+            List.fold_left
+              (fun acc (lib : Packages.libty) ->
+                Util.StringSet.add lib.lib_name
+                  (Util.StringSet.union lib.lib_deps acc))
+              Util.StringSet.empty pkg.Packages.libraries
+          in
+          let libs_of_cfg_pkgs =
+            List.fold_left
+              (fun acc pkgname ->
+                match Util.StringMap.find_opt pkgname libs_of_pkg with
+                | Some libs ->
+                    List.fold_left
+                      (fun acc l -> Util.StringSet.add l acc)
+                      acc libs
+                | None -> acc)
+              Util.StringSet.empty cfg_pkgs
+          in
+          let lib_set =
+            Util.StringSet.union libs_from_pkg
+              (Util.StringSet.union
+                 (Util.StringSet.of_list cfg_libs)
+                 libs_of_cfg_pkgs)
+          in
+          let libs = List.concat_map dash_l (Util.StringSet.to_list lib_set) in
+          let pkg_set =
+            Util.StringSet.fold
+              (fun libname acc ->
+                match Util.StringMap.find_opt libname pkg_of_lib with
+                | Some p -> Util.StringSet.add p acc
+                | None -> acc)
+              lib_set
+              (Util.StringSet.add pkg.Packages.name
+                 (Util.StringSet.of_list cfg_pkgs))
+          in
+          let pages =
+            Util.StringSet.to_list pkg_set
+            |> List.filter_map (fun pkgname ->
+                   match Util.StringMap.find_opt pkgname pkg_paths with
+                   | Some path -> Some (dash_p pkgname path)
+                   | None -> None)
+          in
+          let result =
+            Pkg_args.v ~pages ~libs ~includes:[] ~odoc_dir ~odocl_dir
+          in
+          Hashtbl.add cache pkg.Packages.name result;
           result
   in
 
@@ -117,13 +148,13 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
     }
   in
 
-  let make_unit ~name ~kind ~rel_dir ~input_file ~pkg ~lib_deps ~deps
-      ~enable_warnings ~to_output ~stash_input : _ t =
+  let make_unit ~name ~kind ~rel_dir ~input_file ~pkg ~lib_name ~deps
+      ~lib_deps ~enable_warnings ~to_output ~stash_input : _ t =
     let to_output = to_output || not remap in
     (* If we haven't got active remapping, we output everything *)
     let ( // ) = Fpath.( // ) in
     let ( / ) = Fpath.( / ) in
-    let pkg_args = args_of pkg lib_deps in
+    let pkg_args = link_args_of pkg lib_deps in
     let parent_id = rel_dir |> Odoc.Id.of_fpath in
     let odoc_file =
       odoc_dir // rel_dir / (String.uncapitalize_ascii name ^ ".odoc")
@@ -141,7 +172,9 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
       output_dir = odoc_dir;
       pkgname = Some pkg.Packages.name;
       pkg_args;
+      lib_name;
       deps;
+      lib_deps;
       parent_id;
       input_file;
       input_copy;
@@ -160,8 +193,9 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
     let kind = `Intf { hidden; hash = intf.mif_hash } in
     let name = intf.mif_path |> Fpath.rem_ext |> Fpath.basename in
     let stash_input = lib.archive_name = None in
-    make_unit ~name ~kind ~rel_dir ~input_file:intf.mif_path ~pkg ~lib_deps
-      ~deps:intf.mif_deps ~enable_warnings:pkg.selected ~to_output:pkg.selected
+    make_unit ~name ~kind ~rel_dir
+      ~input_file:intf.mif_path ~pkg ~lib_name:lib.lib_name ~deps:intf.mif_deps
+      ~lib_deps ~enable_warnings:pkg.selected ~to_output:pkg.selected
       ~stash_input
   in
   let of_impl pkg lib lib_deps (impl : Packages.impl) : impl t option =
@@ -181,8 +215,9 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
           |> String.uncapitalize_ascii |> ( ^ ) "impl-"
         in
         let unit =
-          make_unit ~name ~kind ~rel_dir ~input_file:impl.mip_path ~pkg
-            ~lib_deps ~deps:impl.mip_deps ~enable_warnings:false
+          make_unit ~name ~kind ~rel_dir
+            ~input_file:impl.mip_path ~pkg ~lib_name:lib.lib_name
+            ~deps:impl.mip_deps ~lib_deps ~enable_warnings:false
             ~to_output:pkg.selected ~stash_input:false
         in
         Some unit
@@ -217,9 +252,9 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
       |> Util.StringSet.of_list
     in
     let unit =
-      make_unit ~name ~kind ~rel_dir ~input_file:mld_path ~pkg ~lib_deps
-        ~deps:[] ~enable_warnings:pkg.selected ~to_output:pkg.selected
-        ~stash_input:false
+      make_unit ~name ~kind ~rel_dir
+        ~input_file:mld_path ~pkg ~lib_name:"" ~deps:[] ~lib_deps
+        ~enable_warnings:pkg.selected ~to_output:pkg.selected ~stash_input:false
     in
     [ unit ]
   in
@@ -238,8 +273,9 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
         in
         let lib_deps = Util.StringSet.empty in
         let unit =
-          make_unit ~name ~kind ~rel_dir ~input_file:md_path ~pkg ~lib_deps
-            ~deps:[] ~enable_warnings:pkg.selected ~to_output:pkg.selected
+          make_unit ~name ~kind ~rel_dir
+            ~input_file:md_path ~pkg ~lib_name:"" ~deps:[] ~lib_deps
+            ~enable_warnings:pkg.selected ~to_output:pkg.selected
             ~stash_input:false
         in
         [ unit ]
@@ -257,9 +293,10 @@ let packages ~dirs ~extra_paths ~remap ~indices_style (pkgs : Packages.t list) :
     let kind = `Asset in
     let unit =
       let name = asset_path |> Fpath.basename |> ( ^ ) "asset-" in
-      make_unit ~name ~kind ~rel_dir ~input_file:asset_path ~pkg
-        ~lib_deps:Util.StringSet.empty ~deps:[] ~enable_warnings:false
-        ~to_output:true ~stash_input:false
+      make_unit ~name ~kind ~rel_dir
+        ~input_file:asset_path ~pkg ~lib_name:"" ~deps:[]
+        ~lib_deps:Util.StringSet.empty ~enable_warnings:false ~to_output:true
+        ~stash_input:false
     in
     [ unit ]
   in

--- a/src/driver/packages.ml
+++ b/src/driver/packages.ml
@@ -303,23 +303,30 @@ let mk_mlds docs =
             { md_path = doc.file; md_rel_path = doc.rel_path } :: others ))
     ([], [], []) docs
 
-let fix_missing_deps pkgs =
-  let lib_name_by_hash =
-    List.fold_right
-      (fun pkg acc ->
-        List.fold_left
-          (fun acc lib ->
-            List.fold_left
-              (fun acc m ->
-                Util.StringMap.update m.m_intf.mif_hash
-                  (function
-                    | None -> Some [ lib.lib_name ]
-                    | Some l -> Some (lib.lib_name :: l))
-                  acc)
-              acc lib.modules)
-          acc pkg.libraries)
-      pkgs Util.StringMap.empty
-  in
+(* Map from a module's interface hash to the name(s) of the library(ies) that
+   provide it. This is the raw material [fix_missing_deps] uses to recover
+   library dependencies that a package's META files fail to declare. *)
+let lib_name_by_hash pkgs =
+  List.fold_right
+    (fun pkg acc ->
+      List.fold_left
+        (fun acc lib ->
+          List.fold_left
+            (fun acc m ->
+              Util.StringMap.update m.m_intf.mif_hash
+                (function
+                  | None -> Some [ lib.lib_name ]
+                  | Some l -> Some (lib.lib_name :: l))
+                acc)
+            acc lib.modules)
+        acc pkg.libraries)
+    pkgs Util.StringMap.empty
+
+(* Like [fix_missing_deps] but with a caller-supplied [lib_name_by_hash]. In
+   voodoo mode the dependencies' modules aren't loaded in memory, so the map is
+   assembled from the [lib_name] recorded in the partials of already-compiled
+   dependencies and merged with the current package's own modules. *)
+let fix_missing_deps_with lib_name_by_hash pkgs =
   List.map
     (fun pkg ->
       let libraries =
@@ -363,6 +370,8 @@ let fix_missing_deps pkgs =
       in
       { pkg with libraries })
     pkgs
+
+let fix_missing_deps pkgs = fix_missing_deps_with (lib_name_by_hash pkgs) pkgs
 
 let of_libs ~packages_dir libs =
   let Ocamlfind.Db.
@@ -579,26 +588,32 @@ let remap_virtual_interfaces duplicate_hashes pkgs =
       })
     pkgs
 
+(* Modules grouped by interface hash, keeping only hashes shared by more than
+   one module (a virtual library's modules with those of its implementations),
+   each paired with its library. Underlies both interface remapping and
+   sibling-implementation exclusion. *)
+let virtual_modules pkgs =
+  let by_hash =
+    List.fold_left
+      (fun acc pkg ->
+        List.fold_left
+          (fun acc lib ->
+            List.fold_left
+              (fun acc m ->
+                Util.StringMap.update m.m_intf.mif_hash
+                  (function
+                    | None -> Some [ (lib, m) ] | Some l -> Some ((lib, m) :: l))
+                  acc)
+              acc lib.modules)
+          acc pkg.libraries)
+      Util.StringMap.empty pkgs
+  in
+  Util.StringMap.filter (fun _hash ms -> List.length ms > 1) by_hash
+
 let remap_virtual all =
   let virtual_check =
-    let hashes =
-      List.fold_left
-        (fun acc pkg ->
-          List.fold_left
-            (fun acc lib ->
-              List.fold_left
-                (fun acc m ->
-                  let hash = m.m_intf.mif_hash in
-                  Util.StringMap.update hash
-                    (function
-                      | None -> Some [ m.m_intf ]
-                      | Some l -> Some (m.m_intf :: l))
-                    acc)
-                acc lib.modules)
-            acc pkg.libraries)
-        Util.StringMap.empty all
-    in
-    Util.StringMap.filter (fun _hash intfs -> List.length intfs > 1) hashes
+    Util.StringMap.map
+      (List.map (fun (_lib, m) -> m.m_intf))
+      (virtual_modules all)
   in
-
   remap_virtual_interfaces virtual_check all

--- a/src/driver/packages.mli
+++ b/src/driver/packages.mli
@@ -91,6 +91,17 @@ val pp : Format.formatter -> t -> unit
 
 val fix_missing_deps : t list -> t list
 
+val lib_name_by_hash : t list -> string list Util.StringMap.t
+(** [lib_name_by_hash pkgs] maps each module interface hash to the name(s) of
+    the library(ies) in [pkgs] providing a module with that hash. *)
+
+val fix_missing_deps_with : string list Util.StringMap.t -> t list -> t list
+(** [fix_missing_deps_with lib_name_by_hash pkgs] is like {!fix_missing_deps}
+    but resolves module hashes against the supplied map rather than only the
+    modules present in [pkgs]. Used in voodoo mode, where the dependencies'
+    modules aren't loaded but their hashes and library names are available from
+    the partials of already-compiled dependencies. *)
+
 val mk_mlds : Opam.doc_file list -> mld list * asset list * md list
 
 val of_libs : packages_dir:Fpath.t option -> Util.StringSet.t -> t list

--- a/src/driver/voodoo.ml
+++ b/src/driver/voodoo.ml
@@ -104,34 +104,11 @@ let of_voodoo pkg =
       (Util.StringMap.empty, []) metas
   in
 
-  (* Transitively close [all_lib_deps] over itself so each lib's deps
-     reflect every lib reachable through META requires. *)
-  let all_lib_deps =
-    let cache : (string, Util.StringSet.t) Hashtbl.t =
-      Hashtbl.create (Util.StringMap.cardinal all_lib_deps)
-    in
-    let rec close lib =
-      match Hashtbl.find_opt cache lib with
-      | Some r -> r
-      | None ->
-          Hashtbl.add cache lib Util.StringSet.empty;
-          let direct =
-            match Util.StringMap.find_opt lib all_lib_deps with
-            | Some s -> s
-            | None -> Util.StringSet.empty
-          in
-          let closed =
-            Util.StringSet.fold
-              (fun dep acc ->
-                Util.StringSet.union (Util.StringSet.add dep (close dep)) acc)
-              direct Util.StringSet.empty
-          in
-          Hashtbl.replace cache lib closed;
-          closed
-    in
-    Util.StringMap.mapi (fun lib _ -> close lib) all_lib_deps
-  in
-
+  (* [all_lib_deps] holds only the directly-declared META dependencies of each
+     library. We deliberately do not take the transitive closure here: missing
+     dependencies are instead recovered by digest (see
+     [Packages.fix_missing_deps_with] wired into the voodoo driver), which is
+     both more precise and able to reach libraries the META files omit. *)
   let ss_pp fmt ss = Format.fprintf fmt "[%d]" (Util.StringSet.cardinal ss) in
   Logs.debug (fun m ->
       m "all_lib_deps: %a\n%!"

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -239,32 +239,45 @@ end = struct
     let output = output_file ~dst ~input in
     let cli_spec =
       let error message = Error (`Cli_error message) in
-      match
-        (parent_name_opt, package_opt, parent_id_opt, children, output_dir)
-      with
-      | Some _, None, None, _, None ->
-          Ok (Compile.CliParent { parent = parent_name_opt; children; output })
-      | None, Some p, None, [], None ->
-          Ok (Compile.CliPackage { package = p; output })
-      | None, None, Some p, [], Some output_dir ->
-          Ok (Compile.CliParentId { parent_id = p; output_dir })
-      | None, None, None, _ :: _, None ->
-          Ok (Compile.CliParent { parent = None; output; children })
-      | None, None, None, [], None -> Ok (Compile.CliNoParent output)
-      | Some _, Some _, _, _, _ ->
+      let no_output_dir =
+        match output_dir with
+        | None -> Ok ()
+        | Some _ -> error "--output-dir can only be passed with --parent-id."
+      in
+      let no_children flag =
+        match children with
+        | [] -> Ok ()
+        | _ :: _ -> error ("--child cannot be passed with " ^ flag ^ ".")
+      in
+      match (parent_name_opt, package_opt, parent_id_opt) with
+      | Some _, Some _, _ ->
           error "Either --package or --parent should be specified, not both."
-      | _, Some _, Some _, _, _ ->
+      | _, Some _, Some _ ->
           error "Either --package or --parent-id should be specified, not both."
-      | Some _, _, Some _, _, _ ->
+      | Some _, _, Some _ ->
           error "Either --parent or --parent-id should be specified, not both."
-      | _, _, None, _, Some _ ->
-          error "--output-dir can only be passed with --parent-id."
-      | None, Some _, _, _ :: _, _ ->
-          error "--child cannot be passed with --package."
-      | None, _, Some _, _ :: _, _ ->
-          error "--child cannot be passed with --parent-id."
-      | _, _, Some _, _, None ->
-          error "--output-dir is required when passing --parent-id."
+      | (Some _ as parent), None, None ->
+          no_output_dir >>= fun () ->
+          Ok (Compile.CliParent { parent; children; output })
+      | None, Some package, None ->
+          no_output_dir >>= fun () ->
+          no_children "--package" >>= fun () ->
+          Ok (Compile.CliPackage { package; output })
+      | None, None, Some parent_id -> (
+          no_children "--parent-id" >>= fun () ->
+          match (dst, output_dir) with
+          | Some _, _ ->
+              Ok (Compile.CliParentId { parent_id; output = `File output })
+          | None, Some output_dir ->
+              Ok (Compile.CliParentId { parent_id; output = `Dir output_dir })
+          | None, None ->
+              error "--output-dir or -o is required when passing --parent-id.")
+      | None, None, None -> (
+          no_output_dir >>= fun () ->
+          match children with
+          | [] -> Ok (Compile.CliNoParent output)
+          | _ :: _ -> Ok (Compile.CliParent { parent = None; output; children })
+          )
     in
     cli_spec >>= fun cli_spec ->
     Fs.Directory.mkdir_p (Fs.File.dirname output);
@@ -281,7 +294,8 @@ end = struct
        absent outputs a $(i,BASE.odoc) file in the same directory as the input \
        file where $(i,BASE) is the basename of the input file. For mld files \
        the \"page-\" prefix will be added if not already present in the input \
-       basename."
+       basename. Takes precedence over the output path computed from \
+       $(b,--parent-id) and $(b,--output-dir)."
     in
     Arg.(value & opt (some string) None & info ~docs ~docv:"PATH" ~doc [ "o" ])
 

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -426,6 +426,13 @@ module Compile_impl = struct
       & opt (some string) None
       & info ~docs ~docv:"PATH" ~doc [ "output-dir" ])
 
+  let dst =
+    let doc =
+      "Output file path. Takes precedence over the output path computed from \
+       $(b,--parent-id) and $(b,--output-dir), which is then not required."
+    in
+    Arg.(value & opt (some string) None & info ~docs ~docv:"PATH" ~doc [ "o" ])
+
   let output_file output_dir parent_id input =
     let name =
       Fs.File.basename input |> Fpath.set_ext "odoc" |> Fs.File.to_string
@@ -439,16 +446,20 @@ module Compile_impl = struct
       ~name
 
   let compile_impl directories output_dir parent_id source_id input
-      warnings_options =
+      warnings_options dst =
     let input = Fs.File.of_string input in
-    let output_dir =
-      match output_dir with Some x -> Fpath.v x | None -> Fpath.v "."
-    in
     let output =
-      output_file output_dir
-        (match parent_id with Some x -> Fpath.v x | None -> Fpath.v ".")
-        input
+      match dst with
+      | Some dst -> Fs.File.of_string dst
+      | None ->
+          let output_dir =
+            match output_dir with Some x -> Fpath.v x | None -> Fpath.v "."
+          in
+          output_file output_dir
+            (match parent_id with Some x -> Fpath.v x | None -> Fpath.v ".")
+            input
     in
+    Fs.Directory.mkdir_p (Fs.File.dirname output);
     let resolver =
       Resolver.create ~important_digests:true ~directories ~open_modules:[]
         ~roots:None
@@ -478,7 +489,7 @@ module Compile_impl = struct
     Term.(
       const handle_error
       $ (const compile_impl $ odoc_file_directories $ output_dir $ parent_id
-       $ source_id $ input $ warnings_options))
+       $ source_id $ input $ warnings_options $ dst))
 
   let info ~docs =
     let doc =

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -26,7 +26,10 @@ type parent_spec = {
   output : Fpath.t;
 }
 
-type parent_id_spec = { parent_id : string; output_dir : string }
+type parent_id_spec = {
+  parent_id : string;
+  output : [ `Dir of string | `File of Fpath.t ];
+}
 
 type cli_spec =
   | CliNoParent of Fpath.t
@@ -370,20 +373,25 @@ let resolve_spec ~input resolver cli_spec =
           parents_children = None;
           children = [];
         }
-  | CliParentId { parent_id; output_dir } ->
+  | CliParentId { parent_id; output } ->
       let parent_id = mk_id parent_id in
-      let directory =
-        path_of_id output_dir parent_id
-        |> Fpath.to_string |> Fs.Directory.of_string
+      let output =
+        match output with
+        | `File output -> output
+        | `Dir output_dir ->
+            let directory =
+              path_of_id output_dir parent_id
+              |> Fpath.to_string |> Fs.Directory.of_string
+            in
+            let name =
+              let ext = Fs.File.get_ext input in
+              let name = Fs.File.set_ext ".odoc" input in
+              let name = Fs.File.basename name in
+              if ext = ".mld" then "page-" ^ Fs.File.to_string name
+              else name |> Fpath.to_string |> String.Ascii.uncapitalize
+            in
+            Fs.File.create ~directory ~name
       in
-      let name =
-        let ext = Fs.File.get_ext input in
-        let name = Fs.File.set_ext ".odoc" input in
-        let name = Fs.File.basename name in
-        if ext = ".mld" then "page-" ^ Fs.File.to_string name
-        else name |> Fpath.to_string |> String.Ascii.uncapitalize
-      in
-      let output = Fs.File.create ~directory ~name in
       Ok { parent_id; output; parents_children = None; children = [] }
   | CliNoParent output ->
       Ok { output; parent_id = None; parents_children = None; children = [] }

--- a/src/odoc/compile.mli
+++ b/src/odoc/compile.mli
@@ -25,7 +25,13 @@ type parent_spec = {
   output : Fpath.t;
 }
 
-type parent_id_spec = { parent_id : string; output_dir : string }
+type parent_id_spec = {
+  parent_id : string;
+  output : [ `Dir of string | `File of Fpath.t ];
+      (** With [`Dir], the output path is computed from the directory, the
+          parent id and the input file name. [`File] specifies the output path
+          directly. *)
+}
 
 type cli_spec =
   | CliNoParent of Fpath.t

--- a/test/parent_id/parent_id.t/run.t
+++ b/test/parent_id/parent_id.t/run.t
@@ -34,6 +34,15 @@ Passing -o overrides the output path computed from --parent-id and
   page-renamed.odoc
   unit.odoc
 
+compile-impl also honours -o, writing to the given path instead of the one
+computed from --parent-id and --output-dir:
+
+  $ odoc compile-impl --parent-id pkg/libname --source-id pkg/src/unit.ml -o custom/impl-unit.odoc unit.cmt
+  $ ls custom
+  impl-unit.odoc
+  page-renamed.odoc
+  unit.odoc
+
 Either -o or --output-dir must be passed with --parent-id:
 
   $ odoc compile --parent-id pkg file.mld

--- a/test/parent_id/parent_id.t/run.t
+++ b/test/parent_id/parent_id.t/run.t
@@ -6,6 +6,40 @@
   $ odoc compile --output-dir _odoc/ --parent-id pkg index.mld
   $ odoc compile --output-dir _odoc/ --parent-id pkg/libname unit.cmt
 
+Passing -o overrides the output path computed from --parent-id and
+--output-dir. The parent id is still used for the identifier:
+
+  $ odoc compile --output-dir _odoc/ --parent-id pkg -o custom/page-renamed.odoc file.mld
+  $ ls custom
+  page-renamed.odoc
+  $ odoc_print custom/page-renamed.odoc | jq ".name"
+  {
+    "`LeafPage": [
+      {
+        "Some": {
+          "`Page": [
+            "None",
+            "pkg"
+          ]
+        }
+      },
+      "renamed"
+    ]
+  }
+
+--output-dir is not required when -o is passed:
+
+  $ odoc compile --parent-id pkg/libname -o custom/unit.odoc unit.cmt
+  $ ls custom
+  page-renamed.odoc
+  unit.odoc
+
+Either -o or --output-dir must be passed with --parent-id:
+
+  $ odoc compile --parent-id pkg file.mld
+  --output-dir or -o is required when passing --parent-id.
+  [2]
+
   $ odoc link _odoc/pkg/page-file.odoc 2>&1 >/dev/null | grep 'Failure'
   [1]
   $ odoc link -P pkg:_odoc/pkg/ _odoc/pkg/page-file.odoc


### PR DESCRIPTION
Before this commit, we were very strict about where the output of `odoc compile` and `odoc compile-impl` went, as it's very important to ensure that we can specify paths correctly for `-L`. However, with the idea of putting the odoc files into the switch, we can relax this somewhat, on the basis that if the output files go alongside the cmis, then we're inheriting exactly the same path-based resolution that the compiler has, and if it's good enough for the compiler, it should be good enough for us!

This is on top of the driver changes commits.