### PR TITLE
OxCaml: support for kind abbreviations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Support OxCaml 5.2.0minus39 (@jonludlam, #1469)
 - Support for OxCaml modes (@art-w, #1454)
 - Fix OxCaml with-bounds for arbitrary types (@art-w, #1466)
+- Support for OxCaml kind abbreviations (@art-w, #1467)
 
 ### Fixed
 - Remove requirement for ppx_expect in tests (@jonludlam, #1445)

--- a/sherlodoc/index/load_doc.ml
+++ b/sherlodoc/index/load_doc.ml
@@ -101,6 +101,7 @@ let searchable_type_of_record parent_type type_ =
 let convert_kind ~db (Odoc_index.Entry.{ kind; _ } as entry) =
   match kind with
   | TypeDecl _ -> Entry.Kind.Type_decl (Odoc_search.Html.typedecl_params_of_entry entry)
+  | KindAbbreviation -> Entry.Kind.Type_decl None
   | Value { value = _; type_ } ->
       let typ = Db_writer.type_of_odoc ~db type_ in
       Entry.Kind.Val typ
@@ -149,8 +150,9 @@ let rec categorize id =
   | `ModuleType _ -> `declaration
   | `Parameter _ -> `ignore (* redundant with indexed signature *)
   | ( `InstanceVariable _ | `Method _ | `Field _ | `Result _ | `Label _ | `Type _
-    | `Exception _ | `Class _ | `ClassType _ | `Value _ | `Constructor _ | `Extension _
-    | `ExtensionDecl _ | `Module _ | `UnboxedField _ ) as x ->
+    | `KindAbbreviation _ | `Exception _ | `Class _ | `ClassType _ | `Value _
+    | `Constructor _ | `Extension _ | `ExtensionDecl _ | `Module _ | `UnboxedField _ ) as
+    x ->
       let parent = Identifier.label_parent { id with iv = x } in
       categorize (parent :> Identifier.Any.t)
   | `AssetFile _ | `SourceLocationMod _ | `SourceLocation _ | `SourcePage _

--- a/sherlodoc/index/load_doc.ml
+++ b/sherlodoc/index/load_doc.ml
@@ -102,6 +102,7 @@ let searchable_type_of_record parent_type type_ =
 let convert_kind ~db (Odoc_index.Entry.{ kind; _ } as entry) =
   match kind with
   | TypeDecl _ -> Entry.Kind.Type_decl (Odoc_search.Html.typedecl_params_of_entry entry)
+  | KindAbbreviation -> Entry.Kind.Type_decl None
   | Value { value = _; type_ } ->
       let typ = Db_writer.type_of_odoc ~db type_ in
       Entry.Kind.Val typ
@@ -150,8 +151,9 @@ let rec categorize id =
   | `ModuleType _ -> `declaration
   | `Parameter _ -> `ignore (* redundant with indexed signature *)
   | ( `InstanceVariable _ | `Method _ | `Field _ | `Result _ | `Label _ | `Type _
-    | `Exception _ | `Class _ | `ClassType _ | `Value _ | `Constructor _ | `Extension _
-    | `ExtensionDecl _ | `Module _ | `UnboxedField _ ) as x ->
+    | `KindAbbreviation _ | `Exception _ | `Class _ | `ClassType _ | `Value _
+    | `Constructor _ | `Extension _ | `ExtensionDecl _ | `Module _ | `UnboxedField _ ) as
+    x ->
       let parent = Identifier.label_parent { id with iv = x } in
       categorize (parent :> Identifier.Any.t)
   | `AssetFile _ | `SourceLocationMod _ | `SourceLocation _ | `SourcePage _

--- a/src/.ocamlformat-ignore
+++ b/src/.ocamlformat-ignore
@@ -3,6 +3,7 @@ loader/cmi.ml
 loader/cmi.mli
 loader/cmt.ml
 loader/cmti.ml
+loader/cmti.mli
 loader/doc_attr.ml
 loader/ident_env.ml
 loader/implementation.ml

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -87,6 +87,8 @@ module Reference = struct
     | `ModuleType (p, f) ->
         render_unresolved (p :> t) ^ "." ^ ModuleTypeName.to_string f
     | `Type (p, f) -> render_unresolved (p :> t) ^ "." ^ TypeName.to_string f
+    | `KindAbbreviation (p, f) ->
+        render_unresolved (p :> t) ^ "." ^ TypeName.to_string f
     | `Constructor (p, f) ->
         render_unresolved (p :> t) ^ "." ^ ConstructorName.to_string f
     | `Field (p, f) -> render_unresolved (p :> t) ^ "." ^ FieldName.to_string f

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -95,11 +95,19 @@ module Make (Syntax : SYNTAX) = struct
   module Link : sig
     val from_path : Paths.Path.t -> text
 
+    val from_identifier : ?text:string -> Paths.Identifier.t -> text
+
     val from_fragment : Paths.Fragment.leaf -> text
 
     val render_fragment_any : Paths.Fragment.t -> string
   end = struct
     open Paths
+
+    let from_identifier ?text : Identifier.t -> _ =
+     fun id ->
+      let href = Url.from_identifier ~stop_before:false id in
+      let label = match text with Some t -> t | None -> Identifier.name id in
+      resolved href [ inline @@ Text label ]
 
     let rec from_path : Path.t -> text =
      fun path ->
@@ -451,8 +459,15 @@ module Make (Syntax : SYNTAX) = struct
       in
       match k with
       | Default -> O.noop
-      | Abbreviation frag ->
-          O.txt (Link.render_fragment_any (frag :> Paths.Fragment.t))
+      | Abbreviation (name, ref_opt) -> (
+          let id_opt =
+            match ref_opt with
+            | Some (`Resolved r) -> Paths.Reference.Resolved.identifier r
+            | _ -> None
+          in
+          match id_opt with
+          | Some id -> Link.from_identifier ~text:name id
+          | None -> O.txt name)
       | Mod (base, modes) ->
           let res =
             kind_annotation ~needs_parentheses:true base
@@ -592,6 +607,8 @@ module Make (Syntax : SYNTAX) = struct
       ?is_substitution:bool ->
       Lang.Signature.recursive * Lang.TypeDecl.t ->
       Item.t
+
+    val kind_abbreviation : Lang.KindAbbreviation.t -> Item.t
 
     val extension : Lang.Extension.t -> Item.t
 
@@ -1045,6 +1062,21 @@ module Make (Syntax : SYNTAX) = struct
       let doc = Comment.to_ir t.doc.elements in
       let source_anchor = source_anchor t.source_loc in
       Item.Declaration { attr; anchor; doc; content; source_anchor }
+
+    let kind_abbreviation (t : Lang.KindAbbreviation.t) =
+      let name = Paths.Identifier.name t.id in
+      let intro = O.keyword "kind_" ++ O.sp ++ O.txt name in
+      let manifest =
+        match t.manifest with
+        | None -> O.noop
+        | Some k -> O.txt " =" ++ O.sp ++ Type_expression.kind_annotation k
+      in
+      let content = O.documentedSrc (intro ++ manifest) in
+      let attr = [ "type"; "kind-abbreviation" ] in
+      let anchor = path_to_id t.id in
+      let doc = Comment.to_ir t.doc.elements in
+      let source_anchor = source_anchor t.source_loc in
+      Item.Declaration { attr; anchor; doc; content; source_anchor }
   end
 
   open Type_declaration
@@ -1447,6 +1479,7 @@ module Make (Syntax : SYNTAX) = struct
             | TypeSubstitution t ->
                 continue @@ type_decl ~is_substitution:true (Ordinary, t)
             | Type (r, t) -> continue @@ type_decl (r, t)
+            | KindAbbreviation t -> continue @@ kind_abbreviation t
             | TypExt e -> continue @@ extension e
             | Exception e -> continue @@ exn e
             | Value v -> continue @@ value v

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -95,11 +95,19 @@ module Make (Syntax : SYNTAX) = struct
   module Link : sig
     val from_path : Paths.Path.t -> text
 
+    val from_identifier : ?text:string -> Paths.Identifier.t -> text
+
     val from_fragment : Paths.Fragment.leaf -> text
 
     val render_fragment_any : Paths.Fragment.t -> string
   end = struct
     open Paths
+
+    let from_identifier ?text : Identifier.t -> _ =
+     fun id ->
+      let href = Url.from_identifier ~stop_before:false id in
+      let label = match text with Some t -> t | None -> Identifier.name id in
+      resolved href [ inline @@ Text label ]
 
     let rec from_path : Path.t -> text =
      fun path ->
@@ -456,8 +464,15 @@ module Make (Syntax : SYNTAX) = struct
       in
       match k with
       | Default -> O.noop
-      | Abbreviation frag ->
-          O.txt (Link.render_fragment_any (frag :> Paths.Fragment.t))
+      | Abbreviation (name, ref_opt) -> (
+          let id_opt =
+            match ref_opt with
+            | Some (`Resolved r) -> Paths.Reference.Resolved.identifier r
+            | _ -> None
+          in
+          match id_opt with
+          | Some id -> Link.from_identifier ~text:name id
+          | None -> O.txt name)
       | Mod (base, modes) ->
           let res =
             kind_annotation ~needs_parentheses:true base
@@ -588,6 +603,8 @@ module Make (Syntax : SYNTAX) = struct
       ?is_substitution:bool ->
       Lang.Signature.recursive * Lang.TypeDecl.t ->
       Item.t
+
+    val kind_abbreviation : Lang.KindAbbreviation.t -> Item.t
 
     val extension : Lang.Extension.t -> Item.t
 
@@ -1041,6 +1058,21 @@ module Make (Syntax : SYNTAX) = struct
       let doc = Comment.to_ir t.doc.elements in
       let source_anchor = source_anchor t.source_loc in
       Item.Declaration { attr; anchor; doc; content; source_anchor }
+
+    let kind_abbreviation (t : Lang.KindAbbreviation.t) =
+      let name = Paths.Identifier.name t.id in
+      let intro = O.keyword "kind_" ++ O.sp ++ O.txt name in
+      let manifest =
+        match t.manifest with
+        | None -> O.noop
+        | Some k -> O.txt " =" ++ O.sp ++ Type_expression.kind_annotation k
+      in
+      let content = O.documentedSrc (intro ++ manifest) in
+      let attr = [ "type"; "kind-abbreviation" ] in
+      let anchor = path_to_id t.id in
+      let doc = Comment.to_ir t.doc.elements in
+      let source_anchor = source_anchor t.source_loc in
+      Item.Declaration { attr; anchor; doc; content; source_anchor }
   end
 
   open Type_declaration
@@ -1443,6 +1475,7 @@ module Make (Syntax : SYNTAX) = struct
             | TypeSubstitution t ->
                 continue @@ type_decl ~is_substitution:true (Ordinary, t)
             | Type (r, t) -> continue @@ type_decl (r, t)
+            | KindAbbreviation t -> continue @@ kind_abbreviation t
             | TypExt e -> continue @@ extension e
             | Exception e -> continue @@ exn e
             | Value v -> continue @@ value v

--- a/src/document/targets.ml
+++ b/src/document/targets.ml
@@ -19,8 +19,8 @@ and signature (t : Odoc_model.Lang.Signature.t) =
         | ModuleType mty -> add_items ~don't (module_type mty :: acc) is
         | Include incl -> add_items ~don't (include_ incl :: acc) is
         | Open _ | ModuleSubstitution _ | ModuleTypeSubstitution _
-        | TypeSubstitution _ | Type _ | TypExt _ | Exception _ | Value _
-        | Class _ | ClassType _
+        | TypeSubstitution _ | Type _ | KindAbbreviation _ | TypExt _
+        | Exception _ | Value _ | Class _ | ClassType _
         | Comment (`Docs _) ->
             add_items ~don't acc is)
   in

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -226,6 +226,7 @@ module Anchor = struct
     [ Path.kind
     | `Section
     | `Type
+    | `KindAbbreviation
     | `Extension
     | `ExtensionDecl
     | `Exception
@@ -240,6 +241,7 @@ module Anchor = struct
     | #Path.kind as k -> Path.string_of_kind k
     | `Section -> "section"
     | `Type -> "type"
+    | `KindAbbreviation -> "kind"
     | `Extension -> "extension"
     | `ExtensionDecl -> "extension-decl"
     | `Exception -> "exception"
@@ -301,6 +303,11 @@ module Anchor = struct
         let page = Path.from_identifier (parent :> Path.any) in
         let kind = `Type in
         let name = TypeName.to_string type_name in
+        { page; anchor = Format.asprintf "%a-%s" pp_kind kind name; kind }
+    | { iv = `KindAbbreviation (parent, name); _ } ->
+        let page = Path.from_identifier (parent :> Path.any) in
+        let kind = `KindAbbreviation in
+        let name = TypeName.to_string name in
         { page; anchor = Format.asprintf "%a-%s" pp_kind kind name; kind }
     | { iv = `Extension (parent, name); _ } ->
         let page = Path.from_identifier (parent :> Path.any) in

--- a/src/document/url.mli
+++ b/src/document/url.mli
@@ -61,6 +61,7 @@ module Anchor : sig
     [ Path.kind
     | `Section
     | `Type
+    | `KindAbbreviation
     | `Extension
     | `ExtensionDecl
     | `Exception

--- a/src/index/entry.ml
+++ b/src/index/entry.ml
@@ -44,6 +44,7 @@ type module_entry = { has_expansion : bool }
 
 type kind =
   | TypeDecl of type_decl_entry
+  | KindAbbreviation
   | Module of module_entry
   | Value of value_entry
   | Doc

--- a/src/index/entry.mli
+++ b/src/index/entry.mli
@@ -42,6 +42,7 @@ type module_entry = { has_expansion : bool }
 
 type kind =
   | TypeDecl of type_decl_entry
+  | KindAbbreviation
   | Module of module_entry
   | Value of value_entry
   | Doc

--- a/src/index/skeleton.ml
+++ b/src/index/skeleton.ml
@@ -48,6 +48,9 @@ module Entry = struct
     in
     Entry.entry ~id:td.id ~doc:td.doc.elements ~kind
 
+  let of_kind_abbreviation (ka : KindAbbreviation.t) =
+    Entry.entry ~id:ka.id ~doc:ka.doc.elements ~kind:Entry.KindAbbreviation
+
   let varify_params =
     List.mapi (fun i param ->
         match param.TypeDecl.desc with
@@ -186,6 +189,7 @@ and signature_item id s_item =
   | ModuleTypeSubstitution _ -> []
   | Open _ -> []
   | Type (_, t_decl) -> type_decl t_decl
+  | KindAbbreviation ka -> [ Tree.leaf (Entry.of_kind_abbreviation ka) ]
   | TypeSubstitution _ -> []
   | TypExt te -> type_ext te
   | Exception exc -> exception_ exc

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -495,36 +495,58 @@ let read_parsetree_core_type (ct : Parsetree.core_type) =
   | Ptyp_any _ -> Any
   | _ -> failwith "invalid core type"
 
-let rec read_jkind_annotation (jk : Parsetree.jkind_annotation) =
+let rec kind_signature_reference : Longident.t -> Paths.Reference.Signature.t =
+  function
+  | Longident.Lident m -> `Root (m, `TUnknown)
+  | Longident.Ldot (p, m) -> `Dot (kind_label_parent_reference p, m)
+  | Longident.Lapply _ -> `Root ("_", `TUnknown)
+
+and kind_label_parent_reference x =
+  (kind_signature_reference x :>  Paths.Reference.LabelParent.t)
+
+let read_kind_abbreviation env (lid : Longident.t) =
+  let name = Format.asprintf "%a" Pprintast.longident lid in
+  let reference : Paths.Reference.t option =
+    match lid with
+    | Longident.Lident n ->
+        Option.map
+          (fun id -> `Resolved (`Identifier (id :> Identifier.t)))
+          (Env.find_kind_abbreviation env n)
+    | Longident.Ldot (prefix, n) ->
+        Some (`KindAbbreviation (kind_signature_reference prefix, TypeName.make_std n))
+    | Longident.Lapply _ -> None
+  in
+  Kind.Abbreviation (name, reference)
+
+let rec read_jkind_annotation env (jk : Parsetree.jkind_annotation) =
   let open Kind in
   match jk.pjka_desc with
   | Pjk_default -> Default
-  | Pjk_abbreviation s -> Abbreviation (Env.Fragment.read_type s.txt)
+  | Pjk_abbreviation s -> read_kind_abbreviation env s.txt
   | Pjk_mod (jk', modes) ->
     let modes = List.map (fun (m : Parsetree.mode Location.loc) ->
       let (Parsetree.Mode s) = m.txt in s) modes in
-    Mod (read_jkind_annotation jk', modes)
+    Mod (read_jkind_annotation env jk', modes)
   | Pjk_with (jk', cty, modalities) ->
     let ty = read_parsetree_core_type cty in
     let modalities = List.map (fun (m : Parsetree.modality Location.loc) ->
       let (Parsetree.Modality s) = m.txt in s) modalities in
-    With (read_jkind_annotation jk', ty, modalities)
+    With (read_jkind_annotation env jk', ty, modalities)
   | Pjk_kind_of cty ->
     Kind_of (read_parsetree_core_type cty)
   | Pjk_product jks ->
-    Product (List.map read_jkind_annotation jks)
+    Product (List.map (read_jkind_annotation env) jks)
 
-let read_jkind_annotation = function
+let read_jkind_annotation env = function
   | None -> Kind.Default
-  | Some jk ->
-    match read_jkind_annotation jk with
-    | Abbreviation (`Dot (`Root, "value")) -> Default
-    | k -> k
+  | Some { Parsetree.pjka_desc = Pjk_abbreviation { txt = Longident.Lident "value"; _ }; _ } ->
+    Kind.Default
+  | Some jk -> read_jkind_annotation env jk
 
-let jkind_of_type_desc te =
+let jkind_of_type_desc env te =
   match  te with
   | Tvar { jkind; _ } | Tunivar { jkind; _ } ->
-      read_jkind_annotation jkind.annotation
+      read_jkind_annotation env jkind.annotation
   | _ -> Kind.Default
 
 let read_modalities mut modalities =
@@ -550,7 +572,7 @@ let read_constructor_argument arg =
 
 #else
 
-let jkind_of_type_desc _te = Kind.Default
+let jkind_of_type_desc _env _te = Kind.Default
 let read_value_descr_modalities _vd = []
 let read_label_modalities _ld = []
 let read_constructor_argument arg = arg, []
@@ -618,7 +640,7 @@ let rec read_type_expr env typ =
           let tyl = List.map Compat.repr tyl in
           let vars_with_kinds = List.map (fun ty ->
             let name = name_of_type_repr ty in
-            let kind = jkind_of_type_desc ty.desc in
+            let kind = jkind_of_type_desc env.ident_env ty.desc in
             (name, kind)
           ) tyl in
           let typ = read_type_expr env typ in
@@ -927,7 +949,7 @@ let read_type_parameter abstr var param =
     if name = "_" then Any
     else Var name
   in
-  let kind = jkind_of_type_desc (Compat.get_desc param) in
+  let kind = jkind_of_type_desc (Env.empty ()) (Compat.get_desc param) in
   let variance =
     if not (abstr || aliasable param) then None
     else begin
@@ -1005,7 +1027,7 @@ let read_type_declaration env parent id decl =
   let private_ = (decl.type_private = Private) in
   let kind =
 #if defined OXCAML
-    read_jkind_annotation decl.type_jkind.annotation
+    read_jkind_annotation env.ident_env decl.type_jkind.annotation
 #else
     Kind.Default
 #endif
@@ -1275,6 +1297,19 @@ and read_module_rec_status rec_status =
   | Trec_first -> Rec
   | Trec_next -> And
 
+#if defined OXCAML
+and read_kind_abbreviation_from_types env parent id (jkd : Types.jkind_declaration) =
+  let open KindAbbreviation in
+  let identifier = Env.find_kind_abbreviation_identifier env.ident_env id in
+  let source_loc = None in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
+  let doc =
+    Doc_attr.attached_no_tag ~warnings_tag:env.warnings_tag container
+      jkd.jkind_attributes
+  in
+  { id = identifier; source_loc; doc; manifest = None }
+#endif
+
 and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
   let rec loop (acc,shadowed) items =
     let open Signature in
@@ -1306,6 +1341,19 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
           else shadowed
         in
         loop (Type (read_type_rec_status rec_status, decl)::acc, shadowed) rest
+#if defined OXCAML
+    | Sig_jkind(id, jkd, _)::rest ->
+        let ka = read_kind_abbreviation_from_types env parent id jkd in
+        let shadowed =
+          if Env.is_shadowed env.ident_env id
+          then
+            let identifier = Env.find_kind_abbreviation_identifier env.ident_env id in
+            let `KindAbbreviation (_, name) = identifier.iv in
+            { shadowed with s_kind_abbreviations = (Ident.name id, name) :: shadowed.s_kind_abbreviations }
+          else shadowed
+        in
+        loop (KindAbbreviation ka :: acc, shadowed) rest
+#endif
     | Sig_typext (id, ext, Text_first, _) :: rest ->
         let rec inner_loop inner_acc = function
           | Sig_typext(id, ext, Text_next, _) :: rest ->
@@ -1403,7 +1451,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
 
     | [] -> ({items = List.rev acc; compiled=false; removed = []; doc = empty_doc env }, shadowed)
   in
-    loop ([],{s_modules=[]; s_module_types=[]; s_values=[];s_types=[]; s_classes=[]; s_class_types=[]}) items
+    loop ([],{s_modules=[]; s_module_types=[]; s_values=[];s_types=[]; s_kind_abbreviations=[]; s_classes=[]; s_class_types=[]}) items
 
 and read_signature env parent (items : Odoc_model.Compat.signature) =
   let e' = Env.handle_signature_type_items parent items env.ident_env in

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -1530,7 +1530,7 @@ and read_kind_abbreviation_from_types env parent id (jkd : Types.jkind_declarati
 #endif
 
 and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
-  let rec loop (acc,shadowed) items =
+  let rec loop env (acc,shadowed) items =
     let open Signature in
     let open Odoc_model.Compat in
     let open Include in
@@ -1545,10 +1545,10 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
           | `Value (_, n) -> { shadowed with s_values = (Odoc_model.Names.parenthesise (Ident.name id), n) :: shadowed.s_values }
           else shadowed
         in
-          loop (vd :: acc, shadowed) rest
+          loop env (vd :: acc, shadowed) rest
     | Sig_type(id, _, _, _) :: rest
         when Btype.is_row_name (Ident.name id) ->
-        loop (acc, shadowed) rest
+        loop env (acc, shadowed) rest
     | Sig_type(id, decl, rec_status, _)::rest ->
         let decl = read_type_declaration env parent id decl in
         let shadowed =
@@ -1559,7 +1559,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
             { shadowed with s_types = (Ident.name id, name) :: shadowed.s_types }
           else shadowed
         in
-        loop (Type (read_type_rec_status rec_status, decl)::acc, shadowed) rest
+        loop env (Type (read_type_rec_status rec_status, decl)::acc, shadowed) rest
 #if defined OXCAML
     | Sig_jkind(id, jkd, _)::rest ->
         let ka = read_kind_abbreviation_from_types env parent id jkd in
@@ -1571,7 +1571,11 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
             { shadowed with s_kind_abbreviations = (Ident.name id, name) :: shadowed.s_kind_abbreviations }
           else shadowed
         in
-        loop (KindAbbreviation ka :: acc, shadowed) rest
+        let env =
+          { env with
+            ident_env = Env.add_kind_abbreviation_to_scope env.ident_env id }
+        in
+        loop env (KindAbbreviation ka :: acc, shadowed) rest
 #endif
     | Sig_typext (id, ext, Text_first, _) :: rest ->
         let rec inner_loop inner_acc = function
@@ -1581,15 +1585,15 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
               let ext =
                 read_type_extension env parent id ext (List.rev inner_acc)
               in
-                loop (TypExt ext :: acc, shadowed) rest
+                loop env (TypExt ext :: acc, shadowed) rest
         in
           inner_loop [] rest
     | Sig_typext (id, ext, Text_next, _) :: rest ->
         let ext = read_type_extension env parent id ext [] in
-          loop (TypExt ext :: acc, shadowed) rest
+          loop env (TypExt ext :: acc, shadowed) rest
     | Sig_typext (id, ext, Text_exception, _) :: rest ->
         let exn = read_exception env parent id ext in
-          loop (Exception exn :: acc, shadowed) rest
+          loop env (Exception exn :: acc, shadowed) rest
     | Sig_module (id, _, md, rec_status, _)::rest ->
           let md = read_module_declaration env parent id md in
           let shadowed =
@@ -1605,7 +1609,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
 { shadowed with s_modules = (Ident.name id, name) :: shadowed.s_modules }
             else shadowed
           in
-            loop (Module (read_module_rec_status rec_status, md)::acc, shadowed) rest
+            loop env (Module (read_module_rec_status rec_status, md)::acc, shadowed) rest
     | Sig_modtype(id, mtd, _) :: rest ->
           let mtd = read_module_type_declaration env parent id mtd in
           let shadowed =
@@ -1620,7 +1624,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
               { shadowed with s_module_types = (Ident.name id, name) :: shadowed.s_module_types }
             else shadowed
           in
-            loop (ModuleType mtd :: acc, shadowed) rest
+            loop env (ModuleType mtd :: acc, shadowed) rest
 #if OCAML_VERSION < (5,1,0)
     | Sig_class(id, cl, rec_status, _) :: Sig_class_type _
       :: Sig_type _ :: Sig_type _ :: rest ->
@@ -1641,7 +1645,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
             { shadowed with s_classes = (Ident.name id, name) :: shadowed.s_classes }
             else shadowed
           in
-            loop (Class (read_type_rec_status rec_status, cl)::acc, shadowed) rest
+            loop env (Class (read_type_rec_status rec_status, cl)::acc, shadowed) rest
 #if OCAML_VERSION < (5,1,0)
     | Sig_class_type(id, cltyp, rec_status, _)::Sig_type _::Sig_type _::rest ->
 #else
@@ -1659,7 +1663,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
 { shadowed with s_class_types = (Ident.name id, name) :: shadowed.s_class_types }
           else shadowed
         in
-        loop (ClassType (read_type_rec_status rec_status, cltyp)::acc, shadowed) rest
+        loop env (ClassType (read_type_rec_status rec_status, cltyp)::acc, shadowed) rest
     (* Skip all of the hidden sig items *)
 
 
@@ -1670,7 +1674,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
 
     | [] -> ({items = List.rev acc; compiled=false; removed = []; doc = empty_doc env }, shadowed)
   in
-    loop ([],{s_modules=[]; s_module_types=[]; s_values=[];s_types=[]; s_kind_abbreviations=[]; s_classes=[]; s_class_types=[]}) items
+    loop env ([],{s_modules=[]; s_module_types=[]; s_values=[];s_types=[]; s_kind_abbreviations=[]; s_classes=[]; s_class_types=[]}) items
 
 and read_signature env parent (items : Odoc_model.Compat.signature) =
   let e' = Env.handle_signature_type_items parent items env.ident_env in

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -524,20 +524,43 @@ let read_parsetree_modes (modes : Parsetree.modes) =
     let (Parsetree.Mode s) = m.txt in s)
     modes
 
-let rec read_parsetree_core_type (ct : Parsetree.core_type) =
+let rec kind_signature_reference : Longident.t -> Paths.Reference.Signature.t =
+  function
+  | Longident.Lident m -> `Root (m, `TUnknown)
+  | Longident.Ldot (p, m) -> `Dot (kind_label_parent_reference p, m)
+  | Longident.Lapply _ -> `Root ("_", `TUnknown)
+
+and kind_label_parent_reference x =
+  (kind_signature_reference x :>  Paths.Reference.LabelParent.t)
+
+let read_kind_abbreviation env (lid : Longident.t) =
+  let name = Format.asprintf "%a" Pprintast.longident lid in
+  let reference : Paths.Reference.t option =
+    match lid with
+    | Longident.Lident n ->
+        Option.map
+          (fun id -> `Resolved (`Identifier (id :> Identifier.t)))
+          (Env.find_kind_abbreviation env n)
+    | Longident.Ldot (prefix, n) ->
+        Some (`KindAbbreviation (kind_signature_reference prefix, TypeName.make_std n))
+    | Longident.Lapply _ -> None
+  in
+  Kind.Abbreviation (name, reference)
+
+let rec read_parsetree_core_type env (ct : Parsetree.core_type) =
   let open TypeExpr in
   match ct.ptyp_desc with
   | Ptyp_var (s, _) -> Var s
   | Ptyp_any _ -> Any
   | Ptyp_constr (lid, args) ->
-      Constr (read_longident_type lid.txt, List.map read_parsetree_core_type args)
+      Constr (read_longident_type lid.txt, List.map (read_parsetree_core_type env) args)
   | Ptyp_class (lid, args) ->
       Class
-        (read_longident_class_type lid.txt, List.map read_parsetree_core_type args)
+        (read_longident_class_type lid.txt, List.map (read_parsetree_core_type env) args)
   | Ptyp_tuple ts ->
-      Tuple (List.map (fun (lbl, t) -> (lbl, read_parsetree_core_type t)) ts)
+      Tuple (List.map (fun (lbl, t) -> (lbl, read_parsetree_core_type env t)) ts)
   | Ptyp_unboxed_tuple ts ->
-      Unboxed_tuple (List.map (fun (lbl, t) -> (lbl, read_parsetree_core_type t)) ts)
+      Unboxed_tuple (List.map (fun (lbl, t) -> (lbl, read_parsetree_core_type env t)) ts)
   | Ptyp_arrow (lbl, arg, res, arg_modes, res_modes) ->
       let lbl =
         match lbl with
@@ -547,8 +570,8 @@ let rec read_parsetree_core_type (ct : Parsetree.core_type) =
       in
       Arrow
         ( lbl,
-          (read_parsetree_core_type arg, read_parsetree_modes arg_modes),
-          (read_parsetree_core_type res, read_parsetree_modes res_modes) )
+          (read_parsetree_core_type env arg, read_parsetree_modes arg_modes),
+          (read_parsetree_core_type env res, read_parsetree_modes res_modes) )
   | Ptyp_variant (fields, closed, labels) ->
       let open TypeExpr.Polymorphic_variant in
       let elements =
@@ -560,11 +583,11 @@ let rec read_parsetree_core_type (ct : Parsetree.core_type) =
                   {
                     name = name.txt;
                     constant;
-                    arguments = List.map read_parsetree_core_type args;
+                    arguments = List.map (read_parsetree_core_type env) args;
                     doc =
                       { Odoc_model.Comment.elements = []; warnings_tag = None };
                   }
-            | Rinherit ct -> Type (read_parsetree_core_type ct))
+            | Rinherit ct -> Type (read_parsetree_core_type env ct))
           fields
       in
       let kind =
@@ -581,70 +604,71 @@ let rec read_parsetree_core_type (ct : Parsetree.core_type) =
           (fun (field : Parsetree.object_field) ->
             match field.pof_desc with
             | Otag (name, ct) ->
-                Method { name = name.txt; type_ = read_parsetree_core_type ct }
-            | Oinherit ct -> Inherit (read_parsetree_core_type ct))
+                Method { name = name.txt; type_ = read_parsetree_core_type env ct }
+            | Oinherit ct -> Inherit (read_parsetree_core_type env ct))
           fields
       in
       Object { fields; open_ = (closed = Asttypes.Open) }
-  | Ptyp_alias (ct, None, _) -> read_parsetree_core_type ct
-  | Ptyp_alias (ct, Some name, _) -> Alias (read_parsetree_core_type ct, name.txt)
+  | Ptyp_alias (ct, None, _) -> read_parsetree_core_type env ct
+  | Ptyp_alias (ct, Some name, _) -> Alias (read_parsetree_core_type env ct, name.txt)
   | Ptyp_poly (vars, ct) ->
       let vars =
         List.map
           (fun (name, jk) ->
             let kind =
-              match jk with None -> Kind.Default | Some jk -> read_jkind_annotation jk
+              match jk with
+              | None -> Kind.Default
+              | Some jk -> read_jkind_annotation env jk
             in
             (name.txt, kind))
           vars
       in
-      Poly (vars, read_parsetree_core_type ct)
+      Poly (vars, read_parsetree_core_type env ct)
   | Ptyp_package (lid, substs) ->
       let path = read_longident_module_type lid.txt in
       let substitutions =
         List.map
           (fun (frag, ct) ->
-            (Env.Fragment.read_type frag.txt, read_parsetree_core_type ct))
+            (Env.Fragment.read_type frag.txt, read_parsetree_core_type env ct))
           substs
       in
       Package { path; substitutions }
-  | Ptyp_quote ct -> Quote (read_parsetree_core_type ct)
-  | Ptyp_splice ct -> Splice (read_parsetree_core_type ct)
+  | Ptyp_quote ct -> Quote (read_parsetree_core_type env ct)
+  | Ptyp_splice ct -> Splice (read_parsetree_core_type env ct)
   (* TODO: no good representation available atm *)
   | Ptyp_of_kind _ | Ptyp_repr _ | Ptyp_extension _ -> Any
-  | Ptyp_open (_, ct) -> read_parsetree_core_type ct
+  | Ptyp_open (_, ct) -> read_parsetree_core_type env ct
   | Ptyp_newlayout (_, ct) ->
       (* layout-variable binder; odoc currently ignores the layout vars *)
-      read_parsetree_core_type ct
+      read_parsetree_core_type env ct
 
-and read_jkind_annotation (jk : Parsetree.jkind_annotation) =
+and read_jkind_annotation env (jk : Parsetree.jkind_annotation) =
   let open Kind in
   match jk.pjka_desc with
   | Pjk_default -> Default
-  | Pjk_abbreviation (s, _) -> Abbreviation (Env.Fragment.read_type s.txt)
+  | Pjk_abbreviation (s, _) -> read_kind_abbreviation env s.txt
   | Pjk_mod (jk', modes) ->
-    Mod (read_jkind_annotation jk', read_parsetree_modes modes)
+    Mod (read_jkind_annotation env jk', read_parsetree_modes modes)
   | Pjk_with (jk', cty, modalities) ->
-    let ty = read_parsetree_core_type cty in
+    let ty = read_parsetree_core_type env cty in
     let modalities = List.map (fun (m : Parsetree.modality Location.loc) ->
       let (Parsetree.Modality s) = m.txt in s) modalities in
-    With (read_jkind_annotation jk', ty, modalities)
+    With (read_jkind_annotation env jk', ty, modalities)
   | Pjk_kind_of cty ->
-    Kind_of (read_parsetree_core_type cty)
+    Kind_of (read_parsetree_core_type env cty)
   | Pjk_product jks ->
-    Product (List.map read_jkind_annotation jks)
+    Product (List.map (read_jkind_annotation env) jks)
 
-let read_jkind_annotation = function
+let read_jkind_annotation env = function
   | None -> Kind.Default
-  | Some jk ->
-    match read_jkind_annotation jk with
-    | Abbreviation (`Dot (`Root, "value")) -> Default
-    | k -> k
+  | Some { Parsetree.pjka_desc = Pjk_abbreviation ({ txt = Longident.Lident "value"; _ }, _); _ } ->
+    Kind.Default
+  | Some jk -> read_jkind_annotation env jk
 
-let jkind_of_type_desc te =
+let jkind_of_type_desc env te =
   match  te with
   | Tvar { jkind; _ } | Tunivar { jkind; _ } ->
-      read_jkind_annotation jkind.annotation
+      read_jkind_annotation env jkind.annotation
   | _ -> Kind.Default
 
 let read_modalities mut modalities =
@@ -757,7 +781,7 @@ let read_arrow_modes implied_modes typ =
 
 #else
 
-let jkind_of_type_desc _te = Kind.Default
+let jkind_of_type_desc _env _te = Kind.Default
 let read_value_descr_modalities _vd = []
 let read_label_modalities _ld = []
 let read_constructor_argument arg = arg, []
@@ -834,7 +858,7 @@ and read_type_expr_modal env implied_modes typ =
           let tyl = List.map Compat.repr tyl in
           let vars_with_kinds = List.map (fun ty ->
             let name = name_of_type_repr ty in
-            let kind = jkind_of_type_desc ty.desc in
+            let kind = jkind_of_type_desc env.ident_env ty.desc in
             (name, kind)
           ) tyl in
           let typ = read_type_expr env typ in
@@ -1144,7 +1168,7 @@ let read_type_parameter abstr var param =
     if name = "_" then Any
     else Var name
   in
-  let kind = jkind_of_type_desc (Compat.get_desc param) in
+  let kind = jkind_of_type_desc (Env.empty ()) (Compat.get_desc param) in
   let variance =
     if not (abstr || aliasable param) then None
     else begin
@@ -1222,7 +1246,7 @@ let read_type_declaration env parent id decl =
   let private_ = (decl.type_private = Private) in
   let kind =
 #if defined OXCAML
-    read_jkind_annotation decl.type_jkind.annotation
+    read_jkind_annotation env.ident_env decl.type_jkind.annotation
 #else
     Kind.Default
 #endif
@@ -1492,6 +1516,19 @@ and read_module_rec_status rec_status =
   | Trec_first -> Rec
   | Trec_next -> And
 
+#if defined OXCAML
+and read_kind_abbreviation_from_types env parent id (jkd : Types.jkind_declaration) =
+  let open KindAbbreviation in
+  let identifier = Env.find_kind_abbreviation_identifier env.ident_env id in
+  let source_loc = None in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
+  let doc =
+    Doc_attr.attached_no_tag ~warnings_tag:env.warnings_tag container
+      jkd.jkind_attributes
+  in
+  { id = identifier; source_loc; doc; manifest = None }
+#endif
+
 and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
   let rec loop (acc,shadowed) items =
     let open Signature in
@@ -1523,6 +1560,19 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
           else shadowed
         in
         loop (Type (read_type_rec_status rec_status, decl)::acc, shadowed) rest
+#if defined OXCAML
+    | Sig_jkind(id, jkd, _)::rest ->
+        let ka = read_kind_abbreviation_from_types env parent id jkd in
+        let shadowed =
+          if Env.is_shadowed env.ident_env id
+          then
+            let identifier = Env.find_kind_abbreviation_identifier env.ident_env id in
+            let `KindAbbreviation (_, name) = identifier.iv in
+            { shadowed with s_kind_abbreviations = (Ident.name id, name) :: shadowed.s_kind_abbreviations }
+          else shadowed
+        in
+        loop (KindAbbreviation ka :: acc, shadowed) rest
+#endif
     | Sig_typext (id, ext, Text_first, _) :: rest ->
         let rec inner_loop inner_acc = function
           | Sig_typext(id, ext, Text_next, _) :: rest ->
@@ -1620,7 +1670,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
 
     | [] -> ({items = List.rev acc; compiled=false; removed = []; doc = empty_doc env }, shadowed)
   in
-    loop ([],{s_modules=[]; s_module_types=[]; s_values=[];s_types=[]; s_classes=[]; s_class_types=[]}) items
+    loop ([],{s_modules=[]; s_module_types=[]; s_values=[];s_types=[]; s_kind_abbreviations=[]; s_classes=[]; s_class_types=[]}) items
 
 and read_signature env parent (items : Odoc_model.Compat.signature) =
   let e' = Env.handle_signature_type_items parent items env.ident_env in

--- a/src/loader/cmi.mli
+++ b/src/loader/cmi.mli
@@ -97,6 +97,7 @@ val read_exception : env ->
 
 #if defined OXCAML
 val read_jkind_annotation :
+  Ident_env.t ->
   Parsetree.jkind_annotation option ->
   Odoc_model.Lang.Kind.t
 

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -561,7 +561,8 @@ and read_structure_item env parent item =
         let cltyps = List.map (fun (_, _, clty) -> clty) cltyps in
           Cmti.read_class_type_declarations env parent cltyps
 #if defined OXCAML
-    | Tstr_jkind _ -> []
+    | Tstr_jkind jkd ->
+        [ KindAbbreviation (Cmti.read_kind_abbreviation env parent jkd) ]
 #endif
     | Tstr_attribute attr ->
       let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -612,6 +612,23 @@ and read_open env parent o =
   let expansion, _ = Cmi.read_signature_noenv env parent (Odoc_model.Compat.signature signature) in
   Open.{expansion; doc}
 
+#if defined OXCAML
+and scope_structure_item env item =
+  match item.str_desc with
+  | Tstr_jkind jkd ->
+      { env with
+        ident_env =
+          Env.add_kind_abbreviation_to_scope env.ident_env jkd.jkind_id }
+  | Tstr_include incl ->
+      { env with
+        ident_env =
+          Env.add_signature_kind_abbreviations_to_scope env.ident_env
+            (Odoc_model.Compat.signature incl.incl_type) }
+  | _ -> env
+#else
+and scope_structure_item env _item = env
+#endif
+
 and read_structure :
       'tags. 'tags Odoc_model.Semantics.handle_internal_tags -> _ -> _ -> _ ->
       _ * 'tags =
@@ -627,13 +644,14 @@ and read_structure :
     in
     Doc_attr.extract_top_comment internal_tags ~warnings_tag:env.warnings_tag ~classify parent str.str_items
   in
-  let items =
+  let items, _ =
     List.fold_left
-      (fun items item ->
-        List.rev_append (read_structure_item env parent item) items)
-      [] items
-    |> List.rev
+      (fun (items, env) item ->
+        ( List.rev_append (read_structure_item env parent item) items,
+          scope_structure_item env item ))
+      ([], env) items
   in
+  let items = List.rev items in
   match doc_post with
   | { elements = [] ; _} ->
     ({ Signature.items; compiled = false; removed = []; doc }, tags)

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -565,7 +565,8 @@ and read_structure_item env parent item =
         let cltyps = List.map (fun (_, _, clty) -> clty) cltyps in
           Cmti.read_class_type_declarations env parent cltyps
 #if defined OXCAML
-    | Tstr_jkind _ -> []
+    | Tstr_jkind jkd ->
+        [ KindAbbreviation (Cmti.read_kind_abbreviation env parent jkd) ]
 #endif
     | Tstr_attribute attr ->
       let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -138,7 +138,7 @@ let rec read_core_type env container ctyp =
 #if defined OXCAML
     | Ttyp_poly(vars, typ) ->
       Poly(List.map (fun (name, jk) ->
-        (name, Cmi.read_jkind_annotation jk)
+        (name, Cmi.read_jkind_annotation env.ident_env jk)
       ) vars, read_core_type env container typ)
 #else
     | Ttyp_poly(vars, typ) -> Poly(List.map (fun v -> (v, Kind.Default)) vars, read_core_type env container typ)
@@ -208,13 +208,16 @@ let read_value_description env parent vd =
   let modalities = Cmi.read_value_descr_modalities vd.val_val in
   Value { Value.id; source_loc; doc; type_; value; ext_attrs; modalities }
 
-let read_type_parameter (ctyp, var_and_injectivity)  =
+let read_type_parameter env (ctyp, var_and_injectivity)  =
   let open TypeDecl in
+#if not defined OXCAML
+  ignore env;
+#endif
   let desc, kind =
     match ctyp.ctyp_desc with
 #if defined OXCAML
-    | Ttyp_var (None, layout) -> Any, Cmi.read_jkind_annotation layout
-    | Ttyp_var (Some s, layout) -> Var s, Cmi.read_jkind_annotation layout
+    | Ttyp_var (None, layout) -> Any, Cmi.read_jkind_annotation env.ident_env layout
+    | Ttyp_var (Some s, layout) -> Var s, Cmi.read_jkind_annotation env.ident_env layout
 #else
     | Ttyp_any -> Any, Kind.Default
     | Ttyp_var s -> Var s, Kind.Default
@@ -340,7 +343,7 @@ let read_type_kind env parent =
 
 let read_type_equation env container decl =
   let open TypeDecl.Equation in
-  let params = List.map read_type_parameter decl.typ_params in
+  let params = List.map (read_type_parameter env) decl.typ_params in
   let private_ = (decl.typ_private = Private) in
   let manifest = opt_map (read_core_type env container) decl.typ_manifest in
   let constraints =
@@ -356,7 +359,7 @@ let read_type_equation env container decl =
   in
   let kind =
 #if defined OXCAML
-    Cmi.read_jkind_annotation decl.typ_jkind_annotation
+    Cmi.read_jkind_annotation env.ident_env decl.typ_jkind_annotation
 #else
     Kind.Default
 #endif
@@ -397,6 +400,24 @@ let read_type_declarations env parent rec_flag decls =
 let read_type_substitutions env parent decls =
   List.map (fun decl -> Odoc_model.Lang.Signature.TypeSubstitution (read_type_declaration env parent decl)) decls
 
+#if defined OXCAML
+let read_kind_abbreviation env parent (jkd : Typedtree.jkind_declaration) =
+  let open KindAbbreviation in
+  let id = Env.find_kind_abbreviation_identifier env.ident_env jkd.jkind_id in
+  let source_loc = None in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
+  let doc =
+    Doc_attr.attached_no_tag ~warnings_tag:env.warnings_tag container
+      jkd.jkind_attributes
+  in
+  let manifest =
+    match jkd.jkind_annotation with
+    | None -> None
+    | Some _ as annot -> Some (Cmi.read_jkind_annotation env.ident_env annot)
+  in
+  { id; source_loc; doc; manifest }
+#endif
+
 let read_extension_constructor env parent ext =
   let open Extension.Constructor in
   let id = Env.find_extension_identifier env.ident_env ext.ext_id in
@@ -423,7 +444,7 @@ let read_type_extension env parent tyext =
   let type_path = Env.Path.read_type env.ident_env tyext.tyext_path in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag ~warnings_tag:env.warnings_tag container tyext.tyext_attributes in
-  let type_params = List.map read_type_parameter tyext.tyext_params in
+  let type_params = List.map (read_type_parameter env) tyext.tyext_params in
   let private_ = (tyext.tyext_private = Private) in
   let constructors =
     List.map (read_extension_constructor env parent) tyext.tyext_constructors
@@ -528,7 +549,7 @@ let read_class_type_declaration env parent cltd =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container ~warnings_tag:env.warnings_tag cltd.ci_attributes in
   let virtual_ = (cltd.ci_virt = Virtual) in
-  let params = List.map read_type_parameter cltd.ci_params in
+  let params = List.map (read_type_parameter env) cltd.ci_params in
   let expr = read_class_signature env (id :> Identifier.ClassSignature.t) container cltd.ci_expr in
   { id; source_loc; doc; virtual_; params; expr; expansion = None }
 
@@ -563,7 +584,7 @@ let read_class_description env parent cld =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container ~warnings_tag:env.warnings_tag cld.ci_attributes in
   let virtual_ = (cld.ci_virt = Virtual) in
-  let params = List.map read_type_parameter cld.ci_params in
+  let params = List.map (read_type_parameter env) cld.ci_params in
   let type_ = read_class_type env (id :> Identifier.ClassSignature.t) container cld.ci_expr in
   { id; source_loc; doc; virtual_; params; type_; expansion = None }
 
@@ -853,7 +874,8 @@ and read_signature_item env parent item =
         [ModuleTypeSubstitution (read_module_type_substitution env parent mtst)]
 #endif
 #if defined OXCAML
-    | Tsig_jkind _ -> []
+    | Tsig_jkind jkd ->
+        [ KindAbbreviation (read_kind_abbreviation env parent jkd) ]
 #endif
 
 

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -144,7 +144,7 @@ and read_core_type_modal env modes container ctyp =
 #if defined OXCAML
     | Ttyp_poly(vars, typ) ->
       Poly(List.map (fun (name, jk) ->
-        (name, Cmi.read_jkind_annotation jk)
+        (name, Cmi.read_jkind_annotation env.ident_env jk)
       ) vars, read_core_type env container typ)
 #else
     | Ttyp_poly(vars, typ) -> Poly(List.map (fun v -> (v, Kind.Default)) vars, read_core_type env container typ)
@@ -217,13 +217,16 @@ let read_value_description env parent vd =
   let modalities = Cmi.read_value_descr_modalities vd.val_val in
   Value { Value.id; source_loc; doc; type_; value; ext_attrs; modalities }
 
-let read_type_parameter (ctyp, var_and_injectivity)  =
+let read_type_parameter env (ctyp, var_and_injectivity)  =
   let open TypeDecl in
+#if not defined OXCAML
+  ignore env;
+#endif
   let desc, kind =
     match ctyp.ctyp_desc with
 #if defined OXCAML
-    | Ttyp_var (None, layout) -> Any, Cmi.read_jkind_annotation layout
-    | Ttyp_var (Some s, layout) -> Var s, Cmi.read_jkind_annotation layout
+    | Ttyp_var (None, layout) -> Any, Cmi.read_jkind_annotation env.ident_env layout
+    | Ttyp_var (Some s, layout) -> Var s, Cmi.read_jkind_annotation env.ident_env layout
 #else
     | Ttyp_any -> Any, Kind.Default
     | Ttyp_var s -> Var s, Kind.Default
@@ -349,7 +352,7 @@ let read_type_kind env parent =
 
 let read_type_equation env container decl =
   let open TypeDecl.Equation in
-  let params = List.map read_type_parameter decl.typ_params in
+  let params = List.map (read_type_parameter env) decl.typ_params in
   let private_ = (decl.typ_private = Private) in
   let manifest = opt_map (read_core_type env container) decl.typ_manifest in
   let constraints =
@@ -365,7 +368,7 @@ let read_type_equation env container decl =
   in
   let kind =
 #if defined OXCAML
-    Cmi.read_jkind_annotation decl.typ_jkind_annotation
+    Cmi.read_jkind_annotation env.ident_env decl.typ_jkind_annotation
 #else
     Kind.Default
 #endif
@@ -406,6 +409,24 @@ let read_type_declarations env parent rec_flag decls =
 let read_type_substitutions env parent decls =
   List.map (fun decl -> Odoc_model.Lang.Signature.TypeSubstitution (read_type_declaration env parent decl)) decls
 
+#if defined OXCAML
+let read_kind_abbreviation env parent (jkd : Typedtree.jkind_declaration) =
+  let open KindAbbreviation in
+  let id = Env.find_kind_abbreviation_identifier env.ident_env jkd.jkind_id in
+  let source_loc = None in
+  let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
+  let doc =
+    Doc_attr.attached_no_tag ~warnings_tag:env.warnings_tag container
+      jkd.jkind_attributes
+  in
+  let manifest =
+    match jkd.jkind_annotation with
+    | None -> None
+    | Some _ as annot -> Some (Cmi.read_jkind_annotation env.ident_env annot)
+  in
+  { id; source_loc; doc; manifest }
+#endif
+
 let read_extension_constructor env parent ext =
   let open Extension.Constructor in
   let id = Env.find_extension_identifier env.ident_env ext.ext_id in
@@ -432,7 +453,7 @@ let read_type_extension env parent tyext =
   let type_path = Env.Path.read_type env.ident_env tyext.tyext_path in
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag ~warnings_tag:env.warnings_tag container tyext.tyext_attributes in
-  let type_params = List.map read_type_parameter tyext.tyext_params in
+  let type_params = List.map (read_type_parameter env) tyext.tyext_params in
   let private_ = (tyext.tyext_private = Private) in
   let constructors =
     List.map (read_extension_constructor env parent) tyext.tyext_constructors
@@ -537,7 +558,7 @@ let read_class_type_declaration env parent cltd =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container ~warnings_tag:env.warnings_tag cltd.ci_attributes in
   let virtual_ = (cltd.ci_virt = Virtual) in
-  let params = List.map read_type_parameter cltd.ci_params in
+  let params = List.map (read_type_parameter env) cltd.ci_params in
   let expr = read_class_signature env (id :> Identifier.ClassSignature.t) container cltd.ci_expr in
   { id; source_loc; doc; virtual_; params; expr; expansion = None }
 
@@ -572,7 +593,7 @@ let read_class_description env parent cld =
   let container = (parent : Identifier.Signature.t :> Identifier.LabelParent.t) in
   let doc = Doc_attr.attached_no_tag container ~warnings_tag:env.warnings_tag cld.ci_attributes in
   let virtual_ = (cld.ci_virt = Virtual) in
-  let params = List.map read_type_parameter cld.ci_params in
+  let params = List.map (read_type_parameter env) cld.ci_params in
   let type_ = read_class_type env (id :> Identifier.ClassSignature.t) container cld.ci_expr in
   { id; source_loc; doc; virtual_; params; type_; expansion = None }
 
@@ -867,7 +888,8 @@ and read_signature_item env parent item =
         [ModuleTypeSubstitution (read_module_type_substitution env parent mtst)]
 #endif
 #if defined OXCAML
-    | Tsig_jkind _ -> []
+    | Tsig_jkind jkd ->
+        [ KindAbbreviation (read_kind_abbreviation env parent jkd) ]
 #endif
 
 

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -951,6 +951,23 @@ and read_open env parent o =
   let expansion, _ = Cmi.read_signature_noenv env parent (Odoc_model.Compat.signature signature) in
   { expansion; doc }
 
+#if defined OXCAML
+and scope_signature_item env item =
+  match item.sig_desc with
+  | Tsig_jkind jkd ->
+      { env with
+        ident_env =
+          Env.add_kind_abbreviation_to_scope env.ident_env jkd.jkind_id }
+  | Tsig_include (incl, _) ->
+      { env with
+        ident_env =
+          Env.add_signature_kind_abbreviations_to_scope env.ident_env
+            (Odoc_model.Compat.signature incl.incl_type) }
+  | _ -> env
+#else
+and scope_signature_item env _item = env
+#endif
+
 and read_signature :
       'tags. 'tags Odoc_model.Semantics.handle_internal_tags -> _ -> _ -> _ ->
       _ * 'tags =
@@ -966,13 +983,14 @@ and read_signature :
     in
     Doc_attr.extract_top_comment internal_tags ~warnings_tag:env.warnings_tag ~classify parent sg.sig_items
   in
-  let items =
+  let items, _ =
     List.fold_left
-      (fun items item ->
-        List.rev_append (read_signature_item env parent item) items)
-      [] items
-    |> List.rev
+      (fun (items, env) item ->
+        ( List.rev_append (read_signature_item env parent item) items,
+          scope_signature_item env item ))
+      ([], env) items
   in
+  let items = List.rev items in
   match doc_post with
   | {elements=[]; _} ->
     ({ Signature.items; compiled = false; removed = []; doc }, tags)

--- a/src/loader/cmti.mli
+++ b/src/loader/cmti.mli
@@ -67,3 +67,11 @@ val read_class_type_declarations :
   Paths.Identifier.Signature.t ->
   Typedtree.class_type Typedtree.class_infos list ->
   Odoc_model.Lang.Signature.item list
+
+#if defined OXCAML
+val read_kind_abbreviation :
+  Cmi.env ->
+  Paths.Identifier.Signature.t ->
+  Typedtree.jkind_declaration ->
+  Odoc_model.Lang.KindAbbreviation.t
+#endif

--- a/src/loader/ident_env.ml
+++ b/src/loader/ident_env.ml
@@ -38,6 +38,7 @@ type t =
     values: Id.Value.t Ident.tbl;
     classes : Id.Class.t Ident.tbl;
     class_types : Id.ClassType.t Ident.tbl;
+    kind_abbreviations : Id.KindAbbreviation.t Ident.tbl;
     loc_to_ident : Id.t LocHashtbl.t;
     shadowed : Ident.t list;
   }
@@ -54,6 +55,7 @@ let empty () =
     values = Ident.empty;
     classes = Ident.empty;
     class_types = Ident.empty;
+    kind_abbreviations = Ident.empty;
     loc_to_ident = LocHashtbl.create 100;
     shadowed = [];
   }
@@ -64,6 +66,7 @@ type item = [
     `Module of Ident.t * bool * Location.t option
   | `ModuleType of Ident.t * bool * Location.t option
   | `Type of Ident.t * bool * Location.t option
+  | `KindAbbreviation of Ident.t * bool * Location.t option
   | `Constructor of Ident.t * Ident.t * Location.t option
   (* Second ident.t is for the type parent *)
   | `Value of Ident.t * bool * Location.t option
@@ -90,6 +93,9 @@ let extract_visibility =
   | Sig_value (_, _, vis)
   | Sig_class (_, _, _, vis)
   | Sig_class_type (_, _, _, vis)
+#if defined OXCAML
+  | Sig_jkind (_, _, vis)
+#endif
   | Sig_typext (_, _, _, vis) ->
       vis
 
@@ -142,6 +148,11 @@ and extract_signature_type_items_extract vis ~hidden item rest =
     | Sig_module(id, _, _, _, _), _ ->
       `Module (id, hidden, None) :: extract_signature_type_items vis rest
 
+#if defined OXCAML
+    | Sig_jkind(id, _, _), _ ->
+      `KindAbbreviation (id, hidden, None) :: extract_signature_type_items vis rest
+#endif
+
     | Sig_modtype(id, _, _), _ ->
       `ModuleType (id, hidden, None) :: extract_signature_type_items vis rest
 
@@ -190,6 +201,9 @@ and extract_signature_type_items_skip vis item rest =
   | Sig_modtype _, rest
   | Sig_module _, rest
   | Sig_type _, rest
+#if defined OXCAML
+  | Sig_jkind _, rest
+#endif
   | Sig_value  _, rest ->
     extract_signature_type_items vis rest
 
@@ -301,7 +315,9 @@ let rec extract_signature_tree_items : bool -> Typedtree.signature_item list -> 
 #endif
     | { sig_desc = Tsig_open _;_} :: rest -> extract_signature_tree_items hide_item rest
 #if defined OXCAML
-    | { sig_desc = Tsig_jkind _;_} :: rest -> extract_signature_tree_items hide_item rest
+    | { sig_desc = Tsig_jkind jkd; _} :: rest ->
+        `KindAbbreviation (jkd.jkind_id, hide_item, Some jkd.jkind_loc)
+        :: extract_signature_tree_items hide_item rest
 #endif
     | [] -> []
 
@@ -454,7 +470,9 @@ let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> 
       [`Value (val_id, false, Some str_loc)] @ extract_structure_tree_items hide_item rest
     | { str_desc = Tstr_eval _; _} :: rest -> extract_structure_tree_items hide_item rest
 #if defined OXCAML
-    | { str_desc = Tstr_jkind _; _ } :: rest -> extract_structure_tree_items hide_item rest
+    | { str_desc = Tstr_jkind jkd; _ } :: rest ->
+        `KindAbbreviation (jkd.jkind_id, hide_item, Some jkd.jkind_loc)
+        :: extract_structure_tree_items hide_item rest
 #endif
     | [] -> []
 
@@ -462,6 +480,7 @@ let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> 
 let flatten_includes : items list -> item list = fun items ->
   List.map (function
     | `Type _
+    | `KindAbbreviation _
     | `Constructor _
     | `Module _
     | `ModuleType _
@@ -474,6 +493,9 @@ let flatten_includes : items list -> item list = fun items ->
 
 let type_name_exists name items =
   List.exists (function | `Type (id', _, _) when Ident.name id' = name -> true | _ -> false) items
+
+let kind_abbreviation_name_exists name items =
+  List.exists (function | `KindAbbreviation (id', _, _) when Ident.name id' = name -> true | _ -> false) items
 
 let value_name_exists name items =
     List.exists (function | `Value (id', _, _) when Ident.name id' = name -> true | _ -> false) items
@@ -505,6 +527,18 @@ let add_items : Id.Signature.t -> item list -> t -> t = fun parent items env ->
       let types = Ident.add t identifier env.types in
       (match loc with | Some l -> LocHashtbl.add env.loc_to_ident l (identifier :> Id.any) | _ -> ());
       inner rest { env with types; shadowed }
+
+    | `KindAbbreviation (t, is_hidden_item, loc) :: rest ->
+      let name = Ident.name t in
+      let is_shadowed = kind_abbreviation_name_exists name rest in
+      let identifier, shadowed =
+        if is_shadowed
+        then Mk.kind_abbreviation(parent, TypeName.shadowed_of_string name), t :: env.shadowed
+        else Mk.kind_abbreviation(parent, (if is_hidden_item then TypeName.hidden_of_string else TypeName.make_std) name), env.shadowed
+      in
+      let kind_abbreviations = Ident.add t identifier env.kind_abbreviations in
+      (match loc with | Some l -> LocHashtbl.add env.loc_to_ident l (identifier :> Id.any) | _ -> ());
+      inner rest { env with kind_abbreviations; shadowed }
 
     | `Constructor (t, t_parent, loc) :: rest ->
       let name = Ident.name t in
@@ -661,6 +695,14 @@ let find_module_type env id =
 
 let find_type_identifier env id =
   Ident.find_same id env.types
+
+let find_kind_abbreviation_identifier env id =
+  Ident.find_same id env.kind_abbreviations
+
+let find_kind_abbreviation env name =
+  match Ident.find_name name env.kind_abbreviations with
+  | _id, identifier -> Some identifier
+  | exception Not_found -> None
 
 let find_constructor_identifier env id =
   Ident.find_same id env.constructors

--- a/src/loader/ident_env.ml
+++ b/src/loader/ident_env.ml
@@ -20,6 +20,8 @@ open Names
 module Id = Paths.Identifier
 module P = Paths.Path
 
+module StringMap = Map.Make(String)
+
 module LocHashtbl = Hashtbl.Make(struct
     type t = Location.t
     let equal l1 l2 = l1 = l2
@@ -39,6 +41,7 @@ type t =
     classes : Id.Class.t Ident.tbl;
     class_types : Id.ClassType.t Ident.tbl;
     kind_abbreviations : Id.KindAbbreviation.t Ident.tbl;
+    kind_abbreviations_in_scope : Id.KindAbbreviation.t StringMap.t;
     loc_to_ident : Id.t LocHashtbl.t;
     shadowed : Ident.t list;
   }
@@ -56,6 +59,7 @@ let empty () =
     classes = Ident.empty;
     class_types = Ident.empty;
     kind_abbreviations = Ident.empty;
+    kind_abbreviations_in_scope = StringMap.empty;
     loc_to_ident = LocHashtbl.create 100;
     shadowed = [];
   }
@@ -701,9 +705,28 @@ let find_kind_abbreviation_identifier env id =
   Ident.find_same id env.kind_abbreviations
 
 let find_kind_abbreviation env name =
-  match Ident.find_name name env.kind_abbreviations with
-  | _id, identifier -> Some identifier
-  | exception Not_found -> None
+  StringMap.find_opt name env.kind_abbreviations_in_scope
+
+let add_kind_abbreviation_to_scope env id =
+  match Ident.find_same id env.kind_abbreviations with
+  | identifier ->
+      let kind_abbreviations_in_scope =
+        StringMap.add (Ident.name id) identifier env.kind_abbreviations_in_scope
+      in
+      { env with kind_abbreviations_in_scope }
+  | exception Not_found -> env
+
+#if defined OXCAML
+let add_signature_kind_abbreviations_to_scope env sg =
+  List.fold_left
+    (fun env item ->
+      match item with
+      | Compat.Sig_jkind (id, _, _) -> add_kind_abbreviation_to_scope env id
+      | _ -> env)
+    env sg
+#else
+let add_signature_kind_abbreviations_to_scope env _sg = env
+#endif
 
 let find_constructor_identifier env id =
   Ident.find_same id env.constructors

--- a/src/loader/ident_env.ml
+++ b/src/loader/ident_env.ml
@@ -38,6 +38,7 @@ type t =
     values: Id.Value.t Ident.tbl;
     classes : Id.Class.t Ident.tbl;
     class_types : Id.ClassType.t Ident.tbl;
+    kind_abbreviations : Id.KindAbbreviation.t Ident.tbl;
     loc_to_ident : Id.t LocHashtbl.t;
     shadowed : Ident.t list;
   }
@@ -54,6 +55,7 @@ let empty () =
     values = Ident.empty;
     classes = Ident.empty;
     class_types = Ident.empty;
+    kind_abbreviations = Ident.empty;
     loc_to_ident = LocHashtbl.create 100;
     shadowed = [];
   }
@@ -64,6 +66,7 @@ type item = [
     `Module of Ident.t * bool * Location.t option
   | `ModuleType of Ident.t * bool * Location.t option
   | `Type of Ident.t * bool * Location.t option
+  | `KindAbbreviation of Ident.t * bool * Location.t option
   | `Constructor of Ident.t * Ident.t * Location.t option
   (* Second ident.t is for the type parent *)
   | `Value of Ident.t * bool * Location.t option
@@ -90,6 +93,9 @@ let extract_visibility =
   | Sig_value (_, _, vis)
   | Sig_class (_, _, _, vis)
   | Sig_class_type (_, _, _, vis)
+#if defined OXCAML
+  | Sig_jkind (_, _, vis)
+#endif
   | Sig_typext (_, _, _, vis) ->
       vis
 
@@ -142,6 +148,11 @@ and extract_signature_type_items_extract vis ~hidden item rest =
     | Sig_module(id, _, _, _, _), _ ->
       `Module (id, hidden, None) :: extract_signature_type_items vis rest
 
+#if defined OXCAML
+    | Sig_jkind(id, _, _), _ ->
+      `KindAbbreviation (id, hidden, None) :: extract_signature_type_items vis rest
+#endif
+
     | Sig_modtype(id, _, _), _ ->
       `ModuleType (id, hidden, None) :: extract_signature_type_items vis rest
 
@@ -190,6 +201,9 @@ and extract_signature_type_items_skip vis item rest =
   | Sig_modtype _, rest
   | Sig_module _, rest
   | Sig_type _, rest
+#if defined OXCAML
+  | Sig_jkind _, rest
+#endif
   | Sig_value  _, rest ->
     extract_signature_type_items vis rest
 
@@ -301,7 +315,9 @@ let rec extract_signature_tree_items : bool -> Typedtree.signature_item list -> 
 #endif
     | { sig_desc = Tsig_open _;_} :: rest -> extract_signature_tree_items hide_item rest
 #if defined OXCAML
-    | { sig_desc = Tsig_jkind _;_} :: rest -> extract_signature_tree_items hide_item rest
+    | { sig_desc = Tsig_jkind jkd; _} :: rest ->
+        `KindAbbreviation (jkd.jkind_id, hide_item, Some jkd.jkind_loc)
+        :: extract_signature_tree_items hide_item rest
 #endif
     | [] -> []
 
@@ -455,7 +471,9 @@ let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> 
       [`Value (val_id, false, Some str_loc)] @ extract_structure_tree_items hide_item rest
     | { str_desc = Tstr_eval _; _} :: rest -> extract_structure_tree_items hide_item rest
 #if defined OXCAML
-    | { str_desc = Tstr_jkind _; _ } :: rest -> extract_structure_tree_items hide_item rest
+    | { str_desc = Tstr_jkind jkd; _ } :: rest ->
+        `KindAbbreviation (jkd.jkind_id, hide_item, Some jkd.jkind_loc)
+        :: extract_structure_tree_items hide_item rest
 #endif
     | [] -> []
 
@@ -463,6 +481,7 @@ let rec extract_structure_tree_items : bool -> Typedtree.structure_item list -> 
 let flatten_includes : items list -> item list = fun items ->
   List.map (function
     | `Type _
+    | `KindAbbreviation _
     | `Constructor _
     | `Module _
     | `ModuleType _
@@ -475,6 +494,9 @@ let flatten_includes : items list -> item list = fun items ->
 
 let type_name_exists name items =
   List.exists (function | `Type (id', _, _) when Ident.name id' = name -> true | _ -> false) items
+
+let kind_abbreviation_name_exists name items =
+  List.exists (function | `KindAbbreviation (id', _, _) when Ident.name id' = name -> true | _ -> false) items
 
 let value_name_exists name items =
     List.exists (function | `Value (id', _, _) when Ident.name id' = name -> true | _ -> false) items
@@ -506,6 +528,18 @@ let add_items : Id.Signature.t -> item list -> t -> t = fun parent items env ->
       let types = Ident.add t identifier env.types in
       (match loc with | Some l -> LocHashtbl.add env.loc_to_ident l (identifier :> Id.any) | _ -> ());
       inner rest { env with types; shadowed }
+
+    | `KindAbbreviation (t, is_hidden_item, loc) :: rest ->
+      let name = Ident.name t in
+      let is_shadowed = kind_abbreviation_name_exists name rest in
+      let identifier, shadowed =
+        if is_shadowed
+        then Mk.kind_abbreviation(parent, TypeName.shadowed_of_string name), t :: env.shadowed
+        else Mk.kind_abbreviation(parent, (if is_hidden_item then TypeName.hidden_of_string else TypeName.make_std) name), env.shadowed
+      in
+      let kind_abbreviations = Ident.add t identifier env.kind_abbreviations in
+      (match loc with | Some l -> LocHashtbl.add env.loc_to_ident l (identifier :> Id.any) | _ -> ());
+      inner rest { env with kind_abbreviations; shadowed }
 
     | `Constructor (t, t_parent, loc) :: rest ->
       let name = Ident.name t in
@@ -662,6 +696,14 @@ let find_module_type env id =
 
 let find_type_identifier env id =
   Ident.find_same id env.types
+
+let find_kind_abbreviation_identifier env id =
+  Ident.find_same id env.kind_abbreviations
+
+let find_kind_abbreviation env name =
+  match Ident.find_name name env.kind_abbreviations with
+  | _id, identifier -> Some identifier
+  | exception Not_found -> None
 
 let find_constructor_identifier env id =
   Ident.find_same id env.constructors

--- a/src/loader/ident_env.mli
+++ b/src/loader/ident_env.mli
@@ -72,6 +72,12 @@ val find_exception_identifier : t -> Ident.t -> Paths.Identifier.Exception.t
 
 val find_type_identifier : t -> Ident.t -> Paths.Identifier.Type.t
 
+val find_kind_abbreviation_identifier :
+  t -> Ident.t -> Paths.Identifier.KindAbbreviation.t
+
+val find_kind_abbreviation :
+  t -> string -> Paths.Identifier.KindAbbreviation.t option
+
 val find_class_identifier : t -> Ident.t -> Paths.Identifier.Class.t
 
 val ident_is_global_or_predef : Ident.t -> bool

--- a/src/loader/ident_env.mli
+++ b/src/loader/ident_env.mli
@@ -78,6 +78,10 @@ val find_kind_abbreviation_identifier :
 val find_kind_abbreviation :
   t -> string -> Paths.Identifier.KindAbbreviation.t option
 
+val add_kind_abbreviation_to_scope : t -> Ident.t -> t
+
+val add_signature_kind_abbreviations_to_scope : t -> Compat.signature -> t
+
 val find_class_identifier : t -> Ident.t -> Paths.Identifier.Class.t
 
 val ident_is_global_or_predef : Ident.t -> bool

--- a/src/loader/implementation.ml
+++ b/src/loader/implementation.ml
@@ -236,6 +236,9 @@ let anchor_of_identifier id =
     | `Type (parent, name) ->
         let anchor = anchor `Type (TypeName.to_string name) in
         continue anchor parent
+    | `KindAbbreviation (parent, name) ->
+        let anchor = anchor `KindAbbreviation (TypeName.to_string name) in
+        continue anchor parent
     | `Label _ -> assert false
     | `Exception (parent, name) ->
         let anchor = anchor `Exception (ExceptionName.to_string name) in

--- a/src/model/compat.cppo.ml
+++ b/src/model/compat.cppo.ml
@@ -58,6 +58,9 @@ and signature_item =
   | Sig_modtype of Ident.t * modtype_declaration * visibility
   | Sig_class of Ident.t * Types.class_declaration * Types.rec_status * visibility
   | Sig_class_type of Ident.t * Types.class_type_declaration * Types.rec_status * visibility
+#if defined OXCAML
+  | Sig_jkind of Ident.t * Types.jkind_declaration * visibility
+#endif
 
 and module_declaration =
   {
@@ -79,13 +82,7 @@ let opt conv = function | None -> None | Some x -> Some (conv x)
 #if OCAML_VERSION >= (4,10,0)
 
 let rec signature : Types.signature -> signature = fun x ->
-#if defined OXCAML
-  List.filter_map (function
-    | Types.Sig_jkind _ -> None
-    | si -> Some (signature_item si)) x
-#else
   List.map signature_item x
-#endif
 
 and signature_item : Types.signature_item -> signature_item = function
   | Types.Sig_value (a,b,c) -> Sig_value (a,b,visibility c)
@@ -96,7 +93,7 @@ and signature_item : Types.signature_item -> signature_item = function
   | Types.Sig_class (a,b,c,d) -> Sig_class (a,b,c, visibility d)
   | Types.Sig_class_type (a,b,c,d) -> Sig_class_type (a,b,c, visibility d)
 #if defined OXCAML
-  | Types.Sig_jkind _ -> assert false  (* filtered in [signature] *)
+  | Types.Sig_jkind (a,b,c) -> Sig_jkind (a, b, visibility c)
 #endif
 
 and visibility : Types.visibility -> visibility = function

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -154,6 +154,7 @@ and Signature : sig
     | Open of Open.t
     | Type of recursive * TypeDecl.t
     | TypeSubstitution of TypeDecl.t
+    | KindAbbreviation of KindAbbreviation.t
     | TypExt of Extension.t
     | Exception of Exception.t
     | Value of Value.t
@@ -189,6 +190,7 @@ and Include : sig
     s_module_types : (string * Names.ModuleTypeName.t) list;
     s_values : (string * Names.ValueName.t) list;
     s_types : (string * Names.TypeName.t) list;
+    s_kind_abbreviations : (string * Names.TypeName.t) list;
     s_classes : (string * Names.TypeName.t) list;
     s_class_types : (string * Names.TypeName.t) list;
   }
@@ -444,13 +446,25 @@ end =
 and Kind : sig
   type t =
     | Default
-    | Abbreviation of Fragment.Type.t
+    | Abbreviation of string * Reference.t option
     | Mod of t * string list
     | With of t * TypeExpr.t * Modalities.t
     | Kind_of of TypeExpr.t
     | Product of t list
 end =
   Kind
+
+(** {3 Kind abbreviation definitions} *)
+
+and KindAbbreviation : sig
+  type t = {
+    id : Identifier.KindAbbreviation.t;
+    source_loc : Identifier.SourceLocation.t option;
+    doc : Comment.docs;
+    manifest : Kind.t option;
+  }
+end =
+  KindAbbreviation
 
 (** {3 Type expressions} *)
 

--- a/src/model/lang.ml
+++ b/src/model/lang.ml
@@ -154,6 +154,7 @@ and Signature : sig
     | Open of Open.t
     | Type of recursive * TypeDecl.t
     | TypeSubstitution of TypeDecl.t
+    | KindAbbreviation of KindAbbreviation.t
     | TypExt of Extension.t
     | Exception of Exception.t
     | Value of Value.t
@@ -189,6 +190,7 @@ and Include : sig
     s_module_types : (string * Names.ModuleTypeName.t) list;
     s_values : (string * Names.ValueName.t) list;
     s_types : (string * Names.TypeName.t) list;
+    s_kind_abbreviations : (string * Names.TypeName.t) list;
     s_classes : (string * Names.TypeName.t) list;
     s_class_types : (string * Names.TypeName.t) list;
   }
@@ -449,13 +451,25 @@ end =
 and Kind : sig
   type t =
     | Default
-    | Abbreviation of Fragment.Type.t
+    | Abbreviation of string * Reference.t option
     | Mod of t * string list
     | With of t * TypeExpr.t * Modalities.t
     | Kind_of of TypeExpr.t
     | Product of t list
 end =
   Kind
+
+(** {3 Kind abbreviation definitions} *)
+
+and KindAbbreviation : sig
+  type t = {
+    id : Identifier.KindAbbreviation.t;
+    source_loc : Identifier.SourceLocation.t option;
+    doc : Comment.docs;
+    manifest : Kind.t option;
+  }
+end =
+  KindAbbreviation
 
 (** {3 Type expressions} *)
 

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -39,6 +39,7 @@ module Identifier = struct
     | `Result x -> name_aux (x :> t)
     | `ModuleType (_, name) -> ModuleTypeName.to_string name
     | `Type (_, name) -> TypeName.to_string name
+    | `KindAbbreviation (_, name) -> TypeName.to_string name
     | `Constructor (_, name) -> ConstructorName.to_string name
     | `Field (_, name) -> FieldName.to_string name
     | `UnboxedField (_, name) -> UnboxedFieldName.to_string name
@@ -70,6 +71,7 @@ module Identifier = struct
     | `Result x -> is_hidden (x :> t)
     | `ModuleType (_, name) -> ModuleTypeName.is_hidden name
     | `Type (_, name) -> TypeName.is_hidden name
+    | `KindAbbreviation (_, name) -> TypeName.is_hidden name
     | `Constructor (parent, _) -> is_hidden (parent :> t)
     | `Field (parent, _) -> is_hidden (parent :> t)
     | `UnboxedField (parent, _) -> is_hidden (parent :> t)
@@ -106,6 +108,8 @@ module Identifier = struct
     | `ModuleType (parent, name) ->
         ModuleTypeName.to_string name :: full_name_aux (parent :> t)
     | `Type (parent, name) ->
+        TypeName.to_string name :: full_name_aux (parent :> t)
+    | `KindAbbreviation (parent, name) ->
         TypeName.to_string name :: full_name_aux (parent :> t)
     | `Constructor (parent, name) ->
         ConstructorName.to_string name :: full_name_aux (parent :> t)
@@ -159,6 +163,7 @@ module Identifier = struct
       | { iv = `Class (p, _); _ }
       | { iv = `ClassType (p, _); _ }
       | { iv = `Type (p, _); _ }
+      | { iv = `KindAbbreviation (p, _); _ }
       | { iv = `Extension (p, _); _ }
       | { iv = `ExtensionDecl (p, _, _); _ }
       | { iv = `Exception (p, _); _ }
@@ -286,6 +291,14 @@ module Identifier = struct
   module Type = struct
     type t = Id.type_
     type t_pv = Id.type_pv
+    let equal = equal
+    let hash = hash
+    let compare = compare
+  end
+
+  module KindAbbreviation = struct
+    type t = Id.kind_abbreviation
+    type t_pv = Id.kind_abbreviation_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -563,6 +576,11 @@ module Identifier = struct
     let type_ :
         Signature.t * TypeName.t -> [> `Type of Signature.t * TypeName.t ] id =
       mk_parent TypeName.to_string "t" (fun (p, n) -> `Type (p, n))
+
+    let kind_abbreviation :
+        Signature.t * TypeName.t ->
+        [> `KindAbbreviation of Signature.t * TypeName.t ] id =
+      mk_parent TypeName.to_string "ka" (fun (p, n) -> `KindAbbreviation (p, n))
 
     let core_type =
       mk_fresh (fun s -> s) "coret" (fun s -> `CoreType (TypeName.make_std s))

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -67,6 +67,11 @@ module Identifier : sig
 
   module Type : IdSig with type t = Id.type_ and type t_pv = Id.type_pv
 
+  module KindAbbreviation :
+    IdSig
+      with type t = Id.kind_abbreviation
+       and type t_pv = Id.kind_abbreviation_pv
+
   module Class : IdSig with type t = Id.class_ and type t_pv = Id.class_pv
 
   module ClassType :
@@ -300,6 +305,10 @@ module Identifier : sig
 
     val type_ :
       Signature.t * TypeName.t -> [> `Type of Signature.t * TypeName.t ] id
+
+    val kind_abbreviation :
+      Signature.t * TypeName.t ->
+      [> `KindAbbreviation of Signature.t * TypeName.t ] id
 
     val core_type : string -> [> `CoreType of TypeName.t ] id
 

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -143,6 +143,12 @@ module Identifier = struct
   and type_ = type_pv id
   (** @canonical Odoc_model.Paths.Identifier.Type.t *)
 
+  type kind_abbreviation_pv = [ `KindAbbreviation of signature * TypeName.t ]
+  (** @canonical Odoc_model.Paths.Identifier.KindAbbreviation.t_pv *)
+
+  and kind_abbreviation = kind_abbreviation_pv id
+  (** @canonical Odoc_model.Paths.Identifier.KindAbbreviation.t *)
+
   type constructor_pv = [ `Constructor of datatype * ConstructorName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Constructor.t_pv *)
 
@@ -230,6 +236,7 @@ module Identifier = struct
     | functor_result_pv
     | module_type_pv
     | type_pv
+    | kind_abbreviation_pv
     | constructor_pv
     | field_pv
     | unboxed_field_pv
@@ -579,10 +586,13 @@ module rec Reference : sig
     | `TCurrentPackage  (** [{!//identifier}] *) ]
   (** @canonical Odoc_model.Paths.Reference.tag_hierarchy *)
 
+  type tag_only_kind_abbreviation = [ `TKindAbbreviation ]
+
   type tag_any =
     [ `TModule
     | `TModuleType
     | `TType
+    | `TKindAbbreviation
     | `TConstructor
     | `TField
     | `TUnboxedField
@@ -805,6 +815,7 @@ module rec Reference : sig
     | `Module of signature * ModuleName.t
     | `ModuleType of signature * ModuleTypeName.t
     | `Type of signature * TypeName.t
+    | `KindAbbreviation of signature * TypeName.t
     | `Constructor of fragment_type_parent * ConstructorName.t
     | `Field of fragment_type_parent * FieldName.t
     | `UnboxedField of fragment_type_parent * UnboxedFieldName.t

--- a/src/model/reference.ml
+++ b/src/model/reference.ml
@@ -87,6 +87,7 @@ let match_extra_odoc_reference_kind (_location as loc) s :
   | "extension-decl" -> Some `TExtensionDecl
   | "field" -> Some `TField
   | "instance-variable" -> Some `TInstanceVariable
+  | "kind" -> Some `TKindAbbreviation
   | "label" ->
       d loc "label" "section";
       Some `TLabel
@@ -474,6 +475,9 @@ let parse whole_reference_location s :
                 (signature next_token tokens, ModuleTypeName.make_std identifier)
           | `TType ->
               `Type (signature next_token tokens, TypeName.make_std identifier)
+          | `TKindAbbreviation ->
+              `KindAbbreviation
+                (signature next_token tokens, TypeName.make_std identifier)
           | `TConstructor ->
               `Constructor
                 (parent next_token tokens, ConstructorName.make_std identifier)

--- a/src/model_desc/lang_desc.ml
+++ b/src/model_desc/lang_desc.ml
@@ -250,6 +250,7 @@ and signature_item =
     | Type (x1, x2) ->
         C ("Type", (x1, x2), Pair (signature_recursive, typedecl_t))
     | TypeSubstitution x -> C ("TypeSubstitution", x, typedecl_t)
+    | KindAbbreviation x -> C ("KindAbbreviation", x, kindabbreviation_t)
     | TypExt x -> C ("TypExt", x, extension_t)
     | Exception x -> C ("Exception", x, exception_t)
     | Value x -> C ("Value", x, value_t)
@@ -284,6 +285,10 @@ and include_shadowed =
       F ("s_module_types", (fun t -> List.map fst t.s_module_types), List string);
       F ("s_values", (fun t -> List.map fst t.s_values), List string);
       F ("s_types", (fun t -> List.map fst t.s_types), List string);
+      F
+        ( "s_kind_abbreviations",
+          (fun t -> List.map fst t.s_kind_abbreviations),
+          List string );
       F ("s_classes", (fun t -> List.map fst t.s_classes), List string);
       F ("s_class_types", (fun t -> List.map fst t.s_class_types), List string);
     ]
@@ -373,7 +378,11 @@ and kind_annotation =
   Variant
     (function
     | Default -> C0 "Default"
-    | Abbreviation x -> C ("Abbreviation", (x :> Paths.Fragment.t), fragment)
+    | Abbreviation (x1, x2) ->
+        C
+          ( "Abbreviation",
+            (x1, (x2 :> Paths.Reference.t option)),
+            Pair (string, Option reference) )
     | Mod (x1, x2) -> C ("Mod", (x1, x2), Pair (kind_annotation, List string))
     | With (x1, x2, x3) ->
         C
@@ -423,6 +432,16 @@ and typedecl_t =
         ( "representation",
           (fun t -> t.representation),
           Option typedecl_representation );
+    ]
+
+and kindabbreviation_t =
+  let open Lang.KindAbbreviation in
+  Record
+    [
+      F ("id", (fun t -> t.id), identifier);
+      F ("source_loc", (fun t -> t.source_loc), Option identifier);
+      F ("doc", (fun t -> t.doc), docs);
+      F ("manifest", (fun t -> t.manifest), Option kind_annotation);
     ]
 
 (** {3 Extension} *)

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -121,6 +121,11 @@ module General_paths = struct
               ( "`Type",
                 ((parent :> id_t), name),
                 Pair (identifier, Names.typename) )
+        | `KindAbbreviation (parent, name) ->
+            C
+              ( "`KindAbbreviation",
+                ((parent :> id_t), name),
+                Pair (identifier, Names.typename) )
         | `Constructor (parent, name) ->
             C
               ( "`Constructor",
@@ -208,6 +213,7 @@ module General_paths = struct
       | `TPage -> C0 "`TPage"
       | `TAsset -> C0 "`TAsset"
       | `TType -> C0 "`TType"
+      | `TKindAbbreviation -> C0 "`TKindAbbreviation"
       | `TUnknown -> C0 "`TUnknown"
       | `TValue -> C0 "`TValue"
       | `TChildPage -> C0 "`TChildPage"
@@ -332,6 +338,11 @@ module General_paths = struct
               Pair (reference, Names.moduletypename) )
       | `Type (x1, x2) ->
           C ("`Type", ((x1 :> r), x2), Pair (reference, Names.typename))
+      | `KindAbbreviation (x1, x2) ->
+          C
+            ( "`KindAbbreviation",
+              ((x1 :> r), x2),
+              Pair (reference, Names.typename) )
       | `Constructor (x1, x2) ->
           C
             ( "`Constructor",

--- a/src/occurrences/table.ml
+++ b/src/occurrences/table.ml
@@ -41,6 +41,7 @@ let add ?(quantity = 1) tbl id =
     | `UnboxedField (parent, _) -> do_ parent
     | `Extension (parent, _) -> do_ parent
     | `Type (parent, _) -> do_ parent
+    | `KindAbbreviation (parent, _) -> do_ parent
     | `Constructor (parent, _) -> do_ parent
     | `Exception (parent, _) -> do_ parent
     | `ExtensionDecl (parent, _, _) -> do_ parent
@@ -73,6 +74,7 @@ let rec get t id =
   | `Extension (parent, _) -> do_ parent
   | `ExtensionDecl (parent, _, _) -> do_ parent
   | `Type (parent, _) -> do_ parent
+  | `KindAbbreviation (parent, _) -> do_ parent
   | `Constructor (parent, _) -> do_ parent
   | `Exception (parent, _) -> do_ parent
   | `Class (parent, _) -> do_ parent
@@ -160,6 +162,8 @@ module Strip = struct
         Mk.extension_decl (strip_sig_path p, (name, args))
     | { iv = `Constructor (p, name); _ } ->
         Mk.constructor (strip_datatype_path p, name)
+    | { iv = `KindAbbreviation (p, name); _ } ->
+        Mk.kind_abbreviation (strip_sig_path p, name)
     | {
      iv =
        ( `AssetFile (_, _)

--- a/src/search/html.ml
+++ b/src/search/html.ml
@@ -138,6 +138,7 @@ let kind_dir = "dir"
 let kind_impl = "impl"
 
 let kind_typedecl = "type"
+let kind_kind_abbreviation = "kind"
 
 let kind_module = "mod"
 
@@ -170,6 +171,7 @@ let string_of_kind =
   | UnboxedField _ -> kind_unboxed_field
   | ExtensionConstructor _ -> kind_extension_constructor
   | TypeDecl _ -> kind_typedecl
+  | KindAbbreviation -> kind_kind_abbreviation
   | Module _ -> kind_module
   | Value _ -> kind_value
   | Exception _ -> kind_exception
@@ -194,6 +196,7 @@ let of_strings ~kind ~prefix_name ~name ~rhs ~typedecl_params ~doc =
 let rhs_of_kind (entry : Entry.kind) =
   match entry with
   | TypeDecl td -> typedecl_rhs td
+  | KindAbbreviation -> None
   | Value t -> Some (value_rhs t)
   | Constructor t | ExtensionConstructor t | Exception t ->
       Some (constructor_rhs t)

--- a/src/search/json_index/json_search.ml
+++ b/src/search/json_index/json_search.ml
@@ -54,6 +54,8 @@ let rec of_id x =
       ret "ModuleType" (ModuleTypeName.to_string name) :: of_id (parent :> t)
   | `Type (parent, name) ->
       ret "Type" (TypeName.to_string name) :: of_id (parent :> t)
+  | `KindAbbreviation (parent, name) ->
+      ret "KindAbbreviation" (TypeName.to_string name) :: of_id (parent :> t)
   | `Constructor (parent, name) ->
       ret "Constructor" (ConstructorName.to_string name) :: of_id (parent :> t)
   | `Field (parent, name) ->
@@ -109,6 +111,8 @@ let rec prefix_name_kind_of_id (n : Odoc_model.Paths.Identifier.t) =
       (prefix_of_parent parent, ModuleTypeName.to_string name, "module_type")
   | `Type (parent, name) ->
       (prefix_of_parent parent, TypeName.to_string name, "type")
+  | `KindAbbreviation (parent, name) ->
+      (prefix_of_parent parent, TypeName.to_string name, "kind")
   | `Constructor (parent, name) ->
       (prefix_of_parent parent, ConstructorName.to_string name, "constructor")
   | `Field (parent, name) ->
@@ -182,6 +186,7 @@ let of_entry ({ Entry.id; doc; kind } as entry) html occurrences =
             ("manifest", manifest);
             ("constraints", constraints);
           ]
+    | KindAbbreviation -> return "KindAbbreviation" []
     | Module _ -> return "Module" []
     | Value { value = _; type_ } ->
         return "Value" [ ("type", `String (Text.of_type type_)) ]

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -318,6 +318,7 @@ and signature_items : Env.t -> Id.Signature.t -> Signature.item list -> _ =
         | TypeSubstitution t ->
             let env' = Env.open_type_substitution t env in
             loop (TypeSubstitution (type_decl env t) :: items) env' rest
+        | KindAbbreviation t -> loop (KindAbbreviation t :: items) env rest
         | ModuleType mt ->
             let m' = module_type env mt in
             let ty = Component.Of_Lang.(module_type (empty ()) m') in

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -332,6 +332,7 @@ and Signature : sig
     | ModuleTypeSubstitution of Ident.module_type * ModuleTypeSubstitution.t
     | Type of Ident.type_ * recursive * TypeDecl.t Delayed.t
     | TypeSubstitution of Ident.type_ * TypeDecl.t
+    | KindAbbreviation of Odoc_model.Lang.KindAbbreviation.t
     | Exception of Ident.exception_ * Exception.t
     | TypExt of Extension.t
     | Value of Ident.value * Value.t Delayed.t
@@ -517,6 +518,10 @@ module Element = struct
 
   type datatype = [ `Type of Identifier.Type.t * TypeDecl.t ]
 
+  type kind_abbreviation =
+    [ `KindAbbreviation of
+      Identifier.KindAbbreviation.t * Odoc_model.Lang.KindAbbreviation.t ]
+
   type value = [ `Value of Identifier.Value.t * Value.t ]
 
   type label = [ `Label of Identifier.Label.t * Label.t ]
@@ -557,6 +562,7 @@ module Element = struct
     [ signature
     | value
     | datatype
+    | kind_abbreviation
     | label
     | class_
     | class_type
@@ -574,6 +580,7 @@ module Element = struct
     | `Module (id, _) -> (id :> t)
     | `ModuleType (id, _) -> (id :> t)
     | `Type (id, _) -> (id :> t)
+    | `KindAbbreviation (id, _) -> (id :> t)
     | `ClassType (id, _) -> (id :> t)
     | `Class (id, _) -> (id :> t)
     | `Value (id, _) -> (id :> t)
@@ -707,6 +714,10 @@ module Fmt = struct
         Format.fprintf ppf "%a.%s" (model_identifier c)
           (ty :> id)
           (ConstructorName.to_string x)
+    | `KindAbbreviation (parent, name) ->
+        Format.fprintf ppf "%a.%s" (model_identifier c)
+          (parent :> id)
+          (TypeName.to_string name)
     | `Value (parent, name) ->
         Format.fprintf ppf "%a.%s" (model_identifier c)
           (parent :> id)
@@ -793,6 +804,10 @@ module Fmt = struct
       | TypeSubstitution (id, t) ->
           Format.fprintf ppf "@[<v 2>type %a :=%a@]" ident_fmt id (type_decl c)
             t
+      | KindAbbreviation ka ->
+          Format.fprintf ppf "@[<v 2>kind_ %s@]"
+            (Odoc_model.Paths.Identifier.name
+               ka.Odoc_model.Lang.KindAbbreviation.id)
       | Exception (id, e) ->
           Format.fprintf ppf "@[<v 2>exception %a %a@]" ident_fmt id
             (exception_ c) e
@@ -1789,6 +1804,10 @@ module Fmt = struct
         Format.fprintf ppf "%a.%s" (model_reference c)
           (parent :> t)
           (TypeName.to_string name)
+    | `KindAbbreviation (parent, name) ->
+        Format.fprintf ppf "%a.%s" (model_reference c)
+          (parent :> t)
+          (TypeName.to_string name)
     | `Constructor (parent, name) ->
         Format.fprintf ppf "%a.%s" (model_reference c)
           (parent :> t)
@@ -1883,6 +1902,7 @@ module LocalIdents = struct
             { ids with module_types = id :: ids.module_types }
         | Type (_, t) -> { ids with types = t.TypeDecl.id :: ids.types }
         | TypeSubstitution t -> { ids with types = t.TypeDecl.id :: ids.types }
+        | KindAbbreviation _ -> ids
         | Class (_, c) -> { ids with classes = c.Class.id :: ids.classes }
         | ClassType (_, c) ->
             { ids with class_types = c.ClassType.id :: ids.class_types }
@@ -2804,6 +2824,7 @@ module Of_Lang = struct
              let id = Identifier.Maps.Type.find t.id ident_map.types in
              let t' = type_decl ident_map t in
              Signature.TypeSubstitution (id, t')
+         | KindAbbreviation t -> Signature.KindAbbreviation t
          | Module (r, m) ->
              let id =
                Identifier.Maps.Module.find

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -335,6 +335,7 @@ and Signature : sig
     | ModuleTypeSubstitution of Ident.module_type * ModuleTypeSubstitution.t
     | Type of Ident.type_ * recursive * TypeDecl.t Delayed.t
     | TypeSubstitution of Ident.type_ * TypeDecl.t
+    | KindAbbreviation of Odoc_model.Lang.KindAbbreviation.t
     | Exception of Ident.exception_ * Exception.t
     | TypExt of Extension.t
     | Value of Ident.value * Value.t Delayed.t
@@ -520,6 +521,10 @@ module Element = struct
 
   type datatype = [ `Type of Identifier.Type.t * TypeDecl.t ]
 
+  type kind_abbreviation =
+    [ `KindAbbreviation of
+      Identifier.KindAbbreviation.t * Odoc_model.Lang.KindAbbreviation.t ]
+
   type value = [ `Value of Identifier.Value.t * Value.t ]
 
   type label = [ `Label of Identifier.Label.t * Label.t ]
@@ -560,6 +565,7 @@ module Element = struct
     [ signature
     | value
     | datatype
+    | kind_abbreviation
     | label
     | class_
     | class_type
@@ -577,6 +583,7 @@ module Element = struct
     | `Module (id, _) -> (id :> t)
     | `ModuleType (id, _) -> (id :> t)
     | `Type (id, _) -> (id :> t)
+    | `KindAbbreviation (id, _) -> (id :> t)
     | `ClassType (id, _) -> (id :> t)
     | `Class (id, _) -> (id :> t)
     | `Value (id, _) -> (id :> t)
@@ -710,6 +717,10 @@ module Fmt = struct
         Format.fprintf ppf "%a.%s" (model_identifier c)
           (ty :> id)
           (ConstructorName.to_string x)
+    | `KindAbbreviation (parent, name) ->
+        Format.fprintf ppf "%a.%s" (model_identifier c)
+          (parent :> id)
+          (TypeName.to_string name)
     | `Value (parent, name) ->
         Format.fprintf ppf "%a.%s" (model_identifier c)
           (parent :> id)
@@ -796,6 +807,10 @@ module Fmt = struct
       | TypeSubstitution (id, t) ->
           Format.fprintf ppf "@[<v 2>type %a :=%a@]" ident_fmt id (type_decl c)
             t
+      | KindAbbreviation ka ->
+          Format.fprintf ppf "@[<v 2>kind_ %s@]"
+            (Odoc_model.Paths.Identifier.name
+               ka.Odoc_model.Lang.KindAbbreviation.id)
       | Exception (id, e) ->
           Format.fprintf ppf "@[<v 2>exception %a %a@]" ident_fmt id
             (exception_ c) e
@@ -1792,6 +1807,10 @@ module Fmt = struct
         Format.fprintf ppf "%a.%s" (model_reference c)
           (parent :> t)
           (TypeName.to_string name)
+    | `KindAbbreviation (parent, name) ->
+        Format.fprintf ppf "%a.%s" (model_reference c)
+          (parent :> t)
+          (TypeName.to_string name)
     | `Constructor (parent, name) ->
         Format.fprintf ppf "%a.%s" (model_reference c)
           (parent :> t)
@@ -1886,6 +1905,7 @@ module LocalIdents = struct
             { ids with module_types = id :: ids.module_types }
         | Type (_, t) -> { ids with types = t.TypeDecl.id :: ids.types }
         | TypeSubstitution t -> { ids with types = t.TypeDecl.id :: ids.types }
+        | KindAbbreviation _ -> ids
         | Class (_, c) -> { ids with classes = c.Class.id :: ids.classes }
         | ClassType (_, c) ->
             { ids with class_types = c.ClassType.id :: ids.class_types }
@@ -2810,6 +2830,7 @@ module Of_Lang = struct
              let id = Identifier.Maps.Type.find t.id ident_map.types in
              let t' = type_decl ident_map t in
              Signature.TypeSubstitution (id, t')
+         | KindAbbreviation t -> Signature.KindAbbreviation t
          | Module (r, m) ->
              let id =
                Identifier.Maps.Module.find

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -307,6 +307,7 @@ and Signature : sig
     | ModuleTypeSubstitution of Ident.module_type * ModuleTypeSubstitution.t
     | Type of Ident.type_ * recursive * TypeDecl.t Delayed.t
     | TypeSubstitution of Ident.type_ * TypeDecl.t
+    | KindAbbreviation of Odoc_model.Lang.KindAbbreviation.t
     | Exception of Ident.exception_ * Exception.t
     | TypExt of Extension.t
     | Value of Ident.value * Value.t Delayed.t
@@ -493,6 +494,10 @@ module Element : sig
 
   type datatype = [ `Type of Identifier.Type.t * TypeDecl.t ]
 
+  type kind_abbreviation =
+    [ `KindAbbreviation of
+      Identifier.KindAbbreviation.t * Odoc_model.Lang.KindAbbreviation.t ]
+
   type value = [ `Value of Identifier.Value.t * Value.t ]
 
   type label = [ `Label of Identifier.Label.t * Label.t ]
@@ -533,6 +538,7 @@ module Element : sig
     [ signature
     | value
     | datatype
+    | kind_abbreviation
     | label
     | class_
     | class_type

--- a/src/xref2/component.mli
+++ b/src/xref2/component.mli
@@ -310,6 +310,7 @@ and Signature : sig
     | ModuleTypeSubstitution of Ident.module_type * ModuleTypeSubstitution.t
     | Type of Ident.type_ * recursive * TypeDecl.t Delayed.t
     | TypeSubstitution of Ident.type_ * TypeDecl.t
+    | KindAbbreviation of Odoc_model.Lang.KindAbbreviation.t
     | Exception of Ident.exception_ * Exception.t
     | TypExt of Extension.t
     | Value of Ident.value * Value.t Delayed.t
@@ -496,6 +497,10 @@ module Element : sig
 
   type datatype = [ `Type of Identifier.Type.t * TypeDecl.t ]
 
+  type kind_abbreviation =
+    [ `KindAbbreviation of
+      Identifier.KindAbbreviation.t * Odoc_model.Lang.KindAbbreviation.t ]
+
   type value = [ `Value of Identifier.Value.t * Value.t ]
 
   type label = [ `Label of Identifier.Label.t * Label.t ]
@@ -536,6 +541,7 @@ module Element : sig
     [ signature
     | value
     | datatype
+    | kind_abbreviation
     | label
     | class_
     | class_type

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -83,6 +83,7 @@ type kind =
   | Kind_Module
   | Kind_ModuleType
   | Kind_Type
+  | Kind_KindAbbreviation
   | Kind_Value
   | Kind_Label
   | Kind_Class
@@ -357,6 +358,12 @@ let add_type (identifier : Identifier.Type.t) t env =
     |> List.fold_right (add_cdocs identifier) docs
   else env
 
+let add_kind_abbreviation (identifier : Identifier.KindAbbreviation.t)
+    (t : Odoc_model.Lang.KindAbbreviation.t) env =
+  add_to_elts Kind_KindAbbreviation identifier
+    (`KindAbbreviation (identifier, t))
+    env
+
 let add_module_type identifier (t : Component.ModuleType.t) env =
   let env' =
     add_to_elts Kind_ModuleType identifier (`ModuleType (identifier, t)) env
@@ -607,6 +614,11 @@ let s_type : Component.Element.type_ scope =
 let s_datatype : Component.Element.datatype scope =
   make_scope (function #Component.Element.datatype as r -> Some r | _ -> None)
 
+let s_kind_abbreviation : Component.Element.kind_abbreviation scope =
+  make_scope (function
+    | #Component.Element.kind_abbreviation as r -> Some r
+    | _ -> None)
+
 let s_class : Component.Element.class_ scope =
   make_scope (function #Component.Element.class_ as r -> Some r | _ -> None)
 
@@ -830,6 +842,8 @@ let rec open_signature : Lang.Signature.t -> t -> t =
         | L.Signature.Value v, true ->
             let ty = value ident_map v in
             add_value v.L.Value.id ty env
+        | KindAbbreviation ka, _ ->
+            add_kind_abbreviation ka.L.KindAbbreviation.id ka env
         (* Skip when compiling *)
         | Exception _, false -> env
         | TypExt _, false -> env

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -59,6 +59,9 @@ val add_module :
 
 val add_type : Identifier.Type.t -> Component.TypeDecl.t -> t -> t
 
+val add_kind_abbreviation :
+  Identifier.KindAbbreviation.t -> Odoc_model.Lang.KindAbbreviation.t -> t -> t
+
 val add_module_type :
   Identifier.Path.ModuleType.t -> Component.ModuleType.t -> t -> t
 
@@ -138,6 +141,8 @@ val s_module_type : Component.Element.module_type scope
 val s_type : Component.Element.type_ scope
 
 val s_datatype : Component.Element.datatype scope
+
+val s_kind_abbreviation : Component.Element.kind_abbreviation scope
 
 val s_class : Component.Element.class_ scope
 

--- a/src/xref2/find.ml
+++ b/src/xref2/find.ml
@@ -7,6 +7,9 @@ type module_type = [ `FModuleType of ModuleTypeName.t * ModuleType.t ]
 
 type datatype = [ `FType of TypeName.t * TypeDecl.t ]
 
+type kind_abbreviation =
+  [ `FKindAbbreviation of Odoc_model.Paths.Identifier.KindAbbreviation.t ]
+
 type core_type = [ `CoreType of TypeName.t ]
 
 type class_ =
@@ -122,6 +125,15 @@ let type_in_sig sg name =
     | ClassType (id, _, c)
       when TypeName.equal_modulo_shadowing (N.typed_type id) name ->
         Some (`FClassType (N.typed_type id, c))
+    | _ -> None)
+
+let kind_abbreviation_in_sig sg name =
+  find_in_sig sg (function
+    | Signature.KindAbbreviation ka
+      when TypeName.to_string name
+           = Odoc_model.Paths.Identifier.name
+               ka.Odoc_model.Lang.KindAbbreviation.id ->
+        Some (`FKindAbbreviation ka.Odoc_model.Lang.KindAbbreviation.id)
     | _ -> None)
 
 type removed_type =

--- a/src/xref2/find.mli
+++ b/src/xref2/find.mli
@@ -8,6 +8,9 @@ type module_type = [ `FModuleType of ModuleTypeName.t * ModuleType.t ]
 
 type datatype = [ `FType of TypeName.t * TypeDecl.t ]
 
+type kind_abbreviation =
+  [ `FKindAbbreviation of Odoc_model.Paths.Identifier.KindAbbreviation.t ]
+
 type class_ =
   [ `FClass of TypeName.t * Class.t | `FClassType of TypeName.t * ClassType.t ]
 
@@ -67,6 +70,9 @@ val module_in_sig : Signature.t -> ModuleName.t -> module_ option
 val type_in_sig : Signature.t -> TypeName.t -> type_ option
 
 val datatype_in_sig : Signature.t -> TypeName.t -> datatype option
+
+val kind_abbreviation_in_sig :
+  Signature.t -> TypeName.t -> kind_abbreviation option
 
 val module_type_in_sig : Signature.t -> ModuleTypeName.t -> module_type option
 

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -23,6 +23,7 @@ let empty_shadow =
     s_module_types = [];
     s_values = [];
     s_types = [];
+    s_kind_abbreviations = [];
     s_classes = [];
     s_class_types = [];
   }
@@ -386,6 +387,7 @@ module ExtractIDs = struct
       | Exception (_, _) :: rest
       | Value (_, _) :: rest
       | TypExt _ :: rest
+      | KindAbbreviation _ :: rest
       | Comment _ :: rest ->
           inner rest map
       | Include i :: rest -> inner rest (include_ parent map i)
@@ -439,6 +441,13 @@ let rec signature_items id map items =
           (ModuleSubstitution (module_substitution map parent id m) :: acc)
     | TypeSubstitution (id, t) :: rest ->
         inner rest (TypeSubstitution (type_decl map parent id t) :: acc)
+    | KindAbbreviation t :: rest ->
+        let name =
+          Odoc_model.Paths.Identifier.name t.Odoc_model.Lang.KindAbbreviation.id
+        in
+        if List.mem_assoc name map.shadowed.s_kind_abbreviations then
+          inner rest acc
+        else inner rest (KindAbbreviation t :: acc)
     | Class (id, r, c) :: rest ->
         inner rest (Class (r, class_ map parent id c) :: acc)
     | ClassType (id, r, c) :: rest ->
@@ -637,6 +646,8 @@ and combine_shadowed s1 s2 =
     s_module_types = combine s1.s_module_types s2.s_module_types;
     s_values = combine s1.s_values s2.s_values;
     s_types = combine s1.s_types s2.s_types;
+    s_kind_abbreviations =
+      combine s1.s_kind_abbreviations s2.s_kind_abbreviations;
     s_classes = combine s1.s_classes s2.s_classes;
     s_class_types = combine s1.s_class_types s2.s_class_types;
   }

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -635,6 +635,14 @@ and signature_items :
         | TypeSubstitution t ->
             let env' = Env.open_type_substitution t env in
             (TypeSubstitution (type_decl env id t) :: items, env')
+        | KindAbbreviation t ->
+            std
+            @@ KindAbbreviation
+                 {
+                   t with
+                   Odoc_model.Lang.KindAbbreviation.manifest =
+                     Option.map (resolve_kind env) t.manifest;
+                 }
         | ModuleType mt -> std @@ ModuleType (module_type env mt)
         | ModuleTypeSubstitution mts ->
             let env' = Env.open_module_type_substitution mts env in
@@ -1051,7 +1059,28 @@ and type_decl_equation env parent t =
         (type_expression env parent [] tex1, type_expression env parent [] tex2))
       t.constraints
   in
-  { t with manifest; constraints }
+  let params =
+    List.map
+      (fun (p : TypeDecl.param) -> { p with kind = resolve_kind env p.kind })
+      t.params
+  in
+  { t with params; manifest; constraints; kind = resolve_kind env t.kind }
+
+and resolve_kind env (k : Odoc_model.Lang.Kind.t) : Odoc_model.Lang.Kind.t =
+  let open Odoc_model.Lang.Kind in
+  match k with
+  | Default | Abbreviation (_, None) | Abbreviation (_, Some (`Resolved _)) -> k
+  | Abbreviation (name, Some r) -> (
+      match
+        Odoc_model.Error.unpack_warnings (Ref_tools.resolve_reference env r)
+        |> fst
+      with
+      | Ok (r', _) -> Abbreviation (name, Some (`Resolved r'))
+      | Error _ -> k)
+  | Mod (b, m) -> Mod (resolve_kind env b, m)
+  | With (b, ty, m) -> With (resolve_kind env b, ty, m)
+  | Kind_of ty -> Kind_of ty
+  | Product ks -> Product (List.map (resolve_kind env) ks)
 
 and type_decl_field env parent f =
   let open TypeDecl.Field in
@@ -1215,7 +1244,9 @@ and type_expression : Env.t -> Id.Signature.t -> _ -> _ =
             let p = Lang_of.(Path.resolved_class_type (empty ()) cp') in
             Class (`Resolved p, ts)
         | _ -> Class (path', ts))
-  | Poly (strs, t) -> Poly (strs, type_expression env parent visited t)
+  | Poly (strs, t) ->
+      let strs = List.map (fun (s, k) -> (s, resolve_kind env k)) strs in
+      Poly (strs, type_expression env parent visited t)
   | Quote t -> Quote (type_expression env parent visited t)
   | Splice t -> Splice (type_expression env parent visited t)
   | Package p -> Package (type_expression_package env parent visited p)

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -69,6 +69,7 @@ let ref_kind_of_element = function
   | `Module _ -> "module"
   | `ModuleType _ -> "module-type"
   | `Type _ -> "type"
+  | `KindAbbreviation _ -> "kind"
   | `Value _ -> "val"
   | `Label _ -> "section"
   | `Class _ -> "class"
@@ -378,6 +379,21 @@ module V = struct
   let in_signature _env ((parent, _, sg) : signature_lookup_result) name =
     find Find.value_in_sig sg ValueName.to_string name >>= function
     | `FValue (name, _) -> Ok (`Value (parent, name))
+end
+
+module KA = struct
+  (** Kind abbreviation *)
+
+  type t = Resolved.t
+
+  let in_env env name : t ref_result =
+    env_lookup_by_name Env.s_kind_abbreviation name env
+    >>= fun (`KindAbbreviation (id, _)) -> Ok (`Identifier (id :> Identifier.t))
+
+  let in_signature _env ((_, _, sg) : signature_lookup_result) name :
+      t ref_result =
+    find Find.kind_abbreviation_in_sig sg TypeName.to_string name >>= function
+    | `FKindAbbreviation id -> Ok (`Identifier (id :> Identifier.t))
 end
 
 module L = struct
@@ -978,6 +994,7 @@ let resolve_reference :
             identifier ?text id
         | `Class (id, _) -> identifier id
         | `ClassType (id, _) -> identifier id
+        | `KindAbbreviation (id, _) -> identifier id
         | `Constructor (id, _) -> identifier id
         | `Exception (id, _) -> identifier id
         | `Extension (id, _, _) -> identifier id
@@ -998,6 +1015,10 @@ let resolve_reference :
     | `Type (parent, name) ->
         resolve_signature_reference env parent >>= fun p ->
         T.in_signature env p name >>= resolved_type_lookup
+    | `Root (name, `TKindAbbreviation) -> KA.in_env env name >>= resolved1
+    | `KindAbbreviation (parent, name) ->
+        resolve_signature_reference env parent >>= fun p ->
+        KA.in_signature env p name >>= resolved1
     | `Root (name, `TClass) -> CL.in_env env name >>= resolved2
     | `Class (parent, name) ->
         resolve_signature_reference env parent >>= fun p ->

--- a/src/xref2/shape_tools.cppo.ml
+++ b/src/xref2/shape_tools.cppo.ml
@@ -50,6 +50,7 @@ let rec shape_of_id env :
         proj parent Kind.Class_type (TypeName.to_string_unsafe name)
     | `Page _ | `LeafPage _ | `Label _
     | `Constructor _ | `Field _ | `UnboxedField _ | `Method _ | `InstanceVariable _ | `Parameter _
+    | `KindAbbreviation _
       ->
         (* Not represented in shapes. *)
         None

--- a/src/xref2/strengthen.ml
+++ b/src/xref2/strengthen.ml
@@ -69,7 +69,7 @@ and sig_items prefix ?canonical sg =
             (Include i' :: items, strengthened @ s)
         | Exception _ | TypExt _ | Value _ | Class _ | ClassType _
         | ModuleSubstitution _ | TypeSubstitution _ | ModuleTypeSubstitution _
-        | Comment _ | Open _ ->
+        | KindAbbreviation _ | Comment _ | Open _ ->
             (item :: items, s))
       ([], []) sg.items
   in

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -1002,6 +1002,8 @@ and rename_bound_idents s sg =
         (Open { expansion = { expansion with items; removed = [] }; doc } :: sg)
         rest
   | (Comment _ as item) :: rest -> rename_bound_idents s (item :: sg) rest
+  | (KindAbbreviation _ as item) :: rest ->
+      rename_bound_idents s (item :: sg) rest
 
 and removed_items s items =
   let open Component.Signature in
@@ -1056,6 +1058,7 @@ and apply_sig_map_item s item =
   | Include i -> Include (include_ s i)
   | Open o -> Open (open_ s o)
   | Comment c -> Comment c
+  | KindAbbreviation _ as item -> item
 
 and apply_sig_map_items s items =
   List.rev_map (apply_sig_map_item s) items |> List.rev

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -1003,6 +1003,8 @@ and rename_bound_idents s sg =
         (Open { expansion = { expansion with items; removed = [] }; doc } :: sg)
         rest
   | (Comment _ as item) :: rest -> rename_bound_idents s (item :: sg) rest
+  | (KindAbbreviation _ as item) :: rest ->
+      rename_bound_idents s (item :: sg) rest
 
 and removed_items s items =
   let open Component.Signature in
@@ -1057,6 +1059,7 @@ and apply_sig_map_item s item =
   | Include i -> Include (include_ s i)
   | Open o -> Open (open_ s o)
   | Comment c -> Comment c
+  | KindAbbreviation _ as item -> item
 
 and apply_sig_map_items s items =
   List.rev_map (apply_sig_map_item s) items |> List.rev

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -140,6 +140,7 @@ let prefix_substitution path sg =
     | Exception _ :: rest
     | TypExt _ :: rest
     | Value (_, _) :: rest
+    | KindAbbreviation _ :: rest
     | Comment _ :: rest ->
         get_sub sub' rest
     | Class (id, _, _) :: rest ->
@@ -204,7 +205,8 @@ let prefix_signature (path, sg) =
             ClassType (Ident.Rename.type_ id, r, Subst.class_type sub c)
         | Include i -> Include (Subst.include_ sub i)
         | Open o -> Open (Subst.open_ sub o)
-        | Comment c -> Comment c)
+        | Comment c -> Comment c
+        | KindAbbreviation _ as item -> item)
       sg.items
   in
   { sg with items }

--- a/test/generators/cases/oxcaml.mli
+++ b/test/generators/cases/oxcaml.mli
@@ -114,11 +114,89 @@ type t_inner_mod : float64 & (immediate mod portable)
 
 (** {1 Kind abbreviations} *)
 
+kind_ missing_documentation = value mod portable
+(** BROKEN: this [(** ... *)] comment on a [kind_] declaration is dropped by
+    the OxCaml parser, so it does not render.  *)
+
+(** TODO: The above kind abbreviation uses [(** *)] which are not captured by
+    the OxCaml parser, so its documentation is currently missing. The following
+    [kind_] declarations use an explicit [@@ocaml.doc] to side-step this issue. *)
+
 kind_ my_abbrev = value_or_null mod non_null global
-(** Declares a kind abbreviation named [my_abbrev]. *)
+[@@ocaml.doc "Declares a kind abbreviation named [my_abbrev]."]
 
 type t_abbrev : my_abbrev mod immutable
-(** A type with an abbreviated kind. *)
+(** A type with an abbreviated kind. The use of [my_abbrev] should link to its
+    definition. References to the kind abbreviation resolve too, both
+    unqualified {!my_abbrev} and qualified {!kind:my_abbrev}. *)
+
+kind_ my_derived = my_abbrev mod portable
+[@@ocaml.doc
+  "A kind abbreviation defined in terms of another one; the use of [my_abbrev] \
+   in this definition should also link to its definition."]
+
+type t_derived : my_derived
+(** A type whose kind is the derived abbreviation. *)
+
+kind_ my_abstract [@@ocaml.doc "An abstract kind abbreviation (no manifest)."]
+
+type t_abstract : my_abstract
+(** A type with an abstract abbreviated kind. *)
+
+type ('a : my_abbrev) abbrev_param
+(** A type parameter constrained by an abbreviated kind. *)
+
+val poly_abbrev : ('a : my_abbrev). 'a -> 'a
+(** A polymorphic value with an abbreviated kind constraint. *)
+
+type 'a t_with_abbrev : my_abbrev with 'a
+(** An abbreviated kind in a [with] constraint. *)
+
+module M_kinds : sig
+  kind_ mod_kind = value mod portable
+end
+
+type t_qualified : M_kinds.mod_kind
+(** A qualified use of a kind abbreviation from another module; the use should
+    link to [M_kinds.mod_kind]'s definition. *)
+
+type ('a : M_kinds.mod_kind) qualified_param
+(** A qualified kind abbreviation on a type parameter; the use should link to
+    the definition (resolved during linking, like [t_qualified]). *)
+
+module type S_kind = sig
+  kind_ functor_kind = value mod portable
+  [@@ocaml.doc "A kind declared in a module type."]
+end
+
+module F_kind (X : S_kind) : S_kind
+
+module Arg_kind : S_kind
+
+type t_functor_app : F_kind(Arg_kind).functor_kind
+(** A use behind a functor application. odoc references can't express functor
+    application, so this is rendered as plain text (not a link) rather than
+    crashing. *)
+
+module F_nested (X : S_kind) : sig
+  kind_ abstract_kind [@@ocaml.doc "An abstract kind."]
+
+  module Nested : sig
+    kind_ custom_kind_abbrev = X.functor_kind mod contended
+    [@@ocaml.doc "A nested kind extending the functor argument's kind."]
+  end
+end
+
+kind_ functor_abbrev = F_nested(Arg_kind).abstract_kind
+[@@ocaml.doc
+  "A kind abbreviation defined through a functor-application path. The manifest \
+   is rendered but the functor-application path isn't a link."]
+
+kind_ nested_functor_abbrev = F_nested(Arg_kind).Nested.custom_kind_abbrev
+[@@ocaml.doc
+  "A kind abbreviation defined through a \
+   functor-application-then-nested-module path. The manifest is rendered but \
+   the functor-application path isn't a link."]
 
 (** {1 Zero alloc} *)
 

--- a/test/generators/cases/oxcaml.mli
+++ b/test/generators/cases/oxcaml.mli
@@ -240,6 +240,26 @@ kind_ nested_functor_abbrev = F_nested(Arg_kind).Nested.custom_kind_abbrev
     path. The manifest is rendered but the functor-application path isn't a
     link. *)
 
+kind_ to_be_shadowed = value mod portable
+(** Shadowed below by a kind abbreviation of the same name. *)
+
+module X_shadowing : sig
+  type t : to_be_shadowed
+  (** Uses the outer [to_be_shadowed], declared before the one below, so the
+      link should point outside this module. *)
+
+  kind_ to_be_shadowed = value_or_null mod non_null global
+  (** Shadows the outer [to_be_shadowed]. *)
+end
+
+module M_inc : sig
+  kind_ inc_kind = value mod portable
+end
+
+include module type of M_inc
+
+type t_inc : inc_kind
+
 (** {1 Zero alloc} *)
 
 val add : bool -> int -> int -> int [@@zero_alloc]

--- a/test/generators/cases/oxcaml.mli
+++ b/test/generators/cases/oxcaml.mli
@@ -165,11 +165,89 @@ type t_inner_mod : float64 & (immediate mod portable)
 
 (** {1 Kind abbreviations} *)
 
+kind_ missing_documentation = value mod portable
+(** BROKEN: this [(** ... *)] comment on a [kind_] declaration is dropped by
+    the OxCaml parser, so it does not render.  *)
+
+(** TODO: The above kind abbreviation uses [(** *)] which are not captured by
+    the OxCaml parser, so its documentation is currently missing. The following
+    [kind_] declarations use an explicit [@@ocaml.doc] to side-step this issue. *)
+
 kind_ my_abbrev = value_or_null mod non_null global
-(** Declares a kind abbreviation named [my_abbrev]. *)
+[@@ocaml.doc "Declares a kind abbreviation named [my_abbrev]."]
 
 type t_abbrev : my_abbrev mod immutable
-(** A type with an abbreviated kind. *)
+(** A type with an abbreviated kind. The use of [my_abbrev] should link to its
+    definition. References to the kind abbreviation resolve too, both
+    unqualified {!my_abbrev} and qualified {!kind:my_abbrev}. *)
+
+kind_ my_derived = my_abbrev mod portable
+[@@ocaml.doc
+  "A kind abbreviation defined in terms of another one; the use of [my_abbrev] \
+   in this definition should also link to its definition."]
+
+type t_derived : my_derived
+(** A type whose kind is the derived abbreviation. *)
+
+kind_ my_abstract [@@ocaml.doc "An abstract kind abbreviation (no manifest)."]
+
+type t_abstract : my_abstract
+(** A type with an abstract abbreviated kind. *)
+
+type ('a : my_abbrev) abbrev_param
+(** A type parameter constrained by an abbreviated kind. *)
+
+val poly_abbrev : ('a : my_abbrev). 'a -> 'a
+(** A polymorphic value with an abbreviated kind constraint. *)
+
+type 'a t_with_abbrev : my_abbrev with 'a
+(** An abbreviated kind in a [with] constraint. *)
+
+module M_kinds : sig
+  kind_ mod_kind = value mod portable
+end
+
+type t_qualified : M_kinds.mod_kind
+(** A qualified use of a kind abbreviation from another module; the use should
+    link to [M_kinds.mod_kind]'s definition. *)
+
+type ('a : M_kinds.mod_kind) qualified_param
+(** A qualified kind abbreviation on a type parameter; the use should link to
+    the definition (resolved during linking, like [t_qualified]). *)
+
+module type S_kind = sig
+  kind_ functor_kind = value mod portable
+  [@@ocaml.doc "A kind declared in a module type."]
+end
+
+module F_kind (X : S_kind) : S_kind
+
+module Arg_kind : S_kind
+
+type t_functor_app : F_kind(Arg_kind).functor_kind
+(** A use behind a functor application. odoc references can't express functor
+    application, so this is rendered as plain text (not a link) rather than
+    crashing. *)
+
+module F_nested (X : S_kind) : sig
+  kind_ abstract_kind [@@ocaml.doc "An abstract kind."]
+
+  module Nested : sig
+    kind_ custom_kind_abbrev = X.functor_kind mod contended
+    [@@ocaml.doc "A nested kind extending the functor argument's kind."]
+  end
+end
+
+kind_ functor_abbrev = F_nested(Arg_kind).abstract_kind
+[@@ocaml.doc
+  "A kind abbreviation defined through a functor-application path. The manifest \
+   is rendered but the functor-application path isn't a link."]
+
+kind_ nested_functor_abbrev = F_nested(Arg_kind).Nested.custom_kind_abbrev
+[@@ocaml.doc
+  "A kind abbreviation defined through a \
+   functor-application-then-nested-module path. The manifest is rendered but \
+   the functor-application path isn't a link."]
 
 (** {1 Zero alloc} *)
 

--- a/test/generators/cases/oxcaml.mli
+++ b/test/generators/cases/oxcaml.mli
@@ -165,16 +165,8 @@ type t_inner_mod : float64 & (immediate mod portable)
 
 (** {1 Kind abbreviations} *)
 
-kind_ missing_documentation = value mod portable
-(** BROKEN: this [(** ... *)] comment on a [kind_] declaration is dropped by
-    the OxCaml parser, so it does not render.  *)
-
-(** TODO: The above kind abbreviation uses [(** *)] which are not captured by
-    the OxCaml parser, so its documentation is currently missing. The following
-    [kind_] declarations use an explicit [@@ocaml.doc] to side-step this issue. *)
-
 kind_ my_abbrev = value_or_null mod non_null global
-[@@ocaml.doc "Declares a kind abbreviation named [my_abbrev]."]
+(** Declares a kind abbreviation named [my_abbrev]. *)
 
 type t_abbrev : my_abbrev mod immutable
 (** A type with an abbreviated kind. The use of [my_abbrev] should link to its
@@ -182,14 +174,14 @@ type t_abbrev : my_abbrev mod immutable
     unqualified {!my_abbrev} and qualified {!kind:my_abbrev}. *)
 
 kind_ my_derived = my_abbrev mod portable
-[@@ocaml.doc
-  "A kind abbreviation defined in terms of another one; the use of [my_abbrev] \
-   in this definition should also link to its definition."]
+(** A kind abbreviation defined in terms of another one; the use of [my_abbrev]
+    in this definition should also link to its definition. *)
 
 type t_derived : my_derived
 (** A type whose kind is the derived abbreviation. *)
 
-kind_ my_abstract [@@ocaml.doc "An abstract kind abbreviation (no manifest)."]
+kind_ my_abstract
+(** An abstract kind abbreviation (no manifest). *)
 
 type t_abstract : my_abstract
 (** A type with an abstract abbreviated kind. *)
@@ -217,7 +209,7 @@ type ('a : M_kinds.mod_kind) qualified_param
 
 module type S_kind = sig
   kind_ functor_kind = value mod portable
-  [@@ocaml.doc "A kind declared in a module type."]
+  (** A kind declared in a module type. *)
 end
 
 module F_kind (X : S_kind) : S_kind
@@ -230,24 +222,23 @@ type t_functor_app : F_kind(Arg_kind).functor_kind
     crashing. *)
 
 module F_nested (X : S_kind) : sig
-  kind_ abstract_kind [@@ocaml.doc "An abstract kind."]
+  kind_ abstract_kind
+  (** An abstract kind. *)
 
   module Nested : sig
     kind_ custom_kind_abbrev = X.functor_kind mod contended
-    [@@ocaml.doc "A nested kind extending the functor argument's kind."]
+    (** A nested kind extending the functor argument's kind. *)
   end
 end
 
 kind_ functor_abbrev = F_nested(Arg_kind).abstract_kind
-[@@ocaml.doc
-  "A kind abbreviation defined through a functor-application path. The manifest \
-   is rendered but the functor-application path isn't a link."]
+(** A kind abbreviation defined through a functor-application path. The manifest
+    is rendered but the functor-application path isn't a link. *)
 
 kind_ nested_functor_abbrev = F_nested(Arg_kind).Nested.custom_kind_abbrev
-[@@ocaml.doc
-  "A kind abbreviation defined through a \
-   functor-application-then-nested-module path. The manifest is rendered but \
-   the functor-application path isn't a link."]
+(** A kind abbreviation defined through a functor-application-then-nested-module
+    path. The manifest is rendered but the functor-application path isn't a
+    link. *)
 
 (** {1 Zero alloc} *)
 

--- a/test/generators/cases/oxcaml_impl.ml
+++ b/test/generators/cases/oxcaml_impl.ml
@@ -8,3 +8,19 @@ end
 module Including = struct
   include To_be_included
 end
+
+(* A kind abbreviation defined in an implementation. *)
+kind_ my_abbrev = value_or_null mod non_null global
+
+(* A type that uses the abbreviation; the use should link to the definition. *)
+type t_abbrev : my_abbrev mod immutable
+
+(* Shadowing: [dup] brought in by the include is shadowed by the local [dup].
+   Only the local definition should be rendered (no duplicate anchor). *)
+module Shadowing_source = struct
+  kind_ dup = value mod portable
+end
+
+include Shadowing_source
+
+kind_ dup = value_or_null mod non_null

--- a/test/generators/cases/oxcaml_impl.ml
+++ b/test/generators/cases/oxcaml_impl.ml
@@ -59,3 +59,19 @@ let mode_arg : int @ local -> int = fun x -> x
 
 let mode_multi : string @ local once -> string @ local once = fun x -> x
 (** Multiple modes on argument and return. *)
+
+(* A kind abbreviation defined in an implementation. *)
+kind_ my_abbrev = value_or_null mod non_null global
+
+(* A type that uses the abbreviation; the use should link to the definition. *)
+type t_abbrev : my_abbrev mod immutable
+
+(* Shadowing: [dup] brought in by the include is shadowed by the local [dup].
+   Only the local definition should be rendered (no duplicate anchor). *)
+module Shadowing_source = struct
+  kind_ dup = value mod portable
+end
+
+include Shadowing_source
+
+kind_ dup = value_or_null mod non_null

--- a/test/generators/html/Oxcaml-Arg_kind.html
+++ b/test/generators/html/Oxcaml-Arg_kind.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Arg_kind (Oxcaml.Arg_kind)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; Arg_kind
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Oxcaml.Arg_kind</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-functor_kind">
+     <a href="#kind-functor_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> functor_kind = value 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc"><p>A kind declared in a module type.</p></div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-F_kind-argument-1-X.html
+++ b/test/generators/html/Oxcaml-F_kind-argument-1-X.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>X (Oxcaml.F_kind.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml-F_kind.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; <a href="Oxcaml-F_kind.html">F_kind</a> &#x00BB; X
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Parameter <code><span>F_kind.X</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-functor_kind">
+     <a href="#kind-functor_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> functor_kind = value 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc"><p>A kind declared in a module type.</p></div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-F_kind.html
+++ b/test/generators/html/Oxcaml-F_kind.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>F_kind (Oxcaml.F_kind)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; F_kind
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Oxcaml.F_kind</span></code></h1>
+  </header>
+  <div class="odoc-tocs">
+   <nav class="odoc-toc odoc-local-toc">
+    <ul><li><a href="#parameters">Parameters</a></li>
+     <li><a href="#signature">Signature</a></li>
+    </ul>
+   </nav>
+  </div>
+  <div class="odoc-content">
+   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+   </h2>
+   <div class="odoc-spec">
+    <div class="spec parameter anchored" id="argument-1-X">
+     <a href="#argument-1-X" class="anchor"></a>
+     <code><span><span class="keyword">module</span> </span>
+      <span><a href="Oxcaml-F_kind-argument-1-X.html">X</a></span>
+      <span> : <a href="Oxcaml-module-type-S_kind.html">S_kind</a></span>
+     </code>
+    </div>
+   </div>
+   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-functor_kind">
+     <a href="#kind-functor_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> functor_kind = value 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc"><p>A kind declared in a module type.</p></div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-F_nested-Nested.html
+++ b/test/generators/html/Oxcaml-F_nested-Nested.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Nested (Oxcaml.F_nested.Nested)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml-F_nested.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; <a href="Oxcaml-F_nested.html">F_nested</a> &#x00BB; Nested
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>F_nested.Nested</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored"
+     id="kind-custom_kind_abbrev">
+     <a href="#kind-custom_kind_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> custom_kind_abbrev = 
+       <a href="Oxcaml-module-type-S_kind.html#kind-functor_kind">
+        X.functor_kind
+       </a> <span class="keyword">mod</span> contended
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A nested kind extending the functor argument's kind.</p>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-F_nested-argument-1-X.html
+++ b/test/generators/html/Oxcaml-F_nested-argument-1-X.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>X (Oxcaml.F_nested.X)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml-F_nested.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; <a href="Oxcaml-F_nested.html">F_nested</a> &#x00BB; X
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Parameter <code><span>F_nested.X</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-functor_kind">
+     <a href="#kind-functor_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> functor_kind = value 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc"><p>A kind declared in a module type.</p></div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-F_nested.html
+++ b/test/generators/html/Oxcaml-F_nested.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>F_nested (Oxcaml.F_nested)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; F_nested
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Oxcaml.F_nested</span></code></h1>
+  </header>
+  <div class="odoc-tocs">
+   <nav class="odoc-toc odoc-local-toc">
+    <ul><li><a href="#parameters">Parameters</a></li>
+     <li><a href="#signature">Signature</a></li>
+    </ul>
+   </nav>
+  </div>
+  <div class="odoc-content">
+   <h2 id="parameters"><a href="#parameters" class="anchor"></a>Parameters
+   </h2>
+   <div class="odoc-spec">
+    <div class="spec parameter anchored" id="argument-1-X">
+     <a href="#argument-1-X" class="anchor"></a>
+     <code><span><span class="keyword">module</span> </span>
+      <span><a href="Oxcaml-F_nested-argument-1-X.html">X</a></span>
+      <span> : <a href="Oxcaml-module-type-S_kind.html">S_kind</a></span>
+     </code>
+    </div>
+   </div>
+   <h2 id="signature"><a href="#signature" class="anchor"></a>Signature</h2>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-abstract_kind">
+     <a href="#kind-abstract_kind" class="anchor"></a>
+     <code><span><span class="keyword">kind_</span> abstract_kind</span>
+     </code>
+    </div><div class="spec-doc"><p>An abstract kind.</p></div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-Nested">
+     <a href="#module-Nested" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-F_nested-Nested.html">Nested</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-M_inc.html
+++ b/test/generators/html/Oxcaml-M_inc.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>M_inc (Oxcaml.M_inc)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; M_inc
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Oxcaml.M_inc</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-inc_kind">
+     <a href="#kind-inc_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> inc_kind = value 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-M_kinds.html
+++ b/test/generators/html/Oxcaml-M_kinds.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>M_kinds (Oxcaml.M_kinds)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; M_kinds
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Oxcaml.M_kinds</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-mod_kind">
+     <a href="#kind-mod_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> mod_kind = value 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-X_shadowing.html
+++ b/test/generators/html/Oxcaml-X_shadowing.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>X_shadowing (Oxcaml.X_shadowing)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; X_shadowing
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Oxcaml.X_shadowing</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t">
+     <a href="#type-t" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t : 
+       <a href="Oxcaml.html#kind-to_be_shadowed">to_be_shadowed</a>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>Uses the outer <code>to_be_shadowed</code>, declared before the
+       one below, so the link should point outside this module.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored"
+     id="kind-to_be_shadowed">
+     <a href="#kind-to_be_shadowed" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> to_be_shadowed = value_or_null
+        <span class="keyword">mod</span> non_null global
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>Shadows the outer <code>to_be_shadowed</code>.</p>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-module-type-S_kind.html
+++ b/test/generators/html/Oxcaml-module-type-S_kind.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>S_kind (Oxcaml.S_kind)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; S_kind
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module type <code><span>Oxcaml.S_kind</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-functor_kind">
+     <a href="#kind-functor_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> functor_kind = value 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc"><p>A kind declared in a module type.</p></div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-module-type-S_nested-Nested.html
+++ b/test/generators/html/Oxcaml-module-type-S_nested-Nested.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Nested (Oxcaml.S_nested.Nested)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml-module-type-S_nested.html">Up</a>
+    – <a href="index.html">Index</a> &#x00BB; 
+   <a href="Oxcaml.html">Oxcaml</a> &#x00BB; 
+   <a href="Oxcaml-module-type-S_nested.html">S_nested</a> &#x00BB; Nested
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>S_nested.Nested</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored"
+     id="kind-custom_kind_abbrev">
+     <a href="#kind-custom_kind_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> custom_kind_abbrev = 
+       <a href="Oxcaml-module-type-S_nested.html#kind-k">k</a> 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml-module-type-S_nested.html
+++ b/test/generators/html/Oxcaml-module-type-S_nested.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>S_nested (Oxcaml.S_nested)</title><meta charset="utf-8"/>
+  <link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; <a href="Oxcaml.html">Oxcaml</a>
+    &#x00BB; S_nested
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module type <code><span>Oxcaml.S_nested</span></code></h1>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-k">
+     <a href="#kind-k" class="anchor"></a>
+     <code><span><span class="keyword">kind_</span> k</span></code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-Nested">
+     <a href="#module-Nested" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-module-type-S_nested-Nested.html">Nested</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+  </div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml.html
+++ b/test/generators/html/Oxcaml.html
@@ -493,14 +493,296 @@
     <a href="#kind-abbreviations_2" class="anchor"></a>Kind abbreviations
    </h2>
    <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored"
+     id="kind-missing_documentation">
+     <a href="#kind-missing_documentation" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> missing_documentation =
+        value <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+   </div>
+   <p>TODO: The above kind abbreviation uses <code>(** *)</code> which
+     are not captured by the OxCaml parser, so its documentation is currently
+     missing. The following <code>kind_</code> declarations use an explicit
+     <code>@@ocaml.doc</code> to side-step this issue.
+   </p>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-my_abbrev">
+     <a href="#kind-my_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> my_abbrev = value_or_null
+        <span class="keyword">mod</span> non_null global
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>Declares a kind abbreviation named <code>my_abbrev</code>.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
     <div class="spec type anchored" id="type-t_abbrev">
      <a href="#type-t_abbrev" class="anchor"></a>
      <code>
-      <span><span class="keyword">type</span> t_abbrev : my_abbrev 
+      <span><span class="keyword">type</span> t_abbrev : 
+       <a href="#kind-my_abbrev">my_abbrev</a> 
        <span class="keyword">mod</span> immutable
       </span>
      </code>
-    </div><div class="spec-doc"><p>A type with an abbreviated kind.</p></div>
+    </div>
+    <div class="spec-doc">
+     <p>A type with an abbreviated kind. The use of <code>my_abbrev</code>
+       should link to its definition. References to the kind abbreviation
+       resolve too, both unqualified 
+      <a href="#kind-my_abbrev"><code>my_abbrev</code></a> and qualified
+       <a href="#kind-my_abbrev"><code>my_abbrev</code></a>.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-my_derived">
+     <a href="#kind-my_derived" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> my_derived = 
+       <a href="#kind-my_abbrev">my_abbrev</a> 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A kind abbreviation defined in terms of another one; the use 
+      of <code>my_abbrev</code> in this definition should also link to
+       its definition.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_derived">
+     <a href="#type-t_derived" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_derived : 
+       <a href="#kind-my_derived">my_derived</a>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A type whose kind is the derived abbreviation.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-my_abstract">
+     <a href="#kind-my_abstract" class="anchor"></a>
+     <code><span><span class="keyword">kind_</span> my_abstract</span></code>
+    </div>
+    <div class="spec-doc"><p>An abstract kind abbreviation (no manifest).</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_abstract">
+     <a href="#type-t_abstract" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_abstract : 
+       <a href="#kind-my_abstract">my_abstract</a>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc"><p>A type with an abstract abbreviated kind.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-abbrev_param">
+     <a href="#type-abbrev_param" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> 
+       <span>('a : <a href="#kind-my_abbrev">my_abbrev</a>) abbrev_param
+       </span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A type parameter constrained by an abbreviated kind.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-poly_abbrev">
+     <a href="#val-poly_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">val</span> poly_abbrev : ('a : 
+       <a href="#kind-my_abbrev">my_abbrev</a>). 
+       <span><span class="type-var">'a</span> 
+        <span class="arrow">&#45;&gt;</span>
+       </span> <span class="type-var">'a</span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A polymorphic value with an abbreviated kind constraint.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_with_abbrev">
+     <a href="#type-t_with_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> <span>'a t_with_abbrev</span>
+        : <a href="#kind-my_abbrev">my_abbrev</a> 
+       <span class="keyword">with</span> <span class="type-var">'a</span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>An abbreviated kind in a <code>with</code> constraint.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-M_kinds">
+     <a href="#module-M_kinds" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-M_kinds.html">M_kinds</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_qualified">
+     <a href="#type-t_qualified" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_qualified : 
+       <a href="Oxcaml-M_kinds.html#kind-mod_kind">M_kinds.mod_kind</a>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A qualified use of a kind abbreviation from another module; the
+       use should link to <code>M_kinds.mod_kind</code>'s definition.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-qualified_param">
+     <a href="#type-qualified_param" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> 
+       <span>('a : 
+        <a href="Oxcaml-M_kinds.html#kind-mod_kind">M_kinds.mod_kind</a>
+        ) qualified_param
+       </span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A qualified kind abbreviation on a type parameter; the use should
+       link to the definition (resolved during linking, like 
+      <code>t_qualified</code>).
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module-type anchored" id="module-type-S_kind">
+     <a href="#module-type-S_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <span class="keyword">type</span> 
+       <a href="Oxcaml-module-type-S_kind.html">S_kind</a>
+      </span>
+      <span> = <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-F_kind">
+     <a href="#module-F_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-F_kind.html">F_kind</a>
+      </span>
+      <span> (<a href="Oxcaml-F_kind-argument-1-X.html">X</a> : 
+       <a href="Oxcaml-module-type-S_kind.html">S_kind</a>) : 
+       <a href="Oxcaml-module-type-S_kind.html">S_kind</a>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-Arg_kind">
+     <a href="#module-Arg_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-Arg_kind.html">Arg_kind</a>
+      </span>
+      <span> : <a href="Oxcaml-module-type-S_kind.html">S_kind</a></span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_functor_app">
+     <a href="#type-t_functor_app" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_functor_app : 
+       F_kind(Arg_kind).functor_kind
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A use behind a functor application. odoc references can't express
+       functor application, so this is rendered as plain text (not a 
+      link) rather than crashing.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-F_nested">
+     <a href="#module-F_nested" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-F_nested.html">F_nested</a>
+      </span>
+      <span> (<a href="Oxcaml-F_nested-argument-1-X.html">X</a> : 
+       <a href="Oxcaml-module-type-S_kind.html">S_kind</a>) : 
+       <span class="keyword">sig</span> ... <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored"
+     id="kind-functor_abbrev">
+     <a href="#kind-functor_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> functor_abbrev = 
+       F_nested(Arg_kind).abstract_kind
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A kind abbreviation defined through a functor-application path.
+       The manifest is rendered but the functor-application path isn't
+       a link.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored"
+     id="kind-nested_functor_abbrev">
+     <a href="#kind-nested_functor_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> nested_functor_abbrev =
+        F_nested(Arg_kind).Nested.custom_kind_abbrev
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A kind abbreviation defined through a 
+      functor-application-then-nested-module path. The manifest is rendered
+       but the functor-application path isn't a link.
+     </p>
+    </div>
    </div>
    <h2 id="zero-alloc"><a href="#zero-alloc" class="anchor"></a>Zero alloc
    </h2>

--- a/test/generators/html/Oxcaml.html
+++ b/test/generators/html/Oxcaml.html
@@ -1020,6 +1020,79 @@
      </p>
     </div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored"
+     id="kind-to_be_shadowed">
+     <a href="#kind-to_be_shadowed" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> to_be_shadowed = value
+        <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>Shadowed below by a kind abbreviation of the same name.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-X_shadowing">
+     <a href="#module-X_shadowing" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-X_shadowing.html">X_shadowing</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-M_inc">
+     <a href="#module-M_inc" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-M_inc.html">M_inc</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-include">
+    <details open="open">
+     <summary class="spec include">
+      <code>
+       <span><span class="keyword">include</span> 
+        <span class="keyword">module</span> <span class="keyword">type</span>
+         <span class="keyword">of</span> 
+        <a href="Oxcaml-M_inc.html">M_inc</a>
+       </span>
+      </code>
+     </summary>
+     <div class="odoc-spec">
+      <div class="spec type kind-abbreviation anchored" id="kind-inc_kind">
+       <a href="#kind-inc_kind" class="anchor"></a>
+       <code>
+        <span><span class="keyword">kind_</span> inc_kind = value 
+         <span class="keyword">mod</span> portable
+        </span>
+       </code>
+      </div>
+     </div>
+    </details>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_inc">
+     <a href="#type-t_inc" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_inc : 
+       <a href="#kind-inc_kind">inc_kind</a>
+      </span>
+     </code>
+    </div>
+   </div>
    <h2 id="zero-alloc"><a href="#zero-alloc" class="anchor"></a>Zero alloc
    </h2>
    <div class="odoc-spec">

--- a/test/generators/html/Oxcaml.html
+++ b/test/generators/html/Oxcaml.html
@@ -745,14 +745,296 @@
     <a href="#kind-abbreviations_2" class="anchor"></a>Kind abbreviations
    </h2>
    <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored"
+     id="kind-missing_documentation">
+     <a href="#kind-missing_documentation" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> missing_documentation =
+        value <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+   </div>
+   <p>TODO: The above kind abbreviation uses <code>(** *)</code> which
+     are not captured by the OxCaml parser, so its documentation is currently
+     missing. The following <code>kind_</code> declarations use an explicit
+     <code>@@ocaml.doc</code> to side-step this issue.
+   </p>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-my_abbrev">
+     <a href="#kind-my_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> my_abbrev = value_or_null
+        <span class="keyword">mod</span> non_null global
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>Declares a kind abbreviation named <code>my_abbrev</code>.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
     <div class="spec type anchored" id="type-t_abbrev">
      <a href="#type-t_abbrev" class="anchor"></a>
      <code>
-      <span><span class="keyword">type</span> t_abbrev : my_abbrev 
+      <span><span class="keyword">type</span> t_abbrev : 
+       <a href="#kind-my_abbrev">my_abbrev</a> 
        <span class="keyword">mod</span> immutable
       </span>
      </code>
-    </div><div class="spec-doc"><p>A type with an abbreviated kind.</p></div>
+    </div>
+    <div class="spec-doc">
+     <p>A type with an abbreviated kind. The use of <code>my_abbrev</code>
+       should link to its definition. References to the kind abbreviation
+       resolve too, both unqualified 
+      <a href="#kind-my_abbrev"><code>my_abbrev</code></a> and qualified
+       <a href="#kind-my_abbrev"><code>my_abbrev</code></a>.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-my_derived">
+     <a href="#kind-my_derived" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> my_derived = 
+       <a href="#kind-my_abbrev">my_abbrev</a> 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A kind abbreviation defined in terms of another one; the use 
+      of <code>my_abbrev</code> in this definition should also link to
+       its definition.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_derived">
+     <a href="#type-t_derived" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_derived : 
+       <a href="#kind-my_derived">my_derived</a>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A type whose kind is the derived abbreviation.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-my_abstract">
+     <a href="#kind-my_abstract" class="anchor"></a>
+     <code><span><span class="keyword">kind_</span> my_abstract</span></code>
+    </div>
+    <div class="spec-doc"><p>An abstract kind abbreviation (no manifest).</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_abstract">
+     <a href="#type-t_abstract" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_abstract : 
+       <a href="#kind-my_abstract">my_abstract</a>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc"><p>A type with an abstract abbreviated kind.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-abbrev_param">
+     <a href="#type-abbrev_param" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> 
+       <span>('a : <a href="#kind-my_abbrev">my_abbrev</a>) abbrev_param
+       </span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A type parameter constrained by an abbreviated kind.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec value anchored" id="val-poly_abbrev">
+     <a href="#val-poly_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">val</span> poly_abbrev : ('a : 
+       <a href="#kind-my_abbrev">my_abbrev</a>). 
+       <span><span class="type-var">'a</span> 
+        <span class="arrow">&#45;&gt;</span>
+       </span> <span class="type-var">'a</span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A polymorphic value with an abbreviated kind constraint.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_with_abbrev">
+     <a href="#type-t_with_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> <span>'a t_with_abbrev</span>
+        : <a href="#kind-my_abbrev">my_abbrev</a> 
+       <span class="keyword">with</span> <span class="type-var">'a</span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>An abbreviated kind in a <code>with</code> constraint.</p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-M_kinds">
+     <a href="#module-M_kinds" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-M_kinds.html">M_kinds</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_qualified">
+     <a href="#type-t_qualified" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_qualified : 
+       <a href="Oxcaml-M_kinds.html#kind-mod_kind">M_kinds.mod_kind</a>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A qualified use of a kind abbreviation from another module; the
+       use should link to <code>M_kinds.mod_kind</code>'s definition.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-qualified_param">
+     <a href="#type-qualified_param" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> 
+       <span>('a : 
+        <a href="Oxcaml-M_kinds.html#kind-mod_kind">M_kinds.mod_kind</a>
+        ) qualified_param
+       </span>
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A qualified kind abbreviation on a type parameter; the use should
+       link to the definition (resolved during linking, like 
+      <code>t_qualified</code>).
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module-type anchored" id="module-type-S_kind">
+     <a href="#module-type-S_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <span class="keyword">type</span> 
+       <a href="Oxcaml-module-type-S_kind.html">S_kind</a>
+      </span>
+      <span> = <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-F_kind">
+     <a href="#module-F_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-F_kind.html">F_kind</a>
+      </span>
+      <span> (<a href="Oxcaml-F_kind-argument-1-X.html">X</a> : 
+       <a href="Oxcaml-module-type-S_kind.html">S_kind</a>) : 
+       <a href="Oxcaml-module-type-S_kind.html">S_kind</a>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-Arg_kind">
+     <a href="#module-Arg_kind" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-Arg_kind.html">Arg_kind</a>
+      </span>
+      <span> : <a href="Oxcaml-module-type-S_kind.html">S_kind</a></span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_functor_app">
+     <a href="#type-t_functor_app" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_functor_app : 
+       F_kind(Arg_kind).functor_kind
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A use behind a functor application. odoc references can't express
+       functor application, so this is rendered as plain text (not a 
+      link) rather than crashing.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-F_nested">
+     <a href="#module-F_nested" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml-F_nested.html">F_nested</a>
+      </span>
+      <span> (<a href="Oxcaml-F_nested-argument-1-X.html">X</a> : 
+       <a href="Oxcaml-module-type-S_kind.html">S_kind</a>) : 
+       <span class="keyword">sig</span> ... <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored"
+     id="kind-functor_abbrev">
+     <a href="#kind-functor_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> functor_abbrev = 
+       F_nested(Arg_kind).abstract_kind
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A kind abbreviation defined through a functor-application path.
+       The manifest is rendered but the functor-application path isn't
+       a link.
+     </p>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored"
+     id="kind-nested_functor_abbrev">
+     <a href="#kind-nested_functor_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> nested_functor_abbrev =
+        F_nested(Arg_kind).Nested.custom_kind_abbrev
+      </span>
+     </code>
+    </div>
+    <div class="spec-doc">
+     <p>A kind abbreviation defined through a 
+      functor-application-then-nested-module path. The manifest is rendered
+       but the functor-application path isn't a link.
+     </p>
+    </div>
    </div>
    <h2 id="zero-alloc"><a href="#zero-alloc" class="anchor"></a>Zero alloc
    </h2>

--- a/test/generators/html/Oxcaml.html
+++ b/test/generators/html/Oxcaml.html
@@ -745,22 +745,6 @@
     <a href="#kind-abbreviations_2" class="anchor"></a>Kind abbreviations
    </h2>
    <div class="odoc-spec">
-    <div class="spec type kind-abbreviation anchored"
-     id="kind-missing_documentation">
-     <a href="#kind-missing_documentation" class="anchor"></a>
-     <code>
-      <span><span class="keyword">kind_</span> missing_documentation =
-        value <span class="keyword">mod</span> portable
-      </span>
-     </code>
-    </div>
-   </div>
-   <p>TODO: The above kind abbreviation uses <code>(** *)</code> which
-     are not captured by the OxCaml parser, so its documentation is currently
-     missing. The following <code>kind_</code> declarations use an explicit
-     <code>@@ocaml.doc</code> to side-step this issue.
-   </p>
-   <div class="odoc-spec">
     <div class="spec type kind-abbreviation anchored" id="kind-my_abbrev">
      <a href="#kind-my_abbrev" class="anchor"></a>
      <code>

--- a/test/generators/html/Oxcaml_impl-Shadowing_source.html
+++ b/test/generators/html/Oxcaml_impl-Shadowing_source.html
@@ -14,6 +14,18 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Oxcaml_impl.Shadowing_source</span></code></h1>
-  </header><div class="odoc-content"></div>
+  </header>
+  <div class="odoc-content">
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-dup">
+     <a href="#kind-dup" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> dup = value 
+       <span class="keyword">mod</span> portable
+      </span>
+     </code>
+    </div>
+   </div>
+  </div>
  </body>
 </html>

--- a/test/generators/html/Oxcaml_impl-Shadowing_source.html
+++ b/test/generators/html/Oxcaml_impl-Shadowing_source.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>Shadowing_source (Oxcaml_impl.Shadowing_source)</title>
+  <meta charset="utf-8"/><link rel="stylesheet" href="odoc.css"/>
+  <meta name="generator" content="odoc %%VERSION%%"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="highlight.pack.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+ </head>
+ <body class="odoc">
+  <nav class="odoc-nav"><a href="Oxcaml_impl.html">Up</a> – 
+   <a href="index.html">Index</a> &#x00BB; 
+   <a href="Oxcaml_impl.html">Oxcaml_impl</a> &#x00BB; Shadowing_source
+  </nav>
+  <header class="odoc-preamble">
+   <h1>Module <code><span>Oxcaml_impl.Shadowing_source</span></code></h1>
+  </header><div class="odoc-content"></div>
+ </body>
+</html>

--- a/test/generators/html/Oxcaml_impl.html
+++ b/test/generators/html/Oxcaml_impl.html
@@ -54,6 +54,44 @@
      </code>
     </div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_abbrev">
+     <a href="#type-t_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_abbrev : my_abbrev 
+       <span class="keyword">mod</span> immutable
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-Shadowing_source">
+     <a href="#module-Shadowing_source" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml_impl-Shadowing_source.html">Shadowing_source</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-include shadowed-include">
+    <details open="open">
+     <summary class="spec include">
+      <code>
+       <span><span class="keyword">include</span> 
+        <span class="keyword">module</span> <span class="keyword">type</span>
+         <span class="keyword">of</span> <span class="keyword">struct</span>
+         <span class="keyword">include</span> 
+        <a href="Oxcaml_impl-Shadowing_source.html">Shadowing_source</a>
+         <span class="keyword">end</span>
+       </span>
+      </code>
+     </summary>
+    </details>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/Oxcaml_impl.html
+++ b/test/generators/html/Oxcaml_impl.html
@@ -55,10 +55,21 @@
     </div>
    </div>
    <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-my_abbrev">
+     <a href="#kind-my_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> my_abbrev = value_or_null
+        <span class="keyword">mod</span> non_null global
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
     <div class="spec type anchored" id="type-t_abbrev">
      <a href="#type-t_abbrev" class="anchor"></a>
      <code>
-      <span><span class="keyword">type</span> t_abbrev : my_abbrev 
+      <span><span class="keyword">type</span> t_abbrev : 
+       <a href="#kind-my_abbrev">my_abbrev</a> 
        <span class="keyword">mod</span> immutable
       </span>
      </code>
@@ -91,6 +102,16 @@
       </code>
      </summary>
     </details>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-dup">
+     <a href="#kind-dup" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> dup = value_or_null 
+       <span class="keyword">mod</span> non_null
+      </span>
+     </code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Oxcaml_impl.html
+++ b/test/generators/html/Oxcaml_impl.html
@@ -319,10 +319,21 @@
     <div class="spec-doc"><p>Multiple modes on argument and return.</p></div>
    </div>
    <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-my_abbrev">
+     <a href="#kind-my_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> my_abbrev = value_or_null
+        <span class="keyword">mod</span> non_null global
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
     <div class="spec type anchored" id="type-t_abbrev">
      <a href="#type-t_abbrev" class="anchor"></a>
      <code>
-      <span><span class="keyword">type</span> t_abbrev : my_abbrev 
+      <span><span class="keyword">type</span> t_abbrev : 
+       <a href="#kind-my_abbrev">my_abbrev</a> 
        <span class="keyword">mod</span> immutable
       </span>
      </code>
@@ -355,6 +366,16 @@
       </code>
      </summary>
     </details>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec type kind-abbreviation anchored" id="kind-dup">
+     <a href="#kind-dup" class="anchor"></a>
+     <code>
+      <span><span class="keyword">kind_</span> dup = value_or_null 
+       <span class="keyword">mod</span> non_null
+      </span>
+     </code>
+    </div>
    </div>
   </div>
  </body>

--- a/test/generators/html/Oxcaml_impl.html
+++ b/test/generators/html/Oxcaml_impl.html
@@ -318,6 +318,44 @@
     </div>
     <div class="spec-doc"><p>Multiple modes on argument and return.</p></div>
    </div>
+   <div class="odoc-spec">
+    <div class="spec type anchored" id="type-t_abbrev">
+     <a href="#type-t_abbrev" class="anchor"></a>
+     <code>
+      <span><span class="keyword">type</span> t_abbrev : my_abbrev 
+       <span class="keyword">mod</span> immutable
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-spec">
+    <div class="spec module anchored" id="module-Shadowing_source">
+     <a href="#module-Shadowing_source" class="anchor"></a>
+     <code>
+      <span><span class="keyword">module</span> 
+       <a href="Oxcaml_impl-Shadowing_source.html">Shadowing_source</a>
+      </span>
+      <span> : <span class="keyword">sig</span> ... 
+       <span class="keyword">end</span>
+      </span>
+     </code>
+    </div>
+   </div>
+   <div class="odoc-include shadowed-include">
+    <details open="open">
+     <summary class="spec include">
+      <code>
+       <span><span class="keyword">include</span> 
+        <span class="keyword">module</span> <span class="keyword">type</span>
+         <span class="keyword">of</span> <span class="keyword">struct</span>
+         <span class="keyword">include</span> 
+        <a href="Oxcaml_impl-Shadowing_source.html">Shadowing_source</a>
+         <span class="keyword">end</span>
+       </span>
+      </code>
+     </summary>
+    </details>
+   </div>
   </div>
  </body>
 </html>

--- a/test/generators/html/oxcaml.targets
+++ b/test/generators/html/oxcaml.targets
@@ -1,4 +1,12 @@
 Oxcaml.html
+Oxcaml-M_kinds.html
+Oxcaml-module-type-S_kind.html
+Oxcaml-F_kind.html
+Oxcaml-F_kind-argument-1-X.html
+Oxcaml-Arg_kind.html
+Oxcaml-F_nested.html
+Oxcaml-F_nested-argument-1-X.html
+Oxcaml-F_nested-Nested.html
 Oxcaml-module-type-S.html
 Oxcaml-M1.html
 Oxcaml-M2.html

--- a/test/generators/html/oxcaml.targets
+++ b/test/generators/html/oxcaml.targets
@@ -12,6 +12,8 @@ Oxcaml-Arg_kind.html
 Oxcaml-F_nested.html
 Oxcaml-F_nested-argument-1-X.html
 Oxcaml-F_nested-Nested.html
+Oxcaml-X_shadowing.html
+Oxcaml-M_inc.html
 Oxcaml-module-type-S.html
 Oxcaml-M1.html
 Oxcaml-M2.html

--- a/test/generators/html/oxcaml.targets
+++ b/test/generators/html/oxcaml.targets
@@ -4,6 +4,14 @@ Oxcaml-module-type-Arg_with.html
 Oxcaml-F_with.html
 Oxcaml-F_with-argument-1-X.html
 Oxcaml-X_with.html
+Oxcaml-M_kinds.html
+Oxcaml-module-type-S_kind.html
+Oxcaml-F_kind.html
+Oxcaml-F_kind-argument-1-X.html
+Oxcaml-Arg_kind.html
+Oxcaml-F_nested.html
+Oxcaml-F_nested-argument-1-X.html
+Oxcaml-F_nested-Nested.html
 Oxcaml-module-type-S.html
 Oxcaml-M1.html
 Oxcaml-M2.html

--- a/test/generators/html/oxcaml_impl.targets
+++ b/test/generators/html/oxcaml_impl.targets
@@ -1,3 +1,4 @@
 Oxcaml_impl.html
 Oxcaml_impl-To_be_included.html
 Oxcaml_impl-Including.html
+Oxcaml_impl-Shadowing_source.html

--- a/test/generators/latex/Oxcaml.Arg_kind.tex
+++ b/test/generators/latex/Oxcaml.Arg_kind.tex
@@ -1,0 +1,5 @@
+\section{Module \ocamlinlinecode{Oxcaml.\allowbreak{}Arg\_\allowbreak{}kind}}\label{Oxcaml-Arg_kind}%
+\label{Oxcaml-module-type-S_kind--kind-functor_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} functor\_\allowbreak{}kind = value \ocamltag{keyword}{mod} portable}\begin{ocamlindent}A kind declared in a module type.\end{ocamlindent}%
+\medbreak
+
+

--- a/test/generators/latex/Oxcaml.F_kind.tex
+++ b/test/generators/latex/Oxcaml.F_kind.tex
@@ -1,0 +1,11 @@
+\section{Module \ocamlinlinecode{Oxcaml.\allowbreak{}F\_\allowbreak{}kind}}\label{Oxcaml-F_kind}%
+\subsection{Parameters\label{Oxcaml-F_kind--parameters}}%
+\label{Oxcaml-F_kind--argument-1-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-F_kind-argument-1-X]{\ocamlinlinecode{X}}}\label{Oxcaml-F_kind-argument-1-X}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml-module-type-S_kind--kind-functor_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} functor\_\allowbreak{}kind = value \ocamltag{keyword}{mod} portable}\begin{ocamlindent}A kind declared in a module type.\end{ocamlindent}%
+\medbreak
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\subsection{Signature\label{Oxcaml-F_kind--signature}}%
+\label{Oxcaml-module-type-S_kind--kind-functor_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} functor\_\allowbreak{}kind = value \ocamltag{keyword}{mod} portable}\begin{ocamlindent}A kind declared in a module type.\end{ocamlindent}%
+\medbreak
+
+

--- a/test/generators/latex/Oxcaml.F_nested.tex
+++ b/test/generators/latex/Oxcaml.F_nested.tex
@@ -1,0 +1,15 @@
+\section{Module \ocamlinlinecode{Oxcaml.\allowbreak{}F\_\allowbreak{}nested}}\label{Oxcaml-F_nested}%
+\subsection{Parameters\label{Oxcaml-F_nested--parameters}}%
+\label{Oxcaml-F_nested--argument-1-X}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-F_nested-argument-1-X]{\ocamlinlinecode{X}}}\label{Oxcaml-F_nested-argument-1-X}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml-module-type-S_kind--kind-functor_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} functor\_\allowbreak{}kind = value \ocamltag{keyword}{mod} portable}\begin{ocamlindent}A kind declared in a module type.\end{ocamlindent}%
+\medbreak
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\subsection{Signature\label{Oxcaml-F_nested--signature}}%
+\label{Oxcaml-F_nested--kind-abstract_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} abstract\_\allowbreak{}kind}\begin{ocamlindent}An abstract kind.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml-F_nested--module-Nested}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-F_nested-Nested]{\ocamlinlinecode{Nested}}}\label{Oxcaml-F_nested-Nested}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml-F_nested-Nested--kind-custom_kind_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} custom\_\allowbreak{}kind\_\allowbreak{}abbrev = \hyperref[Oxcaml-module-type-S_kind--kind-functor_kind]{\ocamlinlinecode{X.\allowbreak{}functor\_\allowbreak{}kind}} \ocamltag{keyword}{mod} contended}\begin{ocamlindent}A nested kind extending the functor argument's kind.\end{ocamlindent}%
+\medbreak
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+
+

--- a/test/generators/latex/Oxcaml.tex
+++ b/test/generators/latex/Oxcaml.tex
@@ -84,7 +84,46 @@ Unboxed types have a trailing hash '\#'
 \label{Oxcaml--type-t_inner_mod}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}inner\_\allowbreak{}mod : float64 \& (immediate \ocamltag{keyword}{mod} portable)}\begin{ocamlindent}Should render as \ocamlinlinecode{float64 \& (immediate mod portable)}.\end{ocamlindent}%
 \medbreak
 \subsection{Kind abbreviations\label{Oxcaml--kind-abbreviations_2}}%
-\label{Oxcaml--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : my\_\allowbreak{}abbrev \ocamltag{keyword}{mod} immutable}\begin{ocamlindent}A type with an abbreviated kind.\end{ocamlindent}%
+\label{Oxcaml--kind-missing_documentation}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} missing\_\allowbreak{}documentation = value \ocamltag{keyword}{mod} portable}\\
+TODO: The above kind abbreviation uses \ocamlinlinecode{(** *)} which are not captured by the OxCaml parser, so its documentation is currently missing. The following \ocamlinlinecode{kind\_\allowbreak{}} declarations use an explicit \ocamlinlinecode{@@ocaml.\allowbreak{}doc} to side-step this issue.
+
+\label{Oxcaml--kind-my_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} my\_\allowbreak{}abbrev = value\_\allowbreak{}or\_\allowbreak{}null \ocamltag{keyword}{mod} non\_\allowbreak{}null global}\begin{ocamlindent}Declares a kind abbreviation named \ocamlinlinecode{my\_\allowbreak{}abbrev}.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}} \ocamltag{keyword}{mod} immutable}\begin{ocamlindent}A type with an abbreviated kind. The use of \ocamlinlinecode{my\_\allowbreak{}abbrev} should link to its definition. References to the kind abbreviation resolve too, both unqualified \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{\ocamlinlinecode{my\_\allowbreak{}abbrev}}[p\pageref*{Oxcaml--kind-my_abbrev}]} and qualified \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{\ocamlinlinecode{my\_\allowbreak{}abbrev}}[p\pageref*{Oxcaml--kind-my_abbrev}]}.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--kind-my_derived}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} my\_\allowbreak{}derived = \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}} \ocamltag{keyword}{mod} portable}\begin{ocamlindent}A kind abbreviation defined in terms of another one; the use of \ocamlinlinecode{my\_\allowbreak{}abbrev} in this definition should also link to its definition.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-t_derived}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}derived : \hyperref[Oxcaml--kind-my_derived]{\ocamlinlinecode{my\_\allowbreak{}derived}}}\begin{ocamlindent}A type whose kind is the derived abbreviation.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--kind-my_abstract}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} my\_\allowbreak{}abstract}\begin{ocamlindent}An abstract kind abbreviation (no manifest).\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-t_abstract}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abstract : \hyperref[Oxcaml--kind-my_abstract]{\ocamlinlinecode{my\_\allowbreak{}abstract}}}\begin{ocamlindent}A type with an abstract abbreviated kind.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-abbrev_param}\ocamlcodefragment{\ocamltag{keyword}{type} ('a : \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}}) abbrev\_\allowbreak{}param}\begin{ocamlindent}A type parameter constrained by an abbreviated kind.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--val-poly_abbrev}\ocamlcodefragment{\ocamltag{keyword}{val} poly\_\allowbreak{}abbrev : ('a : \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}}).\allowbreak{} \ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a}}\begin{ocamlindent}A polymorphic value with an abbreviated kind constraint.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-t_with_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} 'a t\_\allowbreak{}with\_\allowbreak{}abbrev : \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}} \ocamltag{keyword}{with} \ocamltag{type-var}{'a}}\begin{ocamlindent}An abbreviated kind in a \ocamlinlinecode{with} constraint.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--module-M_kinds}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-M_kinds]{\ocamlinlinecode{M\_\allowbreak{}kinds}}}\label{Oxcaml-M_kinds}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml-M_kinds--kind-mod_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} mod\_\allowbreak{}kind = value \ocamltag{keyword}{mod} portable}\\
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\label{Oxcaml--type-t_qualified}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}qualified : \hyperref[Oxcaml-M_kinds--kind-mod_kind]{\ocamlinlinecode{M\_\allowbreak{}kinds.\allowbreak{}mod\_\allowbreak{}kind}}}\begin{ocamlindent}A qualified use of a kind abbreviation from another module; the use should link to \ocamlinlinecode{M\_\allowbreak{}kinds.\allowbreak{}mod\_\allowbreak{}kind}'s definition.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-qualified_param}\ocamlcodefragment{\ocamltag{keyword}{type} ('a : \hyperref[Oxcaml-M_kinds--kind-mod_kind]{\ocamlinlinecode{M\_\allowbreak{}kinds.\allowbreak{}mod\_\allowbreak{}kind}}) qualified\_\allowbreak{}param}\begin{ocamlindent}A qualified kind abbreviation on a type parameter; the use should link to the definition (resolved during linking, like \ocamlinlinecode{t\_\allowbreak{}qualified}).\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--module-type-S_kind}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Oxcaml-module-type-S_kind]{\ocamlinlinecode{S\_\allowbreak{}kind}}}\label{Oxcaml-module-type-S_kind}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml-module-type-S_kind--kind-functor_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} functor\_\allowbreak{}kind = value \ocamltag{keyword}{mod} portable}\begin{ocamlindent}A kind declared in a module type.\end{ocamlindent}%
+\medbreak
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\label{Oxcaml--module-F_kind}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-F_kind]{\ocamlinlinecode{F\_\allowbreak{}kind}}}\ocamlcodefragment{ (\hyperref[Oxcaml-F_kind-argument-1-X]{\ocamlinlinecode{X}} : \hyperref[Oxcaml-module-type-S_kind]{\ocamlinlinecode{S\_\allowbreak{}kind}}) : \hyperref[Oxcaml-module-type-S_kind]{\ocamlinlinecode{S\_\allowbreak{}kind}}}\\
+\label{Oxcaml--module-Arg_kind}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-Arg_kind]{\ocamlinlinecode{Arg\_\allowbreak{}kind}}}\ocamlcodefragment{ : \hyperref[Oxcaml-module-type-S_kind]{\ocamlinlinecode{S\_\allowbreak{}kind}}}\\
+\label{Oxcaml--type-t_functor_app}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}functor\_\allowbreak{}app : F\_\allowbreak{}kind(Arg\_\allowbreak{}kind).\allowbreak{}functor\_\allowbreak{}kind}\begin{ocamlindent}A use behind a functor application. odoc references can't express functor application, so this is rendered as plain text (not a link) rather than crashing.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--module-F_nested}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-F_nested]{\ocamlinlinecode{F\_\allowbreak{}nested}}}\ocamlcodefragment{ (\hyperref[Oxcaml-F_nested-argument-1-X]{\ocamlinlinecode{X}} : \hyperref[Oxcaml-module-type-S_kind]{\ocamlinlinecode{S\_\allowbreak{}kind}}) : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\\
+\label{Oxcaml--kind-functor_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} functor\_\allowbreak{}abbrev = F\_\allowbreak{}nested(Arg\_\allowbreak{}kind).\allowbreak{}abstract\_\allowbreak{}kind}\begin{ocamlindent}A kind abbreviation defined through a functor-application path. The manifest is rendered but the functor-application path isn't a link.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--kind-nested_functor_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} nested\_\allowbreak{}functor\_\allowbreak{}abbrev = F\_\allowbreak{}nested(Arg\_\allowbreak{}kind).\allowbreak{}Nested.\allowbreak{}custom\_\allowbreak{}kind\_\allowbreak{}abbrev}\begin{ocamlindent}A kind abbreviation defined through a functor-application-then-nested-module path. The manifest is rendered but the functor-application path isn't a link.\end{ocamlindent}%
 \medbreak
 \subsection{Zero alloc\label{Oxcaml--zero-alloc}}%
 \label{Oxcaml--val-add}\ocamlcodefragment{\ocamltag{keyword}{val} add : bool \ocamltag{arrow}{$\rightarrow$} int \ocamltag{arrow}{$\rightarrow$} int \ocamltag{arrow}{$\rightarrow$} int [@@zero\_\allowbreak{}alloc]}\begin{ocamlindent}Zero allocation bindings have an extension attribute attached. See https://oxcaml.org/documentation/miscellaneous-extensions/zero\_alloc\_check/\end{ocamlindent}%
@@ -241,4 +280,7 @@ Unboxed types have a trailing hash '\#'
 \ocamlcodefragment{\ocamltag{keyword}{end}}\begin{ocamlindent}\ocamlinlinecode{contended} modality applied to all definitions in the module, except the ones which have already specified this axis.\end{ocamlindent}%
 \medbreak
 
+\input{Oxcaml.F_kind.tex}
+\input{Oxcaml.Arg_kind.tex}
+\input{Oxcaml.F_nested.tex}
 \input{Oxcaml.M1.tex}

--- a/test/generators/latex/Oxcaml.tex
+++ b/test/generators/latex/Oxcaml.tex
@@ -153,6 +153,19 @@ Unboxed types have a trailing hash '\#'
 \medbreak
 \label{Oxcaml--kind-nested_functor_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} nested\_\allowbreak{}functor\_\allowbreak{}abbrev = F\_\allowbreak{}nested(Arg\_\allowbreak{}kind).\allowbreak{}Nested.\allowbreak{}custom\_\allowbreak{}kind\_\allowbreak{}abbrev}\begin{ocamlindent}A kind abbreviation defined through a functor-application-then-nested-module path. The manifest is rendered but the functor-application path isn't a link.\end{ocamlindent}%
 \medbreak
+\label{Oxcaml--kind-to_be_shadowed}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} to\_\allowbreak{}be\_\allowbreak{}shadowed = value \ocamltag{keyword}{mod} portable}\begin{ocamlindent}Shadowed below by a kind abbreviation of the same name.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--module-X_shadowing}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-X_shadowing]{\ocamlinlinecode{X\_\allowbreak{}shadowing}}}\label{Oxcaml-X_shadowing}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml-X_shadowing--type-t}\ocamlcodefragment{\ocamltag{keyword}{type} t : \hyperref[Oxcaml--kind-to_be_shadowed]{\ocamlinlinecode{to\_\allowbreak{}be\_\allowbreak{}shadowed}}}\begin{ocamlindent}Uses the outer \ocamlinlinecode{to\_\allowbreak{}be\_\allowbreak{}shadowed}, declared before the one below, so the link should point outside this module.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml-X_shadowing--kind-to_be_shadowed}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} to\_\allowbreak{}be\_\allowbreak{}shadowed = value\_\allowbreak{}or\_\allowbreak{}null \ocamltag{keyword}{mod} non\_\allowbreak{}null global}\begin{ocamlindent}Shadows the outer \ocamlinlinecode{to\_\allowbreak{}be\_\allowbreak{}shadowed}.\end{ocamlindent}%
+\medbreak
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\label{Oxcaml--module-M_inc}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-M_inc]{\ocamlinlinecode{M\_\allowbreak{}inc}}}\label{Oxcaml-M_inc}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml-M_inc--kind-inc_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} inc\_\allowbreak{}kind = value \ocamltag{keyword}{mod} portable}\\
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \hyperref[Oxcaml-M_inc]{\ocamlinlinecode{M\_\allowbreak{}inc}}\label{Oxcaml-M_inc--kind-inc_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} inc\_\allowbreak{}kind = value \ocamltag{keyword}{mod} portable}\\
+\label{Oxcaml--type-t_inc}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}inc : \hyperref[Oxcaml--kind-inc_kind]{\ocamlinlinecode{inc\_\allowbreak{}kind}}}\\
 \subsection{Zero alloc\label{Oxcaml--zero-alloc}}%
 \label{Oxcaml--val-add}\ocamlcodefragment{\ocamltag{keyword}{val} add : bool \ocamltag{arrow}{$\rightarrow$} int \ocamltag{arrow}{$\rightarrow$} int \ocamltag{arrow}{$\rightarrow$} int [@@zero\_\allowbreak{}alloc]}\begin{ocamlindent}Zero allocation bindings have an extension attribute attached. See https://oxcaml.org/documentation/miscellaneous-extensions/zero\_alloc\_check/\end{ocamlindent}%
 \medbreak

--- a/test/generators/latex/Oxcaml.tex
+++ b/test/generators/latex/Oxcaml.tex
@@ -115,9 +115,6 @@ Unboxed types have a trailing hash '\#'
 \label{Oxcaml--type-t_inner_mod}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}inner\_\allowbreak{}mod : float64 \& (immediate \ocamltag{keyword}{mod} portable)}\begin{ocamlindent}Should render as \ocamlinlinecode{float64 \& (immediate mod portable)}.\end{ocamlindent}%
 \medbreak
 \subsection{Kind abbreviations\label{Oxcaml--kind-abbreviations_2}}%
-\label{Oxcaml--kind-missing_documentation}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} missing\_\allowbreak{}documentation = value \ocamltag{keyword}{mod} portable}\\
-TODO: The above kind abbreviation uses \ocamlinlinecode{(** *)} which are not captured by the OxCaml parser, so its documentation is currently missing. The following \ocamlinlinecode{kind\_\allowbreak{}} declarations use an explicit \ocamlinlinecode{@@ocaml.\allowbreak{}doc} to side-step this issue.
-
 \label{Oxcaml--kind-my_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} my\_\allowbreak{}abbrev = value\_\allowbreak{}or\_\allowbreak{}null \ocamltag{keyword}{mod} non\_\allowbreak{}null global}\begin{ocamlindent}Declares a kind abbreviation named \ocamlinlinecode{my\_\allowbreak{}abbrev}.\end{ocamlindent}%
 \medbreak
 \label{Oxcaml--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}} \ocamltag{keyword}{mod} immutable}\begin{ocamlindent}A type with an abbreviated kind. The use of \ocamlinlinecode{my\_\allowbreak{}abbrev} should link to its definition. References to the kind abbreviation resolve too, both unqualified \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{\ocamlinlinecode{my\_\allowbreak{}abbrev}}[p\pageref*{Oxcaml--kind-my_abbrev}]} and qualified \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{\ocamlinlinecode{my\_\allowbreak{}abbrev}}[p\pageref*{Oxcaml--kind-my_abbrev}]}.\end{ocamlindent}%

--- a/test/generators/latex/Oxcaml.tex
+++ b/test/generators/latex/Oxcaml.tex
@@ -115,7 +115,46 @@ Unboxed types have a trailing hash '\#'
 \label{Oxcaml--type-t_inner_mod}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}inner\_\allowbreak{}mod : float64 \& (immediate \ocamltag{keyword}{mod} portable)}\begin{ocamlindent}Should render as \ocamlinlinecode{float64 \& (immediate mod portable)}.\end{ocamlindent}%
 \medbreak
 \subsection{Kind abbreviations\label{Oxcaml--kind-abbreviations_2}}%
-\label{Oxcaml--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : my\_\allowbreak{}abbrev \ocamltag{keyword}{mod} immutable}\begin{ocamlindent}A type with an abbreviated kind.\end{ocamlindent}%
+\label{Oxcaml--kind-missing_documentation}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} missing\_\allowbreak{}documentation = value \ocamltag{keyword}{mod} portable}\\
+TODO: The above kind abbreviation uses \ocamlinlinecode{(** *)} which are not captured by the OxCaml parser, so its documentation is currently missing. The following \ocamlinlinecode{kind\_\allowbreak{}} declarations use an explicit \ocamlinlinecode{@@ocaml.\allowbreak{}doc} to side-step this issue.
+
+\label{Oxcaml--kind-my_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} my\_\allowbreak{}abbrev = value\_\allowbreak{}or\_\allowbreak{}null \ocamltag{keyword}{mod} non\_\allowbreak{}null global}\begin{ocamlindent}Declares a kind abbreviation named \ocamlinlinecode{my\_\allowbreak{}abbrev}.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}} \ocamltag{keyword}{mod} immutable}\begin{ocamlindent}A type with an abbreviated kind. The use of \ocamlinlinecode{my\_\allowbreak{}abbrev} should link to its definition. References to the kind abbreviation resolve too, both unqualified \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{\ocamlinlinecode{my\_\allowbreak{}abbrev}}[p\pageref*{Oxcaml--kind-my_abbrev}]} and qualified \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{\ocamlinlinecode{my\_\allowbreak{}abbrev}}[p\pageref*{Oxcaml--kind-my_abbrev}]}.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--kind-my_derived}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} my\_\allowbreak{}derived = \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}} \ocamltag{keyword}{mod} portable}\begin{ocamlindent}A kind abbreviation defined in terms of another one; the use of \ocamlinlinecode{my\_\allowbreak{}abbrev} in this definition should also link to its definition.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-t_derived}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}derived : \hyperref[Oxcaml--kind-my_derived]{\ocamlinlinecode{my\_\allowbreak{}derived}}}\begin{ocamlindent}A type whose kind is the derived abbreviation.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--kind-my_abstract}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} my\_\allowbreak{}abstract}\begin{ocamlindent}An abstract kind abbreviation (no manifest).\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-t_abstract}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abstract : \hyperref[Oxcaml--kind-my_abstract]{\ocamlinlinecode{my\_\allowbreak{}abstract}}}\begin{ocamlindent}A type with an abstract abbreviated kind.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-abbrev_param}\ocamlcodefragment{\ocamltag{keyword}{type} ('a : \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}}) abbrev\_\allowbreak{}param}\begin{ocamlindent}A type parameter constrained by an abbreviated kind.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--val-poly_abbrev}\ocamlcodefragment{\ocamltag{keyword}{val} poly\_\allowbreak{}abbrev : ('a : \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}}).\allowbreak{} \ocamltag{type-var}{'a} \ocamltag{arrow}{$\rightarrow$} \ocamltag{type-var}{'a}}\begin{ocamlindent}A polymorphic value with an abbreviated kind constraint.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-t_with_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} 'a t\_\allowbreak{}with\_\allowbreak{}abbrev : \hyperref[Oxcaml--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}} \ocamltag{keyword}{with} \ocamltag{type-var}{'a}}\begin{ocamlindent}An abbreviated kind in a \ocamlinlinecode{with} constraint.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--module-M_kinds}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-M_kinds]{\ocamlinlinecode{M\_\allowbreak{}kinds}}}\label{Oxcaml-M_kinds}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml-M_kinds--kind-mod_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} mod\_\allowbreak{}kind = value \ocamltag{keyword}{mod} portable}\\
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\label{Oxcaml--type-t_qualified}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}qualified : \hyperref[Oxcaml-M_kinds--kind-mod_kind]{\ocamlinlinecode{M\_\allowbreak{}kinds.\allowbreak{}mod\_\allowbreak{}kind}}}\begin{ocamlindent}A qualified use of a kind abbreviation from another module; the use should link to \ocamlinlinecode{M\_\allowbreak{}kinds.\allowbreak{}mod\_\allowbreak{}kind}'s definition.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--type-qualified_param}\ocamlcodefragment{\ocamltag{keyword}{type} ('a : \hyperref[Oxcaml-M_kinds--kind-mod_kind]{\ocamlinlinecode{M\_\allowbreak{}kinds.\allowbreak{}mod\_\allowbreak{}kind}}) qualified\_\allowbreak{}param}\begin{ocamlindent}A qualified kind abbreviation on a type parameter; the use should link to the definition (resolved during linking, like \ocamlinlinecode{t\_\allowbreak{}qualified}).\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--module-type-S_kind}\ocamlcodefragment{\ocamltag{keyword}{module} \ocamltag{keyword}{type} \hyperref[Oxcaml-module-type-S_kind]{\ocamlinlinecode{S\_\allowbreak{}kind}}}\label{Oxcaml-module-type-S_kind}\ocamlcodefragment{ = \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml-module-type-S_kind--kind-functor_kind}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} functor\_\allowbreak{}kind = value \ocamltag{keyword}{mod} portable}\begin{ocamlindent}A kind declared in a module type.\end{ocamlindent}%
+\medbreak
+\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\label{Oxcaml--module-F_kind}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-F_kind]{\ocamlinlinecode{F\_\allowbreak{}kind}}}\ocamlcodefragment{ (\hyperref[Oxcaml-F_kind-argument-1-X]{\ocamlinlinecode{X}} : \hyperref[Oxcaml-module-type-S_kind]{\ocamlinlinecode{S\_\allowbreak{}kind}}) : \hyperref[Oxcaml-module-type-S_kind]{\ocamlinlinecode{S\_\allowbreak{}kind}}}\\
+\label{Oxcaml--module-Arg_kind}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-Arg_kind]{\ocamlinlinecode{Arg\_\allowbreak{}kind}}}\ocamlcodefragment{ : \hyperref[Oxcaml-module-type-S_kind]{\ocamlinlinecode{S\_\allowbreak{}kind}}}\\
+\label{Oxcaml--type-t_functor_app}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}functor\_\allowbreak{}app : F\_\allowbreak{}kind(Arg\_\allowbreak{}kind).\allowbreak{}functor\_\allowbreak{}kind}\begin{ocamlindent}A use behind a functor application. odoc references can't express functor application, so this is rendered as plain text (not a link) rather than crashing.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--module-F_nested}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml-F_nested]{\ocamlinlinecode{F\_\allowbreak{}nested}}}\ocamlcodefragment{ (\hyperref[Oxcaml-F_nested-argument-1-X]{\ocamlinlinecode{X}} : \hyperref[Oxcaml-module-type-S_kind]{\ocamlinlinecode{S\_\allowbreak{}kind}}) : \ocamltag{keyword}{sig} .\allowbreak{}.\allowbreak{}.\allowbreak{} \ocamltag{keyword}{end}}\\
+\label{Oxcaml--kind-functor_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} functor\_\allowbreak{}abbrev = F\_\allowbreak{}nested(Arg\_\allowbreak{}kind).\allowbreak{}abstract\_\allowbreak{}kind}\begin{ocamlindent}A kind abbreviation defined through a functor-application path. The manifest is rendered but the functor-application path isn't a link.\end{ocamlindent}%
+\medbreak
+\label{Oxcaml--kind-nested_functor_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} nested\_\allowbreak{}functor\_\allowbreak{}abbrev = F\_\allowbreak{}nested(Arg\_\allowbreak{}kind).\allowbreak{}Nested.\allowbreak{}custom\_\allowbreak{}kind\_\allowbreak{}abbrev}\begin{ocamlindent}A kind abbreviation defined through a functor-application-then-nested-module path. The manifest is rendered but the functor-application path isn't a link.\end{ocamlindent}%
 \medbreak
 \subsection{Zero alloc\label{Oxcaml--zero-alloc}}%
 \label{Oxcaml--val-add}\ocamlcodefragment{\ocamltag{keyword}{val} add : bool \ocamltag{arrow}{$\rightarrow$} int \ocamltag{arrow}{$\rightarrow$} int \ocamltag{arrow}{$\rightarrow$} int [@@zero\_\allowbreak{}alloc]}\begin{ocamlindent}Zero allocation bindings have an extension attribute attached. See https://oxcaml.org/documentation/miscellaneous-extensions/zero\_alloc\_check/\end{ocamlindent}%
@@ -397,4 +436,7 @@ Some axes have a default value that is implied by another axis; the implied valu
 
 \input{Oxcaml.F_with.tex}
 \input{Oxcaml.X_with.tex}
+\input{Oxcaml.F_kind.tex}
+\input{Oxcaml.Arg_kind.tex}
+\input{Oxcaml.F_nested.tex}
 \input{Oxcaml.M1.tex}

--- a/test/generators/latex/Oxcaml_impl.tex
+++ b/test/generators/latex/Oxcaml_impl.tex
@@ -6,5 +6,8 @@
 \label{Oxcaml_impl--module-Including}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml_impl-Including]{\ocamlinlinecode{Including}}}\label{Oxcaml_impl-Including}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[Oxcaml_impl-To_be_included]{\ocamlinlinecode{To\_\allowbreak{}be\_\allowbreak{}included}} \ocamltag{keyword}{end}\label{Oxcaml_impl-Including--val-add}\ocamlcodefragment{\ocamltag{keyword}{val} add : bool \ocamltag{arrow}{$\rightarrow$} int \ocamltag{arrow}{$\rightarrow$} int \ocamltag{arrow}{$\rightarrow$} int [@@zero\_\allowbreak{}alloc]}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-
+\label{Oxcaml_impl--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : my\_\allowbreak{}abbrev \ocamltag{keyword}{mod} immutable}\\
+\label{Oxcaml_impl--module-Shadowing_source}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}}}\label{Oxcaml_impl-Shadowing_source}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}} \ocamltag{keyword}{end}
 

--- a/test/generators/latex/Oxcaml_impl.tex
+++ b/test/generators/latex/Oxcaml_impl.tex
@@ -6,8 +6,11 @@
 \label{Oxcaml_impl--module-Including}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml_impl-Including]{\ocamlinlinecode{Including}}}\label{Oxcaml_impl-Including}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[Oxcaml_impl-To_be_included]{\ocamlinlinecode{To\_\allowbreak{}be\_\allowbreak{}included}} \ocamltag{keyword}{end}\label{Oxcaml_impl-Including--val-add}\ocamlcodefragment{\ocamltag{keyword}{val} add : bool \ocamltag{arrow}{$\rightarrow$} int \ocamltag{arrow}{$\rightarrow$} int \ocamltag{arrow}{$\rightarrow$} int [@@zero\_\allowbreak{}alloc]}\\
 \end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\label{Oxcaml_impl--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : my\_\allowbreak{}abbrev \ocamltag{keyword}{mod} immutable}\\
-\label{Oxcaml_impl--module-Shadowing_source}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}}}\label{Oxcaml_impl-Shadowing_source}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
+\label{Oxcaml_impl--kind-my_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} my\_\allowbreak{}abbrev = value\_\allowbreak{}or\_\allowbreak{}null \ocamltag{keyword}{mod} non\_\allowbreak{}null global}\\
+\label{Oxcaml_impl--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : \hyperref[Oxcaml_impl--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}} \ocamltag{keyword}{mod} immutable}\\
+\label{Oxcaml_impl--module-Shadowing_source}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}}}\label{Oxcaml_impl-Shadowing_source}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml_impl-Shadowing_source--kind-dup}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} dup = value \ocamltag{keyword}{mod} portable}\\
+\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}} \ocamltag{keyword}{end}
+\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}} \ocamltag{keyword}{end}\label{Oxcaml_impl--kind-dup}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} dup = value\_\allowbreak{}or\_\allowbreak{}null \ocamltag{keyword}{mod} non\_\allowbreak{}null}\\
+
 

--- a/test/generators/latex/Oxcaml_impl.tex
+++ b/test/generators/latex/Oxcaml_impl.tex
@@ -44,8 +44,11 @@
 \medbreak
 \label{Oxcaml_impl--val-mode_multi}\ocamlcodefragment{\ocamltag{keyword}{val} mode\_\allowbreak{}multi : string @ local once \ocamltag{arrow}{$\rightarrow$} string @ local once}\begin{ocamlindent}Multiple modes on argument and return.\end{ocamlindent}%
 \medbreak
-\label{Oxcaml_impl--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : my\_\allowbreak{}abbrev \ocamltag{keyword}{mod} immutable}\\
-\label{Oxcaml_impl--module-Shadowing_source}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}}}\label{Oxcaml_impl-Shadowing_source}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
+\label{Oxcaml_impl--kind-my_abbrev}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} my\_\allowbreak{}abbrev = value\_\allowbreak{}or\_\allowbreak{}null \ocamltag{keyword}{mod} non\_\allowbreak{}null global}\\
+\label{Oxcaml_impl--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : \hyperref[Oxcaml_impl--kind-my_abbrev]{\ocamlinlinecode{my\_\allowbreak{}abbrev}} \ocamltag{keyword}{mod} immutable}\\
+\label{Oxcaml_impl--module-Shadowing_source}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}}}\label{Oxcaml_impl-Shadowing_source}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\label{Oxcaml_impl-Shadowing_source--kind-dup}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} dup = value \ocamltag{keyword}{mod} portable}\\
+\end{ocamlindent}%
 \ocamlcodefragment{\ocamltag{keyword}{end}}\\
-\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}} \ocamltag{keyword}{end}
+\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}} \ocamltag{keyword}{end}\label{Oxcaml_impl--kind-dup}\ocamlcodefragment{\ocamltag{keyword}{kind\_\allowbreak{}} dup = value\_\allowbreak{}or\_\allowbreak{}null \ocamltag{keyword}{mod} non\_\allowbreak{}null}\\
+
 

--- a/test/generators/latex/Oxcaml_impl.tex
+++ b/test/generators/latex/Oxcaml_impl.tex
@@ -44,5 +44,8 @@
 \medbreak
 \label{Oxcaml_impl--val-mode_multi}\ocamlcodefragment{\ocamltag{keyword}{val} mode\_\allowbreak{}multi : string @ local once \ocamltag{arrow}{$\rightarrow$} string @ local once}\begin{ocamlindent}Multiple modes on argument and return.\end{ocamlindent}%
 \medbreak
-
+\label{Oxcaml_impl--type-t_abbrev}\ocamlcodefragment{\ocamltag{keyword}{type} t\_\allowbreak{}abbrev : my\_\allowbreak{}abbrev \ocamltag{keyword}{mod} immutable}\\
+\label{Oxcaml_impl--module-Shadowing_source}\ocamlcodefragment{\ocamltag{keyword}{module} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}}}\label{Oxcaml_impl-Shadowing_source}\ocamlcodefragment{ : \ocamltag{keyword}{sig}}\begin{ocamlindent}\end{ocamlindent}%
+\ocamlcodefragment{\ocamltag{keyword}{end}}\\
+\ocamltag{keyword}{include} \ocamltag{keyword}{module} \ocamltag{keyword}{type} \ocamltag{keyword}{of} \ocamltag{keyword}{struct} \ocamltag{keyword}{include} \hyperref[Oxcaml_impl-Shadowing_source]{\ocamlinlinecode{Shadowing\_\allowbreak{}source}} \ocamltag{keyword}{end}
 

--- a/test/generators/latex/oxcaml.targets
+++ b/test/generators/latex/oxcaml.targets
@@ -1,2 +1,5 @@
 Oxcaml.tex
+Oxcaml.F_kind.tex
+Oxcaml.Arg_kind.tex
+Oxcaml.F_nested.tex
 Oxcaml.M1.tex

--- a/test/generators/latex/oxcaml.targets
+++ b/test/generators/latex/oxcaml.targets
@@ -1,4 +1,7 @@
 Oxcaml.tex
 Oxcaml.F_with.tex
 Oxcaml.X_with.tex
+Oxcaml.F_kind.tex
+Oxcaml.Arg_kind.tex
+Oxcaml.F_nested.tex
 Oxcaml.M1.tex

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -11948,6 +11948,14 @@
  (rule
   (targets
    Oxcaml.html.gen
+   Oxcaml-M_kinds.html.gen
+   Oxcaml-module-type-S_kind.html.gen
+   Oxcaml-F_kind.html.gen
+   Oxcaml-F_kind-argument-1-X.html.gen
+   Oxcaml-Arg_kind.html.gen
+   Oxcaml-F_nested.html.gen
+   Oxcaml-F_nested-argument-1-X.html.gen
+   Oxcaml-F_nested-Nested.html.gen
    Oxcaml-module-type-S.html.gen
    Oxcaml-M1.html.gen
    Oxcaml-M2.html.gen
@@ -11970,6 +11978,56 @@
   (package odoc)
   (action
    (diff Oxcaml.html Oxcaml.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-M_kinds.html Oxcaml-M_kinds.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-module-type-S_kind.html Oxcaml-module-type-S_kind.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_kind.html Oxcaml-F_kind.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_kind-argument-1-X.html Oxcaml-F_kind-argument-1-X.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-Arg_kind.html Oxcaml-Arg_kind.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_nested.html Oxcaml-F_nested.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff
+    Oxcaml-F_nested-argument-1-X.html
+    Oxcaml-F_nested-argument-1-X.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_nested-Nested.html Oxcaml-F_nested-Nested.html.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
   (alias runtest)
@@ -12016,7 +12074,12 @@
 (subdir
  latex
  (rule
-  (targets Oxcaml.tex.gen Oxcaml.M1.tex.gen)
+  (targets
+   Oxcaml.tex.gen
+   Oxcaml.F_kind.tex.gen
+   Oxcaml.Arg_kind.tex.gen
+   Oxcaml.F_nested.tex.gen
+   Oxcaml.M1.tex.gen)
   (package odoc)
   (action
    (run odoc latex-generate -o . --extra-suffix gen %{dep:../oxcaml.odocl}))
@@ -12026,6 +12089,24 @@
   (package odoc)
   (action
    (diff Oxcaml.tex Oxcaml.tex.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.F_kind.tex Oxcaml.F_kind.tex.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.Arg_kind.tex Oxcaml.Arg_kind.tex.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.F_nested.tex Oxcaml.F_nested.tex.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
   (alias runtest)
@@ -12054,7 +12135,16 @@
 (subdir
  man
  (rule
-  (targets Oxcaml.3o.gen Oxcaml.M1.3o.gen Oxcaml.M2.3o.gen Oxcaml.M3.3o.gen)
+  (targets
+   Oxcaml.3o.gen
+   Oxcaml.M_kinds.3o.gen
+   Oxcaml.F_kind.3o.gen
+   Oxcaml.Arg_kind.3o.gen
+   Oxcaml.F_nested.3o.gen
+   Oxcaml.F_nested.Nested.3o.gen
+   Oxcaml.M1.3o.gen
+   Oxcaml.M2.3o.gen
+   Oxcaml.M3.3o.gen)
   (package odoc)
   (action
    (run odoc man-generate -o . --extra-suffix gen %{dep:../oxcaml.odocl}))
@@ -12064,6 +12154,36 @@
   (package odoc)
   (action
    (diff Oxcaml.3o Oxcaml.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.M_kinds.3o Oxcaml.M_kinds.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.F_kind.3o Oxcaml.F_kind.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.Arg_kind.3o Oxcaml.Arg_kind.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.F_nested.3o Oxcaml.F_nested.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.F_nested.Nested.3o Oxcaml.F_nested.Nested.3o.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
   (alias runtest)
@@ -12106,6 +12226,14 @@
  (rule
   (targets
    Oxcaml.md.gen
+   Oxcaml-M_kinds.md.gen
+   Oxcaml-module-type-S_kind.md.gen
+   Oxcaml-F_kind.md.gen
+   Oxcaml-F_kind-argument-1-X.md.gen
+   Oxcaml-Arg_kind.md.gen
+   Oxcaml-F_nested.md.gen
+   Oxcaml-F_nested-argument-1-X.md.gen
+   Oxcaml-F_nested-Nested.md.gen
    Oxcaml-module-type-S.md.gen
    Oxcaml-M1.md.gen
    Oxcaml-M2.md.gen
@@ -12126,6 +12254,54 @@
   (package odoc)
   (action
    (diff Oxcaml.md Oxcaml.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-M_kinds.md Oxcaml-M_kinds.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-module-type-S_kind.md Oxcaml-module-type-S_kind.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_kind.md Oxcaml-F_kind.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_kind-argument-1-X.md Oxcaml-F_kind-argument-1-X.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-Arg_kind.md Oxcaml-Arg_kind.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_nested.md Oxcaml-F_nested.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_nested-argument-1-X.md Oxcaml-F_nested-argument-1-X.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_nested-Nested.md Oxcaml-F_nested-Nested.md.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
   (alias runtest)

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -12175,7 +12175,8 @@
   (targets
    Oxcaml_impl.html.gen
    Oxcaml_impl-To_be_included.html.gen
-   Oxcaml_impl-Including.html.gen)
+   Oxcaml_impl-Including.html.gen
+   Oxcaml_impl-Shadowing_source.html.gen)
   (package odoc)
   (action
    (run
@@ -12206,6 +12207,14 @@
   (package odoc)
   (action
    (diff Oxcaml_impl-Including.html Oxcaml_impl-Including.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff
+    Oxcaml_impl-Shadowing_source.html
+    Oxcaml_impl-Shadowing_source.html.gen))
   (enabled_if %{ocaml-config:ox})))
 
 (subdir
@@ -12270,7 +12279,8 @@
   (targets
    Oxcaml_impl.3o.gen
    Oxcaml_impl.To_be_included.3o.gen
-   Oxcaml_impl.Including.3o.gen)
+   Oxcaml_impl.Including.3o.gen
+   Oxcaml_impl.Shadowing_source.3o.gen)
   (package odoc)
   (action
    (run
@@ -12299,6 +12309,12 @@
   (package odoc)
   (action
    (diff Oxcaml_impl.Including.3o Oxcaml_impl.Including.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml_impl.Shadowing_source.3o Oxcaml_impl.Shadowing_source.3o.gen))
   (enabled_if %{ocaml-config:ox})))
 
 (subdir
@@ -12324,7 +12340,8 @@
   (targets
    Oxcaml_impl.md.gen
    Oxcaml_impl-To_be_included.md.gen
-   Oxcaml_impl-Including.md.gen)
+   Oxcaml_impl-Including.md.gen
+   Oxcaml_impl-Shadowing_source.md.gen)
   (package odoc)
   (action
    (run
@@ -12353,6 +12370,12 @@
   (package odoc)
   (action
    (diff Oxcaml_impl-Including.md Oxcaml_impl-Including.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml_impl-Shadowing_source.md Oxcaml_impl-Shadowing_source.md.gen))
   (enabled_if %{ocaml-config:ox})))
 
 (subdir

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -12288,7 +12288,8 @@
   (targets
    Oxcaml_impl.html.gen
    Oxcaml_impl-To_be_included.html.gen
-   Oxcaml_impl-Including.html.gen)
+   Oxcaml_impl-Including.html.gen
+   Oxcaml_impl-Shadowing_source.html.gen)
   (package odoc)
   (action
    (run
@@ -12319,6 +12320,14 @@
   (package odoc)
   (action
    (diff Oxcaml_impl-Including.html Oxcaml_impl-Including.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff
+    Oxcaml_impl-Shadowing_source.html
+    Oxcaml_impl-Shadowing_source.html.gen))
   (enabled_if %{ocaml-config:ox})))
 
 (subdir
@@ -12383,7 +12392,8 @@
   (targets
    Oxcaml_impl.3o.gen
    Oxcaml_impl.To_be_included.3o.gen
-   Oxcaml_impl.Including.3o.gen)
+   Oxcaml_impl.Including.3o.gen
+   Oxcaml_impl.Shadowing_source.3o.gen)
   (package odoc)
   (action
    (run
@@ -12412,6 +12422,12 @@
   (package odoc)
   (action
    (diff Oxcaml_impl.Including.3o Oxcaml_impl.Including.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml_impl.Shadowing_source.3o Oxcaml_impl.Shadowing_source.3o.gen))
   (enabled_if %{ocaml-config:ox})))
 
 (subdir
@@ -12437,7 +12453,8 @@
   (targets
    Oxcaml_impl.md.gen
    Oxcaml_impl-To_be_included.md.gen
-   Oxcaml_impl-Including.md.gen)
+   Oxcaml_impl-Including.md.gen
+   Oxcaml_impl-Shadowing_source.md.gen)
   (package odoc)
   (action
    (run
@@ -12466,6 +12483,12 @@
   (package odoc)
   (action
    (diff Oxcaml_impl-Including.md Oxcaml_impl-Including.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml_impl-Shadowing_source.md Oxcaml_impl-Shadowing_source.md.gen))
   (enabled_if %{ocaml-config:ox})))
 
 (subdir

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -11953,6 +11953,14 @@
    Oxcaml-F_with.html.gen
    Oxcaml-F_with-argument-1-X.html.gen
    Oxcaml-X_with.html.gen
+   Oxcaml-M_kinds.html.gen
+   Oxcaml-module-type-S_kind.html.gen
+   Oxcaml-F_kind.html.gen
+   Oxcaml-F_kind-argument-1-X.html.gen
+   Oxcaml-Arg_kind.html.gen
+   Oxcaml-F_nested.html.gen
+   Oxcaml-F_nested-argument-1-X.html.gen
+   Oxcaml-F_nested-Nested.html.gen
    Oxcaml-module-type-S.html.gen
    Oxcaml-M1.html.gen
    Oxcaml-M2.html.gen
@@ -12012,6 +12020,56 @@
   (alias runtest)
   (package odoc)
   (action
+   (diff Oxcaml-M_kinds.html Oxcaml-M_kinds.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-module-type-S_kind.html Oxcaml-module-type-S_kind.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_kind.html Oxcaml-F_kind.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_kind-argument-1-X.html Oxcaml-F_kind-argument-1-X.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-Arg_kind.html Oxcaml-Arg_kind.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_nested.html Oxcaml-F_nested.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff
+    Oxcaml-F_nested-argument-1-X.html
+    Oxcaml-F_nested-argument-1-X.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_nested-Nested.html Oxcaml-F_nested-Nested.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
    (diff Oxcaml-module-type-S.html Oxcaml-module-type-S.html.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
@@ -12057,6 +12115,9 @@
    Oxcaml.tex.gen
    Oxcaml.F_with.tex.gen
    Oxcaml.X_with.tex.gen
+   Oxcaml.F_kind.tex.gen
+   Oxcaml.Arg_kind.tex.gen
+   Oxcaml.F_nested.tex.gen
    Oxcaml.M1.tex.gen)
   (package odoc)
   (action
@@ -12079,6 +12140,24 @@
   (package odoc)
   (action
    (diff Oxcaml.X_with.tex Oxcaml.X_with.tex.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.F_kind.tex Oxcaml.F_kind.tex.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.Arg_kind.tex Oxcaml.Arg_kind.tex.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.F_nested.tex Oxcaml.F_nested.tex.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
   (alias runtest)
@@ -12112,6 +12191,11 @@
    Oxcaml.M_with.3o.gen
    Oxcaml.F_with.3o.gen
    Oxcaml.X_with.3o.gen
+   Oxcaml.M_kinds.3o.gen
+   Oxcaml.F_kind.3o.gen
+   Oxcaml.Arg_kind.3o.gen
+   Oxcaml.F_nested.3o.gen
+   Oxcaml.F_nested.Nested.3o.gen
    Oxcaml.M1.3o.gen
    Oxcaml.M2.3o.gen
    Oxcaml.M3.3o.gen)
@@ -12142,6 +12226,36 @@
   (package odoc)
   (action
    (diff Oxcaml.X_with.3o Oxcaml.X_with.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.M_kinds.3o Oxcaml.M_kinds.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.F_kind.3o Oxcaml.F_kind.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.Arg_kind.3o Oxcaml.Arg_kind.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.F_nested.3o Oxcaml.F_nested.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.F_nested.Nested.3o Oxcaml.F_nested.Nested.3o.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
   (alias runtest)
@@ -12189,6 +12303,14 @@
    Oxcaml-F_with.md.gen
    Oxcaml-F_with-argument-1-X.md.gen
    Oxcaml-X_with.md.gen
+   Oxcaml-M_kinds.md.gen
+   Oxcaml-module-type-S_kind.md.gen
+   Oxcaml-F_kind.md.gen
+   Oxcaml-F_kind-argument-1-X.md.gen
+   Oxcaml-Arg_kind.md.gen
+   Oxcaml-F_nested.md.gen
+   Oxcaml-F_nested-argument-1-X.md.gen
+   Oxcaml-F_nested-Nested.md.gen
    Oxcaml-module-type-S.md.gen
    Oxcaml-M1.md.gen
    Oxcaml-M2.md.gen
@@ -12239,6 +12361,54 @@
   (package odoc)
   (action
    (diff Oxcaml-X_with.md Oxcaml-X_with.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-M_kinds.md Oxcaml-M_kinds.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-module-type-S_kind.md Oxcaml-module-type-S_kind.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_kind.md Oxcaml-F_kind.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_kind-argument-1-X.md Oxcaml-F_kind-argument-1-X.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-Arg_kind.md Oxcaml-Arg_kind.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_nested.md Oxcaml-F_nested.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_nested-argument-1-X.md Oxcaml-F_nested-argument-1-X.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-F_nested-Nested.md Oxcaml-F_nested-Nested.md.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
   (alias runtest)

--- a/test/generators/link.dune.inc
+++ b/test/generators/link.dune.inc
@@ -11961,6 +11961,8 @@
    Oxcaml-F_nested.html.gen
    Oxcaml-F_nested-argument-1-X.html.gen
    Oxcaml-F_nested-Nested.html.gen
+   Oxcaml-X_shadowing.html.gen
+   Oxcaml-M_inc.html.gen
    Oxcaml-module-type-S.html.gen
    Oxcaml-M1.html.gen
    Oxcaml-M2.html.gen
@@ -12065,6 +12067,18 @@
   (package odoc)
   (action
    (diff Oxcaml-F_nested-Nested.html Oxcaml-F_nested-Nested.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-X_shadowing.html Oxcaml-X_shadowing.html.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-M_inc.html Oxcaml-M_inc.html.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
   (alias runtest)
@@ -12196,6 +12210,8 @@
    Oxcaml.Arg_kind.3o.gen
    Oxcaml.F_nested.3o.gen
    Oxcaml.F_nested.Nested.3o.gen
+   Oxcaml.X_shadowing.3o.gen
+   Oxcaml.M_inc.3o.gen
    Oxcaml.M1.3o.gen
    Oxcaml.M2.3o.gen
    Oxcaml.M3.3o.gen)
@@ -12261,6 +12277,18 @@
   (alias runtest)
   (package odoc)
   (action
+   (diff Oxcaml.X_shadowing.3o Oxcaml.X_shadowing.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml.M_inc.3o Oxcaml.M_inc.3o.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
    (diff Oxcaml.M1.3o Oxcaml.M1.3o.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
@@ -12311,6 +12339,8 @@
    Oxcaml-F_nested.md.gen
    Oxcaml-F_nested-argument-1-X.md.gen
    Oxcaml-F_nested-Nested.md.gen
+   Oxcaml-X_shadowing.md.gen
+   Oxcaml-M_inc.md.gen
    Oxcaml-module-type-S.md.gen
    Oxcaml-M1.md.gen
    Oxcaml-M2.md.gen
@@ -12409,6 +12439,18 @@
   (package odoc)
   (action
    (diff Oxcaml-F_nested-Nested.md Oxcaml-F_nested-Nested.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-X_shadowing.md Oxcaml-X_shadowing.md.gen))
+  (enabled_if %{ocaml-config:ox}))
+ (rule
+  (alias runtest)
+  (package odoc)
+  (action
+   (diff Oxcaml-M_inc.md Oxcaml-M_inc.md.gen))
   (enabled_if %{ocaml-config:ox}))
  (rule
   (alias runtest)

--- a/test/generators/man/Oxcaml.3o
+++ b/test/generators/man/Oxcaml.3o
@@ -288,11 +288,129 @@ Should render as float64 & (immediate mod portable)\.
 \fB9 Kind abbreviations\fR
 .in 
 .sp 
+\f[CB]kind_\fR missing_documentation = value \f[CB]mod\fR portable
+.sp 
+.fi 
+TODO: The above kind abbreviation uses (** *) which are not captured by the OxCaml parser, so its documentation is currently missing\. The following kind_ declarations use an explicit @@ocaml\.doc to side-step this issue\.
+.nf 
+.sp 
+\f[CB]kind_\fR my_abbrev = value_or_null \f[CB]mod\fR non_null global
+.fi 
+.br 
+.ti +2
+Declares a kind abbreviation named my_abbrev\.
+.nf 
+.sp 
 \f[CB]type\fR t_abbrev : my_abbrev \f[CB]mod\fR immutable
 .fi 
 .br 
 .ti +2
-A type with an abbreviated kind\.
+A type with an abbreviated kind\. The use of my_abbrev should link to its definition\. References to the kind abbreviation resolve too, both unqualified \f[CI]my_abbrev\fR and qualified \f[CI]my_abbrev\fR\.
+.nf 
+.sp 
+\f[CB]kind_\fR my_derived = my_abbrev \f[CB]mod\fR portable
+.fi 
+.br 
+.ti +2
+A kind abbreviation defined in terms of another one; the use of my_abbrev in this definition should also link to its definition\.
+.nf 
+.sp 
+\f[CB]type\fR t_derived : my_derived
+.fi 
+.br 
+.ti +2
+A type whose kind is the derived abbreviation\.
+.nf 
+.sp 
+\f[CB]kind_\fR my_abstract
+.fi 
+.br 
+.ti +2
+An abstract kind abbreviation (no manifest)\.
+.nf 
+.sp 
+\f[CB]type\fR t_abstract : my_abstract
+.fi 
+.br 
+.ti +2
+A type with an abstract abbreviated kind\.
+.nf 
+.sp 
+\f[CB]type\fR ('a : my_abbrev) abbrev_param
+.fi 
+.br 
+.ti +2
+A type parameter constrained by an abbreviated kind\.
+.nf 
+.sp 
+\f[CB]val\fR poly_abbrev : ('a : my_abbrev)\. \f[CB]'a\fR \f[CB]\->\fR \f[CB]'a\fR
+.fi 
+.br 
+.ti +2
+A polymorphic value with an abbreviated kind constraint\.
+.nf 
+.sp 
+\f[CB]type\fR 'a t_with_abbrev : my_abbrev \f[CB]with\fR \f[CB]'a\fR
+.fi 
+.br 
+.ti +2
+An abbreviated kind in a with constraint\.
+.nf 
+.sp 
+\f[CB]module\fR M_kinds : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.sp 
+\f[CB]type\fR t_qualified : M_kinds\.mod_kind
+.fi 
+.br 
+.ti +2
+A qualified use of a kind abbreviation from another module; the use should link to M_kinds\.mod_kind's definition\.
+.nf 
+.sp 
+\f[CB]type\fR ('a : M_kinds\.mod_kind) qualified_param
+.fi 
+.br 
+.ti +2
+A qualified kind abbreviation on a type parameter; the use should link to the definition (resolved during linking, like t_qualified)\.
+.nf 
+.sp 
+\f[CB]module\fR \f[CB]type\fR S_kind = \f[CB]sig\fR
+.br 
+.ti +2
+\f[CB]kind_\fR functor_kind = value \f[CB]mod\fR portable
+.fi 
+.br 
+.ti +4
+A kind declared in a module type\.
+.nf 
+
+.br 
+\f[CB]end\fR
+.sp 
+\f[CB]module\fR F_kind (X : S_kind) : S_kind
+.sp 
+\f[CB]module\fR Arg_kind : S_kind
+.sp 
+\f[CB]type\fR t_functor_app : F_kind(Arg_kind)\.functor_kind
+.fi 
+.br 
+.ti +2
+A use behind a functor application\. odoc references can't express functor application, so this is rendered as plain text (not a link) rather than crashing\.
+.nf 
+.sp 
+\f[CB]module\fR F_nested (X : S_kind) : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.sp 
+\f[CB]kind_\fR functor_abbrev = F_nested(Arg_kind)\.abstract_kind
+.fi 
+.br 
+.ti +2
+A kind abbreviation defined through a functor-application path\. The manifest is rendered but the functor-application path isn't a link\.
+.nf 
+.sp 
+\f[CB]kind_\fR nested_functor_abbrev = F_nested(Arg_kind)\.Nested\.custom_kind_abbrev
+.fi 
+.br 
+.ti +2
+A kind abbreviation defined through a functor-application-then-nested-module path\. The manifest is rendered but the functor-application path isn't a link\.
 .nf 
 .sp 
 .in 3

--- a/test/generators/man/Oxcaml.3o
+++ b/test/generators/man/Oxcaml.3o
@@ -382,12 +382,6 @@ Should render as float64 & (immediate mod portable)\.
 \fB9 Kind abbreviations\fR
 .in 
 .sp 
-\f[CB]kind_\fR missing_documentation = value \f[CB]mod\fR portable
-.sp 
-.fi 
-TODO: The above kind abbreviation uses (** *) which are not captured by the OxCaml parser, so its documentation is currently missing\. The following kind_ declarations use an explicit @@ocaml\.doc to side-step this issue\.
-.nf 
-.sp 
 \f[CB]kind_\fR my_abbrev = value_or_null \f[CB]mod\fR non_null global
 .fi 
 .br 

--- a/test/generators/man/Oxcaml.3o
+++ b/test/generators/man/Oxcaml.3o
@@ -501,6 +501,21 @@ A kind abbreviation defined through a functor-application path\. The manifest is
 A kind abbreviation defined through a functor-application-then-nested-module path\. The manifest is rendered but the functor-application path isn't a link\.
 .nf 
 .sp 
+\f[CB]kind_\fR to_be_shadowed = value \f[CB]mod\fR portable
+.fi 
+.br 
+.ti +2
+Shadowed below by a kind abbreviation of the same name\.
+.nf 
+.sp 
+\f[CB]module\fR X_shadowing : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.sp 
+\f[CB]module\fR M_inc : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.sp 
+\f[CB]kind_\fR inc_kind = value \f[CB]mod\fR portable
+.sp 
+\f[CB]type\fR t_inc : inc_kind
+.sp 
 .in 3
 \fB10 Zero alloc\fR
 .in 

--- a/test/generators/man/Oxcaml.3o
+++ b/test/generators/man/Oxcaml.3o
@@ -382,11 +382,129 @@ Should render as float64 & (immediate mod portable)\.
 \fB9 Kind abbreviations\fR
 .in 
 .sp 
+\f[CB]kind_\fR missing_documentation = value \f[CB]mod\fR portable
+.sp 
+.fi 
+TODO: The above kind abbreviation uses (** *) which are not captured by the OxCaml parser, so its documentation is currently missing\. The following kind_ declarations use an explicit @@ocaml\.doc to side-step this issue\.
+.nf 
+.sp 
+\f[CB]kind_\fR my_abbrev = value_or_null \f[CB]mod\fR non_null global
+.fi 
+.br 
+.ti +2
+Declares a kind abbreviation named my_abbrev\.
+.nf 
+.sp 
 \f[CB]type\fR t_abbrev : my_abbrev \f[CB]mod\fR immutable
 .fi 
 .br 
 .ti +2
-A type with an abbreviated kind\.
+A type with an abbreviated kind\. The use of my_abbrev should link to its definition\. References to the kind abbreviation resolve too, both unqualified \f[CI]my_abbrev\fR and qualified \f[CI]my_abbrev\fR\.
+.nf 
+.sp 
+\f[CB]kind_\fR my_derived = my_abbrev \f[CB]mod\fR portable
+.fi 
+.br 
+.ti +2
+A kind abbreviation defined in terms of another one; the use of my_abbrev in this definition should also link to its definition\.
+.nf 
+.sp 
+\f[CB]type\fR t_derived : my_derived
+.fi 
+.br 
+.ti +2
+A type whose kind is the derived abbreviation\.
+.nf 
+.sp 
+\f[CB]kind_\fR my_abstract
+.fi 
+.br 
+.ti +2
+An abstract kind abbreviation (no manifest)\.
+.nf 
+.sp 
+\f[CB]type\fR t_abstract : my_abstract
+.fi 
+.br 
+.ti +2
+A type with an abstract abbreviated kind\.
+.nf 
+.sp 
+\f[CB]type\fR ('a : my_abbrev) abbrev_param
+.fi 
+.br 
+.ti +2
+A type parameter constrained by an abbreviated kind\.
+.nf 
+.sp 
+\f[CB]val\fR poly_abbrev : ('a : my_abbrev)\. \f[CB]'a\fR \f[CB]\->\fR \f[CB]'a\fR
+.fi 
+.br 
+.ti +2
+A polymorphic value with an abbreviated kind constraint\.
+.nf 
+.sp 
+\f[CB]type\fR 'a t_with_abbrev : my_abbrev \f[CB]with\fR \f[CB]'a\fR
+.fi 
+.br 
+.ti +2
+An abbreviated kind in a with constraint\.
+.nf 
+.sp 
+\f[CB]module\fR M_kinds : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.sp 
+\f[CB]type\fR t_qualified : M_kinds\.mod_kind
+.fi 
+.br 
+.ti +2
+A qualified use of a kind abbreviation from another module; the use should link to M_kinds\.mod_kind's definition\.
+.nf 
+.sp 
+\f[CB]type\fR ('a : M_kinds\.mod_kind) qualified_param
+.fi 
+.br 
+.ti +2
+A qualified kind abbreviation on a type parameter; the use should link to the definition (resolved during linking, like t_qualified)\.
+.nf 
+.sp 
+\f[CB]module\fR \f[CB]type\fR S_kind = \f[CB]sig\fR
+.br 
+.ti +2
+\f[CB]kind_\fR functor_kind = value \f[CB]mod\fR portable
+.fi 
+.br 
+.ti +4
+A kind declared in a module type\.
+.nf 
+
+.br 
+\f[CB]end\fR
+.sp 
+\f[CB]module\fR F_kind (X : S_kind) : S_kind
+.sp 
+\f[CB]module\fR Arg_kind : S_kind
+.sp 
+\f[CB]type\fR t_functor_app : F_kind(Arg_kind)\.functor_kind
+.fi 
+.br 
+.ti +2
+A use behind a functor application\. odoc references can't express functor application, so this is rendered as plain text (not a link) rather than crashing\.
+.nf 
+.sp 
+\f[CB]module\fR F_nested (X : S_kind) : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.sp 
+\f[CB]kind_\fR functor_abbrev = F_nested(Arg_kind)\.abstract_kind
+.fi 
+.br 
+.ti +2
+A kind abbreviation defined through a functor-application path\. The manifest is rendered but the functor-application path isn't a link\.
+.nf 
+.sp 
+\f[CB]kind_\fR nested_functor_abbrev = F_nested(Arg_kind)\.Nested\.custom_kind_abbrev
+.fi 
+.br 
+.ti +2
+A kind abbreviation defined through a functor-application-then-nested-module path\. The manifest is rendered but the functor-application path isn't a link\.
 .nf 
 .sp 
 .in 3

--- a/test/generators/man/Oxcaml.Arg_kind.3o
+++ b/test/generators/man/Oxcaml.Arg_kind.3o
@@ -1,0 +1,20 @@
+
+.TH Arg_kind 3 "" "Odoc" "OCaml Library"
+.SH Name
+Oxcaml\.Arg_kind
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Oxcaml\.Arg_kind\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]kind_\fR functor_kind = value \f[CB]mod\fR portable
+.fi 
+.br 
+.ti +2
+A kind declared in a module type\.
+.nf 
+

--- a/test/generators/man/Oxcaml.F_kind.3o
+++ b/test/generators/man/Oxcaml.F_kind.3o
@@ -1,0 +1,42 @@
+
+.TH F_kind 3 "" "Odoc" "OCaml Library"
+.SH Name
+Oxcaml\.F_kind
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Oxcaml\.F_kind\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+.sp 
+.in 3
+\fB1 Parameters\fR
+.in 
+.sp 
+\f[CB]module\fR X : \f[CB]sig\fR
+.br 
+.ti +2
+\f[CB]kind_\fR functor_kind = value \f[CB]mod\fR portable
+.fi 
+.br 
+.ti +4
+A kind declared in a module type\.
+.nf 
+
+.br 
+\f[CB]end\fR
+.sp 
+.in 3
+\fB2 Signature\fR
+.in 
+.sp 
+\f[CB]kind_\fR functor_kind = value \f[CB]mod\fR portable
+.fi 
+.br 
+.ti +2
+A kind declared in a module type\.
+.nf 
+

--- a/test/generators/man/Oxcaml.F_nested.3o
+++ b/test/generators/man/Oxcaml.F_nested.3o
@@ -1,0 +1,43 @@
+
+.TH F_nested 3 "" "Odoc" "OCaml Library"
+.SH Name
+Oxcaml\.F_nested
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Oxcaml\.F_nested\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+.sp 
+.in 3
+\fB1 Parameters\fR
+.in 
+.sp 
+\f[CB]module\fR X : \f[CB]sig\fR
+.br 
+.ti +2
+\f[CB]kind_\fR functor_kind = value \f[CB]mod\fR portable
+.fi 
+.br 
+.ti +4
+A kind declared in a module type\.
+.nf 
+
+.br 
+\f[CB]end\fR
+.sp 
+.in 3
+\fB2 Signature\fR
+.in 
+.sp 
+\f[CB]kind_\fR abstract_kind
+.fi 
+.br 
+.ti +2
+An abstract kind\.
+.nf 
+.sp 
+\f[CB]module\fR Nested : \f[CB]sig\fR \.\.\. \f[CB]end\fR

--- a/test/generators/man/Oxcaml.F_nested.Nested.3o
+++ b/test/generators/man/Oxcaml.F_nested.Nested.3o
@@ -1,0 +1,20 @@
+
+.TH Nested 3 "" "Odoc" "OCaml Library"
+.SH Name
+Oxcaml\.F_nested\.Nested
+.SH Synopsis
+.sp 
+.in 2
+\fBModule F_nested\.Nested\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]kind_\fR custom_kind_abbrev = X\.functor_kind \f[CB]mod\fR contended
+.fi 
+.br 
+.ti +2
+A nested kind extending the functor argument's kind\.
+.nf 
+

--- a/test/generators/man/Oxcaml.M_inc.3o
+++ b/test/generators/man/Oxcaml.M_inc.3o
@@ -1,0 +1,14 @@
+
+.TH M_inc 3 "" "Odoc" "OCaml Library"
+.SH Name
+Oxcaml\.M_inc
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Oxcaml\.M_inc\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]kind_\fR inc_kind = value \f[CB]mod\fR portable

--- a/test/generators/man/Oxcaml.M_kinds.3o
+++ b/test/generators/man/Oxcaml.M_kinds.3o
@@ -1,0 +1,14 @@
+
+.TH M_kinds 3 "" "Odoc" "OCaml Library"
+.SH Name
+Oxcaml\.M_kinds
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Oxcaml\.M_kinds\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]kind_\fR mod_kind = value \f[CB]mod\fR portable

--- a/test/generators/man/Oxcaml.X_shadowing.3o
+++ b/test/generators/man/Oxcaml.X_shadowing.3o
@@ -1,0 +1,27 @@
+
+.TH X_shadowing 3 "" "Odoc" "OCaml Library"
+.SH Name
+Oxcaml\.X_shadowing
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Oxcaml\.X_shadowing\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+\f[CB]type\fR t : to_be_shadowed
+.fi 
+.br 
+.ti +2
+Uses the outer to_be_shadowed, declared before the one below, so the link should point outside this module\.
+.nf 
+.sp 
+\f[CB]kind_\fR to_be_shadowed = value_or_null \f[CB]mod\fR non_null global
+.fi 
+.br 
+.ti +2
+Shadows the outer to_be_shadowed\.
+.nf 
+

--- a/test/generators/man/Oxcaml_impl.3o
+++ b/test/generators/man/Oxcaml_impl.3o
@@ -16,3 +16,9 @@ Oxcaml_impl
 \f[CB]module\fR To_be_included : \f[CB]sig\fR \.\.\. \f[CB]end\fR
 .sp 
 \f[CB]module\fR Including : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.sp 
+\f[CB]type\fR t_abbrev : my_abbrev \f[CB]mod\fR immutable
+.sp 
+\f[CB]module\fR Shadowing_source : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.sp 
+

--- a/test/generators/man/Oxcaml_impl.3o
+++ b/test/generators/man/Oxcaml_impl.3o
@@ -17,8 +17,10 @@ Oxcaml_impl
 .sp 
 \f[CB]module\fR Including : \f[CB]sig\fR \.\.\. \f[CB]end\fR
 .sp 
+\f[CB]kind_\fR my_abbrev = value_or_null \f[CB]mod\fR non_null global
+.sp 
 \f[CB]type\fR t_abbrev : my_abbrev \f[CB]mod\fR immutable
 .sp 
 \f[CB]module\fR Shadowing_source : \f[CB]sig\fR \.\.\. \f[CB]end\fR
 .sp 
-
+\f[CB]kind_\fR dup = value_or_null \f[CB]mod\fR non_null

--- a/test/generators/man/Oxcaml_impl.3o
+++ b/test/generators/man/Oxcaml_impl.3o
@@ -143,4 +143,9 @@ Mode on a function argument, via a type annotation\.
 .ti +2
 Multiple modes on argument and return\.
 .nf 
+.sp 
+\f[CB]type\fR t_abbrev : my_abbrev \f[CB]mod\fR immutable
+.sp 
+\f[CB]module\fR Shadowing_source : \f[CB]sig\fR \.\.\. \f[CB]end\fR
+.sp 
 

--- a/test/generators/man/Oxcaml_impl.3o
+++ b/test/generators/man/Oxcaml_impl.3o
@@ -144,8 +144,10 @@ Mode on a function argument, via a type annotation\.
 Multiple modes on argument and return\.
 .nf 
 .sp 
+\f[CB]kind_\fR my_abbrev = value_or_null \f[CB]mod\fR non_null global
+.sp 
 \f[CB]type\fR t_abbrev : my_abbrev \f[CB]mod\fR immutable
 .sp 
 \f[CB]module\fR Shadowing_source : \f[CB]sig\fR \.\.\. \f[CB]end\fR
 .sp 
-
+\f[CB]kind_\fR dup = value_or_null \f[CB]mod\fR non_null

--- a/test/generators/man/Oxcaml_impl.Shadowing_source.3o
+++ b/test/generators/man/Oxcaml_impl.Shadowing_source.3o
@@ -1,0 +1,14 @@
+
+.TH Shadowing_source 3 "" "Odoc" "OCaml Library"
+.SH Name
+Oxcaml_impl\.Shadowing_source
+.SH Synopsis
+.sp 
+.in 2
+\fBModule Oxcaml_impl\.Shadowing_source\fR
+.in 
+.sp 
+.SH Documentation
+.sp 
+.nf 
+

--- a/test/generators/man/Oxcaml_impl.Shadowing_source.3o
+++ b/test/generators/man/Oxcaml_impl.Shadowing_source.3o
@@ -11,4 +11,4 @@ Oxcaml_impl\.Shadowing_source
 .SH Documentation
 .sp 
 .nf 
-
+\f[CB]kind_\fR dup = value \f[CB]mod\fR portable

--- a/test/generators/man/oxcaml.targets
+++ b/test/generators/man/oxcaml.targets
@@ -1,4 +1,9 @@
 Oxcaml.3o
+Oxcaml.M_kinds.3o
+Oxcaml.F_kind.3o
+Oxcaml.Arg_kind.3o
+Oxcaml.F_nested.3o
+Oxcaml.F_nested.Nested.3o
 Oxcaml.M1.3o
 Oxcaml.M2.3o
 Oxcaml.M3.3o

--- a/test/generators/man/oxcaml.targets
+++ b/test/generators/man/oxcaml.targets
@@ -2,6 +2,11 @@ Oxcaml.3o
 Oxcaml.M_with.3o
 Oxcaml.F_with.3o
 Oxcaml.X_with.3o
+Oxcaml.M_kinds.3o
+Oxcaml.F_kind.3o
+Oxcaml.Arg_kind.3o
+Oxcaml.F_nested.3o
+Oxcaml.F_nested.Nested.3o
 Oxcaml.M1.3o
 Oxcaml.M2.3o
 Oxcaml.M3.3o

--- a/test/generators/man/oxcaml.targets
+++ b/test/generators/man/oxcaml.targets
@@ -7,6 +7,8 @@ Oxcaml.F_kind.3o
 Oxcaml.Arg_kind.3o
 Oxcaml.F_nested.3o
 Oxcaml.F_nested.Nested.3o
+Oxcaml.X_shadowing.3o
+Oxcaml.M_inc.3o
 Oxcaml.M1.3o
 Oxcaml.M2.3o
 Oxcaml.M3.3o

--- a/test/generators/man/oxcaml_impl.targets
+++ b/test/generators/man/oxcaml_impl.targets
@@ -1,3 +1,4 @@
 Oxcaml_impl.3o
 Oxcaml_impl.To_be_included.3o
 Oxcaml_impl.Including.3o
+Oxcaml_impl.Shadowing_source.3o

--- a/test/generators/markdown/Oxcaml-Arg_kind.md
+++ b/test/generators/markdown/Oxcaml-Arg_kind.md
@@ -1,0 +1,7 @@
+
+# Module `Oxcaml.Arg_kind`
+
+```ocaml
+kind_ functor_kind = value mod portable
+```
+A kind declared in a module type.

--- a/test/generators/markdown/Oxcaml-F_kind-argument-1-X.md
+++ b/test/generators/markdown/Oxcaml-F_kind-argument-1-X.md
@@ -1,0 +1,7 @@
+
+# Parameter `F_kind.X`
+
+```ocaml
+kind_ functor_kind = value mod portable
+```
+A kind declared in a module type.

--- a/test/generators/markdown/Oxcaml-F_kind.md
+++ b/test/generators/markdown/Oxcaml-F_kind.md
@@ -1,0 +1,16 @@
+
+# Module `Oxcaml.F_kind`
+
+
+## Parameters
+
+```ocaml
+module X : S_kind
+```
+
+## Signature
+
+```ocaml
+kind_ functor_kind = value mod portable
+```
+A kind declared in a module type.

--- a/test/generators/markdown/Oxcaml-F_nested-Nested.md
+++ b/test/generators/markdown/Oxcaml-F_nested-Nested.md
@@ -1,0 +1,7 @@
+
+# Module `F_nested.Nested`
+
+```ocaml
+kind_ custom_kind_abbrev = X.functor_kind mod contended
+```
+A nested kind extending the functor argument's kind.

--- a/test/generators/markdown/Oxcaml-F_nested-argument-1-X.md
+++ b/test/generators/markdown/Oxcaml-F_nested-argument-1-X.md
@@ -1,0 +1,7 @@
+
+# Parameter `F_nested.X`
+
+```ocaml
+kind_ functor_kind = value mod portable
+```
+A kind declared in a module type.

--- a/test/generators/markdown/Oxcaml-F_nested.md
+++ b/test/generators/markdown/Oxcaml-F_nested.md
@@ -1,0 +1,20 @@
+
+# Module `Oxcaml.F_nested`
+
+
+## Parameters
+
+```ocaml
+module X : S_kind
+```
+
+## Signature
+
+```ocaml
+kind_ abstract_kind
+```
+An abstract kind.
+
+```ocaml
+module Nested : sig ... end
+```

--- a/test/generators/markdown/Oxcaml-M_inc.md
+++ b/test/generators/markdown/Oxcaml-M_inc.md
@@ -1,0 +1,6 @@
+
+# Module `Oxcaml.M_inc`
+
+```ocaml
+kind_ inc_kind = value mod portable
+```

--- a/test/generators/markdown/Oxcaml-M_kinds.md
+++ b/test/generators/markdown/Oxcaml-M_kinds.md
@@ -1,0 +1,6 @@
+
+# Module `Oxcaml.M_kinds`
+
+```ocaml
+kind_ mod_kind = value mod portable
+```

--- a/test/generators/markdown/Oxcaml-X_shadowing.md
+++ b/test/generators/markdown/Oxcaml-X_shadowing.md
@@ -1,0 +1,12 @@
+
+# Module `Oxcaml.X_shadowing`
+
+```ocaml
+type t : to_be_shadowed
+```
+Uses the outer `to_be_shadowed`, declared before the one below, so the link should point outside this module.
+
+```ocaml
+kind_ to_be_shadowed = value_or_null mod non_null global
+```
+Shadows the outer `to_be_shadowed`.

--- a/test/generators/markdown/Oxcaml-module-type-S_kind.md
+++ b/test/generators/markdown/Oxcaml-module-type-S_kind.md
@@ -1,0 +1,7 @@
+
+# Module type `Oxcaml.S_kind`
+
+```ocaml
+kind_ functor_kind = value mod portable
+```
+A kind declared in a module type.

--- a/test/generators/markdown/Oxcaml-module-type-S_nested-Nested.md
+++ b/test/generators/markdown/Oxcaml-module-type-S_nested-Nested.md
@@ -1,0 +1,6 @@
+
+# Module `S_nested.Nested`
+
+```ocaml
+kind_ custom_kind_abbrev = k mod portable
+```

--- a/test/generators/markdown/Oxcaml-module-type-S_nested.md
+++ b/test/generators/markdown/Oxcaml-module-type-S_nested.md
@@ -1,0 +1,9 @@
+
+# Module type `Oxcaml.S_nested`
+
+```ocaml
+kind_ k
+```
+```ocaml
+module Nested : sig ... end
+```

--- a/test/generators/markdown/Oxcaml.md
+++ b/test/generators/markdown/Oxcaml.md
@@ -198,9 +198,94 @@ Should render as `float64 & (immediate mod portable)`.
 ## Kind abbreviations
 
 ```ocaml
+kind_ missing_documentation = value mod portable
+```
+TODO: The above kind abbreviation uses `(** *)` which are not captured by the OxCaml parser, so its documentation is currently missing. The following `kind_` declarations use an explicit `@@ocaml.doc` to side-step this issue.
+
+```ocaml
+kind_ my_abbrev = value_or_null mod non_null global
+```
+Declares a kind abbreviation named `my_abbrev`.
+
+```ocaml
 type t_abbrev : my_abbrev mod immutable
 ```
-A type with an abbreviated kind.
+A type with an abbreviated kind. The use of `my_abbrev` should link to its definition. References to the kind abbreviation resolve too, both unqualified [`my_abbrev`](./#kind-my_abbrev) and qualified [`my_abbrev`](./#kind-my_abbrev).
+
+```ocaml
+kind_ my_derived = my_abbrev mod portable
+```
+A kind abbreviation defined in terms of another one; the use of `my_abbrev` in this definition should also link to its definition.
+
+```ocaml
+type t_derived : my_derived
+```
+A type whose kind is the derived abbreviation.
+
+```ocaml
+kind_ my_abstract
+```
+An abstract kind abbreviation (no manifest).
+
+```ocaml
+type t_abstract : my_abstract
+```
+A type with an abstract abbreviated kind.
+
+```ocaml
+type ('a : my_abbrev) abbrev_param
+```
+A type parameter constrained by an abbreviated kind.
+
+```ocaml
+val poly_abbrev : ('a : my_abbrev). 'a -> 'a
+```
+A polymorphic value with an abbreviated kind constraint.
+
+```ocaml
+type 'a t_with_abbrev : my_abbrev with 'a
+```
+An abbreviated kind in a `with` constraint.
+
+```ocaml
+module M_kinds : sig ... end
+```
+```ocaml
+type t_qualified : M_kinds.mod_kind
+```
+A qualified use of a kind abbreviation from another module; the use should link to `M_kinds.mod_kind`'s definition.
+
+```ocaml
+type ('a : M_kinds.mod_kind) qualified_param
+```
+A qualified kind abbreviation on a type parameter; the use should link to the definition (resolved during linking, like `t_qualified`).
+
+```ocaml
+module type S_kind = sig ... end
+```
+```ocaml
+module F_kind (X : S_kind) : S_kind
+```
+```ocaml
+module Arg_kind : S_kind
+```
+```ocaml
+type t_functor_app : F_kind(Arg_kind).functor_kind
+```
+A use behind a functor application. odoc references can't express functor application, so this is rendered as plain text (not a link) rather than crashing.
+
+```ocaml
+module F_nested (X : S_kind) : sig ... end
+```
+```ocaml
+kind_ functor_abbrev = F_nested(Arg_kind).abstract_kind
+```
+A kind abbreviation defined through a functor-application path. The manifest is rendered but the functor-application path isn't a link.
+
+```ocaml
+kind_ nested_functor_abbrev = F_nested(Arg_kind).Nested.custom_kind_abbrev
+```
+A kind abbreviation defined through a functor-application-then-nested-module path. The manifest is rendered but the functor-application path isn't a link.
 
 
 ## Zero alloc

--- a/test/generators/markdown/Oxcaml.md
+++ b/test/generators/markdown/Oxcaml.md
@@ -349,6 +349,23 @@ kind_ nested_functor_abbrev = F_nested(Arg_kind).Nested.custom_kind_abbrev
 ```
 A kind abbreviation defined through a functor-application-then-nested-module path. The manifest is rendered but the functor-application path isn't a link.
 
+```ocaml
+kind_ to_be_shadowed = value mod portable
+```
+Shadowed below by a kind abbreviation of the same name.
+
+```ocaml
+module X_shadowing : sig ... end
+```
+```ocaml
+module M_inc : sig ... end
+```
+```ocaml
+kind_ inc_kind = value mod portable
+```
+```ocaml
+type t_inc : inc_kind
+```
 
 ## Zero alloc
 

--- a/test/generators/markdown/Oxcaml.md
+++ b/test/generators/markdown/Oxcaml.md
@@ -265,9 +265,94 @@ Should render as `float64 & (immediate mod portable)`.
 ## Kind abbreviations
 
 ```ocaml
+kind_ missing_documentation = value mod portable
+```
+TODO: The above kind abbreviation uses `(** *)` which are not captured by the OxCaml parser, so its documentation is currently missing. The following `kind_` declarations use an explicit `@@ocaml.doc` to side-step this issue.
+
+```ocaml
+kind_ my_abbrev = value_or_null mod non_null global
+```
+Declares a kind abbreviation named `my_abbrev`.
+
+```ocaml
 type t_abbrev : my_abbrev mod immutable
 ```
-A type with an abbreviated kind.
+A type with an abbreviated kind. The use of `my_abbrev` should link to its definition. References to the kind abbreviation resolve too, both unqualified [`my_abbrev`](./#kind-my_abbrev) and qualified [`my_abbrev`](./#kind-my_abbrev).
+
+```ocaml
+kind_ my_derived = my_abbrev mod portable
+```
+A kind abbreviation defined in terms of another one; the use of `my_abbrev` in this definition should also link to its definition.
+
+```ocaml
+type t_derived : my_derived
+```
+A type whose kind is the derived abbreviation.
+
+```ocaml
+kind_ my_abstract
+```
+An abstract kind abbreviation (no manifest).
+
+```ocaml
+type t_abstract : my_abstract
+```
+A type with an abstract abbreviated kind.
+
+```ocaml
+type ('a : my_abbrev) abbrev_param
+```
+A type parameter constrained by an abbreviated kind.
+
+```ocaml
+val poly_abbrev : ('a : my_abbrev). 'a -> 'a
+```
+A polymorphic value with an abbreviated kind constraint.
+
+```ocaml
+type 'a t_with_abbrev : my_abbrev with 'a
+```
+An abbreviated kind in a `with` constraint.
+
+```ocaml
+module M_kinds : sig ... end
+```
+```ocaml
+type t_qualified : M_kinds.mod_kind
+```
+A qualified use of a kind abbreviation from another module; the use should link to `M_kinds.mod_kind`'s definition.
+
+```ocaml
+type ('a : M_kinds.mod_kind) qualified_param
+```
+A qualified kind abbreviation on a type parameter; the use should link to the definition (resolved during linking, like `t_qualified`).
+
+```ocaml
+module type S_kind = sig ... end
+```
+```ocaml
+module F_kind (X : S_kind) : S_kind
+```
+```ocaml
+module Arg_kind : S_kind
+```
+```ocaml
+type t_functor_app : F_kind(Arg_kind).functor_kind
+```
+A use behind a functor application. odoc references can't express functor application, so this is rendered as plain text (not a link) rather than crashing.
+
+```ocaml
+module F_nested (X : S_kind) : sig ... end
+```
+```ocaml
+kind_ functor_abbrev = F_nested(Arg_kind).abstract_kind
+```
+A kind abbreviation defined through a functor-application path. The manifest is rendered but the functor-application path isn't a link.
+
+```ocaml
+kind_ nested_functor_abbrev = F_nested(Arg_kind).Nested.custom_kind_abbrev
+```
+A kind abbreviation defined through a functor-application-then-nested-module path. The manifest is rendered but the functor-application path isn't a link.
 
 
 ## Zero alloc

--- a/test/generators/markdown/Oxcaml.md
+++ b/test/generators/markdown/Oxcaml.md
@@ -265,11 +265,6 @@ Should render as `float64 & (immediate mod portable)`.
 ## Kind abbreviations
 
 ```ocaml
-kind_ missing_documentation = value mod portable
-```
-TODO: The above kind abbreviation uses `(** *)` which are not captured by the OxCaml parser, so its documentation is currently missing. The following `kind_` declarations use an explicit `@@ocaml.doc` to side-step this issue.
-
-```ocaml
 kind_ my_abbrev = value_or_null mod non_null global
 ```
 Declares a kind abbreviation named `my_abbrev`.

--- a/test/generators/markdown/Oxcaml_impl-Shadowing_source.md
+++ b/test/generators/markdown/Oxcaml_impl-Shadowing_source.md
@@ -1,2 +1,6 @@
 
 # Module `Oxcaml_impl.Shadowing_source`
+
+```ocaml
+kind_ dup = value mod portable
+```

--- a/test/generators/markdown/Oxcaml_impl-Shadowing_source.md
+++ b/test/generators/markdown/Oxcaml_impl-Shadowing_source.md
@@ -1,0 +1,2 @@
+
+# Module `Oxcaml_impl.Shadowing_source`

--- a/test/generators/markdown/Oxcaml_impl.md
+++ b/test/generators/markdown/Oxcaml_impl.md
@@ -10,3 +10,9 @@ module To_be_included : sig ... end
 ```ocaml
 module Including : sig ... end
 ```
+```ocaml
+type t_abbrev : my_abbrev mod immutable
+```
+```ocaml
+module Shadowing_source : sig ... end
+```

--- a/test/generators/markdown/Oxcaml_impl.md
+++ b/test/generators/markdown/Oxcaml_impl.md
@@ -11,8 +11,14 @@ module To_be_included : sig ... end
 module Including : sig ... end
 ```
 ```ocaml
+kind_ my_abbrev = value_or_null mod non_null global
+```
+```ocaml
 type t_abbrev : my_abbrev mod immutable
 ```
 ```ocaml
 module Shadowing_source : sig ... end
+```
+```ocaml
+kind_ dup = value_or_null mod non_null
 ```

--- a/test/generators/markdown/Oxcaml_impl.md
+++ b/test/generators/markdown/Oxcaml_impl.md
@@ -72,8 +72,14 @@ val mode_multi : string @ local once -> string @ local once
 Multiple modes on argument and return.
 
 ```ocaml
+kind_ my_abbrev = value_or_null mod non_null global
+```
+```ocaml
 type t_abbrev : my_abbrev mod immutable
 ```
 ```ocaml
 module Shadowing_source : sig ... end
+```
+```ocaml
+kind_ dup = value_or_null mod non_null
 ```

--- a/test/generators/markdown/Oxcaml_impl.md
+++ b/test/generators/markdown/Oxcaml_impl.md
@@ -70,3 +70,10 @@ Mode on a function argument, via a type annotation.
 val mode_multi : string @ local once -> string @ local once
 ```
 Multiple modes on argument and return.
+
+```ocaml
+type t_abbrev : my_abbrev mod immutable
+```
+```ocaml
+module Shadowing_source : sig ... end
+```

--- a/test/generators/markdown/oxcaml.targets
+++ b/test/generators/markdown/oxcaml.targets
@@ -1,4 +1,12 @@
 Oxcaml.md
+Oxcaml-M_kinds.md
+Oxcaml-module-type-S_kind.md
+Oxcaml-F_kind.md
+Oxcaml-F_kind-argument-1-X.md
+Oxcaml-Arg_kind.md
+Oxcaml-F_nested.md
+Oxcaml-F_nested-argument-1-X.md
+Oxcaml-F_nested-Nested.md
 Oxcaml-module-type-S.md
 Oxcaml-M1.md
 Oxcaml-M2.md

--- a/test/generators/markdown/oxcaml.targets
+++ b/test/generators/markdown/oxcaml.targets
@@ -4,6 +4,14 @@ Oxcaml-module-type-Arg_with.md
 Oxcaml-F_with.md
 Oxcaml-F_with-argument-1-X.md
 Oxcaml-X_with.md
+Oxcaml-M_kinds.md
+Oxcaml-module-type-S_kind.md
+Oxcaml-F_kind.md
+Oxcaml-F_kind-argument-1-X.md
+Oxcaml-Arg_kind.md
+Oxcaml-F_nested.md
+Oxcaml-F_nested-argument-1-X.md
+Oxcaml-F_nested-Nested.md
 Oxcaml-module-type-S.md
 Oxcaml-M1.md
 Oxcaml-M2.md

--- a/test/generators/markdown/oxcaml.targets
+++ b/test/generators/markdown/oxcaml.targets
@@ -12,6 +12,8 @@ Oxcaml-Arg_kind.md
 Oxcaml-F_nested.md
 Oxcaml-F_nested-argument-1-X.md
 Oxcaml-F_nested-Nested.md
+Oxcaml-X_shadowing.md
+Oxcaml-M_inc.md
 Oxcaml-module-type-S.md
 Oxcaml-M1.md
 Oxcaml-M2.md

--- a/test/generators/markdown/oxcaml_impl.targets
+++ b/test/generators/markdown/oxcaml_impl.targets
@@ -1,3 +1,4 @@
 Oxcaml_impl.md
 Oxcaml_impl-To_be_included.md
 Oxcaml_impl-Including.md
+Oxcaml_impl-Shadowing_source.md


### PR DESCRIPTION
This PR adds support for rendering and linking to kind abbreviations (this introduces a new namespace, similar to types, so a lot of mechanical changes are required!).

As we are currently testing with OxCaml-minus31, there's a small inconvenience that one has to write an explicit `[@@ocaml.doc "..."]` to document `kind_` abbreviation as the parser was missing an `add_docs_attrs` ( https://github.com/oxcaml/oxcaml/blob/5.2.0minus-31/parsing/parser.mly#L4123-L4134 ). The oxcaml parser has since been [fixed](https://github.com/oxcaml/oxcaml/blob/main/parsing/parser.mly#L4197-L4209) so we'll be able to clean up the test in the near future :)

Fix https://github.com/ocaml/odoc/issues/1443