### PR TITLE
Identifier lookup fails to lookup functors and warns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 - Support for OxCaml zero alloc definitions (@Leonidas-from-XIV, #1422, #1444)
 - Remove requirement for ppx_expect in tests (@jonludlam, #1445)
 - Support for OxCaml modalities (@art-w, #1420)
+- Fix resolving functor through `module type of` (@Leonidas-from-XIV, #1471)
 
 # 3.2.1
 

--- a/src/xref2/errors.ml
+++ b/src/xref2/errors.ml
@@ -31,9 +31,7 @@ module Tools_error = struct
       (* The module signature depends upon a forward path *)
     | `UnresolvedPath of
       [ `Module of Cpath.module_ * simple_module_lookup_error
-      | `ModuleType of Cpath.module_type * simple_module_type_lookup_error ]
-      (* The path to the module or module type could not be resolved *)
-    | `UnresolvedOriginalPath of Cpath.module_ * simple_module_lookup_error ]
+      | `ModuleType of Cpath.module_type * simple_module_type_lookup_error ] ]
 
   and simple_module_lookup_error =
     [ `Local of Env.t * Ident.module_
@@ -188,11 +186,6 @@ module Tools_error = struct
     | `UnresolvedPath (`ModuleType (p, e)) ->
         Format.fprintf fmt "Unresolved module type path %a (%a)"
           (module_type_path c) p pp
-          (e :> any)
-    | `UnresolvedOriginalPath (p, e) ->
-        Format.fprintf fmt "Unresolved original module path %a (%a)"
-          Component.Fmt.(module_path default)
-          p pp
           (e :> any)
     | `LocalMT (_, id) -> Format.fprintf fmt "Local id found: %a" Ident.fmt id
     | `Local (_, id) -> Format.fprintf fmt "Local id found: %a" Ident.fmt id

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -383,41 +383,21 @@ let simplify_type : Env.t -> Cpath.Resolved.type_ -> Cpath.Resolved.type_ =
   | _ -> m
 
 let rec handle_apply env func_path arg_path m =
-  let rec find_functor mty =
-    match mty with
-    | Component.ModuleType.Functor (Named arg, expr) ->
-        Ok (arg.Component.FunctorParameter.id, expr)
-    | Component.ModuleType.Path { p_path; _ } -> (
-        match resolve_module_type env p_path with
-        | Ok (_, { Component.ModuleType.expr = Some mty'; _ }) ->
-            find_functor mty'
-        | _ -> Error `OpaqueModule)
-    | Component.ModuleType.TypeOf { t_desc = ModPath path; _ } ->
-        let rec recurse_module path =
-          match resolve_module env path with
-          | Ok (_, delayed_module) -> (
-              let module_ = Component.Delayed.get delayed_module in
-              match module_.type_ with
-              | ModuleType mty' -> find_functor mty'
-              | Alias (path, _) -> recurse_module path)
-          | _ -> Error `ApplyNotFunctor
-        in
-        recurse_module path
-    | _ -> Error `ApplyNotFunctor
-  in
-  module_type_expr_of_module env m >>= fun mty' ->
-  find_functor mty' >>= fun (arg_id, result) ->
-  let new_module = { m with Component.Module.type_ = ModuleType result } in
-  let substitution = `Substituted arg_path in
-
-  let path = `Apply (func_path, arg_path) in
-  let subst =
-    Subst.add_module
-      (arg_id :> Ident.module_)
-      (`Resolved substitution) substitution Subst.identity
-  in
-  let subst = Subst.unresolve_opaque_paths subst in
-  Ok (path, Subst.module_ subst new_module)
+  expansion_of_module env m
+  |> map_error (fun e -> (e :> simple_module_type_expr_of_module_error))
+  >>= function
+  | Signature _ | Functor (Unit, _) -> Error `ApplyNotFunctor
+  | Functor (Named arg, result) ->
+      let new_module = { m with Component.Module.type_ = ModuleType result } in
+      let substitution = `Substituted arg_path in
+      let path = `Apply (func_path, arg_path) in
+      let subst =
+        Subst.add_module
+          (arg.id :> Ident.module_)
+          (`Resolved substitution) substitution Subst.identity
+      in
+      let subst = Subst.unresolve_opaque_paths subst in
+      Ok (path, Subst.module_ subst new_module)
 
 and add_canonical_path :
     Component.Module.t -> Cpath.Resolved.module_ -> Cpath.Resolved.module_ =
@@ -2221,10 +2201,7 @@ and resolve_module_fragment :
         match expansion_of_module env m' with
         | Ok (_m : expansion) -> f'
         | Error `OpaqueModule -> `OpaqueModule f'
-        | Error
-            ( `UnresolvedForwardPath | `UnresolvedPath _
-            | `UnresolvedOriginalPath _ ) ->
-            f'
+        | Error (`UnresolvedForwardPath | `UnresolvedPath _) -> f'
       in
       Some (fixup_module_cfrag f'')
 
@@ -2250,9 +2227,7 @@ and resolve_module_type_fragment :
       let f'' =
         match expansion_of_module_type env m' with
         | Ok (_m : expansion) -> f'
-        | Error
-            ( `UnresolvedForwardPath | `UnresolvedPath _ | `OpaqueModule
-            | `UnresolvedOriginalPath _ ) ->
+        | Error (`UnresolvedForwardPath | `UnresolvedPath _ | `OpaqueModule) ->
             f'
       in
       Some (fixup_module_type_cfrag f'')
@@ -2344,20 +2319,14 @@ let resolve_module_path env p =
       match expansion_of_module_cached env p m with
       | Ok _ -> Ok p
       | Error `OpaqueModule -> Ok (`OpaqueModule p)
-      | Error
-          ( `UnresolvedForwardPath | `UnresolvedPath _
-          | `UnresolvedOriginalPath _ ) ->
-          Ok p)
+      | Error (`UnresolvedForwardPath | `UnresolvedPath _) -> Ok p)
 
 let resolve_module_type_path env p =
   resolve_module_type env p >>= fun (p, mt) ->
   match expansion_of_module_type env mt with
   | Ok _ -> Ok p
   | Error `OpaqueModule -> Ok (`OpaqueModuleType p)
-  | Error
-      (`UnresolvedForwardPath | `UnresolvedPath _ | `UnresolvedOriginalPath _)
-    ->
-      Ok p
+  | Error (`UnresolvedForwardPath | `UnresolvedPath _) -> Ok p
 
 let resolve_type_path env p = resolve_type env p >>= fun (p, _) -> Ok p
 

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -392,6 +392,18 @@ let rec handle_apply env func_path arg_path m =
         | Ok (_, { Component.ModuleType.expr = Some mty'; _ }) ->
             find_functor mty'
         | _ -> Error `OpaqueModule)
+    | Component.ModuleType.TypeOf { t_desc; _ } ->
+        let path = match t_desc with ModPath p -> p | StructInclude p -> p in
+        let rec recurse_module path =
+          match resolve_module env path with
+          | Ok (_, delayed_module) -> (
+              let module_ = Component.Delayed.get delayed_module in
+              match module_.type_ with
+              | ModuleType mty' -> find_functor mty'
+              | Alias (path, _) -> recurse_module path)
+          | _ -> Error `ApplyNotFunctor
+        in
+        recurse_module path
     | _ -> Error `ApplyNotFunctor
   in
   module_type_expr_of_module env m >>= fun mty' ->

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -392,8 +392,7 @@ let rec handle_apply env func_path arg_path m =
         | Ok (_, { Component.ModuleType.expr = Some mty'; _ }) ->
             find_functor mty'
         | _ -> Error `OpaqueModule)
-    | Component.ModuleType.TypeOf { t_desc; _ } ->
-        let path = match t_desc with ModPath p -> p | StructInclude p -> p in
+    | Component.ModuleType.TypeOf { t_desc = ModPath path; _ } ->
         let rec recurse_module path =
           match resolve_module env path with
           | Ok (_, delayed_module) -> (

--- a/test/xref2/functor_type_of.t/run.t
+++ b/test/xref2/functor_type_of.t/run.t
@@ -1,0 +1,35 @@
+Testing functor applications that go through `module type of`
+=============================================================
+
+It is not very common to define types of functors in OCaml, but it is possible
+and it is also possible to get the type checker to determine the type via the
+`module type of` operator.
+
+Modules can use this type which, in turn, makes them functors.
+
+Setup
+-----
+
+In this file we have a simple functor `Make` and create another module, `Named`
+which has the same type as `Make` and thus also a functor.
+
+  $ cat test.mli
+  module Make (T : sig end) : sig type included end
+  module Named : module type of Make
+  
+  module Applicant : sig end
+  
+  module Applied : module type of Named(Applicant)
+
+There is also the module which it is applied to (`Applicant`) which is of no
+particular importance and the functor application.
+
+Test
+----
+
+However, at the moment Odoc can't see through the indirection and emits a
+warning that the new functor, `Named`, is not a functor:
+
+  $ compile test.mli
+  File "test.odoc":
+  Warning: Failed to lookup type identifier(root(Test).Named,false)(identifier(root(Test).Applicant,false)).included Parent_module: Parent_expr: Apply module is not a functor

--- a/test/xref2/functor_type_of.t/run.t
+++ b/test/xref2/functor_type_of.t/run.t
@@ -27,9 +27,7 @@ particular importance and the functor application.
 Test
 ----
 
-However, at the moment Odoc can't see through the indirection and emits a
-warning that the new functor, `Named`, is not a functor:
+Odoc should successfully resolve the functor and don't emit warnings about
+unknown functors:
 
   $ compile test.mli
-  File "test.odoc":
-  Warning: Failed to lookup type identifier(root(Test).Named,false)(identifier(root(Test).Applicant,false)).included Parent_module: Parent_expr: Apply module is not a functor

--- a/test/xref2/functor_type_of.t/run.t
+++ b/test/xref2/functor_type_of.t/run.t
@@ -20,6 +20,8 @@ which has the same type as `Make` and thus also a functor.
   module Applicant : sig end
   
   module Applied : module type of Named(Applicant)
+  
+  module StructApplied : module type of struct include Named(Applicant) end
 
 There is also the module which it is applied to (`Applicant`) which is of no
 particular importance and the functor application.

--- a/test/xref2/functor_type_of.t/test.mli
+++ b/test/xref2/functor_type_of.t/test.mli
@@ -4,3 +4,5 @@ module Named : module type of Make
 module Applicant : sig end
 
 module Applied : module type of Named(Applicant)
+
+module StructApplied : module type of struct include Named(Applicant) end

--- a/test/xref2/functor_type_of.t/test.mli
+++ b/test/xref2/functor_type_of.t/test.mli
@@ -1,0 +1,6 @@
+module Make (T : sig end) : sig type included end
+module Named : module type of Make
+
+module Applicant : sig end
+
+module Applied : module type of Named(Applicant)


### PR DESCRIPTION
Given a module like this:

```ocaml
module Xref_failure : sig
  module Make (T : sig end) : sig type included end
  module Named : module type of Make

  module Applicant : sig end

  module Applied : module type of Named(Applicant)
end
```

That is where the functor `Make` is not directly applied but goes through the redirection of `Named` the xref code fails to see this and can't link it up, creating a spurious warning:

```
Warning: Failed to lookup type identifier(root(Functor).Xref_failure.Named,false)(identifier(root(Functor).Xref_failure.Applicant,false)).included Parent_module: Parent_expr: Apply module is not a functor
```

So basically it is missing that `Named` is actually referring to a functor.