### PR TITLE
fix: odoc driver linking to stdlib in `$prefix/lib64`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 - Support for OxCaml zero alloc definitions (@Leonidas-from-XIV, #1422, #1444)
 - Remove requirement for ppx_expect in tests (@jonludlam, #1445)
 - Support for OxCaml modalities (@art-w, #1420)
+- Use Findlib to detect library directories in odoc_driver, avoiding hard-coding (@katrinafyi, #1474)
 
 # 3.2.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - Remove requirement for ppx_expect in tests (@jonludlam, #1445)
 - Support for OxCaml modalities (@art-w, #1420)
 - Fix resolving functor through `module type of` (@Leonidas-from-XIV, #1471)
-- Use Findlib to detect library directories in odoc_driver, requires ocamlfind >= 1.9.8 (@katrinafyi, #1474)
+- Fix odoc_driver's detection of `stdlib` when it is in `$prefix/lib64`, requires ocamlfind >= 1.9.8 (@katrinafyi, #1477, #1474)
 
 # 3.2.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - Remove requirement for ppx_expect in tests (@jonludlam, #1445)
 - Support for OxCaml modalities (@art-w, #1420)
 - Fix resolving functor through `module type of` (@Leonidas-from-XIV, #1471)
-- Use Findlib to detect library directories in odoc_driver, avoiding hard-coding (@katrinafyi, #1474)
+- Use Findlib to detect library directories in odoc_driver, requires ocamlfind >= 1.9.8 (@katrinafyi, #1474)
 
 # 3.2.1
 

--- a/odoc-driver.opam
+++ b/odoc-driver.opam
@@ -40,7 +40,7 @@ depends: [
   "bos"
   "fpath" {>= "0.7.3"}
   "yojson" {>= "2.0.0"}
-  "ocamlfind"
+  "ocamlfind" {>= "1.9.8"}
   "opam-format" {>= "2.1.0"}
   "logs"
   "eio_main"

--- a/src/driver/ocamlfind.ml
+++ b/src/driver/ocamlfind.ml
@@ -1,8 +1,6 @@
 let init =
   let initialized = ref false in
-  fun () ->
-    if !initialized then ()
-    else Findlib.init ()
+  fun () -> if !initialized then () else Findlib.init ()
 
 let all () =
   init ();

--- a/src/driver/ocamlfind.ml
+++ b/src/driver/ocamlfind.ml
@@ -2,11 +2,7 @@ let init =
   let initialized = ref false in
   fun () ->
     if !initialized then ()
-    else
-      let prefix = Opam.prefix () in
-      let env_camllib = Fpath.(v prefix / "lib" / "ocaml" |> to_string) in
-      let config = Fpath.(v prefix / "lib" / "findlib.conf" |> to_string) in
-      Findlib.init ~config ~env_camllib ()
+    else Findlib.init ()
 
 let all () =
   init ();

--- a/src/driver/opam.ml
+++ b/src/driver/opam.ml
@@ -196,18 +196,19 @@ let classify_libs prefix only_package contents =
     match only_package with None -> true | Some p -> p = pkg
   in
 
-  let libs =
-    List.fold_left
-      (fun set fpath ->
-        match Fpath.segs fpath with
-        | "lib" :: "stublibs" :: _ -> set
-        | "lib" :: pkg :: _ :: _
-          when Fpath.has_ext ".cmi" fpath && pkg_match pkg ->
-            Fpath.Set.add Fpath.(prefix // fpath |> split_base |> fst) set
-        | _ -> set)
-      Fpath.Set.empty contents
-  in
-  libs
+  contents
+  |> List.filter (Fpath.has_ext ".cmi")
+  |> List.filter_map (fun fpath ->
+         match Fpath.segs fpath with
+         | ("lib" | "lib64") :: "stublibs" :: _ -> None
+         (* e.g., [lib/cohttp/**/*.cmi] *)
+         | ("lib" | "lib64") :: pkg :: _ :: _ when pkg_match pkg ->
+             Some Fpath.(prefix // fpath |> split_base |> fst)
+         (* e.g., [lib64/stdlib.cmi] *)
+         | [ ("lib" | "lib64"); _ ] ->
+             Some Fpath.(prefix // fpath |> split_base |> fst)
+         | _ -> None)
+  |> Fpath.Set.of_list
 
 let find_odoc_config prefix only_package contents =
   let pkg_match pkg =


### PR DESCRIPTION
This does two related changes to fix https://github.com/ocaml/odoc/issues/1477:

- Use Findlib's own logic for inferring stdlib directory
- Adjust odoc_driver's classify_libs logic to also accept `lib64/` and also accept files appearing outside of a package subdirectory, as the ocaml stdlib files do.

I can test that it works with `dune exec odoc_driver -- fmt`.

--------

Removing the explicitly provided arguments to findlib  will be more reliable than hardcoding a subpath of the opam prefix.

As of about 2 years ago, ocamlfind is able to automatically infer the config path from opam environment variables: https://github.com/ocaml/ocamlfind/blob/be2335f14cc45b5551dea4278affdfb2718eb72e/src/findlib/findlib_config.mlp#L71-L77

Also, hardcoding the `env_camllib` can be risky because it's not portable or overridable. On openSUSE Tumbleweed, my stdlib was actually in `{prefix}/lib64` rather than the `lib/ocaml` which was hardcoded.

Findlib also has logic to let the user override the paths using environment variables, if needed: https://github.com/ocaml/ocamlfind/blob/be2335f14cc45b5551dea4278affdfb2718eb72e/src/findlib/findlib.ml#L281-L289

