### PR TITLE
Use implementations from `Stdlib` if available

### DIFF
--- a/src/utils/odoc_list.ml
+++ b/src/utils/odoc_list.ml
@@ -6,7 +6,6 @@ let rec concat_map_sep ~sep ~f = function
       let tl = concat_map_sep ~sep ~f xs in
       hd @ (sep :: tl)
 
-(** @raise Failure if the list is empty. *)
 let rec last = function
   | [] -> failwith "Odoc_utils.List.last"
   | [ x ] -> x
@@ -25,17 +24,6 @@ let split_at ~f lst =
   loop [] lst
 
 module Overlay = struct
-  (* Since 4.12. Copied from ocaml/ocaml *)
-  let partition_map p l =
-    let rec part left right = function
-      | [] -> (List.rev left, List.rev right)
-      | x :: l -> (
-          match p x with
-          | Either.Left v -> part (v :: left) right l
-          | Either.Right v -> part left (v :: right) l)
-    in
-    part [] [] l
-
   (* Since 5.1 *)
   let is_empty = function [] -> true | _ :: _ -> false
 

--- a/src/utils/odoc_list.ml
+++ b/src/utils/odoc_list.ml
@@ -1,5 +1,3 @@
-include List
-
 let rec concat_map_sep ~sep ~f = function
   | [] -> []
   | [ x ] -> f x
@@ -8,30 +6,11 @@ let rec concat_map_sep ~sep ~f = function
       let tl = concat_map_sep ~sep ~f xs in
       hd @ (sep :: tl)
 
-(* Since 4.10 *)
-let concat_map f l =
-  let rec aux f acc = function
-    | [] -> rev acc
-    | x :: l ->
-        let xs = f x in
-        aux f (rev_append xs acc) l
-  in
-  aux f [] l
-
 (** @raise Failure if the list is empty. *)
 let rec last = function
   | [] -> failwith "Odoc_utils.List.last"
   | [ x ] -> x
   | _ :: tl -> last tl
-
-(* Since 4.10. Copied ocaml/ocaml *)
-let rec find_map f = function
-  | [] -> None
-  | x :: l -> (
-      match f x with Some _ as result -> result | None -> find_map f l)
-
-(* Since 5.1 *)
-let is_empty = function [] -> true | _ :: _ -> false
 
 let rec skip_until ~p = function
   | [] -> []
@@ -44,3 +23,40 @@ let split_at ~f lst =
     | hd :: tl -> loop (hd :: acc) tl
   in
   loop [] lst
+
+module Overlay = struct
+  (* Since 4.12. Copied from ocaml/ocaml *)
+  let partition_map p l =
+    let rec part left right = function
+      | [] -> (List.rev left, List.rev right)
+      | x :: l -> (
+          match p x with
+          | Either.Left v -> part (v :: left) right l
+          | Either.Right v -> part left (v :: right) l)
+    in
+    part [] [] l
+
+  (* Since 5.1 *)
+  let is_empty = function [] -> true | _ :: _ -> false
+
+  (* Since 4.10. Copied ocaml/ocaml *)
+  let rec find_map f = function
+    | [] -> None
+    | x :: l -> (
+        match f x with Some _ as result -> result | None -> find_map f l)
+
+  (* Since 4.10 *)
+  let concat_map f l =
+    let rec aux f acc = function
+      | [] -> List.rev acc
+      | x :: l ->
+          let xs = f x in
+          aux f (List.rev_append xs acc) l
+    in
+    aux f [] l
+
+  (* shadow the functions defined above with the stdlib variants if available *)
+  include List
+end
+
+include Overlay

--- a/src/utils/odoc_list.mli
+++ b/src/utils/odoc_list.mli
@@ -1,0 +1,12 @@
+val concat_map_sep : sep:'a -> f:('b -> 'a list) -> 'b list -> 'a list
+val split_at : f:('a -> bool) -> 'a list -> 'a list * 'a list
+val skip_until : p:('a -> bool) -> 'a list -> 'a list
+
+val last : 'a list -> 'a
+(** @raise Failure if the list is empty. *)
+
+val is_empty : 'a list -> bool
+val find_map : ('a -> 'b option) -> 'a list -> 'b option
+val concat_map : ('a -> 'b list) -> 'a list -> 'b list
+
+include module type of List


### PR DESCRIPTION
In my `include functor` PR I've used `List.partition_map`, which made the CI fail on OCaml 4.11, so I looked for the place where Odoc (like every project) would have its own Stdlib extensions.

However the way it is currently implemented the Odoc implementations take preference over the OCaml stdlib. This is mostly fine, however it would be somewhat nicer if Odoc could profit from potential future improvements. In Dune we have arrived at a pattern which allows us to polyfill missing functions while also using the compilers implementation of them - without having to resort to conditional compilation.

This PR implements that pattern.