### PR TITLE
Remove `Forward constructor

### DIFF
--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -112,7 +112,6 @@ module Make (Syntax : SYNTAX) = struct
       | `SubstitutedCT m -> from_path (m :> Path.t)
       | `Unbox t -> from_path (t :> Path.t)
       | `Root root -> unresolved [ inline @@ Text (ModuleName.to_string root) ]
-      | `Forward root -> unresolved [ inline @@ Text root ] (* FIXME *)
       | `Dot (prefix, suffix) ->
           let link = from_path (prefix :> Path.t) in
           link ++ O.txt ("." ^ ModuleName.to_string suffix)

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -51,7 +51,6 @@ let render_path : Path.t -> string =
     match x with
     | `Identifier (id, _) -> Identifier.name id
     | `Root root -> ModuleName.to_string root
-    | `Forward root -> root
     | `Dot (p, s) -> dot p (ModuleName.to_string s)
     | `DotT (p, s) -> dot p (TypeName.to_string s)
     | `DotMT (p, s) -> dot p (ModuleTypeName.to_string s)

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -745,7 +745,6 @@ module Path = struct
     | `SubstitutedCT r -> is_path_hidden (r :> any)
     | `Unbox r -> is_path_hidden (r :> any)
     | `Root s -> ModuleName.is_hidden s
-    | `Forward _ -> false
     | `Dot (p, n) ->
         ModuleName.is_hidden n || is_path_hidden (p : module_ :> any)
     | `DotMT (p, n) ->

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -331,7 +331,6 @@ module rec Path : sig
     | `Identifier of Identifier.path_module * bool
     | `Substituted of module_
     | `Root of ModuleName.t
-    | `Forward of string
     | `Dot of module_ * ModuleName.t
     | `Apply of module_ * module_ ]
   (** @canonical Odoc_model.Paths.Path.Module.t *)
@@ -372,7 +371,6 @@ module rec Path : sig
     | `SubstitutedCT of class_type
     | `Identifier of Identifier.path_any * bool
     | `Root of ModuleName.t
-    | `Forward of string
     | `Dot of module_ * ModuleName.t
     | `DotT of module_ * TypeName.t
     | `DotMT of module_ * ModuleTypeName.t

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -220,7 +220,6 @@ module General_paths = struct
       | `Identifier (x1, x2) ->
           C ("`Identifier", ((x1 :> id_t), x2), Pair (identifier, bool))
       | `Root x -> C ("`Root", x, Names.modulename)
-      | `Forward x -> C ("`Forward", x, string)
       | `Dot (x1, x2) ->
           C ("`Dot", ((x1 :> p), x2), Pair (path, Names.modulename))
       | `DotT (x1, x2) ->

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -1265,7 +1265,6 @@ module Fmt = struct
         wrap2 c "identifier" model_identifier bool ppf (id :> id) b
     | `Local (id, b) -> wrap2 c "local" ident_fmt bool ppf id b
     | `Substituted p -> wrap c "substituted" module_path ppf p
-    | `Forward s -> wrap c "forward" str ppf s
     | `Root r -> wrap c "unresolvedroot" str ppf (ModuleName.to_string r)
 
   and resolved_module_type_path :
@@ -1423,7 +1422,6 @@ module Fmt = struct
     | `Identifier (id, b) ->
         wrap2 c "identifier" model_identifier bool ppf (id :> id) b
     | `Root s -> wrap c "root" str ppf (ModuleName.to_string s)
-    | `Forward s -> wrap c "forward" str ppf s
     | `Dot (p, s) -> dot p (ModuleName.to_string s)
     | `DotMT (p, s) -> dot p (ModuleTypeName.to_string s)
     | `DotT (p, s) -> dot p (TypeName.to_string s)
@@ -2111,7 +2109,6 @@ module Of_Lang = struct
     | `Dot (path', x) -> `Dot (module_path ident_map path', x)
     | `Apply (p1, p2) ->
         `Apply (module_path ident_map p1, module_path ident_map p2)
-    | `Forward str -> `Forward str
     | `Root str -> `Root str
 
   and module_type_path :

--- a/src/xref2/cpath.ml
+++ b/src/xref2/cpath.ml
@@ -176,14 +176,6 @@ let is_class_type_substituted : class_type -> bool = function
   | `DotT (a, _) -> is_module_substituted a
   | `Class (a, _) | `ClassType (a, _) -> is_resolved_parent_substituted a
 
-let rec is_module_forward : module_ -> bool = function
-  | `Resolved _ -> false
-  | `Root _ -> false
-  | `Identifier _ -> false
-  | `Local _ -> false
-  | `Substituted p | `Dot (p, _) | `Apply (p, _) -> is_module_forward p
-  | `Module (_, _) -> false
-
 let rec is_module_hidden : module_ -> bool = function
   | `Resolved r -> is_resolved_module_hidden ~weak_canonical_test:false r
   | `Substituted p | `Dot (p, _) | `Apply (p, _) -> is_module_hidden p

--- a/src/xref2/cpath.ml
+++ b/src/xref2/cpath.ml
@@ -57,7 +57,6 @@ and Cpath : sig
     | `Local of Ident.module_ * bool
     | `Identifier of Identifier.Path.Module.t * bool
     | `Root of ModuleName.t
-    | `Forward of string
     | `Dot of module_ * ModuleName.t
     | `Module of Resolved.parent * ModuleName.t (* Like dot, but typed *)
     | `Apply of module_ * module_ ]
@@ -148,7 +147,6 @@ let rec is_module_substituted : module_ -> bool = function
   | `Local _ -> false
   | `Substituted _ -> true
   | `Dot (a, _) | `Apply (a, _) -> is_module_substituted a
-  | `Forward _ -> false
   | `Root _ -> false
   | `Module (a, _) -> is_resolved_parent_substituted a
 
@@ -179,7 +177,6 @@ let is_class_type_substituted : class_type -> bool = function
   | `Class (a, _) | `ClassType (a, _) -> is_resolved_parent_substituted a
 
 let rec is_module_forward : module_ -> bool = function
-  | `Forward _ -> true
   | `Resolved _ -> false
   | `Root _ -> false
   | `Identifier _ -> false
@@ -192,7 +189,6 @@ let rec is_module_hidden : module_ -> bool = function
   | `Substituted p | `Dot (p, _) | `Apply (p, _) -> is_module_hidden p
   | `Identifier (_, b) -> b
   | `Local (_, b) -> b
-  | `Forward _ -> false
   | `Root _ -> false
   | `Module (p, _) -> is_resolved_parent_hidden ~weak_canonical_test:false p
 
@@ -350,7 +346,6 @@ and unresolve_module_path : module_ -> module_ = function
   | `Local (_, _) as x -> x
   | `Identifier _ as x -> x
   | `Root _ as x -> x
-  | `Forward _ as x -> x
   | `Dot (p, x) -> `Dot (unresolve_module_path p, x)
   | `Module (p, x) -> `Dot (unresolve_resolved_parent_path p, x)
   | `Apply (x, y) -> `Apply (unresolve_module_path x, unresolve_module_path y)

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -74,7 +74,6 @@ module Path = struct
     | `Resolved x -> `Resolved (resolved_module map x)
     | `Root x -> `Root x
     | `Dot (p, s) -> `Dot (module_ map p, s)
-    | `Forward s -> `Forward s
     | `Apply (m1, m2) -> `Apply (module_ map m1, module_ map m2)
     | `Module (`Module p, n) -> `Dot (`Resolved (resolved_module map p), n)
     | `Module (_, _) -> failwith "Probably shouldn't happen"

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -94,7 +94,6 @@ exception Loop
 let rec is_forward : Paths.Path.Module.t -> bool = function
   | `Resolved _ -> false
   | `Root _ -> false
-  | `Forward _ -> true
   | `Identifier _ -> false
   | `Dot (p, _) -> is_forward p
   | `Apply (p1, p2) -> is_forward p1 || is_forward p2

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -91,14 +91,6 @@ let expansion_needed self target =
 
 exception Loop
 
-let rec is_forward : Paths.Path.Module.t -> bool = function
-  | `Resolved _ -> false
-  | `Root _ -> false
-  | `Identifier _ -> false
-  | `Dot (p, _) -> is_forward p
-  | `Apply (p1, p2) -> is_forward p1 || is_forward p2
-  | `Substituted s -> is_forward s
-
 let rec should_reresolve : Paths.Path.Resolved.t -> bool =
  fun p ->
   let open Paths.Path.Resolved in
@@ -226,7 +218,6 @@ and module_path : Env.t -> Paths.Path.Module.t -> Paths.Path.Module.t =
         | Ok p' ->
             let result = Tools.reresolve_module env p' in
             `Resolved Lang_of.(Path.resolved_module (empty ()) result)
-        | Error _ when is_forward p -> p
         | Error e ->
             Errors.report ~what:(`Module_path cp) ~tools_error:e `Resolve;
             p)

--- a/src/xref2/shape_tools.cppo.ml
+++ b/src/xref2/shape_tools.cppo.ml
@@ -73,7 +73,6 @@ let rec shape_of_module_path env : _ -> Shape.t option =
             | Some (shape, _) -> Some shape
             | None -> None)
         | _ -> None)
-    | `Forward _ -> None
     | `Dot (parent, name) ->
         proj (parent :> Odoc_model.Paths.Path.Module.t) Kind.Module (ModuleName.to_string_unsafe name)
     | `Apply (parent, arg) ->
@@ -106,7 +105,6 @@ let rec shape_of_kind_path env kind :
     | `Identifier (id, _) -> shape_of_id env (id :> Odoc_model.Paths.Identifier.NonSrc.t)
     | `Substituted t -> shape_of_kind_path env kind (t :> Odoc_model.Paths.Path.t)
     | `Unbox t -> shape_of_kind_path env kind (t :> Odoc_model.Paths.Path.t)
-    | `Forward _
     | `Dot _
     | `Root _
     | `Apply _ -> None

--- a/src/xref2/subst.ml
+++ b/src/xref2/subst.ml
@@ -289,7 +289,6 @@ and module_path : t -> Cpath.module_ -> Cpath.module_ =
       | None -> `Local (id, b))
   | `Identifier _ -> p
   | `Substituted p -> `Substituted (module_path s p)
-  | `Forward _ -> p
   | `Root _ -> p
 
 and resolved_module_type_path :

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -953,9 +953,6 @@ and resolve_module : Env.t -> Cpath.module_ -> resolve_module_result =
         | Some Env.Forward ->
             Error (`Parent (`Parent_sig `UnresolvedForwardPath))
         | None -> Error (`Lookup_failure_root r))
-    | `Forward f ->
-        resolve_module env (`Root (ModuleName.make_std f))
-        |> map_error (fun e -> `Parent (`Parent_module e))
   in
   LookupAndResolveMemo.memoize resolve env' id
 
@@ -1525,8 +1522,6 @@ and module_type_expr_of_module_decl :
       | Ok (_, m) ->
           let m = Component.Delayed.get m in
           module_type_expr_of_module env m
-      | Error _ when Cpath.is_module_forward path ->
-          Error `UnresolvedForwardPath
       | Error e -> Error (`UnresolvedPath (`Module (path, e))))
   | Component.Module.ModuleType expr -> Ok expr
 
@@ -1558,7 +1553,6 @@ and expansion_of_module_path :
           in
           Ok (Signature sg)
       | Functor _ as f -> Ok f)
-  | Error _ when Cpath.is_module_forward path -> Error `UnresolvedForwardPath
   | Error e -> Error (`UnresolvedPath (`Module (path, e)))
 
 and handle_signature_with_subs :

--- a/src/xref2/tools.mli
+++ b/src/xref2/tools.mli
@@ -30,12 +30,6 @@ type expansion =
     - [add_canonical] asks for [`Canonical] constructors to be added to modules
       for which there is a defined canonical path. If the
 
-    If the path is a 'Forward' path, that is, a path to a module that has not
-    yet been compiled, then it may not be possible to resolve the path if this
-    is being called during the 'compile' phase, in which case the function will
-    return an unresolved path with no component. Resolution should be attempted
-    again during the link phase.
-
     On entry the assumption is that all
     {{!type:Odoc_model.Paths.Identifier.t}Identifiers} in the paths are
     available in [env], except where there are forward paths. If the environment

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -574,7 +574,6 @@ module LangUtils = struct
             | `Resolved rp -> Format.fprintf ppf "resolved[%a]" resolved_path (rp :> Odoc_model.Paths.Path.Resolved.t)
             | `Identifier (i,b) -> Format.fprintf ppf "identifier(%a,%b)" identifier i b
             | `Root s -> Format.fprintf ppf "%a" ModuleName.fmt s
-            | `Forward s -> Format.fprintf ppf "%s" s
             | `Dot (parent,s) -> Format.fprintf ppf "%a.%a" path (parent :> Odoc_model.Paths.Path.t) ModuleName.fmt s
             | `DotMT (parent,s) -> Format.fprintf ppf "%a.%a" path (parent :> Odoc_model.Paths.Path.t) ModuleTypeName.fmt s
             | `DotT (parent,s) -> Format.fprintf ppf "%a.%a" path (parent :> Odoc_model.Paths.Path.t) TypeName.fmt s


### PR DESCRIPTION
I was trying to understand what `` `Forward`` does. To do so figure out where a value of `` `Forward`` is constructed (from scratch, not as part of a `map` operation) and see what context this is useful. But it seems that such a value is never constructed. To test my hypothesis I removed the `` `Forward`` constructor from the codebase and it seems to compile fine and the tests also pass.

Thus my investigation seems to point to the fact that `` `Forward`` is unnecessary and can be removed. I'm opening a draft PR and invite maintainers to take a look - maybe I am missing some context in which `` `Forward`` is used, but if anything then at least it points at the fact that this functionality is not covered by any tests.